### PR TITLE
OMN-3832: add validate-string-versions pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,14 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=1000]
+  # ONEX String Version Anti-Pattern Detection (from omnibase_core)
+  # Prevents hardcoded __version__ in __init__.py and string version anti-patterns
+  - repo: https://github.com/OmniNode-ai/omnibase_core
+    rev: v0.24.0  # Pin to latest tag; bump during coordinated releases
+    hooks:
+      - id: validate-string-versions
+        name: ONEX String Version Anti-Pattern Detection
+
   # ONEX Python Development Hooks (from shared templates)
   # Order: ruff format → ruff check → mypy (formatting before linting before type checking)
   # Note: ruff replaces both black and isort (10-100x faster)


### PR DESCRIPTION
## Summary
- Add `validate-string-versions` pre-commit hook from omnibase_core (pinned to v0.24.0)
- Prevents reintroduction of hardcoded `__version__` in `__init__.py`

## Depends on
- OMN-3831 (hardcoded versions removed)
- OMN-3832 in omnibase_core (hook source must be tagged first)

## Test plan
- `pre-commit run validate-string-versions` passes on current codebase
- Adding `__version__ = "9.9.9"` to any `__init__.py` fails the hook

Part of Release Pipeline Resilience epic.