### PR TITLE
feat(adapters): implement sync generate_stream() with async generator cleanup (OMN-4483)

### DIFF
--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -21,6 +21,7 @@ Related Tickets:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
@@ -506,19 +507,27 @@ class AdapterLlmProviderOpenai:
     def generate_stream(self, request: ModelLlmAdapterRequest) -> Iterator[str]:
         """Generate a streaming response (synchronous).
 
-        Not supported for OpenAI-compatible adapter in v1. Raises
-        NotImplementedError.
+        Uses a dedicated event loop per call. Safe for single-threaded use.
+        Not safe to share across threads. The async generator is explicitly
+        closed after iteration to prevent resource leaks.
 
         Args:
-            request: The LLM request.
+            request: The LLM request with prompt and parameters.
 
-        Raises:
-            NotImplementedError: Streaming is not supported in v1.
+        Yields:
+            Generated text chunks as they are produced.
         """
-        raise NotImplementedError(
-            "Synchronous streaming is not supported in v1. "
-            "Use generate_stream_async for async streaming."
-        )
+        loop = asyncio.new_event_loop()
+        agen = self.generate_stream_async(request)
+        try:
+            while True:
+                try:
+                    yield loop.run_until_complete(agen.__anext__())
+                except StopAsyncIteration:
+                    break
+        finally:
+            loop.run_until_complete(agen.aclose())
+            loop.close()
 
     async def generate_stream_async(
         self,
@@ -671,15 +680,15 @@ class AdapterLlmProviderOpenai:
             "base_url": self._sanitize_url(self._base_url),
             "default_model": self._default_model,
             "is_available": self._is_available,
-            "supports_streaming": False,
+            "supports_streaming": True,
             "supports_async": True,
         }
 
     # ── Feature support ────────────────────────────────────────────────
 
     def supports_streaming(self) -> bool:
-        """Check if provider supports streaming. Returns False for v1."""
-        return False
+        """Check if provider supports streaming. Returns True (generate_stream implemented)."""
+        return True
 
     def supports_async(self) -> bool:
         """Check if provider supports async operations. Always True."""

--- a/tests/unit/adapters/llm/test_adapter_llm_openai_sync_stream.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_openai_sync_stream.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for AdapterLlmProviderOpenai.generate_stream() sync method (OMN-4483)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.adapters.llm.adapter_llm_provider_openai import (
+    AdapterLlmProviderOpenai,
+)
+from omnibase_infra.adapters.llm.model_llm_adapter_request import ModelLlmAdapterRequest
+
+
+def _make_request() -> ModelLlmAdapterRequest:
+    return ModelLlmAdapterRequest(
+        prompt="Say hello",
+        model_name="test-model",
+        max_tokens=64,
+        temperature=0.0,
+    )
+
+
+@pytest.mark.unit
+def test_generate_stream_yields_chunks() -> None:
+    """Sync stream must yield all chunks from the async generator."""
+    adapter = AdapterLlmProviderOpenai.__new__(AdapterLlmProviderOpenai)
+
+    async def fake_stream(request: ModelLlmAdapterRequest) -> object:
+        for chunk in ["Hello", " world", "!"]:
+            yield chunk
+
+    request = _make_request()
+    with patch.object(adapter, "generate_stream_async", side_effect=fake_stream):
+        results = list(adapter.generate_stream(request))
+
+    assert results == ["Hello", " world", "!"]
+
+
+@pytest.mark.unit
+def test_generate_stream_closes_generator_on_completion() -> None:
+    """Async generator finalizer must run after stream is consumed."""
+    adapter = AdapterLlmProviderOpenai.__new__(AdapterLlmProviderOpenai)
+    close_called: list[bool] = []
+
+    async def fake_stream_with_close_check(
+        request: ModelLlmAdapterRequest,
+    ) -> object:
+        try:
+            for chunk in ["A", "B"]:
+                yield chunk
+        finally:
+            close_called.append(True)
+
+    request = _make_request()
+    with patch.object(
+        adapter, "generate_stream_async", side_effect=fake_stream_with_close_check
+    ):
+        list(adapter.generate_stream(request))
+
+    assert close_called, "Async generator finalizer must run after stream is consumed"

--- a/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
@@ -44,10 +44,10 @@ class TestAdapterLlmProviderOpenaiProperties:
         adapter = AdapterLlmProviderOpenai()
         assert adapter.is_available is True
 
-    def test_supports_streaming_v1(self) -> None:
-        """Streaming is not supported in v1."""
+    def test_supports_streaming(self) -> None:
+        """Streaming is supported (generate_stream implemented via asyncio.new_event_loop)."""
         adapter = AdapterLlmProviderOpenai()
-        assert adapter.supports_streaming() is False
+        assert adapter.supports_streaming() is True
 
     def test_supports_async(self) -> None:
         """Async is always supported."""
@@ -132,16 +132,26 @@ class TestAdapterLlmProviderOpenaiCostEstimation:
 class TestAdapterLlmProviderOpenaiGenerate:
     """Tests for generation methods."""
 
-    @pytest.mark.asyncio
-    async def test_generate_stream_raises(self) -> None:
-        """Synchronous streaming raises NotImplementedError."""
-        adapter = AdapterLlmProviderOpenai()
+    def test_generate_stream_does_not_raise_not_implemented(self) -> None:
+        """Synchronous streaming is implemented and does not raise NotImplementedError.
+
+        generate_stream() wraps generate_stream_async() using asyncio.new_event_loop()
+        per call. This test verifies the stub has been replaced with the real impl.
+        """
+        from unittest.mock import patch
+
+        adapter = AdapterLlmProviderOpenai.__new__(AdapterLlmProviderOpenai)
         request = ModelLlmAdapterRequest(
             prompt="Hello",
             model_name="test",
         )
-        with pytest.raises(NotImplementedError):
-            adapter.generate_stream(request)
+
+        async def fake_stream(req: ModelLlmAdapterRequest) -> object:
+            yield "ok"
+
+        with patch.object(adapter, "generate_stream_async", side_effect=fake_stream):
+            result = list(adapter.generate_stream(request))
+        assert result == ["ok"]
 
     @pytest.mark.asyncio
     async def test_get_provider_info(self) -> None:


### PR DESCRIPTION
## Summary

Implements `generate_stream()` sync method in `AdapterLlmProviderOpenai`. Previously raised `NotImplementedError`.

**Changes:**
- `adapter_llm_provider_openai.py`: Added `import asyncio`, replaced stub with `asyncio.new_event_loop()` per call, explicit `agen.aclose()` in `finally` block, updated `supports_streaming()` to return `True` and `get_provider_info()` accordingly
- `test_adapter_llm_openai_sync_stream.py` (new): 2 TDD tests — yields_chunks, closes_generator_on_completion
- `test_adapter_llm_provider_openai.py`: Updated stale tests (`test_supports_streaming_v1 → test_supports_streaming`, `test_generate_stream_raises → test_generate_stream_does_not_raise_not_implemented`)

## Ticket

[OMN-4483](https://linear.app/omninode/issue/OMN-4483)

## Test Evidence

```
19 passed in 0.20s
```

## Risk

Low — additive change. Dedicated loop per call (no shared state). Explicit generator close prevents resource leaks.

## Rollback

Revert this commit. The adapter falls back to `NotImplementedError` (prior stub state).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled synchronous streaming support for the OpenAI-compatible LLM provider.
  * Provider now correctly reports streaming capability availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->