### PR TITLE
test(registration): verify advisory lock executes inside transaction block (OMN-3573)

### DIFF
--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
@@ -285,18 +285,18 @@ class TestSchemaInitAdvisoryLock:
         ):
             await plugin._initialize_schema(config)  # type: ignore[attr-defined]
 
-        assert (
-            conn.execute.call_count == 2
-        ), f"Expected 2 execute() calls, got {conn.execute.call_count}"
+        assert conn.execute.call_count == 2, (
+            f"Expected 2 execute() calls, got {conn.execute.call_count}"
+        )
         first_call_sql: str = conn.execute.call_args_list[0][0][0]
         second_call_sql: str = conn.execute.call_args_list[1][0][0]
 
-        assert (
-            "pg_advisory_xact_lock" in first_call_sql
-        ), f"First execute() should be advisory lock, got: {first_call_sql!r}"
-        assert (
-            second_call_sql == schema_sql_text
-        ), f"Second execute() should be schema SQL, got: {second_call_sql!r}"
+        assert "pg_advisory_xact_lock" in first_call_sql, (
+            f"First execute() should be advisory lock, got: {first_call_sql!r}"
+        )
+        assert second_call_sql == schema_sql_text, (
+            f"Second execute() should be schema SQL, got: {second_call_sql!r}"
+        )
 
 
 # =============================================================================
@@ -384,9 +384,9 @@ class TestSchemaInitIdempotency:
 
         # Must NOT have WARNING-level log for this specific duplicate error
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert not any(
-            "duplicate" in r.message.lower() for r in warning_msgs
-        ), f"Unexpected WARNING for duplicate table error: {[r.message for r in warning_msgs]}"
+        assert not any("duplicate" in r.message.lower() for r in warning_msgs), (
+            f"Unexpected WARNING for duplicate table error: {[r.message for r in warning_msgs]}"
+        )
 
 
 # =============================================================================
@@ -458,9 +458,9 @@ class TestSchemaInitErrorHandling:
             await plugin._initialize_schema(config)  # type: ignore[attr-defined]
 
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert any(
-            "pool" in r.message.lower() for r in warning_msgs
-        ), f"Expected WARNING about pool being None. Got: {[r.message for r in warning_msgs]}"
+        assert any("pool" in r.message.lower() for r in warning_msgs), (
+            f"Expected WARNING about pool being None. Got: {[r.message for r in warning_msgs]}"
+        )
 
     @pytest.mark.unit
     async def test_missing_schema_file_returns_early_without_error(
@@ -482,9 +482,9 @@ class TestSchemaInitErrorHandling:
             await plugin._initialize_schema(config)  # type: ignore[attr-defined]
 
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert any(
-            "schema file" in r.message.lower() for r in warning_msgs
-        ), f"Expected WARNING about missing schema file. Got: {[r.message for r in warning_msgs]}"
+        assert any("schema file" in r.message.lower() for r in warning_msgs), (
+            f"Expected WARNING about missing schema file. Got: {[r.message for r in warning_msgs]}"
+        )
 
         # Pool should NOT have been touched (early return before pool access)
         pool.acquire.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `test_advisory_lock_inside_transaction` to `TestSchemaInitAdvisoryLock` that uses a transaction-tracking async context manager to prove `pg_advisory_xact_lock` is called while `conn.transaction()` is active
- Closes the most structurally significant gap from the OMN-3567 hostile review (Risk 2, confidence 0.87): existing ordering tests pass even if advisory lock is moved outside the transaction block
- Mutation-verified: new test FAILS when advisory lock is moved outside `async with conn.transaction()`, while all 13 existing tests still PASS with that mutation

## Test plan

- [x] New test passes with correct implementation (advisory lock inside transaction)
- [x] New test FAILS when advisory lock is moved outside transaction (mutation verified)
- [x] All 13 existing tests still pass (no regressions)
- [x] No implementation changes -- test-only PR

Closes OMN-3573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test that verifies advisory lock execution occurs while a database transaction is active.
  * Improved test coverage around transaction handling for schema initialization, increasing confidence in advisory lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->