### PR TITLE
test(reducer): add comprehensive reducer test suite [OMN-942]

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1969,6 +1969,39 @@ requests = ">=2.27.1,<3.0.0"
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
 
 [[package]]
+name = "hypothesis"
+version = "6.148.7"
+description = "The property-based testing library for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "hypothesis-6.148.7-py3-none-any.whl", hash = "sha256:94dbd58ebf259afa3bafb1d3bf5761ac1bde6f1477de494798cbf7960aabbdee"},
+    {file = "hypothesis-6.148.7.tar.gz", hash = "sha256:b96e817e715c5b1a278411e3b9baf6d599d5b12207ba25e41a8f066929f6c2a6"},
+]
+
+[package.dependencies]
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=20.8b0)", "click (>=7.0)", "crosshair-tool (>=0.0.99)", "django (>=4.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.26)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.21.6)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2025.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\"", "watchdog (>=4.0.0)"]
+cli = ["black (>=20.8b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+crosshair = ["crosshair-tool (>=0.0.99)", "hypothesis-crosshair (>=0.0.26)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=4.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=20.8b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.21.6)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+watchdog = ["watchdog (>=4.0.0)"]
+zoneinfo = ["tzdata (>=2025.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\""]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 description = "File identification library for Python"
@@ -5308,6 +5341,18 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -6165,4 +6210,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "8c5614c1f22289aa3ab9f001784eb0ae56a75e67094e20348fadd9c544bf1f0b"
+content-hash = "879c55110b65eee82719b814536f088a11cd88681f78002c8021f29f368719bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ kafka-python = "^2.0.2"  # Kafka client for integration testing
 # Additional type stubs for better mypy coverage
 types-aiofiles = "^23.2.0.20240403"
 types-requests = "^2.32.0.20250914"
+hypothesis = "^6.148.7"
 
 [tool.ruff]
 target-version = "py312"

--- a/tests/unit/nodes/reducers/test_registration_reducer.py
+++ b/tests/unit/nodes/reducers/test_registration_reducer.py
@@ -1718,6 +1718,677 @@ class TestPerformance:
 
 
 # -----------------------------------------------------------------------------
+# Complete State Transitions Tests (OMN-942)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCompleteStateTransitions:
+    """Comprehensive tests for all FSM state transitions (OMN-942).
+
+    This test class documents and validates all valid and invalid state
+    transitions in the registration FSM. The FSM has 5 states:
+    idle, pending, partial, complete, failed.
+
+    State Diagram::
+
+        +-------+   introspection   +---------+
+        | idle  | ----------------> | pending |
+        +-------+                   +---------+
+           ^                         |       |
+           |       consul confirmed  |       | postgres confirmed
+           |       (first)          v       v (first)
+           |                  +---------+
+           |                  | partial |
+           |                  +---------+
+           |                    |       |
+           |   remaining        |       | error received
+           |   confirmed        v       v
+           |              +---------+ +---------+
+           +---reset------| complete| | failed  |---reset---+
+                          +---------+ +---------+           |
+                               |                            v
+                               +---reset--->  +-------+
+                                              | idle  |
+                                              +-------+
+
+    Valid State Transitions (13 total):
+        1. idle -> pending (introspection event via reduce())
+        2. pending -> partial (first confirmation - consul confirmed)
+        3. pending -> partial (first confirmation - postgres confirmed)
+        4. pending -> failed (validation error or backend error)
+        5. partial -> complete (second confirmation - consul then postgres)
+        6. partial -> complete (second confirmation - postgres then consul)
+        7. partial -> failed (error on remaining backend)
+        8. failed -> idle (reset via reduce_reset())
+        9. complete -> idle (reset via reduce_reset())
+        10. idle -> failed (invalid reset attempt via reduce_reset())
+        11. pending -> failed (invalid reset attempt via reduce_reset())
+        12. partial -> failed (invalid reset attempt via reduce_reset())
+        13. pending -> complete is IMPOSSIBLE (requires partial first)
+
+    Invalid Transitions:
+        - complete -> pending (no direct path)
+        - complete -> partial (no direct path)
+        - failed -> pending (must reset to idle first)
+        - idle -> complete (requires pending and partial)
+        - partial -> pending (cannot regress)
+    """
+
+    # -------------------------------------------------------------------------
+    # Document all valid states
+    # -------------------------------------------------------------------------
+
+    def test_all_valid_states_exist(self) -> None:
+        """Document all valid FSM states."""
+        from typing import get_args
+
+        from omnibase_infra.nodes.reducers.models.model_registration_state import (
+            RegistrationStatus,
+        )
+
+        # Extract valid states from the Literal type
+        valid_states = set(get_args(RegistrationStatus))
+
+        expected_states = {"idle", "pending", "partial", "complete", "failed"}
+        assert valid_states == expected_states, (
+            f"Expected states {expected_states}, got {valid_states}"
+        )
+
+    def test_initial_state_is_idle(self) -> None:
+        """Verify that the default initial state is idle."""
+        state = ModelRegistrationState()
+
+        assert state.status == "idle"
+        assert state.node_id is None
+        assert state.consul_confirmed is False
+        assert state.postgres_confirmed is False
+        assert state.failure_reason is None
+
+    # -------------------------------------------------------------------------
+    # Transition 1: idle -> pending (via reduce())
+    # -------------------------------------------------------------------------
+
+    def test_transition_idle_to_pending_via_introspection(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test idle -> pending transition on introspection event.
+
+        This is the primary entry point to the FSM. When a node introspection
+        event is processed, the state transitions from idle to pending.
+        """
+        state = ModelRegistrationState()
+        assert state.status == "idle"
+
+        event = create_introspection_event()
+        output = reducer.reduce(state, event)
+
+        assert output.result.status == "pending"
+        assert output.result.node_id == event.node_id
+        assert len(output.intents) == 2  # Consul + PostgreSQL intents
+
+    # -------------------------------------------------------------------------
+    # Transition 2: pending -> partial (Consul confirmed first)
+    # -------------------------------------------------------------------------
+
+    def test_transition_pending_to_partial_consul_first(self) -> None:
+        """Test pending -> partial when Consul confirms first.
+
+        When Consul confirms registration before PostgreSQL, the state
+        transitions to 'partial' with consul_confirmed=True.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        assert pending_state.status == "pending"
+        assert pending_state.consul_confirmed is False
+        assert pending_state.postgres_confirmed is False
+
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is True
+        assert partial_state.postgres_confirmed is False
+        assert partial_state.node_id == node_id
+
+    # -------------------------------------------------------------------------
+    # Transition 3: pending -> partial (PostgreSQL confirmed first)
+    # -------------------------------------------------------------------------
+
+    def test_transition_pending_to_partial_postgres_first(self) -> None:
+        """Test pending -> partial when PostgreSQL confirms first.
+
+        When PostgreSQL confirms registration before Consul, the state
+        transitions to 'partial' with postgres_confirmed=True.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        assert pending_state.status == "pending"
+
+        partial_state = pending_state.with_postgres_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is False
+        assert partial_state.postgres_confirmed is True
+        assert partial_state.node_id == node_id
+
+    # -------------------------------------------------------------------------
+    # Transition 4: pending -> failed (validation or backend error)
+    # -------------------------------------------------------------------------
+
+    def test_transition_pending_to_failed_validation_error(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test pending -> failed on validation error.
+
+        When an invalid event is processed, the state transitions to failed
+        with failure_reason='validation_failed'.
+        """
+        from unittest.mock import MagicMock
+
+        state = ModelRegistrationState()
+
+        # Create an invalid event (missing node_id)
+        mock_event = MagicMock(spec=ModelNodeIntrospectionEvent)
+        mock_event.node_id = None
+        mock_event.node_type = "effect"
+        mock_event.correlation_id = uuid4()
+
+        output = reducer.reduce(state, mock_event)
+
+        assert output.result.status == "failed"
+        assert output.result.failure_reason == "validation_failed"
+
+    def test_transition_pending_to_failed_backend_error(self) -> None:
+        """Test pending -> failed on backend error.
+
+        When a backend (Consul or PostgreSQL) returns an error, the state
+        transitions to failed with the appropriate failure_reason.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Simulate Consul failure
+        failed_state = pending_state.with_failure("consul_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "consul_failed"
+        assert failed_state.node_id == node_id
+
+    def test_transition_pending_to_failed_postgres_error(self) -> None:
+        """Test pending -> failed on PostgreSQL error."""
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        failed_state = pending_state.with_failure("postgres_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "postgres_failed"
+
+    # -------------------------------------------------------------------------
+    # Transition 5: partial -> complete (Consul first, then PostgreSQL)
+    # -------------------------------------------------------------------------
+
+    def test_transition_partial_to_complete_consul_then_postgres(self) -> None:
+        """Test partial -> complete: Consul confirmed, then PostgreSQL.
+
+        When Consul confirms first (pending -> partial), and then PostgreSQL
+        confirms, the state transitions to 'complete'.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Consul confirms first -> partial
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is True
+        assert partial_state.postgres_confirmed is False
+
+        # PostgreSQL confirms second -> complete
+        complete_state = partial_state.with_postgres_confirmed(uuid4())
+
+        assert complete_state.status == "complete"
+        assert complete_state.consul_confirmed is True
+        assert complete_state.postgres_confirmed is True
+        assert complete_state.node_id == node_id
+
+    # -------------------------------------------------------------------------
+    # Transition 6: partial -> complete (PostgreSQL first, then Consul)
+    # -------------------------------------------------------------------------
+
+    def test_transition_partial_to_complete_postgres_then_consul(self) -> None:
+        """Test partial -> complete: PostgreSQL confirmed, then Consul.
+
+        When PostgreSQL confirms first (pending -> partial), and then Consul
+        confirms, the state transitions to 'complete'.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # PostgreSQL confirms first -> partial
+        partial_state = pending_state.with_postgres_confirmed(uuid4())
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is False
+        assert partial_state.postgres_confirmed is True
+
+        # Consul confirms second -> complete
+        complete_state = partial_state.with_consul_confirmed(uuid4())
+
+        assert complete_state.status == "complete"
+        assert complete_state.consul_confirmed is True
+        assert complete_state.postgres_confirmed is True
+        assert complete_state.node_id == node_id
+
+    # -------------------------------------------------------------------------
+    # Transition 7: partial -> failed (error on remaining backend)
+    # -------------------------------------------------------------------------
+
+    def test_transition_partial_to_failed_consul_confirmed_postgres_fails(self) -> None:
+        """Test partial -> failed: Consul confirmed, PostgreSQL fails.
+
+        When Consul confirms (partial state) but PostgreSQL returns an error,
+        the state transitions to 'failed'. Consul confirmation is preserved
+        for diagnostics.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is True
+
+        failed_state = partial_state.with_failure("postgres_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "postgres_failed"
+        # Consul confirmation preserved for diagnostics
+        assert failed_state.consul_confirmed is True
+        assert failed_state.postgres_confirmed is False
+
+    def test_transition_partial_to_failed_postgres_confirmed_consul_fails(self) -> None:
+        """Test partial -> failed: PostgreSQL confirmed, Consul fails.
+
+        When PostgreSQL confirms (partial state) but Consul returns an error,
+        the state transitions to 'failed'. PostgreSQL confirmation is preserved
+        for diagnostics.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_postgres_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+        assert partial_state.postgres_confirmed is True
+
+        failed_state = partial_state.with_failure("consul_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "consul_failed"
+        # PostgreSQL confirmation preserved for diagnostics
+        assert failed_state.consul_confirmed is False
+        assert failed_state.postgres_confirmed is True
+
+    # -------------------------------------------------------------------------
+    # Transition 8: failed -> idle (reset via reduce_reset())
+    # -------------------------------------------------------------------------
+
+    def test_transition_failed_to_idle_via_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test failed -> idle transition via reduce_reset().
+
+        The reset mechanism allows recovery from failed states.
+        All confirmation flags and failure reason are cleared.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        failed_state = pending_state.with_failure("consul_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "consul_failed"
+
+        reset_output = reducer.reduce_reset(failed_state, uuid4())
+
+        assert reset_output.result.status == "idle"
+        assert reset_output.result.node_id is None
+        assert reset_output.result.consul_confirmed is False
+        assert reset_output.result.postgres_confirmed is False
+        assert reset_output.result.failure_reason is None
+        assert reset_output.items_processed == 1
+
+    # -------------------------------------------------------------------------
+    # Transition 9: complete -> idle (reset via reduce_reset())
+    # -------------------------------------------------------------------------
+
+    def test_transition_complete_to_idle_via_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test complete -> idle transition via reduce_reset().
+
+        The reset mechanism also works from complete state, enabling
+        re-registration of a node if needed.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+        complete_state = partial_state.with_postgres_confirmed(uuid4())
+
+        assert complete_state.status == "complete"
+
+        reset_output = reducer.reduce_reset(complete_state, uuid4())
+
+        assert reset_output.result.status == "idle"
+        assert reset_output.result.node_id is None
+        assert reset_output.result.consul_confirmed is False
+        assert reset_output.result.postgres_confirmed is False
+        assert reset_output.items_processed == 1
+
+    # -------------------------------------------------------------------------
+    # Transition 10: idle -> failed (invalid reset attempt)
+    # -------------------------------------------------------------------------
+
+    def test_transition_idle_to_failed_invalid_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test idle -> failed on invalid reset attempt.
+
+        Resetting from idle is invalid because there's nothing to reset.
+        The state transitions to 'failed' with failure_reason='invalid_reset_state'.
+        """
+        state = ModelRegistrationState()
+        assert state.status == "idle"
+
+        reset_output = reducer.reduce_reset(state, uuid4())
+
+        assert reset_output.result.status == "failed"
+        assert reset_output.result.failure_reason == "invalid_reset_state"
+        assert reset_output.items_processed == 1
+
+    # -------------------------------------------------------------------------
+    # Transition 11: pending -> failed (invalid reset attempt)
+    # -------------------------------------------------------------------------
+
+    def test_transition_pending_to_failed_invalid_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test pending -> failed on invalid reset attempt.
+
+        Resetting from pending is invalid because it would lose in-flight
+        registration state. The state transitions to 'failed'.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        assert pending_state.status == "pending"
+
+        reset_output = reducer.reduce_reset(pending_state, uuid4())
+
+        assert reset_output.result.status == "failed"
+        assert reset_output.result.failure_reason == "invalid_reset_state"
+        # Node ID preserved for diagnostics
+        assert reset_output.result.node_id == node_id
+
+    # -------------------------------------------------------------------------
+    # Transition 12: partial -> failed (invalid reset attempt)
+    # -------------------------------------------------------------------------
+
+    def test_transition_partial_to_failed_invalid_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test partial -> failed on invalid reset attempt.
+
+        Resetting from partial is invalid because it would discard the
+        confirmation from one backend, leaving the system inconsistent.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+
+        reset_output = reducer.reduce_reset(partial_state, uuid4())
+
+        assert reset_output.result.status == "failed"
+        assert reset_output.result.failure_reason == "invalid_reset_state"
+        # Consul confirmation preserved for diagnostics
+        assert reset_output.result.consul_confirmed is True
+
+    # -------------------------------------------------------------------------
+    # Transition 13: pending -> complete is IMPOSSIBLE
+    # -------------------------------------------------------------------------
+
+    def test_pending_to_complete_impossible_without_partial(self) -> None:
+        """Verify pending -> complete is impossible without going through partial.
+
+        The FSM requires both backends to confirm. Each confirmation results
+        in either pending->partial (first) or partial->complete (second).
+        There is no direct path from pending to complete.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Even if we try both confirmations at once, we must go through partial
+        # First confirmation -> partial (not complete)
+        after_first = pending_state.with_consul_confirmed(uuid4())
+        assert after_first.status == "partial", (
+            "First confirmation should result in partial, not complete"
+        )
+
+        # Only second confirmation -> complete
+        after_second = after_first.with_postgres_confirmed(uuid4())
+        assert after_second.status == "complete"
+
+    # -------------------------------------------------------------------------
+    # Invalid Transitions: complete -> pending (no direct path)
+    # -------------------------------------------------------------------------
+
+    def test_invalid_transition_complete_to_pending_not_possible(self) -> None:
+        """Verify no direct complete -> pending transition exists.
+
+        Once complete, the state can only transition to idle via reset.
+        There is no method to go directly from complete to pending.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+        complete_state = partial_state.with_postgres_confirmed(uuid4())
+
+        assert complete_state.status == "complete"
+
+        # The only available transitions from complete state are:
+        # - with_reset() -> idle
+        # - with_failure() -> failed (for error scenarios)
+        # There is no with_pending_registration that works on complete state
+        # (calling it would create a new pending state, not a transition)
+
+        # Verify the state machine doesn't have unintended transitions
+        available_methods = [
+            m
+            for m in dir(complete_state)
+            if m.startswith("with_") and callable(getattr(complete_state, m))
+        ]
+        assert "with_reset" in available_methods
+        assert "with_failure" in available_methods
+
+    # -------------------------------------------------------------------------
+    # Invalid Transitions: failed -> pending (must reset to idle first)
+    # -------------------------------------------------------------------------
+
+    def test_invalid_transition_failed_to_pending_requires_reset(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Verify failed -> pending requires going through idle via reset.
+
+        A failed state cannot directly transition to pending. The correct
+        recovery path is: failed -> idle (via reset) -> pending (via reduce).
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        failed_state = pending_state.with_failure("consul_failed", uuid4())
+
+        assert failed_state.status == "failed"
+
+        # Correct recovery path:
+        # 1. Reset to idle
+        reset_output = reducer.reduce_reset(failed_state, uuid4())
+        assert reset_output.result.status == "idle"
+
+        # 2. New introspection event to pending
+        new_event = create_introspection_event()
+        new_output = reducer.reduce(reset_output.result, new_event)
+        assert new_output.result.status == "pending"
+
+    # -------------------------------------------------------------------------
+    # Invalid Transitions: idle -> complete (requires pending and partial)
+    # -------------------------------------------------------------------------
+
+    def test_invalid_transition_idle_to_complete_not_possible(self) -> None:
+        """Verify no direct idle -> complete transition exists.
+
+        Completing registration requires going through the full FSM path:
+        idle -> pending -> partial -> complete.
+        """
+        state = ModelRegistrationState()
+        assert state.status == "idle"
+
+        # Only available transitions from idle:
+        # - with_pending_registration() -> pending
+        # - with_failure() -> failed (for error scenarios)
+        # There is no way to directly reach complete
+
+        # Verify the correct path is required
+        pending_state = state.with_pending_registration(uuid4(), uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+        complete_state = partial_state.with_postgres_confirmed(uuid4())
+
+        assert complete_state.status == "complete"
+
+    # -------------------------------------------------------------------------
+    # Invalid Transitions: partial -> pending (cannot regress)
+    # -------------------------------------------------------------------------
+
+    def test_invalid_transition_partial_to_pending_cannot_regress(self) -> None:
+        """Verify no partial -> pending regression exists.
+
+        Once in partial state (one backend confirmed), there is no valid
+        transition back to pending. The FSM only moves forward or to failed.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+
+        assert partial_state.status == "partial"
+
+        # Available transitions from partial:
+        # - with_consul_confirmed() -> complete (if postgres already confirmed)
+        # - with_postgres_confirmed() -> complete (if consul already confirmed)
+        # - with_failure() -> failed
+        # There is no with_pending_registration that regresses to pending
+
+        # Calling with_pending_registration on partial would start a NEW
+        # registration, not regress the current one
+        new_pending = partial_state.with_pending_registration(uuid4(), uuid4())
+        assert new_pending.status == "pending"
+        # But this is a new registration (new node_id), not a regression
+        assert new_pending.node_id != node_id
+
+    # -------------------------------------------------------------------------
+    # Full workflow test: idle -> pending -> partial -> complete -> idle
+    # -------------------------------------------------------------------------
+
+    def test_full_successful_registration_workflow(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test the complete successful registration workflow.
+
+        Validates the full FSM path:
+        idle -> pending -> partial -> complete -> idle (reset)
+        """
+        # Start: idle
+        initial_state = ModelRegistrationState()
+        assert initial_state.status == "idle"
+
+        # Step 1: idle -> pending (introspection event)
+        event = create_introspection_event()
+        pending_output = reducer.reduce(initial_state, event)
+        assert pending_output.result.status == "pending"
+        assert len(pending_output.intents) == 2
+
+        # Step 2: pending -> partial (first confirmation)
+        partial_state = pending_output.result.with_consul_confirmed(uuid4())
+        assert partial_state.status == "partial"
+
+        # Step 3: partial -> complete (second confirmation)
+        complete_state = partial_state.with_postgres_confirmed(uuid4())
+        assert complete_state.status == "complete"
+
+        # Step 4: complete -> idle (reset for re-registration)
+        reset_output = reducer.reduce_reset(complete_state, uuid4())
+        assert reset_output.result.status == "idle"
+
+    # -------------------------------------------------------------------------
+    # Full workflow test: idle -> pending -> failed -> idle -> pending
+    # -------------------------------------------------------------------------
+
+    def test_full_failure_and_recovery_workflow(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test the complete failure and recovery workflow.
+
+        Validates the FSM recovery path:
+        idle -> pending -> failed -> idle (reset) -> pending (retry)
+        """
+        # Start: idle
+        initial_state = ModelRegistrationState()
+        assert initial_state.status == "idle"
+
+        # Step 1: idle -> pending
+        event = create_introspection_event()
+        pending_output = reducer.reduce(initial_state, event)
+        assert pending_output.result.status == "pending"
+
+        # Step 2: pending -> failed (simulate backend error)
+        failed_state = pending_output.result.with_failure("consul_failed", uuid4())
+        assert failed_state.status == "failed"
+
+        # Step 3: failed -> idle (reset)
+        reset_output = reducer.reduce_reset(failed_state, uuid4())
+        assert reset_output.result.status == "idle"
+
+        # Step 4: idle -> pending (retry)
+        retry_event = create_introspection_event()
+        retry_output = reducer.reduce(reset_output.result, retry_event)
+        assert retry_output.result.status == "pending"
+        assert len(retry_output.intents) == 2
+
+
+# -----------------------------------------------------------------------------
 # Circuit Breaker Non-Applicability Documentation Tests
 # -----------------------------------------------------------------------------
 
@@ -1822,3 +2493,1406 @@ class TestCircuitBreakerNonApplicability:
             assert output.result == outputs[0].result
             assert len(output.intents) == len(outputs[0].intents)
             assert output.items_processed == outputs[0].items_processed
+
+
+# -----------------------------------------------------------------------------
+# Property-Based Determinism Tests (Hypothesis)
+# -----------------------------------------------------------------------------
+
+
+# Check if hypothesis is available; skip tests if not installed
+try:
+    from hypothesis import given, settings
+    from hypothesis import strategies as st
+
+    HYPOTHESIS_AVAILABLE = True
+except ImportError:
+    HYPOTHESIS_AVAILABLE = False
+
+    # Provide dummy decorators when hypothesis is not available
+    def given(*args, **kwargs):  # type: ignore[no-redef]
+        def decorator(func):
+            return pytest.mark.skip(
+                reason="hypothesis not installed - add to dev dependencies"
+            )(func)
+
+        return decorator
+
+    def settings(*args, **kwargs):  # type: ignore[no-redef]
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class StrategiesStub:
+        """Stub for hypothesis.strategies when Hypothesis is not installed."""
+
+        @staticmethod
+        def sampled_from(values):
+            return values
+
+        @staticmethod
+        def text(*_args, **_kwargs):
+            return None
+
+        @staticmethod
+        def uuids():
+            return None
+
+        @staticmethod
+        def integers(*_args, **_kwargs):
+            return None
+
+        @staticmethod
+        def booleans():
+            return None
+
+        @staticmethod
+        def dictionaries(*_args, **_kwargs):
+            return None
+
+    st = StrategiesStub  # Alias for compatibility
+
+
+@pytest.mark.unit
+class TestDeterminismProperty:
+    """Property-based tests for reducer determinism using Hypothesis.
+
+    These tests validate the core determinism guarantees of the RegistrationReducer:
+    1. Same state + same event always produces identical output (excluding operation_id)
+    2. Replaying N events produces same final state regardless of replay count
+    3. Derived event IDs are deterministic (same content = same derived ID)
+    4. State transitions are idempotent when applied with same event_id
+    5. Multiple reducer instances produce identical results
+
+    Property-based testing with Hypothesis generates many random test cases to find
+    edge cases that example-based tests might miss.
+    """
+
+    @given(
+        node_type=st.sampled_from(["effect", "compute", "reducer", "orchestrator"]),
+        major=st.integers(min_value=0, max_value=99),
+        minor=st.integers(min_value=0, max_value=99),
+        patch=st.integers(min_value=0, max_value=99),
+    )
+    @settings(max_examples=50)
+    def test_reduce_is_deterministic_for_any_valid_input(
+        self, node_type: str, major: int, minor: int, patch: int
+    ) -> None:
+        """Property: reduce(state, event) is deterministic for any valid input.
+
+        For any valid node_type and node_version (semantic version format),
+        calling reduce() twice with the same state and event must produce
+        structurally identical outputs (excluding the operation_id and timestamps
+        which are intentionally unique per call).
+        """
+        reducer = RegistrationReducer()
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        correlation_id = uuid4()
+        node_version = f"{major}.{minor}.{patch}"
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=node_id,
+            node_type=node_type,
+            node_version=node_version,
+            endpoints={"health": "http://localhost:8080/health"},
+            correlation_id=correlation_id,
+        )
+
+        # Execute reduce twice with identical inputs
+        output1 = reducer.reduce(state, event)
+        output2 = reducer.reduce(state, event)
+
+        # State must be identical
+        assert output1.result == output2.result, (
+            f"State mismatch for node_type={node_type}, version={node_version}"
+        )
+
+        # Intent count and structure must be identical
+        assert len(output1.intents) == len(output2.intents)
+
+        # Intent payloads must be identical (compare non-timestamp fields)
+        # Note: Timestamps (registered_at, updated_at) are generated at reduce() time,
+        # so they naturally differ between calls. We exclude them from comparison.
+        for intent1, intent2 in zip(output1.intents, output2.intents, strict=True):
+            assert intent1.intent_type == intent2.intent_type
+            assert intent1.target == intent2.target
+
+            # For postgres intents, exclude timestamp fields from comparison
+            if intent1.intent_type == "postgres.upsert_registration":
+                payload1 = dict(intent1.payload)
+                payload2 = dict(intent2.payload)
+                record1 = dict(payload1.get("record", {}))
+                record2 = dict(payload2.get("record", {}))
+                # Remove timestamps before comparison
+                for key in ["registered_at", "updated_at"]:
+                    record1.pop(key, None)
+                    record2.pop(key, None)
+                payload1["record"] = record1
+                payload2["record"] = record2
+                assert payload1 == payload2
+            else:
+                assert intent1.payload == intent2.payload
+
+        # Items processed must match
+        assert output1.items_processed == output2.items_processed
+
+        # Note: operation_id is intentionally different per call
+
+    @given(replay_count=st.integers(min_value=2, max_value=10))
+    @settings(max_examples=25)
+    def test_replaying_same_event_produces_idempotent_state(
+        self, replay_count: int
+    ) -> None:
+        """Property: Replaying the same event N times produces same final state.
+
+        After the first reduce(), all subsequent replays with the same event
+        should return the same state with no intents (idempotency).
+        """
+        reducer = RegistrationReducer()
+        initial_state = ModelRegistrationState()
+        correlation_id = uuid4()
+        node_id = uuid4()
+
+        event = create_introspection_event(
+            node_id=node_id, correlation_id=correlation_id
+        )
+
+        # First reduce establishes the state
+        output = reducer.reduce(initial_state, event)
+        state_after_first = output.result
+        assert len(output.intents) == 2  # Consul + PostgreSQL
+
+        # All subsequent replays should be idempotent
+        current_state = state_after_first
+        for i in range(replay_count - 1):
+            replay_output = reducer.reduce(current_state, event)
+
+            # State should be unchanged
+            assert replay_output.result == state_after_first, (
+                f"State changed on replay {i + 2}"
+            )
+
+            # No intents should be emitted on replay
+            assert len(replay_output.intents) == 0, f"Intents emitted on replay {i + 2}"
+
+            # Items processed should be 0 (duplicate detection)
+            assert replay_output.items_processed == 0
+
+            current_state = replay_output.result
+
+    @given(
+        node_type=st.sampled_from(["effect", "compute", "reducer", "orchestrator"]),
+    )
+    @settings(max_examples=20)
+    def test_derived_event_id_is_deterministic(self, node_type: str) -> None:
+        """Property: Derived event IDs are deterministic.
+
+        When an event lacks a correlation_id, the reducer derives an event_id
+        from the event's content (node_id, node_type, timestamp). This derived
+        ID must be deterministic - same content always produces same ID.
+        """
+        from unittest.mock import MagicMock
+
+        reducer = RegistrationReducer()
+        node_id = uuid4()
+        fixed_timestamp = datetime.now(UTC)
+
+        # Create mock event without correlation_id (forces derivation)
+        mock_event = MagicMock(spec=ModelNodeIntrospectionEvent)
+        mock_event.node_id = node_id
+        mock_event.node_type = node_type
+        mock_event.node_version = "1.0.0"
+        mock_event.endpoints = {"health": "http://localhost:8080/health"}
+        mock_event.capabilities = ModelNodeCapabilities()
+        mock_event.metadata = ModelNodeMetadata()
+        mock_event.correlation_id = None  # Force deterministic derivation
+        mock_event.timestamp = fixed_timestamp
+
+        # Derive event ID multiple times
+        derived_id_1 = reducer._derive_deterministic_event_id(mock_event)
+        derived_id_2 = reducer._derive_deterministic_event_id(mock_event)
+        derived_id_3 = reducer._derive_deterministic_event_id(mock_event)
+
+        # All derived IDs must be identical
+        assert derived_id_1 == derived_id_2 == derived_id_3, (
+            f"Derived IDs not deterministic for node_type={node_type}"
+        )
+
+        # Derived ID must be a valid UUID
+        assert isinstance(derived_id_1, UUID)
+
+    @given(
+        has_health_endpoint=st.booleans(),
+        has_api_endpoint=st.booleans(),
+    )
+    @settings(max_examples=20)
+    def test_intent_payloads_are_deterministic_for_endpoint_variations(
+        self, has_health_endpoint: bool, has_api_endpoint: bool
+    ) -> None:
+        """Property: Intent payloads are deterministic regardless of endpoint config.
+
+        The reducer must produce identical intent payloads for identical inputs,
+        even when endpoint configuration varies. Timestamps are excluded from
+        comparison since they are generated at reduce() time.
+        """
+        reducer = RegistrationReducer()
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        correlation_id = uuid4()
+
+        # Build endpoints dict based on property inputs
+        endpoints: dict[str, str] = {}
+        if has_health_endpoint:
+            endpoints["health"] = "http://localhost:8080/health"
+        if has_api_endpoint:
+            endpoints["api"] = "http://localhost:8080/api"
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=node_id,
+            node_type="effect",
+            node_version="1.0.0",
+            endpoints=endpoints,
+            correlation_id=correlation_id,
+        )
+
+        # Execute reduce twice
+        output1 = reducer.reduce(state, event)
+        output2 = reducer.reduce(state, event)
+
+        # Compare intent payloads in detail (excluding timestamps)
+        for intent1, intent2 in zip(output1.intents, output2.intents, strict=True):
+            assert intent1.intent_type == intent2.intent_type
+            assert intent1.target == intent2.target
+
+            # For postgres intents, exclude timestamp fields from comparison
+            if intent1.intent_type == "postgres.upsert_registration":
+                payload1 = dict(intent1.payload)
+                payload2 = dict(intent2.payload)
+                record1 = dict(payload1.get("record", {}))
+                record2 = dict(payload2.get("record", {}))
+                # Remove timestamps before comparison
+                for key in ["registered_at", "updated_at"]:
+                    record1.pop(key, None)
+                    record2.pop(key, None)
+                payload1["record"] = record1
+                payload2["record"] = record2
+                assert payload1 == payload2, (
+                    f"Payload mismatch for intent_type={intent1.intent_type}"
+                )
+            else:
+                assert intent1.payload == intent2.payload, (
+                    f"Payload mismatch for intent_type={intent1.intent_type}"
+                )
+
+    @given(
+        num_reducers=st.integers(min_value=2, max_value=5),
+    )
+    @settings(max_examples=10)
+    def test_multiple_reducer_instances_produce_identical_results(
+        self, num_reducers: int
+    ) -> None:
+        """Property: Multiple reducer instances produce identical results.
+
+        Since reducers are stateless pure functions, different instances
+        must produce identical outputs for identical inputs. Timestamps are
+        excluded from comparison since they are generated at reduce() time.
+        """
+        reducers = [RegistrationReducer() for _ in range(num_reducers)]
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        correlation_id = uuid4()
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=node_id,
+            node_type="compute",
+            node_version="2.0.0",
+            endpoints={"health": "http://localhost:8080/health"},
+            correlation_id=correlation_id,
+        )
+
+        # Execute reduce on all reducer instances
+        outputs = [r.reduce(state, event) for r in reducers]
+
+        # All outputs must have identical results
+        first_output = outputs[0]
+        for i, output in enumerate(outputs[1:], start=2):
+            assert output.result == first_output.result, (
+                f"Result mismatch between reducer 1 and {i}"
+            )
+            assert len(output.intents) == len(first_output.intents), (
+                f"Intent count mismatch between reducer 1 and {i}"
+            )
+            for j, (intent1, intent2) in enumerate(
+                zip(first_output.intents, output.intents, strict=True)
+            ):
+                assert intent1.intent_type == intent2.intent_type
+                assert intent1.target == intent2.target
+
+                # For postgres intents, exclude timestamp fields from comparison
+                if intent1.intent_type == "postgres.upsert_registration":
+                    payload1 = dict(intent1.payload)
+                    payload2 = dict(intent2.payload)
+                    record1 = dict(payload1.get("record", {}))
+                    record2 = dict(payload2.get("record", {}))
+                    # Remove timestamps before comparison
+                    for key in ["registered_at", "updated_at"]:
+                        record1.pop(key, None)
+                        record2.pop(key, None)
+                    payload1["record"] = record1
+                    payload2["record"] = record2
+                    assert payload1 == payload2, (
+                        f"Intent {j} payload mismatch between reducer 1 and {i}"
+                    )
+                else:
+                    assert intent1.payload == intent2.payload, (
+                        f"Intent {j} payload mismatch between reducer 1 and {i}"
+                    )
+
+    @given(
+        reset_attempts=st.integers(min_value=1, max_value=5),
+    )
+    @settings(max_examples=15)
+    def test_reset_idempotency_after_first_reset(self, reset_attempts: int) -> None:
+        """Property: Reset is idempotent after the first successful reset.
+
+        After resetting from a failed state to idle, subsequent reset attempts
+        with the same event_id should be no-ops (idempotent).
+        """
+        reducer = RegistrationReducer()
+
+        # Create a failed state
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+        failed_state = pending_state.with_failure("consul_failed", uuid4())
+
+        reset_event_id = uuid4()
+
+        # First reset should succeed
+        output = reducer.reduce_reset(failed_state, reset_event_id)
+        assert output.result.status == "idle"
+        assert output.items_processed == 1
+        idle_state = output.result
+
+        # Subsequent resets with same event_id should be idempotent
+        current_state = idle_state
+        for i in range(reset_attempts):
+            replay_output = reducer.reduce_reset(current_state, reset_event_id)
+
+            # State should be unchanged (same as idle_state)
+            assert replay_output.result == idle_state, (
+                f"State changed on reset replay {i + 1}"
+            )
+
+            # No items processed (duplicate detection)
+            assert replay_output.items_processed == 0, (
+                f"Items processed on reset replay {i + 1}"
+            )
+
+            current_state = replay_output.result
+
+    @given(
+        node_type=st.sampled_from(["effect", "compute", "reducer", "orchestrator"]),
+    )
+    @settings(max_examples=20)
+    def test_state_hash_stability_across_reduce_calls(self, node_type: str) -> None:
+        """Property: State model hash is stable across identical reduce calls.
+
+        The ModelRegistrationState uses Pydantic's frozen models. The resulting
+        state from identical reduce calls must have identical hash values,
+        enabling reliable comparison and caching.
+        """
+        reducer = RegistrationReducer()
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        correlation_id = uuid4()
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=node_id,
+            node_type=node_type,
+            node_version="1.0.0",
+            endpoints={"health": "http://localhost:8080/health"},
+            correlation_id=correlation_id,
+        )
+
+        # Execute reduce twice
+        output1 = reducer.reduce(state, event)
+        output2 = reducer.reduce(state, event)
+
+        # States must be equal (uses Pydantic's __eq__)
+        assert output1.result == output2.result
+
+        # States should be hashable (frozen=True in Pydantic model)
+        # If the model is properly frozen, hash() should work
+        try:
+            hash1 = hash(output1.result)
+            hash2 = hash(output2.result)
+            assert hash1 == hash2, "State hashes differ for identical states"
+        except TypeError:
+            # Model might not be hashable if frozen=False
+            # This is acceptable but we should still verify equality
+            pass
+
+
+# -----------------------------------------------------------------------------
+# Comprehensive Edge Case Tests (OMN-942)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEdgeCasesComprehensive:
+    """Comprehensive edge case testing for reducer robustness.
+
+    These tests cover unusual but valid input combinations, boundary conditions,
+    and edge cases that may occur in production environments.
+
+    Related: OMN-942 - Reducer Test Suite Enhancement
+    """
+
+    def test_event_with_minimal_fields(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test reduce with only required fields populated.
+
+        Validates that the reducer handles events where all optional fields
+        use their default values. This is the minimal valid event case.
+        """
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type="effect",
+            node_version="1.0.0",
+            endpoints={},
+            correlation_id=uuid4(),
+        )
+
+        output = reducer.reduce(initial_state, event)
+
+        assert output.result.status == "pending"
+        assert len(output.intents) == 2
+
+        # Verify intents are still built correctly with minimal data
+        consul_intent = next(
+            (i for i in output.intents if i.intent_type == "consul.register"), None
+        )
+        assert consul_intent is not None
+        assert consul_intent.payload["health_check"] is None
+
+        postgres_intent = next(
+            (
+                i
+                for i in output.intents
+                if i.intent_type == "postgres.upsert_registration"
+            ),
+            None,
+        )
+        assert postgres_intent is not None
+        assert postgres_intent.payload["record"]["health_endpoint"] is None
+
+    def test_event_with_many_endpoints(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test reduce with large endpoints dictionary.
+
+        Validates that the reducer handles events with many endpoints,
+        simulating a complex service with multiple interfaces.
+        """
+        many_endpoints = {
+            "health": "http://localhost:8080/health",
+            "api": "http://localhost:8080/api",
+            "metrics": "http://localhost:9090/metrics",
+            "admin": "http://localhost:8081/admin",
+            "grpc": "grpc://localhost:50051",
+            "websocket": "ws://localhost:8082/ws",
+            "graphql": "http://localhost:8083/graphql",
+            "debug": "http://localhost:8084/debug",
+            "internal": "http://localhost:8085/internal",
+            "status": "http://localhost:8086/status",
+        }
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type="orchestrator",
+            node_version="2.5.0",
+            endpoints=many_endpoints,
+            correlation_id=uuid4(),
+        )
+
+        output = reducer.reduce(initial_state, event)
+
+        assert output.result.status == "pending"
+        assert len(output.intents) == 2
+
+        # Verify all endpoints are captured in PostgreSQL intent
+        postgres_intent = next(
+            (
+                i
+                for i in output.intents
+                if i.intent_type == "postgres.upsert_registration"
+            ),
+            None,
+        )
+        assert postgres_intent is not None
+
+        record_endpoints = postgres_intent.payload["record"]["endpoints"]
+        assert len(record_endpoints) == 10
+        for key in many_endpoints:
+            assert key in record_endpoints
+
+    def test_event_with_very_long_version_string(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test reduce with a very long version string.
+
+        Validates that the reducer handles unusually long version strings
+        without truncation or error. SemVer with build metadata can be lengthy.
+        """
+        long_version = (
+            "1.2.3-alpha.4.5.6+build.metadata.with.many.segments.202512211234"
+        )
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type="compute",
+            node_version=long_version,
+            endpoints={"health": "http://localhost:8080/health"},
+            correlation_id=uuid4(),
+        )
+
+        output = reducer.reduce(initial_state, event)
+
+        assert output.result.status == "pending"
+
+        # Verify long version is preserved in tags
+        consul_intent = next(
+            (i for i in output.intents if i.intent_type == "consul.register"), None
+        )
+        assert consul_intent is not None
+        tags = consul_intent.payload["tags"]
+        assert f"node_version:{long_version}" in tags
+
+    def test_rapid_state_transitions(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test multiple state transitions in quick succession.
+
+        Validates that the reducer correctly handles rapid state changes
+        without state corruption or missed transitions.
+        """
+        state = ModelRegistrationState()
+
+        # Rapid-fire: introspection -> consul confirm -> postgres confirm
+        node_id = uuid4()
+        event1 = create_introspection_event(node_id=node_id)
+        output1 = reducer.reduce(state, event1)
+        assert output1.result.status == "pending"
+
+        # First confirmation
+        state2 = output1.result.with_consul_confirmed(uuid4())
+        assert state2.status == "partial"
+
+        # Second confirmation
+        state3 = state2.with_postgres_confirmed(uuid4())
+        assert state3.status == "complete"
+
+        # Verify final state is consistent
+        assert state3.consul_confirmed is True
+        assert state3.postgres_confirmed is True
+        assert state3.node_id == node_id
+
+    def test_same_node_re_registration_after_complete(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test that a node can re-register after complete->reset->idle.
+
+        Validates the full recovery workflow where a node completes registration,
+        is reset (perhaps for re-deployment), and re-registers successfully.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+
+        # First registration
+        event1 = create_introspection_event(node_id=node_id)
+        output1 = reducer.reduce(state, event1)
+        assert output1.result.status == "pending"
+
+        # Complete the registration
+        consul_state = output1.result.with_consul_confirmed(uuid4())
+        complete_state = consul_state.with_postgres_confirmed(uuid4())
+        assert complete_state.status == "complete"
+
+        # Reset
+        reset_output = reducer.reduce_reset(complete_state, uuid4())
+        assert reset_output.result.status == "idle"
+
+        # Re-register same node with new event
+        event2 = create_introspection_event(node_id=node_id)
+        output2 = reducer.reduce(reset_output.result, event2)
+        assert output2.result.status == "pending"
+        assert output2.result.node_id == node_id
+        assert len(output2.intents) == 2
+
+    def test_events_with_same_timestamp(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test reduce with events having identical timestamps.
+
+        Validates that deterministic event ID derivation still produces
+        unique IDs when timestamps match but node_ids differ.
+        """
+        from unittest.mock import MagicMock
+
+        fixed_timestamp = datetime.now(UTC)
+        node_id1 = uuid4()
+        node_id2 = uuid4()
+
+        # Create two events with same timestamp but different node_ids
+        # Use mocks to set correlation_id=None to trigger deterministic ID derivation
+        mock_event1 = MagicMock(spec=ModelNodeIntrospectionEvent)
+        mock_event1.node_id = node_id1
+        mock_event1.node_type = "effect"
+        mock_event1.node_version = "1.0.0"
+        mock_event1.endpoints = {"health": "http://localhost:8080/health"}
+        mock_event1.capabilities = ModelNodeCapabilities()
+        mock_event1.metadata = ModelNodeMetadata()
+        mock_event1.correlation_id = None
+        mock_event1.timestamp = fixed_timestamp
+
+        mock_event2 = MagicMock(spec=ModelNodeIntrospectionEvent)
+        mock_event2.node_id = node_id2
+        mock_event2.node_type = "effect"
+        mock_event2.node_version = "1.0.0"
+        mock_event2.endpoints = {"health": "http://localhost:8080/health"}
+        mock_event2.capabilities = ModelNodeCapabilities()
+        mock_event2.metadata = ModelNodeMetadata()
+        mock_event2.correlation_id = None
+        mock_event2.timestamp = fixed_timestamp
+
+        output1 = reducer.reduce(initial_state, mock_event1)
+        output2 = reducer.reduce(initial_state, mock_event2)
+
+        # Both should process successfully
+        assert output1.result.status == "pending"
+        assert output2.result.status == "pending"
+
+        # They should have different derived event IDs
+        assert (
+            output1.result.last_processed_event_id
+            != output2.result.last_processed_event_id
+        )
+
+    def test_nil_uuid_handling(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test that nil UUID (all zeros) is handled correctly.
+
+        Validates that a nil UUID is accepted as a valid node_id.
+        This is a boundary case for UUID handling.
+        """
+        nil_uuid = UUID("00000000-0000-0000-0000-000000000000")
+
+        event = ModelNodeIntrospectionEvent(
+            node_id=nil_uuid,
+            node_type="effect",
+            node_version="1.0.0",
+            endpoints={"health": "http://localhost:8080/health"},
+            correlation_id=uuid4(),
+        )
+
+        output = reducer.reduce(initial_state, event)
+
+        assert output.result.status == "pending"
+        assert output.result.node_id == nil_uuid
+
+        # Verify nil UUID appears in intents
+        consul_intent = next(
+            (i for i in output.intents if i.intent_type == "consul.register"), None
+        )
+        assert consul_intent is not None
+        assert str(nil_uuid) in consul_intent.payload["service_id"]
+
+    def test_unicode_in_endpoint_urls(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Test that unicode characters in endpoint URLs are handled.
+
+        Validates that the reducer preserves unicode in endpoint strings.
+        Some international deployments may have unicode in paths.
+        """
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type="effect",
+            node_version="1.0.0",
+            endpoints={
+                "health": "http://localhost:8080/health",
+                "api": "http://localhost:8080/api/v1/donnees",
+                "docs": "http://localhost:8080/wendang/index",
+            },
+            correlation_id=uuid4(),
+        )
+
+        output = reducer.reduce(initial_state, event)
+
+        assert output.result.status == "pending"
+
+        postgres_intent = next(
+            (
+                i
+                for i in output.intents
+                if i.intent_type == "postgres.upsert_registration"
+            ),
+            None,
+        )
+        assert postgres_intent is not None
+
+        endpoints = postgres_intent.payload["record"]["endpoints"]
+        assert endpoints["api"] == "http://localhost:8080/api/v1/donnees"
+        assert endpoints["docs"] == "http://localhost:8080/wendang/index"
+
+    def test_state_transition_preserves_event_order(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test that state transitions maintain event order via last_processed_event_id.
+
+        Validates that each state transition correctly updates the
+        last_processed_event_id to maintain event ordering.
+        """
+        state = ModelRegistrationState()
+        event_ids: list[UUID] = []
+
+        # Generate a sequence of events and track their IDs
+        for i in range(5):
+            event_id = uuid4()
+            event_ids.append(event_id)
+
+            if i == 0:
+                # First event: introspection
+                event = create_introspection_event(correlation_id=event_id)
+                output = reducer.reduce(state, event)
+                state = output.result
+            elif i == 1:
+                # Second: consul confirmation
+                state = state.with_consul_confirmed(event_id)
+            elif i == 2:
+                # Third: postgres confirmation (now complete)
+                state = state.with_postgres_confirmed(event_id)
+            elif i == 3:
+                # Fourth: reset
+                output = reducer.reduce_reset(state, event_id)
+                state = output.result
+            else:
+                # Fifth: new introspection
+                event = create_introspection_event(correlation_id=event_id)
+                output = reducer.reduce(state, event)
+                state = output.result
+
+        # Final state should have the last event ID
+        assert state.last_processed_event_id == event_ids[-1]
+
+    def test_confirmation_order_independence(
+        self,
+    ) -> None:
+        """Test that confirmation order doesn't affect final complete state.
+
+        Validates that whether consul or postgres confirms first, the
+        final complete state is equivalent.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        event_id = uuid4()
+
+        pending_state = state.with_pending_registration(node_id, event_id)
+
+        # Path 1: Consul first, then Postgres
+        path1_partial = pending_state.with_consul_confirmed(uuid4())
+        path1_complete = path1_partial.with_postgres_confirmed(uuid4())
+
+        # Path 2: Postgres first, then Consul
+        path2_partial = pending_state.with_postgres_confirmed(uuid4())
+        path2_complete = path2_partial.with_consul_confirmed(uuid4())
+
+        # Both paths should reach complete with same confirmations
+        assert path1_complete.status == "complete"
+        assert path2_complete.status == "complete"
+        assert path1_complete.consul_confirmed == path2_complete.consul_confirmed
+        assert path1_complete.postgres_confirmed == path2_complete.postgres_confirmed
+        assert path1_complete.node_id == path2_complete.node_id
+
+
+# -----------------------------------------------------------------------------
+# Timeout Scenario Tests (OMN-942)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTimeoutScenarios:
+    """Tests for timeout-related state transitions.
+
+    Architecture Note:
+        Per DESIGN_TWO_WAY_REGISTRATION_ARCHITECTURE.md, the Orchestrator owns
+        timeout detection and emits timeout events. The Reducer folds timeout
+        events as failure confirmations. This test class validates the reducer's
+        handling of timeout-induced failure states.
+
+    Timeout Event Flow:
+        1. Orchestrator tracks pending registrations with deadlines
+        2. Orchestrator consumes RuntimeTick events for timeout evaluation
+        3. When deadline passes, Orchestrator emits RegistrationTimedOut event
+        4. Reducer folds RegistrationTimedOut as failure with reason "consul_failed"
+           or "postgres_failed" depending on what timed out
+
+    Related: OMN-942 - Reducer Test Suite Enhancement
+    """
+
+    def test_timeout_in_pending_state_causes_failure(
+        self,
+    ) -> None:
+        """Test that pending state + timeout event = failed state.
+
+        When a registration times out while waiting for both confirmations,
+        the state transitions to failed with an appropriate failure reason.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Simulate timeout as a failure (orchestrator would emit this)
+        timeout_event_id = uuid4()
+        failed_state = pending_state.with_failure("consul_failed", timeout_event_id)
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "consul_failed"
+        assert failed_state.node_id == node_id
+        # Confirmation flags remain false (neither confirmed before timeout)
+        assert failed_state.consul_confirmed is False
+        assert failed_state.postgres_confirmed is False
+
+    def test_timeout_in_partial_state_causes_failure(
+        self,
+    ) -> None:
+        """Test that partial state + timeout event = failed state.
+
+        When one backend confirms but the other times out, the state
+        transitions to failed while preserving the successful confirmation
+        for diagnostic purposes.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Consul confirmed, waiting for postgres
+        partial_state = pending_state.with_consul_confirmed(uuid4())
+        assert partial_state.status == "partial"
+        assert partial_state.consul_confirmed is True
+
+        # Postgres times out
+        timeout_event_id = uuid4()
+        failed_state = partial_state.with_failure("postgres_failed", timeout_event_id)
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "postgres_failed"
+        # Consul confirmation is preserved for diagnostics
+        assert failed_state.consul_confirmed is True
+        assert failed_state.postgres_confirmed is False
+
+    def test_recovery_after_timeout_failure(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test reset and retry workflow after timeout failure.
+
+        Validates the complete recovery workflow:
+        1. Start registration
+        2. Timeout occurs (failure)
+        3. Reset to idle
+        4. Retry registration
+        5. Complete successfully
+        """
+        initial_state = ModelRegistrationState()
+        node_id = uuid4()
+
+        # Step 1: Start registration
+        event1 = create_introspection_event(node_id=node_id)
+        output1 = reducer.reduce(initial_state, event1)
+        assert output1.result.status == "pending"
+
+        # Step 2: Timeout occurs (simulated as failure)
+        failed_state = output1.result.with_failure("consul_failed", uuid4())
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "consul_failed"
+
+        # Step 3: Reset to idle
+        reset_output = reducer.reduce_reset(failed_state, uuid4())
+        assert reset_output.result.status == "idle"
+        assert reset_output.result.failure_reason is None
+
+        # Step 4: Retry registration (new correlation_id for new attempt)
+        event2 = create_introspection_event(node_id=node_id)
+        output2 = reducer.reduce(reset_output.result, event2)
+        assert output2.result.status == "pending"
+        assert len(output2.intents) == 2
+
+        # Step 5: Complete successfully
+        consul_confirmed = output2.result.with_consul_confirmed(uuid4())
+        both_confirmed = consul_confirmed.with_postgres_confirmed(uuid4())
+        assert both_confirmed.status == "complete"
+        assert both_confirmed.failure_reason is None
+
+    def test_timeout_preserves_node_id_for_retry(
+        self,
+    ) -> None:
+        """Test that timeout failure preserves node_id for debugging.
+
+        When a timeout occurs, the node_id should be preserved in the
+        failed state so operators can identify which node failed.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Timeout failure
+        failed_state = pending_state.with_failure("both_failed", uuid4())
+
+        assert failed_state.status == "failed"
+        assert failed_state.failure_reason == "both_failed"
+        assert failed_state.node_id == node_id  # Preserved for debugging
+
+    def test_multiple_timeout_retries(
+        self,
+        reducer: RegistrationReducer,
+    ) -> None:
+        """Test multiple timeout-retry cycles before success.
+
+        Validates that the reducer correctly handles multiple retry attempts
+        after repeated timeouts, eventually reaching success.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+
+        # Simulate 3 failed attempts before success
+        for attempt in range(3):
+            # Start registration
+            event = create_introspection_event(node_id=node_id)
+            output = reducer.reduce(state, event)
+            assert output.result.status == "pending"
+
+            # Timeout failure
+            failed_state = output.result.with_failure("consul_failed", uuid4())
+            assert failed_state.status == "failed"
+
+            # Reset for next attempt
+            reset_output = reducer.reduce_reset(failed_state, uuid4())
+            state = reset_output.result
+            assert state.status == "idle"
+
+        # Final successful attempt
+        event = create_introspection_event(node_id=node_id)
+        output = reducer.reduce(state, event)
+        assert output.result.status == "pending"
+
+        consul_confirmed = output.result.with_consul_confirmed(uuid4())
+        both_confirmed = consul_confirmed.with_postgres_confirmed(uuid4())
+
+        assert both_confirmed.status == "complete"
+        assert both_confirmed.node_id == node_id
+
+    def test_timeout_different_failure_reasons(
+        self,
+    ) -> None:
+        """Test that different timeout scenarios produce correct failure reasons.
+
+        Validates that the failure_reason correctly identifies which
+        component timed out.
+        """
+        state = ModelRegistrationState()
+        node_id = uuid4()
+        pending_state = state.with_pending_registration(node_id, uuid4())
+
+        # Scenario 1: Consul times out first (waiting for both)
+        consul_timeout = pending_state.with_failure("consul_failed", uuid4())
+        assert consul_timeout.failure_reason == "consul_failed"
+
+        # Scenario 2: Postgres times out first (waiting for both)
+        postgres_timeout = pending_state.with_failure("postgres_failed", uuid4())
+        assert postgres_timeout.failure_reason == "postgres_failed"
+
+        # Scenario 3: Both time out (no confirmations received)
+        both_timeout = pending_state.with_failure("both_failed", uuid4())
+        assert both_timeout.failure_reason == "both_failed"
+
+        # Scenario 4: Consul confirmed but postgres times out
+        partial_consul = pending_state.with_consul_confirmed(uuid4())
+        postgres_after_consul = partial_consul.with_failure("postgres_failed", uuid4())
+        assert postgres_after_consul.failure_reason == "postgres_failed"
+        assert postgres_after_consul.consul_confirmed is True
+
+        # Scenario 5: Postgres confirmed but consul times out
+        partial_postgres = pending_state.with_postgres_confirmed(uuid4())
+        consul_after_postgres = partial_postgres.with_failure("consul_failed", uuid4())
+        assert consul_after_postgres.failure_reason == "consul_failed"
+        assert consul_after_postgres.postgres_confirmed is True
+
+
+# -----------------------------------------------------------------------------
+# Command Folding Prevention Tests
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCommandFoldingPrevention:
+    """Tests verifying reducer ONLY processes events, never commands.
+
+    Per ONEX architecture, reducers follow a strict separation:
+    - **Events**: Describe what HAS happened (past tense)
+        - Examples: NodeIntrospectionEvent, ConsulRegistered, RegistrationFailed
+        - Reducers fold events into state using pure functions
+    - **Commands**: Describe what SHOULD happen (imperative)
+        - Examples: RegisterNode, DeregisterNode, RefreshRegistration
+        - Commands are handled by Effect layer, NOT reducers
+
+    This separation is critical because:
+    1. Reducers are pure functions - they cannot execute side effects
+    2. Commands require I/O (network, database) - reducers do no I/O
+    3. Event sourcing requires immutable event history - commands are not logged
+    4. Replay/recovery relies on events only - replaying commands would cause duplicates
+
+    The reducer's output (intents) are NOT commands - they are declarative
+    descriptions of desired side effects that the Effect layer will execute.
+    Intents describe WHAT should happen, but the reducer doesn't DO it.
+
+    See Also:
+        - CLAUDE.md: "Enum Usage: Message Routing vs Node Validation"
+        - DESIGN_TWO_WAY_REGISTRATION_ARCHITECTURE.md: Pure reducer pattern
+        - OMN-942: Reducer test suite ticket
+    """
+
+    def test_reduce_only_accepts_introspection_events(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Verify reduce() signature only accepts ModelNodeIntrospectionEvent.
+
+        The type system enforces that reduce() takes events, not commands.
+        This test documents and verifies the contract through introspection.
+
+        Key points:
+        - reduce() accepts ModelNodeIntrospectionEvent (an EVENT type)
+        - There is no reduce() overload for command types
+        - Type annotations serve as compile-time enforcement
+        """
+        import inspect
+
+        # Get the reduce method signature
+        sig = inspect.signature(reducer.reduce)
+        params = list(sig.parameters.values())
+
+        # Should have exactly 2 params: state and event
+        assert len(params) == 2, (
+            f"reduce() should have 2 parameters (state, event), "
+            f"found {len(params)}: {[p.name for p in params]}"
+        )
+
+        # Verify parameter names match expected pattern
+        assert params[0].name == "state", (
+            f"First parameter should be 'state', found '{params[0].name}'"
+        )
+        assert params[1].name == "event", (
+            f"Second parameter should be 'event', found '{params[1].name}'"
+        )
+
+        # Verify event parameter type annotation is the Event type
+        event_param = params[1]
+        annotation = event_param.annotation
+
+        # Handle string annotations (from __future__ import annotations)
+        if isinstance(annotation, str):
+            assert "Event" in annotation, (
+                f"Event parameter should have Event type annotation, "
+                f"found '{annotation}'"
+            )
+        else:
+            # Direct type annotation
+            type_name = getattr(annotation, "__name__", str(annotation))
+            assert "Event" in type_name or "Introspection" in type_name, (
+                f"Event parameter should have Event type annotation, "
+                f"found '{type_name}'"
+            )
+
+    def test_reducer_has_no_command_handlers(self) -> None:
+        """Verify reducer has no methods for handling commands.
+
+        Per ONEX architecture, reducers ONLY process events. This test verifies
+        there are no command handler methods that would violate this principle.
+
+        Forbidden patterns (should NOT exist):
+        - handle_command, execute_command, process_command
+        - do_*, perform_*, run_* (imperative action methods)
+        - register_node, deregister_node (direct action methods)
+
+        Allowed patterns:
+        - reduce, reduce_* (pure event folding)
+        - _build_* (internal helpers)
+        - _validate_* (validation helpers)
+        """
+        reducer = RegistrationReducer()
+
+        # Get all public methods
+        public_methods = [
+            name
+            for name in dir(reducer)
+            if callable(getattr(reducer, name)) and not name.startswith("_")
+        ]
+
+        # Forbidden command-like method patterns
+        forbidden_patterns = [
+            "handle_command",
+            "execute_command",
+            "process_command",
+            "do_",
+            "perform_",
+            "run_",
+            "register_node",  # Direct action - should be via events
+            "deregister_node",  # Direct action - should be via events
+            "send_",  # I/O operation
+            "publish_",  # I/O operation
+            "write_",  # I/O operation
+            "delete_",  # I/O operation
+        ]
+
+        for method_name in public_methods:
+            for pattern in forbidden_patterns:
+                assert (
+                    not method_name.startswith(pattern) and pattern not in method_name
+                ), (
+                    f"Reducer has forbidden command-like method: {method_name}. "
+                    f"Reducers should only have reduce() methods for event processing."
+                )
+
+        # Verify the only public methods are reduce-related
+        allowed_prefixes = ["reduce"]
+        for method_name in public_methods:
+            is_allowed = any(
+                method_name.startswith(prefix) for prefix in allowed_prefixes
+            )
+            assert is_allowed, (
+                f"Reducer has unexpected public method: {method_name}. "
+                f"Public methods should be reduce() or reduce_*() only."
+            )
+
+    def test_output_contains_intents_not_direct_commands(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+        valid_event: ModelNodeIntrospectionEvent,
+    ) -> None:
+        """Verify reducer emits intents (for Effect layer) not commands.
+
+        Intents and commands are fundamentally different:
+
+        - **Intents**: Declarative descriptions of desired side effects.
+            The reducer says "I want X to happen" but doesn't do it.
+            Intent types: consul.register, postgres.upsert_registration
+
+        - **Commands**: Imperative instructions to execute immediately.
+            Commands say "DO X NOW" and expect immediate execution.
+            Command types would be: RegisterNode, DeregisterNode
+
+        This test verifies that:
+        1. Output intents have declarative intent_type names (not imperative)
+        2. Intents target external systems (consul://, postgres://)
+        3. Intents contain data for Effect layer, not execution results
+        """
+        output = reducer.reduce(initial_state, valid_event)
+
+        # Verify intents exist
+        assert len(output.intents) > 0, "Reducer should emit intents for Effect layer"
+
+        for intent in output.intents:
+            # Verify intent_type uses declarative naming (noun.verb pattern)
+            # Declarative: "consul.register" (describes what should be registered)
+            # Imperative would be: "RegisterInConsul" (commands action)
+            assert "." in intent.intent_type, (
+                f"Intent type should use namespace.action pattern, "
+                f"found '{intent.intent_type}'"
+            )
+
+            # Verify intent targets external system (Effect layer responsibility)
+            # Targets like "consul://..." or "postgres://..." indicate
+            # the Effect layer will handle the actual I/O
+            assert "://" in intent.target, (
+                f"Intent target should be a URI for Effect layer, "
+                f"found '{intent.target}'"
+            )
+
+            # Verify payload is data, not execution results
+            assert isinstance(intent.payload, dict), (
+                f"Intent payload should be a dict of data for Effect layer, "
+                f"found {type(intent.payload)}"
+            )
+
+            # Verify payload doesn't contain execution indicators
+            # (no "result", "status", "executed", "completed" keys)
+            execution_indicators = [
+                "result",
+                "executed",
+                "completed",
+                "success",
+                "error",
+            ]
+            for key in intent.payload:
+                assert key not in execution_indicators, (
+                    f"Intent payload contains execution indicator '{key}'. "
+                    f"Intents should contain input data, not execution results."
+                )
+
+    def test_reducer_processes_events_not_command_messages(
+        self,
+        reducer: RegistrationReducer,
+        initial_state: ModelRegistrationState,
+    ) -> None:
+        """Verify reducer does not execute command-like inputs.
+
+        This test verifies the reducer's behavior with mock inputs:
+        1. A mock "command" with an execute() method is passed to reduce
+        2. The reducer NEVER calls execute() - it only processes data
+        3. The reducer treats inputs as data, not as executable commands
+
+        This demonstrates the fundamental difference:
+        - Commands have execute() methods that perform actions
+        - Events are data that reducers fold into state
+        - Reducers don't execute anything - they only transform data
+
+        Note: In production, the dispatch engine routes commands to Effect
+        layer, not to reducers. The type system prevents command objects
+        from reaching reduce() at compile time.
+        """
+        from unittest.mock import MagicMock
+
+        # Create a mock "command" object (what a command might look like)
+        mock_command = MagicMock(spec=ModelNodeIntrospectionEvent)
+        mock_command.command_type = "RegisterNode"  # Imperative name
+        mock_command.node_id = uuid4()
+        mock_command.action = "register"  # Action field (commands have actions)
+        mock_command.execute = MagicMock()  # Commands might have execute()
+
+        # Set required event fields so validation passes
+        mock_command.node_type = "effect"
+        mock_command.node_version = "1.0.0"
+        mock_command.correlation_id = uuid4()
+        mock_command.endpoints = {"health": "http://localhost:8080/health"}
+        mock_command.capabilities = ModelNodeCapabilities()
+        mock_command.metadata = ModelNodeMetadata()
+
+        # When passed to reduce(), it processes as data
+        output = reducer.reduce(initial_state, mock_command)  # type: ignore[arg-type]
+
+        # CRITICAL: The reducer NEVER calls execute() on the input
+        # This is the key difference between commands and events:
+        # - Commands would be executed (execute() called)
+        # - Events are only read as data (no execute() call)
+        mock_command.execute.assert_not_called()
+
+        # The reducer treats the input as data and emits intents
+        # (it doesn't "do" anything, it describes what should be done)
+        for intent in output.intents:
+            # Intent types should be our standard declarative types
+            assert intent.intent_type in (
+                "consul.register",
+                "postgres.upsert_registration",
+            ), f"Unexpected intent type: {intent.intent_type}"
+
+    def test_event_naming_convention_enforced(
+        self,
+        valid_event: ModelNodeIntrospectionEvent,
+    ) -> None:
+        """Verify event type follows past-tense naming convention.
+
+        ONEX events use past-tense or noun-based naming to indicate
+        they describe what HAS happened:
+        - ModelNodeIntrospectionEvent (noun-based: the event OF introspection)
+        - ConsulRegistered (past-tense: registration completed)
+        - RegistrationFailed (past-tense: failure occurred)
+
+        Commands would use imperative naming:
+        - RegisterNode (imperative: DO this)
+        - DeregisterService (imperative: DO this)
+
+        This test documents the naming convention through the model class name.
+        """
+        event_type_name = type(valid_event).__name__
+
+        # Event names should contain "Event" suffix or past-tense verbs
+        event_indicators = [
+            "Event",  # Explicit event suffix
+            "ed",  # Past tense (Registered, Completed, Failed)
+            "tion",  # Noun form (Introspection, Registration)
+        ]
+
+        has_event_indicator = any(
+            indicator in event_type_name for indicator in event_indicators
+        )
+
+        assert has_event_indicator, (
+            f"Event type '{event_type_name}' should follow event naming convention "
+            f"(contain 'Event', past-tense verb like 'ed', or noun like 'tion')"
+        )
+
+        # Verify it does NOT use imperative command naming
+        command_indicators = [
+            "Command",
+            "Request",
+            "Do",
+            "Execute",
+            "Perform",
+        ]
+
+        for indicator in command_indicators:
+            assert indicator not in event_type_name, (
+                f"Event type '{event_type_name}' uses command-like naming "
+                f"(contains '{indicator}'). Events should use past-tense "
+                f"or noun-based naming."
+            )
+
+    def test_reduce_method_is_synchronous_not_async(self) -> None:
+        """Verify reduce() is synchronous (no I/O, therefore no async).
+
+        Commands often require async execution because they perform I/O.
+        Reducers are pure functions that do NO I/O, therefore reduce()
+        should be synchronous.
+
+        This is another way to verify reducers don't execute commands:
+        - If reduce() were async, it could perform I/O (command execution)
+        - Since reduce() is sync, it can only do pure computation (event folding)
+        """
+        import inspect
+
+        reducer = RegistrationReducer()
+
+        # Verify reduce() is not a coroutine function
+        assert not inspect.iscoroutinefunction(reducer.reduce), (
+            "reduce() should be synchronous, not async. "
+            "Async methods indicate I/O operations, but reducers are pure."
+        )
+
+        # Also verify reduce_reset() is synchronous
+        assert not inspect.iscoroutinefunction(reducer.reduce_reset), (
+            "reduce_reset() should be synchronous, not async. "
+            "All reducer methods should be pure and sync."
+        )


### PR DESCRIPTION
## Summary

Add comprehensive test suite for the registration reducer (OMN-942), fulfilling all ticket requirements:

- **53 new tests** added (was 84, now 137 total)
- **All tests pass** in 1.59s
- **Property-based testing** with Hypothesis for determinism verification

## Test Classes Added

| Class | Tests | Purpose |
|-------|-------|---------|
| `TestDeterminismProperty` | 7 | Property-based tests using Hypothesis |
| `TestCommandFoldingPrevention` | 6 | Verify reducer only processes events |
| `TestCompleteStateTransitions` | 24 | All 13 FSM transitions tested |
| `TestEdgeCasesComprehensive` | 10 | Edge cases (nil UUID, unicode, etc.) |
| `TestTimeoutScenarios` | 6 | Timeout handling and recovery |

## Ticket Requirements

- [x] Same input event sequence produces same outputs (determinism)
- [x] Command folding is forbidden and tested
- [x] All state transitions tested
- [x] Edge cases covered
- [x] Property-based tests for determinism using Hypothesis

## Dependencies Added

- `hypothesis ^6.148.7` for property-based testing

## Test Plan

- [x] All 137 tests pass locally
- [x] Pre-commit hooks pass (ruff format, ruff check, ONEX validation)
- [ ] CI pipeline passes