### PR TITLE
test(slack): isolate ambient Slack env vars in webhook handler tests [OMN-2681]

### DIFF
--- a/tests/unit/handlers/test_handler_slack_webhook.py
+++ b/tests/unit/handlers/test_handler_slack_webhook.py
@@ -38,6 +38,19 @@ from omnibase_infra.handlers.models.model_slack_alert import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_slack_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove ambient Slack credentials from the environment for test isolation.
+
+    Prevents SLACK_BOT_TOKEN, SLACK_WEBHOOK_URL, and SLACK_CHANNEL_ID present in
+    the developer's shell from leaking into handler constructor env-var lookups and
+    affecting test assertions about mode selection.
+    """
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_CHANNEL_ID", raising=False)
+
+
 class TestModelSlackAlert:
     """Tests for ModelSlackAlert input model."""
 


### PR DESCRIPTION
## Summary

- Adds a module-level `autouse` fixture `_clear_slack_env_vars` to `test_handler_slack_webhook.py`
- Strips `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL`, and `SLACK_CHANNEL_ID` from the environment before each test via `monkeypatch.delenv`
- Fixes 6 tests that fail on `main` when the developer's shell has a real `SLACK_BOT_TOKEN` set (causing the handler to unexpectedly enter Web API mode)

## Root Cause

`HandlerSlackWebhook.__init__` falls through to `os.getenv("SLACK_BOT_TOKEN", "")` when `bot_token` is not explicitly provided. The `TestHandlerSlackWebhook` fixtures create handlers with only `webhook_url`, leaving `bot_token` to be picked up from the ambient environment.

## Test Plan

- [x] 48/48 pass with `SLACK_BOT_TOKEN=xoxb-fake-ambient-token` set in shell
- [x] 48/48 pass without any ambient token
- [x] All pre-commit hooks green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for Slack webhook handler tests to ensure more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->