### PR TITLE
feat(OMN-1650): configure ledger retention script for platform topics

### DIFF
--- a/scripts/configure_ledger_retention.py
+++ b/scripts/configure_ledger_retention.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Configure infinite retention on platform topics for ledger support.
+
+WARNING: This script overrides retention.ms=-1 on ALL platform topics,
+including topic-catalog topics that have intentional bounded retention
+(1h for query/response, 7d for changed events).
+"""
+
+import subprocess
+
+from omnibase_infra.topics import ALL_PLATFORM_SUFFIXES
+
+
+def main() -> None:
+    print(
+        f"Configuring infinite retention on {len(ALL_PLATFORM_SUFFIXES)} platform topics"
+    )
+    print()
+
+    for suffix in ALL_PLATFORM_SUFFIXES:
+        # Topics are realm-agnostic — no env prefix. Suffix IS the topic name.
+        print(f"  Setting infinite retention on: {suffix}")
+        subprocess.run(
+            [
+                "rpk",
+                "topic",
+                "alter",
+                suffix,
+                "--set",
+                "retention.ms=-1",
+                "--set",
+                "retention.bytes=-1",
+            ],
+            check=True,
+        )
+
+    print()
+    print(f"Done. {len(ALL_PLATFORM_SUFFIXES)} topics configured.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/configure_ledger_retention.py` — a one-shot ops script that sets `retention.ms=-1` and `retention.bytes=-1` on all platform topics via `rpk topic alter`
- Uses `ALL_PLATFORM_SUFFIXES` as the live source of truth (no hardcoded topic list); automatically covers all 14 current platform topics
- Fixes a stale ticket assumption: topics are realm-agnostic — no `{env}.` prefix is added to topic names

## Pre-implementation audit findings

The original ticket (written Jan 2026) had two bugs caught before implementation:
1. **Wrong topic naming**: ticket used `f"{env}.{suffix}"` — architecture is realm-agnostic; `TopicResolver.resolve()` is a pure pass-through
2. **Stale topic count**: ticket listed 7 topics; `ALL_PLATFORM_SUFFIXES` now has 14 (7 added since Jan 2026)

⚠️ Three topic-catalog topics (`topic-catalog-query`, `topic-catalog-response`, `topic-catalog-changed`) have intentional bounded retention in their `ModelTopicSpec.kafka_config`. This script overrides them to infinite retention — documented in the script's module docstring.

## Test plan

- [ ] Script imports successfully: `python -c "from scripts.configure_ledger_retention import main"`
- [ ] Syntax check: `python -m py_compile scripts/configure_ledger_retention.py`
- [ ] Lint: `uv run ruff check scripts/configure_ledger_retention.py`
- [ ] Manual run against dev Redpanda: `uv run python scripts/configure_ledger_retention.py`
- [ ] Verify: `rpk topic describe "onex.evt.platform.node-registration.v1" | grep retention`

## Linear

Closes OMN-1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new tooling to automatically configure infinite retention settings for platform topics in the ledger system, improving operational management and enabling better control over data lifecycle policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->