### PR TITLE
feat(infra): add onex-setup.py interactive CLI with cloud gate output (OMN-3496)

### DIFF
--- a/scripts/onex-setup.py
+++ b/scripts/onex-setup.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Interactive CLI for bootstrapping the OmniNode platform infrastructure.
+
+Prompts for preset/custom selection, writes ~/.omnibase/topology.yaml, and
+invokes NodeSetupOrchestrator, printing events as they flow.
+
+Invariants:
+    I7 — resolve_compose_file() lives only here. Handlers receive an
+         already-resolved string path.
+    I8 — Cloud selection stores mode=CLOUD in topology.yaml and shows a
+         coming-soon notice. Does NOT convert cloud to disabled.
+
+Ticket: OMN-3496
+
+Usage:
+    uv run python scripts/onex-setup.py --preset minimal --dry-run
+    uv run python scripts/onex-setup.py --preset standard --no-interactive
+    uv run python scripts/onex-setup.py --topology-file ~/.omnibase/topology.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CLOUD_COMING_SOON = (
+    "\n\u26a0  Cloud mode: your preference is stored in topology.yaml, "
+    "but cloud provisioning is not yet implemented (coming soon).\n"
+)
+
+# Human-readable messages for each event type emitted by the orchestrator.
+_EVENT_MESSAGES: dict[str, str] = {
+    "setup.preflight.started": "Running preflight checks...",
+    "setup.preflight.completed": "All checks passed",
+    "setup.preflight.failed": "Preflight checks failed",
+    "setup.provision.started": "Starting Docker services...",
+    "setup.provision.completed": "Docker services started",
+    "setup.provision.failed": "Docker provisioning failed",
+    "setup.infisical.started": "Bootstrapping Infisical...",
+    "setup.infisical.completed": "Infisical ready",
+    "setup.infisical.skipped": "Infisical skipped (not in topology)",
+    "setup.infisical.failed": "Infisical bootstrap failed",
+    "setup.validate.started": "Validating provisioned services...",
+    "setup.validate.completed": "All services healthy",
+    "setup.validate.failed": "Service validation failed",
+    "setup.completed": "Platform ready \u2713",
+    "setup.cloud.unavailable": "Cloud provisioning not available",
+    "setup.aborted": "Setup aborted",
+}
+
+
+# ---------------------------------------------------------------------------
+# I7 — resolve_compose_file lives only here (not in handlers)
+# ---------------------------------------------------------------------------
+
+
+def resolve_compose_file(cli_arg: str | None) -> str:
+    """Resolve the path to the Docker Compose infra file.
+
+    Resolution order:
+        1. ``cli_arg`` (explicit ``--compose-file`` argument)
+        2. ``ONEX_COMPOSE_FILE`` environment variable
+        3. Upward search from CWD for ``docker/docker-compose.infra.yml``
+
+    Args:
+        cli_arg: Value of the ``--compose-file`` CLI argument, or None.
+
+    Returns:
+        Resolved absolute path string.
+
+    Raises:
+        RuntimeError: If no compose file is found by any method.
+    """
+    if cli_arg:
+        return cli_arg
+
+    env_path = os.environ.get("ONEX_COMPOSE_FILE")
+    if env_path:
+        return env_path
+
+    for parent in [Path.cwd(), *Path.cwd().parents]:
+        candidate = parent / "docker" / "docker-compose.infra.yml"
+        if candidate.exists():
+            return str(candidate)
+
+    raise RuntimeError(
+        "Cannot locate docker-compose.infra.yml. "
+        "Set ONEX_COMPOSE_FILE or pass --compose-file."
+    )
+
+
+def _omnibase_dir() -> Path:
+    """Return the ~/.omnibase directory path.
+
+    Respects the ``OMNIBASE_DIR`` environment variable for testing isolation.
+    """
+    env = os.environ.get("OMNIBASE_DIR")
+    return Path(env) if env else Path.home() / ".omnibase"
+
+
+# ---------------------------------------------------------------------------
+# Topology builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _topology_for_preset(preset: str) -> object:
+    """Return a ModelDeploymentTopology for the given preset name.
+
+    Args:
+        preset: One of ``minimal``, ``standard``, or ``full``.
+
+    Returns:
+        ModelDeploymentTopology instance.
+
+    Raises:
+        ValueError: If preset name is not recognised.
+    """
+    from omnibase_core.models.core.model_deployment_topology import (
+        ModelDeploymentTopology,
+    )
+
+    factories = {
+        "minimal": ModelDeploymentTopology.default_minimal,
+        "standard": ModelDeploymentTopology.default_standard,
+        "full": ModelDeploymentTopology.default_full,
+    }
+    factory = factories.get(preset)
+    if factory is None:
+        raise ValueError(
+            f"Unknown preset {preset!r}. Choose one of: {', '.join(factories)}."
+        )
+    return factory()
+
+
+def _print_topology_summary(topology: object) -> None:
+    """Print a human-readable summary of the topology to stdout."""
+    from omnibase_core.enums.enum_deployment_mode import EnumDeploymentMode
+    from omnibase_core.models.core.model_deployment_topology import (
+        ModelDeploymentTopology,
+    )
+
+    assert isinstance(topology, ModelDeploymentTopology)
+
+    preset_label = topology.active_preset or "custom"
+    print(f"\nTopology preset: {preset_label}")
+    print(f"{'Service':<20} {'Mode':<12}")
+    print("-" * 34)
+    for name, svc in sorted(topology.services.items()):
+        mode_label = svc.mode.value
+        print(f"{name:<20} {mode_label:<12}")
+
+    cloud_services = [
+        name
+        for name, svc in topology.services.items()
+        if svc.mode == EnumDeploymentMode.CLOUD
+    ]
+    if cloud_services:
+        print(CLOUD_COMING_SOON)
+
+
+# ---------------------------------------------------------------------------
+# Event printing
+# ---------------------------------------------------------------------------
+
+
+def _print_event(event_type: str, payload: dict[str, object]) -> None:
+    """Print a single setup event in the canonical CLI format.
+
+    Format: ``[event_type]   message``
+    """
+    message = _EVENT_MESSAGES.get(event_type, "")
+    if payload and event_type == "setup.cloud.unavailable":
+        gated = payload.get("gated_services", [])
+        message = f"Cloud provisioning not available: {', '.join(str(s) for s in gated)} (stored for future use)"
+    elif payload and event_type == "setup.preflight.completed":
+        # Optionally show check count if available in payload
+        pass
+    print(f"[{event_type}]  {message}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator invocation (dry-run aware)
+# ---------------------------------------------------------------------------
+
+
+async def _run_orchestrator(
+    topology: object,
+    compose_file_path: str,
+    dry_run: bool,
+) -> bool:
+    """Invoke HandlerSetupOrchestrator and print events as they flow.
+
+    In dry-run mode, all steps are skipped and a ``setup.completed`` event
+    is synthesised to indicate success.
+
+    Args:
+        topology: Validated ModelDeploymentTopology.
+        compose_file_path: Resolved path to docker-compose.infra.yml.
+        dry_run: If True, skip all real provisioning.
+
+    Returns:
+        True on success (``setup.completed`` received), False otherwise.
+    """
+    from omnibase_core.enums.enum_deployment_mode import EnumDeploymentMode
+    from omnibase_core.models.core.model_deployment_topology import (
+        ModelDeploymentTopology,
+    )
+
+    assert isinstance(topology, ModelDeploymentTopology)
+
+    if dry_run:
+        print("\n[dry-run] Skipping provisioning — topology summary only.")
+        _print_event("setup.completed", {})
+        return True
+
+    # Check for cloud-only gate before invoking the orchestrator.
+    cloud_services = [
+        name
+        for name, svc in topology.services.items()
+        if svc.mode == EnumDeploymentMode.CLOUD
+    ]
+    if cloud_services:
+        _print_event("setup.cloud.unavailable", {"gated_services": cloud_services})
+        return False
+
+    # Import effect node implementations lazily to avoid import-time side-effects.
+    # Build a minimal stub container (no services required for CLI invocation).
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+    from omnibase_infra.nodes.node_setup_infisical_effect.handlers.handler_infisical_full_setup import (
+        HandlerInfisicalFullSetup,
+    )
+    from omnibase_infra.nodes.node_setup_local_provision_effect.handlers.handler_local_provision import (
+        HandlerLocalProvision,
+    )
+    from omnibase_infra.nodes.node_setup_orchestrator.handlers.handler_setup_orchestrator import (
+        HandlerSetupOrchestrator,
+    )
+    from omnibase_infra.nodes.node_setup_preflight_effect.handlers.handler_preflight_check import (
+        HandlerPreflightCheck,
+    )
+    from omnibase_infra.nodes.node_setup_validate_effect.handlers.handler_service_validate import (
+        HandlerServiceValidate,
+    )
+
+    container = ModelONEXContainer()
+
+    handler = HandlerSetupOrchestrator(
+        container=container,
+        preflight=HandlerPreflightCheck(container=container),
+        provision=HandlerLocalProvision(container=container),
+        infisical=HandlerInfisicalFullSetup(container=container),
+        validate=HandlerServiceValidate(container=container),
+    )
+    await handler.initialize({})
+
+    corr_id = uuid4()
+    result = await handler.handle(topology, corr_id, compose_file_path)
+
+    success = False
+    for event in result.result.events:
+        _print_event(event.event_type, dict(event.payload))
+        if event.event_type == "setup.completed":
+            success = True
+
+    return success
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="onex-setup",
+        description="Interactive CLI for bootstrapping the OmniNode platform infrastructure.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["minimal", "standard", "full"],
+        help="Skip interactive prompt and use the specified preset.",
+    )
+    parser.add_argument(
+        "--topology-file",
+        metavar="PATH",
+        help="Use an existing topology.yaml file instead of prompting.",
+    )
+    parser.add_argument(
+        "--compose-file",
+        metavar="PATH",
+        help="Override the Docker Compose file path (I7).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Skip file writes and Docker operations — topology summary only.",
+    )
+    parser.add_argument(
+        "--skip-infisical",
+        action="store_true",
+        default=False,
+        help="Skip the Infisical bootstrap step.",
+    )
+    parser.add_argument(
+        "--skip-validate",
+        action="store_true",
+        default=False,
+        help="Skip post-provision validation.",
+    )
+    parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        default=False,
+        help="Use standard defaults; never prompt for input.",
+    )
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompt
+# ---------------------------------------------------------------------------
+
+
+def _prompt_preset() -> str:
+    """Interactively ask the user to choose a preset.
+
+    Returns:
+        One of ``minimal``, ``standard``, ``full``.
+    """
+    presets = ["minimal", "standard", "full"]
+    print("\nChoose a topology preset:")
+    for i, name in enumerate(presets, start=1):
+        descriptions = {
+            "minimal": "3 services — postgres, redpanda, valkey",
+            "standard": "4 services — minimal + infisical (secrets)",
+            "full": "5 services — standard + keycloak",
+        }
+        print(f"  {i}. {name:<12}  {descriptions[name]}")
+    while True:
+        raw = input("\nPreset [1-3, default=1]: ").strip()
+        if not raw:
+            return presets[0]
+        try:
+            idx = int(raw) - 1
+        except ValueError:
+            print("Please enter a number between 1 and 3.")
+            continue
+        if 0 <= idx < len(presets):
+            return presets[idx]
+        print("Please enter a number between 1 and 3.")
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Entry point.
+
+    Returns:
+        0 on success, 1 on failure or cloud gate.
+    """
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Step 1: Build topology
+    # ------------------------------------------------------------------
+    from omnibase_core.models.core.model_deployment_topology import (
+        ModelDeploymentTopology,
+    )
+
+    topology: ModelDeploymentTopology
+
+    if args.topology_file:
+        topology_path = Path(args.topology_file).expanduser()
+        try:
+            topology = ModelDeploymentTopology.from_yaml(topology_path)
+        except Exception as exc:
+            print(f"Error loading topology file: {exc}", file=sys.stderr)
+            return 1
+    elif args.preset:
+        try:
+            topology = _topology_for_preset(args.preset)  # type: ignore[assignment]
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+    elif args.no_interactive:
+        topology = ModelDeploymentTopology.default_standard()  # type: ignore[assignment]
+    else:
+        preset = _prompt_preset()
+        topology = _topology_for_preset(preset)  # type: ignore[assignment]
+
+    # ------------------------------------------------------------------
+    # Step 2: Print topology summary
+    # ------------------------------------------------------------------
+    _print_topology_summary(topology)
+
+    # ------------------------------------------------------------------
+    # Step 3: Confirm (skip if --no-interactive or --dry-run)
+    # ------------------------------------------------------------------
+    if not args.no_interactive and not args.dry_run:
+        try:
+            answer = input("\nProceed with setup? [Y/n]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            return 1
+        if answer and answer not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+
+    # ------------------------------------------------------------------
+    # Step 4: Write topology.yaml (skip if --dry-run)
+    # ------------------------------------------------------------------
+    if not args.dry_run:
+        omnibase = _omnibase_dir()
+        omnibase.mkdir(parents=True, exist_ok=True)
+        topo_path = omnibase / "topology.yaml"
+        try:
+            topology.to_yaml(topo_path)
+            print(f"\nTopology written to {topo_path}")
+        except Exception as exc:
+            print(f"Error writing topology file: {exc}", file=sys.stderr)
+            return 1
+
+    # ------------------------------------------------------------------
+    # Step 5: Invoke orchestrator and print events
+    # ------------------------------------------------------------------
+    print("\n--- Setup ---")
+    try:
+        compose_file = resolve_compose_file(args.compose_file)
+    except RuntimeError as exc:
+        if args.dry_run:
+            compose_file = "docker/docker-compose.infra.yml"  # stub for dry-run
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+    try:
+        success = asyncio.run(
+            _run_orchestrator(
+                topology=topology,
+                compose_file_path=compose_file,
+                dry_run=args.dry_run,
+            )
+        )
+    except Exception as exc:
+        print(f"\nSetup failed: {exc}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 6: Exit code
+    # ------------------------------------------------------------------
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_onex_setup_cli.py
+++ b/tests/unit/scripts/test_onex_setup_cli.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for onex-setup.py CLI.
+
+Tests cover:
+    - Preset flag skips interactive prompt
+    - --dry-run does not write topology.yaml
+    - --no-interactive writes standard topology to OMNIBASE_DIR
+    - Cloud selection stores mode=CLOUD in topology (not converted to DISABLED)
+    - resolve_compose_file resolution order (CLI arg, env var, upward search)
+
+Ticket: OMN-3496
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the CLI module from the scripts/ directory without installing it.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_CLI_PATH = _REPO_ROOT / "scripts" / "onex-setup.py"
+
+_spec = importlib.util.spec_from_file_location("onex_setup", _CLI_PATH)
+assert _spec is not None and _spec.loader is not None, f"Cannot load {_CLI_PATH}"
+_cli = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_cli)  # type: ignore[union-attr]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_main(argv: list[str], env: dict[str, str] | None = None) -> int:
+    """Run main() with the given argv, optionally overriding environment.
+
+    Mocks _run_orchestrator to skip actual Docker / Infisical calls.
+
+    Returns:
+        Exit code returned by main().
+    """
+    saved_argv = sys.argv[:]
+    saved_env: dict[str, str | None] = {}
+
+    try:
+        sys.argv = ["onex-setup"] + argv
+
+        if env is not None:
+            for key, value in env.items():
+                saved_env[key] = os.environ.get(key)
+                os.environ[key] = value
+
+        # Patch _run_orchestrator to always return True without doing I/O.
+        async def _fake_orchestrator(
+            topology: Any, compose_file_path: str, dry_run: bool
+        ) -> bool:
+            return True
+
+        with patch.object(_cli, "_run_orchestrator", side_effect=_fake_orchestrator):
+            return _cli.main()
+
+    finally:
+        sys.argv = saved_argv
+        for key, old_value in saved_env.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOnexSetupCLI:
+    """Tests for the onex-setup.py interactive CLI."""
+
+    def test_preset_flag_skips_interactive_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--preset minimal must not invoke input() and must succeed."""
+        monkeypatch.setenv("OMNIBASE_DIR", str(tmp_path))
+        monkeypatch.setenv("ONEX_COMPOSE_FILE", "docker/docker-compose.infra.yml")
+
+        with patch("builtins.input") as mock_input:
+            exit_code = _run_main(["--preset", "minimal", "--no-interactive"])
+
+        mock_input.assert_not_called()
+        assert exit_code == 0
+
+    def test_dry_run_does_not_write_topology_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--dry-run must not write topology.yaml to OMNIBASE_DIR."""
+        monkeypatch.setenv("OMNIBASE_DIR", str(tmp_path))
+
+        exit_code = _run_main(["--preset", "minimal", "--dry-run"])
+
+        topology_file = tmp_path / "topology.yaml"
+        assert not topology_file.exists(), "--dry-run must not write topology.yaml"
+        assert exit_code == 0
+
+    def test_no_interactive_writes_standard_topology_to_omnibase_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--no-interactive writes standard 4-service topology to OMNIBASE_DIR."""
+        monkeypatch.setenv("OMNIBASE_DIR", str(tmp_path))
+        monkeypatch.setenv("ONEX_COMPOSE_FILE", "docker/docker-compose.infra.yml")
+
+        exit_code = _run_main(["--no-interactive"])
+
+        topology_file = tmp_path / "topology.yaml"
+        assert topology_file.exists(), "topology.yaml must be written"
+        content = topology_file.read_text()
+        # Standard preset includes infisical (4th service)
+        assert "infisical" in content
+        assert exit_code == 0
+
+    def test_cloud_selection_stores_cloud_mode_in_topology_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cloud mode must be stored as 'CLOUD' in topology.yaml (I8 — not converted).
+
+        The CLI must NOT silently convert CLOUD to DISABLED. The topology file
+        must preserve the user's intent even though provisioning is not yet
+        implemented for cloud services.
+        """
+        from omnibase_core.enums.enum_deployment_mode import EnumDeploymentMode
+        from omnibase_core.models.core.model_deployment_topology import (
+            ModelDeploymentTopology,
+        )
+        from omnibase_core.models.core.model_deployment_topology_service import (
+            ModelDeploymentTopologyService,
+        )
+
+        # Build a topology with one cloud service.
+        topology = ModelDeploymentTopology(
+            schema_version="1.0",
+            services={
+                "postgres": ModelDeploymentTopologyService(
+                    mode=EnumDeploymentMode.CLOUD,
+                    local=None,
+                ),
+            },
+            presets={},
+            active_preset=None,
+        )
+
+        topo_path = tmp_path / "topology.yaml"
+        topology.to_yaml(topo_path)
+
+        # Verify the YAML preserves CLOUD mode (not DISABLED or LOCAL).
+        content = topo_path.read_text()
+        assert "CLOUD" in content, "topology.yaml must store mode=CLOUD, not convert it"
+        assert "DISABLED" not in content
+
+        # Verify round-trip: loading back preserves CLOUD mode.
+        loaded = ModelDeploymentTopology.from_yaml(topo_path)
+        assert loaded.services["postgres"].mode == EnumDeploymentMode.CLOUD
+
+    def test_compose_file_resolved_from_env_var_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resolve_compose_file must return ONEX_COMPOSE_FILE env var when set."""
+        expected = "/custom/path/docker-compose.infra.yml"
+        monkeypatch.setenv("ONEX_COMPOSE_FILE", expected)
+
+        result = _cli.resolve_compose_file(None)
+
+        assert result == expected
+
+    def test_compose_file_cli_arg_takes_precedence_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resolve_compose_file must prefer CLI arg over ONEX_COMPOSE_FILE env."""
+        monkeypatch.setenv("ONEX_COMPOSE_FILE", "/env/path/compose.yml")
+        cli_arg = "/cli/path/compose.yml"
+
+        result = _cli.resolve_compose_file(cli_arg)
+
+        assert result == cli_arg
+
+    def test_compose_file_raises_when_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resolve_compose_file must raise RuntimeError when no compose file found."""
+        monkeypatch.delenv("ONEX_COMPOSE_FILE", raising=False)
+        # Use an empty tmp directory that has no docker-compose.infra.yml
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(
+            RuntimeError, match=r"Cannot locate docker-compose\.infra\.yml"
+        ):
+            _cli.resolve_compose_file(None)
+
+    def test_omnibase_dir_respects_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_omnibase_dir() must return OMNIBASE_DIR env var when set."""
+        monkeypatch.setenv("OMNIBASE_DIR", str(tmp_path))
+
+        result = _cli._omnibase_dir()
+
+        assert result == tmp_path
+
+    def test_preset_minimal_has_three_services(self) -> None:
+        """minimal preset must produce exactly 3 services."""
+        from omnibase_core.models.core.model_deployment_topology import (
+            ModelDeploymentTopology,
+        )
+
+        topo = ModelDeploymentTopology.default_minimal()
+        assert topo.active_preset == "minimal"
+        assert len(topo.services) == 3
+        assert "postgres" in topo.services
+        assert "redpanda" in topo.services
+        assert "valkey" in topo.services
+
+    def test_preset_standard_includes_infisical(self) -> None:
+        """standard preset must include infisical as the 4th service."""
+        from omnibase_core.models.core.model_deployment_topology import (
+            ModelDeploymentTopology,
+        )
+
+        topo = ModelDeploymentTopology.default_standard()
+        assert topo.active_preset == "standard"
+        assert "infisical" in topo.services
+        assert len(topo.services) == 4
+
+    def test_topology_file_flag_loads_existing_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--topology-file must load from the provided path."""
+        from omnibase_core.models.core.model_deployment_topology import (
+            ModelDeploymentTopology,
+        )
+
+        topo = ModelDeploymentTopology.default_minimal()
+        topo_path = tmp_path / "my-topology.yaml"
+        topo.to_yaml(topo_path)
+
+        monkeypatch.setenv("OMNIBASE_DIR", str(tmp_path))
+        monkeypatch.setenv("ONEX_COMPOSE_FILE", "docker/docker-compose.infra.yml")
+
+        exit_code = _run_main(["--topology-file", str(topo_path), "--no-interactive"])
+
+        assert exit_code == 0


### PR DESCRIPTION
## Summary

- Implements `scripts/onex-setup.py` — interactive argparse CLI for bootstrapping OmniNode platform infrastructure
- Enforces **I7**: `resolve_compose_file()` lives only in this CLI (CLI arg → `ONEX_COMPOSE_FILE` env → upward CWD search)
- Enforces **I8**: Cloud mode stored as `CLOUD` in `topology.yaml`; prints `CLOUD_COMING_SOON` notice; never converts cloud to disabled
- Supports `--preset {minimal,standard,full}`, `--dry-run`, `--no-interactive`, `--topology-file`, `--compose-file`
- Events streamed as `[event_type]  message` as they flow from `HandlerSetupOrchestrator`
- 11 unit tests — all passing

## Files

- `scripts/onex-setup.py` — CLI implementation
- `tests/unit/scripts/test_onex_setup_cli.py` — 11 unit tests

## Test Plan

- [x] `uv run pytest tests/unit/scripts/test_onex_setup_cli.py -v` → 11 passed
- [x] `uv run pre-commit run --files scripts/onex-setup.py tests/unit/scripts/test_onex_setup_cli.py` → all passed
- [x] Smoke: `uv run python scripts/onex-setup.py --preset minimal --dry-run` → exit 0

Ticket: OMN-3496