### PR TITLE
feat(event_bus): wire reconnect_backoff kwargs to all AIOKafka instantiation sites

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -621,6 +621,8 @@ class EventBusKafka(
                     bootstrap_servers=self._bootstrap_servers,
                     acks=self._config.acks_aiokafka,
                     enable_idempotence=self._config.enable_idempotence,
+                    reconnect_backoff_ms=self._config.reconnect_backoff_ms,
+                    reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
                     **self._build_auth_kwargs(),
                 )
 
@@ -934,6 +936,8 @@ class EventBusKafka(
                 bootstrap_servers=self._bootstrap_servers,
                 acks=self._config.acks_aiokafka,
                 enable_idempotence=self._config.enable_idempotence,
+                reconnect_backoff_ms=self._config.reconnect_backoff_ms,
+                reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
                 **self._build_auth_kwargs(),
             )
 
@@ -1534,6 +1538,8 @@ class EventBusKafka(
             group_id=effective_group_id,
             auto_offset_reset=self._config.auto_offset_reset,
             enable_auto_commit=self._config.enable_auto_commit,
+            reconnect_backoff_ms=self._config.reconnect_backoff_ms,
+            reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
             **self._build_auth_kwargs(),
         )
 

--- a/tests/unit/event_bus/test_kafka_reconnect_backoff_wiring.py
+++ b/tests/unit/event_bus/test_kafka_reconnect_backoff_wiring.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests verifying reconnect_backoff kwargs are wired to AIOKafka constructors.
+
+Tests that reconnect_backoff_ms and reconnect_backoff_max_ms from
+ModelKafkaEventBusConfig are passed through to:
+1. AIOKafkaProducer in start()
+2. AIOKafkaProducer in _ensure_producer() (recreation after failure)
+3. AIOKafkaConsumer in _start_consumer_for_topic()
+
+OMN-2919
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+
+TEST_BOOTSTRAP_SERVERS: str = "localhost:9092"
+TEST_ENVIRONMENT: str = "local"
+TEST_RECONNECT_BACKOFF_MS: int = 4000
+TEST_RECONNECT_BACKOFF_MAX_MS: int = 60000
+
+
+@pytest.fixture
+def config_with_backoff() -> ModelKafkaEventBusConfig:
+    """Create config with non-default reconnect backoff values for assertion clarity."""
+    return ModelKafkaEventBusConfig(
+        bootstrap_servers=TEST_BOOTSTRAP_SERVERS,
+        environment=TEST_ENVIRONMENT,
+        reconnect_backoff_ms=TEST_RECONNECT_BACKOFF_MS,
+        reconnect_backoff_max_ms=TEST_RECONNECT_BACKOFF_MAX_MS,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_start_producer_receives_reconnect_backoff_kwargs(
+    config_with_backoff: ModelKafkaEventBusConfig,
+) -> None:
+    """start() passes reconnect_backoff_ms and reconnect_backoff_max_ms to AIOKafkaProducer."""
+    mock_producer = AsyncMock()
+    mock_producer.start = AsyncMock()
+    mock_producer.stop = AsyncMock()
+    mock_producer._closed = False
+
+    with patch(
+        "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+        return_value=mock_producer,
+    ) as mock_producer_cls:
+        bus = EventBusKafka(config=config_with_backoff)
+        await bus.start()
+
+        # Verify AIOKafkaProducer was constructed with the backoff kwargs
+        assert mock_producer_cls.call_count == 1
+        _, kwargs = mock_producer_cls.call_args
+        assert kwargs["reconnect_backoff_ms"] == TEST_RECONNECT_BACKOFF_MS
+        assert kwargs["reconnect_backoff_max_ms"] == TEST_RECONNECT_BACKOFF_MAX_MS
+
+        await bus.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ensure_producer_receives_reconnect_backoff_kwargs(
+    config_with_backoff: ModelKafkaEventBusConfig,
+) -> None:
+    """_ensure_producer() passes reconnect_backoff_ms and reconnect_backoff_max_ms to AIOKafkaProducer.
+
+    Simulates producer recreation after failure: bus is started, producer is set
+    to None (as happens after a publish failure), then _ensure_producer is called
+    under the producer lock to recreate it.
+    """
+    mock_producer = AsyncMock()
+    mock_producer.start = AsyncMock()
+    mock_producer.stop = AsyncMock()
+    mock_producer._closed = False
+
+    with patch(
+        "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+        return_value=mock_producer,
+    ) as mock_producer_cls:
+        bus = EventBusKafka(config=config_with_backoff)
+        # Start the bus so _started=True
+        await bus.start()
+
+        # Reset call count after initial start
+        mock_producer_cls.reset_mock()
+
+        # Simulate producer being lost (e.g., after a failed publish)
+        bus._producer = None
+
+        # Call _ensure_producer under the producer lock (as the real code does)
+        async with bus._producer_lock:
+            await bus._ensure_producer(uuid4())
+
+        # Verify recreation call also passes backoff kwargs
+        assert mock_producer_cls.call_count == 1
+        _, kwargs = mock_producer_cls.call_args
+        assert kwargs["reconnect_backoff_ms"] == TEST_RECONNECT_BACKOFF_MS
+        assert kwargs["reconnect_backoff_max_ms"] == TEST_RECONNECT_BACKOFF_MAX_MS
+
+        await bus.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_start_consumer_for_topic_receives_reconnect_backoff_kwargs(
+    config_with_backoff: ModelKafkaEventBusConfig,
+) -> None:
+    """_start_consumer_for_topic() passes reconnect_backoff_ms and reconnect_backoff_max_ms to AIOKafkaConsumer."""
+    mock_producer = AsyncMock()
+    mock_producer.start = AsyncMock()
+    mock_producer.stop = AsyncMock()
+    mock_producer._closed = False
+
+    mock_consumer = AsyncMock()
+    mock_consumer.start = AsyncMock()
+    mock_consumer.stop = AsyncMock()
+    mock_consumer.__aiter__ = MagicMock(return_value=iter([]))
+
+    with (
+        patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ),
+        patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ) as mock_consumer_cls,
+    ):
+        bus = EventBusKafka(config=config_with_backoff)
+        await bus.start()
+
+        # Directly call _start_consumer_for_topic with a valid group_id
+        await bus._start_consumer_for_topic("test-topic", "test-group")
+
+        # Verify AIOKafkaConsumer was constructed with the backoff kwargs
+        assert mock_consumer_cls.call_count == 1
+        _, kwargs = mock_consumer_cls.call_args
+        assert kwargs["reconnect_backoff_ms"] == TEST_RECONNECT_BACKOFF_MS
+        assert kwargs["reconnect_backoff_max_ms"] == TEST_RECONNECT_BACKOFF_MAX_MS
+
+        await bus.close()
+
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary

Wires `reconnect_backoff_ms` and `reconnect_backoff_max_ms` from `ModelKafkaEventBusConfig` to all three `AIOKafkaProducer` and `AIOKafkaConsumer` constructor call sites in `event_bus_kafka.py`.

**Changes:**
- `start()` (~line 620): initial producer creation now passes backoff kwargs
- `_ensure_producer()` (~line 933): producer recreation after failure now passes backoff kwargs
- `_start_consumer_for_topic()` (~line 1531): consumer creation per topic now passes backoff kwargs

**New tests** (`tests/unit/event_bus/test_kafka_reconnect_backoff_wiring.py`):
- `test_start_producer_receives_reconnect_backoff_kwargs` — asserts start() path
- `test_ensure_producer_receives_reconnect_backoff_kwargs` — asserts recreation path
- `test_start_consumer_for_topic_receives_reconnect_backoff_kwargs` — asserts consumer path

All 3 tests use `unittest.mock.patch` to intercept constructors and assert on `call_args`.

## Dependencies

This branch includes the changes from OMN-2916 (#466) via `git merge`. The PR depends on OMN-2916 being merged first.

Part of OMN-2915 (Redpanda Connection Exhaustion Prevention).

Closes OMN-2919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit test coverage for Kafka reconnection backoff configuration verification across producer and consumer initialization flows.

* **Chores**
  * Enhanced Kafka client reconnection backoff configuration to improve connection resilience during producer startup, producer recreation, and consumer initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->