### PR TITLE
feat(ci): DB quality gate to forbid domain-specific DB adapters [OMN-1785]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,13 @@ jobs:
           echo "================================================================"
           uv run python scripts/validate.py markdown_links --verbose
 
+      - name: Run DB quality gate
+        run: |
+          echo "================================================================"
+          echo "DB Quality Gate - Forbid Domain-Specific Adapters (OMN-1785)"
+          echo "================================================================"
+          uv run python scripts/validate.py db_quality_gate --verbose
+
   # Fingerprint drift detection -- CI twins for runtime assertions B2 and B3
   # Prevents stale fingerprint artifacts from being merged (OMN-2149)
   fingerprint-check:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,6 +222,16 @@ repos:
         types: [markdown]
         pass_filenames: true
         stages: [pre-commit]
+      # DB quality gate - forbid domain-specific DB adapters (OMN-1785)
+      # Detects forbidden patterns: adapter classes, direct SQL, direct connections
+      # outside of omnibase_infra and tests. Escape hatches: # db-adapter-ok, # sql-ok
+      - id: onex-validate-db-quality-gate
+        name: ONEX DB Quality Gate
+        entry: uv run python scripts/validate.py db_quality_gate
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-commit]
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/scripts/validation/validate_db_quality_gate.py
+++ b/scripts/validation/validate_db_quality_gate.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""CI quality gate to forbid new domain-specific DB adapters.
+
+Enforces the contract-driven database architecture by detecting and blocking:
+
+1. **Adapter class patterns** - Classes matching ``*Adapter*Postgres`` or
+   ``*Postgres*Adapter`` in non-infra code indicate domain-specific DB coupling.
+2. **Direct SQL in domain code** - Raw SQL keywords (``SELECT ... FROM``,
+   ``INSERT``, ``UPDATE``, ``DELETE ... FROM``) outside of contracts and infra
+   layers indicate schema coupling.
+3. **Direct connection calls** - ``psycopg.connect`` / ``asyncpg.connect`` usage
+   outside infra indicates bypass of the connection pool and circuit breaker.
+
+Escape hatches:
+    - ``# db-adapter-ok`` comment on the same line suppresses adapter class checks.
+    - ``# sql-ok`` comment on the same line suppresses direct SQL checks.
+    - Files under ``omnibase_infra/`` are exempt (infra owns DB access).
+    - Test files (under ``tests/``) are exempt.
+
+Usage:
+    python scripts/validation/validate_db_quality_gate.py
+    python scripts/validation/validate_db_quality_gate.py --verbose
+    python scripts/validation/validate_db_quality_gate.py --check-paths src/omniclaude src/omnimemory
+
+Exit Codes:
+    0 - No violations found.
+    1 - Violations detected.
+
+Ticket: OMN-1785
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Forbidden patterns
+# ---------------------------------------------------------------------------
+
+# Adapter class patterns that indicate domain-specific DB coupling
+_ADAPTER_CLASS_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"class\s+\w*Adapter\w*Postgres"),
+    re.compile(r"class\s+\w*Postgres\w*Adapter"),
+    re.compile(r"class\s+\w*Adapter\w*Asyncpg"),
+    re.compile(r"class\s+\w*Asyncpg\w*Adapter"),
+]
+
+# Direct SQL patterns (case-insensitive)
+_DIRECT_SQL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(SELECT)\s+.*\bFROM\b", re.IGNORECASE),
+    re.compile(r"\b(INSERT)\s+INTO\b", re.IGNORECASE),
+    re.compile(r"\b(UPDATE)\s+\w+\s+SET\b", re.IGNORECASE),
+    re.compile(r"\b(DELETE)\s+FROM\b", re.IGNORECASE),
+]
+
+# Direct DB connection patterns
+_DIRECT_CONNECT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"psycopg[23]?\.connect"),
+    re.compile(r"asyncpg\.connect"),
+    re.compile(r"psycopg[23]?\.AsyncConnection\.connect"),
+]
+
+# Escape-hatch comment markers
+_ADAPTER_ESCAPE = "# db-adapter-ok"
+_SQL_ESCAPE = "# sql-ok"
+
+# Directories that are exempt from all checks (infra owns DB access)
+_EXEMPT_DIR_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "omnibase_infra",
+        "tests",
+        "test",
+        "__pycache__",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        "migrations",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DbQualityViolation:
+    """A single DB quality gate violation.
+
+    Attributes:
+        file_path: Absolute or relative path to the offending file.
+        line_number: 1-based line number.
+        category: One of ``adapter_class``, ``direct_sql``, ``direct_connect``.
+        matched_text: The portion of the line that matched.
+        message: Human-readable remediation guidance.
+    """
+
+    file_path: str
+    line_number: int
+    category: str
+    matched_text: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.file_path}:{self.line_number}: [{self.category}] {self.message}"
+
+
+@dataclass
+class DbQualityGateResult:
+    """Aggregated result of the DB quality gate scan.
+
+    Attributes:
+        violations: All violations discovered.
+        files_checked: Total Python files scanned.
+        files_skipped: Files skipped due to exemptions.
+    """
+
+    violations: list[DbQualityViolation] = field(default_factory=list)
+    files_checked: int = 0
+    files_skipped: int = 0
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.violations) == 0
+
+    @property
+    def adapter_violations(self) -> list[DbQualityViolation]:
+        return [v for v in self.violations if v.category == "adapter_class"]
+
+    @property
+    def sql_violations(self) -> list[DbQualityViolation]:
+        return [v for v in self.violations if v.category == "direct_sql"]
+
+    @property
+    def connect_violations(self) -> list[DbQualityViolation]:
+        return [v for v in self.violations if v.category == "direct_connect"]
+
+
+# ---------------------------------------------------------------------------
+# Core scanning logic
+# ---------------------------------------------------------------------------
+
+
+def _is_exempt(file_path: Path) -> bool:
+    """Check whether a file resides in an exempt directory."""
+    return any(part in _EXEMPT_DIR_SEGMENTS for part in file_path.parts)
+
+
+def _is_in_string_or_comment(line: str, match_start: int) -> bool:
+    """Rough heuristic: skip matches inside triple-quoted strings or comments.
+
+    This is intentionally simple -- it catches the common cases of
+    ``# comment`` and ``\"\"\"docstring lines\"\"\"`` without requiring a full
+    AST parse of every file.
+    """
+    stripped = line.lstrip()
+    # Entire line is a comment
+    if stripped.startswith("#"):
+        return True
+    # Match is after a ``#`` on the same line (inline comment containing the pattern)
+    hash_pos = line.find("#")
+    if 0 <= hash_pos < match_start:
+        return True
+    return False
+
+
+def scan_file(file_path: Path) -> list[DbQualityViolation]:
+    """Scan a single Python file for DB quality gate violations.
+
+    Args:
+        file_path: Path to the Python file.
+
+    Returns:
+        List of violations found in the file.
+    """
+    violations: list[DbQualityViolation] = []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return violations
+
+    lines = content.splitlines()
+
+    for line_no_0, line in enumerate(lines):
+        line_no = line_no_0 + 1
+
+        # --- Adapter class checks ---
+        if _ADAPTER_ESCAPE not in line:
+            for pattern in _ADAPTER_CLASS_PATTERNS:
+                m = pattern.search(line)
+                if m and not _is_in_string_or_comment(line, m.start()):
+                    violations.append(
+                        DbQualityViolation(
+                            file_path=str(file_path),
+                            line_number=line_no,
+                            category="adapter_class",
+                            matched_text=m.group(0),
+                            message=(
+                                "Domain-specific DB adapter class is forbidden. "
+                                "Use repository contracts instead. "
+                                "Add '# db-adapter-ok' to suppress if intentional."
+                            ),
+                        )
+                    )
+
+        # --- Direct SQL checks ---
+        if _SQL_ESCAPE not in line:
+            for pattern in _DIRECT_SQL_PATTERNS:
+                m = pattern.search(line)
+                if m and not _is_in_string_or_comment(line, m.start()):
+                    violations.append(
+                        DbQualityViolation(
+                            file_path=str(file_path),
+                            line_number=line_no,
+                            category="direct_sql",
+                            matched_text=m.group(0),
+                            message=(
+                                "Direct SQL in domain code is forbidden. "
+                                "Use repository contracts instead. "
+                                "Add '# sql-ok' to suppress if intentional."
+                            ),
+                        )
+                    )
+
+        # --- Direct connect checks ---
+        if _SQL_ESCAPE not in line and _ADAPTER_ESCAPE not in line:
+            for pattern in _DIRECT_CONNECT_PATTERNS:
+                m = pattern.search(line)
+                if m and not _is_in_string_or_comment(line, m.start()):
+                    violations.append(
+                        DbQualityViolation(
+                            file_path=str(file_path),
+                            line_number=line_no,
+                            category="direct_connect",
+                            matched_text=m.group(0),
+                            message=(
+                                "Direct DB connection is forbidden outside infra. "
+                                "Use the connection pool via omnibase_infra. "
+                                "Add '# db-adapter-ok' to suppress if intentional."
+                            ),
+                        )
+                    )
+
+    return violations
+
+
+def validate_db_quality_gate(
+    check_paths: list[Path] | None = None,
+    *,
+    verbose: bool = False,
+) -> DbQualityGateResult:
+    """Run the DB quality gate scan across one or more source trees.
+
+    Args:
+        check_paths: Directories to scan. Defaults to ``[Path("src/")]`` which
+            relies on the exemption logic to skip ``omnibase_infra/`` and
+            ``tests/`` automatically.
+        verbose: If True, log each file being scanned.
+
+    Returns:
+        Aggregated scan result.
+    """
+    if check_paths is None:
+        check_paths = [Path("src/")]
+
+    result = DbQualityGateResult()
+
+    for root in check_paths:
+        if not root.exists():
+            if verbose:
+                print(f"  Skipping non-existent path: {root}")
+            continue
+
+        for py_file in sorted(root.rglob("*.py")):
+            if _is_exempt(py_file):
+                result.files_skipped += 1
+                continue
+
+            result.files_checked += 1
+            if verbose:
+                print(f"  Scanning: {py_file}")
+
+            file_violations = scan_file(py_file)
+            result.violations.extend(file_violations)
+
+    return result
+
+
+def generate_report(result: DbQualityGateResult) -> str:
+    """Generate a human-readable report from the scan result.
+
+    Args:
+        result: The scan result to report on.
+
+    Returns:
+        Formatted multi-line report string.
+    """
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("DB Quality Gate (OMN-1785)")
+    lines.append("=" * 60)
+
+    if result.is_valid:
+        lines.append(f"PASS - {result.files_checked} files checked, 0 violations")
+    else:
+        lines.append(
+            f"FAIL - {len(result.violations)} violation(s) "
+            f"in {result.files_checked} files"
+        )
+        lines.append("")
+
+        if result.adapter_violations:
+            lines.append(
+                f"  Adapter class violations ({len(result.adapter_violations)}):"
+            )
+            for v in result.adapter_violations:
+                lines.append(f"    {v}")
+            lines.append("")
+
+        if result.sql_violations:
+            lines.append(f"  Direct SQL violations ({len(result.sql_violations)}):")
+            for v in result.sql_violations:
+                lines.append(f"    {v}")
+            lines.append("")
+
+        if result.connect_violations:
+            lines.append(
+                f"  Direct connect violations ({len(result.connect_violations)}):"
+            )
+            for v in result.connect_violations:
+                lines.append(f"    {v}")
+            lines.append("")
+
+        lines.append("Remediation:")
+        lines.append("  - Use repository contracts for data access")
+        lines.append("  - DB adapters belong in omnibase_infra only")
+        lines.append(
+            "  - Add '# db-adapter-ok' or '# sql-ok' to suppress false positives"
+        )
+
+    lines.append(
+        f"\nFiles checked: {result.files_checked}, skipped: {result.files_skipped}"
+    )
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="CI quality gate: forbid domain-specific DB adapters (OMN-1785)"
+    )
+    parser.add_argument(
+        "--check-paths",
+        nargs="*",
+        default=None,
+        help="Directories to scan (default: src/)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show each file being scanned",
+    )
+    args = parser.parse_args()
+
+    paths = [Path(p) for p in args.check_paths] if args.check_paths else None
+    result = validate_db_quality_gate(paths, verbose=args.verbose)
+    report = generate_report(result)
+    print(report)
+
+    return 0 if result.is_valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/validation/test_db_quality_gate.py
+++ b/tests/unit/validation/test_db_quality_gate.py
@@ -1,0 +1,335 @@
+"""Tests for the DB quality gate validator (OMN-1785).
+
+Validates that the quality gate correctly detects and reports:
+- Domain-specific DB adapter classes
+- Direct SQL in domain code
+- Direct DB connection calls
+- Proper exemption of infra and test directories
+- Escape-hatch comment markers
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+@pytest.fixture
+def tmp_src(tmp_path: Path) -> Path:
+    """Create a temporary src directory with the expected structure."""
+    src = tmp_path / "src"
+    src.mkdir()
+    return src
+
+
+def _write_py(directory: Path, filename: str, content: str) -> Path:
+    """Helper to write a Python file with dedented content."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(dedent(content), encoding="utf-8")
+    return path
+
+
+class TestAdapterClassDetection:
+    """Tests for forbidden adapter class pattern detection."""
+
+    def test_detects_adapter_postgres_class(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "adapters.py",
+            """\
+            class UserAdapterPostgres:
+                pass
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "adapter_class"
+        assert "UserAdapterPostgres" in violations[0].matched_text
+
+    def test_detects_postgres_adapter_class(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "db.py",
+            """\
+            class PostgresAdapterUser:
+                pass
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "adapter_class"
+
+    def test_escape_hatch_suppresses_adapter_check(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "adapters.py",
+            """\
+            class UserAdapterPostgres:  # db-adapter-ok
+                pass
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 0
+
+
+class TestDirectSqlDetection:
+    """Tests for direct SQL pattern detection."""
+
+    def test_detects_select_from(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "queries.py",
+            """\
+            query = "SELECT id, name FROM users WHERE active = true"
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "direct_sql"
+
+    def test_detects_insert_into(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "writer.py",
+            """\
+            query = "INSERT INTO users (name) VALUES ($1)"
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "direct_sql"
+
+    def test_detects_update_set(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "updater.py",
+            """\
+            query = "UPDATE users SET name = $1 WHERE id = $2"
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "direct_sql"
+
+    def test_detects_delete_from(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "cleaner.py",
+            """\
+            query = "DELETE FROM users WHERE expired = true"
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 1
+        assert violations[0].category == "direct_sql"
+
+    def test_escape_hatch_suppresses_sql_check(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "queries.py",
+            """\
+            query = "SELECT id FROM users"  # sql-ok
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 0
+
+    def test_comment_lines_are_not_flagged(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "notes.py",
+            """\
+            # SELECT id FROM users
+            # This is just a comment about the query
+            """,
+        )
+        violations = scan_file(f)
+        assert len(violations) == 0
+
+
+class TestDirectConnectDetection:
+    """Tests for direct DB connection pattern detection."""
+
+    def test_detects_psycopg_connect(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "db.py",
+            """\
+            import psycopg
+            conn = psycopg.connect("dbname=test")
+            """,
+        )
+        violations = scan_file(f)
+        assert any(v.category == "direct_connect" for v in violations)
+
+    def test_detects_asyncpg_connect(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import scan_file
+
+        f = _write_py(
+            tmp_src / "myapp",
+            "db.py",
+            """\
+            import asyncpg
+            conn = await asyncpg.connect("postgresql://localhost/test")
+            """,
+        )
+        violations = scan_file(f)
+        assert any(v.category == "direct_connect" for v in violations)
+
+
+class TestExemptions:
+    """Tests for directory-level exemptions."""
+
+    def test_omnibase_infra_files_exempt(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        _write_py(
+            tmp_src / "omnibase_infra" / "handlers",
+            "handler_db.py",
+            """\
+            class UserAdapterPostgres:
+                pass
+            query = "SELECT id FROM users"
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        assert result.is_valid
+        assert result.files_skipped >= 1
+
+    def test_test_files_exempt(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        _write_py(
+            tmp_src / "tests" / "unit",
+            "test_db.py",
+            """\
+            class TestAdapterPostgres:
+                pass
+            query = "SELECT id FROM users"
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        assert result.is_valid
+
+    def test_domain_code_not_exempt(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        _write_py(
+            tmp_src / "omniclaude",
+            "persistence.py",
+            """\
+            class ChatAdapterPostgres:
+                pass
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        assert not result.is_valid
+        assert len(result.adapter_violations) == 1
+
+
+class TestFullScan:
+    """Integration tests for the full scan pipeline."""
+
+    def test_clean_codebase_passes(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        _write_py(
+            tmp_src / "myapp",
+            "service.py",
+            """\
+            from omnibase_infra.runtime.db import PostgresRepositoryRuntime
+
+            class UserService:
+                def __init__(self, repo: PostgresRepositoryRuntime) -> None:
+                    self.repo = repo
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        assert result.is_valid
+        assert result.files_checked >= 1
+
+    def test_nonexistent_path_skipped(self, tmp_path: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        result = validate_db_quality_gate([tmp_path / "nonexistent"], verbose=False)
+        assert result.is_valid
+        assert result.files_checked == 0
+
+    def test_report_generation(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import (
+            generate_report,
+            validate_db_quality_gate,
+        )
+
+        _write_py(
+            tmp_src / "myapp",
+            "bad.py",
+            """\
+            class FooAdapterPostgres:
+                pass
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        report = generate_report(result)
+        assert "FAIL" in report
+        assert "OMN-1785" in report
+        assert "adapter_class" in report.lower() or "Adapter class" in report
+
+    def test_report_pass(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import (
+            generate_report,
+            validate_db_quality_gate,
+        )
+
+        _write_py(
+            tmp_src / "myapp",
+            "clean.py",
+            """\
+            x = 1
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        report = generate_report(result)
+        assert "PASS" in report
+
+
+class TestMigrationDirectoryExempt:
+    """Tests that migration files are exempt."""
+
+    def test_migration_files_exempt(self, tmp_src: Path) -> None:
+        from scripts.validation.validate_db_quality_gate import validate_db_quality_gate
+
+        _write_py(
+            tmp_src / "migrations" / "versions",
+            "001_create_users.py",
+            """\
+            def upgrade():
+                op.execute("SELECT 1 FROM users")
+                op.execute("INSERT INTO users (name) VALUES ('admin')")
+            """,
+        )
+        result = validate_db_quality_gate([tmp_src])
+        assert result.is_valid


### PR DESCRIPTION
## Summary

Adds a CI quality gate enforcing the contract-driven database architecture by detecting and blocking domain-specific DB adapter classes, direct SQL, and direct DB connection calls outside of `omnibase_infra`.

- **Adapter class detection**: Catches `class *Adapter*Postgres`, `*Postgres*Adapter`, and asyncpg variants
- **Direct SQL detection**: Catches `SELECT...FROM`, `INSERT INTO`, `UPDATE...SET`, `DELETE FROM` in domain code
- **Direct connect detection**: Catches `psycopg.connect`, `asyncpg.connect` outside infra
- **Exemptions**: `omnibase_infra/` (infra owns DB access), `tests/`, `migrations/`
- **Escape hatches**: `# db-adapter-ok` and `# sql-ok` comments for intentional exceptions

## Files Changed

| File | Purpose |
|------|---------|
| `scripts/validation/validate_db_quality_gate.py` | Standalone validator with CLI |
| `scripts/validate.py` | Added `db_quality_gate` command |
| `.pre-commit-config.yaml` | Added `onex-validate-db-quality-gate` hook |
| `.github/workflows/test.yml` | Added CI job in onex-validation |
| `tests/unit/validation/test_db_quality_gate.py` | 19 unit tests |

## Test Plan

- [x] 19 unit tests covering adapter detection, SQL detection, connect detection, exemptions, escape hatches, and report generation
- [x] All pre-commit hooks pass (22/22)
- [x] mypy clean on new files
- [x] Validator runs correctly against omnibase_infra codebase (1374 files correctly exempted)
- [ ] CI pipeline validates on GitHub Actions

## Ticket

Closes OMN-1785