### PR TITLE
chore: add no-planning-docs pre-commit hook (OMN-3617)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -273,6 +273,14 @@ repos:
         entry: uv run python scripts/check_migration_required.py --pre-commit
         pass_filenames: false
         stages: [pre-commit]
+      # OMN-3617: Block planning docs (belong in omni_home/docs/plans/)
+      - id: no-planning-docs
+        name: Block planning docs (belong in omni_home/docs/plans/)
+        entry: 'bash -c ''PLAN_FILES=$(git diff --cached --name-only -- "docs/plans/"); if [ -n "$PLAN_FILES" ]; then echo "ERROR: Planning docs must live in omni_home/docs/plans/, not in this repo:"; echo "$PLAN_FILES"; echo ""; echo "Move your file to /Volumes/PRO-G40/Code/omni_home/docs/plans/"; exit 1; fi'''
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]


### PR DESCRIPTION
## Summary
- Add `no-planning-docs` pre-commit hook that blocks `docs/plans/` files from being committed to this repo
- Planning docs belong in `omni_home/docs/plans/`, not in individual repos
- Remove stray untracked `docs/plans/` directory from working tree

## Verification
- Hook passes on clean tree (`pre-commit run no-planning-docs --all-files`)
- Hook correctly rejects staged files under `docs/plans/` with actionable error message
- No false positives on existing files

## Test plan
- [x] `pre-commit run no-planning-docs --all-files` passes on clean tree
- [x] Staging a file under `docs/plans/` triggers the hook with actionable error
- [x] `docs/plans/` directory no longer exists in working tree

Closes OMN-3617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit hook to enforce correct placement of planning documentation, blocking commits with planning files in incorrect locations and providing guidance for proper file placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->