### PR TITLE
chore: bump version to 0.2.4, update omnibase-core to 0.9.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2796,14 +2796,14 @@ files = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.9.4"
+version = "0.9.5"
 description = "ONEX Core Framework - Base classes and essential implementations"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "omnibase_core-0.9.4-py3-none-any.whl", hash = "sha256:31ecabb94b2b2e8b8b4ef964a5669844d847eea77e613e97d8a81096387bdf99"},
-    {file = "omnibase_core-0.9.4.tar.gz", hash = "sha256:8bf1e3000135ca7bff743b09ce1e9dde9be73eb9abfe1d0de47f0ec9698da9d0"},
+    {file = "omnibase_core-0.9.5-py3-none-any.whl", hash = "sha256:068d52a4a4af344ec0e6097c20dec25025568eb3dc1b519003033d371e9dd131"},
+    {file = "omnibase_core-0.9.5.tar.gz", hash = "sha256:07d95e26a6757747608fa8aba1ad0a633101465ca7a065a94ab71ccad146423d"},
 ]
 
 [package.dependencies]
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "16f1537821bea5a4d9fc4ae5dbd80ccea1ab4bbcfc1706e8050f3ad499ff3603"
+content-hash = "fc8d7c740d66ebf5628c2391fe2821f893118ba10717de755d93c0137b0c3c13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnibase_infra"
-version = "0.2.3"
+version = "0.2.4"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = ["OmniNode Team <team@omninode.ai>"]
 license = "MIT"
@@ -35,8 +35,8 @@ python = "^3.12"
 #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
 # Remember to switch back to PyPI versions before merging to main.
 #
-# omnibase-core v0.9.4: Core release with latest updates
-omnibase-core = "^0.9.4"
+# omnibase-core v0.9.5: Topic suffix validation utilities (OMN-1537)
+omnibase-core = "^0.9.5"
 # omnibase-spi v0.6.0: Protocol updates for omnibase-core 0.9.4 compatibility
 omnibase-spi = "^0.6.0"
 

--- a/src/omnibase_infra/validation/__init__.py
+++ b/src/omnibase_infra/validation/__init__.py
@@ -91,13 +91,22 @@ Security Design (Intentional Fail-Open Architecture):
     - validator_routing_coverage.py: Routing gap detection (module docstring)
 """
 
+# Topic suffix validation models (OMN-1537)
+from omnibase_core.models.validation import (
+    ModelTopicSuffixParts,
+    ModelTopicValidationResult,
+)
 from omnibase_core.validation import (
     CircularImportValidator,
     ModelModuleImportResult,
+    compose_full_topic,
+    is_valid_topic_suffix,
+    parse_topic_suffix,
     validate_all,
     validate_architecture,
     validate_contracts,
     validate_patterns,
+    validate_topic_suffix,
     validate_union_usage,
 )
 
@@ -222,6 +231,13 @@ __all__: list[str] = [
     "NODE_ARCHETYPE_EXPECTED_CATEGORIES",  # Node archetype categories
     "TOPIC_CATEGORY_PATTERNS",  # Topic category patterns
     "TOPIC_SUFFIXES",  # Topic suffix constants
+    # Topic suffix validation (OMN-1537)
+    "ModelTopicSuffixParts",  # Topic suffix parsed parts
+    "ModelTopicValidationResult",  # Topic validation result
+    "compose_full_topic",  # Compose full topic from parts
+    "is_valid_topic_suffix",  # Check if topic suffix is valid
+    "parse_topic_suffix",  # Parse topic suffix into parts
+    "validate_topic_suffix",  # Validate topic suffix format
     # Errors
     "ChainPropagationError",  # Chain propagation error (OMN-951)
     "ExecutionShapeViolationError",  # Execution shape violation


### PR DESCRIPTION
## Summary

- Update omnibase-core from 0.9.4 to 0.9.5 (OMN-1537 topic utilities)
- Add topic suffix validation re-exports to `omnibase_infra.validation`
- Bump package version to 0.2.4

## New Exports

Downstream repos can now import topic utilities from `omnibase_infra.validation`:

```python
from omnibase_infra.validation import (
    # Functions
    compose_full_topic,
    validate_topic_suffix,
    parse_topic_suffix,
    is_valid_topic_suffix,
    # Models
    ModelTopicSuffixParts,
    ModelTopicValidationResult,
)
```

## Related

- Depends on: [omnibase_core PR #435](https://github.com/OmniNode-ai/omnibase_core/pull/435) (OMN-1537) ✅ Merged
- Blocks: OMN-1550 (Runtime topic resolution from contracts)

## Test Plan

- [x] Pre-commit hooks pass
- [x] Import verification successful
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced topic validation capabilities with new utilities and data models now available in the public API.

* **Chores**
  * Updated package version to 0.2.4.
  * Updated internal dependencies to latest compatible versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->