### PR TITLE
feat(ci): add auto-tag-on-merge caller workflow

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -1,0 +1,12 @@
+name: Auto-Tag on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  auto-tag:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    uses: OmniNode-ai/omnibase_core/.github/workflows/auto-tag-reusable.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
Add auto-tag-on-merge caller workflow that inherits from omnibase_core's reusable workflow.

When a PR with the `release` label merges, automatically creates a git tag from pyproject.toml version.
Requires: OmniNode-ai/omnibase_core/.github/workflows/auto-tag-reusable.yml@main