### PR TITLE
OMN-3894: add USE_EVENT_ROUTING to docker-compose passthrough

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -165,6 +165,9 @@ x-runtime-env: &runtime-env
   OMNIMEMORY_ENABLED: ${OMNIMEMORY_ENABLED:-}
   # OmniClaude domain plugin (OMN-3182): required by PluginClaude.wire_dispatchers()
   OMNICLAUDE_CONTRACTS_ROOT: ${OMNICLAUDE_CONTRACTS_ROOT:-}
+  # OMN-3894: Enable event-based agent routing in containers. App defaults to false;
+  # compose ensures containers always enable it via :-true default.
+  USE_EVENT_ROUTING: ${USE_EVENT_ROUTING:-true}
   # --- Keycloak / Auth (auth profile, OMN-3361) ---
   # KEYCLOAK_ADMIN_URL: internal container DNS — NEVER set to localhost here.
   # KEYCLOAK_ISSUER: external browser-visible URL — must match token iss claim.

--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -74,6 +74,11 @@ OMNINODE_CLOUD_DB_URL=postgresql://role_omninode_cloud:__REPLACE_WITH_SECURE_PAS
 #   KAFKA_BOOTSTRAP_SERVERS=<your-server-ip>:19092
 KAFKA_BOOTSTRAP_SERVERS=your-kafka-host:19092
 
+# Enable event-based agent routing via Kafka (OMN-3894).
+# When true, ProtocolEventBusPublisher registers and routing flows through Kafka.
+# Docker containers default to true via compose; host scripts should set explicitly.
+USE_EVENT_ROUTING=true
+
 # Kafka advanced settings (optional - defaults shown)
 #
 # Environment and group identification


### PR DESCRIPTION
## Summary

- Add `USE_EVENT_ROUTING: ${USE_EVENT_ROUTING:-true}` to `x-runtime-env` in `docker-compose.infra.yml` after `OMNICLAUDE_CONTRACTS_ROOT`
- Add `USE_EVENT_ROUTING=true` with documentation comment to `docs/env-example-full.txt`

Without this passthrough, the omniclaude plugin defaults `USE_EVENT_ROUTING` to `false` inside containers, `ProtocolEventBusPublisher` never registers, and handler wiring fails with `ONEX_CORE_066_REGISTRY_RESOLUTION_FAILED`.

Compose default is `:-true` so containers always enable event routing. Host `.env` can override.

## Test plan

- [ ] Verify `docker compose config` shows `USE_EVENT_ROUTING: "true"` in runtime services
- [ ] Verify runtime boots without `ONEX_CORE_066_REGISTRY_RESOLUTION_FAILED`
- [ ] Verify `USE_EVENT_ROUTING=false` in host env propagates correctly to containers

Closes OMN-3894 (omnibase_infra portion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-based routing configuration option (USE_EVENT_ROUTING) with default enabled behavior for improved agent processing.

* **Documentation**
  * Updated environment variable documentation and infrastructure configuration with new routing option and setup guidance for both containerized and host deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->