### PR TITLE
fix(skill-lifecycle-consumer): schema-tolerant parsing for legacy fixture messages [OMN-4064]

### DIFF
--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -67,91 +67,91 @@ x-runner-base: &runner-base
       max-file: "3"
 services:
   omninode-runner-1:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-1
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-1-creds:/home/runner/.runner-creds
   omninode-runner-2:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-2
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-2-creds:/home/runner/.runner-creds
   omninode-runner-3:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-3
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-3
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-3-creds:/home/runner/.runner-creds
   omninode-runner-4:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-4
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-4
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-4-creds:/home/runner/.runner-creds
   omninode-runner-5:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-5
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-5
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-5-creds:/home/runner/.runner-creds
   omninode-runner-6:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-6
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-6
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-6-creds:/home/runner/.runner-creds
   omninode-runner-7:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-7
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-7
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-7-creds:/home/runner/.runner-creds
   omninode-runner-8:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-8
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-8
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-8-creds:/home/runner/.runner-creds
   omninode-runner-9:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-9
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-9
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-9-creds:/home/runner/.runner-creds
   omninode-runner-10:
-    <<: *runner-base
+    !!merge <<: *runner-base
     container_name: omninode-runner-10
     environment:
-      <<: *runner-env
+      !!merge <<: *runner-env
       RUNNER_NAME: omninode-runner-10
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/src/omnibase_infra/nodes/node_merge_gate_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_merge_gate_effect/contract.yaml
@@ -26,11 +26,7 @@ node_version:
 node_type: "EFFECT_GENERIC"
 # Description
 description: >
-  Effect node that subscribes to onex.evt.platform.merge-gate-decision.v1 events
-  and upserts merge gate decisions into the merge_gate_decisions PostgreSQL table.
-  Uses ON CONFLICT (pr_ref, head_sha) DO UPDATE for idempotent upserts.
-  When decision is QUARANTINE, opens a Linear ticket with violation details.
-  Emits no outbound events (side-effect only).
+  Effect node that subscribes to onex.evt.platform.merge-gate-decision.v1 events and upserts merge gate decisions into the merge_gate_decisions PostgreSQL table. Uses ON CONFLICT (pr_ref, head_sha) DO UPDATE for idempotent upserts. When decision is QUARANTINE, opens a Linear ticket with violation details. Emits no outbound events (side-effect only).
 
 # =============================================================================
 # EVENT BUS SUBSCRIPTION (Kafka topic wiring)

--- a/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
+++ b/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
@@ -400,7 +400,26 @@ class SkillLifecycleConsumer:
         """
         try:
             raw = json.loads(record.value.decode("utf-8"))
-            return dict(raw) if isinstance(raw, dict) else None
+            if isinstance(raw, dict):
+                payload: dict[str, object] = dict(raw)
+            elif isinstance(raw, list) and len(raw) == 1 and isinstance(raw[0], dict):
+                # Legacy fixture format: array-wrapped single event
+                logger.warning(
+                    "Unwrapping array-wrapped legacy message",
+                    extra={"topic": record.topic, "offset": record.offset},
+                )
+                payload = dict(raw[0])
+            else:
+                return None
+            # Forward-compat: rename deprecated field skill_event_type -> event_type
+            if "skill_event_type" in payload and "event_type" not in payload:
+                logger.warning(
+                    "Migrating deprecated skill_event_type field to event_type",
+                    extra={"topic": record.topic, "offset": record.offset},
+                )
+                payload = dict(payload)
+                payload["event_type"] = payload.pop("skill_event_type")
+            return payload
         except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
             logger.warning(
                 "Failed to parse Kafka message",

--- a/tests/unit/services/observability/skill_lifecycle/test_consumer.py
+++ b/tests/unit/services/observability/skill_lifecycle/test_consumer.py
@@ -254,13 +254,81 @@ class TestParseMessage:
 
     @pytest.mark.unit
     def test_json_array_returns_none(self) -> None:
-        """JSON array (not dict) returns None."""
+        """JSON array of non-dicts (e.g. strings) returns None."""
         consumer = _make_consumer()
         record = _make_mock_record(value=b'["a", "b"]')
 
         result = consumer._parse_message(record)
 
         assert result is None
+
+    @pytest.mark.unit
+    def test_array_wrapped_single_dict_unwrapped(self) -> None:
+        """Legacy array-wrapped single-event format is unwrapped and returned as dict."""
+        consumer = _make_consumer()
+        payload = {"event_id": "abc", "run_id": "xyz", "skill_name": "pr-review"}
+        record = _make_mock_record(value=json.dumps([payload]).encode())
+
+        result = consumer._parse_message(record)
+
+        assert result is not None
+        assert result["event_id"] == "abc"
+        assert result["skill_name"] == "pr-review"
+
+    @pytest.mark.unit
+    def test_array_wrapped_multi_element_returns_none(self) -> None:
+        """Array with more than one element is not a known legacy format and returns None."""
+        consumer = _make_consumer()
+        payload1 = {"event_id": "abc"}
+        payload2 = {"event_id": "def"}
+        record = _make_mock_record(value=json.dumps([payload1, payload2]).encode())
+
+        result = consumer._parse_message(record)
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_deprecated_skill_event_type_migrated(self) -> None:
+        """skill_event_type is renamed to event_type when event_type is absent."""
+        consumer = _make_consumer()
+        record = _make_mock_record(
+            value=b'{"skill_event_type": "started", "run_id": "xyz"}'
+        )
+
+        result = consumer._parse_message(record)
+
+        assert result is not None
+        assert result["event_type"] == "started"
+        assert "skill_event_type" not in result
+        assert result["run_id"] == "xyz"
+
+    @pytest.mark.unit
+    def test_skill_event_type_not_migrated_when_event_type_present(self) -> None:
+        """skill_event_type is left alone when event_type is already present."""
+        consumer = _make_consumer()
+        record = _make_mock_record(
+            value=b'{"skill_event_type": "old_value", "event_type": "started", "run_id": "xyz"}'
+        )
+
+        result = consumer._parse_message(record)
+
+        assert result is not None
+        assert result["event_type"] == "started"
+        # skill_event_type preserved since event_type already present
+        assert result["skill_event_type"] == "old_value"
+
+    @pytest.mark.unit
+    def test_array_wrapped_with_skill_event_type_migration(self) -> None:
+        """Array-wrapped legacy message with deprecated field is unwrapped and migrated."""
+        consumer = _make_consumer()
+        payload = {"skill_event_type": "completed", "run_id": "xyz"}
+        record = _make_mock_record(value=json.dumps([payload]).encode())
+
+        result = consumer._parse_message(record)
+
+        assert result is not None
+        assert result["event_type"] == "completed"
+        assert "skill_event_type" not in result
 
     @pytest.mark.unit
     def test_non_utf8_bytes_returns_none(self) -> None:


### PR DESCRIPTION
## Summary

Fixes DLQ accumulation in the skill lifecycle consumer caused by legacy fixture messages on `onex.evt.omniclaude.skill-started.v1`.

**Root cause**: `_parse_message` returned `None` for any non-dict top-level JSON. Legacy fixture messages used two deprecated formats:
1. Array-wrapped single event: `[{"event_id": "...", ...}]`
2. Deprecated field name: `skill_event_type` instead of `event_type`

Both formats fell through to `return None`, causing DLQ sends and eventually stalling consumer processing.

## Changes

**`src/omnibase_infra/services/observability/skill_lifecycle/consumer.py`**

Replaces the single-line `return dict(raw) if isinstance(raw, dict) else None` with a schema-migration shim:

- Valid dict messages follow the same fast path (no regression)
- Array-wrapped single dicts (`[{...}]`) are unwrapped with a `WARNING` log
- Multi-element arrays and non-dict arrays still return `None`
- `skill_event_type` → `event_type` field migration fires only when `event_type` is absent

**`tests/unit/services/observability/skill_lifecycle/test_consumer.py`**

Adds 6 new `@pytest.mark.unit` tests to `TestParseMessage`:
- `test_array_wrapped_single_dict_unwrapped`
- `test_array_wrapped_multi_element_returns_none`
- `test_deprecated_skill_event_type_migrated`
- `test_skill_event_type_not_migrated_when_event_type_present`
- `test_array_wrapped_with_skill_event_type_migration`
- Updated `test_json_array_returns_none` docstring to clarify it covers string arrays (still returns `None`)

## Test Results

30/30 unit tests pass.

## Post-merge Ops Required

After this PR merges and the new image is deployed, purge stale fixture messages:

```bash
aws ssm send-command \
  --instance-ids i-0e596e8b557e27785 \
  --region us-east-1 \
  --document-name "AWS-RunShellScript" \
  --parameters 'commands=["kubectl exec -n data-plane statefulset/omninode-redpanda -- rpk topic trim-prefix onex.evt.omniclaude.skill-started.v1 --offset end"]'
```

Verify consumer health: `kubectl exec -n onex-dev deployment/omninode-skill-lifecycle-consumer -- wget -qO- http://localhost:8092/health`

## Linear

Closes OMN-4064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy message formats to ensure backward compatibility.
  * Enhanced forward-compatibility migration for event field naming conventions with automatic remapping and warnings.
  * Expanded error handling and logging for message parsing to improve system observability.

* **Chores**
  * Updated YAML configuration syntax for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->