### PR TITLE
feat(OMN-1905): Add declarative Slack webhook handler to omnibase_infra

### DIFF
--- a/src/omnibase_infra/handlers/__init__.py
+++ b/src/omnibase_infra/handlers/__init__.py
@@ -20,6 +20,7 @@ Available Handlers:
 - HandlerGraph: Graph database handler (Memgraph/Neo4j via Bolt protocol)
 - HandlerIntent: Intent storage and query handler wrapping HandlerGraph (demo wiring)
 - HandlerQdrant: Qdrant vector database handler (MVP: create, upsert, search, delete)
+- HandlerSlackWebhook: Slack webhook handler for infrastructure alerting
 
 Response Models:
 - ModelDbQueryPayload: Database query result payload
@@ -45,6 +46,7 @@ from omnibase_infra.handlers.handler_manifest_persistence import (
 )
 from omnibase_infra.handlers.handler_mcp import HandlerMCP
 from omnibase_infra.handlers.handler_qdrant import HandlerQdrant
+from omnibase_infra.handlers.handler_slack_webhook import HandlerSlackWebhook
 from omnibase_infra.handlers.handler_vault import HandlerVault
 from omnibase_infra.handlers.models import (
     ModelConsulHandlerPayload,
@@ -71,6 +73,7 @@ __all__: list[str] = [
     "HandlerManifestPersistence",
     "HandlerMCP",
     "HandlerQdrant",
+    "HandlerSlackWebhook",
     "HandlerVault",
     "ModelConsulHandlerPayload",
     "ModelConsulHandlerResponse",

--- a/src/omnibase_infra/handlers/handler_slack_webhook.py
+++ b/src/omnibase_infra/handlers/handler_slack_webhook.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Slack Webhook Handler - Infrastructure alerting via Slack webhooks.
+
+This handler sends alerts to Slack channels using incoming webhooks,
+with support for Block Kit formatting, retry with exponential backoff,
+and rate limit handling.
+
+Architecture:
+    This handler follows the ONEX operation handler pattern:
+    - Receives typed input (ModelSlackAlert)
+    - Executes a single responsibility (Slack webhook delivery)
+    - Returns typed output (ModelSlackAlertResult)
+    - Uses error sanitization for security
+    - Stateless and coroutine-safe for concurrent calls
+
+Handler Responsibilities:
+    - Format alerts as Slack Block Kit messages
+    - Send webhooks with configurable retry logic
+    - Handle 429 rate limiting gracefully
+    - Sanitize errors to prevent credential exposure
+    - Track operation timing and retry counts
+
+Configuration:
+    The webhook URL is resolved from the SLACK_WEBHOOK_URL environment
+    variable. This keeps credentials out of code and configuration files.
+
+Coroutine Safety:
+    This handler is stateless and coroutine-safe for concurrent calls
+    with different request instances.
+
+Related Tickets:
+    - OMN-1905: Add declarative Slack webhook handler to omnibase_infra
+    - OMN-1895: Wiring Health Monitor alerting (blocked by this)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.errors import (
+    InfraConnectionError,
+    InfraTimeoutError,
+    InfraUnavailableError,
+    ModelInfraErrorContext,
+    ProtocolConfigurationError,
+)
+from omnibase_infra.handlers.models.model_slack_alert import (
+    EnumAlertSeverity,
+    ModelSlackAlert,
+    ModelSlackAlertResult,
+)
+from omnibase_infra.utils import sanitize_error_message
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# Default retry configuration
+_DEFAULT_MAX_RETRIES: int = 3
+_DEFAULT_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0)
+_DEFAULT_TIMEOUT_SECONDS: float = 10.0
+
+# Slack Block Kit emoji mapping for severity levels
+_SEVERITY_EMOJI: dict[EnumAlertSeverity, str] = {
+    EnumAlertSeverity.CRITICAL: ":red_circle:",
+    EnumAlertSeverity.ERROR: ":red_circle:",
+    EnumAlertSeverity.WARNING: ":large_yellow_circle:",
+    EnumAlertSeverity.INFO: ":large_blue_circle:",
+}
+
+# Default titles for each severity level
+_SEVERITY_TITLES: dict[EnumAlertSeverity, str] = {
+    EnumAlertSeverity.CRITICAL: "Critical Alert",
+    EnumAlertSeverity.ERROR: "Error Alert",
+    EnumAlertSeverity.WARNING: "Warning",
+    EnumAlertSeverity.INFO: "Info",
+}
+
+
+class HandlerSlackWebhook:
+    """Handler for Slack webhook alert delivery.
+
+    Encapsulates all Slack-specific alerting logic for declarative
+    node compliance. Supports Block Kit formatting, retry with exponential
+    backoff, and rate limit handling.
+
+    Error Handling:
+        All errors are sanitized before inclusion in the result to prevent
+        credential exposure. The handler never raises exceptions during
+        normal operation - errors are captured in ModelSlackAlertResult.
+
+    Rate Limiting:
+        HTTP 429 responses trigger automatic retry with backoff. After
+        max retries are exhausted, the operation fails gracefully with
+        an error result rather than raising an exception.
+
+    Attributes:
+        _webhook_url: Slack webhook URL (from env or constructor)
+        _http_session: Optional shared aiohttp session
+        _max_retries: Maximum retry attempts for failed requests
+        _retry_backoff: Tuple of backoff delays in seconds
+        _timeout: HTTP request timeout in seconds
+
+    Example:
+        >>> import asyncio
+        >>> handler = HandlerSlackWebhook()
+        >>> alert = ModelSlackAlert(
+        ...     severity=EnumAlertSeverity.ERROR,
+        ...     message="Circuit breaker opened for Consul",
+        ...     title="Infrastructure Alert",
+        ... )
+        >>> # result = await handler.handle(alert)
+    """
+
+    def __init__(
+        self,
+        webhook_url: str | None = None,
+        http_session: aiohttp.ClientSession | None = None,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        retry_backoff: tuple[float, ...] = _DEFAULT_RETRY_BACKOFF_SECONDS,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Initialize handler with webhook URL and optional HTTP session.
+
+        Args:
+            webhook_url: Slack webhook URL. If not provided, reads from
+                SLACK_WEBHOOK_URL environment variable.
+            http_session: Optional shared aiohttp ClientSession. If not
+                provided, a new session is created per request.
+            max_retries: Maximum retry attempts for failed requests.
+                Default is 3.
+            retry_backoff: Tuple of backoff delays in seconds for each
+                retry attempt. Default is (1.0, 2.0, 4.0).
+            timeout: HTTP request timeout in seconds. Default is 10.0.
+        """
+        self._webhook_url: str = (
+            webhook_url if webhook_url else os.getenv("SLACK_WEBHOOK_URL", "")
+        )
+        self._http_session = http_session
+        self._max_retries = max_retries
+        self._retry_backoff = retry_backoff
+        self._timeout = timeout
+
+    async def handle(
+        self,
+        alert: ModelSlackAlert,
+    ) -> ModelSlackAlertResult:
+        """Execute Slack webhook alert delivery.
+
+        Formats the alert as a Slack Block Kit message and sends it
+        to the configured webhook URL with retry logic.
+
+        Args:
+            alert: Alert payload containing severity, message, and optional
+                details.
+
+        Returns:
+            ModelSlackAlertResult with:
+                - success: True if alert was delivered
+                - duration_ms: Time taken for the operation
+                - correlation_id: From the input alert
+                - error: Sanitized error message (only on failure)
+                - error_code: Error code for programmatic handling
+                - retry_count: Number of retry attempts made
+
+        Note:
+            This handler does not raise exceptions during normal operation.
+            All errors are captured and returned in ModelSlackAlertResult
+            to support graceful degradation in alerting scenarios.
+        """
+        start_time = time.perf_counter()
+        correlation_id = alert.correlation_id
+        retry_count = 0
+
+        # Validate webhook URL is configured
+        if not self._webhook_url:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            return ModelSlackAlertResult(
+                success=False,
+                duration_ms=duration_ms,
+                correlation_id=correlation_id,
+                error="SLACK_WEBHOOK_URL not configured",
+                error_code="SLACK_NOT_CONFIGURED",
+                retry_count=0,
+            )
+
+        # Format the alert as Block Kit message
+        slack_payload = self._format_block_kit_message(alert)
+
+        # Create or use existing HTTP session
+        session_created = False
+        session = self._http_session
+        if session is None:
+            session = aiohttp.ClientSession()
+            session_created = True
+
+        try:
+            return await self._send_with_retry(
+                session=session,
+                slack_payload=slack_payload,
+                correlation_id=correlation_id,
+                start_time=start_time,
+            )
+        finally:
+            # Close session if we created it
+            if session_created and session is not None:
+                await session.close()
+
+    async def _send_with_retry(
+        self,
+        session: aiohttp.ClientSession,
+        slack_payload: dict[str, object],
+        correlation_id: UUID,
+        start_time: float,
+    ) -> ModelSlackAlertResult:
+        """Send webhook with retry logic and rate limit handling.
+
+        Args:
+            session: aiohttp ClientSession for HTTP requests
+            slack_payload: Formatted Slack Block Kit payload
+            correlation_id: UUID for distributed tracing
+            start_time: Performance timer start for duration calculation
+
+        Returns:
+            ModelSlackAlertResult with operation outcome
+        """
+        retry_count = 0
+        last_error: str | None = None
+        last_error_code: str | None = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                async with session.post(
+                    self._webhook_url,
+                    json=slack_payload,
+                    timeout=aiohttp.ClientTimeout(total=self._timeout),
+                ) as response:
+                    duration_ms = (time.perf_counter() - start_time) * 1000
+
+                    if response.status == 200:
+                        # Success
+                        logger.info(
+                            "Slack alert delivered successfully",
+                            extra={
+                                "correlation_id": str(correlation_id),
+                                "duration_ms": round(duration_ms, 2),
+                                "retry_count": retry_count,
+                            },
+                        )
+                        return ModelSlackAlertResult(
+                            success=True,
+                            duration_ms=duration_ms,
+                            correlation_id=correlation_id,
+                            retry_count=retry_count,
+                        )
+
+                    elif response.status == 429:
+                        # Rate limited - retry with backoff
+                        last_error = "Slack rate limit (429)"
+                        last_error_code = "SLACK_RATE_LIMITED"
+                        logger.warning(
+                            "Slack rate limited, will retry",
+                            extra={
+                                "correlation_id": str(correlation_id),
+                                "attempt": attempt + 1,
+                                "max_attempts": self._max_retries + 1,
+                            },
+                        )
+
+                    elif response.status >= 400:
+                        # Other HTTP error
+                        response_text = await response.text()
+                        last_error = f"HTTP {response.status}: {response_text[:100]}"
+                        last_error_code = f"SLACK_HTTP_{response.status}"
+                        logger.warning(
+                            "Slack webhook error",
+                            extra={
+                                "correlation_id": str(correlation_id),
+                                "status_code": response.status,
+                                "attempt": attempt + 1,
+                            },
+                        )
+
+            except TimeoutError:
+                last_error = "Request timeout"
+                last_error_code = "SLACK_TIMEOUT"
+                logger.warning(
+                    "Slack webhook timeout",
+                    extra={
+                        "correlation_id": str(correlation_id),
+                        "timeout_seconds": self._timeout,
+                        "attempt": attempt + 1,
+                    },
+                )
+
+            except aiohttp.ClientConnectorError as e:
+                last_error = sanitize_error_message(e)
+                last_error_code = "SLACK_CONNECTION_ERROR"
+                logger.warning(
+                    "Slack webhook connection error",
+                    extra={
+                        "correlation_id": str(correlation_id),
+                        "attempt": attempt + 1,
+                    },
+                )
+
+            except aiohttp.ClientError as e:
+                last_error = sanitize_error_message(e)
+                last_error_code = "SLACK_CLIENT_ERROR"
+                logger.warning(
+                    "Slack webhook client error",
+                    extra={
+                        "correlation_id": str(correlation_id),
+                        "attempt": attempt + 1,
+                        "error_type": type(e).__name__,
+                    },
+                )
+
+            # Retry with backoff if we have retries remaining
+            if attempt < self._max_retries:
+                backoff_index = min(attempt, len(self._retry_backoff) - 1)
+                backoff_seconds = self._retry_backoff[backoff_index]
+                logger.info(
+                    "Retrying Slack webhook",
+                    extra={
+                        "correlation_id": str(correlation_id),
+                        "backoff_seconds": backoff_seconds,
+                        "attempt": attempt + 1,
+                    },
+                )
+                await asyncio.sleep(backoff_seconds)
+                retry_count += 1
+
+        # All retries exhausted
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        logger.error(
+            "Slack alert delivery failed after retries",
+            extra={
+                "correlation_id": str(correlation_id),
+                "duration_ms": round(duration_ms, 2),
+                "retry_count": retry_count,
+                "error_code": last_error_code,
+            },
+        )
+
+        return ModelSlackAlertResult(
+            success=False,
+            duration_ms=duration_ms,
+            correlation_id=correlation_id,
+            error=last_error,
+            error_code=last_error_code,
+            retry_count=retry_count,
+        )
+
+    def _format_block_kit_message(self, alert: ModelSlackAlert) -> dict[str, object]:
+        """Format alert as Slack Block Kit message.
+
+        Creates a rich formatted message using Slack's Block Kit API
+        with header, message body, and optional detail fields.
+
+        Args:
+            alert: Alert payload to format
+
+        Returns:
+            Dict containing Slack Block Kit blocks structure
+        """
+        emoji = _SEVERITY_EMOJI.get(alert.severity, ":white_circle:")
+        title = alert.title or _SEVERITY_TITLES.get(alert.severity, "Alert")
+
+        blocks: list[dict[str, object]] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{emoji} {title}",
+                    "emoji": True,
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": alert.message[:3000],  # Slack limit
+                },
+            },
+        ]
+
+        # Add detail fields if provided
+        if alert.details:
+            fields: list[dict[str, object]] = []
+            for key, value in list(alert.details.items())[:10]:  # Limit to 10 fields
+                # Convert value to string, truncate if needed
+                value_str = str(value)[:100]
+                fields.append({"type": "mrkdwn", "text": f"*{key}:*\n{value_str}"})
+
+            # Slack allows max 10 fields per section
+            if fields:
+                blocks.append({"type": "section", "fields": fields})
+
+        # Add correlation ID for traceability
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Correlation: `{str(alert.correlation_id)[:16]}...`",
+                    }
+                ],
+            }
+        )
+
+        return {"blocks": blocks}
+
+
+__all__: list[str] = ["HandlerSlackWebhook"]

--- a/src/omnibase_infra/handlers/models/__init__.py
+++ b/src/omnibase_infra/handlers/models/__init__.py
@@ -90,6 +90,11 @@ Manifest Persistence Models:
     ModelManifestQueryPayload: Payload for manifest.query operation
     ModelManifestQueryResult: Result from manifest.query operation
     ModelManifestMetadata: Lightweight metadata for manifest queries
+
+Slack Models:
+    EnumAlertSeverity: Alert severity levels (critical, error, warning, info)
+    ModelSlackAlert: Input payload for Slack alert operations
+    ModelSlackAlertResult: Response from Slack webhook operations
 """
 
 from omnibase_infra.handlers.models.consul import (
@@ -104,6 +109,7 @@ from omnibase_infra.handlers.models.consul import (
     ModelConsulKVPutPayload,
     ModelConsulRegisterPayload,
 )
+from omnibase_infra.handlers.models.enum_alert_severity import EnumAlertSeverity
 from omnibase_infra.handlers.models.http import (
     EnumHttpOperationType,
     HttpPayload,
@@ -198,6 +204,10 @@ from omnibase_infra.handlers.models.model_qdrant_handler_response import (
     ModelQdrantHandlerResponse,
 )
 from omnibase_infra.handlers.models.model_retry_state import ModelRetryState
+from omnibase_infra.handlers.models.model_slack_alert_payload import ModelSlackAlert
+from omnibase_infra.handlers.models.model_slack_alert_result import (
+    ModelSlackAlertResult,
+)
 from omnibase_infra.handlers.models.model_vault_handler_response import (
     ModelVaultHandlerResponse,
 )
@@ -283,4 +293,8 @@ __all__: list[str] = [
     "ModelManifestQueryPayload",
     "ModelManifestQueryResult",
     "ModelManifestMetadata",
+    # Slack models
+    "EnumAlertSeverity",
+    "ModelSlackAlert",
+    "ModelSlackAlertResult",
 ]

--- a/src/omnibase_infra/handlers/models/enum_alert_severity.py
+++ b/src/omnibase_infra/handlers/models/enum_alert_severity.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Alert Severity Enumeration.
+
+Defines severity levels for Slack alerts with corresponding
+visual indicators for Block Kit formatting.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumAlertSeverity(str, Enum):
+    """Alert severity levels for Slack notifications.
+
+    Maps to visual indicators in Slack Block Kit messages:
+        - CRITICAL: Red circle emoji (immediate attention required)
+        - ERROR: Red circle emoji (error occurred)
+        - WARNING: Yellow circle emoji (potential issue)
+        - INFO: Blue circle emoji (informational)
+
+    Attributes:
+        CRITICAL: System-critical issue requiring immediate attention
+        ERROR: Error condition that needs investigation
+        WARNING: Warning condition that may need attention
+        INFO: Informational message
+    """
+
+    CRITICAL = "critical"
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+__all__ = ["EnumAlertSeverity"]

--- a/src/omnibase_infra/handlers/models/model_slack_alert.py
+++ b/src/omnibase_infra/handlers/models/model_slack_alert.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Slack Alert Models Re-export.
+
+This module re-exports Slack alert models from their individual files
+to maintain backwards compatibility with existing imports.
+
+Models are split per ONEX convention (one model per file):
+- enum_alert_severity.py: EnumAlertSeverity
+- model_slack_alert_payload.py: ModelSlackAlert
+- model_slack_alert_result.py: ModelSlackAlertResult
+"""
+
+from omnibase_infra.handlers.models.enum_alert_severity import EnumAlertSeverity
+from omnibase_infra.handlers.models.model_slack_alert_payload import ModelSlackAlert
+from omnibase_infra.handlers.models.model_slack_alert_result import (
+    ModelSlackAlertResult,
+)
+
+__all__ = [
+    "EnumAlertSeverity",
+    "ModelSlackAlert",
+    "ModelSlackAlertResult",
+]

--- a/src/omnibase_infra/handlers/models/model_slack_alert_payload.py
+++ b/src/omnibase_infra/handlers/models/model_slack_alert_payload.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Slack Alert Input Payload Model.
+
+Provides the input payload model for Slack alert operations.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+from omnibase_infra.handlers.models.enum_alert_severity import EnumAlertSeverity
+
+
+class ModelSlackAlert(BaseModel):
+    """Input payload for Slack alert operations.
+
+    This model defines the structure of alert payloads sent to
+    the HandlerSlackWebhook. The handler transforms this into
+    Slack Block Kit formatted messages.
+
+    Attributes:
+        severity: Alert severity level for visual formatting
+        message: Main alert message (required)
+        title: Optional alert title (defaults to severity-based title)
+        details: Optional key-value details to include in the alert
+        channel: Optional channel override (webhook default if not specified)
+        correlation_id: UUID for distributed tracing
+
+    Example:
+        >>> alert = ModelSlackAlert(
+        ...     severity=EnumAlertSeverity.WARNING,
+        ...     message="High memory usage detected",
+        ...     title="Resource Alert",
+        ...     details={"node": "registry-effect", "memory_pct": "85"},
+        ... )
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,  # Support pytest-xdist compatibility
+    )
+
+    severity: EnumAlertSeverity = Field(
+        default=EnumAlertSeverity.INFO,
+        description="Alert severity level for visual formatting",
+    )
+    message: str = Field(
+        ...,
+        min_length=1,
+        max_length=3000,
+        description="Main alert message content",
+    )
+    title: str | None = Field(
+        default=None,
+        max_length=150,
+        description="Optional alert title (defaults to severity-based title)",
+    )
+    details: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Additional key-value details to include in the alert",
+    )
+    channel: str | None = Field(
+        default=None,
+        description="Optional channel override (uses webhook default if not specified)",
+    )
+    correlation_id: UUID = Field(
+        default_factory=uuid4,
+        description="UUID for distributed tracing",
+    )
+
+
+__all__ = ["ModelSlackAlert"]

--- a/src/omnibase_infra/handlers/models/model_slack_alert_result.py
+++ b/src/omnibase_infra/handlers/models/model_slack_alert_result.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Slack Alert Result Model.
+
+Provides the response model for Slack webhook operations.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelSlackAlertResult(BaseModel):
+    """Response from Slack webhook operations.
+
+    This model captures the result of a Slack alert send operation,
+    including success/failure status, timing, and retry information.
+
+    Attributes:
+        success: Whether the alert was delivered successfully
+        duration_ms: Time taken for the operation in milliseconds
+        correlation_id: UUID from the original request for tracing
+        error: Sanitized error message if success is False
+        error_code: Error code for programmatic handling
+        retry_count: Number of retry attempts made
+
+    Example:
+        >>> result = ModelSlackAlertResult(
+        ...     success=True,
+        ...     duration_ms=123.45,
+        ...     correlation_id=uuid4(),
+        ... )
+        >>> print(result.success)
+        True
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    success: bool = Field(
+        ...,
+        description="Whether the alert was delivered successfully",
+    )
+    duration_ms: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Time taken for the operation in milliseconds",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="UUID from the original request for tracing",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Sanitized error message if success is False",
+    )
+    error_code: str | None = Field(
+        default=None,
+        description="Error code for programmatic handling",
+    )
+    retry_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of retry attempts made",
+    )
+
+
+__all__ = ["ModelSlackAlertResult"]

--- a/src/omnibase_infra/nodes/node_slack_alerter_effect/__init__.py
+++ b/src/omnibase_infra/nodes/node_slack_alerter_effect/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Slack Alerter Effect Node - Declarative Slack webhook alerting.
+
+This module exports the declarative NodeSlackAlerterEffect for sending
+infrastructure alerts to Slack via webhooks.
+
+Architecture:
+    This node follows the ONEX declarative pattern:
+    - DECLARATIVE effect driven by contract.yaml
+    - Zero custom routing logic - all behavior from handler_routing
+    - Lightweight shell that delegates to HandlerSlackWebhook
+    - Pattern: "Contract-driven, handlers wired externally"
+
+Example:
+    >>> from omnibase_core.models.container import ModelONEXContainer
+    >>> from omnibase_infra.nodes.node_slack_alerter_effect import NodeSlackAlerterEffect
+    >>> from omnibase_infra.handlers import HandlerSlackWebhook
+    >>>
+    >>> container = ModelONEXContainer()
+    >>> node = NodeSlackAlerterEffect(container)
+    >>>
+    >>> # Handler receives dependencies via constructor
+    >>> handler = HandlerSlackWebhook()
+    >>> # result = await handler.handle(alert)
+
+Related Tickets:
+    - OMN-1905: Add declarative Slack webhook handler to omnibase_infra
+"""
+
+from omnibase_infra.nodes.node_slack_alerter_effect.node import NodeSlackAlerterEffect
+
+__all__ = ["NodeSlackAlerterEffect"]

--- a/src/omnibase_infra/nodes/node_slack_alerter_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_slack_alerter_effect/contract.yaml
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+#
+# ONEX Node Contract
+# Node: NodeSlackAlerterEffect
+#
+# This contract defines the interface for the Slack Alerter Effect node,
+# which sends infrastructure alerts to Slack via webhooks. The node uses
+# declarative operation routing to dispatch operations to the handler.
+#
+# Related Tickets:
+#   - OMN-1905: Add declarative Slack webhook handler to omnibase_infra
+# Contract identifiers
+name: "node_slack_alerter_effect"
+contract_name: "node_slack_alerter_effect"
+node_name: "node_slack_alerter_effect"
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+node_version:
+  major: 1
+  minor: 0
+  patch: 0
+# Node type
+node_type: "EFFECT_GENERIC"
+# Description
+description: >
+  Effect node for Slack webhook alerting. Sends infrastructure alerts to Slack channels using incoming webhooks with Block Kit formatting, retry with exponential backoff, and rate limit handling. Uses declarative operation routing to dispatch to the HandlerSlackWebhook.
+
+# Strongly typed I/O models
+input_model:
+  name: "ModelSlackAlert"
+  module: "omnibase_infra.handlers.models.model_slack_alert"
+  description: "Input model containing alert severity, message, and optional details."
+output_model:
+  name: "ModelSlackAlertResult"
+  module: "omnibase_infra.handlers.models.model_slack_alert"
+  description: "Output model containing delivery status, timing, and error information."
+# =============================================================================
+# HANDLER ROUTING (Declarative Handler Dispatch)
+# =============================================================================
+# This section defines how operations are routed to the Slack webhook handler.
+# The routing strategy determines handler selection based on operation type.
+#
+# Design Rationale:
+#   - Single handler for all Slack operations
+#   - Block Kit formatting for rich messages
+#   - Retry with exponential backoff for resilience
+#   - Rate limit handling for graceful degradation
+#
+# Execution Flow:
+#   1. Receive ModelSlackAlert with operation type
+#   2. Route to HandlerSlackWebhook based on operation
+#   3. Execute webhook delivery with retry logic
+#   4. Return ModelSlackAlertResult with delivery status
+# =============================================================================
+handler_routing:
+  routing_strategy: "operation_match"
+  handlers:
+    # Send Alert - Formatted Block Kit message
+    # Sends a rich formatted alert with severity, message, and details.
+    - operation: "send_alert"
+      handler:
+        name: "HandlerSlackWebhook"
+        module: "omnibase_infra.handlers.handler_slack_webhook"
+      description: "Send formatted alert to Slack with Block Kit formatting"
+      output_fields:
+        - success
+        - duration_ms
+        - retry_count
+    # Send Message - Plain text message
+    # Sends a simple text message (uses same handler, alert formatting applied)
+    - operation: "send_message"
+      handler:
+        name: "HandlerSlackWebhook"
+        module: "omnibase_infra.handlers.handler_slack_webhook"
+      description: "Send message to Slack channel"
+      output_fields:
+        - success
+        - duration_ms
+        - retry_count
+# =============================================================================
+# ERROR HANDLING (Retry + Rate Limiting)
+# =============================================================================
+# Error handling configuration for Slack webhook operations.
+# Uses retry with exponential backoff and handles rate limiting gracefully.
+#
+# Note: The handler implements its own retry logic internally rather than
+# relying on external retry orchestration. This ensures consistent behavior
+# and proper rate limit handling.
+# =============================================================================
+error_handling:
+  # Retry policy with exponential backoff
+  retry_policy:
+    max_retries: 3
+    initial_delay_ms: 1000
+    max_delay_ms: 4000
+    exponential_base: 2
+    retry_on:
+      - "SLACK_RATE_LIMITED"
+      - "SLACK_TIMEOUT"
+      - "SLACK_CONNECTION_ERROR"
+      - "SLACK_CLIENT_ERROR"
+  # Error type definitions
+  error_types:
+    - name: "SLACK_NOT_CONFIGURED"
+      description: "SLACK_WEBHOOK_URL environment variable not set"
+      recoverable: false
+      retry_strategy: "none"
+    - name: "SLACK_RATE_LIMITED"
+      description: "Slack returned HTTP 429 rate limit"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "SLACK_TIMEOUT"
+      description: "Webhook request timed out"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "SLACK_CONNECTION_ERROR"
+      description: "Failed to connect to Slack webhook"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "SLACK_CLIENT_ERROR"
+      description: "HTTP client error during request"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "SLACK_HTTP_4XX"
+      description: "Slack returned HTTP 4xx error (non-429)"
+      recoverable: false
+      retry_strategy: "none"
+    - name: "SLACK_HTTP_5XX"
+      description: "Slack returned HTTP 5xx error"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+# IO operations (EFFECT node specific)
+io_operations:
+  - operation: "send_alert"
+    description: "Send a formatted alert to Slack with Block Kit formatting"
+    input_fields:
+      - severity
+      - message
+      - title
+      - details
+      - channel
+      - correlation_id
+    output_fields:
+      - success
+      - duration_ms
+      - correlation_id
+      - error
+      - error_code
+      - retry_count
+  - operation: "send_message"
+    description: "Send a plain text message to Slack"
+    input_fields:
+      - message
+      - channel
+      - correlation_id
+    output_fields:
+      - success
+      - duration_ms
+      - correlation_id
+      - error
+      - error_code
+      - retry_count
+# Dependencies (protocols this node requires)
+dependencies:
+  - name: "http_client"
+    type: "library"
+    library: "aiohttp"
+    description: "Async HTTP client for webhook requests"
+  - name: "slack_webhook_url"
+    type: "environment"
+    env_var: "SLACK_WEBHOOK_URL"
+    description: "Slack incoming webhook URL"
+    required: true
+# Capabilities provided by this node
+capabilities:
+  - name: "slack_alerting"
+    description: "Send infrastructure alerts to Slack channels"
+  - name: "block_kit_formatting"
+    description: "Format messages using Slack Block Kit for rich display"
+  - name: "retry_with_backoff"
+    description: "Retry failed requests with exponential backoff"
+  - name: "rate_limit_handling"
+    description: "Handle Slack rate limiting gracefully"
+# Model definitions
+definitions:
+  ModelSlackAlert:
+    type: object
+    description: "Input payload for Slack alert operations"
+    frozen: true
+    extra: "forbid"
+    properties:
+      severity:
+        type: enum
+        enum_class: "EnumAlertSeverity"
+        module: "omnibase_infra.handlers.models.model_slack_alert"
+        description: "Alert severity level for visual formatting"
+        default: "info"
+        enum:
+          - "critical"
+          - "error"
+          - "warning"
+          - "info"
+      message:
+        type: string
+        description: "Main alert message content"
+        min_length: 1
+        max_length: 3000
+      title:
+        type: string
+        nullable: true
+        default: null
+        max_length: 150
+        description: "Optional alert title"
+      details:
+        type: object
+        key_type: string
+        value_type: any
+        description: "Additional key-value details"
+        default_factory: "dict"
+      channel:
+        type: string
+        nullable: true
+        default: null
+        description: "Optional channel override"
+      correlation_id:
+        type: uuid
+        description: "UUID for distributed tracing"
+        default_factory: "uuid4"
+    required:
+      - message
+  ModelSlackAlertResult:
+    type: object
+    description: "Response from Slack webhook operations"
+    frozen: true
+    extra: "forbid"
+    properties:
+      success:
+        type: boolean
+        description: "Whether the alert was delivered successfully"
+      duration_ms:
+        type: float
+        description: "Time taken for the operation in milliseconds"
+        default: 0.0
+        ge: 0.0
+      correlation_id:
+        type: uuid
+        description: "UUID from the original request"
+      error:
+        type: string
+        nullable: true
+        default: null
+        description: "Sanitized error message if success is False"
+      error_code:
+        type: string
+        nullable: true
+        default: null
+        description: "Error code for programmatic handling"
+      retry_count:
+        type: integer
+        description: "Number of retry attempts made"
+        default: 0
+        ge: 0
+    required:
+      - success
+      - correlation_id
+# Health check configuration
+health_check:
+  enabled: true
+  endpoint: "/health"
+  interval_seconds: 30
+  checks:
+    - name: "webhook_configured"
+      check_type: "environment"
+      env_var: "SLACK_WEBHOOK_URL"
+      description: "Verify SLACK_WEBHOOK_URL is configured"
+# Metadata
+metadata:
+  author: "OmniNode Team"
+  license: "MIT"
+  created: "2026-02-04"
+  updated: "2026-02-04"
+  tags:
+    - effect
+    - slack
+    - alerting
+    - webhook
+    - infrastructure
+    - block-kit

--- a/src/omnibase_infra/nodes/node_slack_alerter_effect/node.py
+++ b/src/omnibase_infra/nodes/node_slack_alerter_effect/node.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Node Slack Alerter Effect - Declarative effect node for Slack alerting.
+
+This node follows the ONEX declarative pattern:
+    - DECLARATIVE effect driven by contract.yaml
+    - Zero custom routing logic - all behavior from handler_routing
+    - Lightweight shell that delegates to handlers via container resolution
+    - Used for ONEX-compliant runtime execution via RuntimeHostProcess
+    - Pattern: "Contract-driven, handlers wired externally"
+
+Extends NodeEffect from omnibase_core for infrastructure I/O operations.
+All handler routing is 100% driven by contract.yaml, not Python code.
+
+Handler Routing Pattern:
+    1. Receive alert request (input_model in contract)
+    2. Route to appropriate handler based on operation (handler_routing)
+    3. Execute infrastructure I/O via handler (Slack webhook)
+    4. Return structured response (output_model in contract)
+
+Design Decisions:
+    - 100% Contract-Driven: All routing logic in YAML, not Python
+    - Zero Custom Routing: Base class handles handler dispatch via contract
+    - Declarative Handlers: handler_routing section defines dispatch rules
+    - Container DI: Handler dependencies resolved via container
+
+Node Responsibilities:
+    - Define I/O model contract (ModelSlackAlert -> ModelSlackAlertResult)
+    - Delegate all execution to handlers via base class
+    - NO custom logic - pure declarative shell
+
+The actual handler execution and routing is performed by:
+    - Direct handler invocation by callers
+    - Or orchestrator layer for workflow coordination
+
+Handlers receive their dependencies directly via constructor injection:
+    - HandlerSlackWebhook(webhook_url, http_session)
+
+Coroutine Safety:
+    This node is async-safe. Handler coordination is performed by the
+    caller or orchestrator layer, not by this effect node.
+
+Related Modules:
+    - contract.yaml: Handler routing and I/O model definitions
+    - ../../handlers/handler_slack_webhook.py: Webhook handler implementation
+    - ../../handlers/models/model_slack_alert.py: Alert payload models
+
+Related Tickets:
+    - OMN-1905: Add declarative Slack webhook handler to omnibase_infra
+"""
+
+from __future__ import annotations
+
+from omnibase_core.nodes.node_effect import NodeEffect
+
+
+class NodeSlackAlerterEffect(NodeEffect):
+    """Declarative effect node for Slack webhook alerting.
+
+    This effect node is a lightweight shell that defines the I/O contract
+    for Slack alert operations. All routing and execution logic is driven
+    by contract.yaml - this class contains NO custom routing code.
+
+    Supported Operations (defined in contract.yaml handler_routing):
+        - send_alert: Send a formatted alert to Slack
+        - send_message: Send a plain text message to Slack
+
+    Dependency Injection:
+        The HandlerSlackWebhook is instantiated by callers with its
+        dependencies (webhook_url from env, optional http_session).
+        This node contains NO instance variables for the handler.
+
+    Example:
+        ```python
+        from omnibase_core.models.container import ModelONEXContainer
+        from omnibase_infra.nodes.node_slack_alerter_effect import NodeSlackAlerterEffect
+        from omnibase_infra.handlers import HandlerSlackWebhook
+        from omnibase_infra.handlers.models import ModelSlackAlert, EnumAlertSeverity
+
+        # Create effect node via container
+        container = ModelONEXContainer()
+        effect = NodeSlackAlerterEffect(container)
+
+        # Handler receives dependencies directly via constructor
+        handler = HandlerSlackWebhook()
+
+        # Create and send alert
+        alert = ModelSlackAlert(
+            severity=EnumAlertSeverity.ERROR,
+            message="Circuit breaker opened",
+            title="Infrastructure Alert",
+            details={"service": "consul", "threshold": "5"},
+        )
+        result = await handler.handle(alert)
+
+        if result.success:
+            print(f"Alert delivered in {result.duration_ms}ms")
+        else:
+            print(f"Alert failed: {result.error}")
+        ```
+    """
+
+    # Pure declarative shell - all behavior defined in contract.yaml
+
+
+__all__ = ["NodeSlackAlerterEffect"]

--- a/tests/integration/handlers/test_slack_integration.py
+++ b/tests/integration/handlers/test_slack_integration.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for HandlerSlackWebhook.
+
+Tests the handler with a mock HTTP server simulating Slack webhook responses.
+Uses pytest-httpserver for realistic HTTP interaction testing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug import Response
+
+from omnibase_infra.handlers.handler_slack_webhook import HandlerSlackWebhook
+from omnibase_infra.handlers.models.model_slack_alert import (
+    EnumAlertSeverity,
+    ModelSlackAlert,
+)
+
+
+@pytest.fixture(scope="session")
+def httpserver_ssl_context():
+    """Disable SSL for local test server."""
+    return
+
+
+class TestSlackIntegration:
+    """Integration tests using mock HTTP server."""
+
+    @pytest.fixture
+    def alert(self) -> ModelSlackAlert:
+        """Create test alert."""
+        return ModelSlackAlert(
+            severity=EnumAlertSeverity.ERROR,
+            message="Integration test alert",
+            title="Test Alert",
+            details={"test": "true", "environment": "test"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_webhook_delivery(
+        self, httpserver: HTTPServer, alert: ModelSlackAlert
+    ) -> None:
+        """Test successful webhook delivery against mock server."""
+        # Configure mock server to return 200
+        httpserver.expect_request("/webhook", method="POST").respond_with_response(
+            Response("ok", status=200)
+        )
+
+        handler = HandlerSlackWebhook(
+            webhook_url=httpserver.url_for("/webhook"),
+            timeout=5.0,
+        )
+
+        result = await handler.handle(alert)
+
+        assert result.success is True
+        assert result.duration_ms > 0
+        assert result.retry_count == 0
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_then_success(
+        self, httpserver: HTTPServer, alert: ModelSlackAlert
+    ) -> None:
+        """Test retry on 429 followed by success."""
+        # First request returns 429, second returns 200
+        call_count = [0]
+
+        def rate_limit_handler(request):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return Response("rate_limited", status=429)
+            return Response("ok", status=200)
+
+        httpserver.expect_request("/webhook", method="POST").respond_with_handler(
+            rate_limit_handler
+        )
+
+        handler = HandlerSlackWebhook(
+            webhook_url=httpserver.url_for("/webhook"),
+            max_retries=2,
+            retry_backoff=(0.1, 0.2),
+            timeout=5.0,
+        )
+
+        result = await handler.handle(alert)
+
+        assert result.success is True
+        assert result.retry_count == 1
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_server_error_exhausts_retries(
+        self, httpserver: HTTPServer, alert: ModelSlackAlert
+    ) -> None:
+        """Test that server errors exhaust retries."""
+        httpserver.expect_request("/webhook", method="POST").respond_with_response(
+            Response("Internal Server Error", status=500)
+        )
+
+        handler = HandlerSlackWebhook(
+            webhook_url=httpserver.url_for("/webhook"),
+            max_retries=2,
+            retry_backoff=(0.05, 0.1),
+            timeout=5.0,
+        )
+
+        result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_HTTP_500"
+        assert result.retry_count == 2
+
+    @pytest.mark.asyncio
+    async def test_block_kit_payload_format(
+        self, httpserver: HTTPServer, alert: ModelSlackAlert
+    ) -> None:
+        """Test that the payload sent to Slack is valid Block Kit format."""
+        received_payload = []
+
+        def capture_payload(request):
+            import json
+
+            received_payload.append(json.loads(request.data))
+            return Response("ok", status=200)
+
+        httpserver.expect_request("/webhook", method="POST").respond_with_handler(
+            capture_payload
+        )
+
+        handler = HandlerSlackWebhook(
+            webhook_url=httpserver.url_for("/webhook"),
+        )
+
+        await handler.handle(alert)
+
+        # Verify Block Kit structure
+        assert len(received_payload) == 1
+        payload = received_payload[0]
+        assert "blocks" in payload
+        blocks = payload["blocks"]
+
+        # Should have: header, divider, message section, fields section, context
+        assert len(blocks) >= 4
+
+        # Verify header block
+        header = blocks[0]
+        assert header["type"] == "header"
+        assert (
+            "Error Alert" in header["text"]["text"]
+            or "Test Alert" in header["text"]["text"]
+        )
+
+        # Verify divider
+        assert blocks[1]["type"] == "divider"
+
+        # Verify message section
+        message_section = blocks[2]
+        assert message_section["type"] == "section"
+        assert "Integration test alert" in message_section["text"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_alerts_concurrent(self, httpserver: HTTPServer) -> None:
+        """Test sending multiple alerts concurrently."""
+        import asyncio
+
+        httpserver.expect_request("/webhook", method="POST").respond_with_response(
+            Response("ok", status=200)
+        )
+
+        handler = HandlerSlackWebhook(
+            webhook_url=httpserver.url_for("/webhook"),
+        )
+
+        alerts = [
+            ModelSlackAlert(
+                severity=EnumAlertSeverity.INFO,
+                message=f"Concurrent alert {i}",
+            )
+            for i in range(5)
+        ]
+
+        results = await asyncio.gather(*[handler.handle(alert) for alert in alerts])
+
+        assert all(r.success for r in results)
+        assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_connection_to_unreachable_server(
+        self, alert: ModelSlackAlert
+    ) -> None:
+        """Test handling of unreachable server."""
+        handler = HandlerSlackWebhook(
+            webhook_url="http://127.0.0.1:1",  # Unreachable port
+            max_retries=1,
+            retry_backoff=(0.1,),
+            timeout=1.0,
+        )
+
+        result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_CONNECTION_ERROR"

--- a/tests/unit/handlers/test_handler_slack_webhook.py
+++ b/tests/unit/handlers/test_handler_slack_webhook.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerSlackWebhook.
+
+Tests the Slack webhook handler's core functionality including:
+- Block Kit message formatting
+- Retry logic with exponential backoff
+- Rate limit handling (HTTP 429)
+- Error handling and sanitization
+- Configuration validation
+
+All tests use mocked HTTP responses to avoid external dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import aiohttp
+import pytest
+
+from omnibase_infra.handlers.handler_slack_webhook import (
+    _DEFAULT_MAX_RETRIES,
+    _DEFAULT_RETRY_BACKOFF_SECONDS,
+    _SEVERITY_EMOJI,
+    _SEVERITY_TITLES,
+    HandlerSlackWebhook,
+)
+from omnibase_infra.handlers.models.model_slack_alert import (
+    EnumAlertSeverity,
+    ModelSlackAlert,
+    ModelSlackAlertResult,
+)
+
+
+class TestModelSlackAlert:
+    """Tests for ModelSlackAlert input model."""
+
+    def test_minimal_alert(self) -> None:
+        """Test creating an alert with only required fields."""
+        alert = ModelSlackAlert(message="Test message")
+
+        assert alert.message == "Test message"
+        assert alert.severity == EnumAlertSeverity.INFO
+        assert alert.title is None
+        assert alert.details == {}
+        assert alert.channel is None
+        assert alert.correlation_id is not None
+
+    def test_full_alert(self) -> None:
+        """Test creating an alert with all fields."""
+        correlation_id = uuid4()
+        alert = ModelSlackAlert(
+            severity=EnumAlertSeverity.CRITICAL,
+            message="Critical error occurred",
+            title="System Alert",
+            details={"service": "consul", "error_code": "CONN_FAILED"},
+            channel="#alerts",
+            correlation_id=correlation_id,
+        )
+
+        assert alert.severity == EnumAlertSeverity.CRITICAL
+        assert alert.message == "Critical error occurred"
+        assert alert.title == "System Alert"
+        assert alert.details == {"service": "consul", "error_code": "CONN_FAILED"}
+        assert alert.channel == "#alerts"
+        assert alert.correlation_id == correlation_id
+
+    def test_alert_is_frozen(self) -> None:
+        """Test that ModelSlackAlert is immutable."""
+        alert = ModelSlackAlert(message="Test")
+        with pytest.raises(Exception):  # Pydantic raises ValidationError for frozen
+            alert.message = "Changed"  # type: ignore[misc]
+
+
+class TestModelSlackAlertResult:
+    """Tests for ModelSlackAlertResult output model."""
+
+    def test_success_result(self) -> None:
+        """Test creating a successful result."""
+        correlation_id = uuid4()
+        result = ModelSlackAlertResult(
+            success=True,
+            duration_ms=123.45,
+            correlation_id=correlation_id,
+            retry_count=0,
+        )
+
+        assert result.success is True
+        assert result.duration_ms == 123.45
+        assert result.correlation_id == correlation_id
+        assert result.error is None
+        assert result.error_code is None
+        assert result.retry_count == 0
+
+    def test_failure_result(self) -> None:
+        """Test creating a failure result."""
+        correlation_id = uuid4()
+        result = ModelSlackAlertResult(
+            success=False,
+            duration_ms=500.0,
+            correlation_id=correlation_id,
+            error="Connection failed",
+            error_code="SLACK_CONNECTION_ERROR",
+            retry_count=3,
+        )
+
+        assert result.success is False
+        assert result.error == "Connection failed"
+        assert result.error_code == "SLACK_CONNECTION_ERROR"
+        assert result.retry_count == 3
+
+
+class TestHandlerSlackWebhook:
+    """Tests for HandlerSlackWebhook."""
+
+    @pytest.fixture
+    def webhook_url(self) -> str:
+        """Return test webhook URL."""
+        return "https://hooks.slack.com/services/T00/B00/XXX"
+
+    @pytest.fixture
+    def handler(self, webhook_url: str) -> HandlerSlackWebhook:
+        """Create handler with test webhook URL."""
+        return HandlerSlackWebhook(
+            webhook_url=webhook_url,
+            max_retries=2,
+            retry_backoff=(0.01, 0.02),  # Fast retries for testing
+            timeout=1.0,
+        )
+
+    @pytest.fixture
+    def alert(self) -> ModelSlackAlert:
+        """Create test alert."""
+        return ModelSlackAlert(
+            severity=EnumAlertSeverity.ERROR,
+            message="Test error message",
+            title="Test Alert",
+            details={"key": "value"},
+        )
+
+    def test_handler_initialization_with_url(self, webhook_url: str) -> None:
+        """Test handler initializes with provided URL."""
+        handler = HandlerSlackWebhook(webhook_url=webhook_url)
+        assert handler._webhook_url == webhook_url
+
+    def test_handler_initialization_from_env(self) -> None:
+        """Test handler reads URL from environment."""
+        with patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://test.slack.com"}):
+            handler = HandlerSlackWebhook()
+            assert handler._webhook_url == "https://test.slack.com"
+
+    def test_handler_initialization_no_url(self) -> None:
+        """Test handler with no URL configured."""
+        with patch.dict("os.environ", {}, clear=True):
+            handler = HandlerSlackWebhook(webhook_url=None)
+            assert handler._webhook_url == ""
+
+    @pytest.mark.asyncio
+    async def test_handle_success(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test successful alert delivery."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(return_value=mock_response)
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is True
+        assert result.duration_ms > 0
+        assert result.correlation_id == alert.correlation_id
+        assert result.retry_count == 0
+
+    @pytest.mark.asyncio
+    async def test_handle_not_configured(self, alert: ModelSlackAlert) -> None:
+        """Test handling when webhook URL is not configured."""
+        handler = HandlerSlackWebhook(webhook_url="")
+        result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error == "SLACK_WEBHOOK_URL not configured"
+        assert result.error_code == "SLACK_NOT_CONFIGURED"
+
+    @pytest.mark.asyncio
+    async def test_handle_rate_limited_with_retry(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test retry on rate limit (429)."""
+        # First call returns 429, second returns 200
+        mock_response_429 = AsyncMock()
+        mock_response_429.status = 429
+        mock_response_429.__aenter__ = AsyncMock(return_value=mock_response_429)
+        mock_response_429.__aexit__ = AsyncMock(return_value=None)
+
+        mock_response_200 = AsyncMock()
+        mock_response_200.status = 200
+        mock_response_200.__aenter__ = AsyncMock(return_value=mock_response_200)
+        mock_response_200.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(
+            side_effect=[mock_response_429, mock_response_200]
+        )
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is True
+        assert result.retry_count == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_rate_limited_exhausted(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test failure when retries exhausted on rate limit."""
+        mock_response = AsyncMock()
+        mock_response.status = 429
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(return_value=mock_response)
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_RATE_LIMITED"
+        assert result.retry_count == 2  # max_retries=2
+
+    @pytest.mark.asyncio
+    async def test_handle_timeout(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test timeout handling."""
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(side_effect=TimeoutError())
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_TIMEOUT"
+        assert result.error == "Request timeout"
+
+    @pytest.mark.asyncio
+    async def test_handle_connection_error(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test connection error handling."""
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(
+            side_effect=aiohttp.ClientConnectorError(
+                connection_key=MagicMock(), os_error=OSError("Connection refused")
+            )
+        )
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_CONNECTION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_handle_http_error(
+        self, handler: HandlerSlackWebhook, alert: ModelSlackAlert
+    ) -> None:
+        """Test HTTP error handling."""
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(return_value=mock_response)
+        mock_session.close = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await handler.handle(alert)
+
+        assert result.success is False
+        assert result.error_code == "SLACK_HTTP_500"
+
+
+class TestBlockKitFormatting:
+    """Tests for Block Kit message formatting."""
+
+    @pytest.fixture
+    def handler(self) -> HandlerSlackWebhook:
+        """Create handler for formatting tests."""
+        return HandlerSlackWebhook(webhook_url="https://test.slack.com")
+
+    def test_format_critical_alert(self, handler: HandlerSlackWebhook) -> None:
+        """Test formatting critical severity alert."""
+        alert = ModelSlackAlert(
+            severity=EnumAlertSeverity.CRITICAL,
+            message="System is down",
+        )
+        payload = handler._format_block_kit_message(alert)
+
+        assert "blocks" in payload
+        blocks = payload["blocks"]
+        header = blocks[0]
+        assert header["type"] == "header"
+        assert ":red_circle:" in header["text"]["text"]
+        assert "Critical Alert" in header["text"]["text"]
+
+    def test_format_with_custom_title(self, handler: HandlerSlackWebhook) -> None:
+        """Test formatting with custom title."""
+        alert = ModelSlackAlert(
+            severity=EnumAlertSeverity.WARNING,
+            message="High memory usage",
+            title="Resource Warning",
+        )
+        payload = handler._format_block_kit_message(alert)
+
+        header = payload["blocks"][0]
+        assert "Resource Warning" in header["text"]["text"]
+
+    def test_format_with_details(self, handler: HandlerSlackWebhook) -> None:
+        """Test formatting with detail fields."""
+        alert = ModelSlackAlert(
+            severity=EnumAlertSeverity.ERROR,
+            message="Connection failed",
+            details={"service": "postgres", "retry_count": "3"},
+        )
+        payload = handler._format_block_kit_message(alert)
+
+        blocks = payload["blocks"]
+        # Find fields section
+        fields_block = None
+        for block in blocks:
+            if block.get("type") == "section" and "fields" in block:
+                fields_block = block
+                break
+
+        assert fields_block is not None
+        fields = fields_block["fields"]
+        assert len(fields) == 2
+
+    def test_format_message_at_max_length(self, handler: HandlerSlackWebhook) -> None:
+        """Test that messages at max length are handled correctly."""
+        # Model enforces max_length=3000, so use max allowed length
+        max_message = "x" * 3000
+        alert = ModelSlackAlert(message=max_message)
+        payload = handler._format_block_kit_message(alert)
+
+        message_block = payload["blocks"][2]  # After header and divider
+        # Message should be exactly 3000 chars (at the Slack limit)
+        assert len(message_block["text"]["text"]) == 3000
+
+    def test_format_correlation_id_context(self, handler: HandlerSlackWebhook) -> None:
+        """Test that correlation ID is included in context."""
+        correlation_id = uuid4()
+        alert = ModelSlackAlert(message="Test", correlation_id=correlation_id)
+        payload = handler._format_block_kit_message(alert)
+
+        # Find context block (last block)
+        context_block = payload["blocks"][-1]
+        assert context_block["type"] == "context"
+        assert str(correlation_id)[:16] in context_block["elements"][0]["text"]
+
+
+class TestSeverityMappings:
+    """Tests for severity emoji and title mappings."""
+
+    def test_all_severities_have_emoji(self) -> None:
+        """Test that all severity levels have emoji mappings."""
+        for severity in EnumAlertSeverity:
+            assert severity in _SEVERITY_EMOJI
+
+    def test_all_severities_have_titles(self) -> None:
+        """Test that all severity levels have title mappings."""
+        for severity in EnumAlertSeverity:
+            assert severity in _SEVERITY_TITLES
+
+    def test_emoji_format(self) -> None:
+        """Test that emojis use Slack colon format."""
+        for emoji in _SEVERITY_EMOJI.values():
+            assert emoji.startswith(":")
+            assert emoji.endswith(":")


### PR DESCRIPTION
## Summary

Add infrastructure alerting capability via Slack webhooks following the ONEX declarative node pattern.

- **HandlerSlackWebhook**: Async handler with Block Kit formatting, retry with exponential backoff, and 429 rate limit handling
- **EnumAlertSeverity**: Severity levels (critical/error/warning/info)  
- **ModelSlackAlert/ModelSlackAlertResult**: Type-safe frozen Pydantic models
- **NodeSlackAlerterEffect**: Pure declarative effect node (NO custom logic)
- **contract.yaml**: ONEX contract with `operation_match` routing strategy

### Features

- Configurable via `SLACK_WEBHOOK_URL` environment variable
- Correlation ID tracking for distributed tracing
- Exponential backoff retry (1s → 2s → 4s)
- 429 rate limit handling with graceful degradation
- Error sanitization to prevent credential exposure

### Files

| File | Description |
|------|-------------|
| `handlers/handler_slack_webhook.py` | Handler with Block Kit, retry, rate limiting |
| `handlers/models/enum_alert_severity.py` | Severity enum |
| `handlers/models/model_slack_alert_payload.py` | Input model |
| `handlers/models/model_slack_alert_result.py` | Result model |
| `nodes/node_slack_alerter_effect/` | Declarative effect node |

## Test plan

- [x] Unit tests pass (23 tests)
- [x] Integration tests pass (6 tests with mock HTTP server)
- [x] Type check passes (mypy)
- [x] Linting passes (ruff)
- [x] ONEX architecture validation passes

## Related

- **Ticket**: [OMN-1905](https://linear.app/omninode/issue/OMN-1905)
- **Blocks**: OMN-1895 (Wiring Health Monitor alerting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added infrastructure alert delivery to Slack via webhook integration
  * Supports multiple alert severity levels with visual formatting
  * Includes automatic retry logic with exponential backoff and rate-limit handling
  * Provides correlation ID tracking for distributed tracing of alerts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->