### PR TITLE
chore: Bump version to 0.6.0 with core 0.16.0 and spi 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the ONEX Infrastructure (omnibase_infra) will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-02-09
+
+### Changed
+
+#### Dependencies
+- Update `omnibase-core` from `^0.15.0` to `^0.16.0`
+- Update `omnibase-spi` from `^0.6.4` to `^0.7.0`
+
 ## [0.4.1] - 2026-02-06
 
 ### Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -2915,14 +2915,14 @@ files = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.15.0"
+version = "0.16.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "omnibase_core-0.15.0-py3-none-any.whl", hash = "sha256:c4146af9831706715f05144575a931e4dc6969a6d3f0ba3261a081c4143dd531"},
-    {file = "omnibase_core-0.15.0.tar.gz", hash = "sha256:6a8bb4b62a552d62770b1a8c1aae806b175aa4802719a37976a9f68170b982d4"},
+    {file = "omnibase_core-0.16.0-py3-none-any.whl", hash = "sha256:7a474183220fd00c154562d7e707d885999f6cf67dc3755a6e926f293b40d42e"},
+    {file = "omnibase_core-0.16.0.tar.gz", hash = "sha256:78cd5c1fe0985194c599ab35d14764142c89f3700c7786a4f4a2163ba87ea399"},
 ]
 
 [package.dependencies]
@@ -2945,18 +2945,18 @@ sql-parser = ["sqlglot (>=26.0.0,<27.0.0)"]
 
 [[package]]
 name = "omnibase-spi"
-version = "0.6.4"
+version = "0.7.0"
 description = "ONEX Service Provider Interface - Protocol definitions"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "omnibase_spi-0.6.4-py3-none-any.whl", hash = "sha256:784e455a9f01c5323437054a9bf13a8f8701e8c1dc27fc2ee92b6052046f01ad"},
-    {file = "omnibase_spi-0.6.4.tar.gz", hash = "sha256:07005ffdef8aead96db9a749708984c8f61f73d37d6775bc1c05aed2e585af4b"},
+    {file = "omnibase_spi-0.7.0-py3-none-any.whl", hash = "sha256:b062ba21af8b8b83c3e3120c235fb048ed4fc4643171f4bee2e8254b7a31896f"},
+    {file = "omnibase_spi-0.7.0.tar.gz", hash = "sha256:f973a4d5025a604928bcb052915cba6db50607fb505424b0f3111315b69235a3"},
 ]
 
 [package.dependencies]
-omnibase-core = ">=0.9.11"
+omnibase-core = ">=0.16.0"
 pydantic = ">=2.11.7"
 typing-extensions = ">=4.5.0"
 
@@ -4162,7 +4162,7 @@ files = [
     {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
     {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "pyyaml"
@@ -5332,4 +5332,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "3f632542775fe111a3ebd7eff582bea6998bb9e45f63b2ffe5d0c910815c4973"
+content-hash = "7806d9ff43576e64ae8ba7e4ae205a3221bfa58823256e271adc08398b13ab51"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnibase_infra"
-version = "0.4.1"
+version = "0.6.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = ["OmniNode Team <team@omninode.ai>"]
 license = "MIT"
@@ -39,10 +39,10 @@ python = "^3.12"
 #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
 # Remember to switch back to PyPI versions before merging to main.
 #
-# omnibase-core v0.15.0: Adds ModelMessageEnvelope, EnvelopeSignature, and crypto utils for gateway signing
-omnibase-core = "^0.15.0"
-# omnibase-spi v0.6.4: Version bump
-omnibase-spi = "^0.6.4"
+# omnibase-core v0.16.0: Version bump
+omnibase-core = "^0.16.0"
+# omnibase-spi v0.7.0: Version bump
+omnibase-spi = "^0.7.0"
 
 # ============================================================================
 # External Dependency Security Guidance

--- a/src/omnibase_infra/__init__.py
+++ b/src/omnibase_infra/__init__.py
@@ -76,7 +76,7 @@ See Also
 - Runtime kernel: omnibase_infra.runtime.service_kernel
 """
 
-__version__ = "0.4.1"
+__version__ = "0.6.0"
 
 from . import (
     enums,


### PR DESCRIPTION
## Summary
- Bump `omnibase_infra` version from 0.4.1 to **0.6.0**
- Update `omnibase-core` from `^0.15.0` to **`^0.16.0`**
- Update `omnibase-spi` from `^0.6.4` to **`^0.7.0`**
- Update CHANGELOG.md with 0.6.0 entry

## Test plan
- [x] `poetry lock` and `poetry install` succeed
- [x] All pre-commit hooks pass
- [x] Full test suite: **13,292 passed**, 256 skipped, 1 xfail
- [x] No compatibility regressions from dependency upgrades

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.6.0 with internal dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->