### PR TITLE
test(adversarial): prove fingerprint CI twins catch drift [OMN-2293]

### DIFF
--- a/tests/unit/test_adversarial_fingerprint_drift.py
+++ b/tests/unit/test_adversarial_fingerprint_drift.py
@@ -40,11 +40,17 @@ import pytest
 
 from scripts.check_event_registry_fingerprint import (
     cmd_stamp as event_cmd_stamp,
+)
+from scripts.check_event_registry_fingerprint import (
     cmd_verify as event_cmd_verify,
 )
 from scripts.check_schema_fingerprint import (
     cmd_stamp as schema_cmd_stamp,
+)
+from scripts.check_schema_fingerprint import (
     cmd_verify as schema_cmd_verify,
+)
+from scripts.check_schema_fingerprint import (
     compute_migration_fingerprint,
     write_artifact,
 )
@@ -335,9 +341,7 @@ class TestEventRegistryFingerprintAdversarial:
             "a stale artifact in CI."
         )
 
-    def test_element_hash_mutation_behavior_is_documented(
-        self, tmp_path: Path
-    ) -> None:
+    def test_element_hash_mutation_behavior_is_documented(self, tmp_path: Path) -> None:
         """Documents how the event registry twin handles element-level corruption.
 
         The twin validates by recomputing the fingerprint from ALL_EVENT_REGISTRATIONS


### PR DESCRIPTION
## Summary

Adds 11 adversarial tests that intentionally introduce fingerprint drift and assert the CI twin system catches it. Proves the twin system (OMN-2149) is NOT cosmetic — it provably catches the specific drift scenarios that caused the Feb 15 incident class.

## Test structure

### Schema fingerprint adversarial tests (5 tests)

| Test | Drift introduced | Expected result |
|------|-----------------|----------------|
| `test_adding_column_to_existing_migration_is_caught` | Edit SQL content (add column) | exit 2 |
| `test_adding_new_migration_file_is_caught` | Add new .sql file | exit 2 |
| `test_renaming_migration_file_is_caught` | Rename existing migration | exit 2 |
| `test_stale_artifact_is_explicitly_rejected` | Write wrong hash directly | exit 2 |
| `test_verify_after_correct_stamp_always_passes` | Negative control | exit 0 |

### Event registry fingerprint adversarial tests (6 tests)

| Test | Drift introduced | Expected result |
|------|-----------------|----------------|
| `test_corrupted_fingerprint_hash_is_caught` | Zero out overall hash | exit 2 |
| `test_element_hash_mutation_behavior_is_documented` | Mutate element sha256 | **Documents exit 0** (informational field) |
| `test_missing_artifact_is_caught` | No artifact file | exit 2 |
| `test_invalid_json_in_artifact_is_caught` | Merge conflict markers | exit 2 |
| `test_extra_element_not_in_registry_is_caught` | Phantom element + corrupted hash | exit 2 |
| `test_verify_after_correct_stamp_always_passes` | Negative control | exit 0 |

## Discovery during implementation

The adversarial tests found that individual `element_sha256` mutation in the artifact JSON does **not** trigger verification failure. The twin recomputes from live `ALL_EVENT_REGISTRATIONS` and compares overall hashes only — element fields in the JSON are informational for diff display. This was correct behavior but previously undocumented. The new test pins and documents it explicitly.

## Linear

Closes [OMN-2293](https://linear.app/omninode/issue/OMN-2293)