### PR TITLE
fix(OMN-2101): add typed __all__: list[str] for LLM enum exports

### DIFF
--- a/src/omnibase_infra/enums/enum_llm_finish_reason.py
+++ b/src/omnibase_infra/enums/enum_llm_finish_reason.py
@@ -41,4 +41,4 @@ class EnumLlmFinishReason(str, Enum):
     UNKNOWN = "unknown"
 
 
-__all__ = ["EnumLlmFinishReason"]
+__all__: list[str] = ["EnumLlmFinishReason"]

--- a/src/omnibase_infra/enums/enum_llm_operation_type.py
+++ b/src/omnibase_infra/enums/enum_llm_operation_type.py
@@ -32,4 +32,4 @@ class EnumLlmOperationType(str, Enum):
     EMBEDDING = "embedding"
 
 
-__all__ = ["EnumLlmOperationType"]
+__all__: list[str] = ["EnumLlmOperationType"]


### PR DESCRIPTION
## Summary
- Adds `list[str]` type annotation to `__all__` in `enum_llm_finish_reason.py` and `enum_llm_operation_type.py`
- Aligns with the typed `__all__` convention used across all other enum modules in `omnibase_infra.enums`

## Context
This was a review fix from OMN-2101 Phase 1 that didn't make it into the original PR before merge.

## Test plan
- [x] `poetry run pytest tests/unit/enums/` passes (114 tests)
- [x] Imports verified: `from omnibase_infra.enums import EnumLlmFinishReason, EnumLlmOperationType`
- [x] mypy passes (validated by pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code quality enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->