### PR TITLE
fix(scripts): restamp_fingerprint calls installed module (OMN-3735)

### DIFF
--- a/scripts/run-migrations.py
+++ b/scripts/run-migrations.py
@@ -261,22 +261,25 @@ async def run(db_url: str, dry_run: bool, target: int | None) -> int:
         await conn.close()
 
 
-def restamp_fingerprint() -> None:
-    """Call check_schema_fingerprint.py stamp after successful apply."""
+def restamp_fingerprint(db_url: str) -> None:
+    """Call util_schema_fingerprint stamp after successful apply."""
     import subprocess
 
-    stamp_script = REPO_ROOT / "scripts" / "check_schema_fingerprint.py"
-    if stamp_script.exists():
-        result = subprocess.run(
-            [sys.executable, str(stamp_script), "stamp"],
-            capture_output=True,
-            text=True,
-            check=False,
+    result = subprocess.run(
+        [sys.executable, "-m", "omnibase_infra.runtime.util_schema_fingerprint", "stamp"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "OMNIBASE_INFRA_DB_URL": db_url},
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        print(
+            f"  warning: fingerprint restamp failed (exit {result.returncode}): "
+            f"{detail}"
         )
-        if result.returncode != 0:
-            print(f"  warning: fingerprint restamp failed: {result.stderr.strip()}")
-        else:
-            print("  fingerprint restamped.")
+    else:
+        print("  fingerprint restamped.")
 
 
 def main() -> None:
@@ -305,7 +308,7 @@ def main() -> None:
     count = asyncio.run(run(args.db_url, args.dry_run, args.target))
 
     if count > 0 and not args.dry_run:
-        restamp_fingerprint()
+        restamp_fingerprint(args.db_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix `restamp_fingerprint()` in `run-migrations.py` to call the installed `util_schema_fingerprint` module via `python -m` instead of the non-existent `check_schema_fingerprint.py` script
- Accept `db_url` parameter and pass it via `OMNIBASE_INFRA_DB_URL` env var
- Include exit code and stderr/stdout fallback in warning output for better diagnostics
- Update call site to pass `args.db_url`

Closes OMN-3735

## Test plan

- [x] `tests/unit/test_cli_schema_fingerprint.py` passes (14 tests)
- [x] `tests/unit/test_schema_fingerprint.py` passes (29 tests)
- [x] `ruff check` passes on modified file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema fingerprint restamping process with enhanced error handling and improved diagnostic messaging. Better status confirmation and failure reporting now included to provide detailed information during migration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->