### PR TITLE
feat(OMN-3428): add autoheal sidecar for aiokafka stuck-state recovery

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -453,6 +453,7 @@ services:
       - "com.omninode.service=runtime-main"
       - "com.omninode.layer=runtime"
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
   # ==========================================================================
   # ONEX Runtime - Effects Handler (Runtime Profile)
   # ==========================================================================
@@ -488,6 +489,7 @@ services:
       - "com.omninode.service=runtime-effects"
       - "com.omninode.layer=runtime"
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
   # ==========================================================================
   # ONEX Runtime - Workers (Runtime Profile)
   # ==========================================================================
@@ -529,6 +531,7 @@ services:
       - "com.omninode.service=runtime-worker"
       - "com.omninode.layer=runtime"
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
   # ==========================================================================
   # Agent Actions Consumer - Observability (Runtime Profile)
   # ==========================================================================
@@ -577,6 +580,7 @@ services:
       - "com.omninode.service=agent-actions-consumer"
       - "com.omninode.layer=runtime"
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
   # ==========================================================================
   # Skill Lifecycle Consumer - Observability (Runtime Profile) [OMN-2934]
   # ==========================================================================
@@ -620,6 +624,7 @@ services:
       - "com.omninode.service=skill-lifecycle-consumer"
       - "com.omninode.layer=runtime"
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
   # ==========================================================================
   # OmniIntelligence HTTP API - Pattern Query Service (Runtime Profile)
   # ==========================================================================
@@ -729,6 +734,41 @@ services:
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
       - "com.omninode.ticket=OMN-2756"
       - "com.omninode.transitional=true"
+  # ==========================================================================
+  # Autoheal - Automatic restart of unhealthy containers (OMN-3428)
+  # ==========================================================================
+  # Rationale: Docker restart: unless-stopped only fires on process exit, not
+  # on healthcheck failure. Kafka consumer services (aiokafka) can enter a
+  # permanent retry loop after a broker disconnect without exiting, leaving
+  # the container alive but unhealthy. Autoheal fills that gap.
+  #
+  # Scope: only containers labeled autoheal=true are watched (not infra services
+  # like postgres/valkey, which could cascade-fail dependents if restarted).
+  #
+  # Profiles: runtime, full only. Not active in dev/bootstrap/auth/consul profiles.
+  #
+  # LOCAL INFRA ONLY: docker.sock mount grants root-equivalent Docker control.
+  # Do not use this pattern in shared or multi-user environments.
+  #
+  # Rollback per-container: remove autoheal=true label from the service in this
+  #   file, then: docker compose -f docker/docker-compose.infra.yml --profile runtime up -d --no-build
+  # Rollback entire watchdog:
+  #   docker compose -f docker/docker-compose.infra.yml --profile runtime stop autoheal
+  autoheal:
+    image: willfarrell/autoheal:1.2.0
+    container_name: omnibase-infra-autoheal
+    profiles: ["runtime", "full"]
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: 60
+      AUTOHEAL_START_PERIOD: 60
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    logging: *logging-defaults
+    labels:
+      - "com.omninode.service=autoheal"
+      - "com.omninode.layer=infrastructure"
 # ==========================================================================
 # Network Configuration
 # ==========================================================================


### PR DESCRIPTION
## Summary

- Add `willfarrell/autoheal:1.2.0` as a `runtime`/`full` profile sidecar service in `docker-compose.infra.yml`
- Label 5 Kafka-consuming services with `autoheal=true` so the watchdog can automatically restart containers that are alive but unhealthy
- Docker's `restart: unless-stopped` only fires on process exit — autoheal fills the gap for healthcheck failures (e.g., aiokafka `NodeNotReadyError` retry loops after a broker disconnect)

**Affected services:**
- `omninode-runtime`
- `runtime-effects`
- `runtime-worker`
- `agent-actions-consumer`
- `skill-lifecycle-consumer`

**Not affected** (HTTP/gRPC services, not Kafka consumers): `intelligence-api`, `omninode-contract-resolver`

## Root Cause

During a Redpanda broker hiccup on 2026-03-02, two containers entered a permanent aiokafka `NodeNotReadyError` retry loop. The broker recovered on its own but the containers couldn't self-heal — Docker's `restart: unless-stopped` only fires when the container *process exits*, not when its healthcheck flips to `unhealthy`. Manual `docker restart` was required.

## Rollback

**Per-container**: Remove `- "autoheal=true"` from the service's labels block, then redeploy with `--no-build`.

**Entire watchdog**: `docker compose -f docker/docker-compose.infra.yml --profile runtime stop autoheal`

## Test plan

- [ ] `docker compose -f docker/docker-compose.infra.yml config --quiet` passes (YAML valid)
- [ ] `docker compose -f docker/docker-compose.infra.yml --profile runtime config --services | grep autoheal` returns `autoheal`
- [ ] `docker ps --filter "label=autoheal=true"` shows all 5 consumer containers after redeploy
- [ ] `docker logs omnibase-infra-autoheal` shows startup message, no permission errors
- [ ] Optionally: force one container unhealthy (`docker update --health-cmd "exit 1" <id>`), observe autoheal restart log

Fixes: OMN-3428