### PR TITLE
feat(scripts): add ECR tag validity check [OMN-4523]

### DIFF
--- a/scripts/compare_environments.py
+++ b/scripts/compare_environments.py
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 # Copyright (c) 2025 OmniNode Team
 """compare-environments.py — local Docker vs k8s environment parity checker.
 
@@ -304,6 +306,138 @@ def probe_infisical_paths(
                     detail=f"Could not reach Infisical at {infisical_addr}: {exc}",
                     auto_fixable=False,
                     fix_hint="Verify INFISICAL_ADDR is set and Infisical is running.",
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# checks — ecr_tag_validity
+# ---------------------------------------------------------------------------
+
+# SSM remote script: emits one JSON object {deployment_name: image_ref}
+_DEPLOYMENT_IMAGE_SCRIPT_TEMPLATE = (
+    'python3 -c "'
+    "import subprocess, json; "
+    "r = subprocess.run(['kubectl','get','deployments','-n','{namespace}',"
+    "  '-o','jsonpath={{range .items[*]}}{{.metadata.name}}={{.spec.template.spec.containers[0].image}}\\\\n{{end}}'],"
+    "  capture_output=True, text=True); "
+    "d = {{}}; "
+    "[d.update({{p.split('=',1)[0].strip(): p.split('=',1)[1].strip()}})"
+    " for p in r.stdout.strip().splitlines() if '=' in p]; "
+    "print(json.dumps(d))"
+    '"'
+)
+
+
+def _ecr_tag_exists(repo: str, tag: str, region: str) -> bool:
+    """Return True if the ECR tag exists in the registry."""
+    r = subprocess.run(
+        [
+            "aws",
+            "ecr",
+            "describe-images",
+            "--repository-name",
+            repo,
+            "--image-ids",
+            f"imageTag={tag}",
+            "--region",
+            region,
+            "--output",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    return r.returncode == 0
+
+
+def _parse_ecr_image(image_ref: str) -> tuple[str, str] | None:
+    """Parse 'registry/repo:tag' → (repo, tag). Returns None if not ECR or no tag."""
+    if ".dkr.ecr." not in image_ref and ".ecr/" not in image_ref:
+        return None
+    if ":" not in image_ref:
+        return None
+    # strip registry prefix: everything after the last '/' before ':'
+    path_part = image_ref.split("/", 1)[-1] if "/" in image_ref else image_ref
+    if ":" not in path_part:
+        return None
+    repo, tag = path_part.rsplit(":", 1)
+    # skip digest-pinned references
+    if tag.startswith("sha256:"):
+        return None
+    return repo, tag
+
+
+def check_ecr_tag_validity(
+    deployments: dict[str, str],
+    region: str,
+) -> list[ModelParityFinding]:
+    """Check that deployment image tags still exist in ECR.
+
+    Scope: primary containers only (spec.template.spec.containers[0]).
+    Does not cover initContainers or digest-pinned references.
+
+    deployments: {deployment_name: image_ref}
+    """
+    findings: list[ModelParityFinding] = []
+
+    if not shutil.which("aws"):
+        for deploy_name, image_ref in deployments.items():
+            findings.append(
+                ModelParityFinding(
+                    check_id="ecr_tag_validity",
+                    severity="INFO",
+                    title=f"ECR check skipped for {deploy_name}",
+                    detail="aws CLI not found — install awscli to enable ECR tag validation",
+                    cloud_value=image_ref,
+                    auto_fixable=False,
+                    fix_hint="Install awscli: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html",
+                )
+            )
+        return findings
+
+    for deploy_name, image_ref in deployments.items():
+        parsed = _parse_ecr_image(image_ref)
+        if parsed is None:
+            # Not an ECR image or digest-pinned — skip silently
+            continue
+        repo, tag = parsed
+        try:
+            exists = _ecr_tag_exists(repo, tag, region)
+        except Exception as exc:
+            findings.append(
+                ModelParityFinding(
+                    check_id="ecr_tag_validity",
+                    severity="INFO",
+                    title=f"ECR check skipped for {deploy_name}",
+                    detail=f"ECR describe-images failed: {exc}",
+                    cloud_value=image_ref,
+                    auto_fixable=False,
+                    fix_hint="Verify aws credentials and ECR access.",
+                )
+            )
+            continue
+
+        if not exists:
+            findings.append(
+                ModelParityFinding(
+                    check_id="ecr_tag_validity",
+                    severity="CRITICAL",
+                    title=f"ECR tag missing for {deploy_name}",
+                    detail=(
+                        f"Image tag '{tag}' for deployment '{deploy_name}' not found"
+                        f" in ECR repo '{repo}'. Active deployment will ErrImagePull on pod restart."
+                    ),
+                    cloud_value=image_ref,
+                    auto_fixable=False,
+                    fix_hint=(
+                        f"Either push a new image with tag '{tag}' to ECR repo '{repo}',"
+                        f" or update the deployment to reference an existing tag."
+                    ),
                 )
             )
 

--- a/tests/unit/scripts/test_compare_environments.py
+++ b/tests/unit/scripts/test_compare_environments.py
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 # Copyright (c) 2025 OmniNode Team
 """Tests for scripts/compare-environments.py — parity checker."""
 
@@ -123,6 +125,39 @@ def test_detects_wrong_postgres_user() -> None:
     assert not any(
         "omnidash" in f.title.lower() and "POSTGRES_USER" in f.title for f in critical
     )
+
+
+@pytest.mark.unit
+def test_detects_missing_ecr_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    from compare_environments import check_ecr_tag_validity
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: type(
+            "R", (), {"returncode": 1, "stderr": "ImageNotFoundException", "stdout": ""}
+        )(),
+    )
+    findings = check_ecr_tag_validity(
+        deployments={
+            "omniintelligence": "123.dkr.ecr.us-east-1.amazonaws.com/omniintelligence:stale"
+        },
+        region="us-east-1",
+    )
+    assert any(f.severity == "CRITICAL" and "stale" in f.detail for f in findings)
+
+
+@pytest.mark.unit
+def test_skips_ecr_check_when_aws_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
+
+    from compare_environments import check_ecr_tag_validity
+
+    monkeypatch.setattr(shutil, "which", lambda _x: None)
+    findings = check_ecr_tag_validity({"svc": "123.ecr/repo:tag"}, region="us-east-1")
+    assert all(f.severity == "INFO" for f in findings)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Implements `check_ecr_tag_validity()` for primary container images only (`spec.template.spec.containers[0]`)
- Does not cover initContainers or digest-pinned (`sha256:`) references
- Adds `_DEPLOYMENT_IMAGE_SCRIPT_TEMPLATE` for SSM remote structured JSON probe
- Adds `_ecr_tag_exists()` via `aws ecr describe-images` subprocess (local call)
- Adds `_parse_ecr_image()` to extract repo+tag from ECR image refs
- Missing ECR tag → CRITICAL finding with ErrImagePull context and fix_hint
- aws CLI not found → INFO skipped for all deployments (not CRITICAL)

## Test Evidence

```
tests/unit/scripts/test_compare_environments.py::test_parity_report_serializes_to_json PASSED
tests/unit/scripts/test_compare_environments.py::test_ssm_runner_skips_when_aws_missing PASSED
tests/unit/scripts/test_compare_environments.py::test_ssm_runner_skips_on_expired_token PASSED
tests/unit/scripts/test_compare_environments.py::test_ssm_runner_never_raises PASSED
tests/unit/scripts/test_compare_environments.py::test_detects_wrong_postgres_user PASSED
tests/unit/scripts/test_compare_environments.py::test_detects_missing_ecr_tag PASSED
tests/unit/scripts/test_compare_environments.py::test_skips_ecr_check_when_aws_missing PASSED
tests/unit/scripts/test_compare_environments.py::test_infisical_path_missing PASSED
8 passed
```

## Risk

Low — additive only, no changes to existing functions or models.

## Rollback

Revert the `check_ecr_tag_validity` function and related helpers from `scripts/compare_environments.py`.

Closes OMN-4523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect missing or stale container image tags in ECR, providing critical alerts when deployment images are unavailable.

* **Tests**
  * Added unit tests for ECR tag validation scenarios, including handling when AWS CLI is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->