### PR TITLE
fix(event-bus): retire orphan policy-state-updated topic constant [OMN-2931]

### DIFF
--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -571,14 +571,6 @@ Consumer: Tool/model/pattern/agent reward consumers
 Ticket: OMN-2552
 """
 
-TOPIC_POLICY_STATE_UPDATED: Final[str] = "onex.evt.omnimemory.policy-state-updated.v1"
-"""Policy state transition with old/new snapshots.
-
-Producer: NodeRewardBinderEffect
-Consumer: Policy state consumers, audit log
-Ticket: OMN-2552
-"""
-
 # Resolution event ledger (OMN-2895 / Phase 6)
 TOPIC_RESOLUTION_DECIDED: Final[str] = "onex.evt.platform.resolution-decided.v1"
 """Resolution decision audit events.
@@ -617,7 +609,6 @@ __all__ = [
     # Effectiveness Invalidation Topics
     "TOPIC_EFFECTIVENESS_INVALIDATION",
     # Reward Architecture Topics (OMN-2552)
-    "TOPIC_POLICY_STATE_UPDATED",
     "TOPIC_REWARD_ASSIGNED",
     # Resolution Event Ledger (OMN-2895)
     "TOPIC_RESOLUTION_DECIDED",


### PR DESCRIPTION
## Summary

Removes `TOPIC_POLICY_STATE_UPDATED` (`onex.evt.omnimemory.policy-state-updated.v1`) from `topic_constants.py` and its `__all__` export.

This constant was an orphan:
- Zero importers anywhere in the codebase (handler uses a private local `_TOPIC_POLICY_STATE_UPDATED` variable)
- Zero consumers subscribed to this topic
- The canonical `policy-state-updated` event is owned by **omniintelligence** (`node_policy_state_reducer`) on `onex.evt.omniintelligence.policy-state-updated.v1`

Closes gap-analysis fingerprint `18306ed9` (CONTRACT_DRIFT — orphan omnimemory-namespace topic constant).

Part of OMN-2933 epic (Objective Functions and Reward Architecture gap cleanup).

## Changes

- `src/omnibase_infra/event_bus/topic_constants.py`: removed `TOPIC_POLICY_STATE_UPDATED` constant and `__all__` entry (9 lines deleted)

## Note on OMN-2928

OMN-2928 (PR #470) is still open and modifies `handler_reward_binder.py` — it touches the private `_TOPIC_POLICY_STATE_UPDATED` local variable in the handler, which is separate from the public constant removed here. No conflict between these two PRs.

## Test plan

- [x] All pre-commit hooks pass
- [x] 18 reward binder unit tests pass
- [x] 1213 topic-related unit tests pass
- [x] mypy strict passes on push hook
- [x] No importers of `TOPIC_POLICY_STATE_UPDATED` from `topic_constants` exist (verified via grep)

Epic: OMN-2933
Ticket: OMN-2931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused event topic from the internal message infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->