### PR TITLE
fix(registration): serialize schema init with advisory lock to prevent deadlock

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -651,7 +651,16 @@ class PluginRegistration:
         try:
             schema_sql = schema_file.read_text()
             async with self._pool.acquire() as conn:
-                await conn.execute(schema_sql)
+                async with conn.transaction():
+                    # Serialize concurrent schema initialization across multiple
+                    # service instances starting simultaneously. Without this lock
+                    # two processes racing to CREATE INDEX IF NOT EXISTS on the same
+                    # table deadlock on catalog-level ShareUpdateExclusiveLock.
+                    # pg_advisory_xact_lock releases automatically at transaction end.
+                    await conn.execute(
+                        "SELECT pg_advisory_xact_lock(hashtext('registration_projection_schema_init'))"
+                    )
+                    await conn.execute(schema_sql)
             logger.info(
                 "Registration projection schema initialized (correlation_id=%s)",
                 correlation_id,


### PR DESCRIPTION
## Summary

- Two service instances starting concurrently both ran `_initialize_schema()` without coordination, racing to execute `CREATE INDEX IF NOT EXISTS` on `registration_projections`
- PostgreSQL deadlocked at the catalog-level `ShareUpdateExclusiveLock` — each process held locks the other needed, in different order across the 8+ index creation statements
- Fix: wrap schema execution in an explicit `conn.transaction()` and acquire `pg_advisory_xact_lock(hashtext('registration_projection_schema_init'))` before running the SQL

## What changed

`plugin.py` `_initialize_schema()`: added `async with conn.transaction()` + `pg_advisory_xact_lock` around the SQL execution.

**Behavior after fix:**
1. First instance acquires the advisory lock and runs schema SQL (creates table + indexes)
2. Second instance blocks on `pg_advisory_xact_lock` until first commits
3. Second instance runs — all `IF NOT EXISTS` clauses return silently, no deadlock
4. Lock releases automatically at transaction end (transaction-level, no manual unlock needed)

## Root cause

```
2026-03-03T20:21:14 ERROR: deadlock detected
  Process 5913 waits for ShareUpdateExclusiveLock on relation 30247; blocked by process 5912.
  Process 5912 waits for ShareUpdateExclusiveLock on relation 30247; blocked by process 5913.
```

Both processes were running the full `schema_registration_projection.sql` in autocommit mode. `CREATE INDEX` requires updating system catalog tables, and with 8+ indexes being created concurrently, the lock ordering creates a circular wait.

## Test plan

- [ ] Unit tests pass (1 pre-existing failure in `test_kernel.py::test_bootstrap_creates_event_bus_with_environment` — unrelated to this change, present on main)
- [ ] Start two service instances simultaneously — no deadlock in PostgreSQL logs
- [ ] Schema initializes correctly on first start
- [ ] Second start (schema already exists) — all `IF NOT EXISTS` succeed silently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential deadlocks that could occur during concurrent schema initialization across multiple service instances, improving deployment reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->