### PR TITLE
release: omnibase_infra v0.15.0 — relax omnibase-core to >=0.23.0,<0.24.0 [OMN-3549]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.14.0"
+version = "0.15.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{name = "OmniNode Team", email = "team@omninode.ai"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps `omnibase_infra` from `v0.14.0` → `v0.15.0`
- The published PyPI `v0.14.0` wheel carried the old constraint `omnibase-core>=0.22.0,<0.23.0`; the constraint was updated to `>=0.23.0,<0.24.0` on main (commit 7b1cea9b) without a version bump, so the fix was never released
- This release publishes `v0.15.0` with the correct `omnibase-core>=0.23.0,<0.24.0` constraint, unblocking omniclaude from pinning `omnibase-core==0.23.0` (which contains `ModelTicketContextBundle`)

## Background

`omniclaude` needs `omnibase-core==0.23.0` to access `ModelTicketContextBundle`. It cannot pin that version until `omnibase_infra` releases a compatible version (one that accepts `omnibase-core 0.23.x`). PyPI's `omnibase_infra==0.14.0` still requires `omnibase-core<0.23.0`, so installing both is impossible. This PR resolves that by cutting `v0.15.0`.

## Changes

- `pyproject.toml`: `version = "0.14.0"` → `version = "0.15.0"` (only change)
- `uv.lock`: updated to reflect new package version

## References

- OMN-3549 (this PR — omnibase_infra v0.15.0 release)
- OMN-3491 (added `omnibase-core>=0.23.0,<0.24.0` constraint on main without version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.15.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->