### PR TITLE
OMN-3902: expose config_prefetch_status in /health endpoint

### DIFF
--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -3073,7 +3073,9 @@ class RuntimeHostProcess:
                 # Step 4: Apply to environment
                 applied = prefetcher.apply_to_environment(result)
 
-                self._config_prefetch_status = "ok"
+                self._config_prefetch_status = (
+                    "degraded_error" if result.errors else "ok"
+                )
                 logger.info(
                     "Config prefetch complete",
                     extra={

--- a/tests/unit/runtime/test_health_config_prefetch_status.py
+++ b/tests/unit/runtime/test_health_config_prefetch_status.py
@@ -165,3 +165,49 @@ class TestHealthCheckIncludesConfigPrefetchStatus:
 
         health = await process.health_check()
         assert health["config_prefetch_status"] == "degraded_error"
+
+    @pytest.mark.asyncio
+    async def test_status_degraded_error_on_soft_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When prefetch returns result.errors (soft failure), status must be 'degraded_error'.
+
+        Regression test for the bug where config_prefetch_status was set to 'ok'
+        unconditionally even when ConfigPrefetcher.prefetch() returned soft errors
+        via result.errors without raising an exception.
+        """
+        monkeypatch.setenv("INFISICAL_ADDR", "http://localhost:8880")
+        monkeypatch.setenv("INFISICAL_CLIENT_ID", "test-id")
+        monkeypatch.setenv("INFISICAL_CLIENT_SECRET", "test-secret")
+        monkeypatch.setenv("INFISICAL_PROJECT_ID", "test-project")
+
+        mock_extractor = MagicMock()
+        mock_requirements = MagicMock()
+        mock_requirements.requirements = [MagicMock()]
+        mock_extractor.return_value.extract_from_paths.return_value = mock_requirements
+
+        # Simulate a soft failure: prefetch() returns without raising,
+        # but result.errors is non-empty.
+        mock_result = MagicMock()
+        mock_result.success_count = 0
+        mock_result.missing = []
+        mock_result.errors = {"SOME_KEY": "fetch failed"}
+
+        mock_prefetcher = MagicMock()
+        mock_prefetcher.return_value.prefetch.return_value = mock_result
+        mock_prefetcher.return_value.apply_to_environment.return_value = 0
+
+        mock_handler_cls = MagicMock()
+        mock_handler_instance = AsyncMock()
+        mock_handler_cls.return_value = mock_handler_instance
+
+        with (
+            patch(_EXTRACTOR_PATH, mock_extractor),
+            patch(_PREFETCHER_PATH, mock_prefetcher),
+            patch(_HANDLER_PATH, mock_handler_cls),
+        ):
+            process = _make_process()
+            await process._prefetch_config_from_infisical()
+
+        health = await process.health_check()
+        assert health["config_prefetch_status"] == "degraded_error"


### PR DESCRIPTION
## Summary

- Adds `_config_prefetch_status` attribute to `RuntimeHostProcess` tracking Infisical config prefetch outcome through a 5-state vocabulary: `pending`, `skipped`, `ok`, `degraded_no_requirements`, `degraded_error`
- Exposes the status in the `health_check()` response dict as `config_prefetch_status`
- Sets status at each decision point in `_prefetch_config_from_infisical` so it reflects the actual prefetch outcome

## Dependencies

- **OMN-3893** (PR #683) introduces the same `_config_prefetch_status` attribute as part of the prefetch contract decoupling. When that PR merges first, this PR's attribute initialization will conflict (trivially resolvable). The status transitions and health endpoint exposure are unique to this PR.

## Test plan

- [x] 7 unit tests covering all 5 status vocabulary values
- [x] Tests verify status appears in `health_check()` response (not just internal attribute)
- [x] Existing health check tests pass unchanged
- [ ] `curl localhost:8085/health` returns `config_prefetch_status` field (manual verification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check responses now include configuration prefetch status, reporting whether prefetch operations succeeded, were skipped due to missing configuration, or encountered errors during execution.

* **Tests**
  * Added comprehensive unit test coverage validating configuration prefetch status reporting across multiple scenarios, including successful prefetches, skipped operations, missing requirements, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->