### PR TITLE
fix(monitor): pass VALKEY_PASSWORD to redis.Redis for dedup auth

### DIFF
--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -32,6 +32,7 @@
 #   VALKEY_HOST        -- Valkey/Redis host for dedup (default: localhost)
 #   VALKEY_PORT        -- Valkey/Redis port for dedup (default: 16379)
 #   VALKEY_DB          -- Valkey/Redis database index (default: 0)
+#   VALKEY_PASSWORD    -- Valkey/Redis password for authentication (required when auth is enabled)
 
 from __future__ import annotations
 
@@ -405,10 +406,12 @@ class PostgresErrorEmitter:
             valkey_host = os.environ.get("VALKEY_HOST", "localhost")
             valkey_port = int(os.environ.get("VALKEY_PORT", "16379"))
             valkey_db = int(os.environ.get("VALKEY_DB", "0"))
+            valkey_password = os.environ.get("VALKEY_PASSWORD")
             self._valkey = redis.Redis(
                 host=valkey_host,
                 port=valkey_port,
                 db=valkey_db,
+                password=valkey_password,
                 socket_timeout=5,
                 decode_responses=True,
             )


### PR DESCRIPTION
## Summary

- `PostgresErrorEmitter._init_clients()` constructed the Valkey (`redis.Redis`) client without passing `password=`, causing every auth attempt to silently fail with an `AUTH` error
- Because the connection failed, dedup keys could never be written or read from Valkey, so every postgres ERROR block re-emitted a Kafka event on each occurrence instead of being deduplicated after the first publish
- Fix reads `VALKEY_PASSWORD` from the environment and passes it as `password=` to `redis.Redis()`; when the var is `None` (local dev without auth), the redis library omits AUTH automatically so those setups are unaffected

## Changes

- `scripts/monitor_logs.py`: add `valkey_password = os.environ.get("VALKEY_PASSWORD")` and `password=valkey_password` to the `redis.Redis(...)` constructor
- `scripts/monitor_logs.py`: document `VALKEY_PASSWORD` in the script-level optional env var comment block

## Test plan

- [ ] Run `monitor_logs.py --dry-run` against a live postgres container with `VALKEY_PASSWORD` set — confirm the Valkey client connects and dedup check succeeds (no auth errors in stderr)
- [ ] Run without `VALKEY_PASSWORD` set (local dev) — confirm script starts normally and Valkey still connects (no password)
- [ ] Trigger a repeated postgres ERROR — confirm only one Kafka event is emitted; subsequent occurrences within the 24-hour TTL window are silently suppressed

Closes OMN-3407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added password authentication support for Redis/Valkey connections via environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->