### PR TITLE
fix(tests): isolate config_prefetcher from host env; fix integration-test environment string

### DIFF
--- a/tests/integration/event_bus/test_adapter_protocol_event_publisher_kafka.py
+++ b/tests/integration/event_bus/test_adapter_protocol_event_publisher_kafka.py
@@ -114,7 +114,7 @@ async def kafka_event_bus(
 
     config = ModelKafkaEventBusConfig(
         bootstrap_servers=kafka_bootstrap_servers,
-        environment="integration-test",
+        environment="local",
         timeout_seconds=TEST_TIMEOUT_SECONDS,
         max_retry_attempts=2,
         retry_backoff_base=0.5,

--- a/tests/integration/event_bus/test_dlq_integration.py
+++ b/tests/integration/event_bus/test_dlq_integration.py
@@ -118,7 +118,7 @@ async def kafka_event_bus_with_dlq(
     # Create config with DLQ enabled
     config = ModelKafkaEventBusConfig(
         bootstrap_servers=kafka_bootstrap_servers,
-        environment="dlq-integration-test",
+        environment="local",
         timeout_seconds=TEST_TIMEOUT_SECONDS,
         max_retry_attempts=2,  # Low retry count for faster testing
         retry_backoff_base=0.1,  # Fast backoff for testing

--- a/tests/integration/event_bus/test_kafka_event_bus_integration.py
+++ b/tests/integration/event_bus/test_kafka_event_bus_integration.py
@@ -98,7 +98,7 @@ async def kafka_event_bus(
 
     config = ModelKafkaEventBusConfig(
         bootstrap_servers=kafka_bootstrap_servers,
-        environment="integration-test",
+        environment="local",
         timeout_seconds=TEST_TIMEOUT_SECONDS,
         max_retry_attempts=2,
         retry_backoff_base=0.5,

--- a/tests/integration/runtime/test_kafka_contract_source_integration.py
+++ b/tests/integration/runtime/test_kafka_contract_source_integration.py
@@ -142,7 +142,7 @@ async def kafka_event_bus(
 
     config = ModelKafkaEventBusConfig(
         bootstrap_servers=kafka_bootstrap_servers,
-        environment="integration-test",
+        environment="local",
         group="test-contract-source",
         timeout_seconds=30,
         max_retry_attempts=2,

--- a/tests/integration/services/mcp/test_service_mcp_tool_sync.py
+++ b/tests/integration/services/mcp/test_service_mcp_tool_sync.py
@@ -265,7 +265,7 @@ async def kafka_event_bus(
 
     config = ModelKafkaEventBusConfig(
         bootstrap_servers=kafka_bootstrap_servers,
-        environment="integration-test",
+        environment="local",
         group="mcp-sync-test",
         timeout_seconds=TEST_TIMEOUT_SECONDS,
         max_retry_attempts=2,

--- a/tests/unit/runtime/config_discovery/test_config_prefetcher.py
+++ b/tests/unit/runtime/config_discovery/test_config_prefetcher.py
@@ -88,8 +88,21 @@ class TestConfigPrefetcher:
             contract_paths=(Path("/test/contract.yaml"),),
         )
 
-    def test_prefetch_database_keys(self) -> None:
+    def test_prefetch_database_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should prefetch database transport keys."""
+        # Remove all DATABASE transport keys from the environment so the
+        # prefetcher is forced to call the handler rather than short-circuiting
+        # via the "already in os.environ" fast-path (which would resolve to
+        # whatever the host machine has set, not the mock value).
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        for key in TransportConfigMap.keys_for_transport(
+            EnumInfraTransportType.DATABASE
+        ):
+            monkeypatch.delenv(key, raising=False)
+
         handler = self._make_handler(secrets={"POSTGRES_HOST": "db.example.com"})
         prefetcher = ConfigPrefetcher(handler=handler)
         reqs = self._make_requirements(
@@ -102,8 +115,20 @@ class TestConfigPrefetcher:
         assert "POSTGRES_HOST" in result.resolved
         assert result.resolved["POSTGRES_HOST"].get_secret_value() == "db.example.com"
 
-    def test_prefetch_missing_keys(self) -> None:
+    def test_prefetch_missing_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should report missing keys when handler returns None."""
+        # Remove all DATABASE transport keys from the environment so none of
+        # them get resolved via the env fast-path — they should all go through
+        # the handler (which returns None) and land in result.missing.
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        for key in TransportConfigMap.keys_for_transport(
+            EnumInfraTransportType.DATABASE
+        ):
+            monkeypatch.delenv(key, raising=False)
+
         handler = self._make_handler(secrets={})
         prefetcher = ConfigPrefetcher(handler=handler)
         reqs = self._make_requirements(


### PR DESCRIPTION
## Summary

Fixes two independent pre-existing test failures that were surfaced during OMN-3431 work (related: #557).

- **`test_prefetch_database_keys` / `test_prefetch_missing_keys`**: `ConfigPrefetcher` has an env-override fast-path — if a key is already in `os.environ` it skips the mock entirely. The developer shell inherits `POSTGRES_HOST=localhost` (and other DATABASE-transport keys) from `~/.omnibase/.env`, causing both tests to fail silently. Fix: `monkeypatch.delenv()` all DATABASE-transport keys before constructing the prefetcher, matching the pattern already used by `test_prefetch_env_override`.

- **`environment 'integration-test' is not a valid Kafka environment`**: Five integration-test files passed `"integration-test"` or `"dlq-integration-test"` as `environment` to `ModelKafkaEventBusConfig`, which validates against `EnumKafkaEnvironment` (`{dev, local, staging, prod}`). This caused all tests in those files to ERROR at setup. Fix: replace all five occurrences with `"local"`.

## Files Changed

| File | Change |
|------|--------|
| `tests/unit/runtime/config_discovery/test_config_prefetcher.py` | Add `monkeypatch.delenv()` isolation for `test_prefetch_database_keys` and `test_prefetch_missing_keys` |
| `tests/integration/event_bus/test_kafka_event_bus_integration.py` | `"integration-test"` → `"local"` |
| `tests/integration/event_bus/test_adapter_protocol_event_publisher_kafka.py` | `"integration-test"` → `"local"` |
| `tests/integration/event_bus/test_dlq_integration.py` | `"dlq-integration-test"` → `"local"` |
| `tests/integration/runtime/test_kafka_contract_source_integration.py` | `"integration-test"` → `"local"` |
| `tests/integration/services/mcp/test_service_mcp_tool_sync.py` | `"integration-test"` → `"local"` |

## Risk

**Low** — test-only changes. No production code modified.

## Test Evidence

```
# Unit tests: all 70 pass
uv run pytest tests/unit/runtime/config_discovery/ -v
# → 70 passed

# Integration test collection: 2084 collected, 0 errors (previously all ERRORed at setup)
uv run pytest tests/integration/ --co -q
# → 2084 tests collected
```

## Rollback

Revert this commit. No runtime impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Kafka event bus test configurations to use consistent local environment settings across multiple integration tests.
  * Enhanced test isolation by explicitly managing environment variables in unit tests to prevent unintended state carryover between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->