### PR TITLE
feat: AST-based cosmetic change filter for writer-migration gate (OMN-3671)

### DIFF
--- a/scripts/check_migration_required.py
+++ b/scripts/check_migration_required.py
@@ -14,6 +14,7 @@ Usage (pre-commit — check staged files):
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import subprocess
 import sys
@@ -40,6 +41,64 @@ def has_bypass_comment(content: str) -> bool:
     return bool(BYPASS_RE.search(content))
 
 
+def _get_merge_base() -> str:
+    """Return the merge-base SHA between HEAD and origin/main."""
+    try:
+        return subprocess.check_output(
+            ["git", "merge-base", "HEAD", "origin/main"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        print(
+            "WARNING: could not determine merge-base with origin/main", file=sys.stderr
+        )
+        return ""
+
+
+def _strip_docstrings(tree: ast.Module) -> ast.Module:
+    """Remove docstring nodes from module/class/function bodies for comparison."""
+    for node in ast.walk(tree):
+        if isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                node.body = node.body[1:]
+    return tree
+
+
+def is_cosmetic_only(path: str, merge_base: str) -> bool:
+    """True if the diff for this file is comments/docstrings/whitespace only."""
+    if not merge_base:
+        return False
+
+    try:
+        base_src = subprocess.check_output(
+            ["git", "show", f"{merge_base}:{path}"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return False  # new file
+
+    current_src = Path(path).read_text(encoding="utf-8")
+
+    try:
+        base_tree = _strip_docstrings(ast.parse(base_src))
+        current_tree = _strip_docstrings(ast.parse(current_src))
+    except SyntaxError:
+        return False
+
+    return ast.dump(base_tree, include_attributes=False) == ast.dump(
+        current_tree, include_attributes=False
+    )
+
+
 def get_changed_files(ci: bool) -> list[str]:
     if ci:
         base = subprocess.check_output(
@@ -56,7 +115,7 @@ def get_changed_files(ci: bool) -> list[str]:
 
 def find_violations(
     changed_files: list[str],
-    bypass_comment: str | None,
+    merge_base: str = "",
 ) -> list[str]:
     """Return list of writer files that lack a corresponding migration."""
     writer_files = [f for f in changed_files if is_writer_file(f)]
@@ -72,13 +131,13 @@ def find_violations(
 
     violations = []
     for wf in writer_files:
+        if merge_base and is_cosmetic_only(wf, merge_base):
+            continue
         path = Path(wf)
         if path.exists():
-            content = path.read_text()
+            content = path.read_text(encoding="utf-8")
             if has_bypass_comment(content):
                 continue
-        if bypass_comment and has_bypass_comment(bypass_comment):
-            continue
         violations.append(wf)
 
     return violations
@@ -90,8 +149,9 @@ def main() -> None:
     parser.add_argument("--pre-commit", action="store_true")
     args = parser.parse_args()
 
+    merge_base = _get_merge_base()
     changed = get_changed_files(ci=args.ci)
-    violations = find_violations(changed, bypass_comment=None)
+    violations = find_violations(changed, merge_base=merge_base)
 
     if violations:
         print("ERROR: Writer file(s) changed without a migration file in this PR:")

--- a/tests/unit/scripts/test_check_migration_required.py
+++ b/tests/unit/scripts/test_check_migration_required.py
@@ -1,7 +1,9 @@
 """Tests for scripts/check_migration_required.py writer-without-migration gate."""
 
 import importlib.util
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +17,25 @@ def load_checker():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def make_git_mock(merge_base_sha: str, base_files: dict[str, str]):
+    """Return a side_effect for subprocess.check_output that dispatches by git subcommand."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd[:2] == ["git", "merge-base"]:
+            return merge_base_sha + "\n"
+        if cmd[:2] == ["git", "show"]:
+            ref_path = cmd[2]
+            path = ref_path.split(":", 1)[1]
+            if path in base_files:
+                return base_files[path]
+            raise subprocess.CalledProcessError(1, cmd)
+        if cmd[:2] == ["git", "diff"]:
+            return ""
+        raise subprocess.CalledProcessError(1, cmd)
+
+    return side_effect
 
 
 @pytest.mark.unit
@@ -45,7 +66,7 @@ class TestWriterDetection:
             "src/omnibase_infra/nodes/foo/writer_postgres.py",
             "docker/migrations/forward/036_add_foo_table.sql",
         ]
-        violations = checker.find_violations(changed_files, bypass_comment=None)
+        violations = checker.find_violations(changed_files)
         assert violations == []
 
     def test_writer_without_migration_fails(self):
@@ -53,6 +74,120 @@ class TestWriterDetection:
         changed_files = [
             "src/omnibase_infra/nodes/foo/writer_postgres.py",
         ]
-        violations = checker.find_violations(changed_files, bypass_comment=None)
+        violations = checker.find_violations(changed_files)
         assert len(violations) == 1
         assert "writer_postgres.py" in violations[0]
+
+
+@pytest.mark.unit
+class TestCosmeticDetection:
+    def test_docstring_only_change_is_cosmetic(self, tmp_path):
+        checker = load_checker()
+        base_src = 'def write():\n    """Old docstring."""\n    return 1\n'
+        current_src = 'def write():\n    """New docstring."""\n    return 1\n'
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {str(writer): base_src}),
+        ):
+            result = checker.is_cosmetic_only(str(writer), "abc123")
+        assert result is True
+
+    def test_comment_only_change_is_cosmetic(self, tmp_path):
+        checker = load_checker()
+        base_src = "# old comment\nx = 1\n"
+        current_src = "# new comment\nx = 1\n"
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {str(writer): base_src}),
+        ):
+            result = checker.is_cosmetic_only(str(writer), "abc123")
+        assert result is True
+
+    def test_code_change_not_cosmetic(self, tmp_path):
+        checker = load_checker()
+        base_src = "x = 1\n"
+        current_src = "x = 2\n"
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {str(writer): base_src}),
+        ):
+            result = checker.is_cosmetic_only(str(writer), "abc123")
+        assert result is False
+
+    def test_new_file_not_cosmetic(self, tmp_path):
+        checker = load_checker()
+        current_src = "x = 1\n"
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        # base_files is empty → git show raises CalledProcessError → new file
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {}),
+        ):
+            result = checker.is_cosmetic_only(str(writer), "abc123")
+        assert result is False
+
+    def test_syntax_error_not_cosmetic(self, tmp_path):
+        checker = load_checker()
+        base_src = "def foo(\n"  # invalid syntax
+        current_src = "def foo(\n"
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {str(writer): base_src}),
+        ):
+            result = checker.is_cosmetic_only(str(writer), "abc123")
+        assert result is False
+
+    def test_empty_merge_base_not_cosmetic(self):
+        checker = load_checker()
+        result = checker.is_cosmetic_only("some/path.py", "")
+        assert result is False
+
+    def test_docstring_removed_empty_body(self, tmp_path):
+        checker = load_checker()
+        # A function with only a docstring — stripping it leaves empty body
+        # ast.walk + body mutation shouldn't crash; just returns False or True
+        base_src = 'def foo():\n    """Only a docstring."""\n'
+        current_src = 'def foo():\n    """Different docstring."""\n'
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=make_git_mock("abc123", {str(writer): base_src}),
+        ):
+            # Should not crash — may return True or False depending on AST
+            checker.is_cosmetic_only(str(writer), "abc123")
+
+    def test_merge_base_used_not_head(self, tmp_path):
+        checker = load_checker()
+        base_src = "x = 1\n"
+        current_src = "x = 1\n"
+        writer = tmp_path / "writer_postgres.py"
+        writer.write_text(current_src)
+        calls = []
+
+        def tracking_mock(cmd, **kwargs):
+            calls.append(cmd)
+            return make_git_mock("deadbeef", {str(writer): base_src})(cmd, **kwargs)
+
+        with patch.object(subprocess, "check_output", side_effect=tracking_mock):
+            checker.is_cosmetic_only(str(writer), "deadbeef")
+
+        # Verify git show was called with the merge-base SHA, not HEAD
+        show_calls = [c for c in calls if c[:2] == ["git", "show"]]
+        assert len(show_calls) == 1
+        assert show_calls[0][2].startswith("deadbeef:")


### PR DESCRIPTION
## Summary

- Add `is_cosmetic_only()` that compares AST dumps of merge-base vs current file versions, stripping docstrings before comparison
- Writer files with only comment/docstring/whitespace changes no longer trigger the migration requirement gate
- Remove dead `bypass_comment` parameter from `find_violations()`
- 8 new unit tests covering all edge cases (docstring, comment, code change, new file, syntax error, empty merge-base, empty body, SHA verification)

Closes OMN-3671

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_check_migration_required.py -v` — all 13 tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `uv run ruff check` — no violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration checks now automatically exclude purely cosmetic changes (comments, docstrings, and whitespace) from requiring migration.

* **Tests**
  * Expanded test coverage for cosmetic change detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->