### PR TITLE
feat(ci): add reusable Python release workflow

### DIFF
--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -13,9 +13,9 @@ on:
         default: true
     secrets:
       PYPI_PRIVATE_UPLOAD_URL:
-        required: true
+        required: false
       PYPI_PRIVATE_TOKEN:
-        required: true
+        required: false
 
 permissions:
   contents: write   # required for softprops/action-gh-release
@@ -33,7 +33,10 @@ jobs:
           fetch-depth: 0
 
       - name: Assert clean working tree
-        run: git diff --exit-code
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code
+          test -z "$(git ls-files --others --exclude-standard)"
 
       - name: Validate tag matches pyproject.toml version
         run: |
@@ -68,15 +71,23 @@ jobs:
             exit 1
           }
 
-      - name: Generate checksums
-        run: sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS.txt
-
       - name: Publish to private PyPI
         if: inputs.publish
         run: |
+          if [ -z "$UV_PUBLISH_URL" ] || [ -z "$UV_PUBLISH_TOKEN" ]; then
+            echo "ERROR: PYPI_PRIVATE_UPLOAD_URL and PYPI_PRIVATE_TOKEN secrets are required when publish is true"
+            exit 1
+          fi
           uv publish \
-            --index-url "${{ secrets.PYPI_PRIVATE_UPLOAD_URL }}" \
-            --token "${{ secrets.PYPI_PRIVATE_TOKEN }}"
+            --publish-url "$UV_PUBLISH_URL" \
+            --token "$UV_PUBLISH_TOKEN" \
+            dist/*.whl dist/*.tar.gz
+        env:
+          UV_PUBLISH_URL: ${{ secrets.PYPI_PRIVATE_UPLOAD_URL }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PRIVATE_TOKEN }}
+
+      - name: Generate checksums
+        run: sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -86,4 +97,4 @@ jobs:
             dist/*.tar.gz
             dist/SHA256SUMS.txt
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'post') }}
+          prerelease: ${{ contains(github.ref_name, 'rc') }}


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Actions workflow for tag-triggered Python package releases.

All OmniNode Python repos will call this workflow pinned to `@release-workflow-v1`.

## Changes
- `.github/workflows/release-python-reusable.yml` — reusable `workflow_call` workflow

## Key properties
- `permissions: contents: write` (required for `softprops/action-gh-release`)
- `concurrency.cancel-in-progress: false` (never cancel a release mid-flight)
- Validates `[project].version` in pyproject.toml matches the git tag (PEP 621 gate)
- `publish` boolean input (default: `true`) — pass `publish: false` for dry-run canary
- Generates `SHA256SUMS.txt` and attaches wheel + sdist + checksums to GitHub Release

## After merge
Tag this commit as `release-workflow-v1`:
```bash
git tag release-workflow-v1
git push --tags
```

## Reviewer checklist
- [ ] `permissions: contents: write` present
- [ ] `cancel-in-progress: false`
- [ ] Tag filter is strict semver only
- [ ] `publish` boolean input with `if: inputs.publish` guard on publish step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable CI workflow for Python package releases: validates package version against Git tag, builds wheel and sdist, ensures artifacts exist, generates SHA256 checksums, optionally publishes to a private PyPI, and creates a GitHub Release attaching artifacts. Prereleases are auto-marked for release refs containing "rc" or "post".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->