### PR TITLE
fix(OMN-3430): update last_poll_at on TimeoutError to prevent false 503 after Kafka reconnect

### DIFF
--- a/src/omnibase_infra/services/observability/agent_actions/consumer.py
+++ b/src/omnibase_infra/services/observability/agent_actions/consumer.py
@@ -933,7 +933,14 @@ class AgentActionsConsumer:
                         + self._config.poll_timeout_buffer_seconds,
                     )
                 except TimeoutError:
-                    # Poll timeout is normal, continue loop
+                    # Poll timeout is normal (happens during Kafka reconnect or
+                    # low-traffic periods). Still record the poll attempt so
+                    # last_poll_at stays fresh and the health check does not
+                    # flip to DEGRADED while aiokafka is reconnecting.
+                    # Without this, health_check_poll_staleness_seconds (default
+                    # 60s) fires after the first coordinator-dead window even
+                    # though the consumer loop is still running. (OMN-3430)
+                    await self.metrics.record_polled()
                     continue
 
                 # Record poll time even if no messages - prevents false DEGRADED

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py
@@ -16,6 +16,7 @@ Related Tickets:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -26,6 +27,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 
 from omnibase_core.errors import OnexError
+from omnibase_core.types import JsonType
 from omnibase_infra.services.observability.agent_actions.config import (
     ConfigAgentActionsConsumer,
 )
@@ -1306,6 +1308,116 @@ class TestRunMethod:
             await consumer.run()
 
 
+# =============================================================================
+# Kafka Reconnect Health Regression Tests (OMN-3430)
+# =============================================================================
+
+
+class TestKafkaReconnectHealth:
+    """Regression tests for OMN-3430.
+
+    When aiokafka is in its internal reconnect/retry loop, every getmany()
+    call blocks until asyncio.wait_for fires a TimeoutError.  Before the fix,
+    the TimeoutError handler called ``continue`` without updating
+    ``last_poll_at``, causing the poll-staleness check to flip health to
+    DEGRADED after 60 s even though the consumer loop was still running.
+    """
+
+    @pytest.mark.asyncio
+    async def test_record_polled_called_on_timeout(
+        self, consumer: AgentActionsConsumer
+    ) -> None:
+        """TimeoutError from getmany must still update last_poll_at (OMN-3430).
+
+        Simulates the Kafka-coordinator-dead scenario where every getmany()
+        call times out.  Verifies that after a single poll-loop iteration that
+        hits TimeoutError, last_poll_at is not None (i.e. record_polled was
+        called inside the TimeoutError handler).
+
+        Implementation: patch asyncio.wait_for so the first call raises
+        TimeoutError (and sets _running=False to stop the loop), then confirm
+        the metrics were updated.
+        """
+        # Consumer must be in running state for the loop to execute.
+        consumer._running = True
+
+        # last_poll_at should be None before any iteration.
+        assert consumer.metrics.last_poll_at is None
+
+        call_count = 0
+
+        async def _wait_for_side_effect(coro: object, timeout: float) -> object:
+            nonlocal call_count
+            call_count += 1
+            # Stop the loop so _consume_loop exits after this iteration.
+            consumer._running = False
+            raise TimeoutError
+
+        mock_kafka = AsyncMock()
+        consumer._consumer = mock_kafka
+
+        with patch(
+            "omnibase_infra.services.observability.agent_actions.consumer.asyncio.wait_for",
+            side_effect=_wait_for_side_effect,
+        ):
+            await consumer._consume_loop(uuid4())
+
+        # After the TimeoutError iteration, last_poll_at must have been updated.
+        assert consumer.metrics.last_poll_at is not None, (
+            "record_polled() was not called during TimeoutError — "
+            "health check will report DEGRADED during Kafka reconnect (OMN-3430)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_poll_staleness_not_triggered_during_kafka_timeout(
+        self, consumer: AgentActionsConsumer
+    ) -> None:
+        """Health stays non-DEGRADED even after repeated poll timeouts (OMN-3430).
+
+        Verifies end-to-end: after a sequence of getmany() TimeoutErrors,
+        _determine_health_status does NOT return DEGRADED due to poll staleness
+        because record_polled() keeps last_poll_at fresh.
+
+        This tests the full chain: TimeoutError → record_polled() → fresh
+        last_poll_at → health check passes staleness check → not DEGRADED.
+        """
+        consumer._running = True
+
+        iteration = 0
+
+        async def _wait_for_side_effect(coro: object, timeout: float) -> object:
+            nonlocal iteration
+            iteration += 1
+            # Stop the loop after 3 iterations to keep the test fast.
+            if iteration >= 3:
+                consumer._running = False
+            raise TimeoutError
+
+        mock_kafka = AsyncMock()
+        consumer._consumer = mock_kafka
+
+        with patch(
+            "omnibase_infra.services.observability.agent_actions.consumer.asyncio.wait_for",
+            side_effect=_wait_for_side_effect,
+        ):
+            await consumer._consume_loop(uuid4())
+
+        # Confirm last_poll_at is fresh (within poll_staleness threshold).
+        assert consumer.metrics.last_poll_at is not None
+        now = datetime.now(UTC)
+        poll_age = (now - consumer.metrics.last_poll_at).total_seconds()
+        assert poll_age < consumer._config.health_check_poll_staleness_seconds, (
+            f"last_poll_at is {poll_age:.1f}s old, exceeds staleness threshold "
+            f"{consumer._config.health_check_poll_staleness_seconds}s"
+        )
+
+        # Health status should NOT be DEGRADED due to poll staleness.
+        metrics_snapshot = await consumer.metrics.snapshot()
+        circuit_state: dict[str, JsonType] = {"state": "closed"}
+        status = consumer._determine_health_status(metrics_snapshot, circuit_state)
+        assert status != EnumHealthStatus.DEGRADED
+
+
 __all__ = [
     "TestMaskDsnPassword",
     "TestTopicModelMapping",
@@ -1318,4 +1430,5 @@ __all__ = [
     "TestConsumerLifecycle",
     "TestCommitOffsets",
     "TestRunMethod",
+    "TestKafkaReconnectHealth",
 ]


### PR DESCRIPTION
## Summary

- **Root cause**: When aiokafka's coordinator dies, `getmany()` blocks until `asyncio.wait_for` fires `TimeoutError`. The `TimeoutError` handler called `continue` without invoking `record_polled()`, leaving `last_poll_at` stale. After `health_check_poll_staleness_seconds` (default 60s), `_determine_health_status` Rule 3 fires: poll staleness → DEGRADED → HTTP 503.
- **Fix**: Call `await self.metrics.record_polled()` inside the `TimeoutError` handler before `continue`. A poll timeout is still a poll attempt — the loop iteration ran. This keeps `last_poll_at` fresh during the aiokafka reconnect window.
- **No change** when Kafka is healthy: the `record_polled()` call after the `wait_for` success path is unchanged.

## Files Changed

- `src/omnibase_infra/services/observability/agent_actions/consumer.py` — 1-line fix in `_consume_loop` `TimeoutError` handler
- `src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py` — 2 new regression tests in `TestKafkaReconnectHealth`

## Test Plan

- [x] `TestKafkaReconnectHealth::test_record_polled_called_on_timeout` — verifies `last_poll_at` is set even when all `wait_for` calls raise `TimeoutError`
- [x] `TestKafkaReconnectHealth::test_poll_staleness_not_triggered_during_kafka_timeout` — verifies repeated timeouts do not cause `_determine_health_status` to return `DEGRADED` due to poll staleness
- [x] All 190 existing tests pass
- [x] Pre-commit hooks pass (ruff, mypy, ONEX validators)

## Linear

Fixes OMN-3430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where polling events were not being properly recorded during timeout scenarios, preventing accurate monitoring and potentially triggering false health degradation alerts.

* **Tests**
  * Added regression tests to verify proper poll event recording during timeout events and ensure health status remains accurate during connection recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->