### PR TITLE
[OMN-2699] MCP-03: Input schema validation before ONEX dispatch

### DIFF
--- a/src/omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py
+++ b/src/omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py
@@ -102,6 +102,11 @@ class MCPToolDefinition:
     requires_auth: bool = False
     tags: list[str] = field(default_factory=list)
     metadata: dict[str, object] = field(default_factory=dict)
+    # Full JSON Schema for input validation (OMN-2699).
+    # When set, HandlerMCP._handle_call_tool() validates arguments against this
+    # schema using jsonschema before dispatching to ONEX.  None means pass-through
+    # (backwards-compatible behaviour for tools registered without a schema).
+    input_schema: dict[str, object] | None = None
 
     def validate_tool_definition(self) -> bool:
         """Validate the tool definition."""
@@ -318,6 +323,9 @@ class ONEXToMCPAdapter:
                 "node_type": str(raw.get("node_type", "")),
                 "source": "contract_discovery",
             },
+            # Store the resolved JSON Schema so HandlerMCP can validate inputs
+            # before dispatching to ONEX (OMN-2699).
+            input_schema=input_schema if input_schema != {"type": "object"} else None,
         )
         self._tool_cache[tool_name] = tool
 
@@ -369,6 +377,7 @@ class ONEXToMCPAdapter:
         version: str = "1.0.0",
         tags: list[str] | None = None,
         timeout_seconds: int = 30,
+        input_schema: dict[str, object] | None = None,
     ) -> MCPToolDefinition:
         """Register an ONEX node as an MCP tool.
 
@@ -382,6 +391,9 @@ class ONEXToMCPAdapter:
             version: Tool version (default: "1.0.0").
             tags: Optional categorization tags.
             timeout_seconds: Execution timeout.
+            input_schema: Optional JSON Schema dict for input validation.
+                When provided, HandlerMCP validates arguments against this
+                schema before dispatching to ONEX (OMN-2699).
 
         Returns:
             The created tool definition.
@@ -394,6 +406,7 @@ class ONEXToMCPAdapter:
             parameters=parameters,
             timeout_seconds=timeout_seconds,
             tags=tags or [],
+            input_schema=input_schema,
         )
 
         self._tool_cache[node_name] = tool

--- a/tests/unit/handlers/test_handler_mcp.py
+++ b/tests/unit/handlers/test_handler_mcp.py
@@ -37,6 +37,7 @@ from omnibase_infra.errors import (
     RuntimeHostError,
 )
 from omnibase_infra.handlers.handler_mcp import HandlerMCP
+from omnibase_infra.handlers.mcp.adapter_onex_to_mcp import MCPToolDefinition
 from omnibase_infra.handlers.models.mcp import (
     EnumMcpOperationType,
     ModelMcpHandlerConfig,
@@ -683,3 +684,282 @@ class TestHandlerMCPConfigValidation:
         assert handler._config is not None
 
         await handler.shutdown()
+
+
+# =============================================================================
+# Input Schema Validation Tests (OMN-2699)
+# =============================================================================
+
+# JSON Schema used across the validation test suite.
+_SCHEMA_WITH_REQUIRED_STRING = {
+    "type": "object",
+    "properties": {
+        "model_name": {"type": "string", "description": "Name of the model"},
+        "temperature": {"type": "number", "description": "Sampling temperature"},
+        "mode": {
+            "type": "string",
+            "enum": ["fast", "precise", "balanced"],
+            "description": "Inference mode",
+        },
+    },
+    "required": ["model_name"],
+}
+
+
+def _make_tool_with_schema(
+    name: str = "test_tool",
+    input_schema: dict[str, object] | None = None,
+) -> MCPToolDefinition:
+    """Return a minimal MCPToolDefinition with an optional input_schema."""
+    return MCPToolDefinition(
+        name=name,
+        tool_type="function",
+        description="A test tool for validation tests.",
+        version="1.0.0",
+        input_schema=input_schema,
+    )
+
+
+class TestHandlerMCPInputSchemaValidation:
+    """Tests for R1/R2: input schema validation before ONEX dispatch (OMN-2699).
+
+    These tests cover:
+    - Missing required field is rejected with isError=True (no dispatch)
+    - Wrong type for a field is rejected with isError=True
+    - Enum value violation is rejected with isError=True
+    - Valid arguments pass validation and reach dispatch
+    - Tool without input_schema passes through unchanged (backwards-compatible)
+    - Error messages identify the failing field (no raw tracebacks)
+    """
+
+    @pytest.fixture
+    async def handler(
+        self, mock_container: MagicMock, mcp_test_config: dict[str, object]
+    ) -> HandlerMCP:
+        """Initialized HandlerMCP with skip_server=True."""
+        h = HandlerMCP(container=mock_container)
+        await h.initialize(mcp_test_config)
+        yield h
+        await h.shutdown()
+
+    # ------------------------------------------------------------------
+    # R1: Validation rejects bad inputs
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_required_field_returns_error(
+        self, handler: HandlerMCP
+    ) -> None:
+        """Missing required field should return isError=True, no dispatch."""
+        tool = _make_tool_with_schema(
+            name="needs_model_name",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["needs_model_name"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "needs_model_name",
+                "arguments": {},  # model_name is required but absent
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        assert result.result["status"] == "error"
+        payload = result.result["payload"]
+        assert payload["is_error"] is True
+        assert payload["success"] is False
+        # Error message must mention the field
+        assert "model_name" in payload["error_message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_wrong_type_returns_error(self, handler: HandlerMCP) -> None:
+        """Wrong type for a field (int instead of string) should return isError=True."""
+        tool = _make_tool_with_schema(
+            name="type_check_tool",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["type_check_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "type_check_tool",
+                "arguments": {"model_name": 42},  # must be string
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        assert result.result["status"] == "error"
+        payload = result.result["payload"]
+        assert payload["is_error"] is True
+        # Error message must name the failing field
+        assert "model_name" in payload["error_message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_enum_violation_returns_error(self, handler: HandlerMCP) -> None:
+        """Enum value not in allowed set should return isError=True."""
+        tool = _make_tool_with_schema(
+            name="enum_tool",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["enum_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "enum_tool",
+                "arguments": {
+                    "model_name": "gpt-4",
+                    "mode": "turbo",  # not in ["fast", "precise", "balanced"]
+                },
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        assert result.result["status"] == "error"
+        payload = result.result["payload"]
+        assert payload["is_error"] is True
+        # Should mention the mode field
+        assert "mode" in payload["error_message"]
+
+    # ------------------------------------------------------------------
+    # R1: Valid inputs dispatch successfully
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_valid_input_dispatches_successfully(
+        self, handler: HandlerMCP
+    ) -> None:
+        """Valid arguments must pass validation and reach dispatch (not short-circuit)."""
+        tool = _make_tool_with_schema(
+            name="valid_tool",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["valid_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "valid_tool",
+                "arguments": {
+                    "model_name": "gpt-4",
+                    "temperature": 0.7,
+                    "mode": "fast",
+                },
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        # Should reach dispatch (placeholder) and return success
+        assert result.result["status"] == "success"
+        payload = result.result["payload"]
+        assert payload["is_error"] is False
+
+    # ------------------------------------------------------------------
+    # R1: Backwards-compatible pass-through when no schema
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_tool_without_schema_passes_through(
+        self, handler: HandlerMCP
+    ) -> None:
+        """Tool with input_schema=None must not validate (pass-through)."""
+        tool = _make_tool_with_schema(
+            name="no_schema_tool",
+            input_schema=None,  # explicitly no schema
+        )
+        handler._tool_registry["no_schema_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "no_schema_tool",
+                "arguments": {"garbage": True},  # would fail if validated
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        # Must succeed (no validation gate applied)
+        assert result.result["status"] == "success"
+
+    # ------------------------------------------------------------------
+    # R2: Error message quality — no raw Python tracebacks
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_validation_error_message_has_no_traceback(
+        self, handler: HandlerMCP
+    ) -> None:
+        """Validation error messages must not contain raw Python tracebacks."""
+        tool = _make_tool_with_schema(
+            name="traceback_check_tool",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["traceback_check_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "traceback_check_tool",
+                "arguments": {},  # missing required field
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        error_message: str = result.result["payload"]["error_message"]
+        # Must NOT contain any Python traceback markers
+        assert "Traceback" not in error_message
+        assert "File " not in error_message
+        assert "jsonschema" not in error_message.lower()
+        # Must be a clean user-facing message
+        assert len(error_message) < 300  # bounded length
+
+    # ------------------------------------------------------------------
+    # R2: Error message names the failing field
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_validation_error_message_names_field(
+        self, handler: HandlerMCP
+    ) -> None:
+        """Validation error message must name the field that failed validation."""
+        tool = _make_tool_with_schema(
+            name="field_naming_tool",
+            input_schema=_SCHEMA_WITH_REQUIRED_STRING,
+        )
+        handler._tool_registry["field_naming_tool"] = tool  # type: ignore[assignment]
+
+        envelope = {
+            "operation": EnumMcpOperationType.CALL_TOOL.value,
+            "payload": {
+                "tool_name": "field_naming_tool",
+                "arguments": {"model_name": 99},  # wrong type
+            },
+            "correlation_id": str(uuid4()),
+        }
+
+        result = await handler.execute(envelope)
+
+        error_message: str = result.result["payload"]["error_message"]
+        assert "model_name" in error_message


### PR DESCRIPTION
## Summary

- Adds JSON Schema validation to `HandlerMCP._handle_call_tool()` before dispatching to ONEX orchestrators, so malformed inputs are rejected at the MCP boundary with a clean `CallToolResult(isError=True)` instead of producing confusing downstream errors
- `MCPToolDefinition` gains an `input_schema: dict | None` field populated from the resolved Pydantic JSON Schema during contract discovery (OMN-2698)
- `register_node_as_tool()` accepts an optional `input_schema` parameter for programmatic registration
- Tools without `input_schema` pass through unchanged (fully backwards-compatible)
- Fixes `model_dump(mode='json')` for UUID serialisation to satisfy `ModelHandlerOutput` JSON-ledger-safe constraint

## Changes

**`src/omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py`**
- `MCPToolDefinition`: add `input_schema: dict[str, object] | None = None` field
- `_load_contract()`: populate `input_schema` from resolved Pydantic JSON Schema
- `register_node_as_tool()`: accept `input_schema` keyword argument

**`src/omnibase_infra/handlers/handler_mcp.py`**
- Import `jsonschema`
- Add `_validate_arguments_against_schema()` — validates via `jsonschema.validate()`, returns clean field-specific error string or `None`; malformed schema degrades gracefully (skips validation, logs warning)
- `_handle_call_tool()`: validate before `_execute_tool()` dispatch; return error result immediately on failure
- Both `model_dump()` calls changed to `model_dump(mode='json')` to serialise UUID fields

**`tests/unit/handlers/test_handler_mcp.py`**
- 7 new `@pytest.mark.unit` tests in `TestHandlerMCPInputSchemaValidation`
- Covers: missing required field, wrong type, enum violation, valid pass-through, no-schema pass-through, no raw tracebacks, field naming in error messages

## Dependencies

- Branched from `main` which already includes OMN-2698 (`feat(mcp): implement contract-driven tool discovery in ONEXToMCPAdapter`)
- Blocked by OMN-2697 (real dispatch) and OMN-2698 (contract schemas) — both in PRs #420 and #424

## Test plan

- [x] `uv run pytest tests/unit/handlers/test_handler_mcp.py -m unit` — 35 passed (28 existing + 7 new)
- [x] `uv run pytest tests/unit/handlers/mcp/ -m unit` — 19 passed
- [x] `uv run pytest tests/unit/handlers/ -m unit` — 1003 passed
- [x] `pre-commit run --all-files` — all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP tool calls now validate input against defined schemas, returning clear error messages when validation fails.

* **Bug Fixes**
  * Improved JSON serialization of tool results and identifiers in MCP responses for better compatibility.

* **Tests**
  * Added comprehensive tests for input validation in MCP tool handling, covering type checking and field validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->