### PR TITLE
OMN-3834: remove broken restore-keys, add reinstall flags

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -50,8 +50,6 @@ runs:
       with:
         path: ~/.cache/uv
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles(inputs.lock-file-path) }}-${{ inputs.cache-version }}
-        restore-keys: |
-          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.cache-version }}-
 
     - name: Install dependencies
       if: inputs.skip-install != 'true'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -71,11 +71,9 @@ jobs:
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.CACHE_VERSION }}-
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
 
       # Run slow and chaos tests with extended timeout
       # These tests validate resilience and performance characteristics


### PR DESCRIPTION
## Summary
- Remove structurally broken `restore-keys` from `.github/actions/setup-python-uv/action.yml`
- Remove `restore-keys` from `nightly-tests.yml` UV cache block
- Add `--reinstall-package omnibase-core --reinstall-package omnibase-spi` to nightly-tests `uv sync`

## Why
The `restore-keys` format (`uv-Linux-3.12-0.6.0-`) never matches cache keys (`uv-Linux-3.12-<hash>-0.6.0`) due to segment ordering mismatch. Removing prevents future accidental partial matches. Reinstall flags ensure fresh resolution of internal ONEX packages.

## Test plan
- CI passes on first run (cache miss expected, new cache populated)
- `uv sync` output shows `Downloaded omnibase-core` (proves reinstall forced fresh fetch)

Part of Release Pipeline Resilience epic.