### PR TITLE
fix(health): skill-lifecycle-consumer healthy when idle (lag=0) (OMN-4568)

### DIFF
--- a/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
+++ b/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
@@ -641,12 +641,13 @@ class SkillLifecycleConsumer:
     def _build_health_response(self) -> tuple[dict[str, object], int]:
         """Build health check response dict and HTTP status code.
 
-        Idle-aware health (OMN-3784): When the consumer is running and polling
-        Kafka but has never received events (last_successful_write_at is None),
+        Idle-aware health (OMN-3784 / OMN-4568): When the consumer is running
+        and polling Kafka but has no incoming traffic (messages_received == 0),
         it is considered idle — not unhealthy.  Write staleness only applies
-        after the first successful write, because only then does a stale write
-        indicate an actual problem.  Poll staleness always applies since a
-        failure to poll indicates a broken Kafka connection.
+        when the consumer has received messages that should have produced writes;
+        a stale write with zero received messages simply means the consumer is
+        caught up (Kafka lag = 0) and waiting for new events.  Poll staleness
+        always applies since a failure to poll indicates a broken Kafka connection.
 
         Returns:
             Tuple of (response_dict, http_status_code).
@@ -658,8 +659,8 @@ class SkillLifecycleConsumer:
         write_age = (now - last_write).total_seconds() if last_write else None
         poll_age = (now - last_poll).total_seconds() if last_poll else None
 
-        # Determine if consumer is idle (running but never received events)
-        idle = self._running and last_write is None
+        # Idle: running but no messages received since startup (lag=0, caught up)
+        idle = self._running and self.metrics.messages_received == 0
 
         if not self._running:
             status = EnumHealthStatus.UNHEALTHY
@@ -672,11 +673,15 @@ class SkillLifecycleConsumer:
         elif (
             write_age is not None
             and write_age > self.config.health_check_staleness_seconds
+            and self.metrics.messages_received > 0
         ):
-            # Has written before but writes are stale — downstream problem
+            # Has written before, writes are stale, AND messages have been received
+            # since startup — traffic that should have produced writes is not being
+            # written (downstream problem).  An idle consumer (lag=0, no messages
+            # received) is HEALTHY regardless of write age (OMN-4568).
             status = EnumHealthStatus.DEGRADED
         else:
-            # Either idle (no writes ever, but polling OK) or actively healthy
+            # Idle (lag=0, no messages received, polls current) or actively healthy
             status = EnumHealthStatus.HEALTHY
 
         http_code = 200 if status == EnumHealthStatus.HEALTHY else 503

--- a/tests/unit/services/observability/skill_lifecycle/test_consumer.py
+++ b/tests/unit/services/observability/skill_lifecycle/test_consumer.py
@@ -354,6 +354,10 @@ class TestHealthResponse:
     OMN-3784: Idle-aware health check — consumer reports HEALTHY when idle
     (connected to Kafka, polling, but no events received yet), and only
     reports DEGRADED for actual failures.
+
+    OMN-4568: Caught-up health check — consumer reports HEALTHY when it has
+    written before but Kafka lag is 0 (messages_received == 0 since startup),
+    even if write_age exceeds the staleness threshold.
     """
 
     @pytest.mark.unit
@@ -363,6 +367,7 @@ class TestHealthResponse:
         consumer._running = True
         now = datetime.now(UTC)
         consumer.metrics.last_successful_write_at = now
+        consumer.metrics.messages_received = 5
         consumer.metrics.last_poll_at = now
 
         response, status_code = consumer._build_health_response()
@@ -391,18 +396,48 @@ class TestHealthResponse:
 
     @pytest.mark.unit
     def test_degraded_when_stale_writes(self) -> None:
-        """Returns DEGRADED when last write exceeds staleness threshold."""
+        """Returns DEGRADED when last write exceeds staleness threshold AND messages received.
+
+        OMN-4568: The stale-write DEGRADED path requires messages_received > 0 to
+        distinguish an active-but-broken pipeline from an idle caught-up consumer.
+        """
         consumer = _make_consumer()
         consumer._running = True
         # Set last write to far in the past
         stale_time = datetime(2020, 1, 1, tzinfo=UTC)
         consumer.metrics.last_successful_write_at = stale_time
         consumer.metrics.last_poll_at = datetime.now(UTC)
+        # Messages were received but not written — write pipeline is broken
+        consumer.metrics.messages_received = 10
 
         response, status_code = consumer._build_health_response()
 
         assert response["status"] == str(EnumHealthStatus.DEGRADED)
         assert status_code == 503
+
+    @pytest.mark.unit
+    def test_healthy_when_caught_up_no_new_messages(self) -> None:
+        """Returns HEALTHY when last write is stale but no messages received (lag=0).
+
+        OMN-4568: Core fix. When the consumer has fully caught up (Kafka lag = 0,
+        messages_received == 0 since startup) and is actively polling, write staleness
+        does NOT indicate a problem — there is simply no traffic to write.
+        Previously this returned DEGRADED (503).
+        """
+        consumer = _make_consumer()
+        consumer._running = True
+        # Last write was long ago (consumer processed events then went idle)
+        stale_time = datetime(2020, 1, 1, tzinfo=UTC)
+        consumer.metrics.last_successful_write_at = stale_time
+        consumer.metrics.last_poll_at = datetime.now(UTC)
+        # No messages received since startup — consumer is caught up (lag=0)
+        consumer.metrics.messages_received = 0
+
+        response, status_code = consumer._build_health_response()
+
+        assert response["status"] == str(EnumHealthStatus.HEALTHY)
+        assert status_code == 200
+        assert response["idle"] is True
 
     @pytest.mark.unit
     def test_unhealthy_when_not_running(self) -> None:
@@ -472,11 +507,16 @@ class TestHealthResponse:
 
     @pytest.mark.unit
     def test_not_idle_after_first_write(self) -> None:
-        """Consumer is not idle once it has processed at least one event."""
+        """Consumer is not idle once it has processed at least one event (OMN-4568).
+
+        idle is True only when messages_received == 0. Once messages have been
+        received and processed, the consumer is active — not idle.
+        """
         consumer = _make_consumer()
         consumer._running = True
         now = datetime.now(UTC)
         consumer.metrics.last_successful_write_at = now
+        consumer.metrics.messages_received = 3
         consumer.metrics.last_poll_at = now
 
         response, _ = consumer._build_health_response()


### PR DESCRIPTION
## Summary

- `_build_health_response()` was marking the consumer `DEGRADED` (→ 503) whenever `write_age > health_check_staleness_seconds (300s)`, even when `messages_received == 0` (consumer caught up, Kafka lag = 0, no new traffic since last write).
- Fix: gate the stale-write DEGRADED check on `messages_received > 0`. Zero messages received = idle/caught-up consumer = HEALTHY regardless of write age.
- Updated the `idle` flag definition from `last_write is None` to `messages_received == 0` to accurately reflect the caught-up state.

## Root Cause

When a consumer processes all pending events and catches up to the Kafka partition head, `last_successful_write_at` drifts past the 300s staleness window with no new writes to refresh it. The previous code had no path for "idle + lag=0 = healthy" — it fired DEGRADED purely on write age.

## Changes

`src/omnibase_infra/services/observability/skill_lifecycle/consumer.py`
- Added `and self.metrics.messages_received > 0` to the stale-write DEGRADED branch
- Updated `idle` definition: `messages_received == 0` (not just `last_write is None`)
- Updated docstring with OMN-4568 reference

`tests/unit/services/observability/skill_lifecycle/test_consumer.py`
- Added `test_healthy_when_caught_up_no_new_messages`: stale write + lag=0 → HEALTHY (the exact failing scenario)
- Updated `test_degraded_when_stale_writes`: now sets `messages_received = 10` to exercise the write-pipeline-broken path correctly
- Updated `test_healthy_when_running_and_recent_writes` and `test_not_idle_after_first_write`: set `messages_received > 0` to align with new `idle` definition

## Test Plan

- [ ] `pytest tests/unit/services/observability/skill_lifecycle/test_consumer.py -v -m unit` — all 31 tests pass
- [ ] New test `test_healthy_when_caught_up_no_new_messages` covers the exact 503-when-idle scenario

Closes OMN-4568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced health monitoring to better track message consumption and idle states.
  * Improved accuracy of application health status determination based on updated metrics evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->