### PR TITLE
feat(scripts): add SsmRunner — fail-open SSM primitive [OMN-4521]

### DIFF
--- a/scripts/compare_environments.py
+++ b/scripts/compare_environments.py
@@ -21,8 +21,13 @@ Checks (default: credential,ecr,infisical):
 from __future__ import annotations
 
 import argparse
+import json
+import shutil
+import subprocess
+import time
 import uuid
-from datetime import UTC, datetime, timezone
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
@@ -57,6 +62,114 @@ class ModelParityReport(BaseModel):
     findings: list[ModelParityFinding]
     summary: ModelParitySummary
 
+
+# ---------------------------------------------------------------------------
+# transport — SsmRunner, SsmResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SsmResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+class SsmRunner:
+    def __init__(self, instance_id: str, region: str, timeout: int = 90) -> None:
+        self.instance_id = instance_id
+        self.region = region
+        self.timeout = timeout
+
+    def run(self, command: str) -> SsmResult:
+        if not shutil.which("aws"):
+            return SsmResult(
+                skipped=True, skip_reason="aws CLI not found — install awscli"
+            )
+        try:
+            send = subprocess.run(
+                [
+                    "aws",
+                    "ssm",
+                    "send-command",
+                    "--instance-ids",
+                    self.instance_id,
+                    "--region",
+                    self.region,
+                    "--document-name",
+                    "AWS-RunShellScript",
+                    "--parameters",
+                    f'commands=["{command}"]',
+                    "--output",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except Exception as exc:
+            return SsmResult(skipped=True, skip_reason=f"send-command failed: {exc}")
+        if send.returncode != 0:
+            if (
+                "ExpiredTokenException" in send.stderr
+                or "ExpiredTokenException" in send.stdout
+            ):
+                return SsmResult(
+                    skipped=True, skip_reason="SSO session expired — run: aws sso login"
+                )
+            return SsmResult(
+                skipped=True, skip_reason=f"send-command error: {send.stderr[:200]}"
+            )
+        try:
+            command_id = json.loads(send.stdout)["Command"]["CommandId"]
+        except Exception as exc:
+            return SsmResult(
+                skipped=True, skip_reason=f"could not parse CommandId: {exc}"
+            )
+        for _ in range(self.timeout // 2):
+            time.sleep(2)
+            try:
+                poll = subprocess.run(
+                    [
+                        "aws",
+                        "ssm",
+                        "get-command-invocation",
+                        "--command-id",
+                        command_id,
+                        "--instance-id",
+                        self.instance_id,
+                        "--region",
+                        self.region,
+                        "--output",
+                        "json",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                )
+                if poll.returncode != 0:
+                    continue
+                inv = json.loads(poll.stdout)
+                if inv["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+                    return SsmResult(
+                        returncode=0 if inv["Status"] == "Success" else 1,
+                        stdout=inv.get("StandardOutputContent", ""),
+                        stderr=inv.get("StandardErrorContent", ""),
+                    )
+            except Exception:
+                continue
+        return SsmResult(
+            skipped=True, skip_reason=f"instance unreachable after {self.timeout}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# checks registry
+# ---------------------------------------------------------------------------
 
 ALL_CHECKS = [
     "credential",

--- a/tests/unit/scripts/test_compare_environments.py
+++ b/tests/unit/scripts/test_compare_environments.py
@@ -43,3 +43,52 @@ def test_parity_report_serializes_to_json() -> None:
     parsed = json.loads(raw)
     assert parsed["findings"][0]["severity"] == "CRITICAL"
     assert parsed["summary"]["critical_count"] == 1
+
+
+@pytest.mark.unit
+def test_ssm_runner_skips_when_aws_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
+
+    from compare_environments import SsmRunner
+
+    monkeypatch.setattr(shutil, "which", lambda _x: None)
+    result = SsmRunner("i-test", "us-east-1", timeout=5).run("echo hi")
+    assert result.skipped is True
+    assert "aws CLI not found" in result.skip_reason
+
+
+@pytest.mark.unit
+def test_ssm_runner_skips_on_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
+    import subprocess
+
+    from compare_environments import SsmRunner
+
+    monkeypatch.setattr(shutil, "which", lambda _x: "/usr/bin/aws")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: type(
+            "R",
+            (),
+            {"returncode": 255, "stdout": "", "stderr": "ExpiredTokenException"},
+        )(),
+    )
+    result = SsmRunner("i-test", "us-east-1", timeout=5).run("echo hi")
+    assert result.skipped is True
+    assert "SSO session expired" in result.skip_reason
+
+
+@pytest.mark.unit
+def test_ssm_runner_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SsmRunner.run() must return SsmResult on all failure paths, never raise."""
+    import shutil
+
+    from compare_environments import SsmRunner
+
+    monkeypatch.setattr(shutil, "which", lambda _x: "/usr/bin/aws")
+    monkeypatch.setattr(
+        "subprocess.run", lambda *_a, **_kw: (_ for _ in ()).throw(OSError("broken"))
+    )
+    result = SsmRunner("i-test", "us-east-1", timeout=5).run("echo hi")
+    assert result.skipped is True


### PR DESCRIPTION
## Summary

- Adds `SsmResult` dataclass and `SsmRunner` class to `scripts/compare_environments.py`
- SsmRunner is fail-open: always returns `SsmResult`, never raises
- Handles aws CLI not found, `ExpiredTokenException`, `OSError`, and timeout gracefully
- Builds on OMN-4520 scaffold (stack-based PR targeting OMN-4520 branch)

## Risk

Low — adds to new file only. No changes to existing production code.

## Test Evidence

```
test_ssm_runner_skips_when_aws_missing PASSED
test_ssm_runner_skips_on_expired_token PASSED  
test_ssm_runner_never_raises PASSED
4 passed, 0 failures
```

## Rollback

Remove SsmResult/SsmRunner from compare_environments.py.

Linear: OMN-4521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced AWS SSM command execution with comprehensive error handling for token expiration and missing dependencies
  * Extended environment parity checks to include "infisical" validation

* **Tests**
  * Added unit tests for AWS SSM command execution covering timeout and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->