### PR TITLE
fix(deploy): extend RUNTIME_SERVICES to all 7 services [OMN-3285]

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -47,6 +47,9 @@ readonly RUNTIME_SERVICES=(
     runtime-effects
     runtime-worker
     agent-actions-consumer
+    skill-lifecycle-consumer
+    intelligence-api
+    omninode-contract-resolver
 )
 
 # Minimum Docker Compose version (nested variable expansion support)


### PR DESCRIPTION
## Summary

Extends `RUNTIME_SERVICES` in `scripts/deploy-runtime.sh` from 4 to all 7 runtime services, so `deploy-runtime.sh` restarts the full set of runtime containers on deploy.

## Changes

- Add `skill-lifecycle-consumer`, `intelligence-api`, and `omninode-contract-resolver` to `RUNTIME_SERVICES`

## Pre-check

All 3 new services verified present in `docker/docker-compose.infra.yml`:
```
skill-lifecycle-consumer:
intelligence-api:
omninode-contract-resolver:
```

## Definition of Done

- [x] `RUNTIME_SERVICES` lists all 7 services
- [x] Verified all 7 service names exist in `docker-compose.infra.yml`
- [x] Pre-commit passes

Closes OMN-3285