### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ONEX Infrastructure (omnibase_infra) will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-02
+
+### Fixed
+
+- **OMN-1842**: Fix ORDER BY injection position when LIMIT clause exists in `PostgresRepositoryRuntime` (#229)
+  - ORDER BY is now correctly inserted BEFORE existing LIMIT clause to produce valid SQL
+  - Added detection for parameterized LIMIT (`$n`) to prevent duplicate LIMIT injection
+  - Before (invalid): `SELECT ... LIMIT $1 ORDER BY id`
+  - After (valid): `SELECT ... ORDER BY id LIMIT $1`
+
 ## [0.3.0] - 2026-02-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnibase_infra"
-version = "0.3.0"
+version = "0.3.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = ["OmniNode Team <team@omninode.ai>"]
 license = "MIT"

--- a/src/omnibase_infra/__init__.py
+++ b/src/omnibase_infra/__init__.py
@@ -76,7 +76,7 @@ See Also
 - Runtime kernel: omnibase_infra.runtime.service_kernel
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from . import (
     enums,


### PR DESCRIPTION
## Summary

Patch release v0.3.1 for OMN-1842 fix.

## Changes

- `pyproject.toml`: version 0.3.0 → 0.3.1
- `src/omnibase_infra/__init__.py`: __version__ 0.3.0 → 0.3.1
- `CHANGELOG.md`: Added 0.3.1 section with OMN-1842 fix

## Included Fix

- **OMN-1842**: Fix ORDER BY injection position when LIMIT clause exists in `PostgresRepositoryRuntime` (#229)

## Post-Merge

After merging, create tag:
```bash
git tag -a v0.3.1 -m "Release v0.3.1 - OMN-1842 fix"
git push origin v0.3.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL ORDER BY injection handling to properly manage query ordering when LIMIT clauses are present, including support for parameterized LIMIT values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->