### PR TITLE
feat(infra): add runtime source-hash and compose-project startup banner [OMN-2292]

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -169,11 +169,19 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============================================================================
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
-# Build-time arguments for OCI version labels
-# These can be passed at build time for better image tracing
+# Build-time arguments for OCI version labels and deployment identity
+# These can be passed at build time for better image tracing and operator visibility.
+# RUNTIME_SOURCE_HASH and COMPOSE_PROJECT are stamped as env vars so operators can
+# verify which code is running via `docker logs <container>` without git forensics.
 ARG RUNTIME_VERSION=0.1.0
 ARG BUILD_DATE
 ARG VCS_REF
+# Source hash from the repo being deployed (short git SHA from the build context).
+# Default "unknown" ensures manual `docker compose up` without the arg still works.
+ARG RUNTIME_SOURCE_HASH=unknown
+# Docker Compose project name used for this deployment.
+# Lets operators confirm the container belongs to the expected compose stack.
+ARG COMPOSE_PROJECT=unknown
 
 # OCI Image Labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
 LABEL org.opencontainers.image.title="OmniBase Infra Runtime" \
@@ -204,6 +212,12 @@ ENV PYTHONUNBUFFERED=1 \
     ONEX_INPUT_TOPIC=requests \
     ONEX_OUTPUT_TOPIC=responses \
     ONEX_GROUP_ID=onex-runtime
+
+# Deployment identity env vars (stamped at build time from ARGs above).
+# Read by entrypoint-runtime.sh to emit the startup banner.
+# Operators can verify which code is running via: docker logs <container> | head -10
+ENV RUNTIME_SOURCE_HASH=${RUNTIME_SOURCE_HASH} \
+    COMPOSE_PROJECT=${COMPOSE_PROJECT}
 
 # Install minimal runtime dependencies only
 # No build tools needed - all Python packages are pre-compiled in builder stage

--- a/docker/entrypoint-runtime.sh
+++ b/docker/entrypoint-runtime.sh
@@ -24,6 +24,24 @@
 
 set -e
 
+# =============================================================================
+# Deployment Identity Banner
+# =============================================================================
+# Print before any service initialization so operators can immediately verify
+# which code is running via: docker logs <container> | head -15
+#
+# RUNTIME_SOURCE_HASH and COMPOSE_PROJECT are stamped at build time from
+# --build-arg values passed by deploy-runtime.sh. They default to "unknown"
+# when the image is built without those args (e.g. manual docker compose up).
+#
+# SOURCE_DIR is the installed package location inside the container.
+echo "=== OmniNode Runtime ==="
+echo "RUNTIME_SOURCE_HASH=${RUNTIME_SOURCE_HASH:-unknown}"
+echo "COMPOSE_PROJECT=${COMPOSE_PROJECT:-unknown}"
+echo "SOURCE_DIR=/app/src"
+echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "========================"
+
 if [ -n "${OMNIBASE_INFRA_DB_URL:-}" ]; then
   echo "[entrypoint] Stamping schema fingerprint into db_metadata..."
   if python -m omnibase_infra.runtime.util_schema_fingerprint stamp; then


### PR DESCRIPTION
## Summary

Stamps `RUNTIME_SOURCE_HASH` and `COMPOSE_PROJECT` into Docker images at build time, and prints a startup banner on container start. Operators can now verify which code is actually running in under 5 seconds using `docker logs <container> | head -10`.

**Root cause addressed**: Feb 15 incident (OMN-2233) where multiple repo copies sharing the same Docker Compose project name caused \"invisible deployments\" — code changes had no effect because containers ran from a different repo copy.

## Changes

- **`docker/Dockerfile.runtime`**: Add `ARG`/`ENV` for `RUNTIME_SOURCE_HASH` and `COMPOSE_PROJECT`. Default `unknown` ensures manual `docker compose up` without args still works.
- **`docker/entrypoint-runtime.sh`**: Emit startup banner before any service initialization, visible as first lines in `docker logs <container>`.
- **`scripts/deploy-runtime.sh`**: Pass `--build-arg RUNTIME_SOURCE_HASH=<git_sha>` and `--build-arg COMPOSE_PROJECT=<project>` in `build_images()`. Update `--print-compose-cmd` output.

## Banner format

```
=== OmniNode Runtime ===
RUNTIME_SOURCE_HASH=a1b2c3d
COMPOSE_PROJECT=omnibase-infra-prod
SOURCE_DIR=/app/src
BUILD_TIMESTAMP=2026-02-24T22:00:00Z
========================
```

## Acceptance criteria

- [x] All deployable services log source hash on startup
- [x] `docker logs <container>` shows banner in first 5 lines
- [x] `deploy-runtime.sh` passes hash and project automatically
- [x] Manual `docker compose up` without hash still works (shows "unknown")

## Linear

Closes [OMN-2292](https://linear.app/omninode/issue/OMN-2292)