### PR TITLE
fix(OMN-1992): Follow-up review fixes for PluginIntelligence bootstrap

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -867,7 +867,10 @@ class PluginRegistration:
 
         # Duck typing: check for subscribe capability rather than concrete type
         # Per CLAUDE.md: "Protocol Resolution - Duck typing through protocols, never isinstance"
-        if not hasattr(config.event_bus, "subscribe"):
+        if not (
+            hasattr(config.event_bus, "subscribe")
+            and callable(getattr(config.event_bus, "subscribe", None))
+        ):
             return ModelDomainPluginResult.skipped(
                 plugin_id=self.plugin_id,
                 reason="Event bus does not support subscribe",

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -730,6 +730,11 @@ async def bootstrap() -> int:
                 version=config.contract_version or "v1",
             )
         else:
+            # Graceful degradation (OMN-1992): config.name absence is logged
+            # rather than raising ProtocolConfigurationError so kernels with
+            # optional introspection can still boot.  Plugins that require
+            # node_identity (e.g. PluginRegistration.start_consumers) will
+            # return a "skipped" result instead of failing.
             logger.error(
                 "runtime_config.yaml missing 'name' field — plugin consumers "
                 "will not subscribe to introspection events. "


### PR DESCRIPTION
## Summary

Follow-up to #262 — one review fix commit that was created locally but not pushed before the PR merged.

- **plugin.py**: Strengthened `subscribe` duck-typing check to also verify `callable()`, aligning with the kernel's contract registry pattern (`hasattr` + `callable` guard)
- **service_kernel.py**: Documented the `config.name` graceful degradation as intentional OMN-1992 behavior, not a regression from fail-fast

## Test plan

- [ ] Pre-commit hooks pass (mypy, architecture validation) — verified on push
- [ ] Existing PluginRegistration and kernel bootstrap tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Strengthened event bus validation to ensure the subscribe capability is callable and operational before use, preventing potential silent failures during event system startup
- Enhanced service kernel boot resilience to gracefully degrade when required configuration name fields are missing, enabling continued operation in limited capacity instead of halting startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->