### PR TITLE
[OMN-3371] fix(kafka-topic-drift): add event_bus publish_topics to validation executor/adjudicator/lifecycle

### DIFF
--- a/src/omnibase_infra/nodes/node_pattern_lifecycle_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_pattern_lifecycle_effect/contract.yaml
@@ -36,6 +36,14 @@ output_model:
   name: "ModelLifecycleResult"
   module: "omnibase_infra.nodes.node_pattern_lifecycle_effect.models"
   description: "Result of the lifecycle tier update operation."
+# Event Bus Configuration [OMN-3371]
+event_bus:
+  version:
+    major: 0
+    minor: 1
+    patch: 0
+  publish_topics:
+    - "onex.evt.platform.validation-candidate-submitted.v1"
 # Capability declaration
 capabilities:
   - name: "lifecycle.update"

--- a/src/omnibase_infra/nodes/node_validation_adjudicator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_validation_adjudicator/contract.yaml
@@ -108,6 +108,16 @@ state_machine:
   persistence_enabled: true
   terminal_states: []
   # verdict_emitted is NOT a true terminal — it resets to collecting
+# Event Bus Configuration [OMN-3371]
+event_bus:
+  version:
+    major: 0
+    minor: 1
+    patch: 0
+  publish_topics:
+    - "onex.evt.platform.validation-adjudication-completed.v1"
+  subscribe_topics:
+    - "onex.evt.platform.validation-candidate-submitted.v1"
 # Intent Emission Configuration
 # ============================
 intent_emission:

--- a/src/omnibase_infra/nodes/node_validation_executor/contract.yaml
+++ b/src/omnibase_infra/nodes/node_validation_executor/contract.yaml
@@ -36,6 +36,14 @@ output_model:
   name: "ModelExecutorResult"
   module: "omnibase_infra.nodes.node_validation_executor.models"
   description: "Aggregated result of all check executions."
+# Event Bus Configuration [OMN-3371]
+event_bus:
+  version:
+    major: 0
+    minor: 1
+    patch: 0
+  publish_topics:
+    - "onex.evt.platform.validation-checks-completed.v1"
 # Capability declaration
 capabilities:
   - name: "validation.execute_checks"


### PR DESCRIPTION
## Summary
- Adds `event_bus` sections to 3 validation pipeline nodes to register their published topics
- Resolves 3 orphaned subscriptions in `node_validation_orchestrator` (YELLOW BEST_EFFORT)

## Changes
- `node_validation_executor/contract.yaml`: added event_bus with `validation-checks-completed.v1`
- `node_validation_adjudicator/contract.yaml`: added event_bus with `validation-adjudication-completed.v1`
- `node_pattern_lifecycle_effect/contract.yaml`: added event_bus with `validation-candidate-submitted.v1`

## Test plan
- [ ] Gap-analysis passes with 0 findings for node_validation_orchestrator
- [ ] CI passes

Closes: OMN-3371
Parent epic: OMN-3366