### PR TITLE
feat(runtime): wire ProjectorShell into ProjectorPluginLoader — OMN-1169 complete (OMN-4484)

### DIFF
--- a/src/omnibase_infra/runtime/projector_plugin_loader.py
+++ b/src/omnibase_infra/runtime/projector_plugin_loader.py
@@ -151,7 +151,7 @@ class ProjectorShellPlaceholder:
         Raises:
             NotImplementedError: Always, as this is a placeholder without DB access.
         """
-        raise NotImplementedError(
+        raise NotImplementedError(  # stub-ok: discovery-only placeholder; no DB pool provided
             f"ProjectorShellPlaceholder for '{self.projector_id}' cannot project events. "
             "Provide a database pool to ProjectorPluginLoader to use ProjectorShell."
         )
@@ -170,7 +170,7 @@ class ProjectorShellPlaceholder:
         Raises:
             NotImplementedError: Always, as this is a placeholder without DB access.
         """
-        raise NotImplementedError(
+        raise NotImplementedError(  # stub-ok: discovery-only placeholder; no DB pool provided
             f"ProjectorShellPlaceholder for '{self.projector_id}' cannot query state. "
             "Provide a database pool to ProjectorPluginLoader to use ProjectorShell."
         )
@@ -685,9 +685,9 @@ class ProjectorPluginLoader:
                 and be readable.
 
         Returns:
-            A configured ProtocolEventProjector instance.
-            Note: Currently returns ProjectorShellPlaceholder until
-            OMN-1169 implements the full ProjectorShell.
+            A configured ProtocolEventProjector instance. Returns ProjectorShell
+            when a database pool is provided, or ProjectorShellPlaceholder for
+            discovery-only scenarios (no pool).
 
         Raises:
             ModelOnexError: If contract parsing or validation fails.
@@ -737,7 +737,6 @@ class ProjectorPluginLoader:
             },
         )
 
-        # Return placeholder until OMN-1169 implements ProjectorShell
         return self._create_projector(contract)
 
     async def load_from_directory(

--- a/tests/unit/runtime/test_projector_plugin_loader_wiring.py
+++ b/tests/unit/runtime/test_projector_plugin_loader_wiring.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests verifying ProjectorShell is wired into ProjectorPluginLoader (OMN-4484).
+
+OMN-1169 implemented ProjectorShell. This test verifies that ProjectorPluginLoader._create_projector
+instantiates ProjectorShell (not ProjectorShellPlaceholder) when a database pool is provided.
+
+Tests call _create_projector() directly to avoid I/O, since the wiring logic lives entirely
+in that method.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.runtime.projector_plugin_loader import (
+    ProjectorPluginLoader,
+    ProjectorShellPlaceholder,
+)
+from omnibase_infra.runtime.projector_shell import ProjectorShell
+
+
+def _make_minimal_contract() -> object:
+    """Build a minimal ModelProjectorContract for testing."""
+    from omnibase_core.models.projectors import ModelProjectorContract
+
+    return ModelProjectorContract.model_validate(
+        {
+            "projector_kind": "materialized_view",
+            "projector_id": "test-projector-wiring",
+            "name": "Wiring Test Projector",
+            "version": "1.0.0",
+            "aggregate_type": "TestAggregate",
+            "consumed_events": ["test.created.v1"],
+            "projection_schema": {
+                "table": "test_wiring_projections",
+                "primary_key": "id",
+                "columns": [
+                    {"name": "id", "type": "UUID", "source": "event.payload.id"}
+                ],
+            },
+            "behavior": {"mode": "upsert"},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_loader_produces_projector_shell_when_pool_provided() -> None:
+    """After OMN-1169, loader must instantiate ProjectorShell when pool is provided."""
+    mock_pool = MagicMock()
+    loader = ProjectorPluginLoader(pool=mock_pool)
+    contract = _make_minimal_contract()
+
+    projector = loader._create_projector(contract)  # type: ignore[arg-type]
+
+    assert isinstance(projector, ProjectorShell), (
+        f"Expected ProjectorShell, got {type(projector).__name__}. "
+        "ProjectorShellPlaceholder indicates pool wiring is broken."
+    )
+    assert not projector.is_placeholder
+    assert callable(projector.project)
+
+
+@pytest.mark.unit
+def test_loader_produces_placeholder_when_no_pool() -> None:
+    """Loader falls back to ProjectorShellPlaceholder when no pool is provided.
+
+    ProjectorShellPlaceholder is the correct fallback for discovery-only scenarios
+    where database access is not needed.
+    """
+    loader = ProjectorPluginLoader(pool=None)
+    contract = _make_minimal_contract()
+
+    projector = loader._create_projector(contract)  # type: ignore[arg-type]
+
+    assert isinstance(projector, ProjectorShellPlaceholder), (
+        f"Expected ProjectorShellPlaceholder without pool, got {type(projector).__name__}."
+    )
+    assert projector.is_placeholder


### PR DESCRIPTION
## Summary

OMN-1169 (PR #144) implemented `ProjectorShell`. The wiring into `ProjectorPluginLoader._create_projector()` was already in place — this ticket confirms and verifies it.

**Changes:**
- `projector_plugin_loader.py`: Add `# stub-ok: discovery-only placeholder` annotations to `ProjectorShellPlaceholder.project()` and `.get_state()` (stub detector was flagging them). Remove stale `# Return placeholder until OMN-1169 implements ProjectorShell` comment.
- `test_projector_plugin_loader_wiring.py` (new): 2 verification tests — `test_loader_produces_projector_shell_when_pool_provided` and `test_loader_produces_placeholder_when_no_pool`

## Ticket

[OMN-4484](https://linear.app/omninode/issue/OMN-4484)

## Verification (Phase A findings)

`_create_projector()` at line 308-310 already correctly routes:
- Pool provided → `ProjectorShell(contract, self._pool)` ✓
- Pool None → `ProjectorShellPlaceholder(contract)` ✓ (valid discovery-only fallback)

## Test Evidence

```
2 passed in 0.10s
```

## Risk

Very low — no behavioral change. Only adds test, stub-ok annotations, and removes stale comment.

## Rollback

Revert this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New unit tests added for projector plugin loader wiring behavior with and without database configuration.

* **Chores**
  * Updated pre-commit configuration with new stub implementation check.

* **Documentation**
  * Clarified projector behavior documentation for different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->