### PR TITLE
feat(db): add migration runner script with unit tests (OMN-3527)

### DIFF
--- a/scripts/run-migrations.py
+++ b/scripts/run-migrations.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Migration runner for omnibase_infra.
+
+Applies pending SQL migrations from both migration sets to a PostgreSQL database
+and updates schema_migrations tracking table. Safe to run on fresh and existing DBs.
+
+Usage:
+    uv run python scripts/run-migrations.py --dry-run
+    uv run python scripts/run-migrations.py
+    uv run python scripts/run-migrations.py --target 030
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+REPO_ROOT = Path(__file__).parent.parent
+
+MIGRATION_SETS = [
+    ("docker", REPO_ROOT / "docker" / "migrations" / "forward"),
+    ("src", REPO_ROOT / "src" / "omnibase_infra" / "migrations" / "forward"),
+]
+
+
+def extract_sequence_number(filename: str) -> int:
+    """Extract leading integer sequence number from migration filename."""
+    stem = Path(filename).stem
+    prefix = ""
+    for ch in stem:
+        if ch.isdigit():
+            prefix += ch
+        else:
+            break
+    if not prefix:
+        raise ValueError(
+            f"no leading sequence number in migration filename: {filename!r}"
+        )
+    return int(prefix)
+
+
+def validate_no_duplicates(files: list[Path]) -> None:
+    """Raise if any two files share a sequence number."""
+    seen: dict[int, Path] = {}
+    for f in files:
+        n = extract_sequence_number(f.name)
+        if n in seen:
+            raise ValueError(
+                f"duplicate sequence number {n}: {seen[n].name!r} and {f.name!r}"
+            )
+        seen[n] = f
+
+
+def file_checksum(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+async def ensure_schema_migrations_table(conn: asyncpg.Connection) -> None:
+    """Create schema_migrations if it does not exist (idempotent)."""
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS public.schema_migrations (
+            migration_id TEXT PRIMARY KEY,
+            applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            checksum     TEXT NOT NULL,
+            source_set   TEXT NOT NULL
+        )
+    """)
+
+
+async def get_applied_ids(conn: asyncpg.Connection) -> set[str]:
+    rows = await conn.fetch("SELECT migration_id FROM public.schema_migrations")
+    return {r["migration_id"] for r in rows}
+
+
+def migration_id(source_set: str, filename: str) -> str:
+    return f"{source_set}/{filename}"
+
+
+async def apply_migration(
+    conn: asyncpg.Connection,
+    source_set: str,
+    path: Path,
+    dry_run: bool,
+) -> None:
+    mid = migration_id(source_set, path.name)
+    sql = path.read_text()
+    checksum = file_checksum(path)
+
+    if dry_run:
+        print(f"  [dry-run] would apply: {mid}")
+        return
+
+    await conn.execute(sql)
+    await conn.execute(
+        """
+        INSERT INTO public.schema_migrations (migration_id, checksum, source_set)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (migration_id) DO NOTHING
+        """,
+        mid,
+        checksum,
+        source_set,
+    )
+    print(f"  applied: {mid}")
+
+
+async def run(db_url: str, dry_run: bool, target: int | None) -> int:
+    """Apply all pending migrations. Returns count of migrations applied."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        await ensure_schema_migrations_table(conn)
+        applied = await get_applied_ids(conn)
+
+        pending: list[tuple[int, str, Path]] = []
+        for source_set, migration_dir in MIGRATION_SETS:
+            if not migration_dir.exists():
+                print(f"  warning: migration directory not found: {migration_dir}")
+                continue
+            files = sorted(
+                [f for f in migration_dir.glob("*.sql")],
+                key=lambda f: f.name,
+            )
+            validate_no_duplicates(files)
+            for f in files:
+                mid = migration_id(source_set, f.name)
+                if mid in applied:
+                    continue
+                seq = extract_sequence_number(f.name)
+                if target is not None and seq > target:
+                    continue
+                pending.append((seq, source_set, f))
+
+        pending.sort(key=lambda t: (t[0], t[1]))
+
+        if not pending:
+            print("No pending migrations.")
+            return 0
+
+        print(f"Applying {len(pending)} pending migration(s)...")
+        for _, source_set, path in pending:
+            await apply_migration(conn, source_set, path, dry_run)
+
+        return len(pending)
+    finally:
+        await conn.close()
+
+
+def restamp_fingerprint() -> None:
+    """Call check_schema_fingerprint.py stamp after successful apply."""
+    import subprocess
+
+    stamp_script = REPO_ROOT / "scripts" / "check_schema_fingerprint.py"
+    if stamp_script.exists():
+        result = subprocess.run(
+            [sys.executable, str(stamp_script), "stamp"],
+            capture_output=True,
+            text=True, check=False,
+        )
+        if result.returncode != 0:
+            print(f"  warning: fingerprint restamp failed: {result.stderr.strip()}")
+        else:
+            print("  fingerprint restamped.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Apply pending omnibase_infra migrations"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print pending migrations without applying",
+    )
+    parser.add_argument(
+        "--target", type=int, help="Only apply up to this sequence number"
+    )
+    parser.add_argument(
+        "--db-url",
+        default=os.environ.get("OMNIBASE_INFRA_DB_URL"),
+        help="PostgreSQL connection URL (default: OMNIBASE_INFRA_DB_URL env var)",
+    )
+    args = parser.parse_args()
+
+    if not args.db_url:
+        print("ERROR: --db-url or OMNIBASE_INFRA_DB_URL required", file=sys.stderr)
+        sys.exit(1)
+
+    count = asyncio.run(run(args.db_url, args.dry_run, args.target))
+
+    if count > 0 and not args.dry_run:
+        restamp_fingerprint()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_run_migrations.py
+++ b/tests/unit/scripts/test_run_migrations.py
@@ -1,0 +1,40 @@
+"""Tests for scripts/run-migrations.py migration runner."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "run-migrations.py"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("run_migrations", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.unit
+class TestSequenceNumberExtraction:
+    def test_extracts_number_from_docker_format(self):
+        runner = load_runner()
+        assert runner.extract_sequence_number("036_create_schema_migrations.sql") == 36
+
+    def test_extracts_number_from_src_format(self):
+        runner = load_runner()
+        assert runner.extract_sequence_number("007_create_skill_executions.sql") == 7
+
+    def test_raises_on_no_leading_number(self):
+        runner = load_runner()
+        with pytest.raises(ValueError, match="no leading sequence number"):
+            runner.extract_sequence_number("init.sql")
+
+    def test_detects_duplicate_sequence_numbers(self):
+        runner = load_runner()
+        files = [
+            Path("006_create_manifest_injection_lifecycle_table.sql"),
+            Path("006_create_skill_executions.sql"),
+        ]
+        with pytest.raises(ValueError, match="duplicate sequence number 6"):
+            runner.validate_no_duplicates(files)


### PR DESCRIPTION
## Summary

- Implement `scripts/run-migrations.py` — applies pending SQL migrations from both migration sets (`docker/migrations/forward/` and `src/omnibase_infra/migrations/forward/`) in sequence-number order
- Track applied migrations in `schema_migrations` table; restamps schema fingerprint after successful apply
- Safe to run on fresh and existing DBs (idempotent via `ON CONFLICT DO NOTHING`)
- Add `tests/unit/scripts/test_run_migrations.py` with 4 unit tests covering `extract_sequence_number()` and `validate_no_duplicates()`

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_run_migrations.py -v` — 4 tests pass
- [x] `uv run python scripts/run-migrations.py --help` — works without DB URL
- [x] `uv run pre-commit run --all-files` — all hooks pass

## Linear

Closes OMN-3527
Epic: OMN-3524