### PR TITLE
docs(OMN-2479): document onboard-repo.py setup with shared_key_registry.yaml

### DIFF
--- a/docs/plans/onboard-repo-setup.md
+++ b/docs/plans/onboard-repo-setup.md
@@ -1,0 +1,53 @@
+# onboard-repo.py Setup
+
+## Overview
+
+`~/.omnibase/scripts/onboard-repo.py` strips shared env vars from a repo's `.env` file.
+It reads `shared_key_registry.yaml` (not `~/.omnibase/.env`) to determine which keys are shared.
+
+This document records the implementation for OMN-2479.
+
+## Home-Dir Files Created
+
+### `~/.omnibase/scripts/onboard-repo.py`
+
+Strips shared keys from a repo `.env` using the registry. Key behavior:
+
+- Reads `shared` section only — `bootstrap_only` and `identity_defaults` are excluded
+- Uses `OMNIBASE_SHARED_KEY_REGISTRY` env var with fallback to `~/.omnibase/infra/shared_key_registry.yaml`
+- Raises `FileNotFoundError` (not silent empty set) when registry missing
+- Sanity-checks that `POSTGRES_PASSWORD` and `INFISICAL_*` are never stripped
+
+### `~/.omnibase/infra/shared_key_registry.yaml`
+
+Copy of `config/shared_key_registry.yaml` from omnibase_infra. Update when registry changes.
+
+## Required Shell Config
+
+Add to `~/.zshrc`:
+
+```bash
+export OMNIBASE_SHARED_KEY_REGISTRY=/path/to/omnibase_infra/config/shared_key_registry.yaml
+```
+
+Replace `/path/to/omnibase_infra` with the actual path to your omnibase_infra checkout.
+
+## Usage
+
+```bash
+# Dry-run to see what would be stripped
+python3 ~/.omnibase/scripts/onboard-repo.py /path/to/repo --dry-run
+
+# Apply stripping
+python3 ~/.omnibase/scripts/onboard-repo.py /path/to/repo
+```
+
+## Verification
+
+POSTGRES_PASSWORD must NOT appear in the strip list:
+
+```bash
+python3 ~/.omnibase/scripts/onboard-repo.py /path/to/repo --dry-run 2>&1 | grep -v POSTGRES_PASSWORD
+```
+
+INFISICAL_* secrets must NOT appear in the strip list.


### PR DESCRIPTION
## Summary
- Creates `~/.omnibase/scripts/onboard-repo.py` (home-dir, not committed) to strip shared env vars from repo `.env` files
- Script reads `shared_key_registry.yaml` instead of `~/.omnibase/.env` — prevents key-list drift
- Uses `OMNIBASE_SHARED_KEY_REGISTRY` env var with fallback to `~/.omnibase/infra/shared_key_registry.yaml`
- Raises `FileNotFoundError` (not silent empty set) if registry missing
- Only `shared` keys returned — `bootstrap_only` and `identity_defaults` excluded
- Adds `docs/plans/onboard-repo-setup.md` to document setup and usage

## Home-Dir Changes (not in PR but tracked)
- `~/.omnibase/scripts/onboard-repo.py` — created
- `~/.omnibase/infra/shared_key_registry.yaml` — copied from `config/shared_key_registry.yaml`

## Linear
Closes https://linear.app/omninode/issue/OMN-2479

## Test plan
- [x] Script loads registry and prints shared key count
- [x] `--dry-run` mode works without writing files
- [x] `POSTGRES_PASSWORD` not in strip list (bootstrap_only)
- [x] `INFISICAL_*` not in strip list (bootstrap_only)
- [x] `FileNotFoundError` raised when registry missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup documentation for the repository onboarding script, including installation instructions, environment variable configuration, registry file setup with customizable precedence, dry-run and production usage examples, and verification procedures to ensure sensitive credentials remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->