### PR TITLE
ci: add conditional self-hosted runner routing to CI workflows [OMN-3278]

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -16,7 +16,16 @@ on:
 jobs:
   check-handshake:
     name: Check architecture handshake
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -52,7 +52,16 @@ permissions:
 jobs:
   compute-matrix:
     name: Compute Downstream Matrix
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     outputs:
       repos: ${{ steps.matrix.outputs.repos }}
     steps:
@@ -84,7 +93,16 @@ jobs:
   open-bump-pr:
     name: Bump ${{ matrix.repo }}
     needs: compute-matrix
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,7 +38,16 @@ env:
 jobs:
   slow-tests:
     name: Slow & Chaos Tests
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 60  # Extended timeout for slow tests
 
     steps:
@@ -94,7 +103,16 @@ jobs:
   # Summary job to report overall status
   nightly-summary:
     name: Nightly Summary
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     needs: [slow-tests]
     if: always()
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,16 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 10
 
     steps:
@@ -76,7 +85,16 @@ jobs:
   # ONEX validation - Infrastructure-specific validators
   onex-validation:
     name: ONEX Validators
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 10
 
     steps:
@@ -140,7 +158,16 @@ jobs:
   # Prevents stale fingerprint artifacts from being merged (OMN-2149)
   fingerprint-check:
     name: Fingerprint Check
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -178,7 +205,16 @@ jobs:
   # Runs in CI mode (skips live infra checks) as pre-deploy validation
   demo-loop-gate:
     name: Demo Loop Gate
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -217,7 +253,16 @@ jobs:
   # Part of DB-per-repo refactor (OMN-2055), tracking: OMN-2071
   migration-freeze:
     name: Migration Freeze Check
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -233,7 +278,16 @@ jobs:
   # Ensures generated enum files stay in sync with contract.yaml definitions
   topic-enum-drift:
     name: Topic Enum Drift Check
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -272,7 +326,16 @@ jobs:
   # Validates onex.{kind}.{producer}.{event}.v{n} format in all contract.yaml files
   topic-naming-lint:
     name: Topic Naming Lint
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -313,7 +376,16 @@ jobs:
   test-parallel:
     name: Tests (Split ${{ matrix.split }}/10)
     needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint]
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -375,7 +447,16 @@ jobs:
   # ============================================================================
   tests-gate:
     name: CI Tests Gate
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     needs: test-parallel
     if: always()
     steps:
@@ -391,7 +472,16 @@ jobs:
 
   test-summary:
     name: Test Summary
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint]
     if: always()
 
@@ -445,7 +535,16 @@ jobs:
   # upstream fix (e.g. OMN-3248) lands, at which point xfail is removed.
   kafka-boundary-compat:
     name: Kafka Boundary Compat (OMN-3256)
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 10
 
     steps:
@@ -506,7 +605,16 @@ jobs:
 
   ai-slop-check:
     name: AI-Slop Pattern Check (strict, PR diff)
-    runs-on: ubuntu-latest
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Staged rollout of self-hosted runner routing to omnibase_infra CI workflows (OMN-3273, first repo).

Replaces bare `runs-on: ubuntu-latest` with the canonical `OMNINODE_SELF_HOSTED_RUNS_ON_V1` expression in all test and quality jobs. Routing is **opt-in via a GitHub repo variable** — no activation without explicit `USE_SELF_HOSTED_RUNNERS = true` being set.

## Changes

| File | Jobs Updated |
|------|-------------|
| `.github/workflows/test.yml` | 12 jobs (lint, onex-validation, fingerprint-check, demo-loop-gate, migration-freeze, topic-enum-drift, topic-naming-lint, test-parallel ×10, tests-gate, test-summary, kafka-boundary-compat, ai-slop-check) |
| `.github/workflows/nightly-tests.yml` | 2 jobs |
| `.github/workflows/check-handshake.yml` | 1 job |
| `.github/workflows/dependency-cascade.yml` | 2 jobs |

**NOT changed** (per spec): `docker-build.yml`, `release.yml`, `release-python-*.yml`, `auto-tag-on-merge.yml`

## Canonical Expression Applied

Every updated job now has:

```yaml
# OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
runs-on: >-
  ${{
    (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
     (github.event_name == 'push' ||
      github.event_name == 'workflow_dispatch' ||
      github.event_name == 'schedule'))
    && fromJSON('["self-hosted","omnibase-ci","linux","x64"]')
    || fromJSON('["ubuntu-latest"]')
  }}
```

The `omnibase-ci` label uniquely routes to the `omnibase-ci` runner group (created in OMN-3274). It is never bare `self-hosted`.

## Activation

**This PR does NOT activate self-hosted routing.** Routing activates only when:

```
GitHub → Settings → Variables → Repository variables
  USE_SELF_HOSTED_RUNNERS = true
```

**Rollback**: Delete the `USE_SELF_HOSTED_RUNNERS` variable → all runs revert to `ubuntu-latest` with zero code changes.

## Staged Rollout Plan

1. Merge this PR
2. Set `USE_SELF_HOSTED_RUNNERS = true` on `omnibase_infra` repo (after OMN-3275/3276/3277 land and runners are deployed)
3. Trigger CI via `workflow_dispatch`
4. Collect ≥10 runs; compare median wall-clock to baseline from OMN-3274 (~600s target: ≤300s)
5. Do NOT proceed to other repos until validation passes

## Pre/Post Audit

```bash
# Verify all 17 updated jobs have canonical marker:
rg -n "OMNINODE_SELF_HOSTED_RUNS_ON_V1" .github/workflows/
# Expected: 17 matches across 4 files

# Verify skipped files still use bare ubuntu-latest:
grep "runs-on" .github/workflows/docker-build.yml .github/workflows/release.yml
```

## Definition of Done

- [x] 17 jobs updated with canonical expression + comment
- [x] OMNINODE_SELF_HOSTED_RUNS_ON_V1 marker on every updated job
- [x] docker-build.yml and release*.yml left unchanged
- [ ] USE_SELF_HOSTED_RUNNERS = true set on repo (post-merge, after runners deployed)
- [ ] ≥10 CI runs validated on self-hosted runners
- [ ] Median wall-clock ≤50% of baseline (≤300s vs 600s baseline from OMN-3274)

## Linear

Ticket: [OMN-3278](https://linear.app/omninode/issue/OMN-3278)
Epic: OMN-3273 — Self-Hosted GitHub Actions Runners + Skill Integration

Depends on: OMN-3274 (runner group), OMN-3275 (Dockerfile), OMN-3276 (compose), OMN-3277 (deploy script)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to support conditional runner selection, enabling improved build performance and execution flexibility across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->