### PR TITLE
chore(release): bump omniintelligence to 0.4.0, version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the ONEX Infrastructure (omnibase_infra) will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-02-19
+
+### Changed
+
+#### Runtime Plugin
+
+- **Bump `omniintelligence`** from `0.2.3` → `0.4.0` in `docker/Dockerfile.runtime`
+
 ## [0.8.0] - 2026-02-19
 
 ### Added

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -162,7 +162,7 @@ RUN uv pip freeze | grep -v '^\(-e\|@\)' > /tmp/constraints.txt
 # Version must be compatible with constraints in /tmp/constraints.txt (generated from uv pip freeze)
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --constraint /tmp/constraints.txt \
-    omniintelligence==0.2.3
+    omniintelligence==0.4.0
 
 # ============================================================================
 # Runtime Stage - Minimal production image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.8.0"
+version = "0.8.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{name = "OmniNode Team", email = "team@omninode.ai"}]
 license = {text = "MIT"}

--- a/src/omnibase_infra/__init__.py
+++ b/src/omnibase_infra/__init__.py
@@ -76,7 +76,7 @@ See Also
 - Runtime kernel: omnibase_infra.runtime.service_kernel
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 from . import (
     enums,

--- a/uv.lock
+++ b/uv.lock
@@ -1847,7 +1847,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- `docker/Dockerfile.runtime`: `omniintelligence==0.2.3` → `omniintelligence==0.4.0`
- `pyproject.toml`: `0.8.0` → `0.8.1`
- `__init__.py`: `__version__` synced to `0.8.1`
- `CHANGELOG.md`: `[0.8.1]` entry added

## Why a patch bump?

`omniintelligence` is a runtime composition-layer plugin (not declared in `pyproject.toml`). The pin lives only in `Dockerfile.runtime`. No contracts, SPI interfaces, or public APIs changed — patch bump is appropriate.

## Test plan

- [ ] CI Docker build passes (`docker-build.yml` builds `Dockerfile.runtime` with `omniintelligence==0.4.0`)
- [ ] `uv pip install omniintelligence==0.4.0` resolves without constraint conflicts