### PR TITLE
docs(OMN-2481): document ~/.omnibase/.env transitional shared vars setup

### DIFF
--- a/docs/plans/omnibase-env-setup.md
+++ b/docs/plans/omnibase-env-setup.md
@@ -1,0 +1,56 @@
+# ~/.omnibase/.env Setup
+
+## Overview
+
+`~/.omnibase/.env` is the transitional home-directory env file that contains all
+shared platform vars for OmniNode repos. This replaces per-repo `.env` files.
+
+This document records the implementation for OMN-2481.
+
+## Status
+
+TRANSITIONAL: will shrink to 5 bootstrap lines once all docker-compose services
+read from Infisical on boot (prerequisite for OMN-2484).
+
+## Sections
+
+| Section | Keys |
+|---------|------|
+| PostgreSQL | POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD |
+| Kafka | KAFKA_BOOTSTRAP_SERVERS, KAFKA_ENVIRONMENT |
+| Consul | CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN |
+| Vault | VAULT_ADDR, VAULT_TOKEN, VAULT_NAMESPACE |
+| Infisical (bootstrap only) | INFISICAL_ADDR, INFISICAL_CLIENT_ID, INFISICAL_CLIENT_SECRET, INFISICAL_PROJECT_ID, INFISICAL_ENCRYPTION_KEY, INFISICAL_AUTH_SECRET |
+| LLM | OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, GEMINI_API_KEY, Z_AI_API_KEY, Z_AI_API_URL, LLM_CODER_URL, LLM_GENERAL_URL |
+| Auth | JWT_SECRET_KEY, JWT_ALGORITHM, JWT_EXPIRY_SECONDS, SERVICE_AUTH_TOKEN, GH_PAT |
+| Valkey | VALKEY_HOST, VALKEY_PORT, VALKEY_PASSWORD |
+| Service URLs | ONEX_TREE_SERVICE_URL, METADATA_STAMPING_SERVICE_URL, REMOTE_SERVER_IP |
+| Environment | ENVIRONMENT, LOG_LEVEL, DEBUG |
+| Slack | SLACK_BOT_TOKEN, SLACK_CHANNEL_ID |
+
+## Rules
+
+1. NEVER add repo-specific vars (POSTGRES_DATABASE, etc.)
+2. File lives in ~ and is NEVER committed to any repo
+3. Source at shell startup: add `source ~/.omnibase/.env` to `~/.zshrc`
+
+## Shell Setup
+
+Add to `~/.zshrc`:
+
+```bash
+# Source shared OmniNode platform vars
+if [ -f ~/.omnibase/.env ]; then
+    source ~/.omnibase/.env
+fi
+```
+
+## Verification
+
+After sourcing in a new terminal:
+
+```bash
+echo "POSTGRES_HOST=$POSTGRES_HOST"       # Expect: 192.168.86.200
+echo "INFISICAL_ADDR=$INFISICAL_ADDR"     # Expect: http://localhost:8880
+echo "LLM_CODER_URL=$LLM_CODER_URL"      # Expect: http://192.168.86.201:8000
+```


### PR DESCRIPTION
## Summary
- Creates `~/.omnibase/.env` (home-dir, never committed) with full shared platform vars structure
- Adds `docs/plans/omnibase-env-setup.md` documenting the setup, sections, and verification steps
- File is transitional — will shrink to 5 bootstrap lines once containers read from Infisical (OMN-2484)
- Covers all sections: PostgreSQL, Kafka, Consul, Vault, Infisical (bootstrap only), LLM, Auth, Valkey, Service URLs, Environment, Slack

## Home-Dir Changes (not in PR but tracked)
- `~/.omnibase/.env` — created with placeholder values, must be filled from secure source

## Linear
Closes https://linear.app/omninode/issue/OMN-2481

## Test plan
- [ ] Fill placeholder values in `~/.omnibase/.env` from Infisical or existing secure source
- [ ] Source in new terminal and verify: `echo "POSTGRES_HOST=$POSTGRES_HOST"` → 192.168.86.200
- [ ] Verify: `echo "INFISICAL_ADDR=$INFISICAL_ADDR"` → http://localhost:8880
- [ ] Verify: `echo "LLM_CODER_URL=$LLM_CODER_URL"` → http://192.168.86.201:8000
- [ ] Verify POSTGRES_PASSWORD is set but not exported to any repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OmniBase environment setup guide detailing home directory configuration of shared platform variables across multiple services. Covers integration requirements for PostgreSQL, Kafka, Consul, Vault, Infisical bootstrap, LLM services, authentication mechanisms, Valkey caching layer, and Slack notifications. Includes shell startup integration instructions and verification commands to validate the setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->