### PR TITLE
feat(infra): add Arize Phoenix service to docker-compose [OMN-3542]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -791,7 +791,7 @@ services:
     environment:
       PHOENIX_WORKING_DIR: /data
     ports:
-      - "6006:6006"
+      - "${PHOENIX_PORT:-6006}:6006"
     volumes:
       - phoenix_data:/data
     networks:

--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -619,6 +619,7 @@ ONEX_OUTPUT_TOPIC=responses
 # Arize Phoenix (LLM observability — OTLP HTTP backend) [OMN-3542]
 # Phoenix runs as a runtime-profile Docker service (omnibase-infra-phoenix).
 # Docker-internal consumers reach it at phoenix:6006; host scripts use localhost:6006.
+# PHOENIX_PORT=6006
 # PHOENIX_OTEL_ENDPOINT=http://localhost:6006/v1/traces
 # PHOENIX_OTEL_ENABLED=true
 


### PR DESCRIPTION
## Summary

- Adds `phoenix` service (`arizephoenix/phoenix:7.6.0`) to `docker-compose.infra.yml` under the `runtime` profile
- Completes OMN-2734's R1 requirement: Phoenix deployed as a local Docker service. The hook-side OTLP exporter landed in omniclaude PR #314; the infra side was never tracked separately.
- Documents `PHOENIX_OTEL_ENDPOINT` and `PHOENIX_OTEL_ENABLED` in `docs/env-example-full.txt`

## Service Details

| Property | Value |
|----------|-------|
| Image | `arizephoenix/phoenix:7.6.0` |
| Container name | `omnibase-infra-phoenix` |
| Port | `6006:6006` |
| Profile | `runtime`, `full` |
| Volume | `phoenix_data:/data` |
| Health check | `curl -sf http://localhost:6006/healthz` |
| Docker-internal | `phoenix:6006` |

## Test Plan

- [ ] `docker compose -f docker/docker-compose.infra.yml --profile runtime up -d phoenix` — service starts cleanly
- [ ] `curl http://localhost:6006/healthz` — returns 200
- [ ] Phoenix UI accessible at `http://localhost:6006`
- [ ] Set `PHOENIX_OTEL_ENABLED=true` in `~/.omnibase/.env` (remove current `=false` workaround), start Claude Code session — spans appear in Phoenix UI
- [ ] `uv run pytest tests/integration/ -k phoenix_otel_export` — passes against running Phoenix

## Notes

- The `PHOENIX_OTEL_ENABLED=false` workaround in `~/.omnibase/.env` (applied as an immediate fix for the session-start `ConnectionRefused` errors) should be removed or set to `true` after this service is running.
- The `phoenix_data` volume persists trace history across restarts.
- Global `~/.claude/CLAUDE.md` service table updated locally (outside this PR's scope).

Closes OMN-3542 | Completes OMN-2734 R1