### PR TITLE
fix(OMN-1709): Add event_type type guard and document topic orphan handling

### DIFF
--- a/docker/migrations/005_create_contracts_topics.sql
+++ b/docker/migrations/005_create_contracts_topics.sql
@@ -65,6 +65,15 @@ CREATE INDEX IF NOT EXISTS idx_contracts_hash
 -- Stores topic suffixes referenced by contracts for routing discovery.
 -- Uses 5-segment naming: onex.evt.platform.contract-registered.v1
 -- Stores SUFFIXES only - environment prefix ({env}.) applied at runtime.
+--
+-- Topic Orphan Handling (OMN-1709):
+--   When all contracts referencing a topic are deregistered, the topic record
+--   remains with an empty contract_ids array. This is intentional:
+--   - Preserves topic routing history for auditing and debugging
+--   - Allows topic reactivation if a new contract references the same topic
+--   - Avoids complex cascading deletes during high-volume deregistration
+--   To clean up orphaned topics, run:
+--     DELETE FROM topics WHERE contract_ids = '[]' AND is_active = FALSE;
 
 CREATE TABLE IF NOT EXISTS topics (
     -- Identity (composite key: same topic can have both publish and subscribe directions)

--- a/src/omnibase_infra/nodes/contract_registry_reducer/reducer.py
+++ b/src/omnibase_infra/nodes/contract_registry_reducer/reducer.py
@@ -702,13 +702,18 @@ class ContractRegistryReducer:
                     # We store it as-is; the Effect layer handles resolution.
                     topic_suffix = consumed.get("topic")
                     if topic_suffix and isinstance(topic_suffix, str):
+                        # Validate event_type is string (may be missing or wrong type in malformed YAML)
+                        event_type_raw = consumed.get("event_type")
+                        event_type = (
+                            event_type_raw if isinstance(event_type_raw, str) else None
+                        )
                         payload = ModelPayloadUpdateTopic(
                             correlation_id=correlation_id,
                             topic_suffix=topic_suffix,
                             direction="subscribe",
                             contract_id=contract_id,
                             node_name=event.node_name,
-                            event_type=consumed.get("event_type"),
+                            event_type=event_type,
                             last_seen_at=event.timestamp,
                         )
                         intents.append(
@@ -728,13 +733,18 @@ class ContractRegistryReducer:
                     # Effect layer handles resolution (see docstring above).
                     topic_suffix = published.get("topic")
                     if topic_suffix and isinstance(topic_suffix, str):
+                        # Validate event_type is string (may be missing or wrong type in malformed YAML)
+                        event_type_raw = published.get("event_type")
+                        event_type = (
+                            event_type_raw if isinstance(event_type_raw, str) else None
+                        )
                         payload = ModelPayloadUpdateTopic(
                             correlation_id=correlation_id,
                             topic_suffix=topic_suffix,
                             direction="publish",
                             contract_id=contract_id,
                             node_name=event.node_name,
-                            event_type=published.get("event_type"),
+                            event_type=event_type,
                             last_seen_at=event.timestamp,
                         )
                         intents.append(


### PR DESCRIPTION
## Summary

Follow-up improvements from PR #212 code review (OMN-1653: Contract Registry Reducer).

- Add `isinstance` guard for `event_type` in `_build_topic_update_intents` to handle malformed YAML
- Document topic orphan handling strategy in migration file with cleanup query
- Add test case for non-string `event_type` values (list, dict, int, None)

## Changes

### 1. Type Guard for `event_type` (reducer.py)

When parsing `contract_yaml`, the reducer now validates that `event_type` is a string before using it:

```python
event_type_raw = consumed.get("event_type")
event_type = event_type_raw if isinstance(event_type_raw, str) else None
```

This prevents model validation errors when malformed YAML contains non-string values.

### 2. Topic Orphan Handling Documentation (005_create_contracts_topics.sql)

Added documentation explaining that when all contracts referencing a topic are deregistered, the topic record remains. This is intentional for:
- Preserving topic routing history for auditing
- Allowing topic reactivation if a new contract references the same topic
- Avoiding complex cascading deletes during high-volume deregistration

Includes cleanup query: `DELETE FROM topics WHERE contract_ids = '[]' AND is_active = FALSE;`

### 3. New Test Case (test_contract_registry_reducer.py)

Added `test_non_string_event_type_handled_gracefully` to verify the reducer handles malformed YAML with non-string `event_type` values (list, dict, int, None).

## Test Plan

- [x] All 33 contract registry reducer tests pass
- [x] New test validates non-string event_type handling
- [x] Pre-commit hooks pass

## Related

- Ticket: [OMN-1709](https://linear.app/omninode/issue/OMN-1709)
- Parent PR: #212 (OMN-1653)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system resilience by gracefully handling malformed contract data with non-string event types, preventing processing errors.

* **Documentation**
  * Updated topic orphan handling documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->