### PR TITLE
OMN-4041: wire contract validation gate into omnibase_infra CI

### DIFF
--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Contract Validation Gate
+#
+# Validates ONEX ticket contracts for PRs in omnibase_infra using the
+# reusable composite action from onex_change_control.
+#
+# Required status check: "contract-validation"
+# Must pass (or skip) before merging to main.
+#
+# The validation is intentionally lenient on missing contracts:
+# - If branch name has no OMN-XXXX ticket ID → skipped
+# - If contracts/<ticket_id>.yaml does not exist → skipped
+# - If contract file exists but fails schema validation → fails
+#
+# This prevents blocking PRs that legitimately have no contract
+# (e.g., dependency bumps, docs-only changes) while enforcing schema
+# correctness when a contract is present.
+
+name: Contract Validation
+
+on:
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        description: "Branch name to validate contracts for (defaults to current branch)"
+        required: false
+        default: ""
+
+# Allow concurrent runs on different PRs; cancel stale runs on the same ref
+concurrency:
+  group: contract-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-validation:
+    name: contract-validation
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Auth preflight — confirm onex_change_control action is accessible
+        id: auth-preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Checking visibility of OmniNode-ai/onex_change_control..."
+          if gh api repos/OmniNode-ai/onex_change_control --silent; then
+            echo "::notice::onex_change_control repo is accessible."
+          else
+            echo "::error::Cannot reach OmniNode-ai/onex_change_control. Composite action will not resolve."
+            exit 1
+          fi
+
+      - name: Resolve branch name
+        id: resolve-branch
+        env:
+          WORKFLOW_INPUT_BRANCH: ${{ inputs.branch-name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Prefer workflow_dispatch input, then PR head ref, then ref name
+          if [[ -n "$WORKFLOW_INPUT_BRANCH" ]]; then
+            BRANCH="$WORKFLOW_INPUT_BRANCH"
+          elif [[ -n "$GITHUB_HEAD_REF" ]]; then
+            BRANCH="$GITHUB_HEAD_REF"
+          else
+            BRANCH="$GITHUB_REF_NAME"
+          fi
+          echo "resolved_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "::notice::Resolved branch name: $BRANCH"
+
+      - name: Run contract validation
+        id: validate-contract
+        uses: OmniNode-ai/onex_change_control/.github/actions/validate-contract@main
+        with:
+          branch-name: ${{ steps.resolve-branch.outputs.resolved_branch }}
+          contracts-path: contracts
+
+      - name: Report validation result
+        if: always()
+        env:
+          TICKET_ID: ${{ steps.validate-contract.outputs.ticket-id }}
+          VALIDATION_STATUS: ${{ steps.validate-contract.outputs.validation-status }}
+        run: |
+          case "$VALIDATION_STATUS" in
+            passed)
+              echo "::notice::Contract validation PASSED for ticket $TICKET_ID"
+              ;;
+            skipped)
+              if [[ -z "$TICKET_ID" ]]; then
+                echo "::notice::Contract validation SKIPPED — no OMN-XXXX ticket ID found in branch name."
+              else
+                echo "::notice::Contract validation SKIPPED — no contract file found for $TICKET_ID in contracts/."
+              fi
+              ;;
+            failed)
+              echo "::error::Contract validation FAILED for ticket $TICKET_ID. See validate-contract step for details."
+              exit 1
+              ;;
+            *)
+              echo "::warning::Unexpected validation status: '$VALIDATION_STATUS'. Treating as skipped."
+              ;;
+          esac

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,14 +39,6 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=1000]
-  # ONEX String Version Anti-Pattern Detection (from omnibase_core)
-  # Prevents hardcoded __version__ in __init__.py and string version anti-patterns
-  - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: v0.24.0  # Pin to latest tag; bump during coordinated releases
-    hooks:
-      - id: validate-string-versions
-        name: ONEX String Version Anti-Pattern Detection
-
   # ONEX Python Development Hooks (from shared templates)
   # Order: ruff format → ruff check → mypy (formatting before linting before type checking)
   # Note: ruff replaces both black and isort (10-100x faster)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/contract-validation.yml` — a required CI gate for ONEX contract validation on every PR to main/develop
- Calls `OmniNode-ai/onex_change_control/.github/actions/validate-contract@main` (from OMN-4040)
- Auth preflight confirms repo visibility before running validation
- Skips gracefully when branch has no OMN-XXXX ticket ID or no contract file found
- All `github.*` context values passed through `env:` variables (no direct interpolation — safe from injection)
- Job name is `contract-validation` — to be added as required status check for branch protection

Also fixes pre-existing broken pre-commit hook: removes `validate-string-versions` reference from `.pre-commit-config.yaml`. This hook was added in OMN-3832 pointing to `omnibase_core@v0.24.0`, which does not export this hook ID, breaking all pre-commit usage in omnibase_infra.

## Risk

Low — adds CI workflow only; no production code changed. Pre-commit fix is a cleanup of broken config.

## Test Evidence

Pre-commit on changed files: all passed. Pre-existing failures on unrelated test fixtures (yamlfmt on intentionally malformed YAML, AI-slop warnings on existing test docstrings) are not introduced by this PR.

## Rollback

Revert this PR. No downstream effects unless branch protection rule has been added.

## Branch Protection Note

After this PR merges, add `contract-validation` as a required status check in branch protection settings for omnibase_infra main branch.

## Linear

Closes OMN-4041
Epic: OMN-4039
Depends on: OMN-4040 (https://github.com/OmniNode-ai/onex_change_control/pull/27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated contract validation to pull request checks
  * Removed obsolete pre-commit validation tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->