### PR TITLE
feat(bootstrap): wire omnidash migrations into Step 1d [OMN-3748]

### DIFF
--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -49,6 +49,8 @@
 OMNIBASE_INFRA_DB_URL=postgresql://role_omnibase_infra:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omnibase_infra
 OMNICLAUDE_DB_URL=postgresql://role_omniclaude:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omniclaude
 OMNIDASH_ANALYTICS_DB_URL=postgresql://role_omnidash:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omnidash_analytics
+# Path to omnidash checkout — used by bootstrap-infisical.sh Step 1d to run read-model migrations (OMN-3748)
+OMNIDASH_DIR=/path/to/omnidash
 OMNIINTELLIGENCE_DB_URL=postgresql://role_omniintelligence:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omniintelligence
 OMNIMEMORY_DB_URL=postgresql://role_omnimemory:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omnimemory
 OMNINODE_CLOUD_DB_URL=postgresql://role_omninode_cloud:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omninode_cloud

--- a/docs/runbooks/apply-migrations.md
+++ b/docs/runbooks/apply-migrations.md
@@ -233,3 +233,63 @@ ON CONFLICT DO NOTHING;
 Or re-run `run-migrations.py` — it uses `ON CONFLICT DO NOTHING` so re-applying is safe
 for already-applied migrations that have tracking rows. For migrations without tracking rows,
 wrap in a transaction and check for idempotency before re-applying.
+
+## Omnidash Read-Model Migrations (OMN-3748)
+
+Omnidash maintains its own `omnidash_analytics` read-model database with SQL migrations
+in `omnidash/migrations/`. These are wired into the bootstrap pipeline as **Step 1d**.
+
+### Bootstrap (advisory -- warn and continue)
+
+During `bootstrap-infisical.sh`, Step 1d runs the omnidash migration runner if both
+`OMNIDASH_DIR` and `OMNIDASH_ANALYTICS_DB_URL` are set. Failures are non-fatal:
+
+```bash
+# Step 1d runs automatically during bootstrap when env vars are set:
+OMNIDASH_DIR=/path/to/omnidash
+OMNIDASH_ANALYTICS_DB_URL=postgresql://postgres:<password>@localhost:5436/omnidash_analytics
+```
+
+If the omnidash database is not yet provisioned or the checkout is not available, the
+bootstrap logs a warning and continues. The read-model may be stale until migrations
+are applied manually.
+
+### Manual run
+
+```bash
+source ~/.omnibase/.env
+cd "${OMNIDASH_DIR}"
+npx tsx scripts/run-migrations.ts
+```
+
+### Deploy-time enforcement (future -- fail closed)
+
+When omnidash moves to containerized deployment, the init container MUST run migrations
+and **fail closed** -- the pod should not start if the schema is not up to date.
+
+The enforcement boundary:
+
+| Context | Behavior | Rationale |
+|---------|----------|-----------|
+| `bootstrap-infisical.sh` (Step 1d) | Warn and continue | Local dev may not have omnidash DB |
+| Container init (future) | Fail closed | Production must have correct schema |
+
+Implementation notes for the init container:
+
+1. Run `npx tsx scripts/run-migrations.ts` as an init container
+2. Exit non-zero on any migration failure (the runner already does this)
+3. The main omnidash container depends on the init container succeeding
+4. No `|| true` or similar suppression -- failures must block pod startup
+
+### Parity check
+
+After applying migrations, verify parity between the migrations directory and the
+`schema_migrations` tracking table:
+
+```bash
+cd "${OMNIDASH_DIR}"
+npx tsx scripts/check-migration-parity.ts
+```
+
+This tool (added in OMN-3747) ensures no migrations are missing from either the
+filesystem or the database.

--- a/scripts/bootstrap-infisical.sh
+++ b/scripts/bootstrap-infisical.sh
@@ -10,6 +10,8 @@
 #   Step 1b:  Pending migrations applied (run-migrations.py, OMN-3528)
 #   Step 1c:  Cross-repo tables provisioned in omniintelligence DB (OMN-3531)
 #             Skipped if OMNIINTELLIGENCE_DB_URL is not set
+#   Step 1d:  Omnidash read-model migrations (OMN-3748)
+#             Non-fatal — skipped if OMNIDASH_DIR or OMNIDASH_ANALYTICS_DB_URL not set
 #   Step 2:   Valkey starts
 #   Step 3:   Infisical starts (depends_on: postgres + valkey healthy)
 #   Step 3.5: Keycloak starts (--profile auth) + provision-keycloak.py runs
@@ -214,6 +216,31 @@ if [ -n "${OMNIINTELLIGENCE_DB_URL:-}" ]; then
     fi
 else
     log_info "Skipping cross-repo provisioning (OMNIINTELLIGENCE_DB_URL not set)"
+fi
+
+# ============================================================================
+# Step 1d: Apply omnidash read-model migrations (OMN-3748)
+# ============================================================================
+# Non-fatal: local dev may not have the omnidash_analytics DB or omnidash
+# checkout available yet. Bootstrap is advisory; deploy-time init is
+# authoritative (see docs/runbooks/apply-migrations.md).
+if [ -n "${OMNIDASH_ANALYTICS_DB_URL:-}" ] && [ -n "${OMNIDASH_DIR:-}" ]; then
+    log_step "1d" "Apply omnidash read-model migrations"
+    if [[ "${DRY_RUN}" != "true" ]]; then
+        if [ -d "${OMNIDASH_DIR}" ] && [ -f "${OMNIDASH_DIR}/scripts/run-migrations.ts" ]; then
+            if (cd "${OMNIDASH_DIR}" && npx tsx scripts/run-migrations.ts); then
+                log_info "Omnidash read-model migrations applied."
+            else
+                log_warn "Omnidash migration runner failed — continuing (read-model may be stale)"
+            fi
+        else
+            log_warn "OMNIDASH_DIR=${OMNIDASH_DIR} does not contain scripts/run-migrations.ts — skipping"
+        fi
+    else
+        log_info "[DRY-RUN] Would run: cd ${OMNIDASH_DIR} && npx tsx scripts/run-migrations.ts"
+    fi
+else
+    log_info "Skipping omnidash migrations (OMNIDASH_ANALYTICS_DB_URL or OMNIDASH_DIR not set)"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds **Step 1d** to `bootstrap-infisical.sh` that runs omnidash's `run-migrations.ts` when `OMNIDASH_DIR` and `OMNIDASH_ANALYTICS_DB_URL` are set
- Step is **non-fatal** (warn and continue) -- local dev may not have the omnidash_analytics DB provisioned
- Adds `OMNIDASH_DIR` to `docs/env-example-full.txt`
- Documents deploy-time enforcement (fail-closed for containers) and parity check workflow in the apply-migrations runbook

Ticket: https://linear.app/omninode/issue/OMN-3748
Epic: OMN-3746

## Changes

| File | Change |
|------|--------|
| `scripts/bootstrap-infisical.sh` | Add Step 1d between 1c and 2 |
| `docs/env-example-full.txt` | Add `OMNIDASH_DIR` env var |
| `docs/runbooks/apply-migrations.md` | Document omnidash migrations, deploy-time enforcement, parity check |

## Test plan

- [ ] `bash -n scripts/bootstrap-infisical.sh` passes (syntax check)
- [ ] `grep "Step 1d" scripts/bootstrap-infisical.sh` matches
- [ ] With `OMNIDASH_DIR` and `OMNIDASH_ANALYTICS_DB_URL` unset, bootstrap skips Step 1d with info log
- [ ] With both set and valid omnidash checkout, Step 1d runs migrations
- [ ] With both set but invalid path, Step 1d warns and continues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added environment variable configuration example for omnidash directory
  * Added comprehensive runbook section covering omnidash read-model migrations, including bootstrap behavior, manual execution steps, and verification procedures

* **Chores**
  * Enhanced bootstrap script with conditional omnidash read-model migration step (non-fatal, only executes when required environment variables are present)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->