### PR TITLE
fix(slack): show full correlation UUID in block-kit context footer

### DIFF
--- a/src/omnibase_infra/handlers/handler_slack_webhook.py
+++ b/src/omnibase_infra/handlers/handler_slack_webhook.py
@@ -908,7 +908,7 @@ class HandlerSlackWebhook:
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": f"Correlation: `{str(alert.correlation_id)[:16]}...`",
+                        "text": f"Correlation: `{alert.correlation_id}`",
                     }
                 ],
             }


### PR DESCRIPTION
## Summary

- Remove hardcoded `[:16]` truncation from the correlation ID in the Slack Block Kit context block — full UUIDs (36 chars) display fine without truncation

## Root cause

`handler_slack_webhook.py` was truncating `alert.correlation_id` to 16 characters and appending `...`, making the correlation ID unreadable (e.g. `0aa6c3fb-39f7-47...` instead of the full UUID).

## Test plan

- [ ] Trigger a Slack alert and verify the context block footer shows the full UUID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Slack webhook alert messages now display the complete correlation ID in alert context information instead of a truncated version, improving tracking and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->