### PR TITLE
feat(OMN-2047): Add omniclaude to trusted plugin namespace prefixes

### DIFF
--- a/src/omnibase_infra/runtime/constants_security.py
+++ b/src/omnibase_infra/runtime/constants_security.py
@@ -22,7 +22,7 @@ Design Decisions:
     - SPI is NOT included because it contains protocols, not handler implementations
     - Third-party namespaces require explicit config file, not env vars
     - Env vars are only acceptable to point to a config file path
-    - Plugin namespace prefixes mirror handler prefixes (same trust boundary)
+    - Plugin namespace prefixes are a superset of handler prefixes
     - Domain plugin entry point group uses PEP 621 naming conventions
 
 Example:
@@ -48,6 +48,9 @@ Example:
 
 .. versionadded:: 0.3.0
     Added plugin security constants as part of OMN-2010.
+
+.. versionchanged:: 0.6.0
+    Added omniclaude. to TRUSTED_PLUGIN_NAMESPACE_PREFIXES (OMN-2047).
 """
 
 from __future__ import annotations
@@ -77,19 +80,23 @@ TRUSTED_HANDLER_NAMESPACE_PREFIXES: Final[tuple[str, ...]] = (
 #
 # SECURITY: This is a security boundary. Changes require review.
 #
-# Plugin namespace prefixes mirror handler prefixes — plugins and handlers share
-# the same trust boundary. Only modules from these namespaces may be dynamically
-# discovered and loaded as domain plugins.
+# Plugin namespace prefixes are a superset of handler prefixes. The core trust
+# boundary (omnibase_core., omnibase_infra.) is shared, but plugins may include
+# additional first-party namespaces that provide domain plugins without providing
+# handler implementations.
 #
-# Why the same namespaces as handlers:
-# - Plugins are an extension mechanism with the same privilege level as handlers
-# - They can execute arbitrary code at import time (same risk profile)
-# - Keeping a single trust boundary simplifies security auditing
+# Why omniclaude. is included:
+# - omniclaude provides PluginClaude, a first-party domain plugin registered via
+#   pyproject.toml entry_points (onex.domain_plugins group)
+# - Without this prefix, RegistryDomainPlugin.discover_from_entry_points() rejects
+#   the entry point with status namespace_rejected (OMN-2047)
+# - omniclaude is a first-party package maintained in the same monorepo ecosystem
 #
 # Third-party plugin namespaces must be explicitly configured via security config file.
 TRUSTED_PLUGIN_NAMESPACE_PREFIXES: Final[tuple[str, ...]] = (
     "omnibase_core.",
     "omnibase_infra.",
+    "omniclaude.",
 )
 
 # PEP 621 entry_points group name for domain plugin discovery.

--- a/src/omnibase_infra/runtime/models/model_security_config.py
+++ b/src/omnibase_infra/runtime/models/model_security_config.py
@@ -8,7 +8,8 @@ configuration file while maintaining secure defaults for both handler loading an
 plugin discovery.
 
 Security Model:
-    - Default: Only omnibase_core. and omnibase_infra. are trusted
+    - Default handlers: Only omnibase_core. and omnibase_infra. are trusted
+    - Default plugins: omnibase_core., omnibase_infra., and omniclaude. are trusted
     - Third-party handlers: Requires allow_third_party_handlers=True AND
       explicit listing in allowed_handler_namespaces
     - Third-party plugins: Requires allow_third_party_plugins=True AND
@@ -21,7 +22,7 @@ Example:
     >>> config.get_effective_namespaces()
     ('omnibase_core.', 'omnibase_infra.')
     >>> config.get_effective_plugin_namespaces()
-    ('omnibase_core.', 'omnibase_infra.')
+    ('omnibase_core.', 'omnibase_infra.', 'omniclaude.')
 
     >>> # Enable third-party handlers
     >>> config = ModelSecurityConfig(
@@ -72,7 +73,9 @@ class ModelSecurityConfig(BaseModel):
     namespaces require explicit opt-in for both handlers and plugins.
 
     Security Model:
-        - Default: Only omnibase_core. and omnibase_infra. are trusted
+        - Default handlers: Only omnibase_core. and omnibase_infra. are trusted
+        - Default plugins: omnibase_core., omnibase_infra., and omniclaude.
+          are trusted (omniclaude provides first-party domain plugins)
         - Third-party handlers: Requires allow_third_party_handlers=True AND
           explicit listing in allowed_handler_namespaces
         - Third-party plugins: Requires allow_third_party_plugins=True AND
@@ -160,7 +163,7 @@ class ModelSecurityConfig(BaseModel):
         Example:
             >>> config = ModelSecurityConfig()
             >>> config.get_effective_plugin_namespaces()
-            ('omnibase_core.', 'omnibase_infra.')
+            ('omnibase_core.', 'omnibase_infra.', 'omniclaude.')
 
             >>> config = ModelSecurityConfig(
             ...     allow_third_party_plugins=True,


### PR DESCRIPTION
## Summary

Add `"omniclaude."` to `TRUSTED_PLUGIN_NAMESPACE_PREFIXES` so that `RegistryDomainPlugin.discover_from_entry_points()` accepts the `PluginClaude` entry point registered in omniclaude's `pyproject.toml`.

**Ticket**: [OMN-2047](https://linear.app/omninode/issue/OMN-2047)
**Pipeline Run**: 07d3340b

## Problem

`omniclaude.runtime.plugin` does not match any prefix in `TRUSTED_PLUGIN_NAMESPACE_PREFIXES`, causing the entry point to be rejected with status `namespace_rejected`. This forces explicit manual registration via `registry.register(PluginClaude())`, bypassing the discovery mechanism entirely.

## Changes

- **`constants_security.py`**: Add `"omniclaude."` to `TRUSTED_PLUGIN_NAMESPACE_PREFIXES` tuple. Updated comments to explain that plugin prefixes are now a superset of handler prefixes (handler prefixes remain unchanged).
- **`model_security_config.py`**: Updated docstrings to reflect the new default plugin namespace set.
- **`test_constants_security.py`**: Added `test_contains_omniclaude_namespace`. Renamed `TestPluginHandlerNamespaceParity` to `TestPluginHandlerNamespaceRelationship` with superset assertions instead of equality.
- **`test_domain_plugin_discovery.py`**: Added `test_omniclaude_namespace_accepted` (namespace validation) and `test_omniclaude_entry_point_accepted` (end-to-end discovery).

## Test Plan

- [x] All 99 directly affected tests pass
- [x] Full unit suite: 10,804 passed, 10 skipped, 1 pre-existing flaky benchmark failure
- [x] ruff check: all passed
- [x] mypy: no issues found
- [x] All pre-commit hooks pass
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended trusted plugin support to include the "omniclaude." namespace.

* **Documentation**
  * Updated configuration documentation to reflect the expanded default plugin trust model for version 0.6.0.

* **Tests**
  * Enhanced test coverage for plugin namespace validation and discovery integration to ensure "omniclaude." plugins are recognized as trusted without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->