### PR TITLE
fix(deps): pin qdrant-client>=1.16.0 and add grpcio>=1.62.0 lower bound [OMN-3548]

### DIFF
--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -71,7 +71,11 @@ jobs:
 
       - name: Smoke test — install wheel and verify import
         run: |
-          pip install dist/*.whl
+          python -m venv .smoke-venv
+          . .smoke-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip check
           python -c "import omnibase_infra; print('import omnibase_infra OK')"
 
       - name: Publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "infisicalsdk>=1.0.15,<2.0.0", # For Infisical secret management (OMN-2286)
     # Vector and graph database dependencies (for Qdrant and Memgraph handlers)
     "qdrant-client>=1.16.0,<2.0.0",  # Vector database client for semantic search
-    "grpcio>=1.62.0",  # Explicit lower bound: fixes EnumTypeWrapper|None runtime error [OMN-3548]
+    "grpcio>=1.62.0,<2.0.0",  # Explicit lower bound: fixes EnumTypeWrapper|None runtime error [OMN-3548]
     "neo4j>=5.15.0,<6.0.0",  # Bolt/Cypher client for Memgraph graph database
     # CLI Dependencies
     "click>=8.1.0,<9.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1959,7 +1959,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.3,<47.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.1,<5.0.0" },
     { name = "fastapi", specifier = ">=0.120.1,<0.121.0" },
-    { name = "grpcio", specifier = ">=1.62.0" },
+    { name = "grpcio", specifier = ">=1.62.0,<2.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "infisicalsdk", specifier = ">=1.0.15,<2.0.0" },
     { name = "jinja2", specifier = ">=3.1.6,<4.0.0" },


### PR DESCRIPTION
## Summary

- **qdrant-client**: tightened lower bound from `>=1.12.0` to `>=1.16.0` (tested working version)
- **grpcio**: added explicit `>=1.62.0` lower bound (was implicit transitive dep with no bound)
- **release workflow**: added post-build smoke test that pip-installs the wheel and verifies `import omnibase_infra` before publishing

## Root Cause

`grpcio`-generated stubs in `qdrant_client` use the `X | Y` union syntax for `EnumTypeWrapper` at runtime. Without an explicit `grpcio` lower bound, pip could resolve an old grpcio (<1.62.0) that doesn't support this syntax, causing:

```
TypeError: unsupported operand type(s) for |: 'EnumTypeWrapper' and 'NoneType'
```

## Verification

- `import omnibase_infra` succeeds locally with qdrant-client 1.16.2 + grpcio 1.78.0
- Pre-commit passes on all changed files
- Smoke test in release workflow will catch this class of issue on future releases

## Note on pre-existing mypy errors

92 mypy errors exist across 55 files in `main` — pre-existing, not introduced by this change. Deferred per pipeline policy.

Closes [OMN-3548](https://linear.app/omninode/issue/OMN-3548)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated qdrant-client minimum version to 1.16.0.
  * Added grpcio as a new dependency with minimum version 1.62.0.
  * Added a release-time smoke test that installs the built package and verifies it can be installed and imported before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->