### PR TITLE
[omnibase_infra] Pre-commit validator: block duplicate migration sequence numbers [OMN-3570]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,13 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-commit]
+      - id: onex-validate-migration-sequence
+        name: ONEX Migration Sequence Duplicate Check
+        entry: uv run python scripts/validation/validate_migration_sequence.py
+        language: system
+        pass_filenames: false
+        always_run: false
+        stages: [pre-commit]
       # Reject any staged .env file at any path depth (OMN-2476)
       # Uses (^|/)\.env([._-].+)?$ to block root/.env, config/.env, .env.production, .env.staging,
       # .env_local, .env_production, .env-secret, etc. (dot-separated, underscore-separated, and

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -10,6 +10,7 @@ Usage:
     python scripts/validate.py architecture
     python scripts/validate.py architecture_layers
     python scripts/validate.py migration_freeze
+    python scripts/validate.py migration_sequence
     python scripts/validate.py clean_root
     python scripts/validate.py contracts
     python scripts/validate.py patterns
@@ -605,6 +606,55 @@ def run_migration_freeze(verbose: bool = False) -> bool:
         return False
 
 
+def run_migration_sequence(verbose: bool = False) -> bool:
+    """Run migration sequence duplicate detection validation.
+
+    Scans docker/ and src/ migration sets as a shared namespace and
+    blocks commits with duplicate sequence numbers (OMN-3570).
+    """
+    import importlib.util
+
+    try:
+        validator_path = (
+            Path(__file__).parent / "validation" / "validate_migration_sequence.py"
+        )
+
+        if not validator_path.exists():
+            print(f"Migration Sequence: SKIP (validator not found: {validator_path})")
+            return True
+
+        spec = importlib.util.spec_from_file_location(
+            "validate_migration_sequence", validator_path
+        )
+        if spec is None or spec.loader is None:
+            print("Migration Sequence: SKIP (could not load validator module)")
+            return True
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["validate_migration_sequence"] = module
+        spec.loader.exec_module(module)
+
+        repo_path = Path(__file__).parent.parent
+        result = module.validate_migration_sequence(repo_path)
+
+        report = module.generate_report(result)
+        if verbose or not result.is_valid or result.has_staged_migrations:
+            print(report)
+
+        return result.is_valid
+
+    except RuntimeError as e:
+        print(f"Migration Sequence: ERROR ({e})", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Migration Sequence: ERROR ({type(e).__name__}: {e})")
+        if verbose:
+            import traceback
+
+            traceback.print_exc()
+        return False
+
+
 def run_clean_root(verbose: bool = False) -> bool:
     """Run root directory cleanliness validation.
 
@@ -955,6 +1005,7 @@ def run_all(verbose: bool = False, quick: bool = False) -> bool:
         ("Architecture", run_architecture),
         ("Architecture Layers", run_architecture_layers),
         ("Migration Freeze", run_migration_freeze),
+        ("Migration Sequence", run_migration_sequence),
         ("Clean Root", run_clean_root),
         ("Contracts", run_contracts),
         ("Patterns", run_patterns),
@@ -1006,6 +1057,7 @@ def main() -> int:
             "architecture",
             "architecture_layers",
             "migration_freeze",
+            "migration_sequence",
             "clean_root",
             "contracts",
             "patterns",
@@ -1036,6 +1088,7 @@ def main() -> int:
         "architecture": run_architecture,
         "architecture_layers": run_architecture_layers,
         "migration_freeze": run_migration_freeze,
+        "migration_sequence": run_migration_sequence,
         "clean_root": run_clean_root,
         "contracts": run_contracts,
         "patterns": run_patterns,

--- a/scripts/validation/validate_migration_sequence.py
+++ b/scripts/validation/validate_migration_sequence.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Pre-commit validator: block duplicate migration sequence numbers.
+
+Scans docker/migrations/forward/ and src/omnibase_infra/migrations/forward/
+as a single shared sequence namespace and exits 1 if any two .sql files
+share the same leading-integer sequence number.
+
+Exit Codes:
+    0 - All sequence numbers are unique (or no migration files staged)
+    1 - Duplicate sequence number detected; message names conflicting files
+    2 - Script error (git unavailable, not a repo, unexpected exception)
+
+Ticket: OMN-3570
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Directories that form the shared migration sequence namespace.
+# Relative to repo root — both sets are applied together by run-migrations.py
+# so cross-set duplicates are equally dangerous.
+MIGRATION_DIRS: tuple[str, ...] = (
+    "docker/migrations/forward",
+    "src/omnibase_infra/migrations/forward",
+)
+
+
+@dataclass
+class DuplicateConflict:
+    """A pair of migration files that share a sequence number."""
+
+    sequence: int
+    file_a: str
+    file_b: str
+
+    def __str__(self) -> str:
+        return f"  seq {self.sequence:03d}: {self.file_a!r}  <-->  {self.file_b!r}"
+
+
+@dataclass
+class SequenceValidationResult:
+    """Result of migration sequence uniqueness validation."""
+
+    conflicts: list[DuplicateConflict] = field(default_factory=list)
+    files_scanned: int = 0
+    has_staged_migrations: bool = False
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.conflicts) == 0
+
+    def __bool__(self) -> bool:
+        return self.is_valid
+
+
+def extract_sequence_number(filename: str) -> int | None:
+    """Extract leading integer sequence number from a migration filename.
+
+    Identical to run-migrations.py's extract_sequence_number() — one definition
+    of sequence number across the codebase.
+
+    Only .sql files are considered migrations (matches run-migrations.py).
+
+    Returns:
+        Integer sequence number, or None if file is not a .sql migration.
+    """
+    path = Path(filename)
+    if path.suffix.lower() != ".sql":
+        return None
+    stem = path.stem
+    prefix = ""
+    for ch in stem:
+        if ch.isdigit():
+            prefix += ch
+        else:
+            break
+    if not prefix:
+        return None
+    return int(prefix)
+
+
+def _get_staged_paths(repo_path: Path) -> list[str]:
+    """Return paths staged in the git index (git diff --cached --name-only).
+
+    Raises:
+        RuntimeError: If git is unavailable or repo_path is not a git repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_path),
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("git diff --cached timed out") from exc
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git diff --cached failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+
+    return [p.strip() for p in result.stdout.strip().splitlines() if p.strip()]
+
+
+def _scan_migration_dir(repo_path: Path, rel_dir: str) -> list[Path]:
+    """Return all .sql files in rel_dir (relative to repo_path), if it exists."""
+    abs_dir = repo_path / rel_dir
+    if not abs_dir.is_dir():
+        return []
+    return sorted(abs_dir.glob("*.sql"))
+
+
+def validate_migration_sequence(
+    repo_path: Path,
+) -> SequenceValidationResult:
+    """Validate that all migration .sql files have unique sequence numbers.
+
+    Treats docker/ and src/ migration sets as one shared namespace.
+    Staged paths are included in the scan so newly added files are caught
+    before they are committed.
+
+    Args:
+        repo_path: Absolute path to the repository root.
+
+    Returns:
+        SequenceValidationResult with any conflicts found.
+
+    Raises:
+        RuntimeError: If git is unavailable or not a git repository.
+    """
+    result = SequenceValidationResult()
+
+    # Collect staged paths to determine whether any migration was staged
+    staged_paths = _get_staged_paths(repo_path)
+    staged_set = set(staged_paths)
+
+    # Check whether any staged file is a migration file
+    staged_migration_rel: set[str] = set()
+    for sp in staged_paths:
+        for mdir in MIGRATION_DIRS:
+            if sp.startswith((mdir + "/", mdir.replace("/", "\\") + "\\")):
+                seq = extract_sequence_number(Path(sp).name)
+                if seq is not None:
+                    staged_migration_rel.add(sp)
+                    break
+
+    result.has_staged_migrations = bool(staged_migration_rel)
+
+    # If no migration files are staged, exit early (hook does not fire)
+    if not result.has_staged_migrations:
+        return result
+
+    # Build the full scan: all existing .sql files in both dirs + staged paths
+    # (staged files may not yet exist on disk if they were just added)
+    seen: dict[int, str] = {}  # seq -> relative path string
+
+    # Gather all .sql files from both migration dirs (filesystem scan)
+    all_files: list[str] = []
+    for mdir in MIGRATION_DIRS:
+        for f in _scan_migration_dir(repo_path, mdir):
+            rel = str(f.relative_to(repo_path))
+            all_files.append(rel)
+
+    # Also include staged paths that are migrations but may not be on disk yet
+    for sp in staged_migration_rel:
+        if sp not in all_files:
+            all_files.append(sp)
+
+    result.files_scanned = len(all_files)
+
+    for rel in sorted(all_files):
+        seq = extract_sequence_number(Path(rel).name)
+        if seq is None:
+            continue
+        if seq in seen:
+            result.conflicts.append(
+                DuplicateConflict(
+                    sequence=seq,
+                    file_a=seen[seq],
+                    file_b=rel,
+                )
+            )
+        else:
+            seen[seq] = rel
+
+    return result
+
+
+def generate_report(result: SequenceValidationResult) -> str:
+    """Generate a human-readable validation report."""
+    if not result.has_staged_migrations:
+        return "Migration Sequence: no migration files staged — skipped"
+
+    if result.is_valid:
+        return (
+            f"Migration Sequence: PASS"
+            f" ({result.files_scanned} file(s) scanned, no duplicates)"
+        )
+
+    lines: list[str] = [
+        "ERROR: DUPLICATE MIGRATION SEQUENCE NUMBER",
+        "=" * 60,
+        "",
+        f"Found {len(result.conflicts)} duplicate sequence number(s):",
+        "",
+    ]
+    for conflict in result.conflicts:
+        lines.append(str(conflict))
+    lines.extend(
+        [
+            "",
+            "=" * 60,
+            "Each migration file must have a unique leading sequence number.",
+            "docker/ and src/ migration sets share the same namespace.",
+            "",
+            "To fix: renumber the new migration to use the next available sequence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Main entry point for CLI and pre-commit hook invocation."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate migration sequence number uniqueness"
+    )
+    parser.add_argument(
+        "repo_path",
+        nargs="?",
+        default=None,
+        help="Path to repository root (default: auto-detect from script location)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+    args = parser.parse_args()
+
+    if args.repo_path:
+        repo_path = Path(args.repo_path).resolve()
+    else:
+        # Auto-detect: script lives at scripts/validation/validate_migration_sequence.py
+        repo_path = Path(__file__).resolve().parent.parent.parent
+
+    try:
+        result = validate_migration_sequence(repo_path)
+        report = generate_report(result)
+        if args.verbose or not result.is_valid or result.has_staged_migrations:
+            print(report)
+        return 0 if result.is_valid else 1
+
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_validate_migration_sequence.py
+++ b/tests/ci/test_validate_migration_sequence.py
@@ -1,0 +1,293 @@
+"""Tests for migration sequence number duplicate detection.
+
+Covers:
+  - extract_sequence_number() — filename parsing variants
+  - validate_migration_sequence() — same-set, cross-set, non-sql, non-migration
+  - generate_report() — pass and failure message content
+  - Main exit codes
+
+Ticket: OMN-3570
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.validation.validate_migration_sequence import (
+    DuplicateConflict,
+    SequenceValidationResult,
+    extract_sequence_number,
+    generate_report,
+    validate_migration_sequence,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+DOCKER_MIGRATIONS = "docker/migrations/forward"
+SRC_MIGRATIONS = "src/omnibase_infra/migrations/forward"
+
+
+def _make_migration_dirs(repo_path: Path) -> tuple[Path, Path]:
+    """Create both migration directories and return them."""
+    docker_dir = repo_path / DOCKER_MIGRATIONS
+    src_dir = repo_path / SRC_MIGRATIONS
+    docker_dir.mkdir(parents=True)
+    src_dir.mkdir(parents=True)
+    return docker_dir, src_dir
+
+
+def _write_sql(directory: Path, name: str, content: str = "-- migration\n") -> Path:
+    """Write a .sql file in directory and return the path."""
+    f = directory / name
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+def _mock_staged(repo_path: Path, paths: list[str]) -> Any:
+    """Return a context manager that patches _get_staged_paths to return paths."""
+    return patch(
+        "scripts.validation.validate_migration_sequence._get_staged_paths",
+        return_value=paths,
+    )
+
+
+# ── extract_sequence_number ───────────────────────────────────────────────────
+
+
+class TestExtractSequenceNumber:
+    """Unit tests for extract_sequence_number()."""
+
+    def test_three_digit_seq(self) -> None:
+        assert extract_sequence_number("006_foo.sql") == 6
+
+    def test_two_digit_seq(self) -> None:
+        assert extract_sequence_number("036_bar.sql") == 36
+
+    def test_one_digit_seq(self) -> None:
+        assert extract_sequence_number("1_create_table.sql") == 1
+
+    def test_zero_padded_seq(self) -> None:
+        assert extract_sequence_number("001_init.sql") == 1
+
+    def test_non_sql_returns_none(self) -> None:
+        assert extract_sequence_number("006_foo.sh") is None
+
+    def test_non_sql_txt_returns_none(self) -> None:
+        assert extract_sequence_number("006_foo.txt") is None
+
+    def test_no_leading_digits_returns_none(self) -> None:
+        assert extract_sequence_number("foo_migration.sql") is None
+
+    def test_bare_number_only_stem(self) -> None:
+        assert extract_sequence_number("007.sql") == 7
+
+    def test_uppercase_extension_is_sql(self) -> None:
+        # .SQL should be treated as sql (case-insensitive suffix check)
+        assert extract_sequence_number("010_foo.SQL") == 10
+
+    def test_path_with_dir_component(self) -> None:
+        # Only the filename part matters
+        assert extract_sequence_number("docker/migrations/forward/036_bar.sql") == 36
+
+
+# ── validate_migration_sequence ──────────────────────────────────────────────
+
+
+class TestValidateMigrationSequence:
+    """Integration tests for validate_migration_sequence()."""
+
+    # ── no staged migrations → hook does not fire ─────────────────────────
+
+    def test_no_staged_files_exits_cleanly(self, tmp_path: Path) -> None:
+        """Hook exits 0 when no migration files are staged."""
+        _make_migration_dirs(tmp_path)
+        with _mock_staged(tmp_path, []):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert not result.has_staged_migrations
+
+    def test_staged_readme_only_does_not_trigger(self, tmp_path: Path) -> None:
+        """Non-migration staged file alone does not trigger the hook (R4 AC)."""
+        _make_migration_dirs(tmp_path)
+        with _mock_staged(tmp_path, ["README.md"]):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert not result.has_staged_migrations
+
+    def test_staged_non_sql_in_migration_dir_does_not_trigger(
+        self, tmp_path: Path
+    ) -> None:
+        """A .sh file staged in the migration dir is not treated as a migration."""
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "000_create.sh", "#!/bin/bash\n")
+        with _mock_staged(tmp_path, [f"{DOCKER_MIGRATIONS}/000_create.sh"]):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert not result.has_staged_migrations
+
+    # ── unique sequences ──────────────────────────────────────────────────
+
+    def test_all_unique_within_docker_set(self, tmp_path: Path) -> None:
+        """Unique sequences in docker set → exit 0."""
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "001_a.sql")
+        _write_sql(docker_dir, "002_b.sql")
+        with _mock_staged(tmp_path, [f"{DOCKER_MIGRATIONS}/002_b.sql"]):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert result.has_staged_migrations
+
+    def test_all_unique_cross_sets(self, tmp_path: Path) -> None:
+        """Unique sequences across both sets → exit 0 (R2 AC)."""
+        docker_dir, src_dir = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "001_a.sql")
+        _write_sql(src_dir, "002_b.sql")
+        with _mock_staged(tmp_path, [f"{SRC_MIGRATIONS}/002_b.sql"]):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert len(result.conflicts) == 0
+
+    # ── duplicate detection ───────────────────────────────────────────────
+
+    def test_same_set_duplicate_detected(self, tmp_path: Path) -> None:
+        """seq 036 in docker set twice → exit 1, message names both files."""
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "036_original.sql")
+        # Simulate staging a new file with duplicate seq
+        staged_path = f"{DOCKER_MIGRATIONS}/036_duplicate.sql"
+        with _mock_staged(tmp_path, [staged_path]):
+            # Also write the staged file to disk so the fs scan picks it up
+            _write_sql(docker_dir, "036_duplicate.sql")
+            result = validate_migration_sequence(tmp_path)
+        assert not result.is_valid
+        assert len(result.conflicts) == 1
+        assert result.conflicts[0].sequence == 36
+        filenames = {
+            Path(result.conflicts[0].file_a).name,
+            Path(result.conflicts[0].file_b).name,
+        }
+        assert "036_original.sql" in filenames
+        assert "036_duplicate.sql" in filenames
+
+    def test_cross_set_duplicate_detected(self, tmp_path: Path) -> None:
+        """seq 036 in docker set + seq 036 in src set → exit 1 (R2 AC)."""
+        docker_dir, src_dir = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "036_docker.sql")
+        staged_path = f"{SRC_MIGRATIONS}/036_cross_set.sql"
+        with _mock_staged(tmp_path, [staged_path]):
+            _write_sql(src_dir, "036_cross_set.sql")
+            result = validate_migration_sequence(tmp_path)
+        assert not result.is_valid
+        assert len(result.conflicts) == 1
+        conflict = result.conflicts[0]
+        assert conflict.sequence == 36
+        names = {Path(conflict.file_a).name, Path(conflict.file_b).name}
+        assert "036_docker.sql" in names
+        assert "036_cross_set.sql" in names
+
+    def test_multiple_duplicate_pairs(self, tmp_path: Path) -> None:
+        """Multiple independent duplicate pairs are all reported."""
+        docker_dir, src_dir = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "010_a.sql")
+        _write_sql(docker_dir, "010_b.sql")
+        _write_sql(src_dir, "010_c.sql")
+        staged = [f"{SRC_MIGRATIONS}/010_c.sql"]
+        with _mock_staged(tmp_path, staged):
+            result = validate_migration_sequence(tmp_path)
+        assert not result.is_valid
+        # Two pairs share seq 10: (010_a, 010_b) and one of those with 010_c
+        conflict_seqs = [c.sequence for c in result.conflicts]
+        assert all(s == 10 for s in conflict_seqs)
+
+    # ── staged file not yet on disk (staged-only file) ────────────────────
+
+    def test_staged_only_file_included_in_scan(self, tmp_path: Path) -> None:
+        """A staged .sql file not yet on disk is included in the duplicate scan."""
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "005_existing.sql")
+        # Staged path that does not exist on disk yet
+        staged_path = f"{DOCKER_MIGRATIONS}/005_staged_only.sql"
+        with _mock_staged(tmp_path, [staged_path]):
+            result = validate_migration_sequence(tmp_path)
+        assert not result.is_valid
+        conflict = result.conflicts[0]
+        assert conflict.sequence == 5
+
+
+# ── generate_report ───────────────────────────────────────────────────────────
+
+
+class TestGenerateReport:
+    def test_no_staged_migrations_report(self) -> None:
+        result = SequenceValidationResult(has_staged_migrations=False)
+        report = generate_report(result)
+        assert "skipped" in report
+
+    def test_pass_report(self) -> None:
+        result = SequenceValidationResult(has_staged_migrations=True, files_scanned=10)
+        report = generate_report(result)
+        assert "PASS" in report
+        assert "10" in report
+
+    def test_failure_report_contains_conflict_info(self) -> None:
+        result = SequenceValidationResult(
+            has_staged_migrations=True,
+            files_scanned=4,
+            conflicts=[
+                DuplicateConflict(
+                    sequence=36,
+                    file_a="docker/migrations/forward/036_original.sql",
+                    file_b="docker/migrations/forward/036_duplicate.sql",
+                )
+            ],
+        )
+        report = generate_report(result)
+        assert "DUPLICATE" in report
+        assert "036" in report
+        assert "036_original.sql" in report
+        assert "036_duplicate.sql" in report
+
+    def test_failure_report_mentions_both_dirs(self) -> None:
+        result = SequenceValidationResult(
+            has_staged_migrations=True,
+            files_scanned=2,
+            conflicts=[
+                DuplicateConflict(
+                    sequence=36,
+                    file_a="docker/migrations/forward/036_docker.sql",
+                    file_b="src/omnibase_infra/migrations/forward/036_src.sql",
+                )
+            ],
+        )
+        report = generate_report(result)
+        assert "036_docker.sql" in report
+        assert "036_src.sql" in report
+        assert "namespace" in report
+
+
+# ── RuntimeError on git failure ───────────────────────────────────────────────
+
+
+class TestGitErrorHandling:
+    def test_git_not_found_raises_runtime_error(self, tmp_path: Path) -> None:
+        """If git is not available, validate raises RuntimeError (exit 2)."""
+        with patch(
+            "scripts.validation.validate_migration_sequence._get_staged_paths",
+            side_effect=RuntimeError("git executable not found"),
+        ):
+            with pytest.raises(RuntimeError, match="git executable not found"):
+                validate_migration_sequence(tmp_path)
+
+    def test_git_nonzero_exit_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Non-zero git exit code raises RuntimeError (exit 2)."""
+        with patch(
+            "scripts.validation.validate_migration_sequence._get_staged_paths",
+            side_effect=RuntimeError("git diff --cached failed"),
+        ):
+            with pytest.raises(RuntimeError, match="git diff --cached failed"):
+                validate_migration_sequence(tmp_path)


### PR DESCRIPTION
## Summary

- Adds `scripts/validation/validate_migration_sequence.py`: scans `docker/migrations/forward/` and `src/omnibase_infra/migrations/forward/` as a **shared sequence namespace** and exits 1 with named conflicting files when any two `.sql` files share a leading sequence number
- Reuses `extract_sequence_number()` logic from `run-migrations.py` (single definition of sequence number across the codebase, per R4)
- Hook only fires when migration `.sql` files are staged — non-migration files (e.g. `README.md`) do not trigger it (R1 AC)
- Staged-only files not yet on disk are included in the scan (R3 AC)
- git unavailable or non-repo exits 2 with a clear error, not a silent pass (R1 AC)
- Registers hook in `.pre-commit-config.yaml` as `onex-validate-migration-sequence` with `pass_filenames: false`, `always_run: false`, `stages: [pre-commit]`
- Adds `migration_sequence` dispatcher entry to `scripts/validate.py`
- 25 unit tests: filename variants, same-set duplicates, cross-set duplicates (R2), non-sql, non-migration staged files, staged-only detection, git error handling

## Motivation

OMN-3525 found a duplicate 006 migration after merge. This hook catches duplicates at authoring time (pre-commit) rather than at apply time.

## Verification

| ID | Check | Result |
|----|-------|--------|
| V1 | `uv run pytest tests/ci/test_validate_migration_sequence.py -v` | 25 passed |
| V5 | `uv run ruff check scripts/validation/validate_migration_sequence.py` | clean |
| - | `uv run mypy scripts/validation/validate_migration_sequence.py --strict` | clean |
| - | `pre-commit run onex-validate-migration-sequence` | Passed |

Closes OMN-3570
Parent: OMN-3524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration sequence validation that automatically detects and prevents duplicate sequence numbers across migration directories, seamlessly integrated into the pre-commit workflow to catch issues early during development.

* **Tests**
  * Added comprehensive test coverage for the migration sequence validation system, including scenarios for duplicate detection across directories, error handling, and various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->