### PR TITLE
feat(scripts): add sync-omnibase-env.py with 5-guard TDD implementation (OMN-3243)

### DIFF
--- a/scripts/sync-omnibase-env.py
+++ b/scripts/sync-omnibase-env.py
@@ -45,12 +45,14 @@ Usage (normally invoked automatically from a shell hook or post-save script)::
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -232,8 +234,6 @@ def acquire_flock(lock_file: Path) -> object | None:
         return fd
     except OSError as exc:
         fd.close()
-        import errno
-
         if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
             # Lock is held by another process — expected during concurrent runs.
             logger.info("Another sync is already running — skipping (flock busy)")
@@ -315,7 +315,6 @@ def _run_seed_infisical(
     # Pass the filtered vars as KEY=VALUE environment so seed-infisical can
     # pick them up via --import-env-from-environ (if supported) or via env.
     # Simpler: write to a temp file and pass --import-env.
-    import tempfile
 
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".env", delete=False, prefix="sync-omnibase-env-"

--- a/tests/unit/scripts/test_sync_omnibase_env.py
+++ b/tests/unit/scripts/test_sync_omnibase_env.py
@@ -169,6 +169,21 @@ class TestThrottleGuard:
         result = mod.check_throttle(last_sync_file)  # type: ignore[attr-defined]
         assert result is True, "Should return True (allow sync) when file is corrupt"
 
+    def test_passes_when_timestamp_is_in_future(self, tmp_path: Path) -> None:
+        """Should return True (allow sync) when last sync timestamp is in the future.
+
+        Clock skew can produce a future timestamp. Treating it as "no prior sync"
+        prevents the negative elapsed value from bypassing the throttle window.
+        """
+        mod = _import_script()
+        last_sync_file = tmp_path / "sync-omnibase-env.last"
+        # Write a timestamp 60 seconds in the future (simulates clock skew)
+        last_sync_file.write_text(str(time.time() + 60))
+        result = mod.check_throttle(last_sync_file)  # type: ignore[attr-defined]
+        assert result is True, (
+            "Should return True (allow sync) when timestamp is future"
+        )
+
     def test_throttle_window_is_5_minutes(self, tmp_path: Path) -> None:
         """Should use exactly 5-minute (300s) throttle window."""
         mod = _import_script()


### PR DESCRIPTION
## Summary

- Implements `scripts/sync-omnibase-env.py` — a safe env→Infisical sync script using TDD (24 tests: RED→GREEN)
- All 5 guards implemented and tested: INFISICAL_ADDR, env file, uv availability, throttle (5 min), flock (concurrent run prevention)
- Bootstrap keys (`POSTGRES_PASSWORD`, `INFISICAL_ENCRYPTION_KEY`, `INFISICAL_AUTH_SECRET`, `INFISICAL_ADDR`, `INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_PROJECT_ID`) are excluded from sync at this layer
- Delegates to `seed-infisical.py --execute` for actual Infisical writes; writes timestamp to `~/.cache/omnibase/sync-omnibase-env.last` on success

## Test plan

- [x] 24 unit tests written before implementation (RED confirmed)
- [x] 24 unit tests pass after implementation (GREEN confirmed)
- [x] All 5 guards tested independently
- [x] Bootstrap key exclusion tested with edge cases (empty dict, all-bootstrap dict)
- [x] Throttle guard tested for boundary conditions and corrupt timestamp file
- [x] flock guard tested for lock acquisition, lock file creation, and concurrent-lock rejection
- [x] `pre-commit run --all-files` clean (all 24 hooks pass)
- [ ] End-to-end test with real Infisical (requires `INFISICAL_ADDR` set — covered by OMN-3244 integration)

Closes OMN-3243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a synchronization utility to push local environment keys to remote with safety guards (connection check, env-file check, runtime availability, 5-minute throttle, and non-blocking lock)
  * Supports dry-run mode and CLI options for custom paths and verbose output

* **Tests**
  * Comprehensive unit tests covering guard behaviors, bootstrap-key exclusion, locking, throttling, and main CLI flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->