### PR TITLE
ops(registration): expose ONEX_REGISTRATION_AUTO_ACK to runtime containers [OMN-3446]

### DIFF
--- a/tests/unit/nodes/node_registration_orchestrator/test_handler_node_introspected.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_handler_node_introspected.py
@@ -247,9 +247,9 @@ class TestHandlerNodeIntrospectedSkipsBlockingStates:
 
         assert isinstance(output, ModelHandlerOutput)
         assert len(output.events) == 0, f"Expected no events for state {blocking_state}"
-        assert (
-            len(output.intents) == 0
-        ), f"Expected no intents for state {blocking_state}"
+        assert len(output.intents) == 0, (
+            f"Expected no intents for state {blocking_state}"
+        )
 
 
 class TestHandlerNodeIntrospectedRetriableStates:
@@ -831,9 +831,9 @@ class TestCapabilitiesJsonbCompatibility:
         caps = record["data"]["capabilities"]
 
         # asyncpg JSONB codec expects a Python dict, not a JSON string
-        assert isinstance(
-            caps, dict
-        ), f"Expected dict for JSONB, got {type(caps).__name__}: {caps!r}"
+        assert isinstance(caps, dict), (
+            f"Expected dict for JSONB, got {type(caps).__name__}: {caps!r}"
+        )
 
         # Verify the dict contains expected capability fields
         assert caps.get("postgres") is True


### PR DESCRIPTION
## Summary

- Adds `ONEX_REGISTRATION_AUTO_ACK: ${ONEX_REGISTRATION_AUTO_ACK:-}` to the `x-runtime-env` anchor in `docker-compose.infra.yml` so the flag reaches `omninode-runtime` (and all runtime-profile containers) when set in `~/.omnibase/.env`
- Stacked on OMN-3444 (#558); includes all OMN-3444 changes

## Note: stacked PR

This PR is based on the OMN-3444 branch. It includes all OMN-3444 commits plus the single OMN-3446 commit (docker-compose env var exposure). Merge OMN-3444 (#558) first, then this PR will show only the docker-compose change.

## Verification

**What passed:**
- Pre-commit hooks: all pass
- 337 registration orchestrator unit tests pass
- 2 auto-ack dispatcher tests pass (from OMN-3444)
- No new test failures (11 pre-existing on both main and branch)
- `registration_projections` table: confirmed exists
- 116 nodes in `awaiting_ack` (expected — pre-OMN-3441 stuck nodes)
- Container rebuilt with OMN-3446 code; registration plugin wires and attests (3/3 checks)

**Infrastructure blockers for full live E2E:**
1. Kafka: `192.168.86.200:29092` unreachable (M2 Ultra Redpanda down)
2. Intelligence schema mismatch: `omninode-intelligence==0.9.1` kills kernel with `SchemaFingerprintMismatchError`

Both are pre-existing. `expired_with_null_marker = 116` until infra is restored.

## Test plan

- [x] `uv run pre-commit run --all-files` — all pass
- [x] `uv run pytest tests/unit/nodes/node_registration_orchestrator/ -m unit` — 337 passed
- [x] `uv run pytest tests/unit/nodes/node_registration_orchestrator/test_dispatcher_node_introspected.py` — 2 passed
- [x] `uv run pytest tests/unit/ -m unit --tb=no -q` — same 11 pre-existing failures as main
- [ ] Live E2E invariant check — blocked by pre-existing infra issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable runtime environment option for node registration auto-acknowledgment in Docker Compose infrastructure configuration (disabled by default).
  * Refactored test assertions for improved readability and expanded test coverage for registration handler scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->