### PR TITLE
feat(ci): env parity test — docker-compose x-runtime-env vs k8s ConfigMap [OMN-4307]

### DIFF
--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -1,0 +1,72 @@
+name: Env Parity Check (OMN-4307)
+
+# Runs on every PR that touches docker-compose or the k8s ConfigMap.
+# Also runs on pushes to main so the gate stays green on the default branch.
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "docker/docker-compose*.yml"
+      - "tests/ci/test_env_parity.py"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "docker/docker-compose*.yml"
+      - "tests/ci/test_env_parity.py"
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  UV_VERSION: "0.6.14"
+  PYTHON_VERSION: "3.12"
+  CACHE_VERSION: "0.6.0"
+
+jobs:
+  env-parity:
+    name: Env Parity (docker-compose vs k8s ConfigMap)
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout omnibase_infra
+        uses: actions/checkout@v4
+        with:
+          path: omnibase_infra
+
+      - name: Checkout omninode_infra (sibling — provides k8s ConfigMap)
+        uses: actions/checkout@v4
+        with:
+          repository: OmniNode-ai/omninode_infra
+          path: omninode_infra
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: ./omnibase_infra/.github/actions/setup-python-uv
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+
+      - name: Run env parity test
+        working-directory: omnibase_infra
+        env:
+          OMNINODE_INFRA_DIR: ${{ github.workspace }}/omninode_infra
+        run: |
+          echo "================================================================"
+          echo "Env Parity Check — docker-compose x-runtime-env vs k8s ConfigMap"
+          echo "Ticket: OMN-4307"
+          echo "================================================================"
+          uv run pytest tests/ci/test_env_parity.py -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ markers = [
     "mcp_protocol: Mock-based MCP JSON-RPC protocol tests (not real SDK integration)",
     "llm: Tests requiring real LLM inference endpoints (local GPU/Apple Silicon servers)",
     "consul: Tests requiring a live Consul instance (legacy marker retained for existing tests — Consul removed in OMN-3995)",
+    "ci: CI/CD parity and configuration tests that run without infrastructure (OMN-4307)",
 ]
 addopts = [
     "--strict-markers",

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -1,0 +1,224 @@
+"""Env parity test: every x-runtime-env key has a k8s ConfigMap or Secret entry.
+
+Ensures that every variable in the docker-compose x-runtime-env anchor is
+accounted for in the k8s ConfigMap, a known Secret, or the LOCAL_ONLY_KEYS
+allowlist. This prevents environment divergence between local docker-compose
+and the k8s cluster.
+
+Run with: uv run pytest tests/ci/test_env_parity.py
+
+Ticket: OMN-4307
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+# COMPOSE_PATH: always relative to this file inside omnibase_infra
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+COMPOSE_PATH = _REPO_ROOT / "docker" / "docker-compose.infra.yml"
+
+# CONFIGMAP_PATH: omninode_infra may live as a sibling in several layouts:
+#   1. Local worktrees: /Volumes/.../omni_worktrees/<ticket>/omnibase_infra/ →
+#      sibling at ../omninode_infra/
+#   2. omni_home monorepo: /Volumes/.../omni_home/omnibase_infra/ →
+#      sibling at ../omninode_infra/
+#   3. CI with dual checkout: both repos checked out side-by-side
+#   4. OMNINODE_INFRA_DIR env var override
+_CONFIGMAP_SUBPATH = "k8s/onex-dev/runtime/configmap.yaml"
+
+
+def _resolve_configmap_path() -> Path | None:
+    """Resolve the ConfigMap path, trying multiple candidate locations."""
+    # Env var override takes precedence
+    override = os.environ.get("OMNINODE_INFRA_DIR", "").strip()
+    if override:
+        candidate = Path(override) / _CONFIGMAP_SUBPATH
+        if candidate.exists():
+            return candidate
+
+    # Try sibling directories relative to the repo root
+    candidates: list[Path] = [
+        # Direct sibling (local worktree or CI dual-checkout)
+        _REPO_ROOT.parent / "omninode_infra" / _CONFIGMAP_SUBPATH,
+        # Two levels up (omni_home monorepo layout: omni_home/omnibase_infra)
+        _REPO_ROOT.parent.parent / "omninode_infra" / _CONFIGMAP_SUBPATH,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+CONFIGMAP_PATH = _resolve_configmap_path()
+
+# ---------------------------------------------------------------------------
+# Key classification
+# ---------------------------------------------------------------------------
+
+# Keys sourced from k8s Secrets or Infisical (not ConfigMap) — expected absent from ConfigMap.
+# In the k8s cluster these are injected via InfisicalSecret or explicit Secret volumes.
+SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        # Bootstrap / Infisical identity — injected via InfisicalSecret (onex-runtime-infisical-secret.yaml)
+        "POSTGRES_PASSWORD",
+        "INFISICAL_CLIENT_ID",
+        "INFISICAL_CLIENT_SECRET",
+        "INFISICAL_PROJECT_ID",
+        "INFISICAL_ENCRYPTION_KEY",
+        "INFISICAL_AUTH_SECRET",
+        # Per-service database DSNs — contain credentials, sourced from Infisical at runtime
+        "OMNIBASE_INFRA_DB_URL",  # k8s uses OMNIBASE_INFRA_DB_HOST + OMNIBASE_INFRA_DB_PORT + Secret
+        "OMNIINTELLIGENCE_DB_URL",  # cross-service DSN with embedded credentials
+        "OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN",
+        "OMNIBASE_INFRA_SKILL_LIFECYCLE_POSTGRES_DSN",
+        # Valkey auth
+        "VALKEY_PASSWORD",  # injected via Infisical at runtime
+        # Keycloak secrets
+        "KEYCLOAK_ADMIN_CLIENT_SECRET",
+        "ONEX_SERVICE_CLIENT_SECRET",
+    }
+)
+
+# Keys that are bootstrap-only or local-docker-only — not propagated to k8s.
+# These are either constructed differently in k8s or are irrelevant in a cluster context.
+LOCAL_ONLY_KEYS: frozenset[str] = frozenset(
+    {
+        # Bus selection — k8s always uses the cluster bus; BUS_ID is in ConfigMap as "cluster"
+        "KAFKA_LOCAL_BOOTSTRAP_SERVERS",
+        "KAFKA_BROKER_ALLOWLIST",  # local Redpanda denylist bypass; k8s uses real DNS
+        # Local postgres bootstrap
+        "POSTGRES_USER",  # k8s uses Infisical-sourced DSN; local docker uses default "postgres"
+        # Local filesystem paths — not meaningful in container images
+        "OMNIBASE_INFRA_DIR",
+    }
+)
+
+# Keys present in docker-compose x-runtime-env but not yet added to the k8s ConfigMap.
+# Each entry here is TECH DEBT that should be resolved by adding to configmap.yaml.
+# Tracked in: OMN-4307
+# NOTE: Do NOT add new keys here — fix them properly in the ConfigMap instead.
+CONFIGMAP_DEBT_KEYS: frozenset[str] = frozenset(
+    {
+        # Keycloak / auth profile — needed when --profile auth is active
+        "KEYCLOAK_ADMIN_URL",
+        "KEYCLOAK_REALM",
+        "KEYCLOAK_ADMIN_CLIENT_ID",
+        "KEYCLOAK_ISSUER",
+        "ONEX_SERVICE_CLIENT_ID",
+        # Plugin / runtime settings
+        "OMNIMEMORY_ENABLED",
+        "OMNICLAUDE_CONTRACTS_ROOT",  # container-internal path — may be k8s-specific
+        "ONEX_REGISTRATION_AUTO_ACK",
+        "USE_EVENT_ROUTING",
+        # OpenTelemetry — opt-in observability (empty = disabled)
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_SERVICE_NAME",
+        "OTEL_TRACES_EXPORTER",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_runtime_env_keys(compose_path: Path) -> set[str]:
+    """Extract all keys declared inside the x-runtime-env anchor.
+
+    Uses a regex over the raw YAML text rather than YAML parsing so that
+    variable-expansion syntax (e.g. ``${VAR:-default}``) is preserved intact
+    and we capture the *key* name without evaluating the value.
+    """
+    raw = compose_path.read_text()
+    block_match = re.search(r"x-runtime-env:.*?(?=\n\S|\Z)", raw, re.DOTALL)
+    if not block_match:
+        return set()
+    block = block_match.group(0)
+    keys = re.findall(r"^\s{2}([A-Z_]+):", block, re.MULTILINE)
+    return set(keys)
+
+
+def extract_configmap_keys(configmap_path: Path) -> set[str]:
+    """Extract all keys from the ConfigMap ``data:`` section."""
+    data = yaml.safe_load(configmap_path.read_text())
+    return set(data.get("data", {}).keys())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+def test_runtime_env_keys_have_k8s_entries() -> None:
+    """Every x-runtime-env key is in ConfigMap, SECRET_KEYS, or LOCAL_ONLY_KEYS.
+
+    If this test fails, a key was added to docker-compose x-runtime-env without
+    a corresponding entry in the k8s ConfigMap (omninode_infra), and it is not
+    registered in SECRET_KEYS (for Infisical/k8s Secret sources),
+    LOCAL_ONLY_KEYS (for local-dev-only bootstrap variables), or
+    CONFIGMAP_DEBT_KEYS (known gaps tracked as tech debt).
+
+    To fix a failure, choose one of:
+      1. Add the key to the k8s ConfigMap (omninode_infra/k8s/onex-dev/runtime/configmap.yaml)
+      2. Add the key to SECRET_KEYS in this file if it is sourced from a k8s Secret
+      3. Add the key to LOCAL_ONLY_KEYS if it is intentionally absent from k8s
+      4. Add temporarily to CONFIGMAP_DEBT_KEYS if the ConfigMap update is blocked
+         (but you MUST file a ticket to resolve the debt)
+    """
+    if CONFIGMAP_PATH is None:
+        pytest.skip(
+            "omninode_infra not found as a sibling — set OMNINODE_INFRA_DIR to run this test"
+        )
+
+    compose_keys = extract_runtime_env_keys(COMPOSE_PATH)
+    assert compose_keys, (
+        f"No x-runtime-env keys extracted from {COMPOSE_PATH}. "
+        "Has the anchor been renamed or removed?"
+    )
+
+    configmap_keys = extract_configmap_keys(CONFIGMAP_PATH)
+    accounted_for = configmap_keys | SECRET_KEYS | LOCAL_ONLY_KEYS | CONFIGMAP_DEBT_KEYS
+    missing = compose_keys - accounted_for
+
+    assert not missing, (
+        "Keys in x-runtime-env but missing from ConfigMap "
+        "(and not in SECRET_KEYS, LOCAL_ONLY_KEYS, or CONFIGMAP_DEBT_KEYS):\n"
+        + "\n".join(f"  {k}" for k in sorted(missing))
+        + "\n\nFix: add each missing key to one of:\n"
+        "  • omninode_infra/k8s/onex-dev/runtime/configmap.yaml  (preferred)\n"
+        "  • SECRET_KEYS in tests/ci/test_env_parity.py           (k8s Secret source)\n"
+        "  • LOCAL_ONLY_KEYS in tests/ci/test_env_parity.py       (local dev only)\n"
+        "  • CONFIGMAP_DEBT_KEYS in tests/ci/test_env_parity.py   (temp — must file ticket)"
+    )
+
+
+@pytest.mark.ci
+def test_compose_path_exists() -> None:
+    """Sanity guard: docker-compose file is present at the expected path."""
+    assert COMPOSE_PATH.exists(), (
+        f"docker-compose file not found at {COMPOSE_PATH}. "
+        "Has the docker/ directory been moved or renamed?"
+    )
+
+
+@pytest.mark.ci
+def test_extract_runtime_env_finds_keys() -> None:
+    """x-runtime-env anchor exists and contains at least one key."""
+    keys = extract_runtime_env_keys(COMPOSE_PATH)
+    assert keys, (
+        f"No x-runtime-env keys found in {COMPOSE_PATH}. "
+        "The anchor may have been removed or renamed."
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/ci/test_env_parity.py` which asserts every key in the docker-compose `x-runtime-env` anchor is accounted for in the k8s ConfigMap, `SECRET_KEYS`, `LOCAL_ONLY_KEYS`, or `CONFIGMAP_DEBT_KEYS`
- Adds `.github/workflows/env-parity.yml` to run the parity test on every PR that modifies `docker-compose.infra.yml` or the test file itself, checking out `omninode_infra` as a sibling to provide the real ConfigMap for comparison
- Registers the `ci` pytest marker in `pyproject.toml`

Prevents silent environment divergence: if a new key is added to `x-runtime-env` without a corresponding ConfigMap entry or explicit classification, the test fails with a clear error message listing the missing keys.

## Key design decisions

- Path resolution handles multiple layouts (local worktrees, CI dual-checkout, `OMNINODE_INFRA_DIR` env override)
- `SECRET_KEYS` covers keys sourced from k8s Secrets/Infisical (DSNs with credentials, passwords, Keycloak secrets)
- `LOCAL_ONLY_KEYS` covers bootstrap-only vars meaningless in k8s (e.g. `POSTGRES_USER`, `KAFKA_BROKER_ALLOWLIST`)
- `CONFIGMAP_DEBT_KEYS` is an explicit tech-debt register for 13 pre-existing gaps (Keycloak, OTel, plugin settings) that should be resolved in follow-up PRs
- When `omninode_infra` is not available (no env var, no sibling), the main parity test `pytest.skip`s cleanly; two sanity guards still run

## Test plan

- [x] `uv run pytest tests/ci/test_env_parity.py` passes (3/3 tests)
- [x] `uv run ruff format` + `ruff check` clean
- [x] `uv run mypy` clean
- [x] `pre-commit run --all-files` clean
- [x] CI workflow triggers on `docker/docker-compose*.yml` and `tests/ci/test_env_parity.py` path filters
- [x] Adding a new unaccounted key to `x-runtime-env` causes the test to fail with the key name listed

Closes OMN-4307