### PR TITLE
test(performance): production baseline benchmarks for ONEX infrastructure [OMN-782]

### DIFF
--- a/tests/performance/test_production_benchmarks.py
+++ b/tests/performance/test_production_benchmarks.py
@@ -1,0 +1,816 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Production performance benchmarks for ONEX infrastructure [OMN-782].
+
+This test suite establishes production baselines per INFRA-041. It validates
+three categories of performance requirements defined in
+`omnibase_infra/docs/milestones/PRODUCTION_v0.3.0.md` (Issue 4.11):
+
+1. Memory per 10 nodes < 200 MB
+   - 10 EventBusInmemory node instances
+   - 10 ModelOnexEnvelope objects (full production payload)
+   - 10 ModelNodeIdentity objects
+
+2. Envelope throughput > 100 envelopes/sec
+   - Sequential envelope publish-and-deliver loop
+   - Concurrent multi-topic envelope dispatch
+   - Envelope construction throughput (pure Python overhead)
+
+3. Handler latency targets
+   - p50 < 5 ms for in-memory handler round-trip
+   - p99 < 20 ms for in-memory handler round-trip
+   - Handler call overhead < 1 ms (trivial no-op)
+
+Implementation Notes:
+    All benchmarks use in-memory components (EventBusInmemory, ModelOnexEnvelope)
+    so no external infrastructure is required. Results are deterministic and
+    reproducible in CI.
+
+    Thresholds are deliberately generous to remain CI-stable:
+    - Memory: 200 MB limit (actual usage is ~0.05 MB for 10 nodes)
+    - Throughput: 100/sec minimum (actual is 1000+ on dev machines)
+    - Latency: 20 ms p99 (actual is <1 ms with in-memory delivery)
+
+    These baselines encode "never regress below X" rather than aspirational
+    performance goals.
+
+CI Behavior:
+    All tests run in CI. No @pytest.mark.skipif guards since the
+    thresholds are generous enough to pass on shared runners.
+
+Usage:
+    uv run pytest tests/performance/test_production_benchmarks.py -v -s
+
+Related:
+    - OMN-782: INFRA-041 Performance benchmarks [PROD]
+    - OMN-57: Event bus performance testing (Phase 9)
+    - tests/performance/event_bus/: Per-component event bus benchmarks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import time
+import tracemalloc
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from statistics import mean, median
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.models.core.model_onex_envelope import ModelOnexEnvelope
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.event_bus.models import ModelEventMessage
+from omnibase_infra.models import ModelNodeIdentity
+from tests.conftest import make_test_node_identity
+from tests.performance.event_bus.conftest import generate_unique_topic
+
+# Mark all tests as performance
+pytestmark = [pytest.mark.performance]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PROD_ENVELOPE_VERSION = ModelSemVer(major=1, minor=0, patch=0)
+
+# Production memory budget: 200 MB for 10 nodes (from ticket spec)
+MEMORY_BUDGET_MB_PER_10_NODES: float = 200.0
+
+# Throughput floor: at least 100 envelopes/sec end-to-end
+MIN_ENVELOPE_THROUGHPUT_PER_SEC: int = 100
+
+# Handler latency ceilings (ms)
+MAX_P50_LATENCY_MS: float = 5.0
+MAX_P99_LATENCY_MS: float = 20.0
+MAX_HANDLER_OVERHEAD_MS: float = 1.0  # Trivial no-op handler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_envelope(
+    source_node: str = "benchmark.node.effect",
+    operation: str = "benchmark_operation",
+) -> ModelOnexEnvelope:
+    """Construct a production-representative ModelOnexEnvelope."""
+    return ModelOnexEnvelope(
+        envelope_id=uuid4(),
+        envelope_version=PROD_ENVELOPE_VERSION,
+        correlation_id=uuid4(),
+        source_node=source_node,
+        operation=operation,
+        payload={
+            "node_id": str(uuid4()),
+            "env": "prod",
+            "service": "omnibase-infra",
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+        timestamp=datetime.now(UTC),
+    )
+
+
+def _mb(bytes_: int) -> float:
+    return bytes_ / (1024 * 1024)
+
+
+# ---------------------------------------------------------------------------
+# 1. Memory per 10 Nodes < 200 MB
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryPer10Nodes:
+    """Validate that 10 in-memory node-equivalent objects stay well under 200 MB.
+
+    The 200 MB budget is a production SLO from PRODUCTION_v0.3.0.md. These
+    tests measure allocation delta (not process RSS) to isolate the cost of
+    the ONEX objects themselves from Python interpreter overhead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_10_event_bus_nodes_under_200mb(self) -> None:
+        """10 EventBusInmemory instances consume < 200 MB total.
+
+        Each ONEX node typically wraps an EventBusInmemory for local pub/sub.
+        This test verifies the memory footprint for 10 such node instances.
+        """
+        gc.collect()
+        tracemalloc.start()
+        snapshot_before = tracemalloc.take_snapshot()
+
+        buses: list[EventBusInmemory] = []
+        for i in range(10):
+            bus = EventBusInmemory(
+                environment="prod-bench",
+                group=f"node-{i}",
+                max_history=1000,
+            )
+            await bus.start()
+            buses.append(bus)
+
+        snapshot_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        # Sum memory allocated between snapshots
+        top_stats = snapshot_after.compare_to(snapshot_before, "lineno")
+        allocated_bytes = sum(
+            stat.size_diff for stat in top_stats if stat.size_diff > 0
+        )
+        allocated_mb = _mb(allocated_bytes)
+
+        for bus in buses:
+            await bus.close()
+
+        print(f"\n10 EventBusInmemory nodes: {allocated_mb:.3f} MB allocated")
+        assert allocated_mb < MEMORY_BUDGET_MB_PER_10_NODES, (
+            f"10 nodes used {allocated_mb:.2f} MB, budget is {MEMORY_BUDGET_MB_PER_10_NODES} MB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_10_envelope_objects_under_200mb(self) -> None:
+        """10 ModelOnexEnvelope objects consume < 200 MB total.
+
+        Envelopes are the primary data structure in ONEX event flow. This test
+        validates that 10 production-representative envelopes fit well within
+        the 200 MB per-10-nodes memory budget.
+        """
+        gc.collect()
+        tracemalloc.start()
+        snapshot_before = tracemalloc.take_snapshot()
+
+        envelopes = [_make_envelope() for _ in range(10)]
+
+        snapshot_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        top_stats = snapshot_after.compare_to(snapshot_before, "lineno")
+        allocated_bytes = sum(
+            stat.size_diff for stat in top_stats if stat.size_diff > 0
+        )
+        allocated_mb = _mb(allocated_bytes)
+
+        # Keep reference alive until measurement complete
+        _ = envelopes
+
+        print(f"\n10 ModelOnexEnvelope objects: {allocated_mb:.3f} MB allocated")
+        assert allocated_mb < MEMORY_BUDGET_MB_PER_10_NODES, (
+            f"10 envelopes used {allocated_mb:.2f} MB, budget is {MEMORY_BUDGET_MB_PER_10_NODES} MB"
+        )
+
+    def test_10_model_node_identity_under_200mb(self) -> None:
+        """10 ModelNodeIdentity objects consume < 200 MB total.
+
+        Node identities are created at startup and held for the node lifetime.
+        This validates their per-node footprint is acceptable for production.
+        """
+        gc.collect()
+        tracemalloc.start()
+        snapshot_before = tracemalloc.take_snapshot()
+
+        identities = [
+            ModelNodeIdentity(
+                env="prod",
+                service=f"service-{i}",
+                node_name=f"node-{i}",
+                version="v1",
+            )
+            for i in range(10)
+        ]
+
+        snapshot_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        top_stats = snapshot_after.compare_to(snapshot_before, "lineno")
+        allocated_bytes = sum(
+            stat.size_diff for stat in top_stats if stat.size_diff > 0
+        )
+        allocated_mb = _mb(allocated_bytes)
+
+        _ = identities
+
+        print(f"\n10 ModelNodeIdentity objects: {allocated_mb:.3f} MB allocated")
+        assert allocated_mb < MEMORY_BUDGET_MB_PER_10_NODES, (
+            f"10 identities used {allocated_mb:.2f} MB, budget is {MEMORY_BUDGET_MB_PER_10_NODES} MB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_node_components_under_200mb(self) -> None:
+        """10 nodes with full component set (bus + identity + envelope) under 200 MB.
+
+        Simulates the aggregate memory footprint of 10 fully-configured ONEX
+        production nodes: event bus + identity + 10 pending envelopes each.
+        """
+        gc.collect()
+        tracemalloc.start()
+        snapshot_before = tracemalloc.take_snapshot()
+
+        buses = []
+        all_objects: list[object] = []
+
+        for i in range(10):
+            bus = EventBusInmemory(
+                environment="prod",
+                group=f"node-{i}",
+                max_history=100,
+            )
+            await bus.start()
+            buses.append(bus)
+
+            identity = ModelNodeIdentity(
+                env="prod",
+                service=f"service-{i}",
+                node_name=f"node-{i}",
+                version="v1",
+            )
+            # Each node holds a pending envelope
+            envelope = _make_envelope(
+                source_node=f"node-{i}.effect",
+                operation="process_event",
+            )
+            all_objects.extend([identity, envelope])
+
+        snapshot_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        top_stats = snapshot_after.compare_to(snapshot_before, "lineno")
+        allocated_bytes = sum(
+            stat.size_diff for stat in top_stats if stat.size_diff > 0
+        )
+        allocated_mb = _mb(allocated_bytes)
+
+        for bus in buses:
+            await bus.close()
+
+        print(
+            f"\n10 full node components (bus+identity+envelope): {allocated_mb:.3f} MB"
+        )
+        assert allocated_mb < MEMORY_BUDGET_MB_PER_10_NODES, (
+            f"Mixed 10-node setup used {allocated_mb:.2f} MB, "
+            f"budget is {MEMORY_BUDGET_MB_PER_10_NODES} MB"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Envelope Throughput > 100/sec
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeThroughput:
+    """Validate that envelope processing exceeds the 100/sec production minimum.
+
+    The 100/sec floor is the minimum throughput for production workloads.
+    Tests measure end-to-end throughput: construction → publish → subscriber
+    delivery. CI threshold is 100/sec; local machines typically achieve 1000+.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sequential_envelope_throughput_over_100_per_sec(self) -> None:
+        """Sequential envelope publish-and-deliver achieves > 100/sec.
+
+        Publishes N envelopes sequentially to a single topic with one subscriber.
+        Measures wall-clock throughput from first to last delivery.
+        """
+        bus = EventBusInmemory(
+            environment="throughput-bench",
+            group="prod",
+            max_history=10000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+        delivered: list[int] = []
+        lock = asyncio.Lock()
+
+        async def subscriber(msg: ModelEventMessage) -> None:
+            async with lock:
+                delivered.append(1)
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="throughput", node_name="consumer"),
+            subscriber,
+        )
+
+        # Warm-up (not counted)
+        for _ in range(5):
+            await bus.publish(
+                topic=topic,
+                key=b"warmup",
+                value=_make_envelope().model_dump_json().encode(),
+            )
+        delivered.clear()
+
+        # Benchmark
+        num_envelopes = 200
+        start = time.perf_counter()
+        for i in range(num_envelopes):
+            envelope = _make_envelope()
+            await bus.publish(
+                topic=topic,
+                key=str(i).encode(),
+                value=envelope.model_dump_json().encode(),
+            )
+        elapsed = time.perf_counter() - start
+
+        await bus.close()
+
+        throughput = num_envelopes / elapsed
+        print(f"\nSequential envelope throughput: {throughput:.0f}/sec")
+
+        assert len(delivered) == num_envelopes, (
+            f"Expected {num_envelopes} deliveries, got {len(delivered)}"
+        )
+        assert throughput >= MIN_ENVELOPE_THROUGHPUT_PER_SEC, (
+            f"Throughput {throughput:.0f}/sec < minimum {MIN_ENVELOPE_THROUGHPUT_PER_SEC}/sec"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_multi_topic_envelope_throughput(self) -> None:
+        """Concurrent multi-topic dispatch achieves > 100/sec aggregate.
+
+        Simulates 5 parallel producers sending envelopes on separate topics.
+        Validates that concurrent operation does not degrade below 100/sec.
+        """
+        num_topics = 5
+        envelopes_per_topic = 40  # 200 total
+
+        bus = EventBusInmemory(
+            environment="concurrent-bench",
+            group="prod",
+            max_history=5000,
+        )
+        await bus.start()
+
+        topics = [generate_unique_topic() for _ in range(num_topics)]
+        total_delivered = 0
+        lock = asyncio.Lock()
+
+        async def make_subscriber() -> None:
+            pass
+
+        async def subscriber(msg: ModelEventMessage) -> None:
+            nonlocal total_delivered
+            async with lock:
+                total_delivered += 1
+
+        for i, topic in enumerate(topics):
+            await bus.subscribe(
+                topic,
+                make_test_node_identity(
+                    service="concurrent-bench", node_name="sub", suffix=f"-{i}"
+                ),
+                subscriber,
+            )
+
+        async def topic_producer(topic: str) -> None:
+            for _ in range(envelopes_per_topic):
+                envelope = _make_envelope()
+                await bus.publish(
+                    topic=topic,
+                    key=b"key",
+                    value=envelope.model_dump_json().encode(),
+                )
+
+        start = time.perf_counter()
+        await asyncio.gather(*[topic_producer(t) for t in topics])
+        elapsed = time.perf_counter() - start
+
+        await bus.close()
+
+        total = num_topics * envelopes_per_topic
+        throughput = total / elapsed
+
+        print(
+            f"\nConcurrent multi-topic throughput: {throughput:.0f}/sec ({num_topics} topics)"
+        )
+
+        assert total_delivered == total, f"Delivered {total_delivered}/{total}"
+        assert throughput >= MIN_ENVELOPE_THROUGHPUT_PER_SEC, (
+            f"Throughput {throughput:.0f}/sec < minimum {MIN_ENVELOPE_THROUGHPUT_PER_SEC}/sec"
+        )
+
+    def test_envelope_construction_throughput_over_100_per_sec(self) -> None:
+        """Envelope construction alone achieves > 100/sec.
+
+        Measures pure Python construction overhead (ModelOnexEnvelope creation)
+        without any I/O. This isolates serialization/validation cost.
+        """
+        num_envelopes = 500
+        start = time.perf_counter()
+        envelopes = [_make_envelope() for _ in range(num_envelopes)]
+        elapsed = time.perf_counter() - start
+
+        _ = envelopes  # prevent GC during measurement
+
+        throughput = num_envelopes / elapsed
+        print(f"\nEnvelope construction throughput: {throughput:.0f}/sec")
+
+        assert throughput >= MIN_ENVELOPE_THROUGHPUT_PER_SEC, (
+            f"Construction throughput {throughput:.0f}/sec < {MIN_ENVELOPE_THROUGHPUT_PER_SEC}/sec"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sustained_throughput_over_1_second(self) -> None:
+        """Sustained envelope throughput > 100/sec over 1 second.
+
+        Runs continuous publish-deliver cycles for 1 second and validates
+        that average throughput meets the production floor.
+        """
+        bus = EventBusInmemory(
+            environment="sustained-bench",
+            group="prod",
+            max_history=50000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+        delivered_count = 0
+        lock = asyncio.Lock()
+
+        async def subscriber(msg: ModelEventMessage) -> None:
+            nonlocal delivered_count
+            async with lock:
+                delivered_count += 1
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="sustained", node_name="consumer"),
+            subscriber,
+        )
+
+        run_seconds = 1.0
+        published = 0
+        start = time.perf_counter()
+
+        while time.perf_counter() - start < run_seconds:
+            envelope = _make_envelope()
+            await bus.publish(
+                topic=topic,
+                key=str(published).encode(),
+                value=envelope.model_dump_json().encode(),
+            )
+            published += 1
+
+        elapsed = time.perf_counter() - start
+        await bus.close()
+
+        throughput = published / elapsed
+        print(f"\nSustained throughput: {throughput:.0f}/sec over {elapsed:.2f}s")
+
+        assert delivered_count == published, f"Parity: {delivered_count}/{published}"
+        assert throughput >= MIN_ENVELOPE_THROUGHPUT_PER_SEC, (
+            f"Sustained throughput {throughput:.0f}/sec < {MIN_ENVELOPE_THROUGHPUT_PER_SEC}/sec"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Handler Latency Targets
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerLatencyTargets:
+    """Validate per-call handler latency meets production targets.
+
+    Production targets (PRODUCTION_v0.3.0.md):
+    - p50 handler latency < 5 ms
+    - p99 handler latency < 20 ms
+    - No-op overhead < 1 ms per call
+
+    All measurements use wall-clock time from publish() call start to
+    subscriber callback return. The in-memory bus delivers synchronously
+    so this accurately measures round-trip latency.
+    """
+
+    @pytest.mark.asyncio
+    async def test_noop_handler_overhead_under_1ms(self) -> None:
+        """Trivial no-op handler overhead < 1 ms per publish-deliver cycle.
+
+        Measures the minimum overhead of publish() + subscriber dispatch
+        with a handler that does no work. This is the floor for all
+        handler latency expectations.
+        """
+        bus = EventBusInmemory(
+            environment="overhead-bench",
+            group="prod",
+            max_history=10000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+
+        async def noop_handler(msg: ModelEventMessage) -> None:
+            pass
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="overhead", node_name="noop"),
+            noop_handler,
+        )
+
+        # Warm up
+        for _ in range(10):
+            await bus.publish(topic=topic, key=b"w", value=b"{}")
+
+        # Measure
+        num_samples = 500
+        latencies_ms: list[float] = []
+        for i in range(num_samples):
+            t0 = time.perf_counter()
+            await bus.publish(
+                topic=topic,
+                key=str(i).encode(),
+                value=b'{"bench": true}',
+            )
+            latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+        await bus.close()
+
+        p50 = median(latencies_ms)
+        p99 = sorted(latencies_ms)[int(num_samples * 0.99)]
+        avg = mean(latencies_ms)
+
+        print(
+            f"\nNo-op handler overhead: avg={avg:.3f}ms p50={p50:.3f}ms p99={p99:.3f}ms"
+        )
+
+        assert p50 < MAX_HANDLER_OVERHEAD_MS, (
+            f"No-op p50 {p50:.3f}ms >= {MAX_HANDLER_OVERHEAD_MS}ms — unexpected overhead"
+        )
+
+    @pytest.mark.asyncio
+    async def test_envelope_handler_p50_under_5ms(self) -> None:
+        """Envelope-processing handler p50 < 5 ms.
+
+        Measures p50 latency for a handler that deserializes an envelope
+        (JSON decode), simulating the lightest realistic production handler.
+        """
+        import json
+
+        bus = EventBusInmemory(
+            environment="p50-bench",
+            group="prod",
+            max_history=10000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+
+        async def envelope_handler(msg: ModelEventMessage) -> None:
+            # Minimal production-like work: decode envelope JSON
+            json.loads(msg.value)
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="p50-bench", node_name="handler"),
+            envelope_handler,
+        )
+
+        # Warm up
+        warmup_payload = _make_envelope().model_dump_json().encode()
+        for _ in range(10):
+            await bus.publish(topic=topic, key=b"w", value=warmup_payload)
+
+        num_samples = 300
+        latencies_ms: list[float] = []
+        for i in range(num_samples):
+            payload = _make_envelope().model_dump_json().encode()
+            t0 = time.perf_counter()
+            await bus.publish(topic=topic, key=str(i).encode(), value=payload)
+            latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+        await bus.close()
+
+        p50 = median(latencies_ms)
+        p99 = sorted(latencies_ms)[int(num_samples * 0.99)]
+        avg = mean(latencies_ms)
+
+        print(
+            f"\nEnvelope handler latency: avg={avg:.2f}ms p50={p50:.2f}ms p99={p99:.2f}ms"
+        )
+
+        assert p50 < MAX_P50_LATENCY_MS, (
+            f"p50 {p50:.2f}ms >= {MAX_P50_LATENCY_MS}ms — latency regression detected"
+        )
+
+    @pytest.mark.asyncio
+    async def test_envelope_handler_p99_under_20ms(self) -> None:
+        """Envelope-processing handler p99 < 20 ms.
+
+        Validates the 99th percentile of handler latency. A p99 > 20 ms
+        would indicate latency spikes that could affect production SLOs.
+        """
+        import json
+
+        bus = EventBusInmemory(
+            environment="p99-bench",
+            group="prod",
+            max_history=10000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+
+        async def json_decode_handler(msg: ModelEventMessage) -> None:
+            json.loads(msg.value)
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="p99-bench", node_name="handler"),
+            json_decode_handler,
+        )
+
+        # Larger sample for reliable p99 estimate
+        num_samples = 500
+        latencies_ms: list[float] = []
+        for i in range(num_samples):
+            payload = _make_envelope().model_dump_json().encode()
+            t0 = time.perf_counter()
+            await bus.publish(topic=topic, key=str(i).encode(), value=payload)
+            latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+        await bus.close()
+
+        sorted_latencies = sorted(latencies_ms)
+        p50 = sorted_latencies[num_samples // 2]
+        p95 = sorted_latencies[int(num_samples * 0.95)]
+        p99 = sorted_latencies[int(num_samples * 0.99)]
+        avg = mean(latencies_ms)
+
+        print(
+            f"\nHandler latency distribution ({num_samples} samples): "
+            f"avg={avg:.2f}ms p50={p50:.2f}ms p95={p95:.2f}ms p99={p99:.2f}ms"
+        )
+
+        assert p99 < MAX_P99_LATENCY_MS, (
+            f"p99 {p99:.2f}ms >= {MAX_P99_LATENCY_MS}ms — tail latency budget exceeded"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multi_subscriber_handler_latency_scales(self) -> None:
+        """Handler latency with 5 subscribers stays < p99 budget.
+
+        With 5 subscribers per topic, each publish call invokes 5 handlers
+        sequentially. This test validates that fan-out latency remains within
+        the p99 budget, ensuring multi-subscriber deployments are viable.
+        """
+        import json
+
+        bus = EventBusInmemory(
+            environment="fanout-latency",
+            group="prod",
+            max_history=10000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+        num_subscribers = 5
+
+        async def subscriber_handler(msg: ModelEventMessage) -> None:
+            json.loads(msg.value)
+
+        for i in range(num_subscribers):
+            await bus.subscribe(
+                topic,
+                make_test_node_identity(
+                    service="fanout-latency", node_name="sub", suffix=f"-{i}"
+                ),
+                subscriber_handler,
+            )
+
+        num_samples = 200
+        latencies_ms: list[float] = []
+        for i in range(num_samples):
+            payload = _make_envelope().model_dump_json().encode()
+            t0 = time.perf_counter()
+            await bus.publish(topic=topic, key=str(i).encode(), value=payload)
+            latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+        await bus.close()
+
+        sorted_latencies = sorted(latencies_ms)
+        p50 = sorted_latencies[num_samples // 2]
+        p99 = sorted_latencies[int(num_samples * 0.99)]
+        avg = mean(latencies_ms)
+
+        print(
+            f"\nFan-out latency ({num_subscribers} subscribers): "
+            f"avg={avg:.2f}ms p50={p50:.2f}ms p99={p99:.2f}ms"
+        )
+
+        # Fan-out p99 must stay within 5x the single-subscriber p99 budget
+        # This accounts for sequential handler invocation overhead
+        fanout_p99_budget = MAX_P99_LATENCY_MS * num_subscribers
+        assert p99 < fanout_p99_budget, (
+            f"Fan-out p99 {p99:.2f}ms >= budget {fanout_p99_budget:.1f}ms "
+            f"({num_subscribers} subscribers x {MAX_P99_LATENCY_MS}ms)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_latency_stable_under_sustained_load(self) -> None:
+        """Handler latency remains stable under 3-second sustained load.
+
+        Validates that latency does not degrade over time due to GC pressure,
+        lock contention, or internal state growth.
+
+        Stability criterion: latest-quarter p50 ≤ 2x initial-quarter p50.
+        """
+        import json
+
+        bus = EventBusInmemory(
+            environment="stability-bench",
+            group="prod",
+            max_history=20000,
+        )
+        await bus.start()
+
+        topic = generate_unique_topic()
+
+        async def handler(msg: ModelEventMessage) -> None:
+            json.loads(msg.value)
+
+        await bus.subscribe(
+            topic,
+            make_test_node_identity(service="stability", node_name="handler"),
+            handler,
+        )
+
+        run_seconds = 2.0
+        latencies_ms: list[float] = []
+        start = time.perf_counter()
+
+        while time.perf_counter() - start < run_seconds:
+            payload = _make_envelope().model_dump_json().encode()
+            t0 = time.perf_counter()
+            await bus.publish(
+                topic=topic,
+                key=str(len(latencies_ms)).encode(),
+                value=payload,
+            )
+            latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+        await bus.close()
+
+        total = len(latencies_ms)
+        quarter = max(total // 4, 1)
+
+        # Compare first quarter vs last quarter p50
+        first_q = sorted(latencies_ms[:quarter])
+        last_q = sorted(latencies_ms[-quarter:])
+        first_p50 = first_q[len(first_q) // 2]
+        last_p50 = last_q[len(last_q) // 2]
+
+        print(
+            f"\nLatency stability ({total} samples over {run_seconds}s): "
+            f"first-quarter p50={first_p50:.3f}ms, last-quarter p50={last_p50:.3f}ms"
+        )
+
+        # Latency should not degrade by more than 3x from initial quarter
+        assert last_p50 <= first_p50 * 3 + 0.5, (
+            f"Latency degraded: first-quarter p50={first_p50:.3f}ms → "
+            f"last-quarter p50={last_p50:.3f}ms (>3x increase)"
+        )


### PR DESCRIPTION
## Summary

- Implements INFRA-041 (OMN-782): production performance benchmarks for the PRODUCTION milestone
- Establishes the three baseline targets from `PRODUCTION_v0.3.0.md` (Issue 4.11): memory per 10 nodes, envelope throughput, and handler latency
- 13 new tests across 3 benchmark classes using in-memory components only — no external infrastructure required, runs in ~4.5s

## Benchmark Classes Added

**`TestMemoryPer10Nodes`** (4 tests) — budget: 200 MB per 10 nodes
- `test_10_event_bus_nodes_under_200mb` — 10 EventBusInmemory instances: ~0.02 MB (tracemalloc delta)
- `test_10_envelope_objects_under_200mb` — 10 ModelOnexEnvelope objects: ~0.03 MB
- `test_10_model_node_identity_under_200mb` — 10 ModelNodeIdentity objects: ~0.002 MB
- `test_mixed_node_components_under_200mb` — Full node setup (bus + identity + envelope x10): ~0.05 MB

**`TestEnvelopeThroughput`** (4 tests) — floor: 100 envelopes/sec
- `test_sequential_envelope_throughput_over_100_per_sec` — Publish-and-deliver 200 envelopes sequentially (1 subscriber)
- `test_concurrent_multi_topic_envelope_throughput` — 5 topics x 40 envelopes in parallel via `asyncio.gather`
- `test_envelope_construction_throughput_over_100_per_sec` — Pure construction overhead (500 envelopes, no I/O)
- `test_sustained_throughput_over_1_second` — 1-second continuous loop with parity assertion

**`TestHandlerLatencyTargets`** (5 tests) — p50 < 5 ms, p99 < 20 ms
- `test_noop_handler_overhead_under_1ms` — Trivial handler floor measurement (500 samples)
- `test_envelope_handler_p50_under_5ms` — JSON-decode handler p50 < 5 ms (300 samples)
- `test_envelope_handler_p99_under_20ms` — JSON-decode handler p99 < 20 ms (500 samples, prints p50/p95/p99)
- `test_multi_subscriber_handler_latency_scales` — 5 subscribers: p99 < 5x single-subscriber budget
- `test_latency_stable_under_sustained_load` — 2-second sustained load: last-quarter p50 <= 3x first-quarter

## Thresholds

Thresholds are deliberately generous to remain CI-stable on shared runners:
- **Memory**: 200 MB limit — actual usage is ~0.05 MB (4000x headroom)
- **Throughput**: 100/sec minimum — actual is 1000+ ops/sec on dev machines
- **Latency p99**: 20 ms ceiling — actual is <1 ms with in-memory delivery

## Test plan

- [x] All 13 tests pass: `uv run pytest tests/performance/test_production_benchmarks.py -v`
- [x] Pre-commit hooks pass (ruff format, ruff check, all ONEX validators)
- [x] `@pytest.mark.performance` applied consistently
- [x] No external infrastructure required

## Pre-existing Issues (DEFER)

93 mypy strict errors across 53 files pre-existed before this branch. None introduced by this PR.

Closes OMN-782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added production performance benchmarks to validate system efficiency. Tests measure memory allocation (targets under 200 MB), envelope throughput (minimum 100 per second), and handler latency with percentile-based requirements. Includes validation under sequential, concurrent, and sustained load scenarios to ensure production-grade performance standards are consistently met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->