### PR TITLE
fix(ops): fix invalid_blocks Slack API error in monitor_logs post_slack() [OMN-3311]

### DIFF
--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -114,7 +114,7 @@ def _cooldown_write(container: str, ts: float, count: int) -> None:
 
 def _backoff_seconds(count: int) -> int:
     """Exponential backoff: 5m, 10m, 20m, 40m, 60m (cap)."""
-    return min(_BACKOFF_BASE * (2**count), _BACKOFF_CAP)
+    return int(min(_BACKOFF_BASE * (2**count), _BACKOFF_CAP))
 
 
 # Resolve docker binary at startup so subprocess calls work without a shell PATH.
@@ -150,12 +150,68 @@ IGNORE_PATTERN = re.compile(
 # Slack
 # ---------------------------------------------------------------------------
 
+# The mrkdwn code-fence wrapper adds exactly 8 chars: "```\n" (4) + "\n```" (4).
+# Cap log text at (MAX_SLACK_CHARS - 8) so the assembled field stays within limit.
+_BLOCK_TEXT_LIMIT = MAX_SLACK_CHARS - 8
+
+# Matches ANSI CSI sequences (colors, cursor), OSC sequences (hyperlinks, titles),
+# and two-byte Fe escape sequences (e.g. ESC [ ... m, ESC ] ... BEL).
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[mGKHF]|\x1b\].*?\x07|\x1b[@-_]")
+
+
+def _sanitize_log_text(text: str) -> str:
+    """Strip ANSI escape codes and non-printable control chars from log content.
+
+    Newlines are preserved; every other control character is replaced with '?'
+    so the structure of the log excerpt remains readable.
+    """
+    text = _ANSI_ESCAPE.sub("", text)
+    return "".join(ch if ch >= " " or ch == "\n" else "?" for ch in text)
+
+
+def _post_slack_plain_text(
+    bot_token: str, channel_id: str, container: str, lines: list[str]
+) -> None:
+    """Fallback: post a plain-text message (no blocks) when blocks are rejected."""
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    text = _sanitize_log_text("\n".join(lines))[:MAX_SLACK_CHARS]
+    fallback_payload = {
+        "channel": channel_id,
+        "text": (
+            f":rotating_light: *Container error:* `{container}` — {timestamp}\n"
+            f"```\n{text}\n```"
+        ),
+    }
+    try:
+        data = json.dumps(fallback_payload).encode("utf-8")
+        req = urllib.request.Request(
+            "https://slack.com/api/chat.postMessage",
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {bot_token}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            result = json.loads(resp.read())
+            if not result.get("ok"):
+                print(
+                    f"[monitor] Slack fallback error for {container}: {result.get('error')}",
+                    file=sys.stderr,
+                )
+    except Exception as exc:
+        print(
+            f"[monitor] Failed to post Slack fallback for {container}: {exc}",
+            file=sys.stderr,
+        )
+
 
 def post_slack(
     bot_token: str, channel_id: str, container: str, lines: list[str], dry_run: bool
 ) -> None:
     timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    text = "\n".join(lines)[:MAX_SLACK_CHARS]
+    text = _sanitize_log_text("\n".join(lines))[:_BLOCK_TEXT_LIMIT]
 
     payload = {
         "channel": channel_id,
@@ -197,10 +253,18 @@ def post_slack(
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             result = json.loads(resp.read())
             if not result.get("ok"):
-                print(
-                    f"[monitor] Slack API error for {container}: {result.get('error')}",
-                    file=sys.stderr,
-                )
+                error = result.get("error")
+                if error == "invalid_blocks":
+                    print(
+                        f"[monitor] invalid_blocks for {container}, retrying with plain text",
+                        file=sys.stderr,
+                    )
+                    _post_slack_plain_text(bot_token, channel_id, container, lines)
+                else:
+                    print(
+                        f"[monitor] Slack API error for {container}: {error}",
+                        file=sys.stderr,
+                    )
     except Exception as exc:
         print(
             f"[monitor] Failed to post Slack alert for {container}: {exc}",

--- a/tests/unit/scripts/test_monitor_logs.py
+++ b/tests/unit/scripts/test_monitor_logs.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for monitor_logs.py Slack alert fixes (OMN-3311)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# monitor_logs.py lives in scripts/ and has no package install; add scripts/ to path.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# Lazy import helper — reload each time to avoid cross-test pollution from
+# the module-level _load_omnibase_env() side-effect.
+_MODULE_NAME = "monitor_logs"
+
+
+def _import() -> Any:
+    if _MODULE_NAME in sys.modules:
+        return sys.modules[_MODULE_NAME]
+    return importlib.import_module(_MODULE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_log_text
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeLogText:
+    """Tests for _sanitize_log_text()."""
+
+    @pytest.mark.unit
+    def test_strips_ansi_color_codes(self) -> None:
+        """ANSI SGR sequences (colors, bold, reset) must be removed."""
+        m = _import()
+        raw = "\x1b[31mERROR\x1b[0m: something went wrong"
+        result = m._sanitize_log_text(raw)
+        assert "\x1b" not in result
+        assert "ERROR" in result
+        assert "something went wrong" in result
+
+    @pytest.mark.unit
+    def test_strips_ansi_cursor_sequences(self) -> None:
+        """ANSI cursor-movement escape sequences must be removed."""
+        m = _import()
+        # ESC[K (erase to end of line), ESC[H (cursor home)
+        raw = "line1\x1b[Kline2\x1b[H"
+        result = m._sanitize_log_text(raw)
+        assert "\x1b" not in result
+        assert "line1" in result
+        assert "line2" in result
+
+    @pytest.mark.unit
+    def test_strips_osc_sequences(self) -> None:
+        """OSC hyperlink/title sequences (ESC ] ... BEL) must be removed."""
+        m = _import()
+        raw = "\x1b]0;window title\x07some log text"
+        result = m._sanitize_log_text(raw)
+        assert "\x1b" not in result
+        assert "some log text" in result
+
+    @pytest.mark.unit
+    def test_preserves_newlines(self) -> None:
+        """Newline characters must be kept intact."""
+        m = _import()
+        raw = "line one\nline two\nline three"
+        result = m._sanitize_log_text(raw)
+        assert result.count("\n") == 2
+
+    @pytest.mark.unit
+    def test_replaces_control_chars_with_question_mark(self) -> None:
+        """Non-newline control characters (e.g. \\x01, \\x07, \\x0c) become '?'."""
+        m = _import()
+        raw = "before\x01\x07\x0cafter"
+        result = m._sanitize_log_text(raw)
+        assert "\x01" not in result
+        assert "\x07" not in result
+        assert "\x0c" not in result
+        assert "?" in result
+        assert "before" in result
+        assert "after" in result
+
+    @pytest.mark.unit
+    def test_passthrough_for_clean_text(self) -> None:
+        """Plain ASCII log text should be returned unchanged."""
+        m = _import()
+        raw = "2026-01-01 ERROR: disk full\nStack trace follows"
+        assert m._sanitize_log_text(raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# post_slack — truncation
+# ---------------------------------------------------------------------------
+
+
+class TestPostSlackTruncation:
+    """Verify the mrkdwn block field never exceeds MAX_SLACK_CHARS."""
+
+    @pytest.mark.unit
+    def test_mrkdwn_block_text_within_limit(self) -> None:
+        """The assembled mrkdwn text field must be <= MAX_SLACK_CHARS chars."""
+        m = _import()
+        # Generate 4000 chars of log — well over the 3000-char limit.
+        long_line = "A" * 4000
+        lines = [long_line]
+
+        captured_payload: dict[str, Any] = {}
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> Any:
+            body = json.loads(req.data)
+            captured_payload.update(body)
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = json.dumps({"ok": True}).encode()
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            m.post_slack("tok", "chan", "my-container", lines, dry_run=False)
+
+        # Find the code-fence block
+        blocks = captured_payload.get("blocks", [])
+        assert len(blocks) == 2
+        mrkdwn_text: str = blocks[1]["text"]["text"]
+        assert len(mrkdwn_text) <= m.MAX_SLACK_CHARS, (
+            f"mrkdwn text is {len(mrkdwn_text)} chars, expected <= {m.MAX_SLACK_CHARS}"
+        )
+
+    @pytest.mark.unit
+    def test_short_log_not_truncated(self) -> None:
+        """Short log text must not be truncated."""
+        m = _import()
+        lines = ["ERROR: disk full", "Traceback: ..."]
+
+        captured_payload: dict[str, Any] = {}
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> Any:
+            body = json.loads(req.data)
+            captured_payload.update(body)
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = json.dumps({"ok": True}).encode()
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            m.post_slack("tok", "chan", "my-container", lines, dry_run=False)
+
+        blocks = captured_payload.get("blocks", [])
+        mrkdwn_text: str = blocks[1]["text"]["text"]
+        # Full content must be present (no truncation for short text)
+        assert "ERROR: disk full" in mrkdwn_text
+        assert "Traceback: ..." in mrkdwn_text
+
+
+# ---------------------------------------------------------------------------
+# post_slack — invalid_blocks fallback
+# ---------------------------------------------------------------------------
+
+
+class TestPostSlackInvalidBlocksFallback:
+    """Verify post_slack retries with plain text when API returns invalid_blocks."""
+
+    @pytest.mark.unit
+    def test_retries_with_plain_text_on_invalid_blocks(self) -> None:
+        """When Slack returns invalid_blocks, a plain-text fallback must be posted."""
+        m = _import()
+        lines = ["ERROR: container crash"]
+        call_count = 0
+        plain_text_payload: dict[str, Any] = {}
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> Any:
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            if call_count == 1:
+                # First call: blocks request — return invalid_blocks
+                mock_resp.read.return_value = json.dumps(
+                    {"ok": False, "error": "invalid_blocks"}
+                ).encode()
+            else:
+                # Second call: plain-text fallback — capture payload and succeed
+                plain_text_payload.update(json.loads(req.data))
+                mock_resp.read.return_value = json.dumps({"ok": True}).encode()
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            m.post_slack("tok", "chan", "crash-container", lines, dry_run=False)
+
+        assert call_count == 2, "Expected exactly 2 Slack API calls (blocks + fallback)"
+        assert "blocks" not in plain_text_payload, "Fallback must not include blocks"
+        assert "text" in plain_text_payload
+        assert "ERROR: container crash" in plain_text_payload["text"]
+
+    @pytest.mark.unit
+    def test_no_retry_on_other_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-invalid_blocks errors must be logged once without retrying."""
+        m = _import()
+        lines = ["ERROR: something"]
+        call_count = 0
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> Any:
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = json.dumps(
+                {"ok": False, "error": "channel_not_found"}
+            ).encode()
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            m.post_slack("tok", "chan", "my-container", lines, dry_run=False)
+
+        assert call_count == 1, "No retry expected for non-invalid_blocks error"
+        captured = capsys.readouterr()
+        assert "channel_not_found" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# post_slack — normal success path
+# ---------------------------------------------------------------------------
+
+
+class TestPostSlackSuccess:
+    """Verify normal (non-error) post_slack path still works correctly."""
+
+    @pytest.mark.unit
+    def test_success_posts_blocks_payload(self) -> None:
+        """A successful response must post a blocks payload with the right shape."""
+        m = _import()
+        lines = ["INFO: startup complete", "ERROR: disk full"]
+        captured_payload: dict[str, Any] = {}
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> Any:
+            captured_payload.update(json.loads(req.data))
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = json.dumps({"ok": True}).encode()
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            m.post_slack("xoxb-token", "C123", "my-container", lines, dry_run=False)
+
+        assert captured_payload["channel"] == "C123"
+        blocks = captured_payload["blocks"]
+        assert blocks[0]["text"]["type"] == "mrkdwn"
+        assert "my-container" in blocks[0]["text"]["text"]
+        assert "```" in blocks[1]["text"]["text"]
+        assert "ERROR: disk full" in blocks[1]["text"]["text"]
+
+    @pytest.mark.unit
+    def test_dry_run_does_not_call_urlopen(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """dry_run=True must print the payload without making any HTTP calls."""
+        m = _import()
+        lines = ["ERROR: crash"]
+
+        with patch("urllib.request.urlopen") as mock_open:
+            m.post_slack("tok", "chan", "ctr", lines, dry_run=True)
+            mock_open.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+        assert "ctr" in captured.out


### PR DESCRIPTION
## Summary

Fixes `invalid_blocks` Slack API errors in `scripts/monitor_logs.py` that caused container alert notifications to be silently dropped.

**Root causes identified and fixed:**

1. **Truncation off-by-8** — `text` was sliced at `MAX_SLACK_CHARS` (3000) before being wrapped in ` ```\n...\n``` ` (8 extra chars), causing the `mrkdwn` block field to exceed Slack's 3000-char text limit. Fixed with `_BLOCK_TEXT_LIMIT = MAX_SLACK_CHARS - 8`.

2. **ANSI/control-char pollution** — container logs contain ANSI escape sequences and raw control characters that break Slack's block kit mrkdwn parser. Added `_sanitize_log_text()` to strip these before building the payload.

3. **Silent drop on `invalid_blocks`** — `post_slack()` logged the error but dropped the alert. Now retries via `_post_slack_plain_text()` (text-only, no blocks) so operators always receive notification.

Also fixes a pre-existing mypy `[no-any-return]` error in `_backoff_seconds`.

## Changes

- `scripts/monitor_logs.py` — targeted bug fix (70 lines added, 6 changed)
- `tests/unit/scripts/test_monitor_logs.py` — 12 new unit tests (new file)

## Test Coverage

| Test Class | Coverage |
|---|---|
| `TestSanitizeLogText` | ANSI stripping, control-char replacement, newline preservation |
| `TestPostSlackTruncation` | mrkdwn field ≤ 3000 chars, short logs not truncated |
| `TestPostSlackInvalidBlocksFallback` | Fallback fires on `invalid_blocks`, no retry on other errors |
| `TestPostSlackSuccess` | Normal path, dry-run |

All 12 tests pass. Pre-commit clean. mypy strict clean.

## Linked Issue

Closes OMN-3311