### PR TITLE
[OMN-3368] fix(kafka-topic-drift): register missing platform publish_topics in node_registration_orchestrator

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -78,6 +78,15 @@ event_bus:
     - "onex.evt.platform.node-liveness-expired.v1"
     - "onex.evt.platform.topic-catalog-response.v1"
     - "onex.evt.platform.topic-catalog-changed.v1"
+    # Platform lifecycle events emitted during registration workflow [OMN-3368]
+    - "onex.evt.platform.node-registration.v1"
+    - "onex.evt.platform.node-heartbeat.v1"
+    - "onex.evt.platform.node-introspection.v1"
+    - "onex.evt.platform.registry-request-introspection.v1"
+    - "onex.evt.platform.fsm-state-transitions.v1"
+    - "onex.intent.platform.runtime-tick.v1"
+    - "onex.cmd.platform.request-introspection.v1"
+    - "onex.snapshot.platform.registration-snapshots.v1"
 input_model:
   name: "ModelOrchestratorInput"
   module: "omnibase_infra.nodes.node_registration_orchestrator.models"


### PR DESCRIPTION
## Summary
- Adds 8 missing platform lifecycle topic declarations to `node_registration_orchestrator.publish_topics`
- Resolves orphaned subscriptions in `node_ledger_projection_compute` (YELLOW BEST_EFFORT)

## Changes
- `src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml`: added platform lifecycle topics to `publish_topics`

## Topics Registered
- `node-registration.v1`, `node-heartbeat.v1`, `node-introspection.v1`
- `registry-request-introspection.v1`, `fsm-state-transitions.v1`
- `runtime-tick.v1`, `request-introspection.v1`, `registration-snapshots.v1`

## Test plan
- [ ] Gap-analysis passes with 0 findings for node_ledger_projection_compute
- [ ] CI passes

Closes: OMN-3368
Parent epic: OMN-3366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced node registration orchestrator with eight new platform lifecycle event topics, enabling improved tracking of node registration, heartbeat, introspection requests, state transitions, and registration snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->