### PR TITLE
chore: rename PYPI_PRIVATE_* secrets to PYPI_* (public PyPI)

### DIFF
--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -12,8 +12,6 @@ on:
         type: boolean
         default: true
     secrets:
-      PYPI_UPLOAD_URL:
-        required: false
       PYPI_TOKEN:
         required: false
 
@@ -74,16 +72,12 @@ jobs:
       - name: Publish to PyPI
         if: inputs.publish
         run: |
-          if [ -z "$UV_PUBLISH_URL" ] || [ -z "$UV_PUBLISH_TOKEN" ]; then
-            echo "ERROR: PYPI_UPLOAD_URL and PYPI_TOKEN secrets are required when publish is true"
+          if [ -z "$UV_PUBLISH_TOKEN" ]; then
+            echo "ERROR: PYPI_TOKEN secret is required when publish is true"
             exit 1
           fi
-          uv publish \
-            --publish-url "$UV_PUBLISH_URL" \
-            --token "$UV_PUBLISH_TOKEN" \
-            dist/*.whl dist/*.tar.gz
+          uv publish --token "$UV_PUBLISH_TOKEN" dist/*.whl dist/*.tar.gz
         env:
-          UV_PUBLISH_URL: ${{ secrets.PYPI_UPLOAD_URL }}
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Generate checksums


### PR DESCRIPTION
PyPI packages are published publicly to https://upload.pypi.org/legacy/, not a private index.

## Changes

- Renamed secret input `PYPI_PRIVATE_UPLOAD_URL` → `PYPI_UPLOAD_URL`
- Renamed secret input `PYPI_PRIVATE_TOKEN` → `PYPI_TOKEN`
- Updated step name "Publish to private PyPI" → "Publish to PyPI"
- Updated error message to reference the renamed secrets

**File changed**: `.github/workflows/release-python-reusable.yml`

No other files in the repo referenced `PYPI_PRIVATE_*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated publishing credentials into a single token and simplified environment mappings.
  * Simplified publish step name to "Publish to PyPI".
  * Streamlined validation to require only the publish token and updated related error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->