### PR TITLE
[OMN-3364] feat(infisical): add auth transport folder + document Keycloak vars

### DIFF
--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -668,3 +668,25 @@ ONEX_OUTPUT_TOPIC=responses
 # Default: 1000 (1 second)
 # Example: 1000 (balanced), 500 (low latency), 5000 (high throughput)
 # AGENT_ACTIONS_BATCH_TIMEOUT_MS=1000
+
+# =============================================================================
+# Keycloak (local Docker, --profile auth)
+# =============================================================================
+# Written by provision-keycloak.py. Do not set manually.
+#
+# KEYCLOAK_ADMIN_URL: ALWAYS internal (http://keycloak:8080).
+#   Used by: runtime containers, onex-api. Never set to localhost.
+#   onex-api in k8s gets this via Infisical /services/onex-api/auth/.
+#
+# KEYCLOAK_ISSUER: ALWAYS external browser-visible URL.
+#   Must match the `iss` claim in Keycloak-issued tokens.
+#   Tokens are issued with iss = http://localhost:28080/realms/omninode in local dev.
+#
+KEYCLOAK_ADMIN_URL=http://keycloak:8080
+KEYCLOAK_REALM=omninode
+KEYCLOAK_ADMIN_CLIENT_ID=onex-admin
+KEYCLOAK_ADMIN_CLIENT_SECRET=          # restricted: /services/onex-api/auth/ in Infisical
+KEYCLOAK_ISSUER=http://localhost:28080/realms/omninode
+ONEX_SERVICE_CLIENT_ID=onex-service
+ONEX_SERVICE_CLIENT_SECRET=            # restricted: /services/onex-api/auth/ in Infisical
+# KEYCLOAK_ADMIN_PASSWORD is NOT stored here (transient, bootstrap-only input)

--- a/scripts/provision-infisical.py
+++ b/scripts/provision-infisical.py
@@ -287,6 +287,7 @@ def _create_infisical_folders(
         "kafka",
         "vault",
         "qdrant",
+        "auth",  # Keycloak OIDC config (added for Keycloak integration)
     ),
 ) -> None:
     """Create the /shared/<transport> folder structure in every environment.


### PR DESCRIPTION
## Summary

Implements Steps 6–7 of the Keycloak integration plan:

- **`scripts/provision-infisical.py`**: Add `"auth"` to `TRANSPORT_FOLDERS` so `provision-infisical.py` creates the `/shared/auth/` path in Infisical. This path is required for Keycloak OIDC config seeded by `provision-keycloak.py`.
- **`docs/env-example-full.txt`**: Add Keycloak section documenting all `KEYCLOAK_*` and `ONEX_SERVICE_*` vars with critical internal/external URL distinction:
  - `KEYCLOAK_ADMIN_URL` = always internal (`http://keycloak:8080`) — never localhost
  - `KEYCLOAK_ISSUER` = always external browser-visible URL — must match token `iss` claim
  - `KEYCLOAK_ADMIN_PASSWORD` explicitly excluded (transient, bootstrap-only input)

## Ticket

[OMN-3364](https://linear.app/omninode/issue/OMN-3364) — Epic OMN-3360

## Files Changed

| File | Change |
|------|--------|
| `scripts/provision-infisical.py` | Add `"auth"` to `TRANSPORT_FOLDERS` list |
| `docs/env-example-full.txt` | Document new KEYCLOAK_* vars with internal/external URL notes |

## Definition of Done

- [x] `provision-infisical.py` creates `/shared/auth/` path in Infisical
- [x] `env-example-full.txt` contains Keycloak section with accurate URL comments
- [x] Comments clarify `KEYCLOAK_ADMIN_URL` = internal, `KEYCLOAK_ISSUER` = external
- [x] `KEYCLOAK_ADMIN_PASSWORD` explicitly excluded from env file
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Keycloak authentication environment configuration example with setup guidance and security notes.

* **Chores**
  * Updated provisioning workflow to support authentication configuration folder creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->