### PR TITLE
fix(topics): correct TOPIC_SESSION_OUTCOME_CANONICAL producer segment to omniclaude [OMN-2946]

### DIFF
--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -505,13 +505,14 @@ Producer: omniclaude (SessionEnd hook)
 Consumer: omniintelligence/node_pattern_feedback_effect
 """
 
-TOPIC_SESSION_OUTCOME_CANONICAL: Final[str] = (
-    "onex.evt.omniintelligence.session-outcome.v1"
-)
+TOPIC_SESSION_OUTCOME_CANONICAL: Final[str] = "onex.evt.omniclaude.session-outcome.v1"
 """Session-outcome event topic for observability.
 
 The evt counterpart of the dual-publish pair. Observability consumers
 (dashboards, metrics) subscribe to this topic for session outcome facts.
+
+Producer: omniclaude (SessionEnd hook)
+See: OMN-2946 - Corrected producer segment from omniintelligence to omniclaude.
 """
 
 # Injection effectiveness topics (already correctly named with 'evt')

--- a/tests/unit/cli/test_service_demo_reset.py
+++ b/tests/unit/cli/test_service_demo_reset.py
@@ -140,7 +140,7 @@ class TestDemoTopicPrefixes:
         [
             "onex.evt.platform.node-registration.v1",
             "onex.cmd.platform.node-introspection.v1",
-            "onex.evt.omniintelligence.session-outcome.v1",
+            "onex.evt.omniclaude.session-outcome.v1",
             "onex.cmd.omniintelligence.pattern-lifecycle.v1",
             "onex.evt.omniclaude.phase-metrics.v1",
             "onex.evt.omniclaude.agent-status.v1",

--- a/tests/unit/validation/test_demo_loop_gate.py
+++ b/tests/unit/validation/test_demo_loop_gate.py
@@ -152,7 +152,7 @@ class TestCanonicalPipelineExclusivity:
         )
 
         legacy_topic = "onex.cmd.omniintelligence.session-outcome.v1"
-        canonical_topic = "onex.evt.omniintelligence.session-outcome.v1"
+        canonical_topic = "onex.evt.omniclaude.session-outcome.v1"
 
         fake_registrations = (
             ModelEventRegistration(
@@ -496,7 +496,7 @@ class TestNoDuplicateEvents:
         )
 
         legacy_topic = "onex.cmd.omniintelligence.session-outcome.v1"
-        canonical_topic = "onex.evt.omniintelligence.session-outcome.v1"
+        canonical_topic = "onex.evt.omniclaude.session-outcome.v1"
 
         fake_registrations = (
             ModelEventRegistration(


### PR DESCRIPTION
## Summary

- Fixes `TOPIC_SESSION_OUTCOME_CANONICAL` in `topic_constants.py`: changed `onex.evt.omniintelligence.session-outcome.v1` → `onex.evt.omniclaude.session-outcome.v1` to match the actual producer (omniclaude's SessionEnd hook)
- Updates hardcoded topic strings in `test_service_demo_reset.py` and `test_demo_loop_gate.py` to match the corrected canonical topic
- CMD side (`TOPIC_SESSION_OUTCOME_CURRENT`) was already correct and is unchanged

## Root Cause

The EVT-side constant used the `omniintelligence` producer segment but omniclaude is the actual producer of this topic. The wiring health monitor's observability consumers were subscribing to a topic that omniclaude never emitted.

## Test Plan

- [x] `tests/unit/cli/test_service_demo_reset.py` — 137 tests pass
- [x] `tests/unit/validation/test_demo_loop_gate.py` — all tests pass
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run mypy src/omnibase_infra/event_bus/topic_constants.py` — clean

Closes OMN-2946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event topic naming for session outcome events to reflect the accurate producer service.

* **Documentation**
  * Updated event topic documentation with producer information and associated tracking references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->