### PR TITLE
ci: rename test-summary → ci-summary aggregator job (OMN-4499)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -32,7 +32,7 @@ required_checks:
 excluded_checks:
   - name: "Tests (Split 1/10) through Tests (Split 10/10)"
     reason: "Individual matrix legs -- aggregated by CI Tests Gate"
-  - name: "Test Summary"
+  - name: "CI Summary"
     reason: "Reporting aggregator -- not a correctness gate (CI Tests Gate covers this)"
   - name: "Check architecture handshake"
     workflow: check-handshake.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -487,8 +487,8 @@ jobs:
           fi
           echo "All 10 test splits passed"
 
-  test-summary:
-    name: Test Summary
+  ci-summary:
+    name: CI Summary
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{

--- a/docs/validation/troubleshooting.md
+++ b/docs/validation/troubleshooting.md
@@ -524,7 +524,7 @@ CI:    Architecture FAIL
 
 2. **Check job dependencies**:
    ```yaml
-   test-summary:
+   ci-summary:
      needs: [smoke-test, test, lint, onex-validation]
      # Must include onex-validation
    ```


### PR DESCRIPTION
## Summary

Renames the `test-summary` CI job to `ci-summary` (display name: `CI Summary`) per OMN-4499.

**Changes:**
- `.github/workflows/test.yml`: job key `test-summary:` → `ci-summary:`, display name `Test Summary` → `CI Summary`
- `.github/required-checks.yaml`: update excluded check name from `Test Summary` → `CI Summary`
- `docs/validation/troubleshooting.md`: update example job name in docs

## Verification

Zero stale `test-summary` / `Test Summary` references remain in `.github/` or `docs/`.

## Definition of Done

- [x] `test-summary` renamed to `ci-summary` in test.yml (job key + display name)
- [x] Zero stale `test-summary` / `Test Summary` references remain
- [x] PR created and CI passes
- [ ] Branch protection updated to `["CI Summary"]` after merge (post-merge step)

## Post-Merge

After this PR merges, update branch protection:
```bash
gh api repos/OmniNode-ai/omnibase_infra/branches/main/protection \
  --method PUT --input - <<'BPEOF'
{
  "required_status_checks": {
    "strict": false,
    "checks": [{"context": "CI Summary", "app_id": 15368}]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null
}
BPEOF
```

Closes OMN-4499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI/CD pipeline naming across build workflows for improved consistency.

* **Documentation**
  * Updated troubleshooting documentation to reflect CI/CD infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->