### PR TITLE
feat(OMN-2342): gate OMNIINTELLIGENCE_PUBLISH_INTROSPECTION on omninode-runtime only

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -340,6 +340,11 @@ services:
       ONEX_INPUT_TOPIC: ${ONEX_INPUT_TOPIC:-requests}
       ONEX_OUTPUT_TOPIC: ${ONEX_OUTPUT_TOPIC:-responses}
       ONEX_GROUP_ID: ${ONEX_GROUP_ID:-onex-runtime-main}
+      # OMN-2342: Gate intelligence introspection/heartbeat publishing to this
+      # container only. Workers and effects containers inherit x-runtime-env but
+      # do NOT set this flag, so they process intelligence events without
+      # starting duplicate heartbeat loops for the same deterministic node IDs.
+      OMNIINTELLIGENCE_PUBLISH_INTROSPECTION: "true"
     ports:
       - "${RUNTIME_MAIN_PORT:-8085}:8085"
     stop_grace_period: 90s


### PR DESCRIPTION
## Summary

Fixes 3× heartbeat fan-out caused by all runtime containers sharing `x-runtime-env` in docker-compose.

- Adds `OMNIINTELLIGENCE_PUBLISH_INTROSPECTION: "true"` to `omninode-runtime` service only
- `runtime-effects`, `runtime-worker`, and `agent-actions-consumer` do NOT get this flag
- Reduces heartbeat traffic from 36/min to 12/min (6 nodes × 1 publisher × 2/min)

## Context

`PluginIntelligence` gates introspection publishing via `OMNIINTELLIGENCE_PUBLISH_INTROSPECTION` (implemented in companion PR on omniintelligence repo). This compose change is the infrastructure side: designating `omninode-runtime` as the single introspection publisher.

## Test plan

- [ ] V1: Single heartbeat source — `kcat -b 192.168.86.200:29092 -t onex.evt.platform.node-heartbeat.v1 -C -c 40` shows ~30s intervals, not [0.1, 2.2, 27.7] pattern
- [ ] V3: `docker compose logs omninode-runtime | grep "Intelligence introspection published"` confirms publish
- [ ] V4: Observe bus for 5 min — expect ~60 total heartbeats (12/min × 5), not 180

## Linear

Closes OMN-2342 (omnibase_infra side — omniintelligence plugin changes tracked separately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker infrastructure configuration to enable heartbeat publishing capability for the runtime service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->