### PR TITLE
OMN-3833: split release.yml into critical publish + advisory checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Verify version_compatibility.py fallback matrix is in sync
-        run: uv run python scripts/update_version_matrix.py --check
-
       - name: Build wheel + sdist
         run: uv build
 
@@ -104,6 +101,34 @@ jobs:
             dist/SHA256SUMS.txt
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
+
+  # ---------------------------------------------------------------------------
+  # Post-release: advisory checks that must NOT block publish (OMN-3833)
+  # ---------------------------------------------------------------------------
+  post-release-checks:
+    name: Post-Release Checks
+    needs: release
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Check fallback matrix sync (advisory)
+        run: |
+          if ! uv run python scripts/update_version_matrix.py --check; then
+            echo "::warning::Fallback matrix is out of sync with pyproject.toml."
+            echo "Run: uv run python scripts/update_version_matrix.py"
+            echo "## ⚠️ Fallback Matrix Drift" >> $GITHUB_STEP_SUMMARY
+            echo "The _FALLBACK_MATRIX in version_compatibility.py is out of sync." >> $GITHUB_STEP_SUMMARY
+            echo "Run \`uv run python scripts/update_version_matrix.py\` to fix." >> $GITHUB_STEP_SUMMARY
+          fi
 
   # ---------------------------------------------------------------------------
   # Post-release: trigger runtime Docker image rebuild (OMN-2751)


### PR DESCRIPTION
## Summary
- Move fallback matrix check (`update_version_matrix.py --check`) from blocking pre-publish gate to advisory `post-release-checks` job
- Release job now only contains critical path: checkout → validate tag → build → publish → GitHub release
- New `post-release-checks` job runs after successful publish, emits `::warning` + `$GITHUB_STEP_SUMMARY` on drift

## Why
When the optional fallback matrix validation failed, nothing was published — requiring tag deletion, fix PR, and retag (a 45+ minute recovery cycle). The matrix check is important but should not block publishing.

## Design
- `post-release-checks` uses `needs: release` + `if: always() && needs.release.result == 'success'`
- Same checkout ref logic as release job for `workflow_dispatch` compatibility
- `trigger-runtime-rebuild` and `dependency-cascade` still depend only on `release`

## Test plan
- Release workflow publishes even if fallback matrix is out of sync
- Post-release-checks emits warning when drift detected
- Existing downstream jobs unaffected

Part of Release Pipeline Resilience epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow by removing a blocking pre-release verification step that could delay publishing.
  * Added post-release validation that runs after successful release to detect potential inconsistencies and provide advisory warnings without affecting the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->