### PR TITLE
docs(install-model): clarify repo clone vs pip-installable package [OMN-3261]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,79 @@ We explicitly do **NOT** optimize for:
 
 ---
 
+## Install Model
+
+`omnibase_infra` ships as both a **pip-installable package** and a **cloneable repository**.
+The two serve different purposes.
+
+### Pip Package (library + runtime CLIs)
+
+Install via pip for:
+- Using `omnibase_infra` as a library dependency in other ONEX services
+- Running the bundled runtime CLIs
+
+```bash
+pip install omnibase-infra
+# or
+uv add omnibase-infra
+```
+
+**Bundled CLI entry points** (available after `pip install omnibase-infra`):
+
+| Command | Entry Point | Purpose |
+|---------|-------------|---------|
+| `omni-infra` | `omnibase_infra.cli.commands:cli` | General CLI |
+| `onex-runtime` | `omnibase_infra.runtime.kernel:main` | Start ONEX runtime |
+| `onex-infra-test` | `omnibase_infra.cli.infra_test.cli:cli` | Infra test runner |
+| `onex-git-hook-relay` | `omnibase_infra.cli.git_hook_relay:main` | Git hook relay |
+| `onex-linear-relay` | `omnibase_infra.cli.linear_relay:main` | Linear relay |
+| `onex-status` | `omnibase_infra.tui.__main__:run_status_tui` | Status TUI |
+
+### Local Clone (operational scripts)
+
+A **local clone is required** to run the operational scripts in `scripts/`. These scripts
+are **not bundled** in the pip package — they live only in the repository source tree.
+
+```bash
+git clone https://github.com/OmniNode-ai/omnibase_infra.git
+cd omnibase_infra
+uv sync
+```
+
+**Scripts that require a local clone:**
+
+| Script | Purpose | Requires Clone |
+|--------|---------|---------------|
+| `scripts/seed-infisical.py` | Populate Infisical from contract YAMLs | Yes |
+| `scripts/bootstrap-infisical.sh` | Full first-time bootstrap sequence | Yes |
+| `scripts/provision-infisical.py` | Create machine identities, write credentials back to `~/.omnibase/.env` | Yes |
+| `scripts/setup-infisical-identity.sh` | Create runtime/admin machine identities | Yes |
+| `scripts/create_kafka_topics.py` | Create Kafka/Redpanda topics | Yes |
+| `scripts/validate.py` | Run ONEX validators | Yes |
+| All other `scripts/*.py` | Operational, CI, or dev tooling | Yes |
+
+**Why scripts require a clone:** These scripts scan the repository source tree directly
+(e.g., `seed-infisical.py` iterates over `src/omnibase_infra/nodes/*/contract.yaml`),
+write back to `~/.omnibase/.env`, or depend on shell tooling co-located with the repo.
+
+### Decision Summary
+
+| Use Case | Install Method |
+|----------|---------------|
+| Add `omnibase_infra` as a library dependency | `pip install omnibase-infra` |
+| Run ONEX runtime services | `pip install omnibase-infra` → `onex-runtime` |
+| Bootstrap Infisical (first-time setup) | Clone + `scripts/bootstrap-infisical.sh` |
+| Seed Infisical from contracts | Clone + `uv run python scripts/seed-infisical.py` |
+| Provision machine identities | Clone + `uv run python scripts/provision-infisical.py` |
+| Run CI validators | Clone + `uv run python scripts/validate.py` |
+| Develop nodes and handlers | Clone (full dev environment) |
+
+> **Note on `sync-omnibase-env.py`**: This script is **not** part of `omnibase_infra`.
+> It is provided by the `omniclaude` plugin and installed separately. See the
+> [omniclaude README](https://github.com/OmniNode-ai/omniclaude) for details.
+
+---
+
 ## Quick Reference
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ This repository provides the **infrastructure layer** for ONEX-based systems. Wh
 
 Built on `omnibase-core` ^0.8.0 and `omnibase-spi` ^0.5.0.
 
+## Install Model
+
+`omnibase_infra` serves two distinct purposes depending on how you use it:
+
+### As a library / runtime (pip install)
+
+```bash
+pip install omnibase-infra
+# or
+uv add omnibase-infra
+```
+
+This gives you the Python library and bundled runtime CLIs (`onex-runtime`, `omni-infra`,
+`onex-status`, etc.). No clone required for library use or running the runtime.
+
+### For operational bootstrapping (clone required)
+
+The **operational scripts** in `scripts/` are not bundled in the pip package. A local
+clone is required to run them:
+
+```bash
+git clone https://github.com/OmniNode-ai/omnibase_infra.git
+cd omnibase_infra
+uv sync
+```
+
+**Scripts that require a clone:**
+- `scripts/seed-infisical.py` — Populate Infisical from contract YAMLs
+- `scripts/bootstrap-infisical.sh` — Full first-time Infisical bootstrap
+- `scripts/provision-infisical.py` — Create machine identities
+
+See [CLAUDE.md — Install Model](CLAUDE.md#install-model) for the full decision matrix.
+
 ## Quick Start
 
 ```bash

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -93,11 +93,44 @@ uv run python -c "from omnibase_infra.nodes.node_hello_effect.node import NodeHe
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - Docker (optional, for infrastructure services)
 
+## Install Model
+
+`omnibase_infra` supports two installation modes depending on your use case.
+
+**Pip install** (library use and runtime CLIs — no clone needed):
+
+```bash
+pip install omnibase-infra
+# or
+uv add omnibase-infra
+```
+
+Use this when you want to:
+- Import `omnibase_infra` as a library dependency in another ONEX service
+- Run the bundled runtime via `onex-runtime`
+- Use `omni-infra`, `onex-status`, or other bundled CLIs
+
+**Clone** (operational bootstrapping and active development — clone required):
+
+```bash
+git clone https://github.com/OmniNode-ai/omnibase_infra.git
+cd omnibase_infra
+uv sync
+```
+
+Use this when you want to:
+- Run `scripts/seed-infisical.py`, `scripts/bootstrap-infisical.sh`, or `scripts/provision-infisical.py`
+- Develop or modify nodes and handlers in this repo
+- Run CI validators (`scripts/validate.py`) locally
+
+> The `scripts/` directory is **not bundled** in the pip package. Any workflow that references
+> `uv run python scripts/seed-infisical.py` requires a local clone.
+
 ## Installation
 
 ```bash
-# Clone and install
-git clone <repo-url> omnibase_infra
+# Clone and install (for development or operational scripting)
+git clone https://github.com/OmniNode-ai/omnibase_infra.git
 cd omnibase_infra
 uv sync
 


### PR DESCRIPTION
## Summary

- Documents the canonical install model for `omnibase_infra`: **pip** for library/runtime use, **local clone** for operational scripts
- Adds an `Install Model` section to `CLAUDE.md` with a per-script matrix and decision table
- Updates `README.md` with a prominent `Install Model` section before Quick Start
- Updates `docs/getting-started/quickstart.md` with explicit pip vs. clone guidance and a note that `scripts/` is not bundled in the pip package
- Clarifies that `sync-omnibase-env.py` is **not** part of this repo (it belongs to `omniclaude`)

Closes OMN-3261

## Decision

**Option B (Library/Runtime via pip; Operational Scripts require clone)**

The pip package (`omnibase-infra`) provides:
- Python library for import as a dependency
- Bundled CLIs: `onex-runtime`, `omni-infra`, `onex-status`, `onex-infra-test`, `onex-git-hook-relay`, `onex-linear-relay`

A local clone is required for:
- `scripts/seed-infisical.py` — scans contract YAML files from the repo source tree
- `scripts/bootstrap-infisical.sh` — shell-based orchestration script
- `scripts/provision-infisical.py` — writes credentials back to `~/.omnibase/.env`
- All other `scripts/*.py` operational/CI tooling

## Test plan

- [ ] Pre-commit hooks pass (verified: all 24 hooks pass)
- [ ] Documentation links are consistent (CLAUDE.md → README.md → quickstart.md reference each other correctly)
- [ ] No ticket workflow references an undocumented local path assumption
- [ ] Verify `sync-omnibase-env.py` note correctly points to `omniclaude` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation model guidance detailing two deployment approaches: pip package for library/runtime use and local clone for operational bootstrapping.
  * Included workflow instructions, use case mapping, and verification steps for both installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->