### PR TITLE
feat(OMN-2012): Add ModelPluginDiscoveryReport + PluginDiscoveryEntry

### DIFF
--- a/src/omnibase_infra/runtime/models/__init__.py
+++ b/src/omnibase_infra/runtime/models/__init__.py
@@ -57,8 +57,9 @@ Exports:
     ModelBindingConfigResolverConfig: Configuration for BindingConfigResolver
     ModelConfigCacheEntry: Internal cache entry for BindingConfigResolver
     ModelSecurityConfig: Security configuration for handler namespace allowlisting
-    PluginDiscoveryEntry: Single entry-point discovery result
+    ModelPluginDiscoveryEntry: Single entry-point discovery result
     ModelPluginDiscoveryReport: Structured report for plugin discovery pass
+    PluginDiscoveryStatus: Literal type for plugin discovery entry statuses
 """
 
 # Re-export from omnibase_core for convenience
@@ -133,9 +134,12 @@ from omnibase_infra.runtime.models.model_optional_correlation_id import (
 )
 from omnibase_infra.runtime.models.model_optional_string import ModelOptionalString
 from omnibase_infra.runtime.models.model_optional_uuid import ModelOptionalUUID
+from omnibase_infra.runtime.models.model_plugin_discovery_entry import (
+    ModelPluginDiscoveryEntry,
+    PluginDiscoveryStatus,
+)
 from omnibase_infra.runtime.models.model_plugin_discovery_report import (
     ModelPluginDiscoveryReport,
-    PluginDiscoveryEntry,
 )
 from omnibase_infra.runtime.models.model_policy_context import ModelPolicyContext
 from omnibase_infra.runtime.models.model_policy_key import ModelPolicyKey
@@ -260,6 +264,7 @@ __all__: list[str] = [
     "ModelMaterializerConfig",
     "ModelPostgresPoolConfig",
     # Plugin discovery models (OMN-2012)
+    "ModelPluginDiscoveryEntry",
     "ModelPluginDiscoveryReport",
-    "PluginDiscoveryEntry",
+    "PluginDiscoveryStatus",
 ]

--- a/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
+++ b/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Plugin discovery entry model.
+
+This module provides the ModelPluginDiscoveryEntry dataclass and the
+PluginDiscoveryStatus Literal type for structured diagnostics of
+individual plugin entry-point discovery outcomes.
+
+Design Pattern:
+    Each entry records the disposition of a single entry-point discovered
+    via ``importlib.metadata``, making "why didn't my plugin load?" a
+    10-second debugging problem.
+
+Thread Safety:
+    The dataclass uses ``frozen=True`` to prevent attribute reassignment
+    after construction.
+
+Example:
+    >>> from omnibase_infra.runtime.models import ModelPluginDiscoveryEntry
+    >>>
+    >>> entry = ModelPluginDiscoveryEntry(
+    ...     entry_point_name="my_plugin",
+    ...     module_path="myapp.plugins.my_plugin",
+    ...     status="accepted",
+    ...     plugin_id="my_plugin",
+    ... )
+    >>> entry.status
+    'accepted'
+
+Related:
+    - OMN-2012: Create ModelPluginDiscoveryReport + ModelPluginDiscoveryEntry
+    - OMN-1346: Registration Code Extraction
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PluginDiscoveryStatus = Literal[
+    "accepted",
+    "namespace_rejected",
+    "import_error",
+    "instantiation_error",
+    "protocol_invalid",
+    "duplicate_skipped",
+]
+
+
+@dataclass(frozen=True)
+class ModelPluginDiscoveryEntry:
+    """A single entry-point discovery result.
+
+    Records the outcome of attempting to load one plugin entry-point,
+    including its final disposition and any diagnostic information.
+
+    Attributes:
+        entry_point_name: Name of the entry-point as declared in
+            ``pyproject.toml`` or ``setup.cfg``.
+        module_path: Dotted module path the entry-point resolves to.
+        status: Disposition of this entry-point. One of:
+            ``"accepted"`` -- successfully loaded and registered.
+            ``"namespace_rejected"`` -- blocked by namespace allowlist.
+            ``"import_error"`` -- ``importlib`` could not load the module.
+            ``"instantiation_error"`` -- class loaded but constructor failed.
+            ``"protocol_invalid"`` -- class does not satisfy required protocol.
+            ``"duplicate_skipped"`` -- a plugin with the same ID was already
+            registered.
+        reason: Human-readable explanation. Empty string for accepted entries.
+        plugin_id: Plugin identifier. Set only for ``"accepted"`` and
+            ``"duplicate_skipped"`` entries; ``None`` otherwise.
+
+    Example:
+        >>> entry = ModelPluginDiscoveryEntry(
+        ...     entry_point_name="my_plugin",
+        ...     module_path="myapp.plugins.my_plugin",
+        ...     status="accepted",
+        ...     plugin_id="my_plugin",
+        ... )
+        >>> entry.status
+        'accepted'
+        >>> entry.reason
+        ''
+    """
+
+    entry_point_name: str
+    module_path: str
+    status: PluginDiscoveryStatus
+    reason: str = ""
+    plugin_id: str | None = None
+
+
+__all__ = ["ModelPluginDiscoveryEntry", "PluginDiscoveryStatus"]


### PR DESCRIPTION
## Summary

- Add `PluginDiscoveryEntry` dataclass recording per-entry-point disposition (accepted, namespace_rejected, import_error, instantiation_error, protocol_invalid, duplicate_skipped) with reason and optional plugin_id
- Add `ModelPluginDiscoveryReport` dataclass aggregating entries for a single entry-point group, with `rejected` property (filters non-accepted) and `has_errors` property (detects import/instantiation failures)
- Export both classes from `omnibase_infra.runtime.models` package `__init__.py`
- 24 unit tests covering construction, defaults, all status values, property filtering, edge cases, and usage patterns

Closes OMN-2012

## Test plan

- [x] 24 dedicated unit tests pass (`tests/unit/models/runtime/test_model_plugin_discovery_report.py`)
- [x] Full unit test suite passes (10,665 passed, 10 skipped, 0 failed)
- [x] mypy type checking passes with no issues
- [x] ruff linting passes with no issues
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured plugin-discovery reporting to track results per plugin group, with built-in filtering for rejected plugins and detection of import/instantiation errors and other validation outcomes.

* **Tests**
  * Added a comprehensive unit test suite covering construction, filtering behavior, error detection, ordering guarantees, immutability, and typical usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->