### PR TITLE
docs(OMN-2066): FK scan report — all references are intra-service

### DIFF
--- a/docs/audits/fk-scan-omnibase-infra.md
+++ b/docs/audits/fk-scan-omnibase-infra.md
@@ -11,8 +11,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Forward migrations scanned | 17 (15 docker + 2 src) |
-| Rollback migrations scanned | 17 (15 docker + 2 src) |
+| Forward migrations scanned | 16 (14 docker + 2 src) |
+| Rollback migrations scanned | 16 (14 docker + 2 src) |
 | Physical FK constraints found | 2 |
 | Cross-service FK violations | **0** |
 | Logical references (no FK) | 2 |
@@ -78,7 +78,7 @@ Integrity is enforced at the application layer (see migration lines 128-135).
 | 001 | `event_ledger` |
 | 002 | `validation_event_ledger` |
 
-**Total: 18 tables, all owned by omnibase_infra.**
+**Total: 19 tables, all owned by omnibase_infra.**
 
 ---
 


### PR DESCRIPTION
## Summary

- Scanned all 32 migration files (16 forward + 16 rollback) for `REFERENCES` and `FOREIGN KEY` constraints
- Found **2 physical FKs**, both intra-service within the session snapshots aggregate (`claude_session_prompts` → `claude_session_snapshots`, `claude_session_tools` → `claude_session_snapshots`)
- Found **0 cross-service FK violations**
- Documented 2 intentional logical references (no FK) in async event-driven tables

## Deliverable

`docs/audits/fk-scan-omnibase-infra.md` — comprehensive FK scan report covering:
- Physical FK inventory with source/target details
- Logical reference documentation with rationale
- Complete table ownership inventory (19 tables)
- Methodology and conclusion

## Test plan

- [x] All migration files scanned via grep + manual review
- [x] FK targets verified as intra-service tables
- [x] Table counts verified against migration files
- [x] No code changes — docs-only PR

Closes OMN-2066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive Foreign Key scan audit report documenting database constraints within the infrastructure domain.
* Report details physical foreign keys, logical references, and service ownership across migration tables.
* Audit confirms all constraints are properly scoped within service boundaries with zero cross-service violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->