### PR TITLE
feat(OMN-2101): add EnumLlmFinishReason and EnumLlmOperationType enums

### DIFF
--- a/src/omnibase_infra/enums/__init__.py
+++ b/src/omnibase_infra/enums/__init__.py
@@ -31,6 +31,8 @@ Exports:
     EnumInfraTransportType: Infrastructure transport type enumeration
     EnumIntrospectionReason: Introspection event reasons (STARTUP, SHUTDOWN, etc.)
     EnumKafkaAcks: Kafka producer acknowledgment policy (ALL, NONE, LEADER, ALL_REPLICAS)
+    EnumLlmFinishReason: LLM finish reasons (STOP, LENGTH, ERROR, CONTENT_FILTER, TOOL_CALLS, UNKNOWN)
+    EnumLlmOperationType: LLM operation types (CHAT_COMPLETION, COMPLETION, EMBEDDING)
     EnumMessageCategory: Message categories (EVENT, COMMAND, INTENT)
     EnumNodeArchetype: 4-node architecture (EFFECT, COMPUTE, REDUCER, ORCHESTRATOR)
     EnumNodeOutputType: Node output types for execution shape validation
@@ -78,6 +80,8 @@ from omnibase_infra.enums.enum_infra_transport_type import EnumInfraTransportTyp
 from omnibase_infra.enums.enum_introspection_reason import EnumIntrospectionReason
 from omnibase_infra.enums.enum_kafka_acks import EnumKafkaAcks
 from omnibase_infra.enums.enum_ledger_sink_drop_policy import EnumLedgerSinkDropPolicy
+from omnibase_infra.enums.enum_llm_finish_reason import EnumLlmFinishReason
+from omnibase_infra.enums.enum_llm_operation_type import EnumLlmOperationType
 from omnibase_infra.enums.enum_message_category import EnumMessageCategory
 from omnibase_infra.enums.enum_node_archetype import EnumNodeArchetype
 from omnibase_infra.enums.enum_node_output_type import EnumNodeOutputType
@@ -124,6 +128,8 @@ __all__: list[str] = [
     "EnumIntrospectionReason",
     "EnumKafkaAcks",
     "EnumLedgerSinkDropPolicy",
+    "EnumLlmFinishReason",
+    "EnumLlmOperationType",
     "EnumMessageCategory",
     "EnumNodeArchetype",
     "EnumNodeOutputType",

--- a/src/omnibase_infra/enums/enum_llm_finish_reason.py
+++ b/src/omnibase_infra/enums/enum_llm_finish_reason.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""LLM Finish Reason Enumeration.
+
+Defines canonical finish reasons for LLM API responses. Used to normalize
+provider-specific finish reason strings into a consistent enum across
+all LLM integrations (OpenAI, vLLM, Ollama, etc.).
+
+Finish reasons:
+    - STOP: Model completed generation naturally
+    - LENGTH: Output was truncated due to max_tokens limit
+    - ERROR: Model or provider error during generation
+    - CONTENT_FILTER: Content was filtered by safety systems
+    - TOOL_CALLS: Model requested tool/function calls
+    - UNKNOWN: Unrecognized provider-specific reason (fallback)
+"""
+
+from enum import Enum
+
+
+class EnumLlmFinishReason(str, Enum):
+    """Canonical LLM finish reasons for response normalization.
+
+    Handlers map provider-specific finish reason strings to these
+    canonical values. Unrecognized strings should map to UNKNOWN.
+
+    Attributes:
+        STOP: Natural generation completion
+        LENGTH: Truncated by max_tokens limit
+        ERROR: Generation error
+        CONTENT_FILTER: Blocked by content safety filter
+        TOOL_CALLS: Model requested tool/function execution
+        UNKNOWN: Unrecognized or unmapped finish reason
+    """
+
+    STOP = "stop"
+    LENGTH = "length"
+    ERROR = "error"
+    CONTENT_FILTER = "content_filter"
+    TOOL_CALLS = "tool_calls"
+    UNKNOWN = "unknown"
+
+
+__all__ = ["EnumLlmFinishReason"]

--- a/src/omnibase_infra/enums/enum_llm_operation_type.py
+++ b/src/omnibase_infra/enums/enum_llm_operation_type.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""LLM Operation Type Enumeration.
+
+Defines the canonical operation types for LLM API calls. Used to classify
+inference requests by their operation category for routing, metrics,
+and cost tracking.
+
+Operation types:
+    - CHAT_COMPLETION: Multi-turn chat with messages array
+    - COMPLETION: Single-turn text completion (legacy)
+    - EMBEDDING: Vector embedding generation
+"""
+
+from enum import Enum
+
+
+class EnumLlmOperationType(str, Enum):
+    """Canonical LLM operation types for inference classification.
+
+    Used to route requests to appropriate handlers and track
+    usage metrics per operation category.
+
+    Attributes:
+        CHAT_COMPLETION: Chat-style multi-turn completion (/v1/chat/completions)
+        COMPLETION: Legacy single-turn text completion (/v1/completions)
+        EMBEDDING: Vector embedding generation (/v1/embeddings)
+    """
+
+    CHAT_COMPLETION = "chat_completion"
+    COMPLETION = "completion"
+    EMBEDDING = "embedding"
+
+
+__all__ = ["EnumLlmOperationType"]


### PR DESCRIPTION
## Summary

- Add `EnumLlmFinishReason` enum with 6 canonical finish reasons: STOP, LENGTH, ERROR, CONTENT_FILTER, TOOL_CALLS, UNKNOWN
- Add `EnumLlmOperationType` enum with 3 operation types: CHAT_COMPLETION, COMPLETION, EMBEDDING
- Export both enums from `omnibase_infra.enums` package

These enums normalize provider-specific LLM API values into a canonical form, enabling consistent handling across OpenAI, vLLM, Ollama, and other backends. UNKNOWN serves as the fallback for unrecognized provider strings.

Follows existing `str, Enum` pattern (e.g., `EnumInfraTransportType`).

**Linear:** OMN-2101

## Test plan

- [x] Import validation: `from omnibase_infra.enums import EnumLlmFinishReason, EnumLlmOperationType`
- [x] All 10,914 unit tests pass (`pytest tests/unit/ -n auto`)
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enumeration definitions for LLM finish reasons (Stop, Length, Error, Content Filter, Tool Calls, Unknown) and operation types (Chat Completion, Completion, Embedding) to standardize system behavior across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->