### PR TITLE
chore: bump version to 0.2.7, update omnibase-core to 0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the ONEX Infrastructure (omnibase_infra) will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-01-30
+
+### Changed
+
+#### Dependencies
+- Update `omnibase-core` from `^0.9.9` to `^0.9.10` for OMN-1551 contract-driven topics
+
 ## [0.2.6] - 2026-01-30
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "a3784e58ac4eea30727f11e800036df4c7ee51f6a57dc97ca022be75c6db0654"
+content-hash = "5b5c80d44a7dadf4b5b5d36f60de3957d406a8b9a137058d3c08e8e90ad98850"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnibase_infra"
-version = "0.2.6"
+version = "0.2.7"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = ["OmniNode Team <team@omninode.ai>"]
 license = "MIT"
@@ -36,8 +36,8 @@ python = "^3.12"
 #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
 # Remember to switch back to PyPI versions before merging to main.
 #
-# omnibase-core v0.9.9: Adds baseline topic constants export
-omnibase-core = "^0.9.9"
+# omnibase-core v0.9.10: OMN-1551 contract-driven topics
+omnibase-core = "^0.9.10"
 # omnibase-spi v0.6.3: Version bump
 omnibase-spi = "^0.6.3"
 


### PR DESCRIPTION
## Summary
- Bump omnibase_infra version from 0.2.6 to 0.2.7
- Update omnibase-core dependency from ^0.9.9 to ^0.9.10
- OMN-1551: Contract-driven topics support

## Test plan
- [ ] CI passes
- [ ] Runtime container builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.2.7 released with updated dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->