### PR TITLE
chore(docker): update Dockerfile.runtime plugin pins

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -172,9 +172,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # in a separate step so plugins have their required third-party libraries.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "omninode-claude==0.4.0" \
-    "omninode-memory==0.6.1" \
-    "omninode-intelligence==0.9.1"
+    "omninode-claude==0.5.0" \
+    "omninode-memory==0.6.4" \
+    "omninode-intelligence==0.10.0"
 
 # Install CPU-only PyTorch (~2GB savings over CUDA wheels).
 # K8s runtime has no GPU; inference offloads to LLM servers via HTTP.


### PR DESCRIPTION
## Summary
- Update plugin pins in Dockerfile.runtime after coordinated release
- omninode-claude: 0.4.0 -> 0.5.0
- omninode-memory: 0.6.1 -> 0.6.4
- omninode-intelligence: 0.9.1 -> 0.10.0

## Test plan
- [ ] CI passes (Docker build validates pins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend plugin dependencies to the latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->