### PR TITLE
OMN-1430: refactor CI workflow to use composite action for Python/uv setup

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -1,0 +1,59 @@
+name: 'Setup Python and uv'
+description: 'Common setup for Python projects with uv: install Python, uv, restore cache, and install dependencies'
+author: 'OmniNode'
+
+inputs:
+  python-version:
+    description: 'Python version to install'
+    required: false
+    default: '3.12'
+  uv-version:
+    description: 'uv version to install'
+    required: false
+    default: '0.6.14'
+  cache-version:
+    description: 'Cache version suffix for busting stale caches'
+    required: false
+    default: '0.6.0'
+  cache-key-prefix:
+    description: 'Custom prefix for the cache key (e.g., uv-boundary, uv-handshake)'
+    required: false
+    default: 'uv'
+  lock-file-path:
+    description: 'Path to uv.lock for cache key hashing (glob pattern)'
+    required: false
+    default: '**/uv.lock'
+  install-args:
+    description: 'Extra arguments passed to uv sync (e.g., --frozen)'
+    required: false
+    default: '--reinstall-package omnibase-core --reinstall-package omnibase-spi'
+  skip-install:
+    description: 'Set to "true" to skip the uv sync step (useful for multi-repo setups that install manually)'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: ${{ inputs.uv-version }}
+
+    - name: Load cached uv
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles(inputs.lock-file-path) }}-${{ inputs.cache-version }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.cache-version }}-
+
+    - name: Install dependencies
+      if: inputs.skip-install != 'true'
+      shell: bash
+      run: uv sync ${{ inputs.install-args }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,26 +52,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Check ruff formatting
         run: uv run ruff format --check src/ tests/
@@ -101,26 +87,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Run architecture layer check
         run: |
@@ -174,26 +146,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Check schema fingerprint (CI twin for B2)
         run: uv run python scripts/check_schema_fingerprint.py verify
@@ -221,26 +179,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Run demo loop assertion gate
         run: |
@@ -294,26 +238,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Check topic enum drift
         run: |
@@ -342,26 +272,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Lint topic names
         run: |
@@ -371,7 +287,7 @@ jobs:
           uv run python scripts/validation/lint_topic_names.py \
             --scan-contracts src/omnibase_infra/nodes
 
-  # Schema handshake gate -- validates producer→consumer Pydantic round-trip
+  # Schema handshake gate -- validates producer->consumer Pydantic round-trip
   # across every registered Kafka boundary pair (OMN-3411).
   # Uses --changed-only in CI: only checks pairs whose models were touched by the PR.
   # Requires sibling repos omniintelligence + omnimemory to be checked out.
@@ -410,23 +326,15 @@ jobs:
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./omnibase_infra/.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-handshake-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('omnibase_infra/**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-handshake-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          cache-key-prefix: uv-handshake
+          lock-file-path: 'omnibase_infra/**/uv.lock'
+          skip-install: 'true'
 
       - name: Install omnibase_infra dev dependencies
         working-directory: omnibase_infra
@@ -466,26 +374,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Check for raw topic literals in production code
         run: |
@@ -522,26 +416,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Run test split ${{ matrix.split }}/10
         run: |
@@ -707,23 +587,15 @@ jobs:
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./omnibase_infra/.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-boundary-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('omnibase_infra/**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-boundary-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          cache-key-prefix: uv-boundary
+          lock-file-path: 'omnibase_infra/**/uv.lock'
+          skip-install: 'true'
 
       - name: Install omnibase_infra dev dependencies
         working-directory: omnibase_infra
@@ -752,14 +624,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
+
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
-          python-version: "3.12"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
+
       - name: Check writer-migration coupling
         run: uv run python scripts/check_migration_required.py --ci
 
@@ -786,26 +659,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached uv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
-
-      - name: Install dependencies
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
       - name: Apply all migrations
         env:
@@ -862,15 +722,18 @@ jobs:
       - name: Compute changed Python/Markdown files vs PR base
         id: changed
         run: |
-          if [ -n "${{ github.base_ref }}" ]; then
-            git fetch origin "${{ github.base_ref }}" --no-tags --depth=1
-            FILES=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.py' '*.md' | tr '\n' ' ')
+          if [ -n "$GITHUB_BASE_REF" ]; then
+            git fetch origin "$GITHUB_BASE_REF" --no-tags --depth=1
+            FILES=$(git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD -- '*.py' '*.md' | tr '\n' ' ')
           else
             FILES=$(git diff --name-only HEAD~1 -- '*.py' '*.md' 2>/dev/null | tr '\n' ' ')
           fi
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
       - name: Check changed files for AI-slop patterns (strict)
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
-          FILES="${{ steps.changed.outputs.files }}"
-          if [ -z "$FILES" ]; then exit 0; fi
-          python scripts/validation/check_ai_slop.py --strict $FILES
+          if [ -z "$CHANGED_FILES" ]; then exit 0; fi
+          python scripts/validation/check_ai_slop.py --strict $CHANGED_FILES


### PR DESCRIPTION
## Summary

- Create `.github/actions/setup-python-uv/` composite action that encapsulates the common 4-step setup sequence (Python install, uv install, cache restore, dependency install) repeated across 12 CI jobs
- Refactor all applicable jobs in `test.yml` to use the composite action, eliminating ~160 lines of duplication (net -78 lines)
- The composite action supports configurable inputs: `cache-key-prefix`, `lock-file-path`, `install-args`, and `skip-install` for multi-repo jobs (schema-handshake, kafka-boundary-compat) that handle installation manually
- Fix command injection risk in `ai-slop-check` by using env vars instead of inline `${{ }}` expression interpolation for `github.base_ref`

## Jobs refactored (12 of 17)

| Job | Composite action usage |
|-----|----------------------|
| lint | Standard (default install-args) |
| onex-validation | Standard |
| fingerprint-check | Standard |
| demo-loop-gate | Standard |
| topic-enum-drift | Standard |
| topic-naming-lint | Standard |
| arch-invariants | Standard |
| test-parallel | Standard |
| migration-required-check | Custom install-args (--frozen) |
| migration-integration | Custom install-args (--frozen) |
| schema-handshake | skip-install + custom cache-key-prefix |
| kafka-boundary-compat | skip-install + custom cache-key-prefix |

Jobs **not** refactored (intentional):
- `migration-freeze` -- shell script only, no Python needed
- `tests-gate` / `test-summary` -- aggregation jobs, no setup needed
- `ai-slop-check` -- uses bare `python` (no uv sync), different pattern

## Test plan

- [ ] CI passes on this PR (the workflow itself is the test)
- [ ] Verify all 17 jobs still appear in the CI run with correct names
- [ ] Verify composite action resolves correctly for both standard (`./`) and multi-repo (`./omnibase_infra/`) path references

Closes OMN-1430