### PR TITLE
feat(OMN-1515): Add execute() dispatcher to HandlerGraph for contract discovery

### DIFF
--- a/tests/integration/handlers/test_filesystem_handler_contract.py
+++ b/tests/integration/handlers/test_filesystem_handler_contract.py
@@ -249,7 +249,7 @@ class TestFilesystemHandlerContractSchema:
         - handler_id
         - name
         - contract_version
-        - descriptor (with handler_kind)
+        - descriptor (with node_archetype)
         - input_model
         - output_model
         """
@@ -278,7 +278,7 @@ class TestFilesystemHandlerContractSchema:
         """Verify the descriptor section contains expected effect handler fields.
 
         Effect handlers should specify:
-        - handler_kind: effect
+        - node_archetype: effect
         - purity: side_effecting
         - Additional effect-specific configuration
         """

--- a/tests/unit/handlers/test_handler_graph.py
+++ b/tests/unit/handlers/test_handler_graph.py
@@ -1753,8 +1753,11 @@ class TestHandlerGraphExecuteDispatcher:
             result = await handler.execute(envelope)
 
             assert result is not None
-            # The result should include the correlation_id
-            assert result.correlation_id is not None
+            # The result should include the correlation_id and match the input
+            assert str(result.correlation_id) == test_correlation_id, (
+                f"Expected correlation_id {test_correlation_id}, "
+                f"got {result.correlation_id}"
+            )
 
             await handler.shutdown()
 


### PR DESCRIPTION
## Summary

- Add envelope-based `execute()` method to HandlerGraph enabling declarative handler registration via contract.yaml
- HandlerGraph is now discoverable via its existing contract at `contracts/handlers/graph/handler_contract.yaml` with `protocol_type="graph"`
- No changes to `_KNOWN_HANDLERS` needed - this follows the correct architectural approach

## Changes

- Add `SUPPORTED_OPERATIONS` constant (7 graph operations)
- Add `execute()` dispatcher that routes to specialized methods based on `envelope["operation"]`
- Add `MixinEnvelopeExtraction` for envelope parsing utilities
- Add operation-specific handler methods (`_execute_query_operation`, etc.)
- Add `_build_graph_response()` helper for consistent `ModelHandlerOutput` formatting
- Add 14 unit tests for dispatcher and `SUPPORTED_OPERATIONS`
- Update omnibase_core to 0.9.4 and omnibase_spi to 0.6.0

## Why This Approach

Research showed that:
1. The `HandlerPluginLoader` requires all handlers implement `ProtocolHandler.execute()`
2. HandlerGraph previously only had specialized methods (`execute_query`, `create_node`, etc.)
3. Adding `execute()` as a dispatcher enables contract discovery without modifying `_KNOWN_HANDLERS`

This aligns with the architectural direction of contract-driven handler registration.

## Test plan

- [x] All 55 HandlerGraph unit tests pass
- [x] Contract discovery verification: HandlerGraph loads via `contracts/handlers/graph/handler_contract.yaml`
- [x] Pre-commit hooks pass (ruff, mypy, ONEX validators)

## Linear

Closes OMN-1515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added envelope-based dispatch and a unified execute API for graph operations (queries single & batch, node/relationship create/delete, traversals) and published supported operations.

* **Tests**
  * Added extensive routing, payload validation, error-handling, correlation-ID propagation, lifecycle and edge-case tests for the new execute flow.
  * Updated contract tests to use node_archetype in descriptors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->