### PR TITLE
fix(tests): add session_id to sensitive field patterns

### DIFF
--- a/tests/integration/registration/workflow/test_workflow_a5_a6.py
+++ b/tests/integration/registration/workflow/test_workflow_a5_a6.py
@@ -182,6 +182,7 @@ SENSITIVE_FIELD_PATTERNS = {
     "master_key",
     "client_secret",
     "session_token",
+    "session_id",  # Session identifiers (e.g., PHP PHPSESSID, Flask session IDs)
     "jwt",
     "oauth_token",
     "ssh_key",
@@ -842,6 +843,8 @@ class TestA6Observability:
             ("private_key: -----BEGIN RSA", "private_key"),
             ("client_secret=xyz", "client_secret"),
             ("connection_string: postgresql://user:pass@host", "connection_string"),
+            # Session identifier patterns
+            ("session_id: abc123def456", "session_id"),
             # New patterns added for comprehensive coverage
             ("dsn: postgresql://user:pass@localhost:5432/db", "dsn"),
             (
@@ -881,6 +884,10 @@ class TestA6Observability:
             "api_key_length: 32",
             "secret: [redacted]",
             "password: ***",
+            # Safe contexts for session identifiers
+            "has_session_id: True",
+            "session_id_present: True",
+            "session_id: [redacted]",
             # Safe contexts for new patterns
             "has_dsn: True",
             "dsn_present: True",


### PR DESCRIPTION
## Summary
- Add `session_id` to `SENSITIVE_FIELD_PATTERNS` for comprehensive secret detection
- Add test cases for session identifier patterns in observability tests

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes