### PR TITLE
fix(OMN-3419): add http://localhost:8080/* to omniweb Keycloak realm export

### DIFF
--- a/docker/keycloak/omninode-realm.json
+++ b/docker/keycloak/omninode-realm.json
@@ -17,11 +17,13 @@
       "adminUrl": "https://app.omninode.ai",
       "redirectUris": [
         "https://app.omninode.ai/*",
-        "http://localhost:3000/*"
+        "http://localhost:3000/*",
+        "http://localhost:8080/*"
       ],
       "webOrigins": [
         "https://app.omninode.ai",
-        "http://localhost:3000"
+        "http://localhost:3000",
+        "http://localhost:8080"
       ],
       "protocol": "openid-connect",
       "publicClient": true,


### PR DESCRIPTION
## Summary

Add `http://localhost:8080/*` to `redirectUris` and `http://localhost:8080` to `webOrigins` in the `omniweb` client entry of `docker/keycloak/omninode-realm.json`.

This ensures that a fresh local Keycloak bootstrap (via `scripts/bootstrap-infisical.sh`) includes the localhost:8080 redirect URI out of the box, so `PORT=8080 pnpm dev` works without manual Keycloak configuration.

Existing URIs are preserved:
- `https://app.omninode.ai/*` (production) — unchanged
- `http://localhost:3000/*` (omnidash local) — unchanged

Closes OMN-3419 (companion PR in omniweb: OmniNode-ai/omniweb#26).

## Test plan

- [ ] Bootstrap a fresh local Keycloak: `./scripts/bootstrap-infisical.sh`
- [ ] Verify `omniweb` client has `http://localhost:8080/*` in Valid Redirect URIs
- [ ] Verify existing `https://app.omninode.ai/*` and `localhost:3000/*` are still present