### PR TITLE
fix(ci): fix Env Parity working-directory for subdirectory checkout (OMN-4317)

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Extra arguments passed to uv sync (e.g., --frozen)'
     required: false
     default: '--reinstall-package omnibase-core --reinstall-package omnibase-spi'
+  working-directory:
+    description: 'Working directory for uv sync (useful when the repo is checked out into a subdirectory)'
+    required: false
+    default: '.'
   skip-install:
     description: 'Set to "true" to skip the uv sync step (useful for multi-repo setups that install manually)'
     required: false
@@ -51,4 +55,5 @@ runs:
     - name: Install dependencies
       if: inputs.skip-install != 'true'
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: uv sync ${{ inputs.install-args }}

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -59,13 +59,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
-          # skip-install because the repo is checked out into a subdirectory;
-          # uv sync must run from the correct working-directory below.
-          skip-install: "true"
-
-      - name: Install dependencies
-        working-directory: omnibase_infra
-        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi
+          working-directory: omnibase_infra
 
       - name: Run env parity test
         working-directory: omnibase_infra


### PR DESCRIPTION
## Root Cause

The `env-parity.yml` workflow checks out `omnibase_infra` into a subdirectory (`path: omnibase_infra`) so the runner workspace looks like:

```
${{ github.workspace }}/
  omnibase_infra/    ← repo here
  omninode_infra/    ← sibling repo
```

The `setup-python-uv` composite action ran `uv sync` with no `working-directory` override, so it ran from `${{ github.workspace }}` — the runner root — where there is no `pyproject.toml`. This produced:

```
error: No `pyproject.toml` found in current directory or any parent directory
Process completed with exit code 2.
```

Note: `CROSS_REPO_PAT` is not the issue. The `omninode_infra` checkout succeeded with `GITHUB_TOKEN` (org-level cross-repo read works).

## Fix

- Pass `skip-install: "true"` to the composite action (installs Python + uv, skips `uv sync`)
- Add an explicit `Install dependencies` step with `working-directory: omnibase_infra`

## Test Plan

- [ ] Env Parity CI check passes on this PR
- [ ] `uv sync` runs from `omnibase_infra/` subdirectory (has `pyproject.toml`)
- [ ] `Run env parity test` step still uses `working-directory: omnibase_infra`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable "working-directory" input for the CI action used to install dependencies.
  * Updated the CI workflow to pass this working-directory so dependency installation runs in the correct project subdirectory during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->