### PR TITLE
fix(ci,docker): Trivy v0.69.3 pin + apt-get upgrade + plugin dep fix (OMN-3523)

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -128,6 +128,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          version: 'v0.69.3'
 
       - name: Push image to Amazon ECR
         if: success()


### PR DESCRIPTION
## Summary

- **Trivy version pin**: `aquasecurity/trivy-action@0.34.1` defaults to `v0.69.1` which was never released. Pin to `v0.69.3` (latest stable 2026-03-03) to unblock ECR pipeline.
- **CVE fix**: Add `apt-get upgrade -y` to builder and runtime stages in `Dockerfile.runtime` so all upstream security patches are applied. Satisfies Trivy scan with `ignore-unfixed: true`.
- **Plugin dep resolution**: Replace `--constraint /tmp/constraints.txt` approach for omninode-memory and omninode-intelligence installs with explicit `omnibase-core==0.22.0` version pin — fixes cold Docker cache failures in CI.

## Context

Phase 7 of OMN-3523 (k3s deployment) is blocked on ECR build. Run 22647843539 and 22648847121 both failed at "Run Trivy vulnerability scanner" because `v0.69.1` doesn't exist as a GitHub release (only `v0.69.2` and `v0.69.3` exist).

## Test plan

- [ ] ECR workflow `build-and-push-runtime.yml` passes on merge to main
- [ ] Trivy step passes with `v0.69.3` binary
- [ ] Image digest artifact uploaded successfully
- [ ] No CRITICAL/HIGH CVEs with upstream fixes in final image