### PR TITLE
feat(scripts): add canonical system health gate (OMN-3772)

### DIFF
--- a/scripts/system_health_check.sh
+++ b/scripts/system_health_check.sh
@@ -71,7 +71,7 @@ log_check() {
     CHECK_STATUSES+=("$status")
     CHECK_DETAILS+=("$detail")
 
-    # Promote overall status
+    # Promote overall status (skip does not affect overall)
     case "$status" in
         red)    OVERALL_STATUS="red" ;;
         yellow) [[ "$OVERALL_STATUS" != "red" ]] && OVERALL_STATUS="yellow" ;;
@@ -83,6 +83,7 @@ log_check() {
             green)  icon="[GREEN]" ;;
             yellow) icon="[YELLOW]" ;;
             red)    icon="[RED]" ;;
+            skip)   icon="[SKIP]" ;;
         esac
         printf "  %-8s %-22s %s\n" "$icon" "$name" "$detail"
     fi
@@ -290,12 +291,16 @@ check_migration_parity() {
     local docker_dir="${REPO_ROOT}/docker/migrations/forward"
     local src_dir="${REPO_ROOT}/src/omnibase_infra/migrations/forward"
 
+    if [[ ! -d "$docker_dir" ]] && [[ ! -d "$src_dir" ]]; then
+        log_check "$name" "skip" "Migration directory not set up"
+        return
+    fi
     if [[ ! -d "$docker_dir" ]]; then
-        log_check "$name" "yellow" "docker migrations dir not found"
+        log_check "$name" "skip" "docker migrations dir not set up"
         return
     fi
     if [[ ! -d "$src_dir" ]]; then
-        log_check "$name" "yellow" "src migrations dir not found"
+        log_check "$name" "skip" "src migrations dir not set up"
         return
     fi
 


### PR DESCRIPTION
## Summary

- Adds `scripts/system_health_check.sh` (~440 lines) that composes 11 individual service health checks into a single pass/fail gate
- Checks: postgres, redpanda, valkey, infra_containers, keycloak, runtime_containers, required_topics, migration_parity, env_audit, cloud_bus_refs, bus_endpoint
- Supports `--json`, `--ci`, `--cross-repo`, `--verbose` flags
- Exit 0 for green/yellow (pass), exit 1 for red (fail)
- Cross-repo checks call the shared cloud bus guard from OMN-3768 and the env audit script
- Positive bus assertion: KAFKA_BOOTSTRAP_SERVERS must not contain 29092

## Test plan

- [x] Syntax check passes (`bash -n`)
- [x] Default run shows green for healthy services, yellow for optional profiles
- [x] `--json` output validates with `python3 -m json.tool`
- [x] `--cross-repo` enables env audit and cloud bus ref checks
- [x] `--help` shows usage
- [x] Valkey auth handled via VALKEY_PASSWORD env var
- [x] rpk topic list uses tabular output (not --format json which is unsupported)

Closes OMN-3772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive system health check tool for infrastructure validation covering database connectivity, message queue health, cache status, container verification, migration parity comparison, and cross-repository configuration audits. Features JSON output, customizable options, and CI integration for pre-deployment checks and local diagnostics.

* **Chores**
  * Added new health diagnostic infrastructure script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->