### PR TITLE
fix(observability): correct agent-execution-logs topic to canonical ONEX format [OMN-2902]

### DIFF
--- a/src/omnibase_infra/services/observability/agent_actions/config.py
+++ b/src/omnibase_infra/services/observability/agent_actions/config.py
@@ -48,8 +48,7 @@ class ConfigAgentActionsConsumer(BaseSettings):
     )
 
     # Topics to subscribe (7 observability topics)
-    # NOTE: 5 topics migrated to ONEX canonical names (OMN-2621, CONTRACT_DRIFT fix).
-    # "agent-execution-logs" stays unchanged (producer name unconfirmed — monitor via counter).
+    # NOTE: All omniclaude-produced topics use canonical ONEX names (OMN-2621, OMN-2902, OMN-2903).
     # "onex.evt.omniclaude.agent-status.v1" renamed from "onex.evt.agent.status.v1" (OMN-2846).
     topics: list[str] = Field(
         default_factory=lambda: [
@@ -58,8 +57,8 @@ class ConfigAgentActionsConsumer(BaseSettings):
             "onex.evt.omniclaude.agent-transformation.v1",
             "onex.evt.omniclaude.performance-metrics.v1",
             "onex.evt.omniclaude.detection-failure.v1",
-            "agent-execution-logs",  # producer name unconfirmed — monitor via per-topic counter
-            "onex.evt.omniclaude.agent-status.v1",  # renamed from onex.evt.agent.status.v1 (OMN-2846)
+            "onex.evt.omniclaude.agent-execution-logs.v1",  # omniclaude TopicBase.EXECUTION_LOGS (OMN-2902)
+            "onex.evt.omniclaude.agent-status.v1",  # renamed from onex.evt.agent.status.v1 (OMN-2846, OMN-2903)
         ],
         description="Kafka topics to consume for agent observability",
     )


### PR DESCRIPTION
## Summary

- Corrects `agent-execution-logs` consumer topic from flat name to canonical `onex.evt.omniclaude.agent-execution-logs.v1`
- Events were silently dropped because the consumer subscribed to the wrong topic name
- All omniclaude-produced topics now use the canonical ONEX naming format

## Problem

The agent-actions observability consumer subscribed to `"agent-execution-logs"` (flat). `omniclaude`'s `TopicBase.EXECUTION_LOGS` emits `"onex.evt.omniclaude.agent-execution-logs.v1"` (canonical). This mismatch caused zero execution logs to reach the consumer.

## Changes

- `src/omnibase_infra/services/observability/agent_actions/config.py`: Update topic string on line 61 to canonical format; update comment block to reflect completed migration

## Test Plan

- [x] Observability unit tests pass (531 tests)
- [x] Pre-commit hooks all pass
- [x] mypy type checking passes

## Linear

Closes OMN-2902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated agent execution logs configuration to align with canonical naming standards, enhancing consistency and reliability in observability monitoring.
  * Replaced legacy agent-execution-logs topic with the canonical topic name and updated related annotations to include additional observability mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->