### PR TITLE
test(infra): add e2e integration tests for NodeSetupOrchestrator [OMN-3497]

### DIFF
--- a/tests/integration/test_setup_orchestrator_e2e.py
+++ b/tests/integration/test_setup_orchestrator_e2e.py
@@ -311,9 +311,9 @@ class TestSetupOrchestratorE2E:
         event_types = [e.event_type for e in output.events]
 
         # Full happy-path events must all be present
-        assert (
-            "setup.completed" in event_types
-        ), f"Expected setup.completed in {event_types}"
+        assert "setup.completed" in event_types, (
+            f"Expected setup.completed in {event_types}"
+        )
         assert "setup.cloud.unavailable" not in event_types
         assert "setup.preflight.completed" in event_types
         assert "setup.provision.completed" in event_types
@@ -325,12 +325,12 @@ class TestSetupOrchestratorE2E:
 
         # I4: Verify phase separation — preflight and validate use separate checks
         # Minimal topology has 3 LOCAL services: postgres (5436), redpanda (19092), valkey (16379)
-        assert (
-            len(preflight_calls) == 3
-        ), f"Expected 3 preflight FREE checks (one per service), got {preflight_calls}"
-        assert (
-            len(validate_calls) == 3
-        ), f"Expected 3 validate OPEN checks (one per service), got {validate_calls}"
+        assert len(preflight_calls) == 3, (
+            f"Expected 3 preflight FREE checks (one per service), got {preflight_calls}"
+        )
+        assert len(validate_calls) == 3, (
+            f"Expected 3 validate OPEN checks (one per service), got {validate_calls}"
+        )
 
         # The two call sets must be disjoint in semantics (both cover the same ports,
         # but via different functions — _check_port_free vs _check_tcp_health).
@@ -372,9 +372,9 @@ class TestSetupOrchestratorE2E:
         event_types = [e.event_type for e in output.events]
 
         # I8: Cloud gate fires, setup stops immediately
-        assert (
-            "setup.cloud.unavailable" in event_types
-        ), f"Expected setup.cloud.unavailable in {event_types}"
+        assert "setup.cloud.unavailable" in event_types, (
+            f"Expected setup.cloud.unavailable in {event_types}"
+        )
 
         # No docker subprocess must have been called (I8 hard stop)
         assert len(docker_calls) == 0, (


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_setup_orchestrator_e2e.py` with 2 integration tests exercising the full `HandlerSetupOrchestrator` → 4 effect handlers pipeline with mocked Docker subprocess and socket I/O
- **Test 1**: Full minimal setup — verifies `setup.completed` emitted, `setup.infisical.skipped` for minimal topology, and I4 phase separation (3 preflight FREE checks + 3 validate OPEN checks tracked separately)
- **Test 2**: Cloud topology → `setup.cloud.unavailable` emitted and `len(docker_calls) == 0` (I8 hard stop before any Docker ops)

## Design

Uses thin protocol adapter wrappers (`_PreflightAdapter`, `_ProvisionAdapter`, `_ValidateAdapter`) that call real handlers via `execute()`, enabling `patch.object` on module-level I/O functions (`_check_port_free`, `_check_tcp_health`, `asyncio.create_subprocess_exec`) to eliminate Docker and socket dependencies without losing the actual handler logic.

## Invariants Verified

- **I4**: Port semantics — preflight tracks calls via `_check_port_free`; validate tracks via `_check_tcp_health`. Both lists have 3 entries (one per local service) confirming phase separation.
- **I8**: Cloud gate is a hard stop — zero docker subprocess calls when any service is `CLOUD`.
- **I5**: `ModelSetupOrchestratorOutput.model_fields` has no `result` field (smoke test passes).

## Test plan

- [x] `uv run pytest tests/integration/test_setup_orchestrator_e2e.py -v -m integration` → 2 PASSED
- [x] `uv run mypy tests/integration/test_setup_orchestrator_e2e.py --strict` → no errors in test file
- [x] `pre-commit run --files tests/integration/test_setup_orchestrator_e2e.py` → all hooks pass
- [x] Smoke tests from ticket pass (no `result` field, cloud+local raises `ValidationError`)

## Ticket

OMN-3497 — Task 8: Integration — End-to-End Test
Parent epic: OMN-3489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests for the setup orchestrator covering preflight, provisioning, and validation phases with explicit phase separation and event sequencing checks.
  * Adds scenarios that verify cloud-gate behavior stops setup early (no container operations) and that minimal topology skips external secret setup.
  * Uses realistic mocked subprocess and socket interactions to validate port semantics and overall orchestration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->