### PR TITLE
fix(compose): override OMNIBASE_INFRA_DB_URL to Docker-internal hostname for containers [OMN-4084]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -128,7 +128,11 @@ x-runtime-env: &runtime-env
   # --- Bootstrap essentials (always needed) ---
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
   POSTGRES_USER: ${POSTGRES_USER:-postgres}
-  OMNIBASE_INFRA_DB_URL: ${OMNIBASE_INFRA_DB_URL:?OMNIBASE_INFRA_DB_URL must be set in ~/.omnibase/.env}
+  # OMN-4084: Containers always use the Docker-internal hostname postgres:5432 regardless
+  # of what ~/.omnibase/.env sets for OMNIBASE_INFRA_DB_URL. The host-side value uses
+  # localhost:5436 (external port); the container-side value must use postgres:5432.
+  # This override ensures containers are never broken by a host-side localhost:5436 URL.
+  OMNIBASE_INFRA_DB_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@postgres:5432/omnibase_infra"
   # OMN-3431: Local Docker Redpanda — containers use Docker-internal redpanda:9092
   KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
   # Allowlist lets service_kernel.py's denylist accept Docker-internal redpanda: hostname

--- a/src/omnibase_infra/cli/commands.py
+++ b/src/omnibase_infra/cli/commands.py
@@ -224,8 +224,10 @@ def _get_db_dsn() -> str:
         raise click.ClickException(
             f"OMNIBASE_INFRA_DB_URL is required but not set "
             f"(correlation_id={correlation_id}). "
-            "Set it to a PostgreSQL DSN, e.g. "
-            "postgresql://user:pass@host:5432/omnibase_infra"
+            "Set it to a PostgreSQL DSN using the host-accessible port, e.g. "
+            "postgresql://postgres:password@localhost:5436/omnibase_infra. "
+            "Note: use localhost:5436 for host-side scripts (Docker exposes port 5436). "
+            "Docker containers use postgres:5432 (internal hostname, set automatically by compose)."
         )
 
     try:

--- a/src/omnibase_infra/cli/infra_test/_helpers.py
+++ b/src/omnibase_infra/cli/infra_test/_helpers.py
@@ -39,8 +39,9 @@ def get_postgres_dsn() -> str:
     if not db_url:
         msg = (
             "OMNIBASE_INFRA_DB_URL is required but not set. "
-            "Set it to a PostgreSQL DSN, e.g. "
-            "postgresql://user:pass@host:5432/omnibase_infra"
+            "For host-side integration tests set: "
+            "OMNIBASE_INFRA_DB_URL=postgresql://postgres:PASSWORD@localhost:5436/omnibase_infra "
+            "(use localhost:5436 — the Docker-exposed port, not postgres:5432 which is Docker-internal only)."
         )
         raise ValueError(msg)
 

--- a/src/omnibase_infra/runtime/util_schema_fingerprint.py
+++ b/src/omnibase_infra/runtime/util_schema_fingerprint.py
@@ -659,7 +659,10 @@ def _main() -> None:
     db_url = os.environ.get("OMNIBASE_INFRA_DB_URL")
     if not db_url:
         print(
-            "ERROR: OMNIBASE_INFRA_DB_URL environment variable is required.",
+            "ERROR: OMNIBASE_INFRA_DB_URL environment variable is required. "
+            "For host-side scripts set: "
+            "OMNIBASE_INFRA_DB_URL=postgresql://postgres:PASSWORD@localhost:5436/omnibase_infra "
+            "(use localhost:5436 — the Docker-exposed port, not postgres:5432 which is Docker-internal only).",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
## Summary

- Fixes HIGH pipeline audit gap: `OMNIBASE_INFRA_DB_URL` in `~/.omnibase/.env` must use `localhost:5436` for host-side access, but containers need `postgres:5432` (Docker-internal DNS)
- The `x-runtime-env` anchor now constructs the container-side URL directly using `postgres:5432` instead of passing through the host value
- Updates error messages in CLI and schema fingerprint utility to show `localhost:5436` as the correct host-accessible example

## Root Cause

`OMNIBASE_INFRA_DB_URL` had a dual-value requirement but no mechanism to enforce it:
- Host-side: `localhost:5436` (Docker external port)
- Container-side: `postgres:5432` (Docker-internal DNS)

If `~/.omnibase/.env` contained `postgres:5432`, host-side CLI commands would fail with DNS errors.
If it contained `localhost:5436`, containers would fail (localhost doesn't resolve inside Docker).

## Fix

The compose `x-runtime-env` anchor now hardcodes the container-side URL using `postgres:5432`. Operators should set `OMNIBASE_INFRA_DB_URL=postgresql://postgres:PASSWORD@localhost:5436/omnibase_infra` in `~/.omnibase/.env` for host-side usage.

## Risk

Low — the change makes container behavior deterministic regardless of what `~/.omnibase/.env` contains. Operators who had `postgres:5432` in `.env` will need to update to `localhost:5436` for host-side scripts to work.

## Test Evidence

- 412 unit tests passed
- `uv run ruff check` — clean
- TypeCheck: `uv run mypy` — no new errors

## Rollback

Revert this PR. No data migration required.

## Linear

Closes OMN-4084
Epic: OMN-4091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved error messages for database connection setup with clearer guidance distinguishing between host-side and Docker-internal connection endpoints.

* **Chores**
  * Updated Docker Compose infrastructure configuration for explicit database connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->