### PR TITLE
test(registration): tighten warning assertion in test_unexpected_error_logged_as_warning (OMN-3574)

### DIFF
--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_schema_init.py
@@ -419,7 +419,13 @@ class TestSchemaInitErrorHandling:
                 await plugin._initialize_schema(config)  # type: ignore[attr-defined]
 
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert warning_msgs, "Expected at least one WARNING log for unexpected error"
+        assert any(
+            "schema" in r.message.lower() or "initialize" in r.message.lower()
+            for r in warning_msgs
+        ), (
+            "WARNING must reference schema initialization, not be a spurious log. "
+            f"Got: {[r.message for r in warning_msgs]}"
+        )
 
     @pytest.mark.unit
     async def test_unexpected_error_does_not_propagate(self) -> None:
@@ -543,9 +549,12 @@ class TestSchemaInitErrorHandling:
             f"Got records: {[(r.levelname, r.message) for r in caplog.records if r.levelno >= logging.ERROR]}"
         )
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert warning_msgs, (
-            "A WARNING must be emitted when the advisory lock call raises. "
-            "No WARNING records found."
+        assert any(
+            "schema" in r.message.lower() or "initialize" in r.message.lower()
+            for r in warning_msgs
+        ), (
+            "WARNING must reference schema initialization, not be a spurious log. "
+            f"Got: {[r.message for r in warning_msgs]}"
         )
 
 


### PR DESCRIPTION
## Summary

- Replace bare `assert warning_msgs` with keyword-specific assertions in `test_unexpected_error_logged_as_warning` — now verifies the WARNING log actually references "schema" or "initialize", rejecting spurious warnings from unrelated code paths
- Apply the same tightening to `test_advisory_lock_failure_logged_as_warning` which had the identical under-constrained pattern

## Mutation test verification

Deleting the `else: logger.warning(...)` branch in `_initialize_schema` now causes `test_unexpected_error_logged_as_warning` to **FAIL** (confirmed manually during development).

## Test plan

- [x] All 14 tests in `test_plugin_schema_init.py` pass
- [x] Mutation test: removing the `logger.warning()` branch causes `test_unexpected_error_logged_as_warning` to fail
- [x] ruff check passes on changed file
- [x] No implementation changes — test-only

Closes OMN-3574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for schema initialization warnings in test suite to ensure messages properly reference schema-related processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->