### PR TITLE
fix(kernel): add run-loop diagnostics for worker exit-code-0 debugging (OMN-3591)

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1514,8 +1514,13 @@ async def bootstrap() -> int:
         shutdown_event = asyncio.Event()
         loop = asyncio.get_running_loop()
 
+        # Track which signal triggered shutdown for diagnostics (OMN-3591)
+        shutdown_reason: str = "unknown"
+
         def handle_shutdown(sig: signal.Signals) -> None:
             """Handle shutdown signal with correlation tracking."""
+            nonlocal shutdown_reason
+            shutdown_reason = f"signal:{sig.name}"
             logger.info(
                 "Received %s, initiating graceful shutdown... (correlation_id=%s)",
                 sig.name,
@@ -1544,7 +1549,9 @@ async def bootstrap() -> int:
                 Uses call_soon_threadsafe to safely communicate with the event
                 loop from the signal handler thread.
                 """
+                nonlocal shutdown_reason
                 sig = signal.Signals(signum)
+                shutdown_reason = f"signal:{sig.name}"
                 logger.info(
                     "Received %s, initiating graceful shutdown... (correlation_id=%s)",
                     sig.name,
@@ -1749,9 +1756,13 @@ async def bootstrap() -> int:
         # Plugin summary for banner
         plugin_names = [p.plugin_id for p in activated_plugins]
 
+        # Runtime profile for operator disambiguation (OMN-3591)
+        runtime_profile = os.getenv("RUNTIME_PROFILE", "default")
+
         banner_lines = [
             "=" * 60,
             f"ONEX Runtime Kernel v{KERNEL_VERSION}",
+            f"Profile: {runtime_profile} (PID {os.getpid()})",
             f"Environment: {environment}",
             f"Contracts: {contracts_dir}",
             f"Event Bus: {event_bus_type} (group: {config.consumer_group})",
@@ -1782,13 +1793,38 @@ async def bootstrap() -> int:
             },
         )
 
+        # Flush log handlers so Docker log driver captures all startup messages
+        # before the process blocks on shutdown_event.wait(). Without this,
+        # buffered log output may not appear in `docker logs` until the process
+        # exits, making it look like the kernel never entered the run loop
+        # (OMN-3591).
+        for handler in logging.root.handlers:
+            handler.flush()
+
+        # Explicit run-loop entry log (OMN-3591)
+        # This message confirms the kernel reached the blocking wait and did
+        # not exit prematurely during bootstrap. If this message is absent
+        # from container logs, the kernel exited before entering the run loop.
+        logger.info(
+            "RUN_LOOP_ENTERED: Kernel idle, waiting for shutdown signal "
+            "(profile=%s, pid=%d, correlation_id=%s)",
+            runtime_profile,
+            os.getpid(),
+            correlation_id,
+        )
+        # Flush again to guarantee the run-loop-entered message is visible
+        for handler in logging.root.handlers:
+            handler.flush()
+
         # Wait for shutdown signal
         await shutdown_event.wait()
 
         grace_period = config.shutdown.grace_period_seconds
         shutdown_start_time = time.time()
         logger.info(
-            "Shutdown signal received, stopping runtime (timeout=%ss, correlation_id=%s)",
+            "RUN_LOOP_EXITED: Shutdown signal received (reason=%s, timeout=%ss, "
+            "correlation_id=%s)",
+            shutdown_reason,
             grace_period,
             correlation_id,
         )

--- a/tests/unit/runtime/test_kernel.py
+++ b/tests/unit/runtime/test_kernel.py
@@ -1011,6 +1011,86 @@ shutdown:
         assert call_kwargs["port"] == DEFAULT_HTTP_PORT
         assert call_kwargs["version"] == KERNEL_VERSION
 
+    async def test_bootstrap_logs_run_loop_entered_and_shutdown_reason(
+        self,
+        mock_wire_infrastructure: MagicMock,
+        mock_inmemory_runtime_config: MagicMock,
+        mock_runtime_host: MagicMock,
+        mock_event_bus: MagicMock,
+        mock_health_server: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test that bootstrap emits RUN_LOOP_ENTERED and RUN_LOOP_EXITED logs (OMN-3591).
+
+        The run-loop markers let operators verify in ``docker logs`` that the
+        kernel reached the blocking wait and did not exit prematurely.
+        """
+        with patch("omnibase_infra.runtime.service_kernel.asyncio.Event") as mock_event:
+            event_instance = MagicMock()
+            event_instance.wait = AsyncMock(return_value=None)
+            mock_event.return_value = event_instance
+
+            with caplog.at_level(
+                "INFO", logger="omnibase_infra.runtime.service_kernel"
+            ):
+                exit_code = await bootstrap()
+
+        assert exit_code == 0
+
+        # Verify RUN_LOOP_ENTERED is logged
+        run_loop_entered = [
+            r for r in caplog.records if "RUN_LOOP_ENTERED" in r.message
+        ]
+        assert len(run_loop_entered) == 1, (
+            "Expected exactly one RUN_LOOP_ENTERED log message"
+        )
+
+        # Verify RUN_LOOP_EXITED is logged with reason
+        run_loop_exited = [r for r in caplog.records if "RUN_LOOP_EXITED" in r.message]
+        assert len(run_loop_exited) == 1, (
+            "Expected exactly one RUN_LOOP_EXITED log message"
+        )
+        # When no signal triggers shutdown (mock returns immediately),
+        # the reason should be "unknown" (no signal handler was invoked)
+        assert "reason=unknown" in run_loop_exited[0].message
+
+    async def test_bootstrap_banner_includes_runtime_profile(
+        self,
+        mock_wire_infrastructure: MagicMock,
+        mock_inmemory_runtime_config: MagicMock,
+        mock_runtime_host: MagicMock,
+        mock_event_bus: MagicMock,
+        mock_health_server: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test that bootstrap banner includes RUNTIME_PROFILE (OMN-3591).
+
+        Workers set RUNTIME_PROFILE=workers so operators can distinguish
+        main/effects/workers in container logs.
+        """
+        monkeypatch.setenv("RUNTIME_PROFILE", "workers")
+
+        with patch("omnibase_infra.runtime.service_kernel.asyncio.Event") as mock_event:
+            event_instance = MagicMock()
+            event_instance.wait = AsyncMock(return_value=None)
+            mock_event.return_value = event_instance
+
+            with caplog.at_level(
+                "INFO", logger="omnibase_infra.runtime.service_kernel"
+            ):
+                exit_code = await bootstrap()
+
+        assert exit_code == 0
+
+        # Find the banner log message (contains the "=" separator)
+        banner_msgs = [
+            r.message for r in caplog.records if "ONEX Runtime Kernel" in r.message
+        ]
+        assert len(banner_msgs) >= 1, "Expected banner log message"
+        # Banner should include profile
+        assert "Profile: workers" in banner_msgs[0]
+
 
 class TestConfigureLogging:
     """Tests for configure_logging function."""


### PR DESCRIPTION
## Summary

- Add `RUN_LOOP_ENTERED` / `RUN_LOOP_EXITED` log markers with PID and runtime profile so operators can definitively confirm whether the kernel reached the blocking wait or exited prematurely during bootstrap
- Track `shutdown_reason` (signal name or `"unknown"`) to distinguish signal-triggered shutdowns from unexpected event-loop completion
- Flush all log handlers before `shutdown_event.wait()` so Docker json-file log driver captures startup messages immediately (prevents buffered output from making it look like the kernel never entered the run loop)
- Add `RUNTIME_PROFILE` and PID to the startup banner so operators can distinguish main/effects/workers in mixed container log output

## Context

`runtime-worker` containers exit code 0 after handler wiring with 302+ restarts observed. The last visible log line is "Intelligence handlers wired" with no indication of whether the kernel entered the run loop. These diagnostics will allow operators to determine the exact failure point on next deployment.

## Test plan

- [x] New unit test `test_bootstrap_logs_run_loop_entered_and_shutdown_reason` verifies both markers are emitted
- [x] New unit test `test_bootstrap_banner_includes_runtime_profile` verifies profile appears in banner
- [x] All 48 existing kernel tests pass (2 pre-existing failures excluded)
- [x] Pre-commit hooks pass
- [ ] Deploy with `--profile runtime` and verify `RUN_LOOP_ENTERED` appears in `docker logs` for worker containers

Closes OMN-3591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime profile now displayed in startup banner
  * Shutdown reason tracking added to capture triggering signals
  * Process ID included in startup messages
  * Improved startup and shutdown diagnostics logging with enhanced log visibility

* **Tests**
  * Added test coverage for bootstrap logging and shutdown diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->