### PR TITLE
feat(topics): multi-bus topic resolution with trust domain scoping [OMN-2894]

### DIFF
--- a/src/omnibase_infra/enums/enum_infra_transport_type.py
+++ b/src/omnibase_infra/enums/enum_infra_transport_type.py
@@ -20,6 +20,7 @@ Supported transport types:
     - QDRANT: Qdrant vector database operations
     - GRAPH: Graph database (Memgraph/Neo4j) operations
     - LLM: LLM service endpoints (vLLM, embedding servers, etc.)
+    - BRIDGE: Cross-domain bridge transport for multi-bus topic routing
 
 Each transport type has a corresponding handler implementation:
     - HandlerConsul: Service registration, health checks, KV store operations
@@ -55,6 +56,7 @@ class EnumInfraTransportType(str, Enum):
         QDRANT: Qdrant vector database transport
         GRAPH: Graph database (Memgraph/Neo4j) transport
         LLM: LLM service endpoint transport (vLLM, embedding servers, etc.)
+        BRIDGE: Cross-domain bridge transport for multi-bus topic routing
     """
 
     HTTP = "http"
@@ -71,6 +73,7 @@ class EnumInfraTransportType(str, Enum):
     QDRANT = "qdrant"
     GRAPH = "graph"
     LLM = "llm"
+    BRIDGE = "bridge"
 
 
 __all__ = ["EnumInfraTransportType"]

--- a/src/omnibase_infra/errors/error_infra.py
+++ b/src/omnibase_infra/errors/error_infra.py
@@ -307,6 +307,7 @@ class InfraConnectionError(RuntimeHostError):
         EnumInfraTransportType.QDRANT: EnumCoreErrorCode.SERVICE_UNAVAILABLE,
         EnumInfraTransportType.GRAPH: EnumCoreErrorCode.SERVICE_UNAVAILABLE,
         EnumInfraTransportType.LLM: EnumCoreErrorCode.SERVICE_UNAVAILABLE,
+        EnumInfraTransportType.BRIDGE: EnumCoreErrorCode.SERVICE_UNAVAILABLE,
         None: EnumCoreErrorCode.SERVICE_UNAVAILABLE,
     }
 

--- a/src/omnibase_infra/topics/__init__.py
+++ b/src/omnibase_infra/topics/__init__.py
@@ -16,6 +16,7 @@ Exports:
     TopicResolutionError: Error raised when topic resolution fails
 """
 
+from omnibase_infra.topics.model_bus_descriptor import ModelBusDescriptor
 from omnibase_infra.topics.model_topic_spec import ModelTopicSpec
 from omnibase_infra.topics.platform_topic_suffixes import (
     ALL_INTELLIGENCE_TOPIC_SPECS,
@@ -56,7 +57,11 @@ from omnibase_infra.topics.platform_topic_suffixes import (
     SUFFIX_TOPIC_CATALOG_QUERY,
     SUFFIX_TOPIC_CATALOG_RESPONSE,
 )
-from omnibase_infra.topics.topic_resolver import TopicResolutionError, TopicResolver
+from omnibase_infra.topics.topic_resolver import (
+    BusDescriptorNotFoundError,
+    TopicResolutionError,
+    TopicResolver,
+)
 
 __all__: list[str] = [
     # Platform suffix constants
@@ -103,7 +108,10 @@ __all__: list[str] = [
     "ALL_PROVISIONED_TOPIC_SPECS",
     # Topic spec model
     "ModelTopicSpec",
+    # Bus descriptor model (Phase 5 - OMN-2894)
+    "ModelBusDescriptor",
     # Topic resolution
     "TopicResolver",
     "TopicResolutionError",
+    "BusDescriptorNotFoundError",
 ]

--- a/src/omnibase_infra/topics/model_bus_descriptor.py
+++ b/src/omnibase_infra/topics/model_bus_descriptor.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Bus descriptor model for trust-domain-scoped multi-bus topic routing.
+
+A ``ModelBusDescriptor`` captures the configuration of a single message bus
+within a trust domain. The ``TopicResolver`` uses these descriptors to prepend
+namespace prefixes when resolving topics for a specific trust domain.
+
+This is Phase 5 of the Authenticated Dependency Resolution epic (OMN-2897).
+The model is intentionally self-contained within omnibase_infra and does not
+depend on omnibase_core routing types -- it will be connected to those types
+in Phase 7 (Contract YAML Integration).
+
+.. versionadded:: 0.10.0
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.enums import EnumInfraTransportType
+
+
+class ModelBusDescriptor(BaseModel):
+    """Descriptor for a trust-domain-scoped message bus.
+
+    Each descriptor defines a single bus endpoint within a trust domain,
+    including its transport type, namespace prefix for topic scoping, and
+    the set of data classifications allowed to traverse it.
+
+    Attributes:
+        bus_id: Unique identifier for this bus instance
+            (e.g., ``"bus.local"``, ``"bus.org.omninode"``).
+        trust_domain: Trust domain this bus belongs to
+            (e.g., ``"local.default"``, ``"org.omninode"``).
+        transport_type: Transport protocol used by this bus.
+        namespace_prefix: Prefix prepended to topic suffixes when routing
+            through this bus (e.g., ``"org.omninode."``). Empty string means
+            no prefix is applied.
+        bootstrap_servers: Kafka/Redpanda bootstrap server addresses for this
+            bus. Empty for in-memory or bridge transports.
+        allowed_classifications: Data classification labels that may traverse
+            this bus (e.g., ``["public", "internal"]``). Empty list means all
+            classifications are allowed.
+
+    Example:
+        >>> descriptor = ModelBusDescriptor(
+        ...     bus_id="bus.local",
+        ...     trust_domain="local.default",
+        ...     transport_type=EnumInfraTransportType.KAFKA,
+        ...     namespace_prefix="",
+        ...     bootstrap_servers=["localhost:9092"],
+        ...     allowed_classifications=["public", "internal"],
+        ... )
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    bus_id: str = Field(
+        ...,
+        description="Unique identifier for this bus instance.",
+        min_length=1,
+    )
+    trust_domain: str = Field(
+        ...,
+        description="Trust domain this bus belongs to.",
+        min_length=1,
+    )
+    transport_type: EnumInfraTransportType = Field(
+        ...,
+        description="Transport protocol used by this bus.",
+    )
+    namespace_prefix: str = Field(
+        default="",
+        description=(
+            "Prefix prepended to topic suffixes when routing through this bus. "
+            "Empty string means no prefix."
+        ),
+    )
+    bootstrap_servers: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Kafka/Redpanda bootstrap server addresses for this bus.",
+    )
+    allowed_classifications: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Data classification labels allowed on this bus. "
+            "Empty tuple means all classifications are allowed."
+        ),
+    )
+
+
+__all__ = ["ModelBusDescriptor"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2400,6 +2400,20 @@ pattern_exemptions:
       - CLAUDE.md (Node Architecture - EFFECT nodes)
     ticket: OMN-2143
   # ==========================================================================
+  # ModelBusDescriptor bus_id Exemption (OMN-2894)
+  # ==========================================================================
+  # bus_id is a human-readable bus instance identifier (e.g., "bus.local",
+  # "bus.org.omninode"), not a UUID. It follows the trust-domain naming
+  # convention from the Authenticated Dependency Resolution epic.
+  - file_pattern: 'model_bus_descriptor\.py'
+    violation_pattern: "Field 'bus_id' should use UUID type instead of str"
+    reason: >
+      bus_id is a human-readable bus instance identifier (e.g., "bus.local", "bus.org.omninode") used for trust-domain-scoped topic routing. It follows the hierarchical naming convention from the epic plan, not a UUID-based system identifier.
+
+    documentation:
+      - CLAUDE.md (Phase 5 - Multi-Bus Topic Resolution)
+    ticket: OMN-2894
+  # ==========================================================================
   # ServiceArtifactStore Method Count Exemption (OMN-2151)
   # ==========================================================================
   # ServiceArtifactStore manages on-disk validation artifacts with cohesive file I/O

--- a/tests/unit/topics/test_model_bus_descriptor.py
+++ b/tests/unit/topics/test_model_bus_descriptor.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for ModelBusDescriptor.
+
+Tests frozen immutability, extra="forbid" validation, serde round-trip,
+and field constraints for the trust-domain-scoped bus descriptor model.
+
+Phase 5 of Authenticated Dependency Resolution epic (OMN-2897).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.topics.model_bus_descriptor import ModelBusDescriptor
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_descriptor(**overrides: object) -> ModelBusDescriptor:
+    """Create a ModelBusDescriptor with sensible defaults, overriding as needed."""
+    defaults: dict[str, object] = {
+        "bus_id": "bus.local",
+        "trust_domain": "local.default",
+        "transport_type": EnumInfraTransportType.KAFKA,
+        "namespace_prefix": "",
+        "bootstrap_servers": ("localhost:9092",),
+        "allowed_classifications": ("public", "internal"),
+    }
+    defaults.update(overrides)
+    return ModelBusDescriptor(**defaults)  # type: ignore[arg-type]
+
+
+class TestModelBusDescriptorFrozen:
+    """Frozen immutability tests."""
+
+    def test_frozen_bus_id(self) -> None:
+        """bus_id cannot be mutated after construction."""
+        desc = _make_descriptor()
+        with pytest.raises(ValidationError):
+            desc.bus_id = "changed"  # type: ignore[misc]
+
+    def test_frozen_trust_domain(self) -> None:
+        """trust_domain cannot be mutated after construction."""
+        desc = _make_descriptor()
+        with pytest.raises(ValidationError):
+            desc.trust_domain = "changed"  # type: ignore[misc]
+
+    def test_frozen_transport_type(self) -> None:
+        """transport_type cannot be mutated after construction."""
+        desc = _make_descriptor()
+        with pytest.raises(ValidationError):
+            desc.transport_type = EnumInfraTransportType.INMEMORY  # type: ignore[misc]
+
+    def test_frozen_namespace_prefix(self) -> None:
+        """namespace_prefix cannot be mutated after construction."""
+        desc = _make_descriptor()
+        with pytest.raises(ValidationError):
+            desc.namespace_prefix = "changed."  # type: ignore[misc]
+
+
+class TestModelBusDescriptorValidation:
+    """Validation and extra="forbid" tests."""
+
+    def test_extra_fields_rejected(self) -> None:
+        """Extra fields not in the schema are rejected."""
+        with pytest.raises(ValidationError, match="extra"):
+            _make_descriptor(unknown_field="value")
+
+    def test_bus_id_required(self) -> None:
+        """bus_id is a required field."""
+        with pytest.raises(ValidationError):
+            ModelBusDescriptor(
+                trust_domain="local.default",
+                transport_type=EnumInfraTransportType.KAFKA,
+            )  # type: ignore[call-arg]
+
+    def test_trust_domain_required(self) -> None:
+        """trust_domain is a required field."""
+        with pytest.raises(ValidationError):
+            ModelBusDescriptor(
+                bus_id="bus.local",
+                transport_type=EnumInfraTransportType.KAFKA,
+            )  # type: ignore[call-arg]
+
+    def test_transport_type_required(self) -> None:
+        """transport_type is a required field."""
+        with pytest.raises(ValidationError):
+            ModelBusDescriptor(
+                bus_id="bus.local",
+                trust_domain="local.default",
+            )  # type: ignore[call-arg]
+
+    def test_bus_id_min_length(self) -> None:
+        """bus_id cannot be an empty string."""
+        with pytest.raises(ValidationError, match="string_too_short"):
+            _make_descriptor(bus_id="")
+
+    def test_trust_domain_min_length(self) -> None:
+        """trust_domain cannot be an empty string."""
+        with pytest.raises(ValidationError, match="string_too_short"):
+            _make_descriptor(trust_domain="")
+
+    def test_invalid_transport_type(self) -> None:
+        """Invalid transport type string is rejected."""
+        with pytest.raises(ValidationError):
+            _make_descriptor(transport_type="not_a_transport")
+
+
+class TestModelBusDescriptorSerde:
+    """Serialization and deserialization round-trip tests."""
+
+    def test_round_trip_model_dump_load(self) -> None:
+        """model_dump -> ModelBusDescriptor round-trip preserves all fields."""
+        original = _make_descriptor(
+            bus_id="bus.org.omninode",
+            trust_domain="org.omninode",
+            transport_type=EnumInfraTransportType.KAFKA,
+            namespace_prefix="org.omninode.",
+            bootstrap_servers=("kafka1:9092", "kafka2:9092"),
+            allowed_classifications=("public",),
+        )
+        data = original.model_dump()
+        restored = ModelBusDescriptor.model_validate(data)
+        assert restored == original
+
+    def test_round_trip_json(self) -> None:
+        """JSON serialization round-trip preserves all fields."""
+        original = _make_descriptor()
+        json_str = original.model_dump_json()
+        restored = ModelBusDescriptor.model_validate_json(json_str)
+        assert restored == original
+
+    def test_model_dump_structure(self) -> None:
+        """model_dump returns expected keys."""
+        desc = _make_descriptor()
+        data = desc.model_dump()
+        expected_keys = {
+            "bus_id",
+            "trust_domain",
+            "transport_type",
+            "namespace_prefix",
+            "bootstrap_servers",
+            "allowed_classifications",
+        }
+        assert set(data.keys()) == expected_keys
+
+
+class TestModelBusDescriptorDefaults:
+    """Default value tests."""
+
+    def test_namespace_prefix_defaults_empty(self) -> None:
+        """namespace_prefix defaults to empty string."""
+        desc = ModelBusDescriptor(
+            bus_id="bus.local",
+            trust_domain="local.default",
+            transport_type=EnumInfraTransportType.KAFKA,
+        )
+        assert desc.namespace_prefix == ""
+
+    def test_bootstrap_servers_defaults_empty_tuple(self) -> None:
+        """bootstrap_servers defaults to empty tuple."""
+        desc = ModelBusDescriptor(
+            bus_id="bus.local",
+            trust_domain="local.default",
+            transport_type=EnumInfraTransportType.KAFKA,
+        )
+        assert desc.bootstrap_servers == ()
+
+    def test_allowed_classifications_defaults_empty_tuple(self) -> None:
+        """allowed_classifications defaults to empty tuple."""
+        desc = ModelBusDescriptor(
+            bus_id="bus.local",
+            trust_domain="local.default",
+            transport_type=EnumInfraTransportType.KAFKA,
+        )
+        assert desc.allowed_classifications == ()
+
+
+class TestModelBusDescriptorTransportTypes:
+    """Transport type coverage tests."""
+
+    def test_kafka_transport(self) -> None:
+        """Kafka transport type is accepted."""
+        desc = _make_descriptor(transport_type=EnumInfraTransportType.KAFKA)
+        assert desc.transport_type == EnumInfraTransportType.KAFKA
+
+    def test_inmemory_transport(self) -> None:
+        """In-memory transport type is accepted."""
+        desc = _make_descriptor(transport_type=EnumInfraTransportType.INMEMORY)
+        assert desc.transport_type == EnumInfraTransportType.INMEMORY
+
+    def test_bridge_transport(self) -> None:
+        """Bridge transport type is accepted."""
+        desc = _make_descriptor(transport_type=EnumInfraTransportType.BRIDGE)
+        assert desc.transport_type == EnumInfraTransportType.BRIDGE

--- a/tests/unit/topics/test_topic_resolver_multi_bus.py
+++ b/tests/unit/topics/test_topic_resolver_multi_bus.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for TopicResolver multi-bus trust-domain routing.
+
+Tests the Phase 5 (OMN-2894) extensions to TopicResolver:
+- Backward compatibility: without bus_descriptors, behavior is identical
+- Trust-domain routing: namespace prefix prepended when trust_domain matches
+- Error handling: BusDescriptorNotFoundError when no descriptor matches
+- Edge cases: empty prefix, trust_domain without descriptors configured
+
+Existing TopicResolver pass-through tests remain in test_topic_resolver.py.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.topics import (
+    BusDescriptorNotFoundError,
+    TopicResolutionError,
+    TopicResolver,
+)
+from omnibase_infra.topics.model_bus_descriptor import ModelBusDescriptor
+
+pytestmark = [pytest.mark.unit]
+
+# Valid ONEX topic suffix used across tests.
+VALID_SUFFIX = "onex.evt.platform.node-registration.v1"
+VALID_CMD_SUFFIX = "onex.cmd.platform.request-introspection.v1"
+
+
+def _local_descriptor(**overrides: object) -> ModelBusDescriptor:
+    """Build a local bus descriptor with sensible defaults."""
+    defaults: dict[str, object] = {
+        "bus_id": "bus.local",
+        "trust_domain": "local.default",
+        "transport_type": EnumInfraTransportType.KAFKA,
+        "namespace_prefix": "",
+        "bootstrap_servers": ("localhost:9092",),
+        "allowed_classifications": ("public", "internal"),
+    }
+    defaults.update(overrides)
+    return ModelBusDescriptor(**defaults)  # type: ignore[arg-type]
+
+
+def _org_descriptor(**overrides: object) -> ModelBusDescriptor:
+    """Build an org-level bus descriptor with namespace prefix."""
+    defaults: dict[str, object] = {
+        "bus_id": "bus.org.omninode",
+        "trust_domain": "org.omninode",
+        "transport_type": EnumInfraTransportType.KAFKA,
+        "namespace_prefix": "org.omninode.",
+        "bootstrap_servers": ("kafka.org:9092",),
+        "allowed_classifications": ("public",),
+    }
+    defaults.update(overrides)
+    return ModelBusDescriptor(**defaults)  # type: ignore[arg-type]
+
+
+class TestTopicResolverBackwardCompatibility:
+    """Regression: TopicResolver without bus_descriptors is identical to original."""
+
+    def test_no_args_constructor(self) -> None:
+        """Default constructor (no bus_descriptors) works identically."""
+        resolver = TopicResolver()
+        assert resolver.resolve(VALID_SUFFIX) == VALID_SUFFIX
+
+    def test_none_bus_descriptors(self) -> None:
+        """Explicit None bus_descriptors works identically."""
+        resolver = TopicResolver(bus_descriptors=None)
+        assert resolver.resolve(VALID_SUFFIX) == VALID_SUFFIX
+
+    def test_empty_bus_descriptors(self) -> None:
+        """Empty list of bus_descriptors works identically."""
+        resolver = TopicResolver(bus_descriptors=[])
+        assert resolver.resolve(VALID_SUFFIX) == VALID_SUFFIX
+
+    def test_trust_domain_ignored_without_descriptors(self) -> None:
+        """trust_domain is silently ignored when no descriptors are configured."""
+        resolver = TopicResolver()
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="org.omninode")
+        assert result == VALID_SUFFIX
+
+    def test_trust_domain_ignored_with_empty_descriptors(self) -> None:
+        """trust_domain is silently ignored when descriptors list is empty."""
+        resolver = TopicResolver(bus_descriptors=[])
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="org.omninode")
+        assert result == VALID_SUFFIX
+
+    def test_invalid_suffix_still_rejected(self) -> None:
+        """Invalid suffixes are still rejected even with bus_descriptors."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        with pytest.raises(TopicResolutionError):
+            resolver.resolve("bad-topic")
+
+    def test_correlation_id_passthrough(self) -> None:
+        """correlation_id is preserved in pass-through mode."""
+        resolver = TopicResolver()
+        cid = uuid4()
+        result = resolver.resolve(VALID_SUFFIX, correlation_id=cid)
+        assert result == VALID_SUFFIX
+
+    def test_bus_descriptors_property_empty_by_default(self) -> None:
+        """bus_descriptors property returns empty list when not configured."""
+        resolver = TopicResolver()
+        assert resolver.bus_descriptors == []
+
+
+class TestTopicResolverMultiBus:
+    """Multi-bus routing with trust_domain."""
+
+    def test_local_descriptor_empty_prefix(self) -> None:
+        """Local descriptor with empty prefix returns suffix unchanged."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="local.default")
+        assert result == VALID_SUFFIX
+
+    def test_org_descriptor_prepends_prefix(self) -> None:
+        """Org descriptor prepends namespace_prefix to suffix."""
+        resolver = TopicResolver(
+            bus_descriptors=[_local_descriptor(), _org_descriptor()]
+        )
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="org.omninode")
+        assert result == f"org.omninode.{VALID_SUFFIX}"
+
+    def test_org_descriptor_cmd_topic(self) -> None:
+        """Org descriptor works with command topics too."""
+        resolver = TopicResolver(bus_descriptors=[_org_descriptor()])
+        result = resolver.resolve(VALID_CMD_SUFFIX, trust_domain="org.omninode")
+        assert result == f"org.omninode.{VALID_CMD_SUFFIX}"
+
+    def test_multiple_descriptors_correct_lookup(self) -> None:
+        """Correct descriptor is selected from multiple options."""
+        fed_descriptor = ModelBusDescriptor(
+            bus_id="bus.fed.partner",
+            trust_domain="fed.partner-a",
+            transport_type=EnumInfraTransportType.BRIDGE,
+            namespace_prefix="fed.partner-a.",
+            bootstrap_servers=(),
+            allowed_classifications=("public",),
+        )
+        resolver = TopicResolver(
+            bus_descriptors=[
+                _local_descriptor(),
+                _org_descriptor(),
+                fed_descriptor,
+            ]
+        )
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="fed.partner-a")
+        assert result == f"fed.partner-a.{VALID_SUFFIX}"
+
+    def test_no_trust_domain_with_descriptors_is_passthrough(self) -> None:
+        """Without trust_domain, resolver is pass-through even with descriptors."""
+        resolver = TopicResolver(
+            bus_descriptors=[_local_descriptor(), _org_descriptor()]
+        )
+        result = resolver.resolve(VALID_SUFFIX)
+        assert result == VALID_SUFFIX
+
+    def test_none_trust_domain_with_descriptors_is_passthrough(self) -> None:
+        """Explicit trust_domain=None is pass-through even with descriptors."""
+        resolver = TopicResolver(
+            bus_descriptors=[_local_descriptor(), _org_descriptor()]
+        )
+        result = resolver.resolve(VALID_SUFFIX, trust_domain=None)
+        assert result == VALID_SUFFIX
+
+    def test_bus_descriptors_property_returns_configured(self) -> None:
+        """bus_descriptors property returns all configured descriptors."""
+        descriptors = [_local_descriptor(), _org_descriptor()]
+        resolver = TopicResolver(bus_descriptors=descriptors)
+        assert len(resolver.bus_descriptors) == 2
+        domains = {d.trust_domain for d in resolver.bus_descriptors}
+        assert domains == {"local.default", "org.omninode"}
+
+
+class TestTopicResolverMultiBusErrors:
+    """Error handling for multi-bus routing."""
+
+    def test_unknown_trust_domain_raises(self) -> None:
+        """Requesting an unconfigured trust domain raises BusDescriptorNotFoundError."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        with pytest.raises(BusDescriptorNotFoundError, match=r"unknown\.domain"):
+            resolver.resolve(VALID_SUFFIX, trust_domain="unknown.domain")
+
+    def test_error_includes_trust_domain(self) -> None:
+        """BusDescriptorNotFoundError exposes the requested trust_domain."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        with pytest.raises(BusDescriptorNotFoundError) as exc_info:
+            resolver.resolve(VALID_SUFFIX, trust_domain="missing.domain")
+        assert exc_info.value.trust_domain == "missing.domain"
+
+    def test_error_includes_correlation_id(self) -> None:
+        """BusDescriptorNotFoundError includes correlation_id when provided."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        cid = uuid4()
+        with pytest.raises(BusDescriptorNotFoundError, match=str(cid)):
+            resolver.resolve(
+                VALID_SUFFIX,
+                trust_domain="missing.domain",
+                correlation_id=cid,
+            )
+
+    def test_error_has_infra_context(self) -> None:
+        """BusDescriptorNotFoundError carries structured infra_context."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        with pytest.raises(BusDescriptorNotFoundError) as exc_info:
+            resolver.resolve(VALID_SUFFIX, trust_domain="missing.domain")
+        err = exc_info.value
+        assert err.infra_context is not None
+        assert err.infra_context.transport_type == EnumInfraTransportType.KAFKA
+        assert err.infra_context.operation == "resolve_topic"
+
+    def test_error_is_topic_resolution_error(self) -> None:
+        """BusDescriptorNotFoundError is a subclass of TopicResolutionError."""
+        assert issubclass(BusDescriptorNotFoundError, TopicResolutionError)
+
+    def test_invalid_suffix_rejected_before_bus_lookup(self) -> None:
+        """Suffix validation happens before bus descriptor lookup."""
+        resolver = TopicResolver(bus_descriptors=[_local_descriptor()])
+        # bad-topic should raise TopicResolutionError, not BusDescriptorNotFoundError
+        with pytest.raises(TopicResolutionError) as exc_info:
+            resolver.resolve("bad-topic", trust_domain="local.default")
+        assert not isinstance(exc_info.value, BusDescriptorNotFoundError)
+
+    def test_last_descriptor_wins_for_duplicate_domains(self) -> None:
+        """When multiple descriptors share a trust_domain, the last one wins."""
+        desc1 = _local_descriptor(namespace_prefix="first.")
+        desc2 = _local_descriptor(namespace_prefix="second.")
+        resolver = TopicResolver(bus_descriptors=[desc1, desc2])
+        result = resolver.resolve(VALID_SUFFIX, trust_domain="local.default")
+        assert result == f"second.{VALID_SUFFIX}"


### PR DESCRIPTION
## Summary

Phase 5 of the Authenticated Dependency Resolution epic (OMN-2897). Adds trust-domain-scoped topic resolution to `TopicResolver` -- the single canonical function for topic name mapping in ONEX.

- **`ModelBusDescriptor`**: New frozen Pydantic model defining a message bus within a trust domain (bus_id, trust_domain, transport_type, namespace_prefix, bootstrap_servers, allowed_classifications)
- **`TopicResolver` extended**: Optional `bus_descriptors` on constructor, optional `trust_domain` on `resolve()` -- when both present, prepends the matching descriptor's namespace prefix to the validated topic suffix
- **`BusDescriptorNotFoundError`**: Raised when `trust_domain` is provided but no descriptor matches
- **`BRIDGE` transport type**: Added to `EnumInfraTransportType` for cross-domain bridge transport
- **Full backward compatibility**: Without new params, behavior is identical to current pass-through

## Files changed

| File | Change |
|------|--------|
| `src/omnibase_infra/topics/model_bus_descriptor.py` | **NEW** - `ModelBusDescriptor` model |
| `src/omnibase_infra/topics/topic_resolver.py` | Extended with multi-bus routing |
| `src/omnibase_infra/topics/__init__.py` | Exports for new types |
| `src/omnibase_infra/enums/enum_infra_transport_type.py` | Added `BRIDGE` |
| `src/omnibase_infra/errors/error_infra.py` | Added `BRIDGE` to transport error code map |
| `src/omnibase_infra/validation/validation_exemptions.yaml` | Exemption for `bus_id` (human-readable, not UUID) |
| `tests/unit/topics/test_model_bus_descriptor.py` | **NEW** - 20 tests for frozen/serde/validation |
| `tests/unit/topics/test_topic_resolver_multi_bus.py` | **NEW** - 22 tests for multi-bus routing |

## Test plan

- [x] ModelBusDescriptor frozen immutability (4 tests)
- [x] ModelBusDescriptor validation and extra=forbid (6 tests)
- [x] ModelBusDescriptor serde round-trip (3 tests)
- [x] ModelBusDescriptor defaults (3 tests)
- [x] ModelBusDescriptor transport types including BRIDGE (3 tests)
- [x] TopicResolver backward compatibility regression (8 tests)
- [x] TopicResolver multi-bus namespace prefixing (7 tests)
- [x] BusDescriptorNotFoundError for unmatched trust domain (7 tests)
- [x] Existing TopicResolver tests all pass (20 tests)
- [x] Full unit regression (4 pre-existing failures, 0 new)
- [x] mypy --strict passes
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Infrastructure now supports BRIDGE as a transport type
  * Topic resolver can route messages across multiple buses using trust-domain scoping
  * New message bus descriptor model for managing bus configurations with transport types and bootstrap settings

* **Bug Fixes**
  * Enhanced error handling for BRIDGE transport connections

* **Tests**
  * Added comprehensive test coverage for multi-bus topic resolution and message bus descriptor functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->