### PR TITLE
feat(infra): provision cross-repo tables script + bootstrap wire-in (OMN-3531)

### DIFF
--- a/scripts/bootstrap-infisical.sh
+++ b/scripts/bootstrap-infisical.sh
@@ -8,6 +8,8 @@
 # Bootstrap Startup Chain (OMN-2287):
 #   Step 1:   PostgreSQL starts (POSTGRES_PASSWORD from .env)
 #   Step 1b:  Pending migrations applied (run-migrations.py, OMN-3528)
+#   Step 1c:  Cross-repo tables provisioned in omniintelligence DB (OMN-3531)
+#             Skipped if OMNIINTELLIGENCE_DB_URL is not set
 #   Step 2:   Valkey starts
 #   Step 3:   Infisical starts (depends_on: postgres + valkey healthy)
 #   Step 3.5: Keycloak starts (--profile auth) + provision-keycloak.py runs
@@ -193,6 +195,25 @@ if [[ "${DRY_RUN}" != "true" ]]; then
     fi
 else
     log_info "[DRY-RUN] Would run: uv run python ${SCRIPT_DIR}/run-migrations.py --db-url postgresql://${POSTGRES_USER:-postgres}:***@localhost:${POSTGRES_EXTERNAL_PORT:-5436}/${POSTGRES_DB:-omnibase_infra}"
+fi
+
+# ============================================================================
+# Step 1c: Provision cross-repo tables into omniintelligence DB (OMN-3531)
+# ============================================================================
+if [ -n "${OMNIINTELLIGENCE_DB_URL:-}" ]; then
+    log_step "1c" "Provisioning cross-repo tables in omniintelligence DB"
+    if [[ "${DRY_RUN}" != "true" ]]; then
+        if uv run python "${SCRIPT_DIR}/provision-cross-repo-tables.py" \
+            --target-db "${OMNIINTELLIGENCE_DB_URL}"; then
+            log_info "Cross-repo tables provisioned."
+        else
+            log_warn "Cross-repo provisioning failed (omniintelligence DB may not be available yet — non-fatal)"
+        fi
+    else
+        log_info "[DRY-RUN] Would run: uv run python ${SCRIPT_DIR}/provision-cross-repo-tables.py --target-db \${OMNIINTELLIGENCE_DB_URL}"
+    fi
+else
+    log_info "Skipping cross-repo provisioning (OMNIINTELLIGENCE_DB_URL not set)"
 fi
 
 # ============================================================================

--- a/scripts/provision-cross-repo-tables.py
+++ b/scripts/provision-cross-repo-tables.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""
+Provision cross-repo tables that omnibase_infra owns but other services need.
+
+omnibase_infra owns the ``idempotency_records`` table definition and migrations.
+Other services (e.g. omniintelligence) share the same database but cannot run
+omnibase_infra migrations directly.  This script provisions those tables into a
+target database so that downstream services can start cleanly.
+
+The DDL is copied verbatim from
+``src/omnibase_infra/idempotency/store_postgres.py`` (the authoritative source).
+
+Usage:
+    uv run python scripts/provision-cross-repo-tables.py \\
+        --target-db postgresql://postgres:pw@localhost:5436/omniintelligence
+
+    # Dry run (prints SQL without executing)
+    uv run python scripts/provision-cross-repo-tables.py \\
+        --target-db postgresql://postgres:pw@localhost:5436/omniintelligence \\
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import asyncpg
+
+# ---------------------------------------------------------------------------
+# DDL — copied verbatim from
+#   src/omnibase_infra/idempotency/store_postgres.py _ensure_table_exists()
+#
+# IMPORTANT: if the idempotency_records schema ever changes, update BOTH files.
+# The table_name literal "idempotency_records" matches the default value of
+# ModelPostgresIdempotencyStoreConfig.table_name.
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "idempotency_records"
+
+CROSS_REPO_TABLES: dict[str, list[str]] = {
+    _TABLE_NAME: [
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE_NAME} (
+            id UUID PRIMARY KEY,
+            domain VARCHAR(255),
+            message_id UUID NOT NULL,
+            correlation_id UUID,
+            processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            UNIQUE (domain, message_id)
+        )
+        """,
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{_TABLE_NAME}_processed_at
+        ON {_TABLE_NAME}(processed_at)
+        """,
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{_TABLE_NAME}_domain
+        ON {_TABLE_NAME}(domain)
+        """,
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{_TABLE_NAME}_correlation_id
+        ON {_TABLE_NAME}(correlation_id)
+        WHERE correlation_id IS NOT NULL
+        """,
+    ],
+}
+
+
+async def provision(target_db_url: str, *, dry_run: bool = False) -> None:
+    """Provision cross-repo tables into the target database.
+
+    Args:
+        target_db_url: asyncpg-compatible DSN for the target database.
+        dry_run: If True, print SQL statements without executing them.
+
+    Raises:
+        SystemExit: On database connection or execution failure.
+    """
+    if dry_run:
+        print("[DRY-RUN] Would execute the following SQL:")
+        for table_name, statements in CROSS_REPO_TABLES.items():
+            print(f"\n  -- table: {table_name}")
+            for stmt in statements:
+                for line in stmt.strip().splitlines():
+                    print(f"  {line}")
+        return
+
+    try:
+        conn = await asyncpg.connect(target_db_url)
+    except Exception as exc:
+        print(
+            f"ERROR: Could not connect to target database: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        for table_name, statements in CROSS_REPO_TABLES.items():
+            async with conn.transaction():
+                for stmt in statements:
+                    await conn.execute(stmt)
+            print(f"  provisioned: {table_name}")
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to provision cross-repo tables: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    """Parse arguments and run provisioning."""
+    parser = argparse.ArgumentParser(
+        description="Provision cross-repo tables owned by omnibase_infra into a target DB.",
+    )
+    parser.add_argument(
+        "--target-db",
+        required=True,
+        help="Target database DSN (postgresql://user:pass@host:port/dbname)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print SQL without executing",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(provision(args.target_db, dry_run=args.dry_run))
+    if not args.dry_run:
+        print("Cross-repo provisioning complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/omnibase_infra/nodes/node_setup_local_provision_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_local_provision_effect/contract.yaml
@@ -9,11 +9,7 @@ contract_version:
   patch: 0
 node_version: "1.0.0"
 description: >
-  EFFECT node that provisions, tears down, and checks status of local Docker Compose
-  services defined in a ModelDeploymentTopology. Runs docker compose up -d (provision),
-  docker compose down (teardown), and docker compose ps (status). Deduplicates
-  --profile flags across services sharing the same profile. Async-polls ports
-  until healthy or max_wait_seconds is exceeded.
+  EFFECT node that provisions, tears down, and checks status of local Docker Compose services defined in a ModelDeploymentTopology. Runs docker compose up -d (provision), docker compose down (teardown), and docker compose ps (status). Deduplicates --profile flags across services sharing the same profile. Async-polls ports until healthy or max_wait_seconds is exceeded.
 
 input_model:
   name: "ModelLocalProvisionEffectInput"

--- a/tests/unit/scripts/test_provision_cross_repo_tables.py
+++ b/tests/unit/scripts/test_provision_cross_repo_tables.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for scripts/provision-cross-repo-tables.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "provision-cross-repo-tables.py"
+
+
+def _load_script():
+    """Load provision-cross-repo-tables.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "provision_cross_repo_tables", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.unit
+class TestScriptLoads:
+    """Smoke test: script is importable and has required symbols."""
+
+    def test_script_exists(self):
+        assert SCRIPT_PATH.exists(), f"Script not found: {SCRIPT_PATH}"
+
+    def test_cross_repo_tables_constant_defined(self):
+        mod = _load_script()
+        assert hasattr(mod, "CROSS_REPO_TABLES")
+        assert isinstance(mod.CROSS_REPO_TABLES, dict)
+        assert "idempotency_records" in mod.CROSS_REPO_TABLES
+
+    def test_idempotency_records_has_create_table(self):
+        mod = _load_script()
+        stmts = mod.CROSS_REPO_TABLES["idempotency_records"]
+        assert isinstance(stmts, list)
+        assert any("CREATE TABLE IF NOT EXISTS" in s for s in stmts)
+
+    def test_idempotency_records_has_indexes(self):
+        mod = _load_script()
+        stmts = mod.CROSS_REPO_TABLES["idempotency_records"]
+        create_index_stmts = [s for s in stmts if "CREATE INDEX IF NOT EXISTS" in s]
+        # Expect at least 3 indexes: processed_at, domain, correlation_id
+        assert len(create_index_stmts) >= 3
+
+
+@pytest.mark.unit
+class TestDryRunMode:
+    """Dry-run path: prints SQL without connecting to the database."""
+
+    def test_dry_run_does_not_call_asyncpg(self, capsys):
+        mod = _load_script()
+
+        import asyncio
+
+        asyncio.run(mod.provision("postgresql://fake/db", dry_run=True))
+
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+        assert "CREATE TABLE IF NOT EXISTS" in captured.out
+        assert "idempotency_records" in captured.out
+
+
+@pytest.mark.unit
+class TestProvisionHappyPath:
+    """Provision path: connects, executes DDL inside transaction, closes."""
+
+    def test_provision_executes_all_statements(self):
+        mod = _load_script()
+
+        mock_conn = AsyncMock()
+        mock_conn.transaction = MagicMock(return_value=AsyncMock())
+        mock_conn.transaction.return_value.__aenter__ = AsyncMock(return_value=None)
+        mock_conn.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        import asyncio
+
+        with patch("asyncpg.connect", new=AsyncMock(return_value=mock_conn)):
+            asyncio.run(
+                mod.provision(
+                    "postgresql://postgres:pw@localhost:5436/omniintelligence"
+                )
+            )
+
+        # execute called once per statement
+        expected_count = len(mod.CROSS_REPO_TABLES["idempotency_records"])
+        assert mock_conn.execute.call_count == expected_count
+        mock_conn.close.assert_called_once()
+
+
+@pytest.mark.unit
+class TestProvisionErrorHandling:
+    """Error handling: SystemExit on connection failure."""
+
+    def test_exits_on_connection_error(self):
+        mod = _load_script()
+
+        import asyncio
+
+        with (
+            patch(
+                "asyncpg.connect",
+                new=AsyncMock(side_effect=OSError("connection refused")),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            asyncio.run(
+                mod.provision(
+                    "postgresql://postgres:pw@localhost:5436/omniintelligence"
+                )
+            )
+
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

- Creates `scripts/provision-cross-repo-tables.py` to provision `idempotency_records` table (owned by omnibase_infra) into a target database (e.g. omniintelligence). DDL is copied verbatim from `store_postgres.py` — includes all 3 indexes (`processed_at`, `domain`, `correlation_id`). Supports `--dry-run` mode. Exits 1 on connection/execution failure.
- Wires Step 1c into `bootstrap-infisical.sh`: calls provision script when `OMNIINTELLIGENCE_DB_URL` is set; non-fatal warning if DB is unavailable.
- Adds 7 unit tests covering DDL content verification, dry-run, happy path execution, and connection error handling.

Part A of OMN-3531. Part B (omniintelligence side) is in a separate PR.

## Test plan

- [ ] `uv run pytest tests/unit/scripts/test_provision_cross_repo_tables.py -v` — 7 tests pass
- [ ] `uv run python scripts/provision-cross-repo-tables.py --target-db $OMNIINTELLIGENCE_DB_URL --dry-run` prints SQL without connecting
- [ ] `bootstrap-infisical.sh` with `OMNIINTELLIGENCE_DB_URL` set calls Step 1c
- [ ] `bootstrap-infisical.sh` with `OMNIINTELLIGENCE_DB_URL` unset skips Step 1c gracefully