### PR TITLE
OMN-926: add observability tests for performance metrics in introspection events

### DIFF
--- a/tests/unit/mixins/test_mixin_node_introspection.py
+++ b/tests/unit/mixins/test_mixin_node_introspection.py
@@ -2112,6 +2112,191 @@ class TestMixinNodeModelIntrospectionPerformanceMetrics:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+class TestMixinNodeIntrospectionEventPerformanceMetrics:
+    """Tests verifying performance metrics are included in introspection events.
+
+    These tests validate the core OMN-926 requirement: performance metrics
+    from introspection operations must be present in the published
+    ModelNodeIntrospectionEvent, enabling distributed observability.
+    """
+
+    async def test_introspection_event_contains_performance_metrics(self) -> None:
+        """Test that get_introspection_data() populates performance_metrics on the event."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+
+        assert event.performance_metrics is not None
+        assert isinstance(
+            event.performance_metrics, ModelIntrospectionPerformanceMetrics
+        )
+
+    async def test_event_metrics_match_standalone_metrics(self) -> None:
+        """Test that event.performance_metrics matches get_performance_metrics()."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+        standalone_metrics = node.get_performance_metrics()
+
+        assert event.performance_metrics is not None
+        assert standalone_metrics is not None
+        # Both should reflect the same timing data
+        assert (
+            event.performance_metrics.total_introspection_ms
+            == standalone_metrics.total_introspection_ms
+        )
+        assert (
+            event.performance_metrics.get_capabilities_ms
+            == standalone_metrics.get_capabilities_ms
+        )
+        assert event.performance_metrics.cache_hit == standalone_metrics.cache_hit
+        assert event.performance_metrics.method_count == standalone_metrics.method_count
+
+    async def test_event_metrics_timing_values_positive_on_fresh_call(self) -> None:
+        """Test that fresh introspection produces positive timing values."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+
+        assert event.performance_metrics is not None
+        assert event.performance_metrics.total_introspection_ms > 0
+        assert event.performance_metrics.get_capabilities_ms >= 0
+        assert event.performance_metrics.get_endpoints_ms >= 0
+        assert event.performance_metrics.get_current_state_ms >= 0
+        assert event.performance_metrics.cache_hit is False
+
+    async def test_event_metrics_cache_hit_on_second_call(self) -> None:
+        """Test that cached introspection event still has metrics with cache_hit=True."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        # First call populates cache
+        await node.get_introspection_data()
+
+        # Second call returns cached event - but metrics are freshly computed
+        event2 = await node.get_introspection_data()
+        standalone = node.get_performance_metrics()
+
+        assert standalone is not None
+        assert standalone.cache_hit is True
+        # The cached event itself was constructed during the first call,
+        # so it has cache_hit=False, but get_performance_metrics() reflects
+        # the latest call which was a cache hit.
+
+    async def test_event_metrics_method_count_matches_discovered(self) -> None:
+        """Test that metrics.method_count matches discovered capabilities."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+
+        assert event.performance_metrics is not None
+        # method_count should match the number of discovered method signatures
+        assert event.performance_metrics.method_count == len(
+            event.discovered_capabilities.method_signatures
+        )
+
+    async def test_event_metrics_serializable_for_event_bus(self) -> None:
+        """Test that event with metrics can be serialized for event bus transmission."""
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+
+        # Simulate event bus serialization (JSON mode)
+        event_data = event.model_dump(mode="json")
+        assert "performance_metrics" in event_data
+        pm = event_data["performance_metrics"]
+        assert pm is not None
+        assert isinstance(pm["total_introspection_ms"], float)
+        assert isinstance(pm["cache_hit"], bool)
+        assert isinstance(pm["method_count"], int)
+        assert isinstance(pm["slow_operations"], list)
+
+        # Verify it can be deserialized back
+        restored = ModelNodeIntrospectionEvent.model_validate(event_data)
+        assert restored.performance_metrics is not None
+        assert (
+            restored.performance_metrics.total_introspection_ms
+            == event.performance_metrics.total_introspection_ms
+        )
+
+    async def test_event_metrics_survive_model_copy_with_reason_update(self) -> None:
+        """Test that performance_metrics survive model_copy when updating reason.
+
+        This mirrors what publish_introspection() does: it calls model_copy
+        to update the reason and correlation_id fields.
+        """
+        node = MockNode()
+        config = ModelIntrospectionConfig(
+            node_id=TEST_NODE_UUID_1,
+            node_type=EnumNodeKind.EFFECT,
+            node_name="test_introspection_node",
+            event_bus=None,
+        )
+        node.initialize_introspection(config)
+
+        event = await node.get_introspection_data()
+        assert event.performance_metrics is not None
+        original_ms = event.performance_metrics.total_introspection_ms
+
+        # Simulate what publish_introspection does
+        from omnibase_infra.enums import EnumIntrospectionReason
+
+        publish_event = event.model_copy(
+            update={
+                "reason": EnumIntrospectionReason.STARTUP,
+                "correlation_id": TEST_NODE_UUID_2,
+            }
+        )
+
+        assert publish_event.performance_metrics is not None
+        assert publish_event.performance_metrics.total_introspection_ms == original_ms
+        assert publish_event.reason == EnumIntrospectionReason.STARTUP
+        assert publish_event.correlation_id == TEST_NODE_UUID_2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 class TestMixinNodeIntrospectionMethodCountBenchmark:
     """Performance benchmarks with varying method counts.
 

--- a/tests/unit/models/discovery/test_model_introspection_performance_metrics.py
+++ b/tests/unit/models/discovery/test_model_introspection_performance_metrics.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for ModelIntrospectionPerformanceMetrics.
+
+Tests validate:
+- Default value instantiation
+- Field constraint validation (ge=0)
+- Frozen model immutability
+- JSON serialization/deserialization roundtrip
+- Threshold tracking fields
+- captured_at auto-generation
+- Schema examples validation
+
+Related:
+    - OMN-926: Add performance metrics to introspection events for observability
+    - ModelNodeIntrospectionEvent.performance_metrics field
+    - MixinNodeIntrospection.get_performance_metrics()
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.models.discovery import ModelIntrospectionPerformanceMetrics
+
+
+class TestModelIntrospectionPerformanceMetricsInstantiation:
+    """Tests for basic model instantiation and defaults."""
+
+    def test_default_instantiation(self) -> None:
+        """Test that default instantiation produces valid metrics with zero values."""
+        metrics = ModelIntrospectionPerformanceMetrics()
+        assert metrics.get_capabilities_ms == 0.0
+        assert metrics.discover_capabilities_ms == 0.0
+        assert metrics.get_endpoints_ms == 0.0
+        assert metrics.get_current_state_ms == 0.0
+        assert metrics.total_introspection_ms == 0.0
+        assert metrics.cache_hit is False
+        assert metrics.method_count == 0
+        assert metrics.threshold_exceeded is False
+        assert metrics.slow_operations == []
+        assert metrics.captured_at is not None
+
+    def test_full_instantiation(self) -> None:
+        """Test instantiation with all fields explicitly set."""
+        captured = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=12.5,
+            discover_capabilities_ms=8.2,
+            get_endpoints_ms=0.5,
+            get_current_state_ms=0.1,
+            total_introspection_ms=21.3,
+            cache_hit=False,
+            method_count=15,
+            threshold_exceeded=False,
+            slow_operations=[],
+            captured_at=captured,
+        )
+        assert metrics.get_capabilities_ms == 12.5
+        assert metrics.discover_capabilities_ms == 8.2
+        assert metrics.get_endpoints_ms == 0.5
+        assert metrics.get_current_state_ms == 0.1
+        assert metrics.total_introspection_ms == 21.3
+        assert metrics.cache_hit is False
+        assert metrics.method_count == 15
+        assert metrics.threshold_exceeded is False
+        assert metrics.slow_operations == []
+        assert metrics.captured_at == captured
+
+    def test_threshold_exceeded_with_slow_operations(self) -> None:
+        """Test metrics indicating threshold violations."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=55.0,
+            discover_capabilities_ms=45.0,
+            get_endpoints_ms=0.2,
+            get_current_state_ms=0.1,
+            total_introspection_ms=100.3,
+            cache_hit=False,
+            method_count=42,
+            threshold_exceeded=True,
+            slow_operations=[
+                "get_capabilities",
+                "discover_capabilities",
+                "total_introspection",
+            ],
+        )
+        assert metrics.threshold_exceeded is True
+        assert len(metrics.slow_operations) == 3
+        assert "get_capabilities" in metrics.slow_operations
+
+    def test_cache_hit_metrics(self) -> None:
+        """Test metrics for a cache hit scenario (minimal timing)."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=0.05,
+            cache_hit=True,
+            threshold_exceeded=False,
+        )
+        assert metrics.cache_hit is True
+        assert metrics.total_introspection_ms == 0.05
+        assert metrics.get_capabilities_ms == 0.0  # Not measured on cache hit
+
+
+class TestModelIntrospectionPerformanceMetricsValidation:
+    """Tests for field validation constraints."""
+
+    def test_negative_timing_ms_rejected(self) -> None:
+        """Test that negative timing values are rejected (ge=0 constraint)."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(get_capabilities_ms=-1.0)
+
+    def test_negative_discover_capabilities_ms_rejected(self) -> None:
+        """Test that negative discover_capabilities_ms is rejected."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(discover_capabilities_ms=-0.001)
+
+    def test_negative_get_endpoints_ms_rejected(self) -> None:
+        """Test that negative get_endpoints_ms is rejected."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(get_endpoints_ms=-5.0)
+
+    def test_negative_get_current_state_ms_rejected(self) -> None:
+        """Test that negative get_current_state_ms is rejected."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(get_current_state_ms=-0.1)
+
+    def test_negative_total_introspection_ms_rejected(self) -> None:
+        """Test that negative total_introspection_ms is rejected."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(total_introspection_ms=-10.0)
+
+    def test_negative_method_count_rejected(self) -> None:
+        """Test that negative method_count is rejected (ge=0 constraint)."""
+        with pytest.raises(ValidationError):
+            ModelIntrospectionPerformanceMetrics(method_count=-1)
+
+    def test_zero_timing_values_allowed(self) -> None:
+        """Test that zero timing values are valid."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=0.0,
+            discover_capabilities_ms=0.0,
+            get_endpoints_ms=0.0,
+            get_current_state_ms=0.0,
+            total_introspection_ms=0.0,
+            method_count=0,
+        )
+        assert metrics.total_introspection_ms == 0.0
+        assert metrics.method_count == 0
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are rejected (extra='forbid')."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelIntrospectionPerformanceMetrics(
+                unknown_field="value",  # type: ignore[call-arg]
+            )
+        assert "unknown_field" in str(exc_info.value)
+
+
+class TestModelIntrospectionPerformanceMetricsImmutability:
+    """Tests for frozen model immutability."""
+
+    def test_cannot_modify_timing_field(self) -> None:
+        """Test that timing fields cannot be modified after creation."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+        )
+        with pytest.raises(ValidationError):
+            metrics.total_introspection_ms = 50.0  # type: ignore[misc]
+
+    def test_cannot_modify_cache_hit(self) -> None:
+        """Test that cache_hit cannot be modified after creation."""
+        metrics = ModelIntrospectionPerformanceMetrics(cache_hit=False)
+        with pytest.raises(ValidationError):
+            metrics.cache_hit = True  # type: ignore[misc]
+
+    def test_cannot_modify_slow_operations(self) -> None:
+        """Test that slow_operations list reference cannot be reassigned."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            slow_operations=["get_capabilities"],
+        )
+        with pytest.raises(ValidationError):
+            metrics.slow_operations = []  # type: ignore[misc]
+
+
+class TestModelIntrospectionPerformanceMetricsSerialization:
+    """Tests for JSON serialization and deserialization."""
+
+    def test_json_roundtrip_default_values(self) -> None:
+        """Test JSON serialization roundtrip with default values."""
+        metrics = ModelIntrospectionPerformanceMetrics()
+        json_str = metrics.model_dump_json()
+        restored = ModelIntrospectionPerformanceMetrics.model_validate_json(json_str)
+        assert restored.get_capabilities_ms == metrics.get_capabilities_ms
+        assert restored.cache_hit == metrics.cache_hit
+        assert restored.method_count == metrics.method_count
+
+    def test_json_roundtrip_full_values(self) -> None:
+        """Test JSON serialization roundtrip with all fields populated."""
+        captured = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=12.5,
+            discover_capabilities_ms=8.2,
+            get_endpoints_ms=0.5,
+            get_current_state_ms=0.1,
+            total_introspection_ms=21.3,
+            cache_hit=False,
+            method_count=15,
+            threshold_exceeded=True,
+            slow_operations=["get_capabilities", "total_introspection"],
+            captured_at=captured,
+        )
+        json_str = metrics.model_dump_json()
+        restored = ModelIntrospectionPerformanceMetrics.model_validate_json(json_str)
+        assert restored.get_capabilities_ms == 12.5
+        assert restored.discover_capabilities_ms == 8.2
+        assert restored.get_endpoints_ms == 0.5
+        assert restored.get_current_state_ms == 0.1
+        assert restored.total_introspection_ms == 21.3
+        assert restored.cache_hit is False
+        assert restored.method_count == 15
+        assert restored.threshold_exceeded is True
+        assert restored.slow_operations == ["get_capabilities", "total_introspection"]
+
+    def test_model_dump_dict_structure(self) -> None:
+        """Test model_dump produces correct dict structure."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=10.0,
+            method_count=5,
+            threshold_exceeded=True,
+            slow_operations=["get_capabilities"],
+        )
+        data = metrics.model_dump()
+        assert isinstance(data, dict)
+        assert data["get_capabilities_ms"] == 10.0
+        assert data["method_count"] == 5
+        assert data["threshold_exceeded"] is True
+        assert data["slow_operations"] == ["get_capabilities"]
+        assert "captured_at" in data
+
+    def test_model_dump_mode_json(self) -> None:
+        """Test model_dump with mode='json' for JSON-compatible output."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+        )
+        data = metrics.model_dump(mode="json")
+        # Datetime should be serialized as ISO string in JSON mode
+        assert isinstance(data["captured_at"], str)
+        # Numeric values remain numeric
+        assert isinstance(data["total_introspection_ms"], float)
+
+
+class TestModelIntrospectionPerformanceMetricsCapturedAt:
+    """Tests for captured_at auto-generation."""
+
+    def test_captured_at_auto_generated(self) -> None:
+        """Test that captured_at is automatically set to current UTC time."""
+        before = datetime.now(UTC)
+        metrics = ModelIntrospectionPerformanceMetrics()
+        after = datetime.now(UTC)
+        assert before <= metrics.captured_at <= after
+
+    def test_captured_at_explicit_value(self) -> None:
+        """Test that captured_at can be explicitly set."""
+        explicit_time = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        metrics = ModelIntrospectionPerformanceMetrics(captured_at=explicit_time)
+        assert metrics.captured_at == explicit_time
+
+
+class TestModelIntrospectionPerformanceMetricsEquality:
+    """Tests for model equality comparison."""
+
+    def test_equal_metrics_are_equal(self) -> None:
+        """Test that two metrics with same values are equal."""
+        captured = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+        m1 = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+            method_count=10,
+            captured_at=captured,
+        )
+        m2 = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+            method_count=10,
+            captured_at=captured,
+        )
+        assert m1 == m2
+
+    def test_different_values_not_equal(self) -> None:
+        """Test that metrics with different values are not equal."""
+        captured = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+        m1 = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+            captured_at=captured,
+        )
+        m2 = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=50.0,
+            captured_at=captured,
+        )
+        assert m1 != m2
+
+
+class TestModelIntrospectionPerformanceMetricsSchemaExamples:
+    """Tests validating the JSON schema examples defined in model_config."""
+
+    def test_schema_example_normal_performance(self) -> None:
+        """Test that the 'normal' schema example validates successfully."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=12.5,
+            discover_capabilities_ms=8.2,
+            get_endpoints_ms=0.5,
+            get_current_state_ms=0.1,
+            total_introspection_ms=21.3,
+            cache_hit=False,
+            method_count=15,
+            threshold_exceeded=False,
+            slow_operations=[],
+            captured_at=datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC),
+        )
+        assert not metrics.threshold_exceeded
+        assert metrics.slow_operations == []
+
+    def test_schema_example_degraded_performance(self) -> None:
+        """Test that the 'degraded' schema example validates successfully."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=55.0,
+            discover_capabilities_ms=45.0,
+            get_endpoints_ms=0.2,
+            get_current_state_ms=0.1,
+            total_introspection_ms=100.3,
+            cache_hit=False,
+            method_count=42,
+            threshold_exceeded=True,
+            slow_operations=[
+                "get_capabilities",
+                "discover_capabilities",
+                "total_introspection",
+            ],
+            captured_at=datetime(2025, 1, 15, 10, 31, 0, tzinfo=UTC),
+        )
+        assert metrics.threshold_exceeded is True
+        assert len(metrics.slow_operations) == 3

--- a/tests/unit/models/registration/test_model_node_introspection_event.py
+++ b/tests/unit/models/registration/test_model_node_introspection_event.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 
 from omnibase_core.enums import EnumNodeKind
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.models.discovery import ModelIntrospectionPerformanceMetrics
 from omnibase_infra.models.registration import (
     ModelNodeCapabilities,
     ModelNodeIntrospectionEvent,
@@ -1031,3 +1032,207 @@ class TestModelNodeIntrospectionEventEndpointUrlValidation:
         json_str = event.model_dump_json()
         restored = ModelNodeIntrospectionEvent.model_validate_json(json_str)
         assert restored.endpoints == event.endpoints
+
+
+class TestModelNodeIntrospectionEventPerformanceMetrics:
+    """Tests for performance_metrics field on introspection events.
+
+    Validates that ModelIntrospectionPerformanceMetrics can be attached to
+    introspection events, serialized, and deserialized correctly. This is
+    the core observability feature from OMN-926.
+    """
+
+    def test_performance_metrics_default_none(self) -> None:
+        """Test that performance_metrics defaults to None when not provided."""
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+        )
+        assert event.performance_metrics is None
+
+    def test_performance_metrics_with_values(self) -> None:
+        """Test that performance_metrics can be set with a valid model."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=12.5,
+            discover_capabilities_ms=8.2,
+            get_endpoints_ms=0.5,
+            get_current_state_ms=0.1,
+            total_introspection_ms=21.3,
+            cache_hit=False,
+            method_count=15,
+            threshold_exceeded=False,
+            slow_operations=[],
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        assert event.performance_metrics is not None
+        assert event.performance_metrics.get_capabilities_ms == 12.5
+        assert event.performance_metrics.total_introspection_ms == 21.3
+        assert event.performance_metrics.method_count == 15
+
+    def test_performance_metrics_with_threshold_exceeded(self) -> None:
+        """Test event with metrics indicating threshold violations."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=55.0,
+            total_introspection_ms=100.3,
+            method_count=42,
+            threshold_exceeded=True,
+            slow_operations=["get_capabilities", "total_introspection"],
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.COMPUTE,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        assert event.performance_metrics is not None
+        assert event.performance_metrics.threshold_exceeded is True
+        assert "get_capabilities" in event.performance_metrics.slow_operations
+        assert "total_introspection" in event.performance_metrics.slow_operations
+
+    def test_performance_metrics_cache_hit(self) -> None:
+        """Test event with cache hit metrics (minimal timing)."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=0.05,
+            cache_hit=True,
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        assert event.performance_metrics is not None
+        assert event.performance_metrics.cache_hit is True
+
+    def test_performance_metrics_json_serialization_roundtrip(self) -> None:
+        """Test that performance_metrics survives JSON serialization roundtrip."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            get_capabilities_ms=15.0,
+            discover_capabilities_ms=10.0,
+            get_endpoints_ms=1.0,
+            get_current_state_ms=0.5,
+            total_introspection_ms=26.5,
+            cache_hit=False,
+            method_count=20,
+            threshold_exceeded=False,
+            slow_operations=[],
+            captured_at=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.REDUCER,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        json_str = event.model_dump_json()
+        restored = ModelNodeIntrospectionEvent.model_validate_json(json_str)
+
+        assert restored.performance_metrics is not None
+        assert restored.performance_metrics.get_capabilities_ms == 15.0
+        assert restored.performance_metrics.discover_capabilities_ms == 10.0
+        assert restored.performance_metrics.get_endpoints_ms == 1.0
+        assert restored.performance_metrics.get_current_state_ms == 0.5
+        assert restored.performance_metrics.total_introspection_ms == 26.5
+        assert restored.performance_metrics.cache_hit is False
+        assert restored.performance_metrics.method_count == 20
+        assert restored.performance_metrics.threshold_exceeded is False
+        assert restored.performance_metrics.slow_operations == []
+
+    def test_performance_metrics_none_json_roundtrip(self) -> None:
+        """Test that None performance_metrics survives JSON serialization."""
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=None,
+        )
+        json_str = event.model_dump_json()
+        restored = ModelNodeIntrospectionEvent.model_validate_json(json_str)
+        assert restored.performance_metrics is None
+
+    def test_performance_metrics_in_model_dump(self) -> None:
+        """Test that performance_metrics appears correctly in model_dump."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=30.0,
+            method_count=10,
+            threshold_exceeded=True,
+            slow_operations=["total_introspection"],
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        data = event.model_dump()
+        assert "performance_metrics" in data
+        pm = data["performance_metrics"]
+        assert pm is not None
+        assert pm["total_introspection_ms"] == 30.0
+        assert pm["method_count"] == 10
+        assert pm["threshold_exceeded"] is True
+        assert pm["slow_operations"] == ["total_introspection"]
+
+    def test_performance_metrics_immutable_on_event(self) -> None:
+        """Test that performance_metrics cannot be reassigned on frozen event."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        with pytest.raises(ValidationError):
+            event.performance_metrics = None  # type: ignore[misc]
+
+    def test_performance_metrics_model_copy_preserves(self) -> None:
+        """Test that model_copy preserves performance_metrics."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+            method_count=10,
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        copied = event.model_copy()
+        assert copied.performance_metrics is not None
+        assert copied.performance_metrics.total_introspection_ms == 25.0
+        assert copied.performance_metrics.method_count == 10
+
+    def test_performance_metrics_model_copy_deep(self) -> None:
+        """Test that deep model_copy creates independent metrics."""
+        metrics = ModelIntrospectionPerformanceMetrics(
+            total_introspection_ms=25.0,
+            slow_operations=["get_capabilities"],
+        )
+        event = ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=TEST_TIMESTAMP,
+            performance_metrics=metrics,
+        )
+        copied = event.model_copy(deep=True)
+        assert copied.performance_metrics is not None
+        assert copied.performance_metrics is not event.performance_metrics
+        assert copied.performance_metrics.total_introspection_ms == 25.0


### PR DESCRIPTION
## Summary

- Adds comprehensive test coverage for `ModelIntrospectionPerformanceMetrics` model (25 tests covering instantiation, validation constraints, immutability, JSON serialization roundtrip, `captured_at` auto-generation, equality, and schema examples)
- Adds tests for the `performance_metrics` field on `ModelNodeIntrospectionEvent` (10 tests covering attachment, threshold tracking, cache hit scenarios, JSON roundtrip, model_dump, immutability, and model_copy behavior)
- Adds integration tests verifying metrics flow through the mixin's `get_introspection_data()` into published events (7 tests covering event population, consistency with standalone `get_performance_metrics()`, timing values, method_count alignment with discovered capabilities, event bus serialization, and model_copy with reason/correlation_id updates)

## Test plan

- [x] All 42 new tests pass locally
- [x] Full unit test suite passes (1370 passed, 1 pre-existing failure in unrelated Kafka config test)
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for performance metrics in introspection events, including serialization, caching, and event-bus compatibility
  * Added validation tests for performance metrics model covering field constraints, immutability, and threshold handling
  * Added integration tests confirming performance metrics work correctly with introspection event models and survive model updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->