### PR TITLE
fix(ci): bump build-and-push-runtime timeout 45→60 min (OMN-3523)

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -44,11 +44,11 @@ jobs:
     name: Build and push runtime image
     runs-on: ubuntu-latest
     # Timeout breakdown (cold cache worst case):
-    #   Docker build:        ~14 min
+    #   Docker build:        ~30 min (protobuf upgrade + cold cache adds ~16 min vs baseline)
     #   ECR push:            ~5 min
     #   GHA cache export:    ~15 min
-    #   Total:               ~34 min — 45 min gives comfortable buffer
-    timeout-minutes: 45
+    #   Total:               ~50 min — 60 min gives comfortable buffer
+    timeout-minutes: 60
 
     outputs:
       image_digest: ${{ steps.resolve-digest.outputs.digest }}


### PR DESCRIPTION
## Summary

The `build-and-push-runtime` job is hitting the 45-minute timeout when running cold (no GHA cache). The protobuf upgrade layer added in #599 adds ~16 minutes to cold builds.

Bump timeout to 60 minutes to give comfortable buffer.

**Cold cache breakdown:**
- Docker build (with protobuf layer): ~30 min
- ECR push: ~5 min
- GHA cache export: ~15 min
- Total: ~50 min

## Context

Run 22653325486 failed with `The job has exceeded the maximum execution time of 45m0s` at the "Build runtime image (local)" step. Subsequent warm-cache builds will be ~15 min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime build timeout configuration to accommodate extended build durations and improve build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->