### PR TITLE
fix(runtime): coerce category input in get_dispatchers() for foreign-enum safety [OMN-4089]

### DIFF
--- a/src/omnibase_infra/runtime/registry_dispatcher.py
+++ b/src/omnibase_infra/runtime/registry_dispatcher.py
@@ -379,7 +379,14 @@ class RegistryDispatcher:
         # Registration stores EnumMessageCategory as the dict key; a caller passing a
         # foreign enum instance with a matching .value would otherwise miss the entry and
         # silently receive an empty list.
-        category = coerce_message_category(category)
+        try:
+            category = coerce_message_category(category)
+        except ValueError as exc:
+            raise ModelOnexError(
+                message=f"get_dispatchers() received an unrecognised category value: {category!r}. "
+                "Provide a valid EnumMessageCategory member or a string matching one of its values.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            ) from exc
 
         entries = self._dispatchers_by_category.get(category, [])
         result: list[ProtocolMessageDispatcher] = []

--- a/tests/unit/runtime/test_dispatcher_registry.py
+++ b/tests/unit/runtime/test_dispatcher_registry.py
@@ -868,3 +868,24 @@ class TestGetDispatchersForeignEnumCoercion:
             message_type="UnknownEvent",
         )
         assert len(result_miss) == 0
+
+    @pytest.mark.unit
+    def test_get_dispatchers_unrecognised_category_raises_model_onex_error(
+        self,
+        dispatcher_registry: RegistryDispatcher,
+    ) -> None:
+        """An unrecognisable category value must raise ModelOnexError with INVALID_PARAMETER.
+
+        coerce_message_category raises ValueError for unknown values; get_dispatchers()
+        must convert that into a typed ModelOnexError so callers can rely on
+        ModelOnexError.error_code handling instead of catching bare ValueError.
+        """
+        import enum
+
+        class BogusCategory(str, enum.Enum):
+            UNKNOWN = "not_a_real_category_value"
+
+        dispatcher_registry.freeze()
+        with pytest.raises(ModelOnexError) as exc_info:
+            dispatcher_registry.get_dispatchers(BogusCategory.UNKNOWN)  # type: ignore[arg-type]
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER


### PR DESCRIPTION
## Summary

Closes OMN-4089. Follow-up to OMN-4087.

`get_dispatchers()` in `registry_dispatcher.py` accepted `category: EnumMessageCategory` but did not coerce the input. A caller passing a foreign enum (e.g., a different package's copy of `EnumMessageCategory`) silently received an empty list — the lookup key never matched the canonical key stored at registration time.

OMN-4087 hardened `register_dispatcher` and `unregister_dispatcher` with `coerce_message_category()`. This PR completes the pattern by applying the same coercion to the lookup path.

## Changes

- `registry_dispatcher.py:get_dispatchers()`: Added `category = coerce_message_category(category)` after the freeze guard, before the dict lookup. Follows the exact same pattern already in `register_dispatcher` and `unregister_dispatcher`.
- `tests/unit/runtime/test_dispatcher_registry.py`: Added `TestGetDispatchersForeignEnumCoercion` class with 3 unit tests covering: foreign-enum lookup (regression), canonical/foreign equivalence assertion, and foreign-enum + message_type filter.

## Test Plan

- [x] `uv run pytest -m unit -k "coerce or dispatch or registry"` — 1764 passed, 7 skipped
- [x] `python -c "import omnibase_infra.runtime.registry_dispatcher"` exits 0 (no circular import regression)
- [x] pre-commit all hooks passed

## Pre-existing Issues (Deferred)

87 mypy errors in 57 files across multiple subsystems are pre-existing and not related to this change. They will be tracked separately.

## Hostile Review Notes

Two risks identified by hostile reviewer (not blocking):

1. **Risk 1 (confidence 0.92)** — `ValueError` may leak from `get_dispatchers()` on invalid foreign-enum input. `coerce_message_category()` raises `ValueError` for unrecognized values. `register_dispatcher()` wraps this in `try/except ValueError → ModelOnexError`; `get_dispatchers()` does not. If a caller passes a truly invalid value (not just foreign but wrong `.value`), a raw `ValueError` escapes instead of the documented `ModelOnexError`. This is a follow-up hardening opportunity.

2. **Risk 2 (confidence 0.78)** — Test coverage gap: `ForeignCategoryDispatcher` passes canonical `EnumMessageCategory.EVENT` to the parent `__init__`, meaning the register path receives a canonical value. A foreign-enum register→lookup round-trip is not tested.

## TCB Suggestions Used

N/A — no TCB bundle existed for this ticket. Implementation followed ticket spec directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatcher registry now correctly resolves alternative enum variants for message categories and raises a clear error for unrecognized categories.

* **Tests**
  * Added comprehensive tests covering foreign-enum coercion, equivalence between canonical and foreign enums, message-type filtering with foreign enums, and error handling for invalid categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->