### PR TITLE
docs(OMN-4038): add Shared Enum Ownership Rule to architecture docs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -64,6 +64,12 @@ Start here to understand the ONEX architecture:
 |----------|-------------|
 | [MCP Service Architecture](MCP_SERVICE_ARCHITECTURE.md) | MCP (Model Context Protocol) service layer: tool registration, schema generation, skip_server testing |
 
+## Shared Enums
+
+| Document | Description |
+|----------|-------------|
+| [Shared Enum Ownership Rule](SHARED_ENUM_OWNERSHIP.md) | Canonical rule: enums defined once in `omnibase_core`, imported downstream, coercion at boundaries |
+
 ## Resilience
 
 | Document | Description |

--- a/docs/architecture/SHARED_ENUM_OWNERSHIP.md
+++ b/docs/architecture/SHARED_ENUM_OWNERSHIP.md
@@ -1,0 +1,29 @@
+## Shared Enum Ownership Rule
+
+**Rule: shared enums are defined once in `omnibase_core`. Downstream repos import or re-export; never redefine.**
+
+### Background
+
+Python's `isinstance()` checks class object identity, not semantic value equality. If two packages independently define `class EnumMessageCategory(Enum)` with identical members, Python treats them as different types. Cross-package `isinstance()` checks silently fail.
+
+This caused a production incident: `Category must be EnumMessageCategory, got EnumMessageCategory.`
+
+### Rule
+
+- `omnibase_core` is the sole canonical owner of all shared messaging enums.
+- Downstream repos (`omnibase_infra`, `omniclaude`, others) must import from `omnibase_core`:
+  `from omnibase_core.enums import EnumMessageCategory`
+- Re-exporting to preserve legacy import paths is allowed: `from omnibase_core.enums import EnumMessageCategory as EnumMessageCategory`
+- Defining a second class with the same name is **forbidden**. CI will block it (`scripts/check_shared_enum_ownership.py`).
+
+### Runtime Boundaries
+
+Any code accepting a message category from an external caller must normalize first:
+
+    category = coerce_message_category(raw_input)
+
+Never rely on `isinstance(x, EnumMessageCategory)` at a package boundary where the calling package may have a different load context.
+
+### Applies to All Future Shared Enums
+
+Any new enum shared across packages: defined once in `omnibase_core`, imported downstream, coercion helper at runtime boundaries.

--- a/scripts/check_shared_enum_ownership.py
+++ b/scripts/check_shared_enum_ownership.py
@@ -4,6 +4,7 @@
 Usage: python scripts/check_shared_enum_ownership.py [src_root]
 Exit 0: clean. Exit 1: duplicate found.
 """
+
 import ast
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/SHARED_ENUM_OWNERSHIP.md` with the canonical Shared Enum Ownership Rule
- Indexes the new doc in `docs/architecture/README.md` under a new "Shared Enums" section
- Includes a trivial ruff auto-fix to `scripts/check_shared_enum_ownership.py` (blank line)

## What the rule documents

Python's `isinstance()` checks class object identity. Two packages independently defining `class EnumMessageCategory(Enum)` with identical members are treated as different types, causing silent cross-package `isinstance()` failures. This caused a production incident: `Category must be EnumMessageCategory, got EnumMessageCategory.`

The rule:
- `omnibase_core` is the sole canonical owner of all shared messaging enums
- Downstream repos must import from `omnibase_core` (re-export with `import X as X` is allowed)
- Redefining the same enum class is forbidden — enforced by CI (`scripts/check_shared_enum_ownership.py`)
- Runtime boundaries must use `coerce_message_category()` rather than `isinstance()` checks

## Test plan

- [x] `grep -r "Shared Enum Ownership Rule" .` returns exactly the doc file and its README index entry
- [x] Pre-commit hooks pass on changed files (AI-slop failure is pre-existing on main, not introduced here)
- [x] No code changes — documentation only

Refs: OMN-4038, OMN-4031, OMN-4033, OMN-4034