### PR TITLE
feat(ci): runtime rebuild trigger and dependency cascade on release [OMN-2751]

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -58,3 +58,15 @@ excluded_checks:
   - name: "Nightly Summary"
     workflow: nightly-tests.yml
     reason: "Nightly schedule only -- never runs on PRs"
+  - name: "Trigger Runtime Image Rebuild"
+    workflow: release.yml
+    reason: "Post-release only -- triggers omninode_infra rebuild (OMN-2751)"
+  - name: "Dependency Cascade"
+    workflow: release.yml
+    reason: "Post-release only -- opens bump PRs in downstream repos (OMN-2751)"
+  - name: "Compute Downstream Matrix"
+    workflow: dependency-cascade.yml
+    reason: "Post-release only -- part of dependency cascade (OMN-2751)"
+  - name: "Bump *"
+    workflow: dependency-cascade.yml
+    reason: "Post-release only -- matrix legs for downstream bump PRs (OMN-2751)"

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Dependency Cascade Workflow (OMN-2751)
+#
+# Opens dependency-bump PRs in downstream repos when a foundation package is
+# released. Each downstream repo gets a PR that runs `uv lock --upgrade-package`
+# to pick up the new version.
+#
+# Downstream mapping:
+#   omnibase_core  -> omnibase_infra, omniintelligence, omnimemory, omniclaude
+#   omnibase_spi   -> omnibase_infra, omniintelligence, omnimemory, omniclaude
+#   omnibase_infra -> omniintelligence, omnimemory, omniclaude
+#
+# This workflow is reusable so that omnibase_core and omnibase_spi can also call
+# it from their own release workflows.
+name: Dependency Cascade
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: 'Released package name (e.g. omnibase_infra)'
+        required: true
+        type: string
+      version:
+        description: 'Released version tag (e.g. v0.11.0)'
+        required: true
+        type: string
+    secrets:
+      cross-repo-pat:
+        description: 'PAT with repo scope for cross-repo operations'
+        required: true
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Released package name (e.g. omnibase_infra)'
+        required: true
+        type: string
+      version:
+        description: 'Released version tag (e.g. v0.11.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  compute-matrix:
+    name: Compute Downstream Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.matrix.outputs.repos }}
+    steps:
+      - name: Determine downstream repos
+        id: matrix
+        run: |
+          PACKAGE="${{ inputs.package }}"
+
+          case "$PACKAGE" in
+            omnibase_core)
+              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude"]'
+              ;;
+            omnibase_spi)
+              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude"]'
+              ;;
+            omnibase_infra)
+              REPOS='["omniintelligence", "omnimemory", "omniclaude"]'
+              ;;
+            *)
+              echo "ERROR: Unknown foundation package: $PACKAGE"
+              echo "Expected one of: omnibase_core, omnibase_spi, omnibase_infra"
+              exit 1
+              ;;
+          esac
+
+          echo "repos=$REPOS" >> $GITHUB_OUTPUT
+          echo "Downstream repos for $PACKAGE: $REPOS"
+
+  open-bump-pr:
+    name: Bump ${{ matrix.repo }}
+    needs: compute-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.compute-matrix.outputs.repos) }}
+    steps:
+      - name: Checkout downstream repo
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/${{ matrix.repo }}
+          token: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+          fetch-depth: 1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      - name: Set branch and PR variables
+        id: vars
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          PACKAGE="${{ inputs.package }}"
+          # Use hyphenated package name for the branch (PyPI convention)
+          PKG_HYPHEN="${PACKAGE//_/-}"
+          BRANCH="automation/bump-${PKG_HYPHEN}-${VERSION}"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "pkg_hyphen=$PKG_HYPHEN" >> $GITHUB_OUTPUT
+
+      - name: Create branch and upgrade lockfile
+        run: |
+          git checkout -b "${{ steps.vars.outputs.branch }}"
+
+          # Upgrade the package in the lockfile
+          uv lock --upgrade-package "${{ inputs.package }}"
+
+          # Check if anything changed
+          if git diff --quiet uv.lock; then
+            echo "SKIP=true" >> $GITHUB_ENV
+            echo "No lockfile changes -- ${{ matrix.repo }} already on latest ${{ inputs.package }}"
+          else
+            echo "SKIP=false" >> $GITHUB_ENV
+            echo "Lockfile updated with new ${{ inputs.package }} version"
+          fi
+
+      - name: Commit and push
+        if: env.SKIP == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(deps): bump ${{ inputs.package }} to ${{ steps.vars.outputs.version }}
+
+          Automated dependency cascade from ${{ github.repository }} release ${{ inputs.version }}.
+
+          Triggered-by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git push origin "${{ steps.vars.outputs.branch }}"
+
+      - name: Open pull request
+        if: env.SKIP == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+        run: |
+          # Check if a PR already exists for this branch
+          EXISTING=$(gh pr list \
+            --repo "OmniNode-ai/${{ matrix.repo }}" \
+            --head "${{ steps.vars.outputs.branch }}" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "PR already exists for branch ${{ steps.vars.outputs.branch }} -- skipping"
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "OmniNode-ai/${{ matrix.repo }}" \
+            --title "chore(deps): bump ${{ steps.vars.outputs.pkg_hyphen }} to ${{ steps.vars.outputs.version }}" \
+            --body "$(cat <<'PREOF'
+          ## Summary
+
+          Automated dependency bump triggered by a new release of `${{ inputs.package }}` (${{ inputs.version }}).
+
+          - Updates `uv.lock` via `uv lock --upgrade-package ${{ inputs.package }}`
+          - No source code changes -- lockfile only
+
+          ## Triggered by
+
+          Release workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ## Test plan
+
+          - [ ] CI passes (lockfile resolution is valid)
+          - [ ] Downstream tests pass with the new dependency version
+          PREOF
+          )" \
+            --head "${{ steps.vars.outputs.branch }}" \
+            --base main
+
+      - name: Skip summary
+        if: env.SKIP == 'true'
+        run: |
+          echo "### Skipped: ${{ matrix.repo }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "${{ matrix.repo }} already uses the latest version of ${{ inputs.package }}." >> $GITHUB_STEP_SUMMARY
+          echo "No lockfile changes needed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,3 +101,43 @@ jobs:
             dist/SHA256SUMS.txt
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
+
+  # ---------------------------------------------------------------------------
+  # Post-release: trigger runtime Docker image rebuild (OMN-2751)
+  # ---------------------------------------------------------------------------
+  # When omnibase_infra is released, the runtime image in omninode_infra must be
+  # rebuilt to pick up the new version. This uses repository_dispatch to trigger
+  # the build-and-push workflow in the omninode_infra repo.
+  trigger-runtime-rebuild:
+    name: Trigger Runtime Image Rebuild
+    needs: release
+    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch runtime rebuild to omninode_infra
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_PAT }}
+          repository: OmniNode-ai/omninode_infra
+          event-type: foundation-release
+          client-payload: >-
+            {
+              "package": "omnibase_infra",
+              "version": "${{ needs.release.outputs.version }}",
+              "source_repo": "${{ github.repository }}",
+              "source_sha": "${{ github.sha }}"
+            }
+
+  # ---------------------------------------------------------------------------
+  # Post-release: open dependency bump PRs in downstream repos (OMN-2751)
+  # ---------------------------------------------------------------------------
+  dependency-cascade:
+    name: Dependency Cascade
+    needs: release
+    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
+    uses: ./.github/workflows/dependency-cascade.yml
+    with:
+      package: omnibase_infra
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      cross-repo-pat: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary

Adds two post-release automations to the release workflow (Phase 5 of OMN-2745 epic):

- **Runtime rebuild trigger**: After a stable release of omnibase_infra, dispatches a `repository_dispatch` event (`foundation-release`) to `omninode_infra`, triggering a Docker image rebuild that picks up the new version
- **Dependency cascade**: Opens lockfile-bump PRs in downstream repos (`omniintelligence`, `omnimemory`, `omniclaude`) via `uv lock --upgrade-package`. The cascade workflow is reusable so `omnibase_core` and `omnibase_spi` can call it from their own release workflows
- **required-checks.yaml**: Documents new post-release jobs as excluded from branch protection (they never run on PRs)

### Design decisions

- Uses `peter-evans/repository-dispatch@v3` for cross-repo triggering (requires `CROSS_REPO_PAT` secret with `repo` scope)
- Pre-release (rc) tags skip both automations via `if: !contains(version, 'rc')`
- Cascade is idempotent: skips repos already on the latest version, skips PR creation if one already exists for the same branch
- Downstream mapping is hardcoded in a `case` statement for explicitness and auditability

### Prerequisites

- `CROSS_REPO_PAT` repository secret must be configured with `repo` scope for cross-repo operations
- `omninode_infra` must add `repository_dispatch` trigger to its `build-and-push-onex-api.yml` to accept the `foundation-release` event (separate PR to that repo)

## Test plan

- [ ] CI passes on this PR (workflow YAML is valid, no existing checks affected)
- [ ] Verify `CROSS_REPO_PAT` secret is configured in repo settings
- [ ] On next stable release, verify runtime rebuild is triggered in omninode_infra
- [ ] On next stable release, verify bump PRs are opened in downstream repos
- [ ] Verify pre-release (rc) tags do NOT trigger either automation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented post-release automation for runtime image rebuilds and cascading dependency updates across downstream repositories.
  * Updated CI configuration to properly handle post-release-only checks and exclude them from PR validation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->