### PR TITLE
feat(OMN-2022): Integration test for real entry_point discovery

### DIFF
--- a/tests/integration/runtime/test_domain_plugin_entry_point_integration.py
+++ b/tests/integration/runtime/test_domain_plugin_entry_point_integration.py
@@ -28,7 +28,11 @@ Related:
 
 from __future__ import annotations
 
-from importlib.metadata import EntryPoint, entry_points
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from importlib.metadata import EntryPoint
 
 import pytest
 


### PR DESCRIPTION
## Summary

- Add integration test verifying `PluginRegistration` is discoverable via real `importlib.metadata.entry_points(group="onex.domain_plugins")` when the package is installed
- Verify full `RegistryDomainPlugin.discover_from_entry_points()` pipeline accepts the plugin with `"registration"` in the accepted list
- 14 tests covering raw entry_point discoverability and full discovery pipeline (strict mode, duplicate handling, default security config)

## Test Plan

- [x] All 14 integration tests pass locally (`poetry run pytest tests/integration/runtime/test_domain_plugin_entry_point_integration.py -xvs`)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] All pre-commit hooks pass
- [ ] CI passes (requires `poetry install` to register entry_points)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify plugin discovery and installation functionality for domain plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->