### PR TITLE
fix(runtime): reorder shutdown to stop runtime before consumers (OMN-3593)

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1793,7 +1793,31 @@ async def bootstrap() -> int:
             correlation_id,
         )
 
-        # Stop plugin consumers first (unsubscribe callbacks from start_consumers)
+        # Stop runtime FIRST so introspection tasks flush their final events
+        # while the event bus is still active. Moving this before consumer
+        # unsubscribe fixes the ~29 introspection errors per shutdown cycle
+        # (OMN-3593).
+        try:
+            runtime_stop_start_time = time.time()
+            await asyncio.wait_for(runtime.stop(), timeout=grace_period)
+            runtime_stop_duration = time.time() - runtime_stop_start_time
+            logger.debug(
+                "Runtime stopped in %.3fs (correlation_id=%s)",
+                runtime_stop_duration,
+                correlation_id,
+                extra={
+                    "duration_seconds": runtime_stop_duration,
+                },
+            )
+        except TimeoutError:
+            logger.warning(
+                "Graceful shutdown timed out after %s seconds, forcing stop (correlation_id=%s)",
+                grace_period,
+                correlation_id,
+            )
+        runtime = None  # Mark as stopped to prevent double-stop in finally
+
+        # Stop plugin consumers (unsubscribe callbacks from start_consumers)
         for unsub_callback in plugin_unsubscribe_callbacks:
             try:
                 await unsub_callback()
@@ -1870,27 +1894,6 @@ async def bootstrap() -> int:
                     },
                 )
             health_server = None
-
-        # Stop runtime with timeout
-        try:
-            runtime_stop_start_time = time.time()
-            await asyncio.wait_for(runtime.stop(), timeout=grace_period)
-            runtime_stop_duration = time.time() - runtime_stop_start_time
-            logger.debug(
-                "Runtime stopped in %.3fs (correlation_id=%s)",
-                runtime_stop_duration,
-                correlation_id,
-                extra={
-                    "duration_seconds": runtime_stop_duration,
-                },
-            )
-        except TimeoutError:
-            logger.warning(
-                "Graceful shutdown timed out after %s seconds, forcing stop (correlation_id=%s)",
-                grace_period,
-                correlation_id,
-            )
-        runtime = None  # Mark as stopped to prevent double-stop in finally
 
         # Shutdown plugins in LIFO order (Last In, First Out)
         # This ensures plugins activated later are shut down before plugins they


### PR DESCRIPTION
## Summary

- Reorder the shutdown sequence in `service_kernel.py` so `runtime.stop()` executes **before** the consumer unsubscribe loop
- This ensures introspection tasks flush their final events while the Kafka event bus is still active
- Eliminates ~29 spurious introspection error log lines per shutdown cycle

## Root Cause

The shutdown sequence unsubscribed Kafka consumers (line ~1797) before calling `runtime.stop()` (line ~1877). When `runtime.stop()` triggered introspection flush, the tasks attempted to publish events through an already-torn-down event bus, producing ~29 errors every shutdown.

## Test plan

- [x] All 3853 runtime unit tests pass
- [x] All pre-commit hooks pass (including architecture validation)
- [ ] Deploy and verify shutdown logs show zero introspection errors

Fixes OMN-3593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential double-shutdown issue through improved runtime state management
  * Improved shutdown sequence to ensure critical tasks complete properly before system shutdown
  * Enhanced event processing during shutdown phase for proper resource cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->