### PR TITLE
fix(scripts): migration_parity skip for missing dirs (OMN-3776)

### DIFF
--- a/scripts/system_health_check.sh
+++ b/scripts/system_health_check.sh
@@ -71,7 +71,7 @@ log_check() {
     CHECK_STATUSES+=("$status")
     CHECK_DETAILS+=("$detail")
 
-    # Promote overall status
+    # Promote overall status (skip does not affect overall)
     case "$status" in
         red)    OVERALL_STATUS="red" ;;
         yellow) [[ "$OVERALL_STATUS" != "red" ]] && OVERALL_STATUS="yellow" ;;
@@ -83,6 +83,7 @@ log_check() {
             green)  icon="[GREEN]" ;;
             yellow) icon="[YELLOW]" ;;
             red)    icon="[RED]" ;;
+            skip)   icon="[SKIP]" ;;
         esac
         printf "  %-8s %-22s %s\n" "$icon" "$name" "$detail"
     fi
@@ -290,12 +291,16 @@ check_migration_parity() {
     local docker_dir="${REPO_ROOT}/docker/migrations/forward"
     local src_dir="${REPO_ROOT}/src/omnibase_infra/migrations/forward"
 
+    if [[ ! -d "$docker_dir" ]] && [[ ! -d "$src_dir" ]]; then
+        log_check "$name" "skip" "Migration directory not set up"
+        return
+    fi
     if [[ ! -d "$docker_dir" ]]; then
-        log_check "$name" "yellow" "docker migrations dir not found"
+        log_check "$name" "skip" "docker migrations dir not set up"
         return
     fi
     if [[ ! -d "$src_dir" ]]; then
-        log_check "$name" "yellow" "src migrations dir not found"
+        log_check "$name" "skip" "src migrations dir not set up"
         return
     fi
 


### PR DESCRIPTION
## Summary

- When `docker/migrations/forward` or `src/omnibase_infra/migrations/forward` directories do not exist, `check_migration_parity` now reports `skip` with detail "Migration directory not set up" instead of `yellow` warning
- Added `[SKIP]` icon to `log_check` output formatting
- Skip status does not promote overall health status (same as green)

Fixes OMN-3776 (stacked on PR #650 / OMN-3772)

## Test plan

- [ ] Run `bash scripts/system_health_check.sh` in a repo without `docker/migrations/forward` -- should show `[SKIP]` not `[YELLOW]`
- [ ] Run with `--json` and verify `"status":"skip"` in output
- [ ] Run in a repo with both migration dirs present -- parity check still works as before