### PR TITLE
fix(docker): upgrade protobuf>=5.29.6 to clear CVE-2026-0994 (OMN-3523)

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -183,6 +183,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "omninode-intelligence==0.9.1" \
     "omnibase-core==0.22.0"
 
+# Security: upgrade protobuf to clear CVE-2026-0994 (HIGH, DoS, fixed in >=5.29.6).
+# protobuf 4.25.8 (from transitive deps) is flagged by Trivy scan (ignore-unfixed: true).
+# Force upgrade here after all plugin installs to ensure the patched version is present.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install "protobuf>=5.29.6"
+
 # ============================================================================
 # Runtime Stage - Minimal production image
 # ============================================================================


### PR DESCRIPTION
## Summary

- **Protobuf CVE fix**: After Trivy v0.69.3 pin merged (#596), the scan now runs successfully and detects `protobuf 4.25.8` as HIGH (CVE-2026-0994, DoS vulnerability, fixed in >=5.29.6).
- Add `uv pip install "protobuf>=5.29.6"` step in builder stage after all plugin installs to ensure the patched version is in the venv.

## Context

The ECR build pipeline (`build-and-push-runtime.yml`) is failing at the Trivy step:

```
Python (python-pkg)
===================
Total: 1 (HIGH: 1, CRITICAL: 0)

│ protobuf (METADATA) │ CVE-2026-0994 │ HIGH │ fixed │ 4.25.8 │ 6.33.5, 5.29.6 │
```

`protobuf 4.25.8` is pulled in by `qdrant-client` and `opentelemetry-proto` as a transitive dep. Since `ignore-unfixed: true` is set and a fix exists, Trivy blocks the push.

This fix forces protobuf to `>=5.29.6` in the final image after all other installs.

## Test plan

- [ ] ECR build passes Trivy scan after this merges
- [ ] No CRITICAL/HIGH CVEs with upstream fixes remain
- [ ] Image digest artifact uploaded to workflow artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated protobuf to >=5.29.6 in Docker runtime to address a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->