### PR TITLE
fix(dispatch): restore _get_route_dispatcher_id shim — hotfix for runtime crash (OMN-4057)

### DIFF
--- a/src/omnibase_infra/runtime/service_message_dispatch_engine.py
+++ b/src/omnibase_infra/runtime/service_message_dispatch_engine.py
@@ -267,6 +267,29 @@ DispatcherOutput = str | list[str] | None | ModelDispatchResult
 # Module-level logger for fallback when no custom logger is provided
 _module_logger = logging.getLogger(__name__)
 
+
+def _get_route_dispatcher_id(route: object) -> str:
+    """Return the dispatcher/handler ID from a route model.
+
+    OMN-4057: omnibase_core's ``ModelDispatchRoute`` uses ``handler_id`` while
+    omnibase_infra's uses ``dispatcher_id``.  This helper resolves either field
+    so that both old and new omniclaude plugin releases work correctly.
+
+    Once omnibase_core publishes a release with a ``dispatcher_id`` property
+    this shim can be removed.
+    """
+    # Prefer dispatcher_id (infra model), fall back to handler_id (core model)
+    dispatcher_id: str | None = getattr(route, "dispatcher_id", None)
+    if dispatcher_id is not None:
+        return dispatcher_id
+    handler_id: str | None = getattr(route, "handler_id", None)
+    if handler_id is not None:
+        return handler_id
+    route_id: str = getattr(route, "route_id", "<unknown>")
+    msg = f"Route '{route_id}' has neither dispatcher_id nor handler_id"
+    raise AttributeError(msg)
+
+
 # Minimum number of parameters for a dispatcher to be considered context-aware.
 # Context-aware dispatchers have signature: (envelope, context, ...)
 # Non-context-aware dispatchers have signature: (envelope)
@@ -593,7 +616,7 @@ class MessageDispatchEngine:
                 route.route_id,
                 route.topic_pattern,
                 route.message_category,
-                route.dispatcher_id,
+                _get_route_dispatcher_id(route),
             )
 
     # --- @overload stubs for static type safety ---
@@ -840,7 +863,7 @@ class MessageDispatchEngine:
 
             # Validate all routes reference existing dispatchers
             for route in self._routes.values():
-                rid = route.dispatcher_id
+                rid = _get_route_dispatcher_id(route)
                 if rid not in self._dispatchers:
                     raise ModelOnexError(
                         message=f"Route '{route.route_id}' references dispatcher "
@@ -1681,7 +1704,7 @@ class MessageDispatchEngine:
                 continue
 
             # Get the dispatcher for this route
-            dispatcher_id = route.dispatcher_id
+            dispatcher_id = _get_route_dispatcher_id(route)
             if dispatcher_id in seen_dispatcher_ids:
                 # Avoid duplicate dispatcher execution
                 continue


### PR DESCRIPTION
## Summary

Hotfix for production crash introduced by PR #718.

- **Root cause**: PR #718 replaced `_get_route_dispatcher_id(route)` call sites with direct `route.dispatcher_id` access, but the installed `omniclaude` plugin's `ModelDispatchRoute` (from `omnibase_core`) uses `handler_id` not `dispatcher_id`, causing `AttributeError` on runtime startup
- **Impact**: `omninode-runtime` enters CrashLoopBackOff immediately after deployment
- **Fix**: Restore the `_get_route_dispatcher_id` shim that falls back to `handler_id` when `dispatcher_id` is absent — same logic as the original OMN-4057 commit

## Deployment status

Hotfix image `20260309-hotfix-dispatcher-shim` already deployed to onex-dev. All 6 runtime deployments show READY 1/1.

## Test plan

- [ ] CI Test Suite passes
- [ ] `omninode-runtime` pod starts without CrashLoopBackOff
- [ ] Deployment READY shows 1/1 for all runtime services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal route handling to support both legacy and current model configurations, enhancing backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->