### PR TITLE
fix(tui): push ScreenStatus via push_screen() instead of compose()

### DIFF
--- a/src/omnibase_infra/tui/app.py
+++ b/src/omnibase_infra/tui/app.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from textual.app import App, ComposeResult
+from textual.app import App
 from textual.binding import Binding
 
 from omnibase_infra.tui.consumers.consumer_status import (
@@ -56,11 +56,9 @@ class StatusApp(App[None]):
         Binding("o", "open_pr", "Open PR"),
     ]
 
-    def compose(self) -> ComposeResult:
-        yield ScreenStatus()
-
     async def on_mount(self) -> None:
         """Push the status screen and start the Kafka consumer task."""
+        await self.push_screen(ScreenStatus())
         self._consumer_task: asyncio.Task[None] = asyncio.create_task(
             consume_all(self),
             name="onex-tui-kafka-consumer",


### PR DESCRIPTION
## Summary

- `App.compose()` was yielding `ScreenStatus()` — a `Screen` subclass. In Textual, `Screen.compose()` is only invoked when the screen is pushed onto the screen stack; yielding it as a widget from `App.compose()` adds it to the DOM as a plain (empty) widget, causing the blank black terminal on launch.
- Fix: remove `compose()` from `StatusApp` and call `await self.push_screen(ScreenStatus())` at the start of `on_mount()`.
- Also removes the now-unused `ComposeResult` import.

## Test plan

- [ ] `uv run pytest tests/unit/tui/` — 33 tests pass
- [ ] `uv run onex-status` — three-panel layout renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal screen initialization in the terminal user interface application.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->