### PR TITLE
fix(gmail): rename producer topic to canonical dash format [OMN-2904]

### DIFF
--- a/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py
+++ b/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py
@@ -58,7 +58,7 @@ from omnibase_infra.nodes.node_gmail_intent_poller_effect.models.model_gmail_int
 logger = logging.getLogger(__name__)
 
 # Event topic for gmail intent received events
-_GMAIL_INTENT_TOPIC: str = "onex.evt.omnibase_infra.gmail-intent-received.v1"
+_GMAIL_INTENT_TOPIC: str = "onex.evt.omnibase-infra.gmail-intent-received.v1"
 
 # Maximum body_text length for event payloads
 _BODY_TEXT_MAX_CHARS: int = 4096


### PR DESCRIPTION
## Summary

Fixes topic naming violation in the Gmail intent poller: changes `_GMAIL_INTENT_TOPIC` constant from `onex.evt.omnibase_infra.gmail-intent-received.v1` (underscore in realm — invalid) to `onex.evt.omnibase-infra.gmail-intent-received.v1` (canonical ONEX dash format).

## Problem

The underscore in the realm segment (`omnibase_infra`) violated ONEX canonical topic naming conventions and would fail `_validate_topic_name()`. The producer and consumer were both wrong so the pipeline worked, but the naming violation caused confusion and would break topic validation.

## Changes

- `src/omnibase_infra/nodes/node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py`: Update `_GMAIL_INTENT_TOPIC` constant to canonical dash format

## Companion PR

The consumer (omniintelligence) is updated in a companion PR: `OmniNode-ai/omniintelligence` — "fix(gmail): update gmail-intent-received subscription to canonical topic name [OMN-2904]"

## Test Plan

- [x] 91 Gmail unit tests pass in omnibase_infra
- [x] Pre-commit hooks all pass
- [x] No remaining references to `omnibase_infra.gmail-intent-received` in source (only in docstrings/descriptions which are informational)

## Linear

Closes OMN-2904 (partial — omnibase_infra side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected event topic naming convention to maintain consistency across infrastructure components.
  * Reformatted configuration file documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->