### PR TITLE
infra(ci): add GitHub Actions runner Dockerfile + entrypoint.sh [OMN-3275]

### DIFF
--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -1,0 +1,114 @@
+# GitHub Actions self-hosted runner image for OmniNode CI
+# Ticket: OMN-3275 / Epic: OMN-3273
+#
+# NOT pre-baked: ruff, mypy — repos pin via pyproject.toml; workflows call `uv run ruff`.
+# Pre-baking causes tool drift. Install at workflow time via `uv run`.
+
+ARG RUNNER_VERSION=2.323.0
+ARG GH_VERSION=2.67.0
+ARG KUBECTL_VERSION=1.32.1
+ARG UV_VERSION=0.6.2
+
+# Pinned digest for reproducible builds — update via: docker pull ubuntu:22.04
+FROM ubuntu:22.04@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751
+
+ARG RUNNER_VERSION
+ARG GH_VERSION
+ARG KUBECTL_VERSION
+ARG UV_VERSION
+
+# Version labels — read by runner-status skill
+LABEL org.omninode.runner.version="${RUNNER_VERSION}"
+LABEL org.omninode.gh.version="${GH_VERSION}"
+LABEL org.omninode.kubectl.version="${KUBECTL_VERSION}"
+LABEL org.omninode.uv.version="${UV_VERSION}"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUNNER_HOME=/home/runner/actions-runner
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    tar \
+    unzip \
+    libicu-dev \
+    libkrb5-3 \
+    zlib1g \
+    libssl3 \
+    lsb-release \
+    gnupg \
+    apt-transport-https \
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python 3.12 via deadsnakes PPA
+RUN add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.12 \
+        python3.12-venv \
+        python3.12-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
+
+# Install uv
+RUN curl -LsSf "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=1 uv-x86_64-unknown-linux-gnu/uv \
+    && chmod +x /usr/local/bin/uv
+
+# Install Docker CLI (no daemon — socket mounted at runtime)
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gh CLI
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh" \
+    && chmod +x /usr/local/bin/gh
+
+# Install kubectl
+RUN curl -fsSLo /usr/local/bin/kubectl \
+    "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl
+
+# Create non-root runner user and add to docker group for socket access
+RUN groupadd --gid 1001 runner \
+    && useradd --uid 1001 --gid runner --shell /bin/bash --create-home runner \
+    && groupadd --force docker \
+    && usermod -aG docker runner
+
+# Download and SHA256-verify GitHub Actions runner binary
+# SHA256 for actions-runner-linux-x64-2.323.0.tar.gz
+ENV RUNNER_SHA256=0dbc9bf5a58620fc52cb6cc0448abcca964a8d74b5f39773b7afcad9ab691e19
+
+RUN mkdir -p "${RUNNER_HOME}" \
+    && cd "${RUNNER_HOME}" \
+    && curl -fsSLo runner.tar.gz \
+        "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && echo "${RUNNER_SHA256}  runner.tar.gz" | sha256sum --check --strict \
+    && tar xzf runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    && chown -R runner:runner "${RUNNER_HOME}"
+
+# Credential cache directory (for entrypoint.sh re-registration cache)
+RUN mkdir -p /home/runner/.runner-creds && chown runner:runner /home/runner/.runner-creds
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER runner
+WORKDIR ${RUNNER_HOME}
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/runners/entrypoint.sh
+++ b/docker/runners/entrypoint.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# GitHub Actions runner entrypoint with bounded re-registration
+# Ticket: OMN-3275 / Epic: OMN-3273
+#
+# Re-registration policy:
+#   - Max 3 retries with exponential backoff: 20s / 40s / 80s
+#   - Only re-register on known "not registered" error strings
+#   - Unknown errors exit immediately (do not retry; surface the real error)
+#   - After max retries: sleep 5m then exit 1
+#     → compose restart: unless-stopped will recover automatically
+#
+# Credential cache:
+#   - Cache key = SHA256(RUNNER_LABELS + GITHUB_ORG_URL)
+#   - Avoids re-registration if version hash matches (token reuse across restarts)
+#   - Cache stored at /home/runner/.runner-creds/<cache-key>
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Required environment variables
+# ---------------------------------------------------------------------------
+: "${RUNNER_TOKEN:?RUNNER_TOKEN must be set}"
+: "${RUNNER_NAME:?RUNNER_NAME must be set}"
+: "${RUNNER_LABELS:?RUNNER_LABELS must be set}"
+: "${GITHUB_ORG_URL:?GITHUB_ORG_URL must be set}"
+
+RUNNER_GROUP="${RUNNER_GROUP:-omnibase-ci}"
+RUNNER_WORK_DIR="${RUNNER_WORK_DIR:-_work}"
+
+MAX_RETRIES=3
+BACKOFF_SECONDS=(20 40 80)
+CRED_CACHE_DIR="/home/runner/.runner-creds"
+LOG_FILE="/tmp/runner-listener.log"
+
+# ---------------------------------------------------------------------------
+# Credential cache helpers
+# ---------------------------------------------------------------------------
+
+_cache_key() {
+    echo -n "${RUNNER_LABELS}:${GITHUB_ORG_URL}" | sha256sum | awk '{print $1}'
+}
+
+_restore_cached_creds() {
+    local key
+    key=$(_cache_key)
+    local cache_file="${CRED_CACHE_DIR}/${key}"
+    if [[ -f "${cache_file}" ]]; then
+        echo "[entrypoint] Restoring cached runner credentials (key=${key:0:12}...)"
+        cp -r "${cache_file}/"* "${RUNNER_HOME}/" 2>/dev/null || true
+        return 0
+    fi
+    return 1
+}
+
+_save_creds() {
+    local key
+    key=$(_cache_key)
+    local cache_file="${CRED_CACHE_DIR}/${key}"
+    mkdir -p "${cache_file}"
+    # Store the registration credential files
+    for f in .runner .credentials .credentials_rsaparams; do
+        if [[ -f "${RUNNER_HOME}/${f}" ]]; then
+            cp "${RUNNER_HOME}/${f}" "${cache_file}/${f}"
+        fi
+    done
+    echo "[entrypoint] Runner credentials cached (key=${key:0:12}...)"
+}
+
+_clear_cached_creds() {
+    local key
+    key=$(_cache_key)
+    local cache_file="${CRED_CACHE_DIR}/${key}"
+    if [[ -d "${cache_file}" ]]; then
+        rm -rf "${cache_file}"
+        echo "[entrypoint] Cleared stale credential cache (key=${key:0:12}...)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Known registration error detection
+# These strings indicate the runner token is stale or the runner was removed
+# from the org — a re-registration is needed.
+# ---------------------------------------------------------------------------
+
+_is_registration_error() {
+    local log_content="${1}"
+    local known_patterns=(
+        "Runner.Listener"
+        "not registered"
+        "HTTP 401"
+        "Failed to get session"
+        "Unable to connect to server"
+        "unauthorized"
+        "invalid token"
+        "runner registration token"
+        "RegistrationError"
+    )
+    for pattern in "${known_patterns[@]}"; do
+        if echo "${log_content}" | grep -qi "${pattern}"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+_register() {
+    echo "[entrypoint] Registering runner: ${RUNNER_NAME} @ ${GITHUB_ORG_URL}"
+    echo "[entrypoint] Labels: ${RUNNER_LABELS} | Group: ${RUNNER_GROUP}"
+
+    "${RUNNER_HOME}/config.sh" \
+        --url "${GITHUB_ORG_URL}" \
+        --token "${RUNNER_TOKEN}" \
+        --name "${RUNNER_NAME}" \
+        --labels "${RUNNER_LABELS}" \
+        --runnergroup "${RUNNER_GROUP}" \
+        --work "${RUNNER_WORK_DIR}" \
+        --unattended \
+        --replace
+}
+
+_deregister() {
+    echo "[entrypoint] Attempting graceful de-registration..."
+    "${RUNNER_HOME}/config.sh" remove --token "${RUNNER_TOKEN}" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Main entrypoint loop
+# ---------------------------------------------------------------------------
+
+RUNNER_HOME="${RUNNER_HOME:-/home/runner/actions-runner}"
+cd "${RUNNER_HOME}"
+
+# Attempt to restore cached credentials to avoid re-registration on clean restart
+if _restore_cached_creds; then
+    echo "[entrypoint] Using cached credentials — skipping registration"
+else
+    echo "[entrypoint] No valid cached credentials found — registering..."
+    _register
+    _save_creds
+fi
+
+attempt=0
+while true; do
+    echo "[entrypoint] Starting runner (attempt $((attempt + 1)))"
+    set +e
+    "${RUNNER_HOME}/run.sh" 2>&1 | tee "${LOG_FILE}"
+    exit_code=${PIPESTATUS[0]}
+    set -e
+
+    log_content=$(cat "${LOG_FILE}" 2>/dev/null || echo "")
+
+    if [[ ${exit_code} -eq 0 ]]; then
+        echo "[entrypoint] Runner exited cleanly (exit 0). Exiting."
+        break
+    fi
+
+    echo "[entrypoint] Runner exited with code ${exit_code}"
+
+    if ! _is_registration_error "${log_content}"; then
+        echo "[entrypoint] Unknown error (not a registration error). Exiting immediately."
+        echo "[entrypoint] Last log output:"
+        tail -20 "${LOG_FILE}" 2>/dev/null || true
+        exit "${exit_code}"
+    fi
+
+    echo "[entrypoint] Registration error detected."
+    _clear_cached_creds
+
+    if [[ ${attempt} -ge ${MAX_RETRIES} ]]; then
+        echo "[entrypoint] Max retries (${MAX_RETRIES}) reached. Sleeping 5m before exit 1."
+        echo "[entrypoint] Compose restart: unless-stopped will recover."
+        sleep 300
+        exit 1
+    fi
+
+    backoff=${BACKOFF_SECONDS[${attempt}]}
+    echo "[entrypoint] Re-registering in ${backoff}s (retry $((attempt + 1))/${MAX_RETRIES})..."
+    sleep "${backoff}"
+
+    _deregister
+    _register
+    _save_creds
+
+    attempt=$((attempt + 1))
+done
+
+echo "[entrypoint] Exiting."


### PR DESCRIPTION
## Summary

Adds `docker/runners/` with the self-hosted runner image for OMN-3273 (Self-Hosted GitHub Actions Runners + Skill Integration).

## Changes

- `docker/runners/Dockerfile` — Ubuntu 22.04 runner image with pinned tool versions
- `docker/runners/entrypoint.sh` — Bounded re-registration with exponential backoff

## Dockerfile Highlights

| Tool | Version | Pinned |
|------|---------|--------|
| ubuntu | 22.04 | SHA256 digest |
| actions-runner | 2.323.0 | SHA256 verified |
| gh CLI | 2.67.0 | ARG |
| kubectl | 1.32.1 | ARG |
| uv | 0.6.2 | ARG |
| Python | 3.12 | deadsnakes PPA |
| Docker CLI | latest stable | apt |

Runner binary SHA256: `0dbc9bf5a58620fc52cb6cc0448abcca964a8d74b5f39773b7afcad9ab691e19`

NOT pre-baked: `ruff`, `mypy` — repos pin via `pyproject.toml`; pre-baking causes drift.

## entrypoint.sh Logic

- Credential cache keyed by `SHA256(RUNNER_LABELS + GITHUB_ORG_URL)` — skips re-registration on clean restarts
- Max 3 retries with exponential backoff: 20s / 40s / 80s
- Only re-registers on known registration error strings; unknown errors exit immediately
- After max retries: sleeps 5m then exits 1 — compose `restart: unless-stopped` recovers automatically

## Smoke Test

```bash
docker build -t omninode-runner-test docker/runners/
docker run --rm \
  -e RUNNER_TOKEN=bad \
  -e RUNNER_NAME=test \
  -e RUNNER_LABELS=self-hosted,omnibase-ci,linux,x64 \
  -e GITHUB_ORG_URL=https://github.com/OmniNode-ai \
  omninode-runner-test
# Expected: retry 3x with backoff, then sleep 5m, then exit 1
```

## Definition of Done

- [x] Dockerfile created with pinned SHA256 ubuntu base
- [x] All ARG versions pinned, runner binary SHA256-verified inline
- [x] Version labels present (org.omninode.runner.version etc.)
- [x] Non-root runner user + docker group
- [x] entrypoint.sh with bounded retry + credential cache
- [ ] Smoke test with bad token (to be done at deploy time with OMN-3276/3277)

## Linear

Ticket: [OMN-3275](https://linear.app/omninode/issue/OMN-3275)
Epic: OMN-3273 — Self-Hosted GitHub Actions Runners + Skill Integration

Depends on: OMN-3274 (runner group created)
Depended on by: OMN-3276 (docker-compose.runners.yml), OMN-3277 (deploy-runners.sh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions self-hosted runner Docker image based on Ubuntu 22.04, pre-configured with Python 3.12, Docker CLI, GitHub CLI, and kubectl.
  * Implemented automatic runner registration recovery with credential caching and exponential backoff retry logic to handle transient registration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->