### PR TITLE
fix(health): idle-aware health check for skill-lifecycle-consumer (OMN-3784)

### DIFF
--- a/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
+++ b/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
@@ -620,6 +620,13 @@ class SkillLifecycleConsumer:
     def _build_health_response(self) -> tuple[dict[str, object], int]:
         """Build health check response dict and HTTP status code.
 
+        Idle-aware health (OMN-3784): When the consumer is running and polling
+        Kafka but has never received events (last_successful_write_at is None),
+        it is considered idle — not unhealthy.  Write staleness only applies
+        after the first successful write, because only then does a stale write
+        indicate an actual problem.  Poll staleness always applies since a
+        failure to poll indicates a broken Kafka connection.
+
         Returns:
             Tuple of (response_dict, http_status_code).
         """
@@ -627,29 +634,41 @@ class SkillLifecycleConsumer:
         last_write = self.metrics.last_successful_write_at
         last_poll = self.metrics.last_poll_at
 
-        write_age = (now - last_write).total_seconds() if last_write else float("inf")
-        poll_age = (now - last_poll).total_seconds() if last_poll else float("inf")
+        write_age = (now - last_write).total_seconds() if last_write else None
+        poll_age = (now - last_poll).total_seconds() if last_poll else None
+
+        # Determine if consumer is idle (running but never received events)
+        idle = self._running and last_write is None
 
         if not self._running:
             status = EnumHealthStatus.UNHEALTHY
         elif (
-            write_age > self.config.health_check_staleness_seconds
+            poll_age is None
             or poll_age > self.config.health_check_poll_staleness_seconds
         ):
+            # No polls at all, or polls are stale — Kafka connection problem
+            status = EnumHealthStatus.DEGRADED
+        elif (
+            write_age is not None
+            and write_age > self.config.health_check_staleness_seconds
+        ):
+            # Has written before but writes are stale — downstream problem
             status = EnumHealthStatus.DEGRADED
         else:
+            # Either idle (no writes ever, but polling OK) or actively healthy
             status = EnumHealthStatus.HEALTHY
 
         http_code = 200 if status == EnumHealthStatus.HEALTHY else 503
         response: dict[str, object] = {
             "status": str(status),
             "running": self._running,
+            "idle": idle,
             "last_successful_write_at": (
                 last_write.isoformat() if last_write else None
             ),
             "last_poll_at": last_poll.isoformat() if last_poll else None,
-            "write_age_seconds": write_age if write_age != float("inf") else None,
-            "poll_age_seconds": poll_age if poll_age != float("inf") else None,
+            "write_age_seconds": write_age,
+            "poll_age_seconds": poll_age,
         }
         if self._writer:
             response["circuit_breaker"] = self._writer.get_circuit_breaker_state()

--- a/tests/unit/services/observability/skill_lifecycle/test_consumer.py
+++ b/tests/unit/services/observability/skill_lifecycle/test_consumer.py
@@ -279,7 +279,12 @@ class TestParseMessage:
 
 
 class TestHealthResponse:
-    """Test _build_health_response health status logic."""
+    """Test _build_health_response health status logic.
+
+    OMN-3784: Idle-aware health check — consumer reports HEALTHY when idle
+    (connected to Kafka, polling, but no events received yet), and only
+    reports DEGRADED for actual failures.
+    """
 
     @pytest.mark.unit
     def test_healthy_when_running_and_recent_writes(self) -> None:
@@ -294,6 +299,25 @@ class TestHealthResponse:
 
         assert response["status"] == str(EnumHealthStatus.HEALTHY)
         assert status_code == 200
+        assert response["idle"] is False
+
+    @pytest.mark.unit
+    def test_healthy_when_idle_no_events(self) -> None:
+        """Returns HEALTHY (200) when consumer is idle — polling but no events received.
+
+        OMN-3784: This is the core fix. Previously returned DEGRADED (503) because
+        last_successful_write_at was None, conflating idle with unhealthy.
+        """
+        consumer = _make_consumer()
+        consumer._running = True
+        consumer.metrics.last_successful_write_at = None  # No events ever received
+        consumer.metrics.last_poll_at = datetime.now(UTC)  # Polling works fine
+
+        response, status_code = consumer._build_health_response()
+
+        assert response["status"] == str(EnumHealthStatus.HEALTHY)
+        assert status_code == 200
+        assert response["idle"] is True
 
     @pytest.mark.unit
     def test_degraded_when_stale_writes(self) -> None:
@@ -337,6 +361,19 @@ class TestHealthResponse:
         assert status_code == 503
 
     @pytest.mark.unit
+    def test_degraded_when_no_polls_at_all(self) -> None:
+        """Returns DEGRADED when consumer has never polled (Kafka not connected)."""
+        consumer = _make_consumer()
+        consumer._running = True
+        consumer.metrics.last_poll_at = None
+        consumer.metrics.last_successful_write_at = None
+
+        response, status_code = consumer._build_health_response()
+
+        assert response["status"] == str(EnumHealthStatus.DEGRADED)
+        assert status_code == 503
+
+    @pytest.mark.unit
     def test_response_includes_running_field(self) -> None:
         """Health response includes 'running' field."""
         consumer = _make_consumer()
@@ -349,3 +386,29 @@ class TestHealthResponse:
 
         assert "running" in response
         assert response["running"] is True
+
+    @pytest.mark.unit
+    def test_response_includes_idle_field(self) -> None:
+        """Health response includes 'idle' field (OMN-3784)."""
+        consumer = _make_consumer()
+        consumer._running = True
+        consumer.metrics.last_successful_write_at = None
+        consumer.metrics.last_poll_at = datetime.now(UTC)
+
+        response, _ = consumer._build_health_response()
+
+        assert "idle" in response
+        assert response["idle"] is True
+
+    @pytest.mark.unit
+    def test_not_idle_after_first_write(self) -> None:
+        """Consumer is not idle once it has processed at least one event."""
+        consumer = _make_consumer()
+        consumer._running = True
+        now = datetime.now(UTC)
+        consumer.metrics.last_successful_write_at = now
+        consumer.metrics.last_poll_at = now
+
+        response, _ = consumer._build_health_response()
+
+        assert response["idle"] is False


### PR DESCRIPTION
## Summary

- Fixes skill-lifecycle-consumer health endpoint returning 503 on cold start when no events exist on the topic
- Write staleness now only applies after the first successful write; idle consumers (polling Kafka but no events received) report HEALTHY (200)
- Poll staleness still detects actual Kafka connection failures
- Adds `idle` field to health response to distinguish idle from active consumers

## Root Cause

`_build_health_response` treated `last_successful_write_at = None` as `write_age = inf`, which always exceeded the 300s staleness threshold, permanently marking idle consumers as DEGRADED.

## Test Plan

- [x] `test_healthy_when_idle_no_events` — idle consumer returns 200
- [x] `test_degraded_when_no_polls_at_all` — no Kafka connection returns 503
- [x] `test_degraded_when_stale_writes` — stale writes still detected
- [x] `test_response_includes_idle_field` — idle field present
- [x] `test_not_idle_after_first_write` — idle=False after processing events
- [x] All 25 existing tests pass

Closes OMN-3784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health status responses now include an "idle" flag indicating services running without prior write events.
  * Write and poll age fields are now optional, appearing only when metrics are available.

* **Bug Fixes**
  * Refined health status determination logic with improved detection of degraded states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->