### PR TITLE
test(registration): cover advisory lock failure path in schema init tests (OMN-3572)

### DIFF
--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
@@ -425,6 +425,65 @@ class TestSchemaInitErrorHandling:
         # Pool should NOT have been touched (early return before pool access)
         pool.acquire.assert_not_called()
 
+    @pytest.mark.unit
+    async def test_advisory_lock_failure_does_not_propagate(self) -> None:
+        """Advisory lock failure (on_call=1) does not propagate out of _initialize_schema (R2).
+
+        If pg_advisory_xact_lock raises (e.g., lock wait timeout, connection drop,
+        role permission error), the exception falls into the generic except branch
+        and must be swallowed. A refactor that accidentally re-raised on advisory
+        lock failure would be caught by this test.
+        """
+        conn = _make_conn_mock_raising(
+            on_call=1, error=RuntimeError("lock wait timeout")
+        )
+        pool = _make_pool_mock(conn)
+        plugin = _make_plugin_with_pool(pool)
+        config = _make_config()
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.read_text", return_value="-- schema"),
+        ):
+            # Must NOT raise — advisory lock failure must be swallowed (R2)
+            await plugin._initialize_schema(config)  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
+    async def test_advisory_lock_failure_logged_as_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Advisory lock failure (on_call=1) is logged as WARNING, not ERROR (R2).
+
+        Covers the untested branch: when pg_advisory_xact_lock itself raises,
+        the code falls into the generic except handler and emits WARNING.
+        No ERROR or exception must propagate to the caller.
+        """
+        conn = _make_conn_mock_raising(
+            on_call=1, error=RuntimeError("lock wait timeout")
+        )
+        pool = _make_pool_mock(conn)
+        plugin = _make_plugin_with_pool(pool)
+        config = _make_config()
+
+        plugin_logger = _PLUGIN_MOD
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.read_text", return_value="-- schema"),
+        ):
+            with caplog.at_level(logging.WARNING, logger=plugin_logger):
+                await plugin._initialize_schema(config)  # type: ignore[attr-defined]
+
+        assert not any(r.levelno >= logging.ERROR for r in caplog.records), (
+            "No ERROR should propagate — advisory lock failure must be swallowed. "
+            f"Got records: {[(r.levelname, r.message) for r in caplog.records if r.levelno >= logging.ERROR]}"
+        )
+        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_msgs, (
+            "A WARNING must be emitted when the advisory lock call raises. "
+            "No WARNING records found."
+        )
+
 
 # =============================================================================
 # TestSchemaInitSuccessPath


### PR DESCRIPTION
## Summary

- Adds two unit tests for the previously untested advisory lock failure branch in `_initialize_schema`
- All prior 5 error-injection tests used `on_call=2` (schema SQL execute); none injected failure into the advisory lock call (`on_call=1`)
- Closes the gap identified in OMN-3567 hostile review (Risk 1, confidence 0.87)

## New Tests

**`test_advisory_lock_failure_does_not_propagate`**: Verifies that when `pg_advisory_xact_lock` raises (e.g., `RuntimeError("lock wait timeout")`), the exception is swallowed and does not propagate out of `_initialize_schema`.

**`test_advisory_lock_failure_logged_as_warning`**: Verifies that a WARNING is emitted and no ERROR-level records appear when the advisory lock call raises — confirming the generic `except Exception` branch handles this correctly.

## Test Results

13/13 tests pass (11 original + 2 new).

## Motivation

If `pg_advisory_xact_lock` raises (lock wait timeout, connection drop, role permission error), the code correctly falls into the `except Exception` branch and emits WARNING. Without these tests, a refactor that accidentally re-raised on advisory lock failure would be undetected.

## TCB

No TCB suggestions were used (this is a pure test-only change — no production code modifications).

## Linear

Closes [OMN-3572](https://linear.app/omninode/issue/OMN-3572)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for advisory lock failure handling in plugin schema initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->