### PR TITLE
feat(contracts): add protocol lockfile snapshot tests [OMN-335]

### DIFF
--- a/contracts/runtime/runtime_protocol.lock.json
+++ b/contracts/runtime/runtime_protocol.lock.json
@@ -1,0 +1,1266 @@
+{
+  "schema_version": "1.0.0",
+  "package_version": "0.11.0",
+  "protocol_count": 19,
+  "protocols": {
+    "ProtocolCapabilityProjection": {
+      "runtime_checkable": true,
+      "method_count": 6,
+      "methods": {
+        "get_by_capability_tag": {
+          "parameters": [
+            {
+              "name": "tag",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "get_by_capability_tags_all": {
+          "parameters": [
+            {
+              "name": "tags",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "list[str]",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "get_by_capability_tags_any": {
+          "parameters": [
+            {
+              "name": "tags",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "list[str]",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "get_by_contract_type": {
+          "parameters": [
+            {
+              "name": "contract_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ContractType",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "get_by_intent_type": {
+          "parameters": [
+            {
+              "name": "intent_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "get_by_protocol": {
+          "parameters": [
+            {
+              "name": "protocol_name",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        }
+      }
+    },
+    "ProtocolCapabilityQuery": {
+      "runtime_checkable": true,
+      "method_count": 4,
+      "methods": {
+        "find_nodes_by_capability": {
+          "parameters": [
+            {
+              "name": "capability",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "contract_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "find_nodes_by_intent_type": {
+          "parameters": [
+            {
+              "name": "intent_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "contract_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": "'effect'"
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "find_nodes_by_protocol": {
+          "parameters": [
+            {
+              "name": "protocol",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "contract_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            },
+            {
+              "name": "state",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumRegistrationState | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelRegistrationProjection]"
+        },
+        "resolve_dependency": {
+          "parameters": [
+            {
+              "name": "dependency_spec",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelDependencySpec",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "ModelRegistrationProjection | None"
+        }
+      }
+    },
+    "ProtocolContainerAware": {
+      "runtime_checkable": true,
+      "method_count": 5,
+      "methods": {
+        "describe": {
+          "parameters": [],
+          "return_annotation": "ModelHandlerDescriptor"
+        },
+        "execute": {
+          "parameters": [
+            {
+              "name": "request",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelProtocolRequest",
+              "default": null
+            },
+            {
+              "name": "operation_config",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelOperationConfig",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelProtocolResponse"
+        },
+        "health_check": {
+          "parameters": [],
+          "return_annotation": "JsonType"
+        },
+        "initialize": {
+          "parameters": [
+            {
+              "name": "config",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelConnectionConfig",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "shutdown": {
+          "parameters": [
+            {
+              "name": "timeout_seconds",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "float",
+              "default": "30.0"
+            }
+          ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolDispatchEngine": {
+      "runtime_checkable": true,
+      "method_count": 2,
+      "methods": {
+        "dispatch": {
+          "parameters": [
+            {
+              "name": "topic",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "envelope",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelEventEnvelope[object]",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelDispatchResult | None"
+        },
+        "dispatch_with_transaction": {
+          "parameters": [
+            {
+              "name": "topic",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "envelope",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "ModelEventEnvelope[object]",
+              "default": null
+            },
+            {
+              "name": "tx",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "object",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelDispatchResult | None"
+        }
+      }
+    },
+    "ProtocolEventBusLike": {
+      "runtime_checkable": true,
+      "method_count": 2,
+      "methods": {
+        "publish": {
+          "parameters": [
+            {
+              "name": "topic",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "key",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "bytes | None",
+              "default": null
+            },
+            {
+              "name": "value",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "bytes",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "publish_envelope": {
+          "parameters": [
+            {
+              "name": "envelope",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "object",
+              "default": null
+            },
+            {
+              "name": "topic",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "key",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "bytes | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolEventProjector": {
+      "runtime_checkable": true,
+      "method_count": 2,
+      "methods": {
+        "get_state": {
+          "parameters": [
+            {
+              "name": "aggregate_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            }
+          ],
+          "return_annotation": "object | None"
+        },
+        "project": {
+          "parameters": [
+            {
+              "name": "event",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelEventEnvelope",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelProjectionResult"
+        }
+      }
+    },
+    "ProtocolIdempotencyStore": {
+      "runtime_checkable": true,
+      "method_count": 4,
+      "methods": {
+        "check_and_record": {
+          "parameters": [
+            {
+              "name": "message_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "cleanup_expired": {
+          "parameters": [
+            {
+              "name": "ttl_seconds",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": null
+            }
+          ],
+          "return_annotation": "int"
+        },
+        "is_processed": {
+          "parameters": [
+            {
+              "name": "message_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "mark_processed": {
+          "parameters": [
+            {
+              "name": "message_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            },
+            {
+              "name": "processed_at",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "datetime | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolLedgerSink": {
+      "runtime_checkable": true,
+      "method_count": 3,
+      "methods": {
+        "close": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "emit": {
+          "parameters": [
+            {
+              "name": "event",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelLedgerEventBase",
+              "default": null
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "flush": {
+          "parameters": [],
+          "return_annotation": "int"
+        }
+      }
+    },
+    "ProtocolMessageDispatcher": {
+      "runtime_checkable": true,
+      "method_count": 1,
+      "methods": {
+        "handle": {
+          "parameters": [
+            {
+              "name": "envelope",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelEventEnvelope[object]",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelDispatchResult"
+        }
+      }
+    },
+    "ProtocolMessageTypeRegistry": {
+      "runtime_checkable": true,
+      "method_count": 8,
+      "methods": {
+        "freeze": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "get_entry": {
+          "parameters": [
+            {
+              "name": "message_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<class 'str'>",
+              "default": null
+            }
+          ],
+          "return_annotation": "omnibase_infra.models.registry.model_message_type_entry.ModelMessageTypeEntry | None"
+        },
+        "get_handlers": {
+          "parameters": [
+            {
+              "name": "message_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<class 'str'>",
+              "default": null
+            },
+            {
+              "name": "topic_category",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<enum 'EnumMessageCategory'>",
+              "default": null
+            },
+            {
+              "name": "topic_domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<class 'str'>",
+              "default": null
+            }
+          ],
+          "return_annotation": "list[str]"
+        },
+        "has_message_type": {
+          "parameters": [
+            {
+              "name": "message_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<class 'str'>",
+              "default": null
+            }
+          ],
+          "return_annotation": "<class 'bool'>"
+        },
+        "list_domains": {
+          "parameters": [],
+          "return_annotation": "list[str]"
+        },
+        "list_message_types": {
+          "parameters": [
+            {
+              "name": "category",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "omnibase_infra.enums.enum_message_category.EnumMessageCategory | None",
+              "default": "None"
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[str]"
+        },
+        "register_message_type": {
+          "parameters": [
+            {
+              "name": "entry",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "<class 'omnibase_infra.models.registry.model_message_type_entry.ModelMessageTypeEntry'>",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "validate_startup": {
+          "parameters": [],
+          "return_annotation": "list[str]"
+        }
+      }
+    },
+    "ProtocolNodeHeartbeat": {
+      "runtime_checkable": true,
+      "method_count": 1,
+      "methods": {
+        "handle": {
+          "parameters": [
+            {
+              "name": "envelope",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelEventEnvelope[ModelNodeHeartbeatEvent]",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelHandlerOutput[object]"
+        }
+      }
+    },
+    "ProtocolNodeIntrospection": {
+      "runtime_checkable": true,
+      "method_count": 3,
+      "methods": {
+        "publish_introspection": {
+          "parameters": [
+            {
+              "name": "reason",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "EnumIntrospectionReason",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "start_heartbeat_task": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "stop_heartbeat_task": {
+          "parameters": [],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolPayloadRegistry": {
+      "runtime_checkable": true,
+      "method_count": 5,
+      "methods": {
+        "freeze": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "has": {
+          "parameters": [
+            {
+              "name": "payload_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "version",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "list_types": {
+          "parameters": [],
+          "return_annotation": "list[tuple[str, str]]"
+        },
+        "register": {
+          "parameters": [
+            {
+              "name": "payload_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "version",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "model_class",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "type[BaseModel]",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "resolve": {
+          "parameters": [
+            {
+              "name": "payload_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "version",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            }
+          ],
+          "return_annotation": "type[BaseModel]"
+        }
+      }
+    },
+    "ProtocolPluginCompute": {
+      "runtime_checkable": true,
+      "method_count": 1,
+      "methods": {
+        "execute": {
+          "parameters": [
+            {
+              "name": "input_data",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelPluginInputData",
+              "default": null
+            },
+            {
+              "name": "context",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelPluginContext",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelPluginOutputData"
+        }
+      }
+    },
+    "ProtocolProjectorSchemaValidator": {
+      "runtime_checkable": true,
+      "method_count": 2,
+      "methods": {
+        "ensure_schema_exists": {
+          "parameters": [
+            {
+              "name": "schema",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelProjectorSchema",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "table_exists": {
+          "parameters": [
+            {
+              "name": "table_name",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "correlation_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "schema_name",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "bool"
+        }
+      }
+    },
+    "ProtocolRegistryMetrics": {
+      "runtime_checkable": true,
+      "method_count": 5,
+      "methods": {
+        "record_cache_hit": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "record_cache_miss": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "record_error": {
+          "parameters": [
+            {
+              "name": "error_type",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "plugin_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "record_get_latency": {
+          "parameters": [
+            {
+              "name": "plugin_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "version",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str | None",
+              "default": null
+            },
+            {
+              "name": "latency_ms",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "float",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        },
+        "record_registry_size": {
+          "parameters": [
+            {
+              "name": "size",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolSnapshotPublisher": {
+      "runtime_checkable": true,
+      "method_count": 5,
+      "methods": {
+        "delete_snapshot": {
+          "parameters": [
+            {
+              "name": "entity_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "get_latest_snapshot": {
+          "parameters": [
+            {
+              "name": "entity_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "domain",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "str",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelRegistrationSnapshot | None"
+        },
+        "publish_batch": {
+          "parameters": [
+            {
+              "name": "snapshots",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "list[ModelRegistrationProjection]",
+              "default": null
+            }
+          ],
+          "return_annotation": "int"
+        },
+        "publish_from_projection": {
+          "parameters": [
+            {
+              "name": "projection",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelRegistrationProjection",
+              "default": null
+            },
+            {
+              "name": "node_name",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str | None",
+              "default": "None"
+            },
+            {
+              "name": "correlation_id",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "UUID | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "ModelRegistrationSnapshot"
+        },
+        "publish_snapshot": {
+          "parameters": [
+            {
+              "name": "snapshot",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelRegistrationProjection",
+              "default": null
+            }
+          ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolSnapshotStore": {
+      "runtime_checkable": true,
+      "method_count": 9,
+      "methods": {
+        "cleanup_expired": {
+          "parameters": [
+            {
+              "name": "max_age_seconds",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "int | None",
+              "default": "None"
+            },
+            {
+              "name": "keep_latest_n",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "int | None",
+              "default": "None"
+            },
+            {
+              "name": "subject",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "ModelSubjectRef | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "int"
+        },
+        "delete": {
+          "parameters": [
+            {
+              "name": "snapshot_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            }
+          ],
+          "return_annotation": "bool"
+        },
+        "get_next_sequence_number": {
+          "parameters": [
+            {
+              "name": "subject",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelSubjectRef",
+              "default": null
+            }
+          ],
+          "return_annotation": "int"
+        },
+        "load": {
+          "parameters": [
+            {
+              "name": "snapshot_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelSnapshot | None"
+        },
+        "load_latest": {
+          "parameters": [
+            {
+              "name": "subject",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelSubjectRef | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "ModelSnapshot | None"
+        },
+        "load_latest_many": {
+          "parameters": [
+            {
+              "name": "subjects",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "list[ModelSubjectRef]",
+              "default": null
+            }
+          ],
+          "return_annotation": "dict[tuple[str, UUID], ModelSnapshot]"
+        },
+        "load_many": {
+          "parameters": [
+            {
+              "name": "snapshot_ids",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "list[UUID]",
+              "default": null
+            }
+          ],
+          "return_annotation": "dict[UUID, ModelSnapshot]"
+        },
+        "query": {
+          "parameters": [
+            {
+              "name": "subject",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelSubjectRef | None",
+              "default": "None"
+            },
+            {
+              "name": "limit",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "50"
+            },
+            {
+              "name": "after",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "datetime | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "list[ModelSnapshot]"
+        },
+        "save": {
+          "parameters": [
+            {
+              "name": "snapshot",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelSnapshot",
+              "default": null
+            }
+          ],
+          "return_annotation": "UUID"
+        }
+      }
+    },
+    "ProtocolValidationLedgerRepository": {
+      "runtime_checkable": true,
+      "method_count": 4,
+      "methods": {
+        "append": {
+          "parameters": [
+            {
+              "name": "run_id",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "repo_id",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "event_type",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "event_version",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "occurred_at",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "datetime",
+              "default": null
+            },
+            {
+              "name": "kafka_topic",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            },
+            {
+              "name": "kafka_partition",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "int",
+              "default": null
+            },
+            {
+              "name": "kafka_offset",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "int",
+              "default": null
+            },
+            {
+              "name": "envelope_bytes",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "bytes",
+              "default": null
+            },
+            {
+              "name": "envelope_hash",
+              "kind": "KEYWORD_ONLY",
+              "annotation": "str",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelValidationLedgerAppendResult"
+        },
+        "cleanup_expired": {
+          "parameters": [
+            {
+              "name": "retention_days",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "30"
+            },
+            {
+              "name": "min_runs_per_repo",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "25"
+            },
+            {
+              "name": "batch_size",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "1000"
+            }
+          ],
+          "return_annotation": "int"
+        },
+        "query": {
+          "parameters": [
+            {
+              "name": "query",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "ModelValidationLedgerQuery",
+              "default": null
+            }
+          ],
+          "return_annotation": "ModelValidationLedgerReplayBatch"
+        },
+        "query_by_run_id": {
+          "parameters": [
+            {
+              "name": "run_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "UUID",
+              "default": null
+            },
+            {
+              "name": "limit",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "100"
+            },
+            {
+              "name": "offset",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int",
+              "default": "0"
+            }
+          ],
+          "return_annotation": "list[ModelValidationLedgerEntry]"
+        }
+      }
+    }
+  }
+}

--- a/src/omnibase_infra/runtime/protocol_lockfile.py
+++ b/src/omnibase_infra/runtime/protocol_lockfile.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Protocol lockfile generator for snapshot testing.
+
+This module generates a deterministic JSON lockfile from the protocol definitions
+in ``omnibase_infra.protocols``. The lockfile captures protocol method signatures,
+parameter types, and return types so that snapshot tests can detect accidental
+breaking changes to protocol interfaces.
+
+The lockfile is stored at ``contracts/runtime/runtime_protocol.lock.json`` and
+verified by CI via ``tests/unit/contracts/test_protocol_lockfile.py``.
+
+Architecture:
+    Protocol interfaces are the primary contract surface between omnibase_infra
+    and its consumers. Changes to protocol method signatures (adding/removing
+    parameters, changing types, renaming methods) are breaking changes that must
+    be intentional and reviewed.
+
+    The lockfile captures:
+    - Protocol class names and their ``runtime_checkable`` status
+    - Method names and full signatures (parameter names, types, defaults)
+    - Return type annotations
+    - Envelope schema version (package version)
+    - Handler protocol versions (per-protocol method count as stability metric)
+
+Usage:
+    Generate/update the lockfile::
+
+        from omnibase_infra.runtime.protocol_lockfile import generate_lockfile
+        lockfile = generate_lockfile()
+
+    Write to disk::
+
+        from omnibase_infra.runtime.protocol_lockfile import write_lockfile
+        write_lockfile()
+
+Related:
+    - OMN-335: Add Protocol Lockfile Snapshot Tests
+    - omnibase_infra.protocols: Protocol definitions
+    - tests/unit/contracts/test_protocol_lockfile.py: Snapshot tests
+
+.. versionadded:: 0.11.0
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import omnibase_infra
+from omnibase_infra.protocols import __all__ as protocol_names
+
+# Type aliases using object-based types (no Any per ONEX conventions).
+# All nested dicts use dict[str, object] to avoid union proliferation.
+JsonDict = dict[str, object]
+
+# Path to the lockfile relative to the repo root
+LOCKFILE_RELATIVE_PATH = Path("contracts") / "runtime" / "runtime_protocol.lock.json"
+
+
+def _get_repo_root() -> Path:
+    """Find the repository root by walking up from this file."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists() and (current / "src").exists():
+            return current
+        current = current.parent
+    msg = "Could not find repository root (no pyproject.toml + src/ found)"
+    raise RuntimeError(msg)
+
+
+def _extract_method_signature(method: object) -> JsonDict:
+    """Extract a deterministic signature dict from a method.
+
+    Args:
+        method: A function/method object from a Protocol class.
+
+    Returns:
+        Dictionary with parameter details and return annotation.
+    """
+    sig = inspect.signature(method)  # type: ignore[arg-type]
+    params: list[dict[str, str | None]] = []
+
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+
+        param_info: dict[str, str | None] = {
+            "name": name,
+            "kind": param.kind.name,
+        }
+
+        # Capture annotation as string
+        if param.annotation is not inspect.Parameter.empty:
+            ann = param.annotation
+            param_info["annotation"] = ann if isinstance(ann, str) else str(ann)
+        else:
+            param_info["annotation"] = None
+
+        # Capture default value
+        if param.default is not inspect.Parameter.empty:
+            param_info["default"] = repr(param.default)
+        else:
+            param_info["default"] = None
+
+        params.append(param_info)
+
+    # Return annotation
+    ret = sig.return_annotation
+    if ret is inspect.Signature.empty:
+        return_annotation = None
+    elif isinstance(ret, str):
+        return_annotation = ret
+    else:
+        return_annotation = str(ret)
+
+    return {
+        "parameters": params,
+        "return_annotation": return_annotation,
+    }
+
+
+def _extract_protocol_info(protocol_cls: type) -> JsonDict:
+    """Extract complete protocol information for the lockfile.
+
+    Args:
+        protocol_cls: A Protocol class to inspect.
+
+    Returns:
+        Dictionary with protocol metadata and method signatures.
+    """
+    # Check if the class has the runtime_checkable decorator
+    # by checking for _is_runtime_protocol attribute
+    is_runtime_checkable: bool = getattr(protocol_cls, "_is_runtime_protocol", False)
+
+    methods: dict[str, JsonDict] = {}
+    for name, method in inspect.getmembers(protocol_cls, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        methods[name] = _extract_method_signature(method)
+
+    return {
+        "runtime_checkable": is_runtime_checkable,
+        "method_count": len(methods),
+        "methods": dict(sorted(methods.items())),
+    }
+
+
+def generate_lockfile() -> JsonDict:
+    """Generate the protocol lockfile data structure.
+
+    Inspects all protocols exported from ``omnibase_infra.protocols`` and
+    captures their method signatures in a deterministic format.
+
+    Returns:
+        Dictionary suitable for JSON serialization as the lockfile.
+    """
+    import omnibase_infra.protocols as proto_module
+
+    protocols: dict[str, JsonDict] = {}
+    for name in sorted(protocol_names):
+        cls = getattr(proto_module, name)
+        protocols[name] = _extract_protocol_info(cls)
+
+    return {
+        "schema_version": "1.0.0",
+        "package_version": omnibase_infra.__version__,
+        "protocol_count": len(protocols),
+        "protocols": protocols,
+    }
+
+
+def write_lockfile(repo_root: Path | None = None) -> Path:
+    """Generate and write the lockfile to disk.
+
+    Args:
+        repo_root: Repository root directory. If None, auto-detected.
+
+    Returns:
+        Path to the written lockfile.
+    """
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    lockfile_path = repo_root / LOCKFILE_RELATIVE_PATH
+    lockfile_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = generate_lockfile()
+    lockfile_path.write_text(
+        json.dumps(data, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return lockfile_path
+
+
+def load_lockfile(repo_root: Path | None = None) -> JsonDict:
+    """Load the existing lockfile from disk.
+
+    Args:
+        repo_root: Repository root directory. If None, auto-detected.
+
+    Returns:
+        Parsed lockfile data.
+
+    Raises:
+        FileNotFoundError: If the lockfile does not exist.
+    """
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    lockfile_path = repo_root / LOCKFILE_RELATIVE_PATH
+    if not lockfile_path.exists():
+        msg = (
+            f"Protocol lockfile not found at {lockfile_path}. "
+            "Run `write_lockfile()` to generate it."
+        )
+        raise FileNotFoundError(msg)
+
+    result: JsonDict = json.loads(lockfile_path.read_text(encoding="utf-8"))
+    return result

--- a/tests/unit/contracts/test_protocol_lockfile.py
+++ b/tests/unit/contracts/test_protocol_lockfile.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Snapshot tests for protocol lockfile integrity.
+
+These tests verify that the protocol definitions in ``omnibase_infra.protocols``
+match the committed lockfile at ``contracts/runtime/runtime_protocol.lock.json``.
+
+If a test fails, it means a protocol signature has changed. This is intentional
+protection against accidental breaking changes to protocol interfaces.
+
+To update the lockfile after an intentional protocol change::
+
+    uv run python -c "
+    from omnibase_infra.runtime.protocol_lockfile import write_lockfile
+    write_lockfile()
+    "
+
+Then commit the updated lockfile alongside the protocol changes.
+
+Related:
+    - OMN-335: Add Protocol Lockfile Snapshot Tests
+    - omnibase_infra.runtime.protocol_lockfile: Lockfile generator
+
+.. versionadded:: 0.11.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.protocol_lockfile import (
+    generate_lockfile,
+    load_lockfile,
+)
+
+# Resolve repo root from test file location
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_LOCKFILE_PATH = _REPO_ROOT / "contracts" / "runtime" / "runtime_protocol.lock.json"
+
+
+@pytest.mark.unit
+class TestProtocolLockfileExists:
+    """Verify the lockfile exists and is valid JSON."""
+
+    def test_lockfile_exists(self) -> None:
+        """The lockfile must exist in the repository."""
+        assert _LOCKFILE_PATH.exists(), (
+            f"Protocol lockfile not found at {_LOCKFILE_PATH}. "
+            "Generate it with: "
+            'uv run python -c "from omnibase_infra.runtime.protocol_lockfile '
+            'import write_lockfile; write_lockfile()"'
+        )
+
+    def test_lockfile_is_valid_json(self) -> None:
+        """The lockfile must be valid JSON."""
+        if not _LOCKFILE_PATH.exists():
+            pytest.skip("Lockfile does not exist")
+        content = _LOCKFILE_PATH.read_text(encoding="utf-8")
+        data = json.loads(content)
+        assert isinstance(data, dict)
+
+    def test_lockfile_has_schema_version(self) -> None:
+        """The lockfile must include a schema version."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        assert "schema_version" in lockfile
+        assert lockfile["schema_version"] == "1.0.0"
+
+    def test_lockfile_has_package_version(self) -> None:
+        """The lockfile must include the package version (envelope schema version)."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        assert "package_version" in lockfile
+        assert isinstance(lockfile["package_version"], str)
+        # Verify it looks like a semver
+        parts = lockfile["package_version"].split(".")
+        assert len(parts) >= 2, (
+            f"Package version '{lockfile['package_version']}' does not look like semver"
+        )
+
+
+@pytest.mark.unit
+class TestProtocolLockfileSnapshot:
+    """Snapshot comparison: lockfile vs current protocol definitions.
+
+    These are the core tests. If any of them fail, a protocol interface has
+    changed and the lockfile needs to be regenerated.
+    """
+
+    def test_protocol_count_matches(self) -> None:
+        """Number of protocols in lockfile must match current definitions."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+        assert lockfile["protocol_count"] == current["protocol_count"], (
+            f"Protocol count mismatch: lockfile has {lockfile['protocol_count']}, "
+            f"current has {current['protocol_count']}. "
+            "A protocol was added or removed. Regenerate the lockfile."
+        )
+
+    def test_protocol_names_match(self) -> None:
+        """Protocol names in lockfile must match current definitions."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+        lockfile_names = set(lockfile["protocols"].keys())
+        current_names = set(current["protocols"].keys())
+
+        added = current_names - lockfile_names
+        removed = lockfile_names - current_names
+
+        assert not added, (
+            f"New protocols not in lockfile: {sorted(added)}. Regenerate the lockfile."
+        )
+        assert not removed, (
+            f"Protocols in lockfile but not in code: {sorted(removed)}. "
+            "Regenerate the lockfile."
+        )
+
+    def test_method_counts_match(self) -> None:
+        """Method counts per protocol must match between lockfile and current."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+
+        mismatches: list[str] = []
+        for name in lockfile["protocols"]:
+            if name not in current["protocols"]:
+                continue
+            lock_count = lockfile["protocols"][name]["method_count"]
+            curr_count = current["protocols"][name]["method_count"]
+            if lock_count != curr_count:
+                mismatches.append(
+                    f"  {name}: lockfile={lock_count}, current={curr_count}"
+                )
+
+        assert not mismatches, (
+            "Method count mismatches detected (handler protocol versions changed):\n"
+            + "\n".join(mismatches)
+            + "\nRegenerate the lockfile."
+        )
+
+    def test_method_names_match(self) -> None:
+        """Method names per protocol must match between lockfile and current."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+
+        mismatches: list[str] = []
+        for name in lockfile["protocols"]:
+            if name not in current["protocols"]:
+                continue
+            lock_methods = set(lockfile["protocols"][name]["methods"].keys())
+            curr_methods = set(current["protocols"][name]["methods"].keys())
+
+            added = curr_methods - lock_methods
+            removed = lock_methods - curr_methods
+
+            if added:
+                mismatches.append(f"  {name}: added methods {sorted(added)}")
+            if removed:
+                mismatches.append(f"  {name}: removed methods {sorted(removed)}")
+
+        assert not mismatches, (
+            "Method name mismatches detected:\n"
+            + "\n".join(mismatches)
+            + "\nRegenerate the lockfile."
+        )
+
+    def test_method_signatures_match(self) -> None:
+        """Full method signatures must match between lockfile and current.
+
+        This is the most granular check: it compares parameter names, types,
+        kinds (positional, keyword-only, etc.), defaults, and return types.
+        """
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+
+        mismatches: list[str] = []
+        for proto_name in lockfile["protocols"]:
+            if proto_name not in current["protocols"]:
+                continue
+            lock_methods = lockfile["protocols"][proto_name]["methods"]
+            curr_methods = current["protocols"][proto_name]["methods"]
+
+            for method_name in lock_methods:
+                if method_name not in curr_methods:
+                    continue
+
+                lock_sig = lock_methods[method_name]
+                curr_sig = curr_methods[method_name]
+
+                # Compare parameters
+                if lock_sig["parameters"] != curr_sig["parameters"]:
+                    mismatches.append(
+                        f"  {proto_name}.{method_name}: parameter signature changed\n"
+                        f"    lockfile: {json.dumps(lock_sig['parameters'], indent=6)}\n"
+                        f"    current:  {json.dumps(curr_sig['parameters'], indent=6)}"
+                    )
+
+                # Compare return annotation
+                if lock_sig["return_annotation"] != curr_sig["return_annotation"]:
+                    mismatches.append(
+                        f"  {proto_name}.{method_name}: return type changed\n"
+                        f"    lockfile: {lock_sig['return_annotation']}\n"
+                        f"    current:  {curr_sig['return_annotation']}"
+                    )
+
+        assert not mismatches, (
+            "Method signature mismatches detected:\n"
+            + "\n".join(mismatches)
+            + "\nRegenerate the lockfile if these changes are intentional."
+        )
+
+    def test_runtime_checkable_status_matches(self) -> None:
+        """runtime_checkable status must match between lockfile and current."""
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+
+        mismatches: list[str] = []
+        for name in lockfile["protocols"]:
+            if name not in current["protocols"]:
+                continue
+            lock_rc = lockfile["protocols"][name]["runtime_checkable"]
+            curr_rc = current["protocols"][name]["runtime_checkable"]
+            if lock_rc != curr_rc:
+                mismatches.append(f"  {name}: lockfile={lock_rc}, current={curr_rc}")
+
+        assert not mismatches, (
+            "runtime_checkable status mismatches detected:\n"
+            + "\n".join(mismatches)
+            + "\nRegenerate the lockfile."
+        )
+
+    def test_full_lockfile_matches(self) -> None:
+        """Complete lockfile content must match current protocol definitions.
+
+        This is the ultimate snapshot test. It compares the entire protocol
+        section of the lockfile against the freshly generated version.
+        The schema_version and package_version are excluded since the package
+        version may legitimately change without protocol changes.
+        """
+        lockfile = load_lockfile(_REPO_ROOT)
+        current = generate_lockfile()
+
+        # Compare only the protocols section (not metadata)
+        assert lockfile["protocols"] == current["protocols"], (
+            "Protocol lockfile is out of sync with current protocol definitions.\n"
+            "This means a protocol interface has changed.\n\n"
+            "If the change is intentional, regenerate the lockfile:\n"
+            '  uv run python -c "from omnibase_infra.runtime.protocol_lockfile '
+            'import write_lockfile; write_lockfile()"\n\n'
+            "Then commit the updated lockfile alongside your protocol changes."
+        )
+
+
+@pytest.mark.unit
+class TestProtocolLockfileGenerator:
+    """Tests for the lockfile generator itself."""
+
+    def test_generate_lockfile_returns_dict(self) -> None:
+        """generate_lockfile must return a dict."""
+        result = generate_lockfile()
+        assert isinstance(result, dict)
+
+    def test_generate_lockfile_has_required_keys(self) -> None:
+        """Generated lockfile must have all required top-level keys."""
+        result = generate_lockfile()
+        required_keys = {
+            "schema_version",
+            "package_version",
+            "protocol_count",
+            "protocols",
+        }
+        assert required_keys.issubset(result.keys()), (
+            f"Missing keys: {required_keys - set(result.keys())}"
+        )
+
+    def test_generate_lockfile_protocols_are_sorted(self) -> None:
+        """Protocol entries must be sorted alphabetically."""
+        result = generate_lockfile()
+        proto_names = list(result["protocols"].keys())
+        assert proto_names == sorted(proto_names), (
+            "Protocols are not sorted alphabetically"
+        )
+
+    def test_generate_lockfile_methods_are_sorted(self) -> None:
+        """Method entries within each protocol must be sorted alphabetically."""
+        result = generate_lockfile()
+        for proto_name, proto_data in result["protocols"].items():
+            method_names = list(proto_data["methods"].keys())
+            assert method_names == sorted(method_names), (
+                f"Methods in {proto_name} are not sorted alphabetically"
+            )
+
+    def test_generate_lockfile_is_json_serializable(self) -> None:
+        """Generated lockfile must be JSON-serializable."""
+        result = generate_lockfile()
+        serialized = json.dumps(result, indent=2, sort_keys=False)
+        roundtripped = json.loads(serialized)
+        assert roundtripped == result
+
+    def test_generate_lockfile_is_deterministic(self) -> None:
+        """Calling generate_lockfile twice must produce identical output."""
+        first = generate_lockfile()
+        second = generate_lockfile()
+        assert first == second, "generate_lockfile() is not deterministic"
+
+    def test_all_protocols_have_at_least_one_method(self) -> None:
+        """Every protocol in the lockfile must have at least one method."""
+        result = generate_lockfile()
+        empty_protocols: list[str] = []
+        for name, data in result["protocols"].items():
+            if data["method_count"] == 0:
+                empty_protocols.append(name)
+
+        assert not empty_protocols, f"Protocols with no methods: {empty_protocols}"
+
+    def test_protocol_count_matches_entries(self) -> None:
+        """protocol_count must match the number of protocol entries."""
+        result = generate_lockfile()
+        assert result["protocol_count"] == len(result["protocols"]), (
+            f"protocol_count ({result['protocol_count']}) does not match "
+            f"number of protocol entries ({len(result['protocols'])})"
+        )


### PR DESCRIPTION
## Summary

- Adds a protocol lockfile generator (`protocol_lockfile.py`) that introspects all 19 protocols from `omnibase_infra.protocols` and captures their method signatures in a deterministic JSON lockfile
- Commits the lockfile at `contracts/runtime/runtime_protocol.lock.json` covering all protocol method names, parameter types/kinds/defaults, return annotations, and `runtime_checkable` status
- Adds 19 snapshot tests that verify the lockfile stays in sync with protocol definitions, detecting any accidental breaking changes to protocol interfaces

## Test plan

- [x] 19 tests pass covering lockfile existence, schema version, protocol count/names/method counts/method names/full signatures/runtime_checkable status
- [x] Generator determinism verified (calling twice produces identical output)
- [x] JSON serialization round-trip verified
- [x] mypy --strict passes on new module
- [x] All ONEX pre-commit hooks pass (architecture, naming, unions, Any types)
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime protocol contract registry to establish and track protocol interface specifications.

* **Tests**
  * Added comprehensive validation tests for protocol contract integrity, including schema validation and signature matching.

* **Chores**
  * Introduced tooling for generating and managing protocol contract lockfiles with deterministic versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->