### PR TITLE
OMN-3831: replace hardcoded __version__ with importlib.metadata

### DIFF
--- a/src/omnibase_infra/__init__.py
+++ b/src/omnibase_infra/__init__.py
@@ -76,7 +76,13 @@ See Also
 - Runtime kernel: omnibase_infra.runtime.service_kernel
 """
 
-__version__ = "0.14.0"
+# Do not hardcode versions here; version is sourced from distribution metadata.
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("omnibase-infra")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
 
 from . import (
     enums,


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "X.Y.Z"` with `importlib.metadata.version()` pattern
- Uses `PackageNotFoundError` fallback to `"0.0.0-dev"` for un-installed source checkouts
- Single source of truth: version now comes from `pyproject.toml` via distribution metadata

## Why
During v0.24.0 release, `pyproject.toml` was bumped but `__init__.py` was not, causing `version_compatibility.py` to see stale versions and failing CI for all downstream repos.

## Test plan
- `uv run python -c "import omnibase_infra; print(omnibase_infra.__version__)"` returns installed version
- `grep -r '__version__ = "' src/` returns only the `"0.0.0-dev"` fallback
- All existing tests pass

Part of Release Pipeline Resilience epic.