### PR TITLE
OMN-4034: add coerce_message_category boundary normalization helper

### DIFF
--- a/src/omnibase_infra/runtime/service_message_dispatch_engine.py
+++ b/src/omnibase_infra/runtime/service_message_dispatch_engine.py
@@ -129,7 +129,7 @@ Category Support:
 
 from __future__ import annotations
 
-__all__ = ["MessageDispatchEngine"]
+__all__ = ["MessageDispatchEngine", "coerce_message_category"]
 
 import asyncio
 import inspect
@@ -188,6 +188,33 @@ if TYPE_CHECKING:
 
     from omnibase_core.enums.enum_node_kind import EnumNodeKind
     from omnibase_core.models.reducer.model_intent import ModelIntent
+
+
+def coerce_message_category(value: object) -> EnumMessageCategory:
+    """Normalize any category input to the canonical EnumMessageCategory.
+
+    Accepts:
+    - A canonical ``EnumMessageCategory`` instance (pass-through).
+    - A string matching a valid enum value (e.g. ``"EVENT"``).
+    - A foreign enum instance whose ``.value`` matches a valid enum value.
+
+    Raises:
+        ValueError: When ``value`` cannot be resolved to a valid enum member.
+            The error message lists all valid values.
+
+    .. versionadded:: 0.8.0
+        Added for boundary coercion at dispatcher registration entry points (OMN-4034).
+    """
+    if isinstance(value, EnumMessageCategory):
+        return value
+    raw: object = value.value if hasattr(value, "value") else value  # type: ignore[union-attr]
+    try:
+        return EnumMessageCategory(raw)
+    except ValueError:
+        raise ValueError(
+            f"Invalid message category: {value!r}. "
+            f"Expected one of: {[e.value for e in EnumMessageCategory]}"
+        )
 
 
 def _derive_dlq_topic(
@@ -721,11 +748,16 @@ class MessageDispatchEngine:
                 error_code=EnumCoreErrorCode.INVALID_PARAMETER,
             )
 
-        if not isinstance(category, EnumMessageCategory):
+        # Normalize category to canonical EnumMessageCategory at the boundary.
+        # Accepts: canonical instance (pass-through), valid string, foreign enum with matching .value.
+        # Raises ValueError (not ModelOnexError) listing valid values for invalid input.
+        try:
+            category = coerce_message_category(category)
+        except ValueError as exc:
             raise ModelOnexError(
-                message=f"Category must be EnumMessageCategory, got {type(category).__name__}.",
+                message=str(exc),
                 error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            )
+            ) from exc
 
         # Runtime validation for node_kind to catch dynamic dispatch issues
         # where type checkers can't help (e.g., dynamically constructed arguments)

--- a/tests/unit/runtime/test_message_dispatch_engine.py
+++ b/tests/unit/runtime/test_message_dispatch_engine.py
@@ -36,7 +36,10 @@ from omnibase_infra.enums.enum_message_category import EnumMessageCategory
 from omnibase_infra.models.dispatch.model_dispatch_outputs import ModelDispatchOutputs
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
-from omnibase_infra.runtime.service_message_dispatch_engine import MessageDispatchEngine
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+    coerce_message_category,
+)
 
 # ============================================================================
 # Test Event Types (for category inference)
@@ -4976,3 +4979,105 @@ class TestDispatchDlqRouting:
 
         assert result.status == EnumDispatchStatus.NO_DISPATCHER
         assert result.dlq_topic is None
+
+
+# ============================================================================
+# coerce_message_category Unit Tests (OMN-4034)
+# ============================================================================
+
+
+class TestCoerceMessageCategory:
+    """Unit tests for the coerce_message_category boundary normalization helper."""
+
+    @pytest.mark.unit
+    def test_canonical_instance_passthrough(self) -> None:
+        """Canonical EnumMessageCategory instance is returned unchanged."""
+        for member in EnumMessageCategory:
+            assert coerce_message_category(member) is member
+
+    @pytest.mark.unit
+    def test_valid_string_coercion(self) -> None:
+        """Valid string values are coerced to the corresponding enum member."""
+        assert coerce_message_category("event") is EnumMessageCategory.EVENT
+        assert coerce_message_category("command") is EnumMessageCategory.COMMAND
+        assert coerce_message_category("intent") is EnumMessageCategory.INTENT
+
+    @pytest.mark.unit
+    def test_foreign_enum_coercion(self) -> None:
+        """A foreign enum whose .value matches a valid string is coerced correctly."""
+        import enum
+
+        class ForeignCategory(enum.Enum):
+            EVENT = "event"
+            COMMAND = "command"
+
+        assert (
+            coerce_message_category(ForeignCategory.EVENT) is EnumMessageCategory.EVENT
+        )
+        assert (
+            coerce_message_category(ForeignCategory.COMMAND)
+            is EnumMessageCategory.COMMAND
+        )
+
+    @pytest.mark.unit
+    def test_invalid_string_raises_value_error(self) -> None:
+        """Invalid string raises ValueError listing valid values."""
+        with pytest.raises(ValueError, match="invalid_garbage") as exc_info:
+            coerce_message_category("invalid_garbage")
+        # Error message must list valid values
+        for member in EnumMessageCategory:
+            assert member.value in str(exc_info.value)
+
+    @pytest.mark.unit
+    def test_invalid_foreign_enum_value_raises_value_error(self) -> None:
+        """Foreign enum whose .value is not a valid category string raises ValueError."""
+        import enum
+
+        class UnrelatedCategory(enum.Enum):
+            UNKNOWN = "UNKNOWN_GARBAGE"
+
+        with pytest.raises(ValueError):
+            coerce_message_category(UnrelatedCategory.UNKNOWN)
+
+    @pytest.mark.unit
+    def test_result_type_is_canonical(self) -> None:
+        """All coercion paths return exactly EnumMessageCategory (not a subclass)."""
+        result = coerce_message_category("event")
+        assert type(result) is EnumMessageCategory
+
+    @pytest.mark.unit
+    def test_register_dispatcher_accepts_string_category(
+        self, dispatch_engine: MessageDispatchEngine
+    ) -> None:
+        """register_dispatcher coerces a valid string category via coerce_message_category."""
+
+        def handler(envelope: ModelEventEnvelope[object]) -> str:
+            return "handled"
+
+        # Passing a valid string should no longer raise; the engine normalises it.
+        dispatch_engine.register_dispatcher(
+            dispatcher_id="str-category-handler",
+            dispatcher=handler,
+            category="event",  # type: ignore[arg-type]
+        )
+        # Verify the dispatcher was stored under the canonical enum key.
+        assert dispatch_engine.dispatcher_count == 1
+
+    @pytest.mark.unit
+    def test_register_dispatcher_invalid_string_still_raises_model_error(
+        self, dispatch_engine: MessageDispatchEngine
+    ) -> None:
+        """register_dispatcher wraps ValueError from coercion into ModelOnexError."""
+
+        def handler(envelope: ModelEventEnvelope[object]) -> str:
+            return "handled"
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            dispatch_engine.register_dispatcher(
+                dispatcher_id="bad-category-handler",
+                dispatcher=handler,
+                category="not_a_category",  # type: ignore[arg-type]
+            )
+
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER
+        assert "not_a_category" in exc_info.value.message


### PR DESCRIPTION
## Summary

- Adds `coerce_message_category()` module-level helper to `service_message_dispatch_engine.py` that normalises any category input (canonical `EnumMessageCategory` instance, valid string, or foreign enum with matching `.value`) to the canonical enum at registration entry points
- Replaces the unhelpful `isinstance` guard at line 724 with a coerce-then-wrap pattern: `coerce_message_category` raises `ValueError` on bad input; `register_dispatcher` wraps it into `ModelOnexError(INVALID_PARAMETER)` with a clear, actionable error message listing valid values
- Exports `coerce_message_category` in `__all__` for direct importers
- Adds 8 unit tests covering all acceptance criteria from the ticket

## Ticket

Closes OMN-4034 / Epic OMN-4031

## Test plan

- [x] `coerce_message_category(EnumMessageCategory.X)` returns the canonical instance unchanged
- [x] `coerce_message_category("event")` returns `EnumMessageCategory.EVENT`
- [x] `coerce_message_category(ForeignEnum.EVENT)` where `.value == "event"` returns `EnumMessageCategory.EVENT`
- [x] `coerce_message_category("invalid_garbage")` raises `ValueError` listing valid values
- [x] `register_dispatcher(category="event")` succeeds via coercion
- [x] `register_dispatcher(category="not_a_category")` raises `ModelOnexError(INVALID_PARAMETER)`
- [x] Full dispatch engine test suite: 133 passed, 2 skipped, 0 failures
- [x] Pre-commit: all hooks pass (2 pre-existing failures on main: naming convention + AI-slop, unrelated to this PR)