### PR TITLE
fix(ci): pipe CHANGED_FILES through xargs to avoid ARG_MAX in AI-slop check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -755,4 +755,4 @@ jobs:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
           if [ -z "$CHANGED_FILES" ]; then exit 0; fi
-          python scripts/validation/check_ai_slop.py --strict $CHANGED_FILES
+          echo "$CHANGED_FILES" | tr ' ' '\n' | xargs python scripts/validation/check_ai_slop.py --strict


### PR DESCRIPTION
## Summary

- Fixes `Argument list too long` error in the **AI-Slop Pattern Check** CI job when a PR changes thousands of files (e.g., the SPDX stamp PR #755 touched 2,547 files)
- The root cause: `$CHANGED_FILES` is passed as unquoted shell arguments to `check_ai_slop.py`, exceeding Linux's `ARG_MAX` (~2MB)
- Fix: pipe `"$CHANGED_FILES"` through `xargs` so the shell never sees an oversized argument list

## Test plan

- [ ] Merge this and verify AI-Slop check passes on subsequent PRs
- [ ] Confirmed locally: all 2547 changed files pass the strict AI-slop check

Surfaced from OMN-4385 SPDX header enforcement PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the robustness of internal validation workflows for better handling of file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->