### PR TITLE
test(integration): add no-publish constraint tests for handlers [OMN-1094]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,7 @@ Each dispatcher should:
 | `TestHandlerNodeIntrospectedBusIsolation` | Introspection handler isolation |
 | `TestHandlerProtocolCompliance` | Protocol-level constraints |
 | `TestOrchestratorBusAccessVerification` | Orchestrator-only bus access |
+| `TestHandlerNoPublishConstraintCrossValidation` | Cross-handler constraint validation |
 
 ### Node Introspection Security
 

--- a/tests/integration/handlers/test_handler_no_publish_constraint.py
+++ b/tests/integration/handlers/test_handler_no_publish_constraint.py
@@ -272,6 +272,10 @@ def http_handler() -> Generator[HttpRestHandler, None, None]:
     Yields handler instance and ensures proper shutdown if initialized.
     This prevents resource warnings from httpx clients that may be
     initialized during handler usage.
+
+    Note: Uses Generator return type (not direct type) because this fixture
+    uses yield with teardown code. See introspection_handler for the simpler
+    return pattern when no cleanup is required.
     """
     handler = HttpRestHandler()
     yield handler


### PR DESCRIPTION
## Summary

- Add explicit integration tests proving `HttpRestHandler` and `HandlerNodeIntrospected` cannot access the event bus structurally
- Validates the existing no-publish constraint is enforced via dependency injection patterns
- 14 tests across 3 test classes, all passing

## What This Proves

**HttpRestHandler** (5 tests):
- Constructor takes only `self` - no dependency injection of bus
- No bus-related attributes (`bus`, `dispatcher`, `publisher`, etc.)
- Returns `ModelHandlerOutput`, not a publish action
- No `publish()`, `emit()`, `dispatch()` methods exist
- Only HTTP-related internal state (`_client`, `_timeout`, etc.)

**HandlerNodeIntrospected** (5 tests):
- Constructor accepts only domain dependencies (projection_reader, projector, consul_handler)
- No bus-related attributes exist on instances
- Returns `list[BaseModel]` for caller to publish
- No publish methods exist
- Only stores domain-specific dependencies

**Cross-Validation** (4 tests):
- No `async with self.bus` patterns in handler source
- Method signatures match expected patterns (no bus parameters)

## Test Plan

- [x] All 14 tests pass locally
- [x] Ruff lint passes
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an expanded integration test suite enforcing a "no-publish" constraint and handler isolation. Validates handler interfaces, lifecycle/async behavior, absence of messaging/bus access patterns, and cross-handler protocol conformance via duck-typing. Includes new test utilities, public constants and fixtures to support pattern detection and isolation assertions.
* **Documentation**
  * Added a new "Handler No-Publish Constraint" section describing verification criteria; duplicated block appears twice.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->