### PR TITLE
feat(runtime): add version compatibility matrix check [OMN-758]

### DIFF
--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1183,6 +1183,14 @@ class RuntimeHostProcess:
             },
         )
 
+        # Step 0: Verify dependency version compatibility (OMN-758)
+        # Logs resolved versions and fails fast if incompatible packages detected
+        from omnibase_infra.runtime.version_compatibility import (
+            log_and_verify_versions,
+        )
+
+        log_and_verify_versions()
+
         # Step 1: Validate architecture compliance FIRST (OMN-1138)
         # This runs before event bus starts or handlers are wired to ensure
         # clean failure without partial state if validation fails

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Version compatibility matrix for ONEX package dependencies.
+
+This module verifies that omnibase_core and omnibase_spi versions meet the
+minimum requirements for omnibase_infra at startup. It logs resolved versions
+and fails fast with a clear error message if incompatible packages are detected.
+
+The version matrix is defined here as the single source of truth and mirrors
+the constraints in pyproject.toml. This runtime check catches version
+mismatches that could occur from manual installs, editable mode conflicts,
+or CI caching issues.
+
+Architecture:
+    Called during RuntimeHostProcess.start() before any other initialization.
+    If versions are incompatible, raises InfraVersionIncompatibleError
+    which prevents the runtime from starting in a broken state.
+
+Related:
+    - OMN-758: INFRA-017: Version compatibility matrix check
+    - pyproject.toml: Declarative dependency constraints
+    - service_runtime_host_process.py: Runtime startup integration
+
+.. versionadded:: 0.11.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VersionConstraint:
+    """A version constraint for a dependency package.
+
+    Attributes:
+        package: The package name (e.g., "omnibase_core").
+        min_version: Minimum required version (inclusive).
+        max_version: Maximum allowed version (exclusive).
+    """
+
+    package: str
+    min_version: str
+    max_version: str
+
+
+# ============================================================================
+# VERSION COMPATIBILITY MATRIX
+# ============================================================================
+# This matrix defines the version constraints for omnibase_infra's dependencies.
+# It MUST be kept in sync with pyproject.toml.
+#
+# When bumping dependency versions:
+#   1. Update pyproject.toml
+#   2. Update this matrix
+#   3. Run tests to verify
+#
+# Format: VersionConstraint(package, min_version_inclusive, max_version_exclusive)
+VERSION_MATRIX: list[VersionConstraint] = [
+    VersionConstraint(
+        package="omnibase_core",
+        min_version="0.20.0",
+        max_version="0.21.0",
+    ),
+    VersionConstraint(
+        package="omnibase_spi",
+        min_version="0.13.0",
+        max_version="0.14.0",
+    ),
+]
+
+
+def _parse_version(version_str: str) -> tuple[int, ...]:
+    """Parse a version string into a tuple of integers.
+
+    Args:
+        version_str: A version string like "0.20.0" or "1.2.3".
+
+    Returns:
+        Tuple of integers for comparison.
+
+    Raises:
+        ValueError: If the version string contains non-numeric parts.
+    """
+    parts: list[int] = []
+    for part in version_str.split("."):
+        # Handle pre-release suffixes (e.g., "0.20.0a1" -> strip "a1")
+        numeric = ""
+        for char in part:
+            if char.isdigit():
+                numeric += char
+            else:
+                break
+        if numeric:
+            parts.append(int(numeric))
+        else:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _version_in_range(
+    version: str,
+    min_version: str,
+    max_version: str,
+) -> bool:
+    """Check if a version falls within [min_version, max_version).
+
+    Args:
+        version: The version to check.
+        min_version: Minimum version (inclusive).
+        max_version: Maximum version (exclusive).
+
+    Returns:
+        True if min_version <= version < max_version.
+    """
+    v = _parse_version(version)
+    v_min = _parse_version(min_version)
+    v_max = _parse_version(max_version)
+    return v_min <= v < v_max
+
+
+def _get_installed_version(package_name: str) -> str | None:
+    """Get the installed version of a package.
+
+    Args:
+        package_name: Package name (using underscores, e.g., "omnibase_core").
+
+    Returns:
+        Version string, or None if the package is not installed.
+    """
+    try:
+        import importlib
+
+        mod = importlib.import_module(package_name)
+        version: str | None = getattr(mod, "__version__", None)
+        return version
+    except ImportError:
+        return None
+
+
+def check_version_compatibility(
+    matrix: list[VersionConstraint] | None = None,
+) -> list[str]:
+    """Check all dependencies against the version compatibility matrix.
+
+    Args:
+        matrix: Version constraints to check. Defaults to VERSION_MATRIX.
+
+    Returns:
+        List of error messages for incompatible versions. Empty if all OK.
+    """
+    if matrix is None:
+        matrix = VERSION_MATRIX
+
+    errors: list[str] = []
+
+    for constraint in matrix:
+        installed = _get_installed_version(constraint.package)
+
+        if installed is None:
+            errors.append(
+                f"{constraint.package}: NOT INSTALLED "
+                f"(required >={constraint.min_version},<{constraint.max_version})"
+            )
+            continue
+
+        if not _version_in_range(
+            installed, constraint.min_version, constraint.max_version
+        ):
+            errors.append(
+                f"{constraint.package}: {installed} is incompatible "
+                f"(required >={constraint.min_version},<{constraint.max_version})"
+            )
+
+    return errors
+
+
+def log_and_verify_versions() -> None:
+    """Log resolved dependency versions and fail fast if incompatible.
+
+    This function is called during RuntimeHostProcess.start() to:
+    1. Log all resolved package versions for debugging
+    2. Verify versions meet minimum requirements
+    3. Raise an error if incompatible versions are detected
+
+    Raises:
+        RuntimeError: If any dependency version is incompatible.
+    """
+    import omnibase_infra
+
+    # Log the infra version first
+    logger.info(
+        "ONEX version compatibility check",
+        extra={"omnibase_infra_version": omnibase_infra.__version__},
+    )
+
+    # Log each dependency version
+    for constraint in VERSION_MATRIX:
+        installed = _get_installed_version(constraint.package)
+        logger.info(
+            "Dependency version resolved",
+            extra={
+                "package": constraint.package,
+                "installed_version": installed or "NOT INSTALLED",
+                "required_min": constraint.min_version,
+                "required_max": constraint.max_version,
+                "compatible": (
+                    _version_in_range(
+                        installed, constraint.min_version, constraint.max_version
+                    )
+                    if installed
+                    else False
+                ),
+            },
+        )
+
+    # Check compatibility
+    errors = check_version_compatibility()
+    if errors:
+        error_msg = (
+            "ONEX version compatibility check FAILED.\n"
+            "The following packages do not meet version requirements:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+            + "\n\nVersion matrix for omnibase_infra "
+            f"{omnibase_infra.__version__}:\n"
+        )
+        for constraint in VERSION_MATRIX:
+            error_msg += (
+                f"  {constraint.package}: "
+                f">={constraint.min_version},<{constraint.max_version}\n"
+            )
+        error_msg += (
+            "\nTo fix: update dependencies with `uv sync` or "
+            "check pyproject.toml version constraints."
+        )
+        raise RuntimeError(error_msg)
+
+    logger.info("ONEX version compatibility check PASSED")

--- a/tests/unit/runtime/test_version_compatibility.py
+++ b/tests/unit/runtime/test_version_compatibility.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Tests for version compatibility matrix check (INFRA-017).
+
+These tests verify that the version compatibility checking logic correctly
+detects compatible and incompatible package versions, and that the version
+matrix stays in sync with pyproject.toml.
+
+Related:
+    - OMN-758: INFRA-017: Version compatibility matrix check
+    - omnibase_infra.runtime.version_compatibility: Implementation
+
+.. versionadded:: 0.11.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.runtime.version_compatibility import (
+    VERSION_MATRIX,
+    VersionConstraint,
+    _parse_version,
+    _version_in_range,
+    check_version_compatibility,
+    log_and_verify_versions,
+)
+
+
+@pytest.mark.unit
+class TestParseVersion:
+    """Tests for version string parsing."""
+
+    def test_simple_version(self) -> None:
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_two_part_version(self) -> None:
+        assert _parse_version("0.20") == (0, 20)
+
+    def test_single_part_version(self) -> None:
+        assert _parse_version("5") == (5,)
+
+    def test_zero_version(self) -> None:
+        assert _parse_version("0.0.0") == (0, 0, 0)
+
+    def test_prerelease_suffix_stripped(self) -> None:
+        """Pre-release suffixes are stripped to numeric parts."""
+        result = _parse_version("0.20.0a1")
+        assert result == (0, 20, 0)
+
+    def test_large_version_numbers(self) -> None:
+        assert _parse_version("100.200.300") == (100, 200, 300)
+
+
+@pytest.mark.unit
+class TestVersionInRange:
+    """Tests for version range checking."""
+
+    def test_version_at_minimum(self) -> None:
+        """Minimum version is inclusive."""
+        assert _version_in_range("0.20.0", "0.20.0", "0.21.0") is True
+
+    def test_version_at_maximum(self) -> None:
+        """Maximum version is exclusive."""
+        assert _version_in_range("0.21.0", "0.20.0", "0.21.0") is False
+
+    def test_version_in_middle(self) -> None:
+        assert _version_in_range("0.20.5", "0.20.0", "0.21.0") is True
+
+    def test_version_below_minimum(self) -> None:
+        assert _version_in_range("0.19.0", "0.20.0", "0.21.0") is False
+
+    def test_version_above_maximum(self) -> None:
+        assert _version_in_range("0.22.0", "0.20.0", "0.21.0") is False
+
+    def test_patch_version_within_range(self) -> None:
+        assert _version_in_range("0.20.99", "0.20.0", "0.21.0") is True
+
+    def test_major_version_mismatch(self) -> None:
+        assert _version_in_range("1.0.0", "0.20.0", "0.21.0") is False
+
+
+@pytest.mark.unit
+class TestCheckVersionCompatibility:
+    """Tests for the full compatibility check function."""
+
+    def test_compatible_versions(self) -> None:
+        """No errors when all versions are in range."""
+        matrix = [
+            VersionConstraint("omnibase_core", "0.1.0", "99.0.0"),
+            VersionConstraint("omnibase_spi", "0.1.0", "99.0.0"),
+        ]
+        errors = check_version_compatibility(matrix)
+        assert errors == []
+
+    def test_missing_package(self) -> None:
+        """Missing package produces clear error."""
+        matrix = [
+            VersionConstraint("nonexistent_package_xyz", "1.0.0", "2.0.0"),
+        ]
+        errors = check_version_compatibility(matrix)
+        assert len(errors) == 1
+        assert "NOT INSTALLED" in errors[0]
+        assert "nonexistent_package_xyz" in errors[0]
+
+    def test_incompatible_version(self) -> None:
+        """Incompatible version produces clear error with version details."""
+        matrix = [
+            VersionConstraint("omnibase_core", "99.0.0", "100.0.0"),
+        ]
+        errors = check_version_compatibility(matrix)
+        assert len(errors) == 1
+        assert "incompatible" in errors[0]
+        assert "omnibase_core" in errors[0]
+
+    def test_default_matrix_passes(self) -> None:
+        """The default VERSION_MATRIX must pass with installed packages.
+
+        This is the critical test: it verifies the currently installed
+        packages are compatible with the declared matrix. If this fails,
+        either the matrix or the installed packages need updating.
+        """
+        errors = check_version_compatibility()
+        assert errors == [], (
+            "Default VERSION_MATRIX check failed with currently installed packages:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    def test_empty_matrix(self) -> None:
+        """Empty matrix produces no errors."""
+        errors = check_version_compatibility([])
+        assert errors == []
+
+
+@pytest.mark.unit
+class TestLogAndVerifyVersions:
+    """Tests for the log_and_verify_versions entry point."""
+
+    def test_passes_with_current_versions(self) -> None:
+        """Must not raise with currently installed packages."""
+        # This should not raise
+        log_and_verify_versions()
+
+    def test_raises_on_incompatible(self) -> None:
+        """Must raise RuntimeError when versions are incompatible."""
+        bad_matrix = [
+            VersionConstraint("omnibase_core", "99.0.0", "100.0.0"),
+        ]
+        with (
+            patch(
+                "omnibase_infra.runtime.version_compatibility.VERSION_MATRIX",
+                bad_matrix,
+            ),
+            pytest.raises(RuntimeError, match="compatibility check FAILED"),
+        ):
+            log_and_verify_versions()
+
+    def test_error_message_contains_fix_instructions(self) -> None:
+        """Error message must contain actionable fix instructions."""
+        bad_matrix = [
+            VersionConstraint("omnibase_core", "99.0.0", "100.0.0"),
+        ]
+        with (
+            patch(
+                "omnibase_infra.runtime.version_compatibility.VERSION_MATRIX",
+                bad_matrix,
+            ),
+            pytest.raises(RuntimeError, match="uv sync") as exc_info,
+        ):
+            log_and_verify_versions()
+
+        error_msg = str(exc_info.value)
+        assert "uv sync" in error_msg
+        assert "pyproject.toml" in error_msg
+
+
+@pytest.mark.unit
+class TestVersionMatrixConsistency:
+    """Tests that the VERSION_MATRIX is consistent with pyproject.toml."""
+
+    def test_matrix_has_core_and_spi(self) -> None:
+        """Matrix must include both omnibase_core and omnibase_spi."""
+        packages = {c.package for c in VERSION_MATRIX}
+        assert "omnibase_core" in packages
+        assert "omnibase_spi" in packages
+
+    def test_matrix_min_less_than_max(self) -> None:
+        """Min version must be less than max version for every constraint."""
+        for constraint in VERSION_MATRIX:
+            v_min = _parse_version(constraint.min_version)
+            v_max = _parse_version(constraint.max_version)
+            assert v_min < v_max, (
+                f"{constraint.package}: min_version {constraint.min_version} "
+                f"is not less than max_version {constraint.max_version}"
+            )
+
+    def test_matrix_matches_pyproject(self) -> None:
+        """VERSION_MATRIX constraints must match pyproject.toml.
+
+        This test reads pyproject.toml and verifies the matrix stays in sync.
+        """
+        import tomllib
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent.parent.parent
+        pyproject_path = repo_root / "pyproject.toml"
+
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        dependencies: list[str] = pyproject["project"]["dependencies"]
+
+        # Build a map of package -> version spec from pyproject.toml
+        pyproject_specs: dict[str, str] = {}
+        for dep in dependencies:
+            # Parse "omnibase-core>=0.20.0,<0.21.0" format
+            # Normalize package name (hyphens -> underscores)
+            dep_clean = dep.strip().strip('"').strip("'")
+            for sep in (">=", "<=", "==", "~=", ">", "<", "!="):
+                if sep in dep_clean:
+                    pkg_name = dep_clean.split(sep)[0].strip()
+                    pkg_name = pkg_name.replace("-", "_")
+                    pyproject_specs[pkg_name] = dep_clean
+                    break
+
+        for constraint in VERSION_MATRIX:
+            assert constraint.package in pyproject_specs, (
+                f"{constraint.package} is in VERSION_MATRIX but not in "
+                "pyproject.toml dependencies"
+            )
+
+            spec = pyproject_specs[constraint.package]
+            # Verify min version appears in the spec
+            assert constraint.min_version in spec, (
+                f"{constraint.package}: VERSION_MATRIX min_version "
+                f"{constraint.min_version} not found in pyproject.toml spec: {spec}"
+            )
+            # Verify max version appears in the spec
+            assert constraint.max_version in spec, (
+                f"{constraint.package}: VERSION_MATRIX max_version "
+                f"{constraint.max_version} not found in pyproject.toml spec: {spec}"
+            )
+
+    def test_constraint_is_frozen_dataclass(self) -> None:
+        """VersionConstraint must be immutable (frozen dataclass)."""
+        constraint = VERSION_MATRIX[0]
+        with pytest.raises(AttributeError):
+            constraint.package = "hacked"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds a version compatibility matrix that verifies omnibase_core and omnibase_spi versions at runtime startup, logging resolved versions and failing fast with actionable error messages if incompatible
- Integrates version check into `RuntimeHostProcess.start()` as the first step (Step 0), before architecture validation or event bus startup
- Includes 25 unit tests covering version parsing, range checking, compatibility verification, pyproject.toml sync validation, and error message quality

## Test plan

- [x] 25 tests pass covering all version parsing, range, compatibility, and matrix consistency scenarios
- [x] Matrix consistency test verifies VERSION_MATRIX matches pyproject.toml constraints
- [x] mypy --strict passes on new module
- [x] All ONEX pre-commit hooks pass
- [ ] CI green on PR