### PR TITLE
fix(OMN-2040): Add missing test marker and exception-safety test

### DIFF
--- a/tests/unit/runtime/test_message_dispatch_engine.py
+++ b/tests/unit/runtime/test_message_dispatch_engine.py
@@ -4814,6 +4814,7 @@ class TestEventTypeRouting:
 # ============================================================================
 
 
+@pytest.mark.unit
 class TestDispatchDlqRouting:
     """Tests for DLQ topic derivation in NO_DISPATCHER results (OMN-2040).
 


### PR DESCRIPTION
## Summary
Follow-up to #283 (feat(OMN-2040): Add DLQ routing for unknown event_type).

These two commits were prepared during local review but didn't make it into the original PR:

- Add missing `@pytest.mark.unit` marker to `TestDispatchDlqRouting` class
- Add exception-safety test verifying `_derive_dlq_topic` wrapper catches errors from `derive_dlq_topic_for_event_type` and returns `None`

## Test plan
- [ ] `poetry run pytest tests/unit/runtime/test_message_dispatch_engine.py::TestDispatchDlqRouting -v` — all DLQ routing tests pass
- [ ] `poetry run pytest tests/unit/runtime/test_message_dispatch_engine.py -m unit` — marker correctly applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for message dispatch error handling to ensure graceful failure scenarios are properly validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->