### PR TITLE
docs(ci): update required-checks.yaml for OMN-4497 CI Summary gate architecture

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -5,35 +5,42 @@
 # branch protection settings (Settings > Branches > main).
 #
 # Added: OMN-2184
-# Last verified: 2026-02-14
+# Last verified: 2026-03-10
+# Architecture: OMN-4497 -- CI Summary is the single required gate across all repos
 required_checks:
   # -- test.yml (primary pipeline) -------------------------------------------
+  - name: "CI Summary"
+    workflow: test.yml
+    job_id: ci-summary
+    rationale: >
+      Umbrella correctness gate (OMN-4497). Aggregates ALL sub-jobs in test.yml via `needs:` -- tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, arch-invariants, schema-handshake, migration-integration, migration-required-check. Fails if any required sub-job fails. This is the single branch protection check required across all repos per OMN-4497.
+
+# -- Sub-jobs (feed into CI Summary -- not required directly in branch protection) -
+sub_jobs:
   - name: "Lint"
     workflow: test.yml
     job_id: lint
-    rationale: "Ruff format, lint, and mypy type checking"
+    rationale: "Ruff format, lint, and mypy type checking -- gated by CI Summary"
   - name: "ONEX Validators"
     workflow: test.yml
     job_id: onex-validation
-    rationale: "Architecture layers, ONEX rules, I/O purity audit, markdown links"
+    rationale: "Architecture layers, ONEX rules, I/O purity audit, markdown links -- gated by CI Summary"
   - name: "Migration Freeze Check"
     workflow: test.yml
     job_id: migration-freeze
-    rationale: "Blocks new migrations during DB-SPLIT freeze (OMN-2055)"
+    rationale: "Blocks new migrations during DB-SPLIT freeze (OMN-2055) -- gated by CI Summary"
   - name: "Fingerprint Check"
     workflow: test.yml
     job_id: fingerprint-check
-    rationale: "CI twins for runtime assertions B2 (schema) and B3 (event registry) -- prevents stale fingerprint artifacts (OMN-2149)"
+    rationale: "CI twins for runtime assertions B2 (schema) and B3 (event registry) -- gated by CI Summary"
   - name: "CI Tests Gate"
     workflow: test.yml
     job_id: tests-gate
-    rationale: "Aggregator for 10-split test matrix -- split count can change without updating branch protection"
+    rationale: "Aggregator for 10-split test matrix -- gated by CI Summary"
 # -- Explicitly excluded ------------------------------------------------------
 excluded_checks:
   - name: "Tests (Split 1/10) through Tests (Split 10/10)"
-    reason: "Individual matrix legs -- aggregated by CI Tests Gate"
-  - name: "CI Summary"
-    reason: "Reporting aggregator -- not a correctness gate (CI Tests Gate covers this)"
+    reason: "Individual matrix legs -- aggregated by CI Tests Gate, which feeds CI Summary"
   - name: "Check architecture handshake"
     workflow: check-handshake.yml
     reason: "paths: filter skips this on most PRs -- requiring it would block unrelated PRs"


### PR DESCRIPTION
## Summary

- Restructures `.github/required-checks.yaml` to reflect the OMN-4497 CI Summary umbrella gate architecture
- Moves **CI Summary** from `excluded_checks` to `required_checks` as the single required branch protection check
- Introduces a new `sub_jobs` section documenting the individual checks (Lint, ONEX Validators, Migration Freeze Check, Fingerprint Check, CI Tests Gate) that feed into CI Summary via `needs:` -- these are enforced by CI Summary, not directly in branch protection
- Removes the stale/incorrect entry that described CI Summary as "Reporting aggregator -- not a correctness gate"

## Context

PR #759 (OMN-4499 task-1) renamed `test-summary` → `ci-summary` and updated `required-checks.yaml` to rename the excluded entry. However, per OMN-4497, CI Summary is the **single required branch protection check across all repos** -- it aggregates all sub-jobs via `needs:` and fails if any required sub-job fails. It is a correctness gate, not a reporting aggregator.

Branch protection for `omnibase_infra/main` has already been updated to `["CI Summary"]` only.

## Test plan

- [ ] CI Summary job in `test.yml` aggregates: tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, arch-invariants, schema-handshake, migration-integration, migration-required-check
- [ ] Branch protection now requires only `["CI Summary"]`
- [ ] `required-checks.yaml` accurately documents the new architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new "CI Summary" gate that aggregates all verification sub-jobs including Lint, ONEX Validators, Migration Freeze Check, Fingerprint Check, and CI Tests.
  * Reorganized CI/CD configuration to clarify check dependencies, exclusions, and aggregation hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->