### PR TITLE
fix(registration): wire TimeoutCoordinator into HandlerRuntimeTick [OMN-3441]

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
@@ -66,6 +66,9 @@ from omnibase_infra.utils import (
 )
 
 if TYPE_CHECKING:
+    from omnibase_infra.nodes.node_registration_orchestrator.timeout_coordinator import (
+        TimeoutCoordinator,
+    )
     from omnibase_infra.protocols.protocol_snapshot_publisher import (
         ProtocolSnapshotPublisher,
     )
@@ -97,6 +100,9 @@ class HandlerRuntimeTick:
         _projection_reader: Reader for registration projection state.
         _reducer: Pure-function service for timeout decisions.
         _snapshot_publisher: Optional publisher for tombstone snapshots.
+        _timeout_coordinator: Optional coordinator for timeout emission with
+            marker stamping. When present, replaces the legacy inline
+            timeout-detection path.
 
     Example:
         >>> from datetime import datetime, timezone
@@ -126,6 +132,7 @@ class HandlerRuntimeTick:
         projection_reader: ProjectionReaderRegistration,
         reducer: RegistrationReducerService,
         snapshot_publisher: ProtocolSnapshotPublisher | None = None,
+        timeout_coordinator: TimeoutCoordinator | None = None,
     ) -> None:
         """Initialize the handler with a projection reader and reducer service.
 
@@ -135,10 +142,16 @@ class HandlerRuntimeTick:
             snapshot_publisher: Optional ProtocolSnapshotPublisher for publishing
                 tombstones when nodes expire. If None, tombstone publishing is skipped.
                 Tombstone publishing is always best-effort and non-blocking.
+            timeout_coordinator: Optional TimeoutCoordinator for emitting timeout
+                events and stamping ack_timeout_emitted_at markers. When provided,
+                the coordinator path is taken and events=() is returned (coordinator
+                already published; no double-publish). When None, the legacy inline
+                timeout-detection path is used.
         """
         self._projection_reader = projection_reader
         self._reducer = reducer
         self._snapshot_publisher = snapshot_publisher
+        self._timeout_coordinator = timeout_coordinator
 
     @property
     def handler_id(self) -> str:
@@ -214,6 +227,26 @@ class HandlerRuntimeTick:
             correlation_id=correlation_id,
         )
         validate_timezone_aware_with_context(now, ctx)
+
+        # Coordinator path: delegate to TimeoutCoordinator when wired.
+        # Single side-effecting operation (best-effort, at-least-once).
+        # Emitter stamps ack_timeout_emitted_at only after publish success.
+        # events=() is mandatory here — coordinator already published; no double-publish.
+        if self._timeout_coordinator is not None:
+            await self._timeout_coordinator.coordinate(tick, domain="registration")
+            processing_time_ms = (time.perf_counter() - start_time) * 1000
+            return ModelHandlerOutput(
+                input_envelope_id=envelope.envelope_id,
+                correlation_id=correlation_id,
+                handler_id=self.handler_id,
+                node_kind=self.node_kind,
+                events=(),
+                intents=(),
+                projections=(),
+                result=None,
+                processing_time_ms=processing_time_ms,
+                timestamp=now,
+            )
 
         # 1. Query overdue projections (I/O stays in handler)
         overdue_ack = await self._projection_reader.get_overdue_ack_registrations(

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -894,6 +894,7 @@ class PluginRegistration:
                 projector=self._projector,
                 consul_handler=self._consul_handler,
                 snapshot_publisher=self._snapshot_publisher,
+                event_bus=config.event_bus,
                 correlation_id=correlation_id,
             )
             duration = time.time() - start_time

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     import asyncpg
 
     from omnibase_core.container import ModelONEXContainer
+    from omnibase_core.protocols.event_bus.protocol_event_bus import ProtocolEventBus
     from omnibase_infra.handlers.handler_consul import HandlerConsul
     from omnibase_infra.nodes.node_registration_orchestrator.handlers import (
         HandlerNodeHeartbeat,
@@ -550,6 +551,7 @@ async def wire_registration_handlers(
     projector: ProjectorShell | None = None,
     consul_handler: HandlerConsul | None = None,
     snapshot_publisher: ProtocolSnapshotPublisher | None = None,
+    event_bus: ProtocolEventBus | None = None,
     correlation_id: UUID | None = None,
 ) -> WiringResult:
     """Register registration orchestrator handlers with the container.
@@ -571,6 +573,11 @@ async def wire_registration_handlers(
         snapshot_publisher: Optional ProtocolSnapshotPublisher for publishing
             compacted snapshots to Kafka. If provided, handlers will publish
             snapshots after state transitions (best-effort, non-blocking).
+        event_bus: Optional ProtocolEventBus for timeout event emission.
+            When provided along with projector, wires TimeoutCoordinator into
+            HandlerRuntimeTick so ack_timeout_emitted_at is stamped after each
+            timeout emission (prevents re-detection on every RuntimeTick).
+            When None, HandlerRuntimeTick uses the legacy inline path.
         correlation_id: Optional correlation ID for error tracking. If not provided,
             one will be auto-generated when errors are raised.
 
@@ -686,10 +693,40 @@ async def wire_registration_handlers(
         services_registered.append("HandlerNodeIntrospected")
         logger.debug("Registered HandlerNodeIntrospected in container")
 
+        # Wire TimeoutCoordinator when both event_bus and projector are available.
+        # Without event_bus, ack_timeout_emitted_at cannot be stamped after publish,
+        # so the coordinator path is skipped and the legacy inline path is used.
+        timeout_coordinator = None
+        if event_bus is not None and projector is not None:
+            from omnibase_infra.nodes.node_registration_orchestrator.timeout_coordinator import (
+                TimeoutCoordinator,
+            )
+            from omnibase_infra.services import (
+                ServiceTimeoutEmitter,
+                ServiceTimeoutScanner,
+            )
+
+            _scanner = ServiceTimeoutScanner(
+                container=container,
+                projection_reader=projection_reader,
+            )
+            _emitter = ServiceTimeoutEmitter(
+                container=container,
+                timeout_query=_scanner,
+                event_bus=event_bus,
+                projector=projector,
+            )
+            timeout_coordinator = TimeoutCoordinator(
+                timeout_query=_scanner,
+                timeout_emission=_emitter,
+            )
+            logger.debug("TimeoutCoordinator wired into HandlerRuntimeTick")
+
         handler_runtime_tick = HandlerRuntimeTick(
             projection_reader,
             reducer=reducer,
             snapshot_publisher=snapshot_publisher,
+            timeout_coordinator=timeout_coordinator,
         )
         await container.service_registry.register_instance(
             interface=HandlerRuntimeTick,

--- a/tests/unit/nodes/node_registration_orchestrator/test_handler_runtime_tick.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_handler_runtime_tick.py
@@ -541,6 +541,86 @@ class TestHandlerRuntimeTickInjectedNow:
         assert output.events[0].emitted_at == custom_now
 
 
+class TestHandlerRuntimeTickTimeoutCoordinator:
+    """Test that handler delegates to TimeoutCoordinator when wired."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_handler_delegates_to_coordinator_and_returns_no_events(
+        self,
+    ) -> None:
+        """Given a HandlerRuntimeTick wired with a TimeoutCoordinator,
+        When handle() is called,
+        Then coordinator.coordinate() is called with tick and domain='registration',
+        And output.events == () (coordinator already published; no double-publish),
+        And output.intents == ().
+        """
+        from omnibase_infra.nodes.node_registration_orchestrator.timeout_coordinator import (
+            ModelTimeoutCoordinationResult,
+            TimeoutCoordinator,
+        )
+
+        mock_reader = create_mock_projection_reader()
+        coordinator = AsyncMock(spec=TimeoutCoordinator)
+        tick = create_runtime_tick(now=TEST_NOW)
+        coordinator.coordinate.return_value = ModelTimeoutCoordinationResult(
+            tick_id=tick.tick_id,
+            tick_now=TEST_NOW,
+            ack_timeouts_found=0,
+            liveness_expirations_found=0,
+            ack_timeouts_emitted=0,
+            liveness_expirations_emitted=0,
+            markers_updated=0,
+            coordination_time_ms=1.0,
+            query_time_ms=0.5,
+            emission_time_ms=0.5,
+            success=True,
+        )
+        handler = HandlerRuntimeTick(
+            mock_reader, _DEFAULT_REDUCER, timeout_coordinator=coordinator
+        )
+        envelope = create_envelope(
+            tick, now=TEST_NOW, correlation_id=tick.correlation_id
+        )
+
+        output = await handler.handle(envelope)
+
+        # domain passed explicitly — no reliance on default
+        coordinator.coordinate.assert_awaited_once_with(tick, domain="registration")
+        # coordinator already published; no double-publish
+        assert output.events == ()
+        assert output.intents == ()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_handler_without_coordinator_uses_legacy_path(self) -> None:
+        """Given a HandlerRuntimeTick without TimeoutCoordinator (coordinator=None),
+        When handle() is called with an overdue ack,
+        Then legacy path executes and events are returned normally.
+        """
+        mock_reader = create_mock_projection_reader()
+        node_id = uuid4()
+        overdue_projection = create_projection(
+            entity_id=node_id,
+            state=EnumRegistrationState.AWAITING_ACK,
+            ack_deadline=TEST_NOW - timedelta(minutes=5),
+            ack_timeout_emitted_at=None,
+        )
+        mock_reader.get_overdue_ack_registrations.return_value = [overdue_projection]
+
+        # No timeout_coordinator — legacy path
+        handler = HandlerRuntimeTick(mock_reader, _DEFAULT_REDUCER)
+        tick = create_runtime_tick(now=TEST_NOW)
+        envelope = create_envelope(
+            tick, now=TEST_NOW, correlation_id=tick.correlation_id
+        )
+
+        output = await handler.handle(envelope)
+
+        assert len(output.events) == 1
+        assert isinstance(output.events[0], ModelNodeRegistrationAckTimedOut)
+
+
 class TestHandlerRuntimeTickTimezoneValidation:
     """Test that handler validates timezone-awareness of envelope timestamp."""
 


### PR DESCRIPTION
## Summary

Wires `TimeoutCoordinator` into `HandlerRuntimeTick` so `ack_timeout_emitted_at` is stamped after each timeout emission. Without this, every RuntimeTick re-detects the same 116 expired nodes.

**Ticket**: [OMN-3441](https://linear.app/omninode/issue/OMN-3441)
**Epic**: OMN-3440 — Registration Lifecycle Fix: Timeout Marker + Auto-ACK

## Changes

- `handler_runtime_tick.py`: Add optional `timeout_coordinator: TimeoutCoordinator | None = None` param. When present, `handle()` delegates to `coordinator.coordinate(tick, domain="registration")` and returns `events=()` (coordinator already published — no double-publish). Legacy inline path preserved when `None`.
- `wiring.py`: Add optional `event_bus: ProtocolEventBus | None = None` param to `wire_registration_handlers()`. When both `event_bus` and `projector` are provided, wires `ServiceTimeoutScanner` + `ServiceTimeoutEmitter` + `TimeoutCoordinator` and passes it to `HandlerRuntimeTick`.
- `plugin.py`: Pass `config.event_bus` to `wire_registration_handlers()`.
- `test_handler_runtime_tick.py`: Add `TestHandlerRuntimeTickTimeoutCoordinator` with 2 tests verifying coordinator delegation and legacy path backward compatibility.

## Key Invariant

When coordinator path is taken, `events=()` is mandatory. Returning events causes double-publish. Tests enforce this invariant.

## Test Results

```
335 passed, 9 warnings in 0.47s
```

All pre-existing tests pass (coordinator is `None` in existing tests — no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional timeout coordination system enabling more flexible timeout emission handling in registration operations while maintaining backward compatibility with existing timeout detection flows.

* **Tests**
  * Added unit tests validating timeout coordinator delegation and legacy timeout detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->