### PR TITLE
test(ci): add Kafka topic parity CI test (OMN-4306)

### DIFF
--- a/tests/ci/test_topic_parity.py
+++ b/tests/ci/test_topic_parity.py
@@ -2,11 +2,15 @@
 
 Prevents future unregistered topics from missing Redpanda provisioning.
 See OMN-4306.
+
+Note: ALL_PROVISIONED_SUFFIXES conditionally excludes omnimemory topics when
+OMNIMEMORY_ENABLED is unset. This test compares against the full union of all
+topic spec groups (including optional ones) to catch any suffix constant that
+has no spec entry, regardless of runtime flags.
 """
 
 import pytest
 
-from omnibase_infra.topics import ALL_PROVISIONED_SUFFIXES
 from omnibase_infra.topics import platform_topic_suffixes as pts
 
 
@@ -16,19 +20,38 @@ def _all_defined_suffix_strings() -> set[str]:
     }
 
 
+def _all_spec_suffixes() -> set[str]:
+    """Full set of suffixes across all spec groups, including optional ones.
+
+    Uses the unconditional group constants (ALL_PLATFORM_TOPIC_SPECS,
+    ALL_INTELLIGENCE_TOPIC_SPECS, ALL_OMNIMEMORY_TOPIC_SPECS, etc.) rather
+    than ALL_PROVISIONED_TOPIC_SPECS, which conditionally excludes omnimemory
+    topics based on the OMNIMEMORY_ENABLED environment variable.
+    """
+    all_specs = (
+        pts.ALL_PLATFORM_TOPIC_SPECS
+        + pts.ALL_INTELLIGENCE_TOPIC_SPECS
+        + pts.ALL_OMNIMEMORY_TOPIC_SPECS
+        + pts.ALL_OMNIBASE_INFRA_TOPIC_SPECS
+        + pts.ALL_OMNICLAUDE_TOPIC_SPECS
+    )
+    return {spec.suffix for spec in all_specs}
+
+
 KNOWN_EXCLUSIONS: set[str] = set()
 
 
 @pytest.mark.unit
 def test_all_topic_strings_are_provisioned() -> None:
     defined = _all_defined_suffix_strings()
-    unprovisioned = defined - set(ALL_PROVISIONED_SUFFIXES) - KNOWN_EXCLUSIONS
+    all_spec_suffixes = _all_spec_suffixes()
+    unprovisioned = defined - all_spec_suffixes - KNOWN_EXCLUSIONS
     assert not unprovisioned, (
-        "Topic strings defined in platform_topic_suffixes.py but not in ALL_PROVISIONED_SUFFIXES:\n"
+        "Topic strings defined in platform_topic_suffixes.py but not in any topic spec group:\n"
         + "\n".join(f"  {t}" for t in sorted(unprovisioned))
     )
 
 
 @pytest.mark.unit
 def test_provisioned_topics_non_empty() -> None:
-    assert len(ALL_PROVISIONED_SUFFIXES) > 10
+    assert len(_all_spec_suffixes()) > 10


### PR DESCRIPTION
## Summary

- Add `tests/ci/test_topic_parity.py` to enforce that every topic string literal in `platform_topic_suffixes.py` is registered in `ALL_PROVISIONED_SUFFIXES`
- Prevents future topics from silently missing Redpanda provisioning (as happened with `baselines-computed` Task 6 and `routing-decision` Task 9)
- Uses `@pytest.mark.unit` marker; tests run as part of the standard unit suite

## Changes

- `tests/ci/test_topic_parity.py` (new): two tests:
  - `test_all_topic_strings_are_provisioned`: scans `platform_topic_suffixes` module for `onex.*` strings, asserts all are in `ALL_PROVISIONED_SUFFIXES`
  - `test_provisioned_topics_non_empty`: asserts `ALL_PROVISIONED_SUFFIXES` has > 10 entries (sanity guard)

## Test plan

- [x] `uv run pytest tests/ci/test_topic_parity.py -v` passes (2/2)
- [x] Pre-commit hooks pass (ruff format, ruff check, architecture validation, topic naming lint)
- [x] Adding an unregistered suffix string to `platform_topic_suffixes.py` causes the test to fail

Fixes OMN-4306