### PR TITLE
feat(deploy): add untagged image prune to Docker cron (OMN-3719)

### DIFF
--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -11,7 +11,7 @@
 #   2. Base64-encode token for safe SSH passing
 #   3. Rsync runner artifacts to 192.168.86.201:~/.omnibase/runners/
 #   4. Deploy via SSH: docker compose up -d --build --force-recreate --remove-orphans
-#   5. Install docker prune cron idempotently (tee, never append)
+#   5. Install docker prune cron idempotently (build cache + untagged images, tee)
 #   6. Install runner health monitor cron (Slack alerts on state transitions)
 #   7. Poll GitHub API until all 10 runners online (max 5 min, 15s interval)
 #   8. Retry once with fresh token if poll times out
@@ -190,11 +190,15 @@ deploy_runners() {
 install_prune_cron() {
     log "Installing docker prune cron on ${RUNNER_HOST} (idempotent tee, not append)..."
 
-    # Prunes BUILD CACHE ONLY when disk usage >/var/lib/docker exceeds 70%.
-    # Does NOT prune images — images are versioned and pinned.
-    # Runs weekly at 03:00 Sunday.
+    # Two weekly prune jobs (Sunday):
+    #   03:00 — Build cache prune, only when disk > 70%, retain 14 days (336h)
+    #   04:00 — Untagged image prune, retain 14 days (336h)
+    # Weekly (not twice-weekly) to avoid cache thrash from Docker builds.
     local cron_content
-    cron_content='0 3 * * 0 root USAGE=$(df --output=pcent /var/lib/docker | tail -1 | tr -d '"'"' %'"'"'); [ "${USAGE:-0}" -ge 70 ] && docker builder prune -f --filter '"'"'until=336h'"'"''
+    cron_content='# Build cache prune (Sunday 03:00) — only when disk > 70%, retain 14 days
+0 3 * * 0 root USAGE=$(df --output=pcent /var/lib/docker | tail -1 | tr -d '"'"' %'"'"'); [ "${USAGE:-0}" -ge 70 ] && docker builder prune -f --filter '"'"'until=336h'"'"'
+# Untagged image prune (Sunday 04:00) — retain 14 days
+0 4 * * 0 root docker image prune -f --filter '"'"'until=336h'"'"''
 
     run_ssh "echo '${cron_content}' | sudo tee /etc/cron.d/docker-prune > /dev/null && echo '[deploy-runners] Prune cron installed (idempotent).'"
 }


### PR DESCRIPTION
## Summary

- Adds a second weekly cron entry in `install_prune_cron` to prune untagged Docker images older than 14 days (336h)
- Existing build-cache prune with 70% disk threshold remains unchanged
- Both jobs scheduled weekly (Sunday) to avoid cache thrash from frequent Docker builds

## Changes

**File**: `scripts/deploy-runners.sh` (`install_prune_cron` function)

The cron file `/etc/cron.d/docker-prune` now contains two entries:
1. **03:00 Sunday** -- Build cache prune (only when disk > 70%, retain 14 days)
2. **04:00 Sunday** -- Untagged image prune (retain 14 days)

## Test plan

- [ ] Deploy to runner host: `./scripts/deploy-runners.sh`
- [ ] Verify cron installed: `ssh <runner> cat /etc/cron.d/docker-prune`
- [ ] Confirm both cron lines present with correct schedule and filters

Closes OMN-3719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined automated maintenance scheduling with improved disk space management, including conditional monitoring during peak usage periods and optimized cleanup routines for system resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->