### PR TITLE
fix: trigger idempotency and forward migration runner for warm Postgres volumes (OMN-4173)

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -420,6 +420,48 @@ services:
       - "com.omninode.layer=infrastructure"
       - "com.omninode.ticket=OMN-3361"
   # ==========================================================================
+  # Forward Migration Runner - Apply pending forward migrations (Runtime Profile) [OMN-4175]
+  # ==========================================================================
+  # One-shot service that applies any pending SQL files from
+  # docker/migrations/forward/ to an existing (warm) Postgres volume.
+  # docker-entrypoint-initdb.d only fires on fresh volume init; this service
+  # closes the gap by running on every compose up via run-forward-migrations.sh.
+  #
+  # Migrations are tracked in public.schema_migrations. Already-applied files
+  # are skipped (idempotent). migration-gate depends on this service completing
+  # successfully before checking the sentinel flag.
+  forward-migration:
+    image: postgres:16-alpine
+    container_name: omnibase-forward-migration
+    profiles: ["runtime", "full"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: omnibase_infra
+      MIGRATIONS_DIR: /migrations/forward
+    volumes:
+      - ../scripts/run-forward-migrations.sh:/run-forward-migrations.sh:ro
+      - ../docker/migrations/forward:/migrations/forward:ro
+    entrypoint: ["sh", "/run-forward-migrations.sh"]
+    networks:
+      - omnibase-infra-network
+    restart: "no"
+    logging: *logging-defaults
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: 64M
+    labels:
+      - "com.omninode.service=forward-migration"
+      - "com.omninode.layer=infrastructure"
+      - "com.omninode.ticket=OMN-4175"
+  # ==========================================================================
   # Migration Gate - Boot-Order Sentinel (Runtime Profile) [OMN-3737]
   # ==========================================================================
   # Lightweight healthcheck-only service that gates runtime service startup
@@ -437,6 +479,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      forward-migration:
+        condition: service_completed_successfully
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}

--- a/docker/migrations/intelligence/001_create_fsm_state_table.sql
+++ b/docker/migrations/intelligence/001_create_fsm_state_table.sql
@@ -86,6 +86,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_fsm_state_updated_at ON fsm_state;
 CREATE TRIGGER trigger_fsm_state_updated_at
     BEFORE UPDATE ON fsm_state
     FOR EACH ROW

--- a/docker/migrations/intelligence/002_create_fsm_state_history.sql
+++ b/docker/migrations/intelligence/002_create_fsm_state_history.sql
@@ -108,6 +108,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_record_fsm_history ON fsm_state;
 CREATE TRIGGER trigger_record_fsm_history
     AFTER INSERT OR UPDATE ON fsm_state
     FOR EACH ROW

--- a/docker/migrations/intelligence/003_create_workflow_executions.sql
+++ b/docker/migrations/intelligence/003_create_workflow_executions.sql
@@ -88,6 +88,7 @@ CREATE INDEX IF NOT EXISTS idx_workflow_exec_completed_steps
 -- Trigger for updated_at
 -- ============================================================================
 
+DROP TRIGGER IF EXISTS trigger_workflow_exec_updated_at ON workflow_executions;
 CREATE TRIGGER trigger_workflow_exec_updated_at
     BEFORE UPDATE ON workflow_executions
     FOR EACH ROW
@@ -107,6 +108,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_calculate_duration ON workflow_executions;
 CREATE TRIGGER trigger_calculate_duration
     BEFORE UPDATE ON workflow_executions
     FOR EACH ROW

--- a/docker/migrations/intelligence/004_create_domain_taxonomy.sql
+++ b/docker/migrations/intelligence/004_create_domain_taxonomy.sql
@@ -67,6 +67,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_domain_taxonomy_updated_at ON domain_taxonomy;
 CREATE TRIGGER trigger_domain_taxonomy_updated_at
     BEFORE UPDATE ON domain_taxonomy
     FOR EACH ROW

--- a/docker/migrations/intelligence/005_create_learned_patterns.sql
+++ b/docker/migrations/intelligence/005_create_learned_patterns.sql
@@ -164,6 +164,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_learned_patterns_updated_at ON learned_patterns;
 CREATE TRIGGER trigger_learned_patterns_updated_at
     BEFORE UPDATE ON learned_patterns
     FOR EACH ROW

--- a/docker/migrations/intelligence/007_create_pattern_injections.sql
+++ b/docker/migrations/intelligence/007_create_pattern_injections.sql
@@ -98,6 +98,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_pattern_injections_updated_at ON pattern_injections;
 CREATE TRIGGER trigger_pattern_injections_updated_at
     BEFORE UPDATE ON pattern_injections
     FOR EACH ROW

--- a/scripts/run-forward-migrations.sh
+++ b/scripts/run-forward-migrations.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# run-forward-migrations.sh — Apply omnibase_infra forward migrations on warm Postgres volumes
+#
+# Tracks applied migrations in public.schema_migrations and applies any
+# pending files from /migrations/forward in sorted order. Safe to run on
+# both fresh volumes (no-op for files already applied via docker-entrypoint-initdb.d)
+# and warm volumes (applies any new files not yet recorded).
+#
+# This script is run by the forward-migration compose service before migration-gate
+# checks the sentinel flag. It replaces the docker-entrypoint-initdb.d-only
+# mechanism for keeping warm Postgres volumes up-to-date with new migrations.
+#
+# Ticket: OMN-4175 (Forward migration runner for warm Postgres volumes)
+#
+# Environment:
+#   POSTGRES_USER     (default: postgres)
+#   POSTGRES_PASSWORD (required)
+#   POSTGRES_HOST     (default: postgres)
+#   POSTGRES_PORT     (default: 5432)
+#   POSTGRES_DB       (default: omnibase_infra)
+#   MIGRATIONS_DIR    (default: /migrations/forward)
+
+set -e
+
+PGUSER="${POSTGRES_USER:-postgres}"
+PGHOST="${POSTGRES_HOST:-postgres}"
+PGPORT="${POSTGRES_PORT:-5432}"
+PGDB="${POSTGRES_DB:-omnibase_infra}"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-/migrations/forward}"
+
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
+# ---------------------------------------------------------------------------
+# 1. Ensure schema_migrations tracking table exists (idempotent)
+# ---------------------------------------------------------------------------
+echo "[forward-migration] Ensuring schema_migrations table exists..."
+
+psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -c "
+CREATE TABLE IF NOT EXISTS public.schema_migrations (
+    migration_id TEXT PRIMARY KEY,
+    applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    checksum     TEXT NOT NULL,
+    source_set   TEXT NOT NULL
+);
+"
+
+# ---------------------------------------------------------------------------
+# 2. Apply pending migrations in sorted order
+# ---------------------------------------------------------------------------
+echo "[forward-migration] Scanning ${MIGRATIONS_DIR} for pending migrations..."
+
+APPLIED=0
+SKIPPED=0
+
+for migration_file in $(ls "${MIGRATIONS_DIR}"/*.sql | sort); do
+  filename=$(basename "$migration_file")
+  migration_id="docker/${filename}"
+
+  # Check if already applied
+  already_applied=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+    -tAc "SELECT 1 FROM public.schema_migrations WHERE migration_id = '${migration_id}'" 2>/dev/null || true)
+
+  if [ "$already_applied" = "1" ]; then
+    echo "[forward-migration]   skip  ${filename} (already applied)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  echo "[forward-migration]   apply ${filename}..."
+
+  # Apply migration then record in tracking table
+  psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+    -v ON_ERROR_STOP=1 -f "$migration_file"
+
+  psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+    -c "INSERT INTO public.schema_migrations (migration_id, checksum, source_set)
+        VALUES ('${migration_id}', 'applied-by-runner', 'docker')
+        ON CONFLICT (migration_id) DO NOTHING;"
+
+  echo "[forward-migration]   done  ${filename}"
+  APPLIED=$((APPLIED + 1))
+done
+
+echo "[forward-migration] Complete: ${APPLIED} applied, ${SKIPPED} skipped."


### PR DESCRIPTION
## Summary

- **OMN-4174**: Add `DROP TRIGGER IF EXISTS` guards before every `CREATE TRIGGER` in intelligence migration SQL files (001–007). The `intelligence-migration` compose service runs with `set -e`; duplicate trigger names on warm volumes caused the entire run to abort, leaving subsequent migrations unapplied on any `infra-down` + `infra-up-runtime` cycle.
- **OMN-4175**: Add `run-forward-migrations.sh` and `forward-migration` compose service to automatically apply pending forward migrations on warm Postgres volumes. `docker-entrypoint-initdb.d` only fires on fresh volume init — this service closes the gap by running on every `compose up`, tracking applied files in `public.schema_migrations`, and skipping already-applied ones (idempotent). `migration-gate` now depends on `forward-migration` completing successfully.

## Files Changed

**OMN-4174 — Trigger idempotency:**
- `docker/migrations/intelligence/001_create_fsm_state_table.sql` — `DROP TRIGGER IF EXISTS trigger_fsm_state_updated_at`
- `docker/migrations/intelligence/002_create_fsm_state_history.sql` — `DROP TRIGGER IF EXISTS trigger_record_fsm_history`
- `docker/migrations/intelligence/003_create_workflow_executions.sql` — `DROP TRIGGER IF EXISTS` for `trigger_workflow_exec_updated_at` and `trigger_calculate_duration`
- `docker/migrations/intelligence/004_create_domain_taxonomy.sql` — `DROP TRIGGER IF EXISTS trigger_domain_taxonomy_updated_at`
- `docker/migrations/intelligence/005_create_learned_patterns.sql` — `DROP TRIGGER IF EXISTS trigger_learned_patterns_updated_at`
- `docker/migrations/intelligence/007_create_pattern_injections.sql` — `DROP TRIGGER IF EXISTS trigger_pattern_injections_updated_at`

**OMN-4175 — Forward migration runner:**
- `scripts/run-forward-migrations.sh` — new idempotent shell runner for `docker/migrations/forward/`
- `docker/docker-compose.infra.yml` — new `forward-migration` service; `migration-gate` now depends on `forward-migration: service_completed_successfully`

## Test Plan

- [ ] `infra-down` followed by `infra-up-runtime` — intelligence migrations complete without error on warm volume
- [ ] Run `infra-up-runtime` twice in a row — second run skips all migrations (idempotent)
- [ ] Confirm `forward-migration` service exits 0 on warm volume with migrations 041/042 already present in `schema_migrations`
- [ ] Confirm `forward-migration` applies a new migration file added to `forward/` on next `infra-up-runtime`
- [ ] Confirm `migration-gate` stays healthy after `forward-migration` completes

Closes OMN-4174, OMN-4175. Parent epic: OMN-4173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated forward database migration system that executes pending migrations in sorted order with idempotent tracking to prevent duplicate applications.
  * Standardized database trigger patterns across migrations to use function-based execution instead of inline logic, enhancing consistency and maintainability of the schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->