### PR TITLE
fix(docker): add apt-get upgrade to clear CVEs in Dockerfile.runtime (OMN-3523)

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -98,10 +98,13 @@ ENV PYTHONUNBUFFERED=1 \
     UV_PROJECT_ENVIRONMENT=/app/.venv
 
 # Install system dependencies required for building Python packages
-# Cache apt packages for faster rebuilds
+# Cache apt packages for faster rebuilds.
+# apt-get upgrade applies all available security patches to base image packages,
+# ensuring no CRITICAL/HIGH CVEs remain for packages with upstream fixes
+# (satisfies Trivy scan with ignore-unfixed: true).
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
     # Build essentials for compiling native extensions
     build-essential \
     # PostgreSQL client library for psycopg2/asyncpg
@@ -235,10 +238,12 @@ ENV RUNTIME_SOURCE_HASH=${RUNTIME_SOURCE_HASH} \
     COMPOSE_PROJECT=${COMPOSE_PROJECT}
 
 # Install minimal runtime dependencies only
-# No build tools needed - all Python packages are pre-compiled in builder stage
+# No build tools needed - all Python packages are pre-compiled in builder stage.
+# apt-get upgrade applies all available security patches to the runtime base image,
+# clearing CRITICAL/HIGH CVEs that have upstream fixes (Trivy ignore-unfixed: true).
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
     # PostgreSQL client library (runtime only, no -dev)
     libpq5 \
     # Curl for health checks


### PR DESCRIPTION
## Summary

- Add `apt-get upgrade -y --no-install-recommends` to both the **builder** and **runtime** stages in `docker/Dockerfile.runtime`
- This ensures all available security patches from the Debian trixie package repository are applied to the `python:3.12-slim` base image
- Satisfies Trivy scanner (`ignore-unfixed: true`) by clearing CRITICAL/HIGH CVEs that have upstream fixes

## Problem

The `Build and push runtime image to ECR` workflow has failed on both runs (22640548689, 22640251573) at the `Run Trivy vulnerability scanner` step with exit code 1 (CRITICAL/HIGH CVEs found with available fixes). Because Trivy runs *before* the ECR push step, no image was ever pushed to ECR. This blocks Phase 7 k3s deployment (OMN-3523).

## Fix

Adding `apt-get upgrade` during the Docker build ensures the final runtime image picks up all patched package versions from the Debian mirror, eliminating the CRITICAL/HIGH findings that Trivy flags as "fixable".

## Test plan

- [ ] PR CI passes (Test Suite, Docker Build checks)
- [ ] Merge to main triggers `Build and push runtime image to ECR` workflow
- [ ] Trivy step passes (exit 0)
- [ ] ECR push step runs and produces valid `sha256:` digest
- [ ] Digest is available for Phase 7 kustomize update in omninode_infra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime configuration to apply security patches to base image packages during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->