### PR TITLE
[OMN-3370] fix(kafka-topic-drift): register cross-repo validation publish_topics in node_validation_orchestrator

### DIFF
--- a/src/omnibase_infra/nodes/node_validation_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_validation_orchestrator/contract.yaml
@@ -56,6 +56,10 @@ event_bus:
     - "onex.evt.platform.validation-adjudication-requested.v1"
     - "onex.evt.platform.validation-result-published.v1"
     - "onex.evt.platform.validation-lifecycle-updated.v1"
+    # Cross-repo validation run lifecycle events [OMN-3370]
+    - "onex.evt.validation.cross-repo-run-started.v1"
+    - "onex.evt.validation.cross-repo-run-completed.v1"
+    - "onex.evt.validation.violations-batch.v1"
 # Handler Routing Configuration
 # ==============================
 # Declarative mapping of consumed events to handler implementations.


### PR DESCRIPTION
## Summary
- Adds 3 cross-repo validation run lifecycle events to `node_validation_orchestrator.publish_topics`
- Resolves orphaned subscriptions in `node_validation_ledger_projection_compute` (YELLOW BEST_EFFORT)

## Changes
- `src/omnibase_infra/nodes/node_validation_orchestrator/contract.yaml`: added validation namespace topics

## Topics Registered
- `onex.evt.validation.cross-repo-run-started.v1`
- `onex.evt.validation.cross-repo-run-completed.v1`
- `onex.evt.validation.violations-batch.v1`

## Test plan
- [ ] Gap-analysis passes with 0 findings for node_validation_ledger_projection_compute
- [ ] CI passes

Closes: OMN-3370
Parent epic: OMN-3366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation event publishing infrastructure to support cross-repository validation workflows and violation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->