### PR TITLE
feat(OMN-2025): Strip omniclaude-specific defaults from EventRegistry

### DIFF
--- a/src/omnibase_infra/runtime/emit_daemon/__init__.py
+++ b/src/omnibase_infra/runtime/emit_daemon/__init__.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 OmniNode Team
-"""Emit Daemon - Event infrastructure for OmniClaude hooks.
+"""Emit Daemon - Event registry and notification infrastructure.
 
-This package provides the event registry and notification infrastructure
-for OmniClaude hook events.
+This package provides the generic event registry and notification
+infrastructure for ONEX event-driven systems.
 
 Components:
 - EventRegistry: Maps event types to Kafka topics with metadata injection
@@ -13,6 +13,9 @@ Components:
 - ModelNotificationCompleted: Event model for completion notifications
 
 Note:
+    The EventRegistry ships with no default registrations. Consumers must
+    register their own event types via ``register()`` or ``register_batch()``.
+
     The EmitDaemon, EmitClient, and BoundedEventQueue were moved to omniclaude3
     as part of OMN-1944/OMN-1945. Only the shared event registry, notification
     consumer, and notification models remain in omnibase_infra.
@@ -25,9 +28,17 @@ Example Usage:
         NotificationConsumer,
     )
 
-    # Use the registry directly
+    # Create and populate the registry
     registry = EventRegistry(environment="dev")
-    topic = registry.resolve_topic("prompt.submitted")
+    registry.register(
+        ModelEventRegistration(
+            event_type="myapp.submitted",
+            topic_template="onex.evt.myapp.submitted.v1",
+            partition_key_field="session_id",
+            required_fields=["session_id"],
+        )
+    )
+    topic = registry.resolve_topic("myapp.submitted")
 
     # Notification consumer usage
     consumer = NotificationConsumer(event_bus=kafka_event_bus)


### PR DESCRIPTION
## Summary

- **EventRegistry now ships with zero hardcoded registrations** — removes 12 omniclaude-specific event types from `_register_defaults()`
- **Adds `register_batch()`** convenience method for bulk event type registration
- **Updates all docstrings** to reflect generic infrastructure positioning (no omniclaude references)
- **Rewrites test suite** — deletes 25 default-assertion tests, adds empty-by-default + register_batch coverage, rewrites remaining tests to use explicit registration

## Why

Infrastructure should provide generic machinery, not application-specific wiring. Every new omniclaude event type previously required a commit to omnibase_infra's `_register_defaults()`. After PR #264 (OMN-1945) moved the emit daemon to omniclaude, the registry was the last piece carrying omniclaude-specific knowledge.

## Breaking change

omniclaude's `EmbeddedEventPublisher` currently expects defaults to exist on `EventRegistry()` init. After this change, it must call `registry.register_batch(OMNICLAUDE_EVENTS)` with its own event definitions at startup. This is a separate omniclaude2 change.

## Test plan

- [x] `poetry run pytest tests/unit/runtime/emit_daemon/test_event_registry.py -xvs` — 54 passed
- [x] `poetry run pytest tests/unit/ -n auto` — 10,728 passed, 0 failed
- [x] `poetry run mypy src/omnibase_infra/runtime/emit_daemon/event_registry.py` — clean
- [x] `poetry run ruff check src/omnibase_infra/runtime/emit_daemon/` — clean
- [x] All pre-commit hooks passed