### PR TITLE
feat(compose): add skill_lifecycle_logs volume to skill-lifecycle-consumer [OMN-4302]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -716,6 +716,8 @@ services:
     ports:
       - "${SKILL_LIFECYCLE_CONSUMER_PORT:-8092}:8092"
     stop_grace_period: 60s
+    volumes:
+      - skill_lifecycle_logs:/app/logs
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8092/health"]
       interval: 30s
@@ -993,6 +995,8 @@ volumes:
     name: omninode-worker-logs
   agent_actions_logs:
     name: omninode-agent-actions-logs
+  skill_lifecycle_logs:
+    name: omninode-skill-lifecycle-logs
   contract_resolver_logs:
     name: omninode-contract-resolver-logs
   phoenix_data:


### PR DESCRIPTION
## Summary

- Adds `skill_lifecycle_logs` named volume (`omninode-skill-lifecycle-logs`) to `docker-compose.infra.yml`
- Mounts the volume at `/app/logs` in the `skill-lifecycle-consumer` service
- Matches the pattern already used by `agent-actions-consumer` (line 671)

## Problem

The `skill-lifecycle-consumer` service writes structured logs to `/app/logs` but had no volume mount for that path. Without a persistent or writable volume, log writes may fail or be lost on container restart.

## Changes

- `docker/docker-compose.infra.yml`: Add `volumes: - skill_lifecycle_logs:/app/logs` to `skill-lifecycle-consumer` service and declare `skill_lifecycle_logs: name: omninode-skill-lifecycle-logs` in the top-level `volumes` block

## Test Plan

- [x] Pattern matches `agent-actions-consumer` (line 671)
- [x] `docker compose config` will validate no syntax errors (yamllint in CI)
- [ ] `infra-up-runtime` confirms service starts and `/app/logs` is writable

## Linear

Closes OMN-4302