### PR TITLE
feat(ci): ECR CI pipeline for omnibase_infra runtime image (OMN-3519)

### DIFF
--- a/.github/actions/resolve-ecr-digest/action.yml
+++ b/.github/actions/resolve-ecr-digest/action.yml
@@ -1,0 +1,184 @@
+name: 'Resolve ECR Digest'
+description: 'Resolve an ECR image digest from a commit SHA tag with retry logic and validation'
+author: 'OmniNode'
+inputs:
+  commit-sha:
+    description: 'The commit SHA to look up in ECR (full 40-char or short 7-char)'
+    required: true
+  ecr-registry:
+    description: 'ECR registry URL (e.g., 123456789012.dkr.ecr.us-east-1.amazonaws.com)'
+    required: true
+  ecr-repository:
+    description: 'ECR repository name (e.g., omnicloud/core)'
+    required: true
+  aws-region:
+    description: 'AWS region for ECR'
+    required: false
+    default: 'us-east-1'
+  fail-on-missing:
+    description: 'Whether to fail the action if digest is not found (set to "false" for graceful handling)'
+    required: false
+    default: 'true'
+  max-attempts:
+    description: 'Maximum number of retry attempts (default: 5)'
+    required: false
+    default: '5'
+  initial-delay:
+    description: 'Initial delay in seconds before first retry (default: 2)'
+    required: false
+    default: '2'
+  max-delay:
+    description: 'Maximum delay in seconds between retries (default: 60)'
+    required: false
+    default: '60'
+  backoff-factor:
+    description: 'Exponential backoff multiplier (default: 2)'
+    required: false
+    default: '2'
+outputs:
+  digest:
+    description: 'The resolved sha256 digest (empty if not found and fail-on-missing is false)'
+    value: ${{ steps.resolve.outputs.digest }}
+  # Output naming convention: Use underscores (image_ref) not hyphens for consistency
+  # with GitHub Actions best practices (outputs are accessed as steps.<id>.outputs.<name>)
+  # and to avoid issues with bracket notation in workflow references.
+  image_ref:
+    description: 'Full image reference with digest (e.g., registry/repo@sha256:abc123...)'
+    value: ${{ steps.resolve.outputs.image_ref }}
+  found:
+    description: 'Whether the digest was found ("true" or "false")'
+    value: ${{ steps.resolve.outputs.found }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve ECR image digest
+      id: resolve
+      shell: bash
+      env:
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        ECR_REGISTRY: ${{ inputs.ecr-registry }}
+        ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        AWS_REGION: ${{ inputs.aws-region }}
+        FAIL_ON_MISSING: ${{ inputs.fail-on-missing }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        INITIAL_DELAY: ${{ inputs.initial-delay }}
+        MAX_DELAY: ${{ inputs.max-delay }}
+        BACKOFF_FACTOR: ${{ inputs.backoff-factor }}
+        # AWS CLI timeout settings prevent indefinite hangs on network issues
+        AWS_CLI_CONNECT_TIMEOUT: '10'
+        AWS_CLI_READ_TIMEOUT: '30'
+      run: |
+        # Validate commit SHA format (7-40 lowercase hex characters)
+        if [[ ! "$COMMIT_SHA" =~ ^[a-f0-9]{7,40}$ ]]; then
+          echo "::error::Invalid commit SHA format: $COMMIT_SHA"
+          echo "Expected: 7-40 lowercase hex characters"
+          exit 1
+        fi
+
+        # Validate numeric inputs with reasonable upper bounds
+        if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$MAX_ATTEMPTS" -lt 1 ] || [ "$MAX_ATTEMPTS" -gt 20 ]; then
+          echo "::error::Invalid max-attempts: $MAX_ATTEMPTS (must be 1-20)"
+          exit 1
+        fi
+
+        if ! [[ "$INITIAL_DELAY" =~ ^[0-9]+$ ]] || [ "$INITIAL_DELAY" -lt 1 ] || [ "$INITIAL_DELAY" -gt 60 ]; then
+          echo "::error::Invalid initial-delay: $INITIAL_DELAY (must be 1-60 seconds)"
+          exit 1
+        fi
+
+        if ! [[ "$MAX_DELAY" =~ ^[0-9]+$ ]] || [ "$MAX_DELAY" -lt 1 ] || [ "$MAX_DELAY" -gt 300 ]; then
+          echo "::error::Invalid max-delay: $MAX_DELAY (must be 1-300 seconds)"
+          exit 1
+        fi
+
+        if ! [[ "$BACKOFF_FACTOR" =~ ^[0-9]+$ ]] || [ "$BACKOFF_FACTOR" -lt 1 ] || [ "$BACKOFF_FACTOR" -gt 10 ]; then
+          echo "::error::Invalid backoff-factor: $BACKOFF_FACTOR (must be 1-10)"
+          exit 1
+        fi
+
+        echo "Querying ECR for digest of ${ECR_REPOSITORY}:${COMMIT_SHA}..."
+        echo "Configuration: max-attempts=${MAX_ATTEMPTS}, initial-delay=${INITIAL_DELAY}s, max-delay=${MAX_DELAY}s, backoff-factor=${BACKOFF_FACTOR}"
+
+        # Verify repository exists before retry loop
+        echo "Verifying ECR repository exists..."
+        if ! aws ecr describe-repositories \
+            --region "$AWS_REGION" \
+            --repository-names "$ECR_REPOSITORY" 2>&1; then
+          echo "::error::ECR repository '${ECR_REPOSITORY}' does not exist or is not accessible in region ${AWS_REGION}"
+          exit 1
+        fi
+        echo "Repository verified: ${ECR_REPOSITORY}"
+
+        # Query ECR for the image digest with retry logic for eventual consistency
+        DIGEST=""
+        DELAY="$INITIAL_DELAY"
+        for i in $(seq 1 "$MAX_ATTEMPTS"); do
+          echo "Attempt $i/$MAX_ATTEMPTS: Querying ECR for image digest..."
+
+          # Capture both stdout and stderr for proper error logging
+          ECR_OUTPUT=$(aws ecr describe-images \
+            --region "$AWS_REGION" \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=${COMMIT_SHA}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>&1) || true
+
+          # Check if output contains an error
+          if echo "$ECR_OUTPUT" | grep -q "ImageNotFoundException\|error\|Error"; then
+            echo "::debug::ECR query returned: $ECR_OUTPUT"
+            DIGEST=""
+          else
+            DIGEST="$ECR_OUTPUT"
+          fi
+
+          if [[ -n "$DIGEST" && "$DIGEST" != "None" && "$DIGEST" != "null" ]]; then
+            echo "Digest resolved on attempt $i"
+            break
+          fi
+
+          if [[ $i -lt $MAX_ATTEMPTS ]]; then
+            echo "Attempt $i: Image not yet available, waiting ${DELAY}s before retry..."
+            sleep "$DELAY"
+            # Calculate next delay with exponential backoff, capped at max-delay
+            DELAY=$((DELAY * BACKOFF_FACTOR))
+            if [[ $DELAY -gt $MAX_DELAY ]]; then
+              DELAY=$MAX_DELAY
+            fi
+          fi
+        done
+
+        # Handle digest not found
+        if [[ -z "$DIGEST" || "$DIGEST" == "None" || "$DIGEST" == "null" ]]; then
+          if [[ "$FAIL_ON_MISSING" == "true" ]]; then
+            echo "::error::Failed to resolve digest for ${ECR_REPOSITORY}:${COMMIT_SHA} after ${MAX_ATTEMPTS} attempts"
+            echo "Ensure the image was built and pushed to ECR with this commit SHA."
+            exit 1
+          else
+            echo "::warning::Digest not available after ${MAX_ATTEMPTS} attempts"
+            echo "::notice title=Digest Not Found::No image digest available for ${ECR_REPOSITORY}:${COMMIT_SHA}." \
+              "This may be expected if the image hasn't been built yet."
+            echo "digest=" >> $GITHUB_OUTPUT
+            echo "image_ref=" >> $GITHUB_OUTPUT
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        fi
+
+        # Validate digest format (sha256:<64 hex characters>)
+        if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+          echo "::error::Invalid digest format: $DIGEST"
+          echo "Expected format: sha256:<64 hex characters>"
+          exit 1
+        fi
+
+        # Build full image reference
+        IMAGE_REF="${ECR_REGISTRY}/${ECR_REPOSITORY}@${DIGEST}"
+
+        # Set outputs
+        echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+        echo "image_ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
+        echo "found=true" >> $GITHUB_OUTPUT
+
+        # Log success
+        echo "Resolved digest: ${DIGEST}"
+        echo "Full image ref: ${IMAGE_REF}"

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -1,0 +1,218 @@
+# Build and push omnibase_infra runtime image to ECR
+#
+# Triggers on push to main for runtime-related paths.
+# Uses OIDC (no long-lived credentials) to assume omninode-github-actions-role.
+# Pushes to ECR with commit SHA tag; never uses :latest.
+# Outputs image digest for use in Phase 4 kustomize override.
+#
+# ECR repository: 272493677981.dkr.ecr.us-east-1.amazonaws.com/omninode-runtime
+# IAM role: arn:aws:iam::272493677981:role/omninode-github-actions-role
+
+name: Build and push runtime image to ECR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/Dockerfile.runtime'
+      - 'docker/entrypoint-runtime.sh'
+      - 'src/**'
+      - 'contracts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/build-and-push-runtime.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: build-runtime-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REPOSITORY: omninode-runtime
+  UV_VERSION: "0.6.14"
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build-and-push:
+    name: Build and push runtime image
+    runs-on: ubuntu-latest
+    # Timeout breakdown (cold cache worst case):
+    #   Docker build:        ~14 min
+    #   ECR push:            ~5 min
+    #   GHA cache export:    ~15 min
+    #   Total:               ~34 min — 45 min gives comfortable buffer
+    timeout-minutes: 45
+
+    outputs:
+      image_digest: ${{ steps.resolve-digest.outputs.digest }}
+      image_ref: ${{ steps.resolve-digest.outputs.image_ref }}
+      commit_sha: ${{ github.sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+
+      - name: Configure AWS credentials (OIDC -> omninode-github-actions-role)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/omninode-github-actions-role
+          role-session-name: gha-build-push-runtime
+
+      - name: Verify AWS caller identity
+        shell: bash
+        env:
+          AWS_CLI_CONNECT_TIMEOUT: '10'
+          AWS_CLI_READ_TIMEOUT: '30'
+        run: aws sts get-caller-identity
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHA_SHORT="${GITHUB_SHA::7}"
+          echo "sha_short=${SHA_SHORT}" >> $GITHUB_OUTPUT
+          echo "image_repo=${ECR_REGISTRY}/${ECR_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+          # Build tags — commit SHA only (no :latest per DoD)
+          IMAGE_REPO="${ECR_REGISTRY}/${ECR_REPOSITORY}"
+          TAGS="${IMAGE_REPO}:${GITHUB_SHA}"
+          TAGS="${TAGS},${IMAGE_REPO}:${SHA_SHORT}"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Generate build timestamp
+        id: timestamp
+        run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Build runtime image (local)
+        id: build-local
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.runtime
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            RUNTIME_VERSION=${{ github.ref_name }}
+            BUILD_DATE=${{ steps.timestamp.outputs.build_date }}
+            VCS_REF=${{ github.sha }}
+            RUNTIME_SOURCE_HASH=${{ steps.meta.outputs.sha_short }}
+            UV_VERSION=${{ env.UV_VERSION }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          image-ref: '${{ steps.meta.outputs.image_repo }}:${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push image to Amazon ECR
+        if: success()
+        shell: bash
+        run: |
+          echo "Trivy scan passed — pushing image to ECR..."
+          IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
+          for TAG in "${TAGS[@]}"; do
+            echo "Pushing: ${TAG}"
+            docker push "${TAG}"
+          done
+          echo "All tags pushed successfully"
+
+      # ECR eventual consistency: brief delay before digest is resolvable.
+      # The composite action retries with exponential backoff (up to 5 attempts).
+      - name: Resolve ECR image digest for commit SHA
+        id: resolve-digest
+        uses: ./.github/actions/resolve-ecr-digest
+        with:
+          commit-sha: ${{ github.sha }}
+          ecr-registry: ${{ env.ECR_REGISTRY }}
+          ecr-repository: ${{ env.ECR_REPOSITORY }}
+          aws-region: ${{ env.AWS_REGION }}
+          fail-on-missing: 'true'
+
+      - name: Verify digest format
+        shell: bash
+        run: |
+          DIGEST="${{ steps.resolve-digest.outputs.digest }}"
+          if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Digest format invalid: $DIGEST"
+            exit 1
+          fi
+          echo "Digest verified: $DIGEST"
+          echo "Full image ref: ${{ steps.resolve-digest.outputs.image_ref }}"
+
+      - name: Create digest mapping artifact
+        shell: bash
+        run: |
+          mkdir -p ops/digests
+
+          jq -n \
+            --arg sha "$GITHUB_SHA" \
+            --arg sha_short "${{ steps.meta.outputs.sha_short }}" \
+            --arg repo "${{ steps.meta.outputs.image_repo }}" \
+            --arg digest "${{ steps.resolve-digest.outputs.digest }}" \
+            --arg ref "${{ steps.resolve-digest.outputs.image_ref }}" \
+            --arg date "${{ steps.meta.outputs.build_date }}" \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_num "$GITHUB_RUN_NUMBER" \
+            '{
+              commit_sha: $sha,
+              commit_sha_short: $sha_short,
+              image_repo: $repo,
+              image_digest: $digest,
+              image_ref: $ref,
+              build_date: $date,
+              branch: $branch,
+              workflow_run_id: $run_id,
+              workflow_run_number: $run_num
+            }' > ops/digests/build-manifest.json
+
+          echo "Build manifest:"
+          cat ops/digests/build-manifest.json
+
+      - name: Upload digest mapping artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-manifest-${{ github.sha }}
+          path: ops/digests/build-manifest.json
+          retention-days: 90
+
+      - name: Generate build summary
+        if: always()
+        shell: bash
+        run: |
+          echo "# Runtime Image Build Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- Repository: \`${ECR_REGISTRY}/${ECR_REPOSITORY}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit SHA: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Digest: \`${{ steps.resolve-digest.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Full ref: \`${{ steps.resolve-digest.outputs.image_ref }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Platform: linux/amd64" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> Use the digest above (not a tag) for the Phase 4 kustomize image override." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-and-push-runtime.yml`: builds `docker/Dockerfile.runtime`, runs Trivy scan (CRITICAL/HIGH), pushes to ECR `omninode-runtime` with commit SHA tag (never `:latest`), resolves and outputs image digest for Phase 4 kustomize override
- Adds `.github/actions/resolve-ecr-digest/action.yml`: composite action with exponential backoff retry for ECR eventual consistency (copied from `omninode_infra`)

## AWS Resources (applied out-of-band before first run)

| Resource | Status |
|----------|--------|
| ECR repo `omninode-runtime` (272493677981/us-east-1) | Created — IMMUTABLE tags, scan-on-push |
| ECR lifecycle policy | Set — retain last 10 images |
| IAM role trust `omninode-github-actions-role` | Updated — added `OmniNode-ai/omnibase_infra:ref:refs/heads/main` (OIDC StringLike) |
| IAM inline policy `GitHubActionsLeastPrivilege` | Updated — added `arn:aws:ecr:us-east-1:272493677981:repository/omninode-runtime` |

## Definition of Done checklist

- [x] ECR repo `omninode-runtime` exists in `272493677981/us-east-1`
- [x] Lifecycle policy set (retain last 10 images)
- [x] IAM OIDC trust allows `OmniNode-ai/omnibase_infra` on `refs/heads/main`
- [x] `.github/workflows/build-and-push-runtime.yml` created
- [x] Digest output step produces a valid `sha256:` value (via `verify digest format` step)
- [x] Image NOT pushed as `:latest` (tags list uses only `$GITHUB_SHA` and short SHA)

## First run prerequisite

The repo var `AWS_ACCOUNT_ID` must be set in the `OmniNode-ai/omnibase_infra` repository settings (Settings > Secrets and variables > Actions > Variables). Value: `272493677981`.

## Part of

Epic: OMN-3515 (Migrate Local Docker Infrastructure to AWS k3s)
Ticket: OMN-3519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image builds for runtime with integrated security vulnerability scanning and failure controls.
  * Implemented container registry publishing with automated digest resolution and build manifest artifact creation for deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->