### PR TITLE
fix(provisioning): add agent-actions DLQ topic to provisioning registry [OMN-2945]

### DIFF
--- a/src/omnibase_infra/topics/__init__.py
+++ b/src/omnibase_infra/topics/__init__.py
@@ -20,6 +20,7 @@ from omnibase_infra.topics.model_bus_descriptor import ModelBusDescriptor
 from omnibase_infra.topics.model_topic_spec import ModelTopicSpec
 from omnibase_infra.topics.platform_topic_suffixes import (
     ALL_INTELLIGENCE_TOPIC_SPECS,
+    ALL_OMNIBASE_INFRA_TOPIC_SPECS,
     ALL_OMNICLAUDE_TOPIC_SPECS,
     ALL_OMNIMEMORY_TOPIC_SPECS,
     ALL_PLATFORM_SUFFIXES,
@@ -29,6 +30,7 @@ from omnibase_infra.topics.platform_topic_suffixes import (
     SUFFIX_CONTRACT_DEREGISTERED,
     SUFFIX_CONTRACT_REGISTERED,
     SUFFIX_FSM_STATE_TRANSITIONS,
+    SUFFIX_GMAIL_ARCHIVE_PURGED,
     SUFFIX_INTELLIGENCE_CLAUDE_HOOK_EVENT,
     SUFFIX_INTELLIGENCE_INTENT_CLASSIFIED,
     SUFFIX_INTELLIGENCE_LLM_CALL_COMPLETED,
@@ -43,6 +45,7 @@ from omnibase_infra.topics.platform_topic_suffixes import (
     SUFFIX_NODE_INTROSPECTION,
     SUFFIX_NODE_REGISTRATION,
     SUFFIX_NODE_REGISTRATION_ACKED,
+    SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ,
     SUFFIX_OMNIMEMORY_CRAWL_REQUESTED,
     SUFFIX_OMNIMEMORY_CRAWL_TICK,
     SUFFIX_OMNIMEMORY_DOCUMENT_CHANGED,
@@ -101,12 +104,17 @@ __all__: list[str] = [
     "SUFFIX_OMNIMEMORY_DOCUMENT_INDEXED",
     "SUFFIX_OMNIMEMORY_CRAWL_TICK",
     "SUFFIX_OMNIMEMORY_CRAWL_REQUESTED",
+    # Omnibase_infra domain suffix constants
+    "SUFFIX_GMAIL_ARCHIVE_PURGED",
+    # OmniClaude observability DLQ suffix constants (OMN-2945)
+    "SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ",
     # Aggregate collections
     "ALL_PLATFORM_SUFFIXES",
     "ALL_PLATFORM_TOPIC_SPECS",
     "ALL_INTELLIGENCE_TOPIC_SPECS",
     "ALL_OMNICLAUDE_TOPIC_SPECS",
     "ALL_OMNIMEMORY_TOPIC_SPECS",
+    "ALL_OMNIBASE_INFRA_TOPIC_SPECS",
     "ALL_PROVISIONED_SUFFIXES",
     "ALL_PROVISIONED_TOPIC_SPECS",
     # Topic spec model

--- a/tests/unit/topics/test_platform_topic_suffixes.py
+++ b/tests/unit/topics/test_platform_topic_suffixes.py
@@ -343,13 +343,17 @@ class TestProvisionedTopicSpecs:
             )
 
     def test_provisioned_count(self) -> None:
-        """Combined provisioned specs should equal platform + intelligence + omnimemory + omniclaude."""
-        from omnibase_infra.topics import ALL_PLATFORM_TOPIC_SPECS
+        """Combined provisioned specs should equal platform + intelligence + omnimemory + omnibase_infra + omniclaude."""
+        from omnibase_infra.topics import (
+            ALL_OMNIBASE_INFRA_TOPIC_SPECS,
+            ALL_PLATFORM_TOPIC_SPECS,
+        )
 
         expected = (
             len(ALL_PLATFORM_TOPIC_SPECS)
             + len(ALL_INTELLIGENCE_TOPIC_SPECS)
             + len(ALL_OMNIMEMORY_TOPIC_SPECS)
+            + len(ALL_OMNIBASE_INFRA_TOPIC_SPECS)
             + len(ALL_OMNICLAUDE_TOPIC_SPECS)
         )
         assert len(ALL_PROVISIONED_TOPIC_SPECS) == expected
@@ -399,15 +403,23 @@ class TestOmniClaudeTopicSuffixes:
             )
 
     def test_omniclaude_topic_count(self) -> None:
-        """OmniClaude spec registry should have 204 topics (68 skills x 3 each)."""
-        assert len(ALL_OMNICLAUDE_TOPIC_SPECS) == 204
+        """OmniClaude spec registry should have 205 topics (68 skills x 3 each + 1 DLQ)."""
+        assert len(ALL_OMNICLAUDE_TOPIC_SPECS) == 205
 
-    def test_omniclaude_topics_use_1_partition(self) -> None:
-        """All OmniClaude topics should use 1 partition (low-throughput skill dispatch)."""
+    def test_omniclaude_skill_topics_use_1_partition(self) -> None:
+        """Skill dispatch topics should use 1 partition; DLQ topics use 3 partitions."""
+        from omnibase_infra.topics import SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ
+
+        dlq_suffixes = {SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ}
         for spec in ALL_OMNICLAUDE_TOPIC_SPECS:
-            assert spec.partitions == 1, (
-                f"Expected 1 partition for {spec.suffix}, got {spec.partitions}"
-            )
+            if spec.suffix in dlq_suffixes:
+                assert spec.partitions == 3, (
+                    f"Expected 3 partitions for DLQ topic {spec.suffix}, got {spec.partitions}"
+                )
+            else:
+                assert spec.partitions == 1, (
+                    f"Expected 1 partition for skill topic {spec.suffix}, got {spec.partitions}"
+                )
 
     def test_no_duplicate_omniclaude_suffixes(self) -> None:
         """OmniClaude topic specs should not contain duplicates."""
@@ -420,9 +432,10 @@ class TestOmniClaudeTopicSuffixes:
         evt_topics = [s for s in ALL_OMNICLAUDE_TOPIC_SPECS if ".evt." in s.suffix]
         assert len(cmd_topics) > 0, "Expected cmd topics in OmniClaude registry"
         assert len(evt_topics) > 0, "Expected evt topics in OmniClaude registry"
-        # 68 cmd topics + 136 evt topics (68 completed + 68 failed) = 204
+        # 68 cmd topics + 136 evt skill topics (68 completed + 68 failed)
+        # + 1 evt DLQ topic (agent-actions-dlq) = 205 total
         assert len(cmd_topics) == 68
-        assert len(evt_topics) == 136
+        assert len(evt_topics) == 137  # 136 skill completion + 1 DLQ (OMN-2945)
 
     def test_epic_team_topic_in_registry(self) -> None:
         """Spot check: epic-team skill topics should be in the registry."""


### PR DESCRIPTION
## Summary

Closes [OMN-2945](https://linear.app/omninode/issue/OMN-2945).

The agent-actions consumer hardcodes `onex.evt.omniclaude.agent-actions-dlq.v1` as its DLQ destination but this topic was absent from all provisioning specs in `platform_topic_suffixes.py`. When broker auto-creation is disabled, DLQ writes would fail silently.

## Changes

**`platform_topic_suffixes.py`**
- Added `SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ = "onex.evt.omniclaude.agent-actions-dlq.v1"` named constant
- Added `_OMNICLAUDE_OBSERVABILITY_DLQ_TOPIC_SUFFIXES` tuple in a new dedicated observability DLQ section (separate from skill topics)
- Included DLQ topics in `ALL_OMNICLAUDE_TOPIC_SPECS` with 3 partitions (matches agent-actions consumer throughput; skill topics use 1 partition)

**`topics/__init__.py`**
- Exported `SUFFIX_OMNICLAUDE_AGENT_ACTIONS_DLQ` (new)
- Exported pre-existing missing constants: `SUFFIX_GMAIL_ARCHIVE_PURGED`, `ALL_OMNIBASE_INFRA_TOPIC_SPECS`

**`tests/unit/topics/test_platform_topic_suffixes.py`**
- Updated `test_provisioned_count` to include `ALL_OMNIBASE_INFRA_TOPIC_SPECS` in expected sum (pre-existing test gap)
- Updated `test_omniclaude_topic_count`: 205 topics (204 skill + 1 DLQ)
- Updated `test_omniclaude_has_cmd_and_evt_topics`: 137 evt topics (136 skill + 1 DLQ)
- Updated `test_omniclaude_topics_use_1_partition` → `test_omniclaude_skill_topics_use_1_partition`: DLQ uses 3 partitions, skill topics use 1

## Verification

- Import-time validation passes (`_validate_all_suffixes()`)
- `ALL_PROVISIONED_TOPIC_SPECS` now contains 237 topics (was 236)
- All 123 topic unit tests pass
- All 30 hardening tests pass
- All pre-commit hooks pass

## Gap Analysis

This resolves fingerprint `068d3213` from the gap analysis report:
- `CONTRACT_DRIFT: agent-actions-dlq-not-provisioned`
- Evidence: AST parse of `config.py:131` vs `platform_topic_suffixes.py`
- Confidence: DETERMINISTIC