### PR TITLE
ops(infra): document runtime-effects profile requirement for Cost Trends [OMN-3337]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -71,6 +71,24 @@
 #     - intelligence-api: 8053 [runtime profile]
 #     - contract-resolver: 8091 [runtime profile] (OMN-2756 transitional bridge)
 #     - skill-lifecycle-consumer: 8092 [runtime profile] (OMN-2934)
+#
+# Dashboard Requirements (OMN-3337):
+#   Several omnidash dashboards require the runtime profile to be active:
+#
+#   Cost Trends dashboard (llm_cost_aggregates):
+#     Requires: --profile runtime
+#     Producer: runtime-effects (NodeLlmInferenceEffect → ServiceLlmMetricsPublisher)
+#     Topic:    onex.evt.omniintelligence.llm-call-completed.v1
+#     Note: LLM inference calls must be routed through the ONEX node pipeline,
+#           not directly to the LLM endpoint, for cost events to be generated.
+#
+#   Skill Executions dashboard (skill_executions):
+#     Requires: --profile runtime
+#     Producer: skill-lifecycle-consumer (already wired)
+#
+#   To start all runtime services:
+#     docker compose -f docker/docker-compose.infra.yml --profile runtime up -d
+#
 name: omnibase-infra
 # ==========================================================================
 # IMPORTANT: Requires Docker Compose v2.20.0 or later (nested variable expansion).


### PR DESCRIPTION
## Summary

- Adds a **Dashboard Requirements** block to the `docker-compose.infra.yml` header that explains which omnidash dashboards require `--profile runtime` and why.

## Problem

The omnidash Cost Trends dashboard is Offline because `llm_cost_aggregates` is empty. The root cause is that `runtime-effects` (which hosts `NodeLlmInferenceEffect` via `ServiceLlmMetricsPublisher`) is only started when the runtime profile is active. There was no documentation explaining this dependency.

## Fix

Documents the profile requirement in the compose file header so operators know to run:

```bash
docker compose -f docker/docker-compose.infra.yml --profile runtime up -d
```

This starts `omninode-runtime-effects`, which processes LLM inference calls and emits `onex.evt.omniintelligence.llm-call-completed.v1` events. The omnidash `read-model-consumer.ts` projects these into `llm_cost_aggregates`.

## Test plan

- [ ] Start stack with `--profile runtime`
- [ ] Route an LLM inference call through the ONEX pipeline
- [ ] Check `llm_cost_aggregates` table for rows
- [ ] Confirm Cost Trends dashboard shows Live

Closes OMN-3337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced infrastructure setup documentation with detailed guidance on dashboard requirements, runtime-profile configurations, producers, topics, and startup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->