### PR TITLE
fix(docker): use venv Python for torch verification [OMN-3819]

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -210,7 +210,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install "protobuf>=5.29.6"
 
 # Verify torch is CPU-only (torch.version.cuda must be None, no nvidia packages)
-RUN python -c "\
+RUN /app/.venv/bin/python -c "\
 import torch, pkgutil; \
 assert torch.version.cuda is None, f'Expected CPU torch, got CUDA {torch.version.cuda}'; \
 nvidia_pkgs = [m.name for m in pkgutil.iter_modules() if 'nvidia' in m.name]; \


### PR DESCRIPTION
## Summary

- Fixed `ModuleNotFoundError: No module named 'torch'` in Docker build by using the venv Python interpreter (`/app/.venv/bin/python`) instead of system Python for the torch CPU-only verification step in the builder stage
- Root cause: `uv pip install torch` installs into `/app/.venv` (via `UV_PROJECT_ENVIRONMENT`), but the verification `RUN python -c "import torch..."` used system Python which doesn't have torch

## Changes

- `docker/Dockerfile.runtime` line 213: `python` → `/app/.venv/bin/python`

## Test plan

- [x] pre-commit hooks pass
- [x] ruff check passes
- [x] mypy passes
- [x] 5028 unit tests pass
- [ ] Docker build workflow passes on `ubuntu-latest` (CI will verify)

Fixes OMN-3819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker runtime verification to ensure CPU-only operation by adding explicit checks confirming NVIDIA packages are not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->