### PR TITLE
fix(ci): use CROSS_REPO_PAT to checkout private omninode_infra in env-parity workflow

### DIFF
--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -47,11 +47,13 @@ jobs:
           path: omnibase_infra
 
       - name: Checkout omninode_infra (sibling — provides k8s ConfigMap)
+        # GITHUB_TOKEN is scoped to omnibase_infra and cannot access the private
+        # omninode_infra repo. Use CROSS_REPO_PAT (same pattern as dependency-cascade.yml).
         uses: actions/checkout@v4
         with:
           repository: OmniNode-ai/omninode_infra
           path: omninode_infra
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CROSS_REPO_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Python and uv
         uses: ./omnibase_infra/.github/actions/setup-python-uv


### PR DESCRIPTION
## Summary

- Fixes env-parity CI check failing because `GITHUB_TOKEN` cannot access the private `omninode_infra` repo
- Root cause: the `Checkout omninode_infra` step uses `GITHUB_TOKEN` which is scoped to `omnibase_infra` only
- Fix: use `CROSS_REPO_PAT` (already used in `dependency-cascade.yml` and other cross-repo workflows) with `GITHUB_TOKEN` as fallback

## Impact

Without this fix, every PR that touches `docker/docker-compose.infra.yml` or `tests/ci/test_env_parity.py` will fail the **Env Parity (docker-compose vs k8s ConfigMap)** check because the `omninode_infra` checkout fails with `Not Found`.

## Test Plan

- [ ] CI passes on PRs touching docker-compose (verify with PR #731 or similar)
- [ ] Env parity test runs successfully and compares docker-compose vs k8s ConfigMap
- [ ] No regression for self-hosted runners