### PR TITLE
fix(OMN-1895): Add missing pytest unit marker

### DIFF
--- a/tests/unit/observability/wiring_health/test_mixin_emission_counter.py
+++ b/tests/unit/observability/wiring_health/test_mixin_emission_counter.py
@@ -8,6 +8,8 @@ import asyncio
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from omnibase_infra.event_bus.topic_constants import WIRING_HEALTH_MONITORED_TOPICS
 from omnibase_infra.observability.wiring_health import MixinEmissionCounter
 


### PR DESCRIPTION
## Summary

- Adds missing `pytestmark = pytest.mark.unit` to `test_mixin_emission_counter.py`
- Ensures consistency with other test files in the wiring health module (`test_mixin_consumption_counter.py`, `test_wiring_health_checker.py`)

## Context

This fix was identified during local code review after PR #245 was merged. The missing marker means tests in this file wouldn't be properly categorized when running filtered test suites (e.g., `pytest -m unit`).

## Test plan

- [x] Tests pass: `poetry run pytest tests/unit/observability/wiring_health/ -v`
- [x] Marker is now consistent across all test files in the module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test organization with enhanced categorization infrastructure for more efficient test selection and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->