### PR TITLE
feat(OMN-2478): add shared_key_registry.yaml as authoritative shared key definition

### DIFF
--- a/config/shared_key_registry.yaml
+++ b/config/shared_key_registry.yaml
@@ -1,0 +1,66 @@
+# shared_key_registry.yaml
+#
+# Authoritative definition of which environment variables are "shared across
+# all OmniNode repos." Tooling reads this file — it must never read
+# ~/.omnibase/.env to determine key names.
+#
+# Schema version: 1.0.0
+#
+# Semantics:
+#   shared        — eligible for Infisical seeding AND for stripping from repo
+#                   .env files; these vars appear in ~/.omnibase/.env (transitional)
+#                   and will eventually come from Infisical on boot
+#   bootstrap_only — excluded from Infisical seeding (circular dep); lives
+#                   outside repos (home dir / deployment secrets); never
+#                   stripped because it must never be in a repo .env in the
+#                   first place
+#   identity_defaults — never in any .env; always as default= in Settings
+#                   class code; each repo has its own database name baked in
+schema_version: "1.0.0"
+shared:
+  db:
+    - POSTGRES_HOST
+    - POSTGRES_PORT
+    - POSTGRES_USER
+  kafka:
+    - KAFKA_BOOTSTRAP_SERVERS
+    - KAFKA_ENVIRONMENT
+  consul:
+    - CONSUL_HTTP_ADDR
+    - CONSUL_HTTP_TOKEN
+  vault:
+    - VAULT_ADDR
+    - VAULT_TOKEN
+    - VAULT_NAMESPACE
+  llm:
+    - OPENAI_API_KEY
+    - ANTHROPIC_API_KEY
+    - OPENAI_API_BASE
+  auth:
+    - JWT_SECRET_KEY
+    - JWT_ALGORITHM
+    - JWT_EXPIRY_SECONDS
+  valkey:
+    - VALKEY_HOST
+    - VALKEY_PORT
+    - VALKEY_PASSWORD
+  env:
+    - ENVIRONMENT
+    - LOG_LEVEL
+    - DEBUG
+# bootstrap_only: lives outside repos (home dir / deployment secrets)
+# These keys are NOT eligible for Infisical seeding — they are needed to
+# authenticate TO Infisical, so they must be available before Infisical is
+# contacted. They live in ~/.omnibase/.env and are never committed to any repo.
+bootstrap_only:
+  - POSTGRES_PASSWORD
+  - INFISICAL_ADDR
+  - INFISICAL_CLIENT_ID
+  - INFISICAL_CLIENT_SECRET
+  - INFISICAL_PROJECT_ID
+  - INFISICAL_ENCRYPTION_KEY
+  - INFISICAL_AUTH_SECRET
+# identity_defaults: each repo sets its own database name as a code-level
+# default= in its Settings class. Never in any .env file.
+identity_defaults:
+  - POSTGRES_DATABASE

--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -123,6 +123,7 @@ ALLOWED_ROOT_DIRECTORIES: frozenset[str] = frozenset(
         "docs",
         "scripts",
         # Common optional directories
+        "config",
         "contracts",
         "docker",
         "examples",


### PR DESCRIPTION
## Summary
- Creates `config/shared_key_registry.yaml` as the versioned, repo-tracked authoritative definition of shared env vars across all OmniNode repos
- Covers `shared` groups: db, kafka, consul, vault, llm, auth, valkey, env
- `bootstrap_only`: POSTGRES_PASSWORD, INFISICAL_ADDR/CLIENT_ID/CLIENT_SECRET/PROJECT_ID/ENCRYPTION_KEY/AUTH_SECRET (lives in home dir, never in repo)
- `identity_defaults`: POSTGRES_DATABASE (set as code-level default in each repo's Settings class)
- Adds `config/` to `ALLOWED_ROOT_DIRECTORIES` in validate_clean_root.py so the registry passes root cleanliness checks

## Linear
Closes https://linear.app/omninode/issue/OMN-2478

## Test plan
- [x] YAML parses without error (`python3 -c "import yaml; yaml.safe_load(open('config/shared_key_registry.yaml'))"`)
- [x] All pre-commit hooks pass (yamlfmt, validate_clean_root, etc.)
- [x] 65 validate_clean_root tests pass (`pytest tests/ -k "clean_root or validate_root"`)
- [x] No .env files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced authoritative environment variable registry to standardize configuration management across deployments, defining shared variables by subsystem, bootstrap-only keys, and code-level defaults.
  * Updated directory validation to support new configuration structure at repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->