### PR TITLE
fix(topics): correct gmail-archive-purged topic name to use hyphen in producer segment [OMN-2937]

### DIFF
--- a/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/contract.yaml
@@ -23,7 +23,7 @@ node_version:
   patch: 0
 node_type: "EFFECT_GENERIC"
 description: >
-  Effect node that permanently deletes archived Gmail messages older than retention_days from each configured archive label. Triggered by onex.int.platform.runtime-tick.v1. Emits a single summary event to onex.evt.omnibase_infra.gmail-archive-purged.v1 per run when any messages were deleted or errors occurred.
+  Effect node that permanently deletes archived Gmail messages older than retention_days from each configured archive label. Triggered by onex.int.platform.runtime-tick.v1. Emits a single summary event to onex.evt.omnibase-infra.gmail-archive-purged.v1 per run when any messages were deleted or errors occurred.
 
 # Input subscriptions: scheduling trigger
 input_subscriptions:
@@ -108,14 +108,14 @@ dependencies:
   - name: "event_publisher"
     type: "protocol"
     protocol: "ProtocolEventPublisher"
-    description: "Event publisher for onex.evt.omnibase_infra.gmail-archive-purged.v1"
+    description: "Event publisher for onex.evt.omnibase-infra.gmail-archive-purged.v1"
 capabilities:
   - name: "gmail_archive_cleanup"
     description: "Permanently delete archived Gmail messages older than retention_days"
   - name: "gmail_label_search"
     description: "Search Gmail by label name and date cutoff"
   - name: "kafka_event_production"
-    description: "Publish summary event to onex.evt.omnibase_infra.gmail-archive-purged.v1"
+    description: "Publish summary event to onex.evt.omnibase-infra.gmail-archive-purged.v1"
 definitions:
   ModelGmailCleanupConfig:
     type: object

--- a/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/handlers/handler_gmail_archive_cleanup.py
+++ b/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/handlers/handler_gmail_archive_cleanup.py
@@ -32,7 +32,7 @@ A single summary event is appended to ``pending_events`` when
 ``purged_count > 0`` OR any errors exist:
 
     {
-        "event_type": "onex.evt.omnibase_infra.gmail-archive-purged.v1",
+        "event_type": "onex.evt.omnibase-infra.gmail-archive-purged.v1",
         "purged_count": <int>,
         "label_counts": {<label_name>: <count>, ...},
         "error_count": <int>,
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["HandlerGmailArchiveCleanup"]
 
 # Event type emitted per cleanup run
-_PURGED_EVENT_TYPE = "onex.evt.omnibase_infra.gmail-archive-purged.v1"
+_PURGED_EVENT_TYPE = "onex.evt.omnibase-infra.gmail-archive-purged.v1"
 
 # Partition key: all cleanup events share a single partition
 _PARTITION_KEY = "gmail-archive-cleanup"

--- a/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/node.py
+++ b/src/omnibase_infra/nodes/node_gmail_archive_cleanup_effect/node.py
@@ -7,7 +7,7 @@ This node follows the ONEX declarative pattern:
     - Triggered by onex.int.platform.runtime-tick.v1 (input_subscriptions)
     - Permanently deletes archived emails older than retention_days
     - Publishes a single summary event to
-      onex.evt.omnibase_infra.gmail-archive-purged.v1
+      onex.evt.omnibase-infra.gmail-archive-purged.v1
     - Lightweight shell — all logic in HandlerGmailArchiveCleanup
 
 Design:
@@ -34,7 +34,7 @@ class NodeGmailArchiveCleanupEffect(NodeEffect):
     contract.yaml ``input_subscriptions``). Permanently deletes messages
     from each configured archive label whose age exceeds ``retention_days``.
     Publishes one summary event to
-    ``onex.evt.omnibase_infra.gmail-archive-purged.v1`` per run when any
+    ``onex.evt.omnibase-infra.gmail-archive-purged.v1`` per run when any
     messages were deleted or errors occurred.
 
     All routing and execution logic is driven by contract.yaml.

--- a/src/omnibase_infra/topics/platform_topic_suffixes.py
+++ b/src/omnibase_infra/topics/platform_topic_suffixes.py
@@ -240,6 +240,43 @@ SUFFIX_OMNIMEMORY_CRAWL_REQUESTED: str = "onex.cmd.omnimemory.crawl-requested.v1
 """Topic for crawl requested commands (explicit crawl request for a document source)."""
 
 # =============================================================================
+# OMNIBASE_INFRA DOMAIN TOPIC SUFFIXES (omnibase-infra gmail nodes)
+# =============================================================================
+# These topics are produced by omnibase_infra gmail effect nodes. They are
+# provisioned alongside platform topics so consumers find them ready at startup.
+
+SUFFIX_GMAIL_ARCHIVE_PURGED: str = "onex.evt.omnibase-infra.gmail-archive-purged.v1"
+"""Topic suffix for Gmail archive purge summary events.
+
+Published by NodeGmailArchiveCleanupEffect after each cleanup run when any
+messages were deleted or errors occurred. This is a fire-and-forget summary
+event — there are no downstream consumers in the current implementation.
+
+No consumer rationale: Gmail archive cleanup events are audit-trail events
+only. Downstream systems (dashboards, alerting) may subscribe in the future,
+but no service currently depends on this event for correctness. The topic is
+provisioned to ensure the correct name exists on the broker and to prevent
+consumer misconfiguration if a subscriber is added later.
+
+Producer: NodeGmailArchiveCleanupEffect / HandlerGmailArchiveCleanup
+Consumer: None (intentionally fire-and-forget; see OMN-2937)
+"""
+
+# =============================================================================
+# OMNIBASE_INFRA DOMAIN TOPIC SPEC REGISTRY
+# =============================================================================
+
+ALL_OMNIBASE_INFRA_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
+    # Gmail cleanup events (3 partitions — low-throughput, one event per run)
+    ModelTopicSpec(suffix=SUFFIX_GMAIL_ARCHIVE_PURGED, partitions=3),
+)
+"""Omnibase_infra domain topic specs for internal effect nodes.
+
+Currently covers gmail cleanup events. Topics are provisioned so the correct
+broker topic name exists even if no consumer is registered yet.
+"""
+
+# =============================================================================
 # OMNICLAUDE SKILL TOPIC SUFFIXES (omniclaude plugin)
 # =============================================================================
 # These topics are consumed/produced by OmniClaude skill orchestrator nodes.
@@ -620,6 +657,7 @@ ALL_PROVISIONED_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
     ALL_PLATFORM_TOPIC_SPECS
     + ALL_INTELLIGENCE_TOPIC_SPECS
     + ALL_OMNIMEMORY_TOPIC_SPECS
+    + ALL_OMNIBASE_INFRA_TOPIC_SPECS
     + ALL_OMNICLAUDE_TOPIC_SPECS
 )
 """All topic specs to be provisioned by TopicProvisioner at startup.

--- a/tests/unit/nodes/node_gmail_archive_cleanup_effect/test_handler_gmail_archive_cleanup.py
+++ b/tests/unit/nodes/node_gmail_archive_cleanup_effect/test_handler_gmail_archive_cleanup.py
@@ -122,7 +122,7 @@ class TestHandlerGmailArchiveCleanup:
         assert len(result.pending_events) == 1
         event = result.pending_events[0]
         assert isinstance(event, dict)
-        assert event["event_type"] == "onex.evt.omnibase_infra.gmail-archive-purged.v1"
+        assert event["event_type"] == "onex.evt.omnibase-infra.gmail-archive-purged.v1"
         assert event["purged_count"] == 5
         assert event["partition_key"] == "gmail-archive-cleanup"
 


### PR DESCRIPTION
## Summary

- Fixes CRITICAL naming violation: `node_gmail_archive_cleanup_effect` was emitting `onex.evt.omnibase_infra.gmail-archive-purged.v1` (underscore in producer segment) instead of the canonical `onex.evt.omnibase-infra.gmail-archive-purged.v1`
- Adds the corrected topic to the provisioning registry (`platform_topic_suffixes.py`) so it exists on the broker at startup
- Documents the no-consumer rationale: this is an intentional fire-and-forget audit event; documented in `SUFFIX_GMAIL_ARCHIVE_PURGED` docstring (OMN-2937)

## Files Changed

| File | Change |
|------|--------|
| `handler_gmail_archive_cleanup.py` | Fix `_PURGED_EVENT_TYPE` constant (underscore → hyphen) + docstring |
| `node.py` | Fix 2 docstring references |
| `contract.yaml` | Fix 3 references in description/capabilities/dependencies |
| `platform_topic_suffixes.py` | Add `SUFFIX_GMAIL_ARCHIVE_PURGED`, `ALL_OMNIBASE_INFRA_TOPIC_SPECS`, wire into `ALL_PROVISIONED_TOPIC_SPECS` |
| `test_handler_gmail_archive_cleanup.py` | Update event_type assertion to match corrected name |

## Gap Analysis

Gap fingerprint `c297b145` will resolve to 0 findings after this fix. The sibling node `node_gmail_intent_poller_effect` has a similar naming violation (`omnibase_infra` vs `omnibase-infra`) which is tracked separately outside this ticket's scope.

## Test plan

- [x] All 15 unit tests in `tests/unit/nodes/node_gmail_archive_cleanup_effect/` pass
- [x] All pre-commit hooks pass (including ONEX Naming Convention Validation, ONEX Contract Validation)
- [x] `mypy src/omnibase_infra/ --strict` passes (0 errors, 1426 files)
- [x] `platform_topic_suffixes.py` import-time validation passes (`_validate_all_suffixes()`)

Closes OMN-2937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Standardized event topic naming convention across Gmail archive cleanup components, updating from underscore to hyphen-separated format (e.g., onex.evt.omnibase_infra to onex.evt.omnibase-infra) for consistency with platform standards.
- Added new topic provisioning configuration for the omnibase-infra Gmail domain, including the Gmail archive purge event topic with 3 partitions to ensure proper infrastructure initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->