### PR TITLE
feat(db): add schema_migrations tracking table (OMN-3526)

### DIFF
--- a/docker/migrations/forward/036_create_schema_migrations.sql
+++ b/docker/migrations/forward/036_create_schema_migrations.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- MIGRATION: Create schema_migrations tracking table
+-- =============================================================================
+-- Ticket: OMN-3526 (DB Migration Reliability)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   Per-migration history table for the omnibase_infra migration runner.
+--   Tracks which migrations have been applied, when, and their file checksum.
+--   Enables idempotent reruns, gap detection, and tamper detection.
+--
+-- ROLLBACK:
+--   See rollback/rollback_036_create_schema_migrations.sql
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.schema_migrations (
+    migration_id    TEXT PRIMARY KEY,          -- e.g. "docker/035_create_skill_executions.sql"
+    applied_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    checksum        TEXT NOT NULL,             -- SHA-256 of file contents at apply time
+    source_set      TEXT NOT NULL              -- "docker" or "src"
+);

--- a/docker/migrations/rollback/rollback_036_create_schema_migrations.sql
+++ b/docker/migrations/rollback/rollback_036_create_schema_migrations.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.schema_migrations;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:6a237c2f41afaa290387743eae03df307225b4f8d45d50602e47ff9626b18061
-generated_at: 2026-03-03T19:32:11Z
-migration_file_count: 22
+sha256:0786f572218670fa3deb78542e84972f3adcde53ad7650b0b221cd5a399e69f7
+generated_at: 2026-03-03T21:30:54Z
+migration_file_count: 23


### PR DESCRIPTION
## Summary

- Creates `docker/migrations/forward/036_create_schema_migrations.sql` with `public.schema_migrations` table
- Adds rollback file `docker/migrations/rollback/rollback_036_create_schema_migrations.sql`
- Re-stamps schema fingerprint from 22 → 23 migration files

## Migration Details

The `schema_migrations` table tracks per-migration history for the omnibase_infra migration runner:

```sql
CREATE TABLE IF NOT EXISTS public.schema_migrations (
    migration_id    TEXT PRIMARY KEY,
    applied_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    checksum        TEXT NOT NULL,
    source_set      TEXT NOT NULL
);
```

**Note**: `schema_migrations` is infrastructure — it is intentionally NOT added to `OMNIBASE_INFRA_SCHEMA_MANIFEST`. It does not need schema drift detection.

## Acceptance Criteria

- [x] `036_create_schema_migrations.sql` exists with columns: `migration_id TEXT PRIMARY KEY`, `applied_at TIMESTAMPTZ`, `checksum TEXT`, `source_set TEXT`
- [x] Rollback file exists at `docker/migrations/rollback/rollback_036_create_schema_migrations.sql`
- [x] `python scripts/check_schema_fingerprint.py verify` exits 0 (23 migration files, fingerprint updated)

## Test Plan

- [x] Pre-commit hooks all pass
- [x] Schema fingerprint verify passes: `Schema fingerprint OK`
- Migration will be applied to DB in Task 3 (OMN-3527) when the runner is implemented

Closes OMN-3526
Part of OMN-3524 (DB Migration Reliability epic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration history tracking system to the database. The system records when each migration is applied, includes checksums for integrity verification, and enables detection of gaps and potential tampering in the migration sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->