### PR TITLE
chore(OMN-2476): add pre-commit hook rejecting .env files anywhere in tree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,13 +89,15 @@ repos:
         always_run: true
         stages: [pre-commit]
       # Reject any staged .env file at any path depth (OMN-2476)
-      # Uses (^|/)\.env([._].+)?$ to block root/.env, config/.env, .env.production, .env.staging,
-      # .env_local, .env_production, etc. (both dot-separated and underscore-separated variants).
+      # Uses (^|/)\.env([._-].+)?$ to block root/.env, config/.env, .env.production, .env.staging,
+      # .env_local, .env_production, .env-secret, etc. (dot-separated, underscore-separated, and
+      # hyphen-separated variants).
       - id: no-env-file
         name: Reject committed .env files (anywhere in tree)
-        entry: 'bash -c ''if git diff --cached --name-only | grep -qE "(^|/)\.env([._].+)?$"; then echo "BLOCKED: .env staged — use ~/.omnibase/.env (root and subdir .env files rejected)"; exit 1; fi'''
+        entry: 'bash -c ''if git diff --cached --name-only | grep -qE "(^|/)\.env([._-].+)?$"; then echo "BLOCKED: .env staged — use ~/.omnibase/.env (root and subdir .env files rejected)"; exit 1; fi'''
         language: system
         pass_filenames: false
+        always_run: true
         stages: [pre-commit]
       # Root directory cleanliness - no ephemeral files in root
       - id: onex-validate-clean-root


### PR DESCRIPTION
## Summary

- Adds `no-env-file` pre-commit hook to `.pre-commit-config.yaml` using `(^|/)\.env$` pattern
- Blocks any staged `.env` file at any path depth (root, `config/`, `docker/`, etc.), not just root
- Defense-in-depth: complements `.gitignore` by catching `git add -f` force-staged files
- Removed stale repo-root `.env` (pre-Infisical credentials superseded by `~/.omnibase/.env`)

## Test plan

- [x] `pre-commit run no-env-file --all-files` passes with no `.env` staged
- [x] Hook rejects `config/.env` when force-staged (`git add -f`)
- [x] All other pre-commit hooks pass on commit
- [x] YAML single-quote escaping avoids `ERROR: ` colon-space YAML parse error

Closes OMN-2476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new pre-commit validation to prevent accidental staging of environment files.
  * Updated CI settings so this new validation is skipped during automated runs, matching existing skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->