### PR TITLE
feat(OMN-2299): demo reset scoped command for safe environment reset

### DIFF
--- a/scripts/check_schema_fingerprint.py
+++ b/scripts/check_schema_fingerprint.py
@@ -73,9 +73,7 @@ def compute_migration_fingerprint(migrations_dir: Path) -> tuple[str, int]:
             f"Migrations directory does not exist: {migrations_dir}"
         )
     if not migrations_dir.is_dir():
-        raise FileNotFoundError(
-            f"Migrations path is not a directory: {migrations_dir}"
-        )
+        raise FileNotFoundError(f"Migrations path is not a directory: {migrations_dir}")
 
     sql_files = sorted(migrations_dir.glob("*.sql"))
 

--- a/src/omnibase_infra/cli/commands.py
+++ b/src/omnibase_infra/cli/commands.py
@@ -569,9 +569,12 @@ def demo_reset(dry_run: bool, purge_topics: bool, env_file: str) -> None:
 
 async def _run_demo_reset(*, dry_run: bool, purge_topics: bool) -> None:
     """Async implementation for demo reset command."""
-    from omnibase_infra.cli.demo_reset import DemoResetConfig, DemoResetEngine
+    from omnibase_infra.cli.service_demo_reset import (
+        DemoResetEngine,
+        ModelDemoResetConfig,
+    )
 
-    config = DemoResetConfig.from_env(purge_topics=purge_topics)
+    config = ModelDemoResetConfig.from_env(purge_topics=purge_topics)
 
     if dry_run:
         console.print("[bold yellow]DRY RUN -- no changes will be made[/bold yellow]\n")

--- a/src/omnibase_infra/cli/enum_reset_action.py
+++ b/src/omnibase_infra/cli/enum_reset_action.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Enum for demo reset action classification.
+
+Defines the possible outcomes of a single reset action: reset, preserved,
+skipped, or error.
+
+.. versionadded:: 0.9.1
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__: list[str] = [
+    "EnumResetAction",
+]
+
+
+class EnumResetAction(str, Enum):
+    """Classification of a reset action."""
+
+    RESET = "reset"
+    PRESERVED = "preserved"
+    SKIPPED = "skipped"
+    ERROR = "error"

--- a/src/omnibase_infra/cli/model_demo_reset_config.py
+++ b/src/omnibase_infra/cli/model_demo_reset_config.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Configuration model for the demo reset engine.
+
+.. versionadded:: 0.9.1
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Final
+
+__all__: list[str] = [
+    "ModelDemoResetConfig",
+]
+
+# Default values imported as module-level constants to avoid circular imports.
+# These match the constants in ``service_demo_reset.py``.
+_DEFAULT_PROJECTION_TABLE: Final[str] = "registration_projections"
+
+_DEFAULT_CONSUMER_GROUP_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"(registration|projector|introspection)", re.IGNORECASE
+)
+
+_DEFAULT_TOPIC_PREFIXES: Final[tuple[str, ...]] = (
+    "onex.evt.platform.",
+    "onex.cmd.platform.",
+    "onex.evt.omniintelligence.",
+    "onex.cmd.omniintelligence.",
+    "onex.evt.omniclaude.",
+    "onex.evt.agent.",
+)
+
+
+@dataclass(frozen=True)
+class ModelDemoResetConfig:
+    """Configuration for the demo reset engine.
+
+    Note:
+        ``consumer_group_pattern`` is typed as ``re.Pattern`` which is
+        technically a mutable object (compiled regex patterns have mutable
+        internal caching).  In practice ``re.Pattern`` is effectively
+        immutable -- its public API is read-only -- so ``frozen=True``
+        is safe here despite the dataclass not performing a deep-freeze.
+
+    Attributes:
+        postgres_dsn: PostgreSQL connection string.
+        kafka_bootstrap_servers: Kafka broker address(es).
+        purge_topics: Whether to delete messages from demo topics.
+        projection_table: Table name for projector state.
+        consumer_group_pattern: Regex to match demo consumer groups.
+        demo_topic_prefixes: Topic prefixes considered demo-scoped.
+    """
+
+    postgres_dsn: str = ""
+    kafka_bootstrap_servers: str = ""
+    purge_topics: bool = False
+    projection_table: str = _DEFAULT_PROJECTION_TABLE
+    consumer_group_pattern: re.Pattern[str] = _DEFAULT_CONSUMER_GROUP_PATTERN
+    demo_topic_prefixes: tuple[str, ...] = _DEFAULT_TOPIC_PREFIXES
+
+    @classmethod
+    def from_env(cls, *, purge_topics: bool = False) -> ModelDemoResetConfig:
+        """Create config from environment variables.
+
+        Reads OMNIBASE_INFRA_DB_URL and KAFKA_BOOTSTRAP_SERVERS from
+        the environment. Falls back to empty strings if not set.
+
+        Args:
+            purge_topics: Whether to purge demo topic data.
+
+        Returns:
+            ModelDemoResetConfig populated from environment.
+        """
+        return cls(
+            postgres_dsn=os.environ.get("OMNIBASE_INFRA_DB_URL", ""),
+            kafka_bootstrap_servers=os.environ.get("KAFKA_BOOTSTRAP_SERVERS", ""),
+            purge_topics=purge_topics,
+        )

--- a/src/omnibase_infra/cli/model_demo_reset_report.py
+++ b/src/omnibase_infra/cli/model_demo_reset_report.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Model for the aggregate demo reset report.
+
+.. versionadded:: 0.9.1
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from omnibase_infra.cli.enum_reset_action import EnumResetAction
+from omnibase_infra.cli.model_reset_action_result import ModelResetActionResult
+
+__all__: list[str] = [
+    "ModelDemoResetReport",
+]
+
+
+@dataclass
+class ModelDemoResetReport:
+    """Aggregate report of all demo reset actions.
+
+    Attributes:
+        actions: List of individual action results.
+        dry_run: Whether this was a dry-run (no changes made).
+    """
+
+    actions: list[ModelResetActionResult] = field(default_factory=list)
+    dry_run: bool = False
+
+    @property
+    def reset_count(self) -> int:
+        """Number of resources that were reset."""
+        return sum(1 for a in self.actions if a.action == EnumResetAction.RESET)
+
+    @property
+    def preserved_count(self) -> int:
+        """Number of resources explicitly preserved."""
+        return sum(1 for a in self.actions if a.action == EnumResetAction.PRESERVED)
+
+    @property
+    def error_count(self) -> int:
+        """Number of actions that failed."""
+        return sum(1 for a in self.actions if a.action == EnumResetAction.ERROR)
+
+    @property
+    def skipped_count(self) -> int:
+        """Number of actions skipped (e.g., already clean)."""
+        return sum(1 for a in self.actions if a.action == EnumResetAction.SKIPPED)
+
+    def format_summary(self) -> str:
+        """Format the report as a human-readable summary.
+
+        Returns:
+            Multi-line string suitable for CLI output.
+        """
+        lines: list[str] = []
+        mode = "DRY RUN" if self.dry_run else "EXECUTED"
+        lines.append(f"Demo Reset Report ({mode})")
+        lines.append("=" * 60)
+
+        # Group by action type
+        for action_type in EnumResetAction:
+            group = [a for a in self.actions if a.action == action_type]
+            if not group:
+                continue
+
+            label = action_type.value.upper()
+            lines.append(f"\n  [{label}]")
+            for item in group:
+                lines.append(f"    {item.resource}: {item.detail}")
+
+        lines.append("")
+        lines.append(
+            f"Summary: {self.reset_count} reset, "
+            f"{self.preserved_count} preserved, "
+            f"{self.skipped_count} skipped, "
+            f"{self.error_count} errors"
+        )
+
+        return "\n".join(lines)

--- a/src/omnibase_infra/cli/model_reset_action_result.py
+++ b/src/omnibase_infra/cli/model_reset_action_result.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Model for a single demo reset action result.
+
+.. versionadded:: 0.9.1
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omnibase_infra.cli.enum_reset_action import EnumResetAction
+
+__all__: list[str] = [
+    "ModelResetActionResult",
+]
+
+
+@dataclass(frozen=True)
+class ModelResetActionResult:
+    """Result of a single reset action.
+
+    Attributes:
+        resource: Name of the resource affected.
+        action: What was done (reset, preserved, skipped, error).
+        detail: Human-readable description of what happened.
+    """
+
+    resource: str
+    action: EnumResetAction
+    detail: str


### PR DESCRIPTION
## Summary

- Adds a `demo reset` CLI command that safely resets demo-scoped resources before a demo
- Clears registration projections, deletes demo consumer groups, and optionally purges demo topic data
- Explicitly preserves all shared infrastructure (34+ tables, non-demo topics, config)

## Changes

- **`src/omnibase_infra/cli/demo_reset.py`** (new): `DemoResetEngine` with three-phase reset (projector state → consumer groups → topic purge), `DemoResetConfig`, `DemoResetReport` with formatted summary, `EnumResetAction`
- **`src/omnibase_infra/cli/commands.py`** (modified): Added `demo reset` Click subcommand with `--dry-run`, `--purge-topics`, `--env-file` options
- **`tests/unit/cli/test_demo_reset.py`** (new): 38 unit tests covering config, patterns, report formatting, engine phases, preservation, idempotency, and CLI integration

## Acceptance Criteria

- [x] `--dry-run` shows what would be reset without doing it
- [x] Only demo-scoped resources are affected
- [x] Shared infrastructure is explicitly preserved
- [x] Summary report shows what was reset vs preserved
- [x] Idempotent (running twice produces same result)

## Test plan

- [x] 38 new unit tests all passing
- [x] Full unit suite regression check (8920 passed, no new failures)
- [x] mypy --strict passes
- [x] ruff check + format clean
- [x] All 18 pre-commit hooks pass

Closes OMN-2299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `demo reset` CLI command for resetting demo environments. Resets projector state, consumer group offsets, and optionally purges configured demo topics. Includes --dry-run mode to safely preview all changes without modifying resources, --purge-topics flag to clear demo topics, and --env-file option for custom environment configuration. Generates detailed reset reports with action summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->