### PR TITLE
feat(infra): wire NodeBaselinesBatchCompute to daily scheduler [OMN-3335]

### DIFF
--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+#
+# baselines-scheduler.yml — Daily Baselines & ROI computation
+#
+# Invokes NodeBaselinesBatchCompute once per day on the self-hosted runner
+# (which has access to the local PostgreSQL and Kafka/Redpanda instances).
+# Emits a baselines-computed.v1 event that the omnidash read-model consumer
+# picks up to populate baselines_snapshots and make the Baselines & ROI
+# dashboard Live.
+#
+# Requirements (self-hosted runner environment):
+#   OMNIBASE_INFRA_DB_URL  — set in ~/.omnibase/.env (runner picks up via env)
+#   KAFKA_BOOTSTRAP_SERVERS — defaults to localhost:19092 in the script
+#
+# Ticket: OMN-3335
+
+name: Baselines Scheduler
+
+on:
+  schedule:
+    # Daily at 06:00 UTC (before business hours)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip Kafka emission (set KAFKA_BOOTSTRAP_SERVERS to empty)'
+        required: false
+        default: 'false'
+
+env:
+  UV_VERSION: "0.8.3"
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  baselines-compute:
+    name: Baselines Batch Compute
+    # Self-hosted runner required: needs PostgreSQL and Kafka access
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run baselines batch compute
+        env:
+          # OMNIBASE_INFRA_DB_URL is sourced from the runner's shell environment
+          # (populated from ~/.omnibase/.env by the runner's session startup).
+          # KAFKA_BOOTSTRAP_SERVERS defaults to localhost:19092 in the script.
+          KAFKA_BOOTSTRAP_SERVERS: ${{ github.event.inputs.dry_run == 'true' && '' || 'localhost:19092' }}
+        run: |
+          source ~/.omnibase/.env 2>/dev/null || true
+          uv run python scripts/run_baselines_batch_compute.py
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## Baselines Batch Compute (OMN-3335)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Ran NodeBaselinesBatchCompute to populate Baselines & ROI dashboard." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Topic: \`onex.evt.omnibase-infra.baselines-computed.v1\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Tables populated: \`baselines_snapshots\`, \`baselines_comparisons\`, \`baselines_trend\`, \`baselines_breakdown\`" >> $GITHUB_STEP_SUMMARY

--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""One-shot runner for NodeBaselinesBatchCompute.
+
+Connects to PostgreSQL and Kafka, runs the 3-phase baselines batch computation,
+emits a baselines-computed snapshot event, then exits.
+
+Intended to be invoked by a scheduler (cron, GitHub Actions) rather than running
+as a long-lived service.
+
+Usage:
+    uv run python scripts/run_baselines_batch_compute.py
+
+Environment Variables:
+    OMNIBASE_INFRA_DB_URL (required)
+        Full PostgreSQL DSN, e.g.:
+        postgresql://postgres:pass@localhost:5436/omnibase_infra
+
+    KAFKA_BOOTSTRAP_SERVERS (optional, default: localhost:19092)
+        Kafka bootstrap address. Set to empty string to skip event emission
+        (DB computation still runs, but no baselines-computed event is emitted).
+
+Exit Codes:
+    0  Success
+    1  Configuration or runtime error
+
+Ticket: OMN-3335
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from uuid import uuid4
+
+import asyncpg
+from aiokafka import AIOKafkaProducer
+from aiokafka.errors import KafkaError
+
+from omnibase_infra.nodes.node_baselines_batch_compute.handlers.handler_baselines_batch_compute import (
+    HandlerBaselinesBatchCompute,
+)
+from omnibase_infra.nodes.node_baselines_batch_compute.models.model_baselines_batch_compute_command import (
+    ModelBaselinesBatchComputeCommand,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("run_baselines_batch_compute")
+
+
+def _make_publisher(
+    producer: AIOKafkaProducer,
+) -> HandlerBaselinesBatchCompute.ProtocolPublisher:  # type: ignore[attr-defined]
+    """Wrap AIOKafkaProducer as the ProtocolPublisher callable expected by the handler."""
+
+    async def publish(
+        event_type: str,
+        payload: object,
+        topic: str | None,
+        correlation_id: object,
+        **kwargs: object,
+    ) -> bool:
+        if topic is None:
+            logger.warning("publish called with topic=None, skipping emission")
+            return False
+        body = json.dumps(
+            {
+                "event_type": event_type,
+                "payload": payload,
+                "correlation_id": str(correlation_id),
+            }
+        ).encode("utf-8")
+        await producer.send_and_wait(topic, body)
+        logger.info("Emitted event %s to topic %s", event_type, topic)
+        return True
+
+    return publish  # type: ignore[return-value]
+
+
+async def _run() -> int:
+    db_url = os.environ.get("OMNIBASE_INFRA_DB_URL", "").strip()
+    if not db_url:
+        logger.error("OMNIBASE_INFRA_DB_URL is required but not set")
+        return 1
+
+    kafka_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092").strip()
+    use_kafka = bool(kafka_servers)
+
+    correlation_id = uuid4()
+    logger.info(
+        "Starting baselines batch compute run (correlation_id=%s)", correlation_id
+    )
+
+    pool: asyncpg.Pool | None = None
+    producer: AIOKafkaProducer | None = None
+
+    try:
+        pool = await asyncpg.create_pool(
+            db_url, min_size=1, max_size=3, command_timeout=60
+        )
+
+        publisher = None
+        if use_kafka:
+            producer = AIOKafkaProducer(
+                bootstrap_servers=kafka_servers,
+                acks="all",
+                enable_idempotence=True,
+            )
+            try:
+                await producer.start()
+                publisher = _make_publisher(producer)
+                logger.info("Kafka producer connected to %s", kafka_servers)
+            except KafkaError:
+                logger.warning(
+                    "Kafka unavailable (%s) — computation will run but no event emitted",
+                    kafka_servers,
+                    exc_info=True,
+                )
+                producer = None
+
+        handler = HandlerBaselinesBatchCompute(pool=pool, publisher=publisher)
+        command = ModelBaselinesBatchComputeCommand(correlation_id=correlation_id)
+        result = await handler.handle(command)
+
+        logger.info(
+            "Baselines computation complete: comparisons=%d trend=%d breakdown=%d snapshot_emitted=%s",
+            result.result.comparisons_rows,
+            result.result.trend_rows,
+            result.result.breakdown_rows,
+            result.snapshot_emitted,
+        )
+
+        if result.result.has_errors:
+            logger.warning("Computation finished with errors: %s", result.result.errors)
+            return 1
+
+        return 0
+
+    except Exception:
+        logger.exception("Baselines batch compute failed")
+        return 1
+
+    finally:
+        if producer is not None:
+            await producer.stop()
+        if pool is not None:
+            await pool.close()
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_run()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/run_baselines_batch_compute.py`: async one-shot runner that creates an asyncpg pool, wraps AIOKafkaProducer as `ProtocolPublisher`, and calls `HandlerBaselinesBatchCompute.handle()`. Kafka failure is non-fatal.
- Adds `.github/workflows/baselines-scheduler.yml`: runs daily at 06:00 UTC on self-hosted runners (which have PostgreSQL and Kafka access); supports `workflow_dispatch` for on-demand runs.

## Problem

`NodeBaselinesBatchCompute` was implemented and tested (OMN-3039) but never had an invocation path. The `baselines_snapshots`, `baselines_comparisons`, `baselines_trend`, and `baselines_breakdown` tables were always empty, keeping the omnidash Baselines & ROI dashboard Offline.

## How it works

1. GH Action triggers daily → runs `scripts/run_baselines_batch_compute.py`
2. Script reads from `agent_routing_decisions` + `agent_actions`, writes baselines tables
3. Emits `onex.evt.omnibase-infra.baselines-computed.v1` to Kafka
4. omnidash `read-model-consumer.ts` projects into `baselines_snapshots` → dashboard goes Live

## Test plan

- [ ] Run `uv run python scripts/run_baselines_batch_compute.py` locally with `OMNIBASE_INFRA_DB_URL` set
- [ ] Verify `baselines_comparisons` table has rows after run
- [ ] Check Redpanda Console for `onex.evt.omnibase-infra.baselines-computed.v1` event
- [ ] Trigger `workflow_dispatch` on GH Actions and confirm green

Closes OMN-3335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated daily baseline computation at 06:00 UTC with configurable infrastructure support (self-hosted runner with database/event system access or standard cloud fallback) and 15-minute timeout enforcement.
  * Added batch processing capability for baseline calculations with database connectivity and optional event publication for operational monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->