### PR TITLE
feat(registration): catalog responder for topic-catalog-request.v1 [OMN-2923]

### DIFF
--- a/src/omnibase_infra/models/registration/__init__.py
+++ b/src/omnibase_infra/models/registration/__init__.py
@@ -43,6 +43,9 @@ from omnibase_infra.models.registration.model_node_registration import (
 from omnibase_infra.models.registration.model_node_registration_record import (
     ModelNodeRegistrationRecord,
 )
+from omnibase_infra.models.registration.model_topic_catalog_request import (
+    ModelTopicCatalogRequest,
+)
 
 __all__ = [
     # Event bus configuration
@@ -65,4 +68,5 @@ __all__ = [
     "ModelNodeRegistrationInitiated",
     "ModelNodeRegistrationRecord",
     "ModelNodeRegistrationRejected",
+    "ModelTopicCatalogRequest",
 ]

--- a/src/omnibase_infra/models/registration/model_topic_catalog_request.py
+++ b/src/omnibase_infra/models/registration/model_topic_catalog_request.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Topic catalog request model for introspection-based catalog queries.
+
+Defines the request payload published on ``request-introspection.v1``
+to trigger a catalog response listing all registered ``onex.evt.*`` topics.
+
+Related Tickets:
+    - OMN-2923: Catalog responder for topic-catalog-request.v1
+
+.. versionadded:: 0.11.0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_infra.utils import validate_timezone_aware_datetime
+
+
+class ModelTopicCatalogRequest(BaseModel):
+    """Request model for topic catalog introspection queries.
+
+    Published on ``onex.cmd.platform.request-introspection.v1`` to trigger
+    the registration orchestrator to return a snapshot of all ``onex.evt.*``
+    topics from registered nodes.
+
+    Attributes:
+        correlation_id: Correlation ID echoed back in the response for
+            request-response pairing.
+        requested_at: UTC timestamp when the request was created.
+        requester: Optional identifier of the requesting client.
+
+    Example:
+        >>> from uuid import uuid4
+        >>> from datetime import datetime, timezone
+        >>> request = ModelTopicCatalogRequest(
+        ...     correlation_id=uuid4(),
+        ...     requested_at=datetime.now(timezone.utc),
+        ...     requester="omnidash",
+        ... )
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID echoed back in the response for request-response pairing.",
+    )
+    requested_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the request was created (must be timezone-aware).",
+    )
+    requester: str | None = Field(
+        default=None,
+        description="Optional identifier of the requesting client.",
+    )
+
+    @field_validator("requested_at")
+    @classmethod
+    def validate_requested_at_timezone_aware(cls, v: datetime) -> datetime:
+        """Validate that requested_at is timezone-aware.
+
+        Delegates to shared utility for consistent validation across all models.
+        """
+        return validate_timezone_aware_datetime(v)
+
+
+__all__: list[str] = ["ModelTopicCatalogRequest"]

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -66,6 +66,7 @@ event_bus:
     - "onex.cmd.platform.node-registration-acked.v1"
     - "onex.evt.platform.node-heartbeat.v1"
     - "onex.cmd.platform.topic-catalog-query.v1"
+    - "onex.cmd.platform.request-introspection.v1"
   publish_topics:
     - "onex.evt.platform.node-registration-result.v1"
     - "onex.evt.platform.node-registration-initiated.v1"
@@ -298,6 +299,15 @@ consumed_events:
     message_category: "COMMAND"
     description: "Request for a topic catalog snapshot from dashboard or other consumers"
     direct_handler: true
+  # OMN-2923: Introspection-based catalog responder
+  # Clients publish a request on request-introspection; runtime responds with
+  # onex.evt.* topics from accumulated node introspection state.
+  # HandlerCatalogRequest processes these requests via ServiceIntrospectionTopicStore.
+  - topic: "onex.cmd.platform.request-introspection.v1"
+    event_type: "TopicCatalogRequest"
+    message_category: "COMMAND"
+    description: "Request for onex.evt.* topics from accumulated node introspection state"
+    direct_handler: true
 # Handler Routing Configuration
 # ==============================
 # Declarative mapping of consumed events to handler implementations.
@@ -423,6 +433,20 @@ handler_routing:
         - "ModelTopicCatalogResponse"
       direct_handler: true
       description: "Returns topic catalog snapshot in response to a catalog query"
+    # ModelTopicCatalogRequest -> HandlerCatalogRequest (OMN-2923)
+    # Introspection-based catalog responder - returns onex.evt.* topics from
+    # accumulated node introspection state via ServiceIntrospectionTopicStore.
+    - event_model:
+        name: "ModelTopicCatalogRequest"
+        module: "omnibase_infra.models.registration.model_topic_catalog_request"
+      handler:
+        name: "HandlerCatalogRequest"
+        module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_catalog_request"
+      message_category: "COMMAND"
+      output_events:
+        - "ModelTopicCatalogResponse"
+      direct_handler: true
+      description: "Returns onex.evt.* topics from accumulated node introspection state"
   # Handler initialization configuration
   # All handlers share the same projection reader dependency
   handler_dependencies:

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/__init__.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/__init__.py
@@ -38,6 +38,9 @@ Related:
     - OMN-1990: Heartbeat Dispatcher Wiring
 """
 
+from omnibase_infra.nodes.node_registration_orchestrator.dispatchers.dispatcher_catalog_request import (
+    DispatcherCatalogRequest,
+)
 from omnibase_infra.nodes.node_registration_orchestrator.dispatchers.dispatcher_node_heartbeat import (
     DispatcherNodeHeartbeat,
 )
@@ -55,6 +58,7 @@ from omnibase_infra.nodes.node_registration_orchestrator.dispatchers.dispatcher_
 )
 
 __all__: list[str] = [
+    "DispatcherCatalogRequest",
     "DispatcherNodeHeartbeat",
     "DispatcherNodeIntrospected",
     "DispatcherNodeRegistrationAcked",

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_catalog_request.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_catalog_request.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+# ruff: noqa: TRY400
+# TRY400 disabled: logger.error is intentional to avoid leaking sensitive data in stack traces
+"""Dispatcher adapter for HandlerCatalogRequest.
+
+This module provides a ``ProtocolMessageDispatcher`` adapter that wraps
+``HandlerCatalogRequest`` for integration with ``MessageDispatchEngine``.
+
+The adapter:
+- Deserializes ``ModelEventEnvelope`` payload to ``ModelTopicCatalogRequest``
+- Extracts ``correlation_id`` from envelope or payload
+- Calls the wrapped handler and collects output events
+- Provides circuit breaker resilience via ``MixinAsyncCircuitBreaker``
+- Returns ``ModelDispatchResult`` with success/failure status
+
+Design:
+    Follows the ONEX dispatcher pattern established by
+    ``dispatcher_topic_catalog_query.py``:
+    - Implements ``ProtocolMessageDispatcher`` protocol
+    - Uses ``MixinAsyncCircuitBreaker`` for fault tolerance
+    - Stateless operation (handler instance is injected)
+    - Returns ``ModelDispatchResult`` with success/failure status
+    - Message category: COMMAND (catalog requests are command semantics)
+
+Circuit Breaker Pattern:
+    - Configured for KAFKA transport (threshold=3, reset_timeout=20.0s)
+    - Opens circuit after 3 consecutive failures
+    - Transitions to HALF_OPEN after timeout to test recovery
+    - Raises ``InfraUnavailableError`` when circuit is OPEN
+
+Related:
+    - OMN-2923: Catalog responder for topic-catalog-request.v1
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from pydantic import ValidationError
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import (
+    EnumDispatchStatus,
+    EnumInfraTransportType,
+    EnumMessageCategory,
+)
+from omnibase_infra.errors import InfraUnavailableError
+from omnibase_infra.mixins import MixinAsyncCircuitBreaker
+from omnibase_infra.models.catalog.model_topic_catalog_response import (
+    ModelTopicCatalogResponse,
+)
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.models.registration.model_topic_catalog_request import (
+    ModelTopicCatalogRequest,
+)
+from omnibase_infra.nodes.node_registration_orchestrator.dispatchers._util_envelope_extract import (
+    extract_envelope_fields,
+)
+from omnibase_infra.utils import sanitize_error_message
+
+if TYPE_CHECKING:
+    from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_catalog_request import (
+        HandlerCatalogRequest,
+    )
+
+__all__ = ["DispatcherCatalogRequest"]
+
+logger = logging.getLogger(__name__)
+
+# Topic identifier used in dispatch results for tracing and observability.
+# Note: Internal identifier for logging/metrics, NOT the actual Kafka topic.
+TOPIC_ID_CATALOG_REQUEST = "platform.request-introspection"
+
+
+class DispatcherCatalogRequest(MixinAsyncCircuitBreaker):
+    """Dispatcher adapter for HandlerCatalogRequest.
+
+    Wraps ``HandlerCatalogRequest`` to integrate it with
+    ``MessageDispatchEngine``'s category-based routing. Handles:
+
+    - Deserialization: Validates and casts payload to ``ModelTopicCatalogRequest``
+    - Correlation tracking: Extracts or generates ``correlation_id``
+    - Error handling: Returns structured ``ModelDispatchResult`` on failure
+    - Circuit breaker: Fault tolerance via ``MixinAsyncCircuitBreaker``
+
+    Circuit Breaker Configuration:
+        - threshold: 3 consecutive failures before opening circuit
+        - reset_timeout: 20.0 seconds before attempting recovery
+        - transport_type: KAFKA (event dispatching transport)
+        - service_name: dispatcher.registration.catalog-request
+
+    Attributes:
+        _handler: The wrapped ``HandlerCatalogRequest`` instance.
+    """
+
+    def __init__(self, handler: HandlerCatalogRequest) -> None:
+        """Initialize dispatcher with wrapped handler and circuit breaker.
+
+        Args:
+            handler: ``HandlerCatalogRequest`` instance to delegate to.
+        """
+        self._handler = handler
+
+        self._init_circuit_breaker(
+            threshold=3,
+            reset_timeout=20.0,
+            service_name="dispatcher.registration.catalog-request",
+            transport_type=EnumInfraTransportType.KAFKA,
+        )
+
+    @property
+    def dispatcher_id(self) -> str:
+        """Unique identifier for this dispatcher."""
+        return "dispatcher.registration.catalog-request"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Message category this dispatcher processes.
+
+        COMMAND category: catalog requests follow request-response semantics.
+        """
+        return EnumMessageCategory.COMMAND
+
+    @property
+    def message_types(self) -> set[str]:
+        """Specific message types this dispatcher accepts."""
+        return {"ModelTopicCatalogRequest", "platform.request-introspection"}
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """ONEX node kind for time injection rules."""
+        return EnumNodeKind.ORCHESTRATOR
+
+    async def handle(
+        self,
+        envelope: ModelEventEnvelope[object] | dict[str, object],
+    ) -> ModelDispatchResult:
+        """Handle a catalog request and return dispatch result.
+
+        Deserializes the envelope payload to ``ModelTopicCatalogRequest``,
+        delegates to the wrapped handler, and returns a structured result.
+
+        Circuit Breaker Integration:
+            - Checks circuit state before processing (raises if OPEN)
+            - Records failures to track service health
+            - Resets on success to maintain circuit health
+
+        Args:
+            envelope: Event envelope or materialized dict from dispatch engine.
+
+        Returns:
+            ``ModelDispatchResult``: Success with output events or error details.
+
+        Raises:
+            ``InfraUnavailableError``: If circuit breaker is OPEN.
+        """
+        started_at = datetime.now(UTC)
+
+        correlation_id, raw_payload = extract_envelope_fields(envelope)
+
+        # Check circuit breaker before processing (coroutine-safe)
+        async with self._circuit_breaker_lock:
+            await self._check_circuit_breaker("handle", correlation_id)
+
+        try:
+            # Validate payload type
+            payload = raw_payload
+            if not isinstance(payload, ModelTopicCatalogRequest):
+                if isinstance(payload, dict):
+                    payload = ModelTopicCatalogRequest.model_validate(payload)
+                else:
+                    return ModelDispatchResult(
+                        dispatch_id=uuid4(),
+                        status=EnumDispatchStatus.INVALID_MESSAGE,
+                        topic=TOPIC_ID_CATALOG_REQUEST,
+                        dispatcher_id=self.dispatcher_id,
+                        started_at=started_at,
+                        completed_at=started_at,
+                        duration_ms=0.0,
+                        error_message=(
+                            f"Expected ModelTopicCatalogRequest payload, "
+                            f"got {type(payload).__name__}"
+                        ),
+                        correlation_id=correlation_id,
+                        output_events=[],
+                    )
+
+            now = datetime.now(UTC)
+
+            handler_envelope: ModelEventEnvelope[ModelTopicCatalogRequest] = (
+                ModelEventEnvelope(
+                    envelope_id=uuid4(),
+                    payload=payload,
+                    envelope_timestamp=now,
+                    correlation_id=correlation_id,
+                    source=self.dispatcher_id,
+                )
+            )
+
+            handler_output = await self._handler.handle(handler_envelope)
+            output_events = list(handler_output.events)
+
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+
+            # Record success for circuit breaker (coroutine-safe)
+            async with self._circuit_breaker_lock:
+                await self._reset_circuit_breaker()
+
+            # Count topics in the response for observability
+            topic_count = 0
+            if output_events and isinstance(
+                output_events[0], ModelTopicCatalogResponse
+            ):
+                topic_count = len(output_events[0].topics)
+
+            logger.info(
+                "DispatcherCatalogRequest processed request",
+                extra={
+                    "topic_count": topic_count,
+                    "output_count": len(output_events),
+                    "duration_ms": duration_ms,
+                    "correlation_id": str(correlation_id),
+                },
+            )
+
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.SUCCESS,
+                topic=TOPIC_ID_CATALOG_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                output_count=len(output_events),
+                output_events=output_events,
+                correlation_id=correlation_id,
+            )
+
+        except ValidationError as e:
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+            sanitized_error = sanitize_error_message(e)
+
+            logger.warning(
+                "DispatcherCatalogRequest received invalid message: %s",
+                sanitized_error,
+                extra={
+                    "duration_ms": duration_ms,
+                    "correlation_id": str(correlation_id),
+                    "error_type": "ValidationError",
+                },
+            )
+
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.INVALID_MESSAGE,
+                topic=TOPIC_ID_CATALOG_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                error_message=sanitized_error,
+                correlation_id=correlation_id,
+                output_events=[],
+            )
+
+        except InfraUnavailableError:
+            # Circuit breaker errors propagate for engine-level handling
+            raise
+
+        except Exception as e:
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+            sanitized_error = sanitize_error_message(e)
+
+            # Record failure for circuit breaker (coroutine-safe)
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure("handle", correlation_id)
+
+            logger.error(
+                "DispatcherCatalogRequest failed: %s",
+                sanitized_error,
+                extra={
+                    "duration_ms": duration_ms,
+                    "correlation_id": str(correlation_id),
+                    "error_type": type(e).__name__,
+                },
+            )
+
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.HANDLER_ERROR,
+                topic=TOPIC_ID_CATALOG_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                error_message=sanitized_error,
+                correlation_id=correlation_id,
+                output_events=[],
+            )

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/__init__.py
@@ -31,6 +31,9 @@ Related Tickets:
     - OMN-1102: Refactor to pure declarative with standard handler signatures
 """
 
+from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_catalog_request import (
+    HandlerCatalogRequest,
+)
 from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_heartbeat import (
     HandlerNodeHeartbeat,
 )
@@ -53,6 +56,7 @@ from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_topic_
 __all__: list[str] = [
     "DEFAULT_LIVENESS_INTERVAL_SECONDS",
     "ENV_LIVENESS_INTERVAL_SECONDS",
+    "HandlerCatalogRequest",
     "HandlerNodeHeartbeat",
     "HandlerNodeIntrospected",
     "HandlerNodeRegistrationAcked",

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_catalog_request.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_catalog_request.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Handler for ModelTopicCatalogRequest - introspection-based catalog responder.
+
+This handler processes catalog requests published on
+``onex.cmd.platform.request-introspection.v1``. It reads the orchestrator's
+accumulated introspection state (via ``ServiceIntrospectionTopicStore``) and
+returns a ``ModelTopicCatalogResponse`` containing all registered ``onex.evt.*``
+topics.
+
+Architecture:
+    Follows the stateless handler pattern from handler_topic_catalog_query.py:
+
+    1. Extract correlation_id from envelope or payload
+    2. Query ServiceIntrospectionTopicStore for accumulated evt topics
+    3. Return ModelHandlerOutput with a single ModelTopicCatalogResponse event
+
+    The handler NEVER fails silently. All error conditions are surfaced via
+    the ``warnings`` field of the catalog response.
+
+Cold-Start Behavior:
+    If no introspection state has accumulated yet (no nodes have registered),
+    the handler responds immediately with:
+    ``topics=(), warnings=["Registry cold — no nodes registered yet"]``
+
+    It NEVER holds the response or times out.
+
+Topic Filter Rule:
+    Only topics starting with ``onex.evt.`` are included in the response.
+    The filter is applied as a simple string prefix check, not regex.
+
+Wire Format:
+    The response is serialized as JSON and published on
+    ``onex.evt.platform.topic-catalog-response.v1``. The omnidash
+    ``TopicCatalogManager`` parses responses with the schema:
+
+    ```json
+    {
+        "correlation_id": "...",
+        "topics": [{"topic_name": "onex.evt.foo.bar.v1"}, ...],
+        "warnings": []
+    }
+    ```
+
+    This handler uses the existing ``ModelTopicCatalogResponse`` model with
+    ``ModelTopicCatalogEntry`` entries to match this wire format.
+
+Coroutine Safety:
+    This handler is stateless with respect to its own fields and is
+    coroutine-safe for concurrent calls with different event instances.
+    The ``ServiceIntrospectionTopicStore`` uses asyncio.Lock internally.
+
+Related Tickets:
+    - OMN-2923: Catalog responder for topic-catalog-request.v1
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import (
+    EnumHandlerType,
+    EnumHandlerTypeCategory,
+)
+from omnibase_infra.models.catalog.model_topic_catalog_entry import (
+    ModelTopicCatalogEntry,
+)
+from omnibase_infra.models.catalog.model_topic_catalog_response import (
+    ModelTopicCatalogResponse,
+)
+from omnibase_infra.models.registration.model_topic_catalog_request import (
+    ModelTopicCatalogRequest,
+)
+from omnibase_infra.nodes.node_registration_orchestrator.services.service_introspection_topic_store import (
+    ServiceIntrospectionTopicStore,
+)
+
+logger = logging.getLogger(__name__)
+
+_WARNING_COLD_REGISTRY = "Registry cold — no nodes registered yet"
+
+
+class HandlerCatalogRequest:
+    """Handler for ModelTopicCatalogRequest - introspection-based catalog responder.
+
+    Processes catalog request commands on ``request-introspection.v1`` and
+    returns a snapshot of all ``onex.evt.*`` topics from the accumulated
+    node introspection state.
+
+    Dependency Injection:
+        Receives ``ServiceIntrospectionTopicStore`` via constructor injection.
+        The store is a shared singleton wired by the registry and also injected
+        into ``HandlerNodeIntrospected`` which populates it on each introspection.
+
+    Always-Respond Contract:
+        This handler ALWAYS returns a ``ModelHandlerOutput`` with exactly one
+        event (``ModelTopicCatalogResponse``). It never raises exceptions to
+        the caller — error conditions are encoded in the ``warnings`` field.
+
+    Attributes:
+        _topic_store: Shared in-memory store of per-node publish topics.
+    """
+
+    def __init__(
+        self,
+        topic_store: ServiceIntrospectionTopicStore,
+    ) -> None:
+        """Initialize with the shared introspection topic store.
+
+        Args:
+            topic_store: Shared ``ServiceIntrospectionTopicStore`` instance.
+                Populated by ``HandlerNodeIntrospected`` and read here.
+        """
+        self._topic_store = topic_store
+
+    @property
+    def handler_id(self) -> str:
+        """Unique identifier for this handler."""
+        return "handler-catalog-request"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Message category this handler processes."""
+        return EnumMessageCategory.COMMAND
+
+    @property
+    def message_types(self) -> set[str]:
+        """Set of message type names this handler can process."""
+        return {"ModelTopicCatalogRequest"}
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """Node kind this handler belongs to."""
+        return EnumNodeKind.ORCHESTRATOR
+
+    @property
+    def handler_type(self) -> EnumHandlerType:
+        """Architectural role classification for this handler."""
+        return EnumHandlerType.INFRA_HANDLER
+
+    @property
+    def handler_category(self) -> EnumHandlerTypeCategory:
+        """Behavioral classification for this handler.
+
+        Returns COMPUTE because the topic union and filter are pure in-memory
+        operations — no external I/O is performed.
+        """
+        return EnumHandlerTypeCategory.COMPUTE
+
+    async def handle(
+        self,
+        envelope: ModelEventEnvelope[ModelTopicCatalogRequest],
+    ) -> ModelHandlerOutput[object]:
+        """Process a catalog request and return a catalog response.
+
+        Reads the accumulated introspection state, unions all ``onex.evt.*``
+        publish topics from registered nodes, and returns a
+        ``ModelTopicCatalogResponse`` with the result.
+
+        Cold-start behavior: if no nodes have registered, responds immediately
+        with an empty topic list and a cold-registry warning.
+
+        Args:
+            envelope: Event envelope containing ``ModelTopicCatalogRequest``
+                payload.
+
+        Returns:
+            ``ModelHandlerOutput`` with exactly one event:
+            ``ModelTopicCatalogResponse``.
+        """
+        start_time = time.perf_counter()
+        now: datetime = envelope.envelope_timestamp
+        correlation_id: UUID = envelope.correlation_id or uuid4()
+
+        # Extract correlation_id from payload if available (preferred over envelope)
+        payload = envelope.payload
+        if isinstance(payload, ModelTopicCatalogRequest):
+            correlation_id = payload.correlation_id
+            logger.debug(
+                "HandlerCatalogRequest received request from requester=%s",
+                payload.requester,
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "requester": payload.requester,
+                },
+            )
+        else:
+            logger.warning(
+                "HandlerCatalogRequest received unexpected payload type: %s — "
+                "using envelope correlation_id",
+                type(payload).__name__,
+                extra={"correlation_id": str(correlation_id)},
+            )
+
+        # Atomically snapshot the accumulated introspection state
+        evt_topics, node_count, nodes_missing = await self._topic_store.snapshot()
+
+        warnings: list[str] = []
+        if node_count == 0:
+            warnings.append(_WARNING_COLD_REGISTRY)
+            logger.info(
+                "HandlerCatalogRequest: registry cold (no nodes registered)",
+                extra={"correlation_id": str(correlation_id)},
+            )
+        else:
+            logger.info(
+                "HandlerCatalogRequest returning %d onex.evt.* topics from %d nodes "
+                "(%d missing event_bus config)",
+                len(evt_topics),
+                node_count,
+                nodes_missing,
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "topic_count": len(evt_topics),
+                    "node_count": node_count,
+                    "nodes_missing_event_bus": nodes_missing,
+                },
+            )
+
+        # Build catalog entries matching the omnidash TopicEntrySchema wire format.
+        # ModelTopicCatalogEntry serializes to {"topic_name": ..., "topic_suffix": ..., ...}.
+        # Omnidash TopicCatalogResponseSchema uses z.object({topic_name: z.string()})
+        # which accepts — and ignores — extra fields. Only topic_name is required.
+        topic_entries = tuple(
+            ModelTopicCatalogEntry(
+                topic_suffix=t,
+                topic_name=t,
+                partitions=1,
+                publisher_count=1,  # known to exist (node published it)
+            )
+            for t in evt_topics
+        )
+
+        response = ModelTopicCatalogResponse(
+            correlation_id=correlation_id,
+            topics=topic_entries,
+            catalog_version=1,
+            node_count=node_count,
+            generated_at=now,
+            warnings=tuple(warnings),
+        )
+
+        processing_time_ms = (time.perf_counter() - start_time) * 1000
+        return ModelHandlerOutput(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=correlation_id,
+            handler_id=self.handler_id,
+            node_kind=self.node_kind,
+            events=(response,),
+            intents=(),
+            projections=(),
+            result=None,
+            processing_time_ms=processing_time_ms,
+            timestamp=now,
+        )
+
+
+__all__: list[str] = ["HandlerCatalogRequest"]

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/registry/registry_infra_node_registration_orchestrator.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/registry/registry_infra_node_registration_orchestrator.py
@@ -417,11 +417,21 @@ class RegistryInfraNodeRegistrationOrchestrator:
         #   Missing entries cause ProtocolConfigurationError at startup (fail-fast).
         #
         # See module docstring "Handler Dependency Map - Design Trade-off" for details.
+        # Create the shared introspection topic store (OMN-2923).
+        # Always created here so HandlerNodeIntrospected and HandlerCatalogRequest
+        # share the same instance without requiring it as a constructor parameter.
+        from omnibase_infra.nodes.node_registration_orchestrator.services import (
+            ServiceIntrospectionTopicStore,
+        )
+
+        _topic_store = ServiceIntrospectionTopicStore()
+
         # =====================================================================
         handler_dependencies: dict[str, dict[str, object]] = {
             "HandlerNodeIntrospected": {
                 "projection_reader": projection_reader,
                 "reducer": reducer,
+                "topic_store": _topic_store,
             },
             "HandlerRuntimeTick": {
                 "projection_reader": projection_reader,
@@ -443,6 +453,9 @@ class RegistryInfraNodeRegistrationOrchestrator:
             # error rather than a clear "catalog_service not provided" message.
             "HandlerTopicCatalogQuery": {
                 "catalog_service": catalog_service,
+            },
+            "HandlerCatalogRequest": {
+                "topic_store": _topic_store,
             },
         }
 

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/services/__init__.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/services/__init__.py
@@ -9,5 +9,8 @@ all four registration workflow decisions without performing any I/O.
 from omnibase_infra.nodes.node_registration_orchestrator.services.registration_reducer_service import (
     RegistrationReducerService,
 )
+from omnibase_infra.nodes.node_registration_orchestrator.services.service_introspection_topic_store import (
+    ServiceIntrospectionTopicStore,
+)
 
-__all__: list[str] = ["RegistrationReducerService"]
+__all__: list[str] = ["RegistrationReducerService", "ServiceIntrospectionTopicStore"]

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/services/service_introspection_topic_store.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/services/service_introspection_topic_store.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""In-memory store for node event bus publish topics accumulated from introspection events.
+
+This service accumulates the ``event_bus.publish_topics`` from every
+``ModelNodeIntrospectionEvent`` processed by the registration orchestrator.
+It is shared between:
+
+    1. ``HandlerNodeIntrospected`` — updates the store on each introspection event.
+    2. ``HandlerCatalogRequest`` — reads the store to build a catalog response.
+
+Thread Safety:
+    Uses ``asyncio.Lock`` for coroutine-safe reads and writes. All public methods
+    are ``async`` to enforce consistent lock acquisition patterns.
+
+Design:
+    - Key: ``node_id`` (UUID as string) — one entry per registered node.
+    - Value: ``frozenset[str]`` of environment-qualified topic strings.
+    - Topics are stored as received from ``event_bus.publish_topics`` entries.
+    - Filtering to ``onex.evt.*`` is performed at read time, not write time,
+      to preserve the full set for future use cases.
+
+Related Tickets:
+    - OMN-2923: Catalog responder for topic-catalog-request.v1
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceIntrospectionTopicStore:
+    """In-memory store for node event bus publish topics.
+
+    Accumulates publish topics from introspection events so that
+    ``HandlerCatalogRequest`` can assemble a complete catalog response
+    without querying Kafka or PostgreSQL.
+
+    Attributes:
+        _topics_by_node: Mapping from node_id string to frozenset of publish topics.
+        _lock: asyncio.Lock for coroutine-safe access.
+
+    Example:
+        >>> store = ServiceIntrospectionTopicStore()
+        >>> await store.update_node("node-id-123", ["onex.evt.platform.foo.v1"])
+        >>> topics = await store.get_evt_topics()
+        >>> assert "onex.evt.platform.foo.v1" in topics
+    """
+
+    def __init__(self) -> None:
+        """Initialize the store with an empty topic map and an asyncio lock."""
+        self._topics_by_node: dict[str, frozenset[str]] = {}
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    async def update_node(
+        self,
+        node_id: str,
+        publish_topics: list[str],
+    ) -> None:
+        """Record or update the publish topics for a node.
+
+        Called by ``HandlerNodeIntrospected`` whenever a node introspection
+        event is processed. Replaces any previously stored topics for the
+        same ``node_id``.
+
+        Args:
+            node_id: Unique node identifier string (UUID as str).
+            publish_topics: List of topic strings from the node's
+                ``event_bus.publish_topics`` configuration. Stored as-is;
+                filtering to ``onex.evt.*`` happens at read time.
+        """
+        async with self._lock:
+            self._topics_by_node[node_id] = frozenset(publish_topics)
+            logger.debug(
+                "IntrospectionTopicStore updated node=%s with %d topics",
+                node_id,
+                len(publish_topics),
+            )
+
+    async def get_evt_topics(self) -> list[str]:
+        """Return sorted deduplicated list of all ``onex.evt.*`` publish topics.
+
+        Unions all publish topics from all registered nodes, filters to those
+        starting with ``onex.evt.``, and returns a sorted deduplicated list.
+
+        Returns:
+            Sorted list of ``onex.evt.*`` topic strings. Empty list when no
+            nodes have registered with event bus configuration.
+        """
+        async with self._lock:
+            all_topics: set[str] = set()
+            for topics in self._topics_by_node.values():
+                all_topics.update(topics)
+        return sorted(t for t in all_topics if t.startswith("onex.evt."))
+
+    async def get_node_count(self) -> int:
+        """Return the number of nodes currently tracked in the store.
+
+        Returns:
+            Count of nodes that have provided event bus configuration.
+        """
+        async with self._lock:
+            return len(self._topics_by_node)
+
+    async def count_nodes_missing_event_bus(self) -> int:
+        """Return count of nodes with no publish topics recorded.
+
+        Nodes that sent introspection events with no ``event_bus`` configured
+        will have an empty frozenset. This count is included in catalog
+        responses as the ``nodes_missing_event_bus`` field.
+
+        Returns:
+            Number of nodes with zero publish topics.
+        """
+        async with self._lock:
+            return sum(1 for topics in self._topics_by_node.values() if not topics)
+
+    async def snapshot(self) -> tuple[list[str], int, int]:
+        """Return an atomic snapshot of catalog data for catalog responses.
+
+        Acquires the lock once to atomically read:
+        - Filtered and sorted ``onex.evt.*`` topic list
+        - Total node count
+        - Count of nodes missing event bus configuration
+
+        Returns:
+            Tuple of (evt_topics, node_count, nodes_missing_event_bus).
+        """
+        async with self._lock:
+            all_topics: set[str] = set()
+            total_nodes = len(self._topics_by_node)
+            missing_count = 0
+            for topics in self._topics_by_node.values():
+                all_topics.update(topics)
+                if not topics:
+                    missing_count += 1
+
+        evt_topics = sorted(t for t in all_topics if t.startswith("onex.evt."))
+        return evt_topics, total_nodes, missing_count
+
+
+__all__: list[str] = ["ServiceIntrospectionTopicStore"]

--- a/src/omnibase_infra/validation/infra_validators.py
+++ b/src/omnibase_infra/validation/infra_validators.py
@@ -468,7 +468,9 @@ INFRA_NODES_PATH = "src/omnibase_infra/nodes/"
 # - 129 (2026-02-25): OMN-2736 bifrost gateway field_validator coercions
 #                     ModelBifrostRequest._coerce_capabilities(): list[str] | tuple[str, ...]
 #                     ModelBifrostRequest._coerce_messages(): list[JsonDict] | tuple[JsonDict, ...]
-INFRA_MAX_UNIONS = 129
+# - 130 (2026-02-27): OMN-2923 catalog responder dispatcher
+#                     DispatcherCatalogRequest.handle(): ModelEventEnvelope[object] | dict[str, object]
+INFRA_MAX_UNIONS = 130
 
 # Maximum allowed architecture violations in infrastructure code.
 # Set to 0 (strict enforcement) to ensure one-model-per-file principle is always followed.

--- a/tests/unit/nodes/node_registration_orchestrator/test_handler_catalog_request.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_handler_catalog_request.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for HandlerCatalogRequest (OMN-2923).
+
+Tests validate:
+- Happy path: handler returns ModelTopicCatalogResponse with onex.evt.* topics
+- Cold-start: no nodes registered -> empty topics + cold registry warning
+- Topic filter: only onex.evt.* topics included, others excluded
+- Correlation ID: echoed from payload (not envelope)
+- Multiple nodes: topics unioned and deduplicated across all registered nodes
+- Handler properties: handler_id, category, message_types, node_kind, handler_type
+
+Related Tickets:
+    - OMN-2923: Catalog responder for topic-catalog-request.v1
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.models.catalog.model_topic_catalog_response import (
+    ModelTopicCatalogResponse,
+)
+from omnibase_infra.models.registration.model_topic_catalog_request import (
+    ModelTopicCatalogRequest,
+)
+from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_catalog_request import (
+    _WARNING_COLD_REGISTRY,
+    HandlerCatalogRequest,
+)
+from omnibase_infra.nodes.node_registration_orchestrator.services.service_introspection_topic_store import (
+    ServiceIntrospectionTopicStore,
+)
+
+TEST_NOW = datetime(2026, 2, 27, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_store() -> ServiceIntrospectionTopicStore:
+    """Create a fresh ServiceIntrospectionTopicStore."""
+    return ServiceIntrospectionTopicStore()
+
+
+def _make_request_envelope(
+    correlation_id: UUID | None = None,
+    requester: str | None = "test-client",
+    store: ServiceIntrospectionTopicStore | None = None,
+) -> tuple[
+    ModelEventEnvelope[ModelTopicCatalogRequest], ServiceIntrospectionTopicStore
+]:
+    """Create a test request envelope and store."""
+    if correlation_id is None:
+        correlation_id = uuid4()
+    if store is None:
+        store = _make_store()
+    payload = ModelTopicCatalogRequest(
+        correlation_id=correlation_id,
+        requested_at=TEST_NOW,
+        requester=requester,
+    )
+    envelope: ModelEventEnvelope[ModelTopicCatalogRequest] = ModelEventEnvelope(
+        envelope_id=uuid4(),
+        payload=payload,
+        envelope_timestamp=TEST_NOW,
+        correlation_id=correlation_id,
+        source="test",
+    )
+    return envelope, store
+
+
+@pytest.mark.unit
+class TestHandlerCatalogRequestProperties:
+    """Verify handler property values."""
+
+    def test_handler_id(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert handler.handler_id == "handler-catalog-request"
+
+    def test_category(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert handler.category == EnumMessageCategory.COMMAND
+
+    def test_message_types(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert "ModelTopicCatalogRequest" in handler.message_types
+
+    def test_node_kind(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert handler.node_kind == EnumNodeKind.ORCHESTRATOR
+
+    def test_handler_type(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert handler.handler_type == EnumHandlerType.INFRA_HANDLER
+
+    def test_handler_category(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        assert handler.handler_category == EnumHandlerTypeCategory.COMPUTE
+
+
+@pytest.mark.unit
+class TestHandlerCatalogRequestColdStart:
+    """Verify cold-start behavior when no nodes have registered."""
+
+    @pytest.mark.asyncio
+    async def test_cold_start_returns_empty_topics(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        assert len(output.events) == 1
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        assert len(response.topics) == 0
+        assert _WARNING_COLD_REGISTRY in response.warnings
+
+    @pytest.mark.asyncio
+    async def test_cold_start_echoes_correlation_id(self) -> None:
+        corr_id = uuid4()
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(correlation_id=corr_id, store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        assert response.correlation_id == corr_id
+
+
+@pytest.mark.unit
+class TestHandlerCatalogRequestTopicFiltering:
+    """Verify only onex.evt.* topics are included."""
+
+    @pytest.mark.asyncio
+    async def test_filters_to_evt_topics_only(self) -> None:
+        store = _make_store()
+        await store.update_node(
+            "node-001",
+            [
+                "onex.evt.platform.node-registration.v1",
+                "onex.evt.omniintelligence.intent-classified.v1",
+                "onex.cmd.platform.request-introspection.v1",  # should be excluded
+                "onex.intent.platform.runtime-tick.v1",  # should be excluded
+            ],
+        )
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        topic_names = {e.topic_name for e in response.topics}
+        assert "onex.evt.platform.node-registration.v1" in topic_names
+        assert "onex.evt.omniintelligence.intent-classified.v1" in topic_names
+        assert "onex.cmd.platform.request-introspection.v1" not in topic_names
+        assert "onex.intent.platform.runtime-tick.v1" not in topic_names
+
+    @pytest.mark.asyncio
+    async def test_no_cold_warning_when_nodes_registered(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        assert _WARNING_COLD_REGISTRY not in response.warnings
+
+
+@pytest.mark.unit
+class TestHandlerCatalogRequestMultiNode:
+    """Verify topic union across multiple registered nodes."""
+
+    @pytest.mark.asyncio
+    async def test_unions_topics_from_multiple_nodes(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        await store.update_node(
+            "node-002",
+            [
+                "onex.evt.platform.bar.v1",
+                "onex.evt.omniintelligence.pattern-stored.v1",
+            ],
+        )
+        await store.update_node("node-003", ["onex.evt.platform.foo.v1"])  # duplicate
+
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        topic_names = {e.topic_name for e in response.topics}
+        # Deduplicated: foo.v1 appears in node-001 and node-003 but listed once
+        assert "onex.evt.platform.foo.v1" in topic_names
+        assert "onex.evt.platform.bar.v1" in topic_names
+        assert "onex.evt.omniintelligence.pattern-stored.v1" in topic_names
+        # Exactly 3 unique evt topics
+        assert len(topic_names) == 3
+
+    @pytest.mark.asyncio
+    async def test_node_count_in_response(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        await store.update_node("node-002", ["onex.evt.platform.bar.v1"])
+
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        assert response.node_count == 2
+
+    @pytest.mark.asyncio
+    async def test_topic_names_sorted(self) -> None:
+        store = _make_store()
+        await store.update_node(
+            "node-001",
+            [
+                "onex.evt.platform.zzz.v1",
+                "onex.evt.platform.aaa.v1",
+                "onex.evt.omnimemory.doc-changed.v1",
+            ],
+        )
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        response = output.events[0]
+        assert isinstance(response, ModelTopicCatalogResponse)
+        names = [e.topic_name for e in response.topics]
+        assert names == sorted(names)
+
+
+@pytest.mark.unit
+class TestHandlerCatalogRequestOutput:
+    """Verify output structure."""
+
+    @pytest.mark.asyncio
+    async def test_output_has_exactly_one_event(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        assert len(output.events) == 1
+        assert len(output.intents) == 0
+        assert len(output.projections) == 0
+
+    @pytest.mark.asyncio
+    async def test_output_event_is_topic_catalog_response(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        assert isinstance(output.events[0], ModelTopicCatalogResponse)
+
+    @pytest.mark.asyncio
+    async def test_handler_id_in_output(self) -> None:
+        store = _make_store()
+        handler = HandlerCatalogRequest(topic_store=store)
+        envelope, _ = _make_request_envelope(store=store)
+
+        output = await handler.handle(envelope)
+
+        assert output.handler_id == "handler-catalog-request"
+
+
+@pytest.mark.unit
+class TestServiceIntrospectionTopicStore:
+    """Unit tests for ServiceIntrospectionTopicStore."""
+
+    @pytest.mark.asyncio
+    async def test_empty_store_returns_no_evt_topics(self) -> None:
+        store = _make_store()
+        topics = await store.get_evt_topics()
+        assert topics == []
+
+    @pytest.mark.asyncio
+    async def test_update_and_retrieve(self) -> None:
+        store = _make_store()
+        await store.update_node(
+            "node-001",
+            ["onex.evt.platform.foo.v1", "onex.cmd.platform.bar.v1"],
+        )
+        topics = await store.get_evt_topics()
+        assert "onex.evt.platform.foo.v1" in topics
+        assert "onex.cmd.platform.bar.v1" not in topics
+
+    @pytest.mark.asyncio
+    async def test_update_replaces_previous_entry(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.old.v1"])
+        await store.update_node("node-001", ["onex.evt.platform.new.v1"])
+        topics = await store.get_evt_topics()
+        assert "onex.evt.platform.new.v1" in topics
+        assert "onex.evt.platform.old.v1" not in topics
+
+    @pytest.mark.asyncio
+    async def test_node_count(self) -> None:
+        store = _make_store()
+        assert await store.get_node_count() == 0
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        await store.update_node("node-002", [])
+        assert await store.get_node_count() == 2
+
+    @pytest.mark.asyncio
+    async def test_nodes_missing_event_bus(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        await store.update_node("node-002", [])  # missing event_bus
+        count = await store.count_nodes_missing_event_bus()
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_snapshot_atomic(self) -> None:
+        store = _make_store()
+        await store.update_node("node-001", ["onex.evt.platform.foo.v1"])
+        await store.update_node("node-002", [])
+
+        topics, node_count, missing = await store.snapshot()
+
+        assert topics == ["onex.evt.platform.foo.v1"]
+        assert node_count == 2
+        assert missing == 1
+
+    @pytest.mark.asyncio
+    async def test_sorted_output(self) -> None:
+        store = _make_store()
+        await store.update_node(
+            "node-001",
+            ["onex.evt.platform.zzz.v1", "onex.evt.platform.aaa.v1"],
+        )
+        topics = await store.get_evt_topics()
+        assert topics == sorted(topics)


### PR DESCRIPTION
## Summary

Implements a catalog responder in `node_registration_orchestrator` that subscribes to `onex.cmd.platform.request-introspection.v1` and responds with all registered `onex.evt.*` topics on `onex.evt.platform.topic-catalog-response.v1`. Required by omnidash `ReadModelConsumer` to replace its hardcoded topic list.

**Ticket**: [OMN-2923](https://linear.app/omninode/issue/OMN-2923)
**Plan item**: Plan Item 3 — `dapper-tickling-snowglobe.md`

## Changes

### New files
- `src/omnibase_infra/models/registration/model_topic_catalog_request.py` — Request model (`ModelTopicCatalogRequest`) with `correlation_id`, `requested_at`, `requester`
- `src/omnibase_infra/nodes/node_registration_orchestrator/services/service_introspection_topic_store.py` — Async-safe in-memory store, updated by `HandlerNodeIntrospected`, read by `HandlerCatalogRequest`
- `src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_catalog_request.py` — Handler: queries store, filters `onex.evt.*` prefix, always responds (cold-start: empty list + warning)
- `src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_catalog_request.py` — Dispatcher wiring the handler into the dispatch engine
- `tests/unit/nodes/node_registration_orchestrator/test_handler_catalog_request.py` — 23 unit tests

### Modified files
- `contract.yaml` — adds subscribed `onex.cmd.platform.request-introspection.v1`, published `onex.evt.platform.topic-catalog-response.v1`
- `handlers/__init__.py`, `dispatchers/__init__.py`, `services/__init__.py` — exports
- `models/registration/__init__.py` — exports `ModelTopicCatalogRequest`
- `handler_node_introspected.py` — feeds `ServiceIntrospectionTopicStore` on introspection events
- `wiring.py` — wires `ServiceIntrospectionTopicStore` + `DispatcherCatalogRequest` into orchestrator
- `validation/infra_validators.py` — `INFRA_MAX_UNIONS` bumped 129→130 for new dispatcher `handle()` signature (same pattern as all other orchestrator dispatchers)

## Behavior

- **Cold start**: responds immediately with `topics=[], warnings=["Registry cold — no nodes registered yet"]`
- **Topic filter**: `onex.evt.*` prefix only (simple `str.startswith`, not regex)
- **Wire format**: `ModelTopicCatalogResponse` with `ModelTopicCatalogEntry` items — matches omnidash `TopicCatalogResponseSchema` (`{topic_name: z.string()}`)
- **Correlation**: echoes `correlation_id` from request payload (falls back to envelope)

## Test Plan

- [x] 23 unit tests pass: cold-start, topic filtering, multi-node union, store atomicity
- [x] 333 orchestrator unit tests pass (no regressions)
- [x] All pre-commit hooks pass (ruff, mypy, ONEX validators)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added introspection-based topic catalog feature enabling clients to discover available event topics and metadata across registered nodes.
  * Enhanced node introspection to accumulate and share topic state for accurate catalog responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->