### PR TITLE
feat(OMN-2475): remove .env from validate_clean_root allowed files

### DIFF
--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -87,7 +87,6 @@ ALLOWED_ROOT_FILES: frozenset[str] = frozenset(
         # ONEX-specific documentation
         "CLAUDE.md",
         # Environment
-        ".env",
         ".env.example",
         ".env.template",
         # Docker (if needed at root)
@@ -149,7 +148,6 @@ ALLOWED_ROOT_DIRECTORIES: frozenset[str] = frozenset(
         # Virtual environments (should be gitignored)
         ".venv",
         "venv",
-        ".env",
         "env",
         # Build directories (should be gitignored)
         "build",

--- a/tests/unit/validation/test_validate_clean_root.py
+++ b/tests/unit/validation/test_validate_clean_root.py
@@ -781,3 +781,34 @@ class TestIntegrationScenarios:
 
         assert result.is_valid
         assert len(result.violations) == 0
+
+
+class TestEnvFileEnforcement:
+    """Test that .env files are correctly denied (zero-repo-env policy)."""
+
+    def test_env_file_is_violation(self, tmp_path: Path) -> None:
+        """Test that .env is flagged as a violation (zero-repo-env policy)."""
+        (tmp_path / ".env").touch()
+
+        result = validate_root_directory(tmp_path)
+
+        assert not result.is_valid
+        assert len(result.violations) == 1
+        assert result.violations[0].path.name == ".env"
+
+    def test_env_example_still_allowed(self, tmp_path: Path) -> None:
+        """Test that .env.example passes (template files are allowed via .env.* pattern)."""
+        (tmp_path / ".env.example").touch()
+
+        result = validate_root_directory(tmp_path)
+
+        assert result.is_valid
+        assert len(result.violations) == 0
+
+    def test_env_not_in_allowed_root_files(self) -> None:
+        """Test that .env is not in ALLOWED_ROOT_FILES allowlist."""
+        assert ".env" not in ALLOWED_ROOT_FILES
+
+    def test_env_not_in_allowed_root_directories(self) -> None:
+        """Test that .env is not in ALLOWED_ROOT_DIRECTORIES allowlist."""
+        assert ".env" not in ALLOWED_ROOT_DIRECTORIES


### PR DESCRIPTION
## Summary

- Removes `.env` from `ALLOWED_ROOT_FILES` in `scripts/validation/validate_clean_root.py`
- Removes `.env` from `ALLOWED_ROOT_DIRECTORIES` (it was erroneously listed as a venv convention)
- Adds `TestEnvFileEnforcement` test class with 4 tests enforcing zero-repo-env policy
- `.env.example`, `.env.template`, and other `.env.*` variants remain allowed via the existing `.env.*` glob pattern

## Motivation

Structural prevention of `.env` files being committed. The pre-commit hook now flags any `.env` file in the root as a violation before it can be committed, even if someone removes the gitignore entry.

## Test Plan

- [x] 65 tests pass in `test_validate_clean_root.py` (4 new)
- [x] Pre-commit hook flags `.env` as violation end-to-end
- [x] `.env.example` still allowed via `.env.*` pattern
- [x] mypy strict: no issues
- [x] ruff: no issues

Closes OMN-2475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite to enforce zero-root-env policy, validating that .env files at project root are flagged as violations while .env.example files remain permitted.

* **Bug Fixes**
  * Updated project validation rules to disallow environment variable files and directories at the project root, ensuring they must be relocated or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->