### PR TITLE
feat(hooks): add pre-commit and pre-push topic enum validation hooks [OMN-2967]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,22 @@ repos:
         files: '\.yaml$'
         pass_filenames: false
         stages: [pre-commit]
+      # Topic enum sync validation (pre-commit) — selective trigger [OMN-2967]
+      - id: onex-validate-topic-enums
+        name: Validate generated topic enums (in sync with contracts)
+        language: system
+        entry: uv run python scripts/generate_topic_enums.py --check
+        pass_filenames: false
+        files: '(contract\.yaml|scripts/generate_topic_enums\.py|src/omnibase_infra/tools/.*\.py|src/omnibase_infra/enums/generated/.*\.py)$'
+        stages: [pre-commit]
+      # Topic enum sync validation (pre-push) — always runs [OMN-2967]
+      - id: onex-validate-topic-enums-push
+        name: Validate generated topic enums (pre-push always)
+        language: system
+        entry: uv run python scripts/generate_topic_enums.py --check
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
       # Pattern validation - naming conventions
       - id: onex-validate-patterns
         name: ONEX Pattern Validation

--- a/src/omnibase_infra/tools/topic_enum_generator.py
+++ b/src/omnibase_infra/tools/topic_enum_generator.py
@@ -106,7 +106,7 @@ class {class_name}(str, Enum):
     \"\"\"
 """
 
-_MEMBER_TEMPLATE = "    {key} = {value!r}  # {topic}"
+_MEMBER_TEMPLATE = '    {key} = "{value}"  # {topic}'
 
 _INIT_HEADER = """\
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Summary

Adds two pre-commit hooks for contract-driven topic enum validation (OMN-2967, T5).

### New Hooks in `.pre-commit-config.yaml`

**`onex-validate-topic-enums`** (pre-commit, selective):
- Triggers on changes to `contract.yaml`, `generate_topic_enums.py`, tool files, or generated enum files
- Runs `generate_topic_enums.py --check` — exits 1 on drift, missing file, or stale enum

**`onex-validate-topic-enums-push`** (pre-push, always_run):
- Always runs unconditionally on push
- Same `--check` invocation — ensures no drift reaches the remote regardless of what was staged

### Generator Improvements (Required for Hook Stability)

The hooks exposed a formatting stability problem: the generator's raw output differed from ruff-formatted output, causing `--check` to always report drift after a `--generate`. Fixed in this PR:

- **`TopicEnumGenerator._MEMBER_TEMPLATE`**: Changed from `{value!r}` (single-quotes) to `"{value}"` (double-quotes, ruff-compatible)
- **`generate_topic_enums.py --generate`**: Now runs `ruff format` on the output directory after writing, ensuring generated files are ruff-stable before committing
- **`generate_topic_enums.py --check`**: Now formats in-memory content in a temp dir before comparing to disk, so check and generate are fully consistent

### Verification

```bash
pre-commit run onex-validate-topic-enums --all-files    # exits 0 on clean state
pre-commit run onex-validate-topic-enums-push --all-files  # exits 0 on clean state
```

## Related

- Parent epic: OMN-917
- OMN-2966 (Generator script — PR #490, base of this branch)
- Next: OMN-2968 (End-to-end integration verification)