### PR TITLE
feat(ci): add writer-migration coupling gate (OMN-3530)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -532,7 +532,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, arch-invariants, migration-integration]
+    needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, arch-invariants, migration-integration, migration-required-check]
     if: always()
 
     steps:
@@ -548,6 +548,7 @@ jobs:
           topicnaminglint="${{ needs.topic-naming-lint.result }}"
           archinvariants="${{ needs.arch-invariants.result }}"
           migrationintegration="${{ needs.migration-integration.result }}"
+          migrationrequiredcheck="${{ needs.migration-required-check.result }}"
 
           if [[ "$gate" == "success" ]] && \
              [[ "$lint" == "success" ]] && \
@@ -558,7 +559,8 @@ jobs:
              [[ "$topicenumdrift" == "success" ]] && \
              [[ "$topicnaminglint" == "success" ]] && \
              [[ "$archinvariants" == "success" ]] && \
-             [[ "$migrationintegration" == "success" ]]; then
+             [[ "$migrationintegration" == "success" ]] && \
+             [[ "$migrationrequiredcheck" == "success" ]]; then
             echo "All checks passed successfully"
             echo "CI Tests Gate (10 splits): Passed"
             echo "Code Quality: Passed"
@@ -570,6 +572,7 @@ jobs:
             echo "Topic Naming Lint: Passed"
             echo "Arch Invariants: Passed"
             echo "Migration Integration: Passed"
+            echo "Writer-Migration Coupling Check: Passed"
             exit 0
           else
             echo "Checks failed"
@@ -583,6 +586,7 @@ jobs:
             echo "Topic Naming Lint: $topicnaminglint"
             echo "Arch Invariants: $archinvariants"
             echo "Migration Integration: $migrationintegration"
+            echo "Writer-Migration Coupling Check: $migrationrequiredcheck"
             exit 1
           fi
 
@@ -660,6 +664,26 @@ jobs:
           echo "================================================================"
           uv run pytest tests/integration/event_bus/test_kafka_boundary_compat.py \
             -v --tb=short
+
+  # Writer-migration coupling check -- ensures any PR touching writer_postgres.py
+  # or handler_*_postgres.py includes a migration file or explicit bypass comment (OMN-3530)
+  migration-required-check:
+    name: Writer-Migration Coupling Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Check writer-migration coupling
+        run: uv run python scripts/check_migration_required.py --ci
 
   # Migration integration test -- spins up real Postgres, applies all migrations,
   # and asserts every manifest table exists (OMN-3529)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -259,6 +259,13 @@ repos:
         pass_filenames: false
         types: [python]
         stages: [pre-commit]
+      # OMN-3530: Ensure writer_postgres.py / handler_*_postgres.py changes include a migration
+      - id: onex-check-migration-required
+        name: Writer-Migration Coupling Check
+        language: system
+        entry: uv run python scripts/check_migration_required.py --pre-commit
+        pass_filenames: false
+        stages: [pre-commit]
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/scripts/check_migration_required.py
+++ b/scripts/check_migration_required.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+CI gate: any PR touching a writer_postgres.py or handler_*_postgres.py file
+must either include a new migration file OR have a '# no-migration: <reason>'
+comment in the changed file.
+
+Usage (CI — compare against base branch):
+    python scripts/check_migration_required.py --ci
+
+Usage (pre-commit — check staged files):
+    python scripts/check_migration_required.py --pre-commit
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WRITER_PATTERNS = [
+    re.compile(r"writer_postgres\.py$"),
+    re.compile(r"handler_\w+_postgres\.py$"),
+]
+
+MIGRATION_DIRS = [
+    "docker/migrations/forward/",
+    "src/omnibase_infra/migrations/forward/",
+]
+
+BYPASS_RE = re.compile(r"#\s*no-migration\s*:", re.IGNORECASE)
+
+
+def is_writer_file(path: str) -> bool:
+    return any(p.search(path) for p in WRITER_PATTERNS)
+
+
+def has_bypass_comment(content: str) -> bool:
+    return bool(BYPASS_RE.search(content))
+
+
+def get_changed_files(ci: bool) -> list[str]:
+    if ci:
+        base = subprocess.check_output(
+            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            text=True,
+        )
+    else:
+        base = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only"],
+            text=True,
+        )
+    return [f.strip() for f in base.splitlines() if f.strip()]
+
+
+def find_violations(
+    changed_files: list[str],
+    bypass_comment: str | None,
+) -> list[str]:
+    """Return list of writer files that lack a corresponding migration."""
+    writer_files = [f for f in changed_files if is_writer_file(f)]
+    if not writer_files:
+        return []
+
+    has_migration = any(
+        any(f.startswith(d) and f.endswith(".sql") for d in MIGRATION_DIRS)
+        for f in changed_files
+    )
+    if has_migration:
+        return []
+
+    violations = []
+    for wf in writer_files:
+        path = Path(wf)
+        if path.exists():
+            content = path.read_text()
+            if has_bypass_comment(content):
+                continue
+        if bypass_comment and has_bypass_comment(bypass_comment):
+            continue
+        violations.append(wf)
+
+    return violations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ci", action="store_true")
+    parser.add_argument("--pre-commit", action="store_true")
+    args = parser.parse_args()
+
+    changed = get_changed_files(ci=args.ci)
+    violations = find_violations(changed, bypass_comment=None)
+
+    if violations:
+        print("ERROR: Writer file(s) changed without a migration file in this PR:")
+        for v in violations:
+            print(f"  {v}")
+        print()
+        print("Either:")
+        print(
+            "  1. Add a migration file to docker/migrations/forward/"
+            " or src/omnibase_infra/migrations/forward/"
+        )
+        print(
+            "  2. Add '# no-migration: <reason>' to the writer file"
+            " if no schema change is needed"
+        )
+        sys.exit(1)
+
+    print("OK: writer-migration coupling check passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validation/check_kafka_no_hardcoded_fallback.sh
+++ b/scripts/validation/check_kafka_no_hardcoded_fallback.sh
@@ -13,6 +13,8 @@ FAILED=0
 
 # R1: os.getenv("KAFKA_*", non-empty) pattern
 MATCHES=$(grep -rn --include="*.py" \
+    --exclude-dir=".venv" \
+    --exclude-dir="node_modules" \
     -E "os\.getenv\([[:space:]]*[\"']KAFKA_[^\"']+[\"'][[:space:]]*,[[:space:]]*[\"'][^\"']+[\"']" \
     . 2>/dev/null | \
     grep -v "# kafka-fallback-ok" | \
@@ -31,6 +33,8 @@ fi
 
 # R2: Private-IP Kafka broker addresses (Kafka-specific ports only)
 IP_MATCHES=$(grep -rn --include="*.py" \
+    --exclude-dir=".venv" \
+    --exclude-dir="node_modules" \
     -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" \
     . 2>/dev/null | \
     grep -v "# kafka-fallback-ok" | \

--- a/tests/unit/scripts/test_check_migration_required.py
+++ b/tests/unit/scripts/test_check_migration_required.py
@@ -1,0 +1,58 @@
+"""Tests for scripts/check_migration_required.py writer-without-migration gate."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "check_migration_required.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_migration_required", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.unit
+class TestWriterDetection:
+    def test_detects_writer_postgres_files(self):
+        checker = load_checker()
+        assert checker.is_writer_file(
+            "src/omnibase_infra/nodes/agent_actions/writer_postgres.py"
+        )
+        assert not checker.is_writer_file("src/omnibase_infra/nodes/other/model.py")
+
+    def test_detects_handler_postgres_files(self):
+        checker = load_checker()
+        assert checker.is_writer_file(
+            "src/omnibase_infra/nodes/foo/handler_registration_storage_postgres.py"
+        )
+
+    def test_no_migration_comment_bypasses_check(self):
+        checker = load_checker()
+        assert checker.has_bypass_comment(
+            "# no-migration: table already exists in docker set\n"
+        )
+        assert not checker.has_bypass_comment("# unrelated comment\n")
+
+    def test_migration_file_present_passes(self):
+        checker = load_checker()
+        changed_files = [
+            "src/omnibase_infra/nodes/foo/writer_postgres.py",
+            "docker/migrations/forward/036_add_foo_table.sql",
+        ]
+        violations = checker.find_violations(changed_files, bypass_comment=None)
+        assert violations == []
+
+    def test_writer_without_migration_fails(self):
+        checker = load_checker()
+        changed_files = [
+            "src/omnibase_infra/nodes/foo/writer_postgres.py",
+        ]
+        violations = checker.find_violations(changed_files, bypass_comment=None)
+        assert len(violations) == 1
+        assert "writer_postgres.py" in violations[0]


### PR DESCRIPTION
## Summary

- Creates `scripts/check_migration_required.py` with `is_writer_file()`, `has_bypass_comment()`, and `find_violations()` public API
- Creates `tests/unit/scripts/test_check_migration_required.py` with 5 passing unit tests
- Adds `migration-required-check` CI job to `.github/workflows/test.yml` and wires it into the final CI gate `needs:` list
- Adds `onex-check-migration-required` pre-commit hook to `.pre-commit-config.yaml`
- Fixes `scripts/validation/check_kafka_no_hardcoded_fallback.sh` to exclude `.venv` and `node_modules` from grep scans (pre-existing false positive on local dev)

## Behavior

Any PR touching `writer_postgres.py` or `handler_*_postgres.py` must either:
1. Include a new migration file in `docker/migrations/forward/` or `src/omnibase_infra/migrations/forward/`
2. OR add a `# no-migration: <reason>` bypass comment in the writer file

## Test plan

- [ ] 5 unit tests pass: `pytest tests/unit/scripts/test_check_migration_required.py -v`
- [ ] `migration-required-check` CI job runs and passes in GitHub Actions
- [ ] Pre-commit hook `onex-check-migration-required` triggers on staged writer files
- [ ] Final CI gate includes `migration-required-check` in `needs:` and check script

## Related

Closes OMN-3530
Epic: OMN-3524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new CI validation gate to enforce writer-migration coupling requirements in pull requests.
  * Integrated a pre-commit hook to validate migration requirements during local development.
  * Enhanced search patterns in test validation scripts to exclude dependency directories.

* **Tests**
  * Added comprehensive unit tests for writer-migration coupling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->