### PR TITLE
feat(monitor): add RestartWatcher thread for restart-loop detection

### DIFF
--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -43,6 +43,7 @@ import os
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import sys
 import threading
@@ -599,6 +600,179 @@ class PostgresErrorTailer(threading.Thread):
 
 
 # ---------------------------------------------------------------------------
+# Restart watcher (OMN-3596)
+# ---------------------------------------------------------------------------
+
+_RESTART_HWM_FILE = Path(
+    os.environ.get(
+        "MONITOR_RESTART_HWM_FILE",
+        str(Path.home() / ".omnibase" / "monitor-restart-hwm.json"),
+    )
+)
+_restart_hwm_lock = threading.Lock()
+
+# Default restart-count delta that triggers an alert.
+_RESTART_THRESHOLD = 3
+
+# Default polling interval in seconds.
+_RESTART_POLL_INTERVAL = 60
+
+
+def _restart_hwm_read(container: str) -> int:
+    """Return the last-seen restart count for *container* (0 if unknown or corrupt)."""
+    try:
+        with _restart_hwm_lock:
+            data = (
+                json.loads(_RESTART_HWM_FILE.read_text())
+                if _RESTART_HWM_FILE.exists()
+                else {}
+            )
+        return int(data.get(container, 0))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return 0
+
+
+def _restart_hwm_write(container: str, count: int) -> None:
+    """Persist *count* as the high-water mark for *container*.
+
+    Creates parent directories if needed.  If the file contains corrupt JSON
+    it is silently reset to ``{}``.  Uses tmp+rename for atomic writes.
+    """
+    try:
+        with _restart_hwm_lock:
+            _RESTART_HWM_FILE.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                data: dict[str, int] = (
+                    json.loads(_RESTART_HWM_FILE.read_text())
+                    if _RESTART_HWM_FILE.exists()
+                    else {}
+                )
+            except (json.JSONDecodeError, ValueError):
+                data = {}
+            data[container] = count
+            tmp = _RESTART_HWM_FILE.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data))
+            tmp.rename(_RESTART_HWM_FILE)
+    except OSError:
+        pass
+
+
+def _get_worker_state(container: str) -> dict[str, int | str] | None:
+    """Return restart count, status, and exit code for *container* via ``docker inspect``.
+
+    Returns ``None`` if the inspect call fails or returns no data.
+    """
+    result = subprocess.run(
+        [
+            _DOCKER,
+            "inspect",
+            "--format",
+            "json",
+            container,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        items = json.loads(result.stdout)
+        if not items:
+            return None
+        item = items[0]
+        return {
+            "restart_count": int(item.get("RestartCount", 0)),
+            "status": str(item.get("State", {}).get("Status", "unknown")),
+            "exit_code": int(item.get("State", {}).get("ExitCode", -1)),
+        }
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def _restart_containers_from_env() -> list[str] | None:
+    """Return an explicit container list from ``MONITOR_RESTART_CONTAINERS`` or ``None``."""
+    raw = os.environ.get("MONITOR_RESTART_CONTAINERS")
+    if not raw:
+        return None
+    return sorted(name.strip() for name in raw.split(",") if name.strip())
+
+
+class RestartWatcher(threading.Thread):
+    """Daemon thread that polls ``docker inspect`` for restart-count deltas.
+
+    When the restart-count delta since the last high-water mark reaches
+    *threshold*, a Slack alert is posted.  The HWM is persisted to disk so
+    it survives process restarts.
+    """
+
+    def __init__(
+        self,
+        containers: list[str],
+        bot_token: str,
+        channel_id: str,
+        dry_run: bool,
+        stop_event: threading.Event,
+        interval: int = _RESTART_POLL_INTERVAL,
+        threshold: int = _RESTART_THRESHOLD,
+    ) -> None:
+        super().__init__(name="restart-watcher", daemon=True)
+        self.containers = containers
+        self.bot_token = bot_token
+        self.channel_id = channel_id
+        self.dry_run = dry_run
+        self.stop_event = stop_event
+        self.interval = interval
+        self.threshold = threshold
+
+    def run(self) -> None:
+        print(
+            f"[monitor] RestartWatcher started (containers={len(self.containers)}, "
+            f"interval={self.interval}s, threshold={self.threshold})"
+        )
+        while not self.stop_event.is_set():
+            self._check()
+            self.stop_event.wait(timeout=self.interval)
+
+    def _check(self) -> None:
+        for container in self.containers:
+            state = _get_worker_state(container)
+            if state is None:
+                continue
+            current = int(state["restart_count"])
+            hwm = _restart_hwm_read(container)
+            delta = current - hwm
+
+            if delta < 0:
+                # Container was recreated — reset HWM without alerting
+                _restart_hwm_write(container, current)
+                continue
+
+            if delta >= self.threshold:
+                self._alert(container, state)
+                _restart_hwm_write(container, current)
+            elif delta > 0:
+                # Below threshold — update HWM silently
+                _restart_hwm_write(container, current)
+
+    def _alert(self, container: str, state: dict[str, int | str]) -> None:
+        hostname = socket.gethostname()
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [
+            f":warning: *Restart loop detected:* `{container}`",
+            f"*Status:* {state['status']}  |  *Exit code:* {state['exit_code']}",
+            f"*Restart count:* {state['restart_count']}",
+            f"*Host:* {hostname}  |  *Time:* {timestamp}",
+        ]
+        if self.dry_run:
+            print(f"[DRY RUN] Would post restart alert for {container}:")
+            for line in lines:
+                print(f"  {line}")
+            return
+        post_slack(self.bot_token, self.channel_id, container, lines, self.dry_run)
+
+
+# ---------------------------------------------------------------------------
 # Slack
 # ---------------------------------------------------------------------------
 
@@ -909,6 +1083,23 @@ class LogMonitor:
         for pg_container in _discover_postgres_containers():
             self._start_pg_tailer(pg_container)
 
+        # Start restart watcher (OMN-3596)
+        _restart_stop = threading.Event()
+        explicit_containers = _restart_containers_from_env()
+        restart_containers = (
+            explicit_containers
+            if explicit_containers is not None
+            else sorted(set(self._get_project_containers()))
+        )
+        restart_watcher = RestartWatcher(
+            containers=restart_containers,
+            bot_token=self.bot_token,
+            channel_id=self.channel_id,
+            dry_run=self.dry_run,
+            stop_event=_restart_stop,
+        )
+        restart_watcher.start()
+
         # Watch for container start/die events
         cmd = [
             _DOCKER,
@@ -952,6 +1143,7 @@ class LogMonitor:
         except KeyboardInterrupt:
             print("\n[monitor] Shutting down...")
         finally:
+            _restart_stop.set()
             proc.terminate()
 
 

--- a/tests/unit/scripts/test_monitor_restart_watcher.py
+++ b/tests/unit/scripts/test_monitor_restart_watcher.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for RestartWatcher in monitor_logs.py (OMN-3596)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# monitor_logs.py lives in scripts/ and has no package install; add scripts/ to path.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_MODULE_NAME = "monitor_logs"
+
+
+def _import() -> Any:
+    if _MODULE_NAME in sys.modules:
+        return importlib.reload(sys.modules[_MODULE_NAME])
+    return importlib.import_module(_MODULE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# HWM persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRestartHwmRead:
+    """Tests for _restart_hwm_read()."""
+
+    @pytest.mark.unit
+    def test_returns_zero_when_file_missing(self, tmp_path: Path) -> None:
+        """HWM read returns 0 for an unknown container."""
+        m = _import()
+        hwm_file = tmp_path / "hwm.json"
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            assert m._restart_hwm_read("some-container") == 0
+
+    @pytest.mark.unit
+    def test_roundtrip_persistence(self, tmp_path: Path) -> None:
+        """Write then read should return the written value."""
+        m = _import()
+        hwm_file = tmp_path / "hwm.json"
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            m._restart_hwm_write("ctr-a", 5)
+            assert m._restart_hwm_read("ctr-a") == 5
+
+    @pytest.mark.unit
+    def test_write_creates_parent_directory(self, tmp_path: Path) -> None:
+        """HWM write should create parent dirs if missing."""
+        m = _import()
+        hwm_file = tmp_path / "nested" / "dir" / "hwm.json"
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            m._restart_hwm_write("ctr-b", 3)
+            assert hwm_file.exists()
+            assert m._restart_hwm_read("ctr-b") == 3
+
+    @pytest.mark.unit
+    def test_returns_zero_when_corrupted(self, tmp_path: Path) -> None:
+        """HWM read returns 0 when file is corrupted JSON."""
+        m = _import()
+        hwm_file = tmp_path / "hwm.json"
+        hwm_file.write_text("NOT VALID JSON{{{")
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            assert m._restart_hwm_read("ctr-c") == 0
+
+    @pytest.mark.unit
+    def test_write_repairs_corrupted_file(self, tmp_path: Path) -> None:
+        """HWM write should reset and repair a corrupted file."""
+        m = _import()
+        hwm_file = tmp_path / "hwm.json"
+        hwm_file.write_text("NOT VALID JSON{{{")
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            m._restart_hwm_write("ctr-d", 7)
+            assert m._restart_hwm_read("ctr-d") == 7
+
+    @pytest.mark.unit
+    def test_multiple_containers_independent(self, tmp_path: Path) -> None:
+        """Each container gets its own independent HWM."""
+        m = _import()
+        hwm_file = tmp_path / "hwm.json"
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            m._restart_hwm_write("ctr-x", 10)
+            m._restart_hwm_write("ctr-y", 20)
+            assert m._restart_hwm_read("ctr-x") == 10
+            assert m._restart_hwm_read("ctr-y") == 20
+
+
+# ---------------------------------------------------------------------------
+# _get_worker_state
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkerState:
+    """Tests for _get_worker_state()."""
+
+    @pytest.mark.unit
+    def test_returns_restart_count_and_status(self) -> None:
+        """Should parse docker inspect output correctly."""
+        m = _import()
+        inspect_json = json.dumps(
+            [
+                {
+                    "RestartCount": 5,
+                    "State": {
+                        "Status": "running",
+                        "ExitCode": 0,
+                    },
+                }
+            ]
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=inspect_json, stderr=""
+            )
+            result = m._get_worker_state("test-container")
+            assert result is not None
+            assert result["restart_count"] == 5
+            assert result["status"] == "running"
+            assert result["exit_code"] == 0
+
+    @pytest.mark.unit
+    def test_returns_none_on_docker_failure(self) -> None:
+        """Should return None if docker inspect fails."""
+        m = _import()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            result = m._get_worker_state("test-container")
+            assert result is None
+
+    @pytest.mark.unit
+    def test_returns_none_on_empty_output(self) -> None:
+        """Should return None if docker inspect returns empty list."""
+        m = _import()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+            result = m._get_worker_state("test-container")
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _restart_containers_from_env
+# ---------------------------------------------------------------------------
+
+
+class TestRestartContainersFromEnv:
+    """Tests for _restart_containers_from_env()."""
+
+    @pytest.mark.unit
+    def test_returns_none_when_env_not_set(self) -> None:
+        """Should return None when MONITOR_RESTART_CONTAINERS is not set."""
+        m = _import()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MONITOR_RESTART_CONTAINERS", None)
+            result = m._restart_containers_from_env()
+            assert result is None
+
+    @pytest.mark.unit
+    def test_returns_sorted_list_from_env(self) -> None:
+        """Should parse comma-separated env var into sorted list."""
+        m = _import()
+        with patch.dict(
+            os.environ, {"MONITOR_RESTART_CONTAINERS": "ctr-b,ctr-a,ctr-c"}
+        ):
+            result = m._restart_containers_from_env()
+            assert result == ["ctr-a", "ctr-b", "ctr-c"]
+
+    @pytest.mark.unit
+    def test_strips_whitespace(self) -> None:
+        """Should strip whitespace from container names."""
+        m = _import()
+        with patch.dict(os.environ, {"MONITOR_RESTART_CONTAINERS": " ctr-a , ctr-b "}):
+            result = m._restart_containers_from_env()
+            assert result == ["ctr-a", "ctr-b"]
+
+
+# ---------------------------------------------------------------------------
+# RestartWatcher._check() logic
+# ---------------------------------------------------------------------------
+
+
+class TestRestartWatcherCheck:
+    """Tests for RestartWatcher._check() alert/no-alert logic."""
+
+    @pytest.mark.unit
+    def test_alert_fires_when_delta_gte_threshold(self, tmp_path: Path) -> None:
+        """Alert should fire when restart delta >= threshold."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+        alerts: list[dict[str, Any]] = []
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=False,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            # Patch _alert to capture calls
+            watcher._alert = lambda ctr, state: alerts.append(  # type: ignore[assignment]
+                {"container": ctr, "state": state}
+            )
+            # Simulate: HWM=0, restart_count=3 → delta=3 >= threshold=3
+            with patch.object(
+                m,
+                "_get_worker_state",
+                return_value={
+                    "restart_count": 3,
+                    "status": "running",
+                    "exit_code": 0,
+                },
+            ):
+                watcher._check()
+
+        assert len(alerts) == 1
+        assert alerts[0]["container"] == "test-ctr"
+
+    @pytest.mark.unit
+    def test_no_alert_below_threshold(self, tmp_path: Path) -> None:
+        """No alert should fire when restart delta < threshold."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+        alerts: list[dict[str, Any]] = []
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=False,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            watcher._alert = lambda ctr, state: alerts.append(  # type: ignore[assignment]
+                {"container": ctr, "state": state}
+            )
+            # Simulate: HWM=0, restart_count=2 → delta=2 < threshold=3
+            with patch.object(
+                m,
+                "_get_worker_state",
+                return_value={
+                    "restart_count": 2,
+                    "status": "running",
+                    "exit_code": 0,
+                },
+            ):
+                watcher._check()
+
+        assert len(alerts) == 0
+
+    @pytest.mark.unit
+    def test_dry_run_does_not_post_slack(self, tmp_path: Path) -> None:
+        """Dry-run mode should not call post_slack."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=True,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            with patch.object(
+                m,
+                "_get_worker_state",
+                return_value={
+                    "restart_count": 5,
+                    "status": "running",
+                    "exit_code": 1,
+                },
+            ):
+                with patch.object(m, "post_slack") as mock_post:
+                    watcher._check()
+                    mock_post.assert_not_called()
+
+    @pytest.mark.unit
+    def test_negative_delta_resets_hwm(self, tmp_path: Path) -> None:
+        """Container recreated (restart_count resets) should update HWM without alerting."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+        alerts: list[dict[str, Any]] = []
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            # Set initial HWM to 10
+            m._restart_hwm_write("test-ctr", 10)
+
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=False,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            watcher._alert = lambda ctr, state: alerts.append(  # type: ignore[assignment]
+                {"container": ctr, "state": state}
+            )
+            # Simulate: HWM=10, restart_count=1 → delta=-9 (container recreated)
+            with patch.object(
+                m,
+                "_get_worker_state",
+                return_value={
+                    "restart_count": 1,
+                    "status": "running",
+                    "exit_code": 0,
+                },
+            ):
+                watcher._check()
+
+            # No alert for negative delta
+            assert len(alerts) == 0
+            # HWM should be updated to new value
+            assert m._restart_hwm_read("test-ctr") == 1
+
+    @pytest.mark.unit
+    def test_hwm_updated_after_alert(self, tmp_path: Path) -> None:
+        """HWM should be updated to current restart_count after alert fires."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=False,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            watcher._alert = lambda ctr, state: None  # type: ignore[assignment]
+            with patch.object(
+                m,
+                "_get_worker_state",
+                return_value={
+                    "restart_count": 5,
+                    "status": "running",
+                    "exit_code": 0,
+                },
+            ):
+                watcher._check()
+
+            assert m._restart_hwm_read("test-ctr") == 5
+
+    @pytest.mark.unit
+    def test_skips_container_when_inspect_fails(self, tmp_path: Path) -> None:
+        """Should skip container when docker inspect fails (returns None)."""
+        m = _import()
+        import threading
+
+        hwm_file = tmp_path / "hwm.json"
+        alerts: list[dict[str, Any]] = []
+
+        with patch.object(m, "_RESTART_HWM_FILE", hwm_file):
+            watcher = m.RestartWatcher(
+                containers=["test-ctr"],
+                bot_token="xoxb-test",
+                channel_id="C123",
+                dry_run=False,
+                stop_event=threading.Event(),
+                interval=60,
+                threshold=3,
+            )
+            watcher._alert = lambda ctr, state: alerts.append(  # type: ignore[assignment]
+                {"container": ctr, "state": state}
+            )
+            with patch.object(m, "_get_worker_state", return_value=None):
+                watcher._check()
+
+        assert len(alerts) == 0


### PR DESCRIPTION
## Summary

Adds a `RestartWatcher` daemon thread to `monitor_logs.py` that detects container restart loops and posts Slack alerts.

- Polls `docker inspect` every 60s for containers from the configured project list
- Fires Slack alert when restart-count delta >= threshold (default: 3)
- Persists per-container high-water marks in `~/.omnibase/monitor-restart-hwm.json` with atomic writes (tmp + rename)
- Handles negative deltas (container recreated) by resetting HWM without alerting
- Repairs corrupted HWM files instead of failing forever
- Alert includes container status, exit code, `socket.gethostname()`, ISO timestamp

## Env Overrides

| Variable | Purpose | Default |
|----------|---------|---------|
| `MONITOR_RESTART_HWM_FILE` | HWM persistence file path | `~/.omnibase/monitor-restart-hwm.json` |
| `MONITOR_RESTART_CONTAINERS` | Comma-separated explicit container list | Auto-discovered from project containers |

## Test Plan

- [x] 18 unit tests in `tests/unit/scripts/test_monitor_restart_watcher.py`
- [x] HWM read returns 0 when file missing
- [x] HWM roundtrip persistence
- [x] HWM write creates parent directories
- [x] HWM read returns 0 when file corrupted
- [x] HWM write repairs corrupted files
- [x] Multiple containers have independent HWMs
- [x] `_get_worker_state` parses docker inspect output
- [x] `_get_worker_state` returns None on docker failure
- [x] `_restart_containers_from_env` returns None when env not set
- [x] `_restart_containers_from_env` parses comma-separated list
- [x] Alert fires when delta >= threshold
- [x] No alert below threshold
- [x] Dry-run does not post to Slack
- [x] Negative delta (container recreated) resets HWM without alerting
- [x] HWM updated after alert fires
- [x] Container skipped when docker inspect fails
- [x] `ruff check` clean
- [x] `mypy --ignore-missing-imports` clean
- [x] Existing `test_monitor_logs.py` tests still pass (12/12)

Closes OMN-3596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Docker container restart monitoring with Slack alerts when restart counts meet or exceed configurable thresholds
  * Supports monitoring specific containers via configuration or all project containers
  * Dry-run mode available for testing alert behavior without posting to Slack

* **Tests**
  * Comprehensive test suite added for restart monitoring functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->