### PR TITLE
chore(deps): point omnibase_core to git main branch [OMN-943]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ onex-runtime = "omnibase_infra.runtime.kernel:main"
 [tool.poetry.dependencies]
 python = "^3.12"
 
-# ONEX dependencies - from PyPI
-omnibase-core = "^0.4.0"
+# ONEX dependencies - git main branch for development
+omnibase-core = {git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main"}
 omnibase-spi = "^0.4.0"
 
 # Core dependencies


### PR DESCRIPTION
## Summary

- Update omnibase_core dependency to track git main branch during active development

## Context

While working on OMN-943 (document canonical vs optional registration triggers), updating the dependency to use the main branch instead of PyPI for development.

## Test plan

- [ ] Poetry install succeeds with git dependency