### PR TITLE
feat(scripts): scaffold compare_environments.py with Pydantic output model [OMN-4520]

### DIFF
--- a/scripts/compare_environments.py
+++ b/scripts/compare_environments.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""compare-environments.py — local Docker vs k8s environment parity checker.
+
+Usage:
+    uv run python scripts/compare-environments.py [--mode check|fix] [--checks CHECKS]
+    uv run python scripts/compare-environments.py --all-checks
+    uv run python scripts/compare-environments.py --json
+
+Checks (default: credential,ecr,infisical):
+    credential   CRITICAL  Service secret POSTGRES_USER/PASSWORD vs onex-runtime-credentials
+    ecr          CRITICAL  Deployment image tags still exist in ECR
+    infisical    CRITICAL  InfisicalSecret paths exist in Infisical project
+    schema       WARNING   DB migration_history latest id matches local vs cloud
+    services     WARNING   Deployments present in local Docker vs cloud k8s
+    flags        WARNING   Feature flag env vars consistent
+    kafka        WARNING   Kafka topic sets match on both buses
+    packages     WARNING   omnibase-core/spi/infra package versions match
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from datetime import UTC, datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelParityFinding(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    check_id: str
+    severity: Literal["CRITICAL", "WARNING", "INFO"]
+    title: str
+    detail: str
+    local_value: str | None = None
+    cloud_value: str | None = None
+    auto_fixable: bool
+    fix_hint: str
+
+
+class ModelParitySummary(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    critical_count: int
+    warning_count: int
+    info_count: int
+    checks_skipped: list[str]
+
+
+class ModelParityReport(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    run_id: str
+    generated_at: str
+    mode: str
+    checks_run: list[str]
+    findings: list[ModelParityFinding]
+    summary: ModelParitySummary
+
+
+ALL_CHECKS = [
+    "credential",
+    "ecr",
+    "infisical",
+    "schema",
+    "services",
+    "flags",
+    "kafka",
+    "packages",
+]
+DEFAULT_CHECKS = ["credential", "ecr", "infisical"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Local Docker vs k8s parity checker")
+    p.add_argument("--mode", choices=["check", "fix"], default="check")
+    p.add_argument("--checks", default=",".join(DEFAULT_CHECKS))
+    p.add_argument("--all-checks", action="store_true")
+    p.add_argument("--namespace", default="onex-dev")
+    p.add_argument("--instance-id", default="i-0e596e8b557e27785")
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--json", dest="json_output", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--timeout", type=int, default=90)
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    checks = (
+        ALL_CHECKS if args.all_checks else [c.strip() for c in args.checks.split(",")]
+    )
+    report = ModelParityReport(
+        run_id=str(uuid.uuid4())[:8],
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        mode=args.mode,
+        checks_run=checks,
+        findings=[],
+        summary=ModelParitySummary(
+            critical_count=0, warning_count=0, info_count=0, checks_skipped=checks
+        ),
+    )
+    print(report.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_compare_environments.py
+++ b/tests/unit/scripts/test_compare_environments.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Tests for scripts/compare-environments.py — parity checker."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+
+@pytest.mark.unit
+def test_parity_report_serializes_to_json() -> None:
+    from compare_environments import (
+        ModelParityFinding,
+        ModelParityReport,
+        ModelParitySummary,
+    )
+
+    finding = ModelParityFinding(
+        check_id="credential_parity",
+        severity="CRITICAL",
+        title="Wrong POSTGRES_USER for omniintelligence-credentials",
+        detail="k8s secret has 'postgres'; expected 'role_omniintelligence'",
+        local_value="role_omniintelligence",
+        cloud_value="postgres",
+        auto_fixable=False,
+        fix_hint="Re-seed /dev/omniintelligence/ in Infisical and force-resync the InfisicalSecret",
+    )
+    report = ModelParityReport(
+        run_id="abc123",
+        generated_at="2026-03-10T00:00:00Z",
+        mode="check",
+        checks_run=["credential_parity"],
+        findings=[finding],
+        summary=ModelParitySummary(
+            critical_count=1, warning_count=0, info_count=0, checks_skipped=[]
+        ),
+    )
+    raw = report.model_dump_json()
+    parsed = json.loads(raw)
+    assert parsed["findings"][0]["severity"] == "CRITICAL"
+    assert parsed["summary"]["critical_count"] == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/compare_environments.py` with `ModelParityFinding`, `ModelParitySummary`, `ModelParityReport` Pydantic models
- Adds `build_parser()` CLI with `--mode`, `--checks`, `--all-checks`, `--namespace`, `--instance-id`, `--json`, `--dry-run`, `--timeout` flags
- Adds stub `main()` that emits a valid empty JSON report
- Adds `tests/unit/scripts/test_compare_environments.py` with `test_parity_report_serializes_to_json`

This is the scaffold for the env parity checker (OMN-4519). Subsequent tickets (OMN-4521–OMN-4528) add SsmRunner, checks, and integration tests on top of this foundation.

## Risk

Low — new files only, no changes to existing code.

## Test Evidence

```
tests/unit/scripts/test_compare_environments.py::test_parity_report_serializes_to_json PASSED
uv run python scripts/compare_environments.py --json → valid JSON
uv run python scripts/compare_environments.py --all-checks --json → all 8 checks enumerated
```

## Rollback

Delete the two new files.

Linear: OMN-4520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New environment comparison utility with configurable check selection
  * JSON output format and dry-run mode support
  * Configurable parameters including namespace, region, and timeout settings

* **Tests**
  * Unit tests added for parity check model validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->