### PR TITLE
fix(reward-binder): remove stale run_evaluated capability from registry [OMN-2930]

### DIFF
--- a/src/omnibase_infra/nodes/node_reward_binder_effect/registry/registry_infra_reward_binder_effect.py
+++ b/src/omnibase_infra/nodes/node_reward_binder_effect/registry/registry_infra_reward_binder_effect.py
@@ -54,7 +54,6 @@ class RegistryInfraRewardBinderEffect:
             "module": "omnibase_infra.nodes.node_reward_binder_effect.handlers.handler_reward_binder",
             "description": "Handler for reward event emission to Kafka",
             "capabilities": [
-                "reward.emit.run_evaluated",
                 "reward.emit.reward_assigned",
                 "reward.emit.policy_state_updated",
             ],


### PR DESCRIPTION
## Summary

Closes OMN-2930 (gap fingerprint \`d826168f\`).

OMN-2929 (#471, merged 2026-02-27) already removed \`TOPIC_RUN_EVALUATED\` from \`topic_constants.py\` and stopped \`NodeRewardBinderEffect\` from emitting to the orphan \`onex.evt.omnimemory.run-evaluated.v1\` topic. This PR completes the cleanup by removing the leftover \`"reward.emit.run_evaluated"\` capability label from \`RegistryInfraRewardBinderEffect\`, which no longer reflects actual handler behaviour.

### Context

- **OMN-2929** (merged #471): Removed \`TOPIC_RUN_EVALUATED\` constant, deleted stale \`ModelRunEvaluatedEvent\`, stopped all producer emissions — handler now emits 2 events only (\`reward_assigned\`, \`policy_state_updated\`)
- **OMN-2930** (this PR): Removes stale \`"reward.emit.run_evaluated"\` capability string from registry metadata

### Changes

- **Removed** \`"reward.emit.run_evaluated"\` from capabilities list in \`RegistryInfraRewardBinderEffect.register()\`

### DoD Verification (gap fingerprint d826168f)

| Item | Status |
|------|--------|
| \`onex.evt.omnimemory.run-evaluated.v1\` removed from \`topic_constants.py\` | ✅ Done in OMN-2929 (tombstone comment at line 561) |
| No producer emits to this topic | ✅ Handler emits only \`reward_assigned\` + \`policy_state_updated\` |
| Registry capabilities reflect actual handler behaviour | ✅ This PR removes stale \`run_evaluated\` capability |

## Test Plan

- [x] \`pytest tests/unit/nodes/node_reward_binder_effect/\` — 18/18 passing
- [x] \`pre-commit run --all-files\` — clean
- [x] \`git push\` pre-push mypy hook — passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made a minor internal configuration adjustment to optimize system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->