### PR TITLE
feat(ci): add release dry-run workflow [OMN-2674]

### DIFF
--- a/.github/workflows/release-python-dry-run.yml
+++ b/.github/workflows/release-python-dry-run.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           if [ ! -f "pyproject.toml" ]; then
             echo "ERROR: pyproject.toml not found at checkout root"
             exit 1


### PR DESCRIPTION
## Summary
- Adds `release-python-dry-run.yml` — `workflow_dispatch` dry run for testing the release pipeline without publishing to PyPI
- Complements `release-python-reusable.yml` already on main (merged via PR #406)
- Pipeline: validate `pyproject.toml` version == simulated tag → `uv build` → verify artifacts → generate SHA256SUMS → skip publish

## Context
The reusable workflow (`release-python-reusable.yml`) was already merged to main in PR #406 and tagged as `release-workflow-v1`. This PR adds the dry-run companion that lets any repo test their release pipeline without polluting PyPI.

## Auth
Dry-run intentionally has no secret inputs — it skips the publish step entirely.

## Call site pattern (Phase 3 repos)
```yaml
uses: OmniNode-ai/omnibase_infra/.github/workflows/release-python-reusable.yml@release-workflow-v1
secrets: inherit
```

## Test plan
- [ ] Trigger dry-run via `workflow_dispatch` with a package name and simulated tag matching the repo's `pyproject.toml` version
- [ ] Verify version mismatch causes hard failure
- [ ] Verify successful run produces wheel + sdist + SHA256SUMS without publishing

Resolves OMN-2674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual dry-run release workflow for Python packages that simulates a full release: accepts a simulated tag, validates tag format and version match, builds wheel and sdist, runs artifact checks, generates SHA256 checksums, uploads the built artifacts as an archive, and prints a dry-run summary—enabling end-to-end release validation without publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->