### PR TITLE
test(OMN-3248): remove xfail from intent boundary pair

### DIFF
--- a/tests/integration/event_bus/test_kafka_boundary_compat.py
+++ b/tests/integration/event_bus/test_kafka_boundary_compat.py
@@ -134,10 +134,9 @@ BOUNDARY_PAIRS: list[BoundaryPair] = [
     # Producer: omniintelligence (ModelIntentClassifiedEvent)
     # Consumer: omnimemory (ModelIntentClassifiedEvent)
     #
-    # Status: XFAIL — OMN-3248 open
-    # The producer emits `intent_class: EnumIntentClass`; the consumer requires
-    # `intent_category: str`.  These are different field names for the same
-    # concept.  Remove xfail_reason once OMN-3248 is merged.
+    # Fixed: OMN-3248 / omnimemory #108 — consumer model now accepts both
+    # `intent_class` (EnumIntentClass) and `intent_category` (str) via a
+    # model_validator, so the boundary round-trip passes clean.
     # -------------------------------------------------------------------------
     BoundaryPair(
         producer_cls=OmniIntelligenceIntentClassifiedEvent,
@@ -152,11 +151,6 @@ BOUNDARY_PAIRS: list[BoundaryPair] = [
             "emitted_at": _EMITTED_AT,
         },
         topic="onex.evt.intent.classified.v1",
-        xfail_reason=(
-            "OMN-3248 open: producer emits intent_class (EnumIntentClass) "
-            "but consumer requires intent_category (str). "
-            "Remove this xfail_reason once OMN-3248 is merged."
-        ),
     ),
 ]
 


### PR DESCRIPTION
## Summary

- Removes the `xfail_reason` from the `onex.evt.intent.classified.v1` boundary pair in `test_kafka_boundary_compat.py`
- Updates the inline comment block to reflect that both upstream fixes have landed (omnimemory #108 + #111)
- Test now runs as a normal PASSED test with zero XFAIL noise

## Context

The original xfail was placed because omnimemory's consumer model required `intent_category: str` while the omniintelligence producer emitted `intent_class: EnumIntentClass`. Two fixes were needed:

1. **omnimemory #108**: Added `model_validator` to normalize the field-name split — accepts both `intent_class` and `intent_category`
2. **omnimemory #111**: Fixed the remaining case-sensitivity gap — the legacy omniintelligence local enum used uppercase values (`FEATURE = "FEATURE"`) while omnibase_core uses lowercase (`FEATURE = "feature"`). The validator now casesfolds all `intent_class` wire values before Pydantic validation.

Both PRs together make the round-trip pass clean.

## Test plan

- [x] `uv run pytest tests/integration/event_bus/test_kafka_boundary_compat.py -v` → 1 PASSED, 0 XFAIL
- [x] Pre-commit passes (all 27 hooks)

## Linear

Closes OMN-3248 (Track B follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved a previously tracked Kafka event boundary compatibility issue. Recent improvements have fixed the issue, which is now validated through the integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->