### PR TITLE
chore(deps): bump omnibase-core to ^0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the ONEX Infrastructure (omnibase_infra) will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-02-06
+
+### Changed
+
+#### Dependencies
+- Update `omnibase-core` from `^0.14.0` to `^0.15.0`
+
 ## [0.4.0] - 2026-02-05
 
 ### Breaking Changes
@@ -74,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `omnibase-core` from `^0.13.1` to `^0.14.0`
 
 ## [0.3.2] - 2026-02-02
+
 
 ### Changed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2915,14 +2915,14 @@ files = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.14.0"
+version = "0.15.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "omnibase_core-0.14.0-py3-none-any.whl", hash = "sha256:695ff9b45e8f7e3f235cb339995763f16e0b42fa0c70d811edb19315db515f1f"},
-    {file = "omnibase_core-0.14.0.tar.gz", hash = "sha256:8b51a3f14311f6a8d5bd4040be6e4920c7194d01ac6c03f3032d7f8e72511544"},
+    {file = "omnibase_core-0.15.0-py3-none-any.whl", hash = "sha256:c4146af9831706715f05144575a931e4dc6969a6d3f0ba3261a081c4143dd531"},
+    {file = "omnibase_core-0.15.0.tar.gz", hash = "sha256:6a8bb4b62a552d62770b1a8c1aae806b175aa4802719a37976a9f68170b982d4"},
 ]
 
 [package.dependencies]
@@ -2939,8 +2939,9 @@ pyyaml = ">=6.0.2,<7.0.0"
 [package.extras]
 cache = ["redis (>=5.0.0,<6.0.0)"]
 cli = ["psutil"]
-full = ["prometheus-client (>=0.21.0,<1.0.0)", "psutil", "redis (>=5.0.0,<6.0.0)"]
+full = ["prometheus-client (>=0.21.0,<1.0.0)", "psutil", "redis (>=5.0.0,<6.0.0)", "sqlglot (>=26.0.0,<27.0.0)"]
 metrics = ["prometheus-client (>=0.21.0,<1.0.0)"]
+sql-parser = ["sqlglot (>=26.0.0,<27.0.0)"]
 
 [[package]]
 name = "omnibase-spi"
@@ -5332,4 +5333,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "648ff3ae6d7222034e18fbbc59c3e173378e57ca9fe5236db58853ae05d5141d"
+content-hash = "8dbc6f7bfbe84860bab03abc20f48d81b3976ca9aeca8e267b8b320abf86b169"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnibase_infra"
-version = "0.4.0"
+version = "0.4.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = ["OmniNode Team <team@omninode.ai>"]
 license = "MIT"
@@ -36,9 +36,9 @@ python = "^3.12"
 #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
 # Remember to switch back to PyPI versions before merging to main.
 #
-# omnibase-core v0.14.0: Latest core release
-# (v0.13.1 included: Contract registration support)
-omnibase-core = "^0.14.0"
+# omnibase-core v0.15.0: Latest core release
+# (v0.14.0 included: Subscribe signature change, ModelEmitterIdentity)
+omnibase-core = "^0.15.0"
 # omnibase-spi v0.6.4: Version bump
 omnibase-spi = "^0.6.4"
 

--- a/src/omnibase_infra/__init__.py
+++ b/src/omnibase_infra/__init__.py
@@ -76,7 +76,7 @@ See Also
 - Runtime kernel: omnibase_infra.runtime.service_kernel
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from . import (
     enums,


### PR DESCRIPTION
## Summary
- Bump `omnibase-core` dependency from `^0.14.0` to `^0.15.0`
- Bump package version from `0.4.0` to `0.4.1`

## Changes
- `pyproject.toml`: version `0.4.1`, `omnibase-core = "^0.15.0"`
- `src/omnibase_infra/__init__.py`: `__version__ = "0.4.1"`
- `CHANGELOG.md`: New `[0.4.1]` entry
- `poetry.lock`: Resolved to `omnibase-core==0.15.0`

## Test plan
- [ ] CI passes with new core dependency
- [ ] No breaking changes from core 0.15.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.1.
  * Updated omnibase-core dependency to ^0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->