### PR TITLE
fix(infra): add OMNIMEMORY_MEMGRAPH_HOST/PORT/DB_URL to x-runtime-env passthrough (OMN-4311)

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -167,6 +167,13 @@ x-runtime-env: &runtime-env
   OMNIINTELLIGENCE_DB_URL: ${OMNIINTELLIGENCE_DB_URL:?OMNIINTELLIGENCE_DB_URL must be set in ~/.omnibase/.env}
   # OmniMemory domain plugin
   OMNIMEMORY_ENABLED: ${OMNIMEMORY_ENABLED:-}
+  # OMN-4311: Memgraph connection passthrough (required by PluginMemory after OMN-4310)
+  # Default: Docker service name resolvable via omnibase-infra-network DNS.
+  # When OMNIMEMORY_ENABLED is unset, PluginMemory.validate_handshake() skips the probe.
+  OMNIMEMORY_MEMGRAPH_HOST: ${OMNIMEMORY_MEMGRAPH_HOST:-omnibase-infra-memgraph}
+  OMNIMEMORY_MEMGRAPH_PORT: ${OMNIMEMORY_MEMGRAPH_PORT:-7687}
+  # OMNIMEMORY_DB_URL uses :- (empty default) so non-memory deployments are unaffected.
+  OMNIMEMORY_DB_URL: ${OMNIMEMORY_DB_URL:-}
   # OmniClaude domain plugin (OMN-3182): required by PluginClaude.wire_dispatchers()
   # Hardcoded to venv path — host OMNICLAUDE_CONTRACTS_ROOT points at /Volumes/...
   # which doesn't exist inside the container. The pip-installed package has its

--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -52,6 +52,9 @@ OMNIDASH_ANALYTICS_DB_URL=postgresql://role_omnidash:__REPLACE_WITH_SECURE_PASSW
 # Path to omnidash checkout — used by bootstrap-infisical.sh Step 1d to run read-model migrations (OMN-3748)
 OMNIDASH_DIR=/path/to/omnidash
 OMNIINTELLIGENCE_DB_URL=postgresql://role_omniintelligence:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omniintelligence
+OMNIMEMORY_ENABLED=true
+OMNIMEMORY_MEMGRAPH_HOST=omnibase-infra-memgraph
+OMNIMEMORY_MEMGRAPH_PORT=7687
 OMNIMEMORY_DB_URL=postgresql://role_omnimemory:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omnimemory
 OMNINODE_CLOUD_DB_URL=postgresql://role_omninode_cloud:__REPLACE_WITH_SECURE_PASSWORD__@your-postgres-host:5432/omninode_cloud
 


### PR DESCRIPTION
## Summary

- Adds `OMNIMEMORY_MEMGRAPH_HOST` (default: `omnibase-infra-memgraph`), `OMNIMEMORY_MEMGRAPH_PORT` (default: `7687`), and `OMNIMEMORY_DB_URL` (empty default) to the `x-runtime-env` anchor in `docker/docker-compose.infra.yml`
- Updates `docs/env-example-full.txt` to document all three OMNIMEMORY_MEMGRAPH_* vars

## Motivation

These vars were documented in `env-example-full.txt` but missing from the `x-runtime-env` passthrough. The runtime container never received them — so even with Memgraph reachable (OMN-4310), `PluginMemory` would not know where to connect.

The default `omnibase-infra-memgraph` resolves via Docker DNS on `omnibase-infra-network` (the service added in OMN-4310).

## Test Evidence

- `docker compose -f docker/docker-compose.infra.yml config --quiet` passes
- `OMNIMEMORY_MEMGRAPH_HOST` and `OMNIMEMORY_MEMGRAPH_PORT` appear in the `omninode-runtime` environment block
- `tests/ci/test_compose_no_nested_expansion.py` passes (no nested vars introduced)

## Dependencies

Builds on OMN-4310 (Memgraph service definition). Branch based on OMN-4310 branch — will be rebased onto main after OMN-4310 merges.

## Linear

Closes OMN-4311 (part of OMN-4309: Memory Pipeline Wiring Fixes + Infrastructure Guardrails)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Memgraph as an optional infrastructure component for enhanced deployment flexibility.
  * Introduced new environment variables to configure Memgraph connectivity (`OMNIMEMORY_MEMGRAPH_HOST`, `OMNIMEMORY_MEMGRAPH_PORT`, `OMNIMEMORY_ENABLED`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->