### PR TITLE
fix(docker): replace broken migration runner with fingerprint stamp (OMN-3734)

### DIFF
--- a/docker/entrypoint-runtime.sh
+++ b/docker/entrypoint-runtime.sh
@@ -4,14 +4,11 @@
 #
 # ONEX Infrastructure Runtime Entrypoint
 #
-# This entrypoint runs the migration runner before starting the runtime kernel.
-# The runner applies any pending SQL migrations and restamps the schema
-# fingerprint into db_metadata (via restamp_fingerprint() inside run-migrations.py).
+# This entrypoint stamps the schema fingerprint into db_metadata before
+# starting the runtime kernel. The fingerprint is computed from the live
+# database schema via the installed util_schema_fingerprint module.
 # Without the fingerprint stamp, the kernel's startup assertion finds
 # expected_schema_fingerprint = NULL and crash-loops.
-#
-# Idempotent: already-applied migrations are skipped; re-stamping an
-# already-stamped database safely overwrites the existing fingerprint value.
 #
 # Environment:
 #   OMNIBASE_INFRA_DB_URL  (required) - PostgreSQL DSN for the infra database
@@ -42,11 +39,55 @@ echo "SOURCE_DIR=/app/src"
 echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 echo "========================"
 
+# =============================================================================
+# Schema Fingerprint Stamp
+# =============================================================================
+# Stamp expected_schema_fingerprint into db_metadata so the kernel's startup
+# assertion can compare live schema against a known-good fingerprint.
+#
+# Retry logic: up to 5 attempts with 1s sleep between failures handles
+# transient DB-not-ready conditions at container startup.
+#
+# Exit code handling from util_schema_fingerprint:
+#   0 = success (fingerprint stamped)
+#   2 = schema mismatch (no point retrying -- bail immediately)
+#   1 = connection or general error (retry)
+#
+# Fail-open: kernel starts regardless of stamp outcome. The kernel's own
+# fingerprint assertion will catch any real problems.
+
 if [ -n "${OMNIBASE_INFRA_DB_URL:-}" ]; then
-  echo "Running migration runner..."
-  python /app/scripts/run-migrations.py --db-url "${OMNIBASE_INFRA_DB_URL}" || {
-    echo "WARNING: migration runner failed — continuing to start kernel"
-  }
+  # Safe log: strip scheme and userinfo, show only host:port/db
+  SAFE_DSN=$(echo "${OMNIBASE_INFRA_DB_URL}" | sed 's|^[^/]*//[^@]*@||')
+  echo "[entrypoint] Stamping schema fingerprint (db: ${SAFE_DSN})..."
+
+  STAMP_OK=0
+  ATTEMPT=1
+  MAX_ATTEMPTS=5
+
+  while [ "${ATTEMPT}" -le "${MAX_ATTEMPTS}" ]; do
+    RC=0
+    python -m omnibase_infra.runtime.util_schema_fingerprint stamp || RC=$?
+    if [ "${RC}" -eq 0 ]; then
+      STAMP_OK=1
+      break
+    fi
+    if [ "${RC}" -eq 2 ]; then
+      echo "[entrypoint] WARNING: fingerprint mismatch (exit 2) -- not retrying"
+      break
+    fi
+    echo "[entrypoint] Stamp attempt ${ATTEMPT}/${MAX_ATTEMPTS} failed (exit ${RC})"
+    ATTEMPT=$((ATTEMPT + 1))
+    if [ "${ATTEMPT}" -le "${MAX_ATTEMPTS}" ]; then
+      sleep 1
+    fi
+  done
+
+  if [ "${STAMP_OK}" -eq 0 ]; then
+    echo "[entrypoint] WARNING: fingerprint stamp did not succeed -- continuing to start kernel"
+  fi
+else
+  echo "[entrypoint] OMNIBASE_INFRA_DB_URL not set -- skipping fingerprint stamp"
 fi
 
 echo "[entrypoint] Starting runtime kernel..."


### PR DESCRIPTION
## Summary

- Replace broken `python /app/scripts/run-migrations.py` call in `entrypoint-runtime.sh` with `python -m omnibase_infra.runtime.util_schema_fingerprint stamp`
- The old migration script was never copied into the Docker image, so the call always failed silently
- Add retry loop (5 attempts, 1s sleep) for transient DB-not-ready at container startup
- Exit code 2 (schema mismatch) stops retrying immediately since retries won't help
- Redact credentials from log output -- only show `host:port/db`
- Fail-open: kernel starts regardless of stamp outcome

Closes OMN-3734

## Test plan

- [ ] `shellcheck docker/entrypoint-runtime.sh` passes (verified locally)
- [ ] Docker build succeeds (entrypoint is a shell script, no build-time deps)
- [ ] Entrypoint stamps fingerprint before kernel starts when `OMNIBASE_INFRA_DB_URL` is set
- [ ] No credentials appear in log output
- [ ] Retry loop handles transient DB failures gracefully
- [ ] Mismatch (exit 2) does not retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured database initialization process to use schema fingerprinting with automatic retry logic (up to 5 attempts) for improved startup reliability.
  * Enhanced security by masking database credentials in startup logs.
  * Application remains operational even if initialization encounters issues.
  * Expanded documentation detailing the initialization flow and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->