### PR TITLE
fix(skill-lifecycle): treat caught-up idle consumer as healthy (OMN-4586)

### DIFF
--- a/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
+++ b/src/omnibase_infra/services/observability/skill_lifecycle/consumer.py
@@ -641,12 +641,28 @@ class SkillLifecycleConsumer:
     def _build_health_response(self) -> tuple[dict[str, object], int]:
         """Build health check response dict and HTTP status code.
 
-        Idle-aware health (OMN-3784): When the consumer is running and polling
-        Kafka but has never received events (last_successful_write_at is None),
-        it is considered idle — not unhealthy.  Write staleness only applies
-        after the first successful write, because only then does a stale write
-        indicate an actual problem.  Poll staleness always applies since a
-        failure to poll indicates a broken Kafka connection.
+        Idle-aware health (OMN-3784, OMN-4586): The only reliable signal that
+        the consumer is broken is poll staleness — if it stops polling Kafka,
+        the Kafka connection is gone and the consumer cannot make progress.
+
+        Write staleness alone is NOT a reliable degraded signal because a
+        healthy consumer that has consumed all available events will not write
+        until new events arrive. Treating write staleness as degraded causes
+        false 503s on low-traffic topics where the consumer is caught up
+        (LAG=0) but the readiness probe sees no writes in the last 5 minutes.
+
+        Health classification:
+            UNHEALTHY  — consumer is not running (stopped/crashed)
+            DEGRADED   — poll is stale or missing (Kafka connection broken)
+            HEALTHY    — running and polling; idle if no writes yet or caught up
+
+        The ``idle`` flag distinguishes two HEALTHY sub-states:
+            idle=True  — polling OK, no successful writes ever or since startup
+            idle=False — polling OK, at least one write completed this session
+
+        Poll staleness always applies because a failure to poll indicates a
+        broken Kafka connection. Write staleness is recorded in the response
+        for observability but does not affect the health status code.
 
         Returns:
             Tuple of (response_dict, http_status_code).
@@ -658,8 +674,20 @@ class SkillLifecycleConsumer:
         write_age = (now - last_write).total_seconds() if last_write else None
         poll_age = (now - last_poll).total_seconds() if last_poll else None
 
-        # Determine if consumer is idle (running but never received events)
-        idle = self._running and last_write is None
+        # Determine if consumer is idle (HEALTHY sub-state — no degradation).
+        # Two idle cases:
+        # 1. Never written (last_write is None) — no events received yet
+        # 2. Caught-up idle — previously written, polls are fresh, but writes
+        #    are stale (LAG=0, consumer consumed all available events)
+        idle = self._running and (
+            last_write is None
+            or (
+                write_age is not None
+                and write_age > self.config.health_check_staleness_seconds
+                and poll_age is not None
+                and poll_age <= self.config.health_check_poll_staleness_seconds
+            )
+        )
 
         if not self._running:
             status = EnumHealthStatus.UNHEALTHY
@@ -669,14 +697,8 @@ class SkillLifecycleConsumer:
         ):
             # No polls at all, or polls are stale — Kafka connection problem
             status = EnumHealthStatus.DEGRADED
-        elif (
-            write_age is not None
-            and write_age > self.config.health_check_staleness_seconds
-        ):
-            # Has written before but writes are stale — downstream problem
-            status = EnumHealthStatus.DEGRADED
         else:
-            # Either idle (no writes ever, but polling OK) or actively healthy
+            # Polling is healthy — consumer is either actively writing or idle/caught up
             status = EnumHealthStatus.HEALTHY
 
         http_code = 200 if status == EnumHealthStatus.HEALTHY else 503

--- a/tests/unit/services/observability/skill_lifecycle/test_consumer.py
+++ b/tests/unit/services/observability/skill_lifecycle/test_consumer.py
@@ -390,19 +390,25 @@ class TestHealthResponse:
         assert response["idle"] is True
 
     @pytest.mark.unit
-    def test_degraded_when_stale_writes(self) -> None:
-        """Returns DEGRADED when last write exceeds staleness threshold."""
+    def test_healthy_when_caught_up_idle(self) -> None:
+        """Returns HEALTHY (200) when consumer has written before but is caught up.
+
+        OMN-4586: The consumer is polling fine (LAG=0, no new events) but
+        last_successful_write_at is stale. This is caught-up idle — not degraded.
+        Write staleness alone is not a degraded signal; only poll staleness is.
+        """
         consumer = _make_consumer()
         consumer._running = True
-        # Set last write to far in the past
+        # Last write was long ago (e.g., 24h — consumed all available events)
         stale_time = datetime(2020, 1, 1, tzinfo=UTC)
         consumer.metrics.last_successful_write_at = stale_time
-        consumer.metrics.last_poll_at = datetime.now(UTC)
+        consumer.metrics.last_poll_at = datetime.now(UTC)  # Polling is healthy
 
         response, status_code = consumer._build_health_response()
 
-        assert response["status"] == str(EnumHealthStatus.DEGRADED)
-        assert status_code == 503
+        assert response["status"] == str(EnumHealthStatus.HEALTHY)
+        assert status_code == 200
+        assert response["idle"] is True  # Caught-up idle
 
     @pytest.mark.unit
     def test_unhealthy_when_not_running(self) -> None:


### PR DESCRIPTION
## Summary

Fixes `omninode-skill-lifecycle-consumer` permanently stuck at `0/1 Ready` due to a false 503 on the readiness probe.

### Root Cause

The health check in `_build_health_response` treated **write staleness** as a degraded signal. After the consumer successfully consumed all available events (LAG=0), `last_successful_write_at` became stale (>300s). The readiness probe saw 503/DEGRADED even though Kafka polling was healthy, the circuit breaker was closed, and the consumer had nothing new to write.

Investigation via SSM showed:
- `poll_age_seconds: 0.01` — actively polling Kafka
- `write_age_seconds: 88779` — last write ~24.6h ago  
- `circuit_breaker: {"state": "closed", "failures": 0}` — Postgres healthy
- Consumer group `skill-lifecycle-postgres`: TOTAL-LAG=0 on both topics

The consumer was fully healthy; the health check logic was wrong.

### Fix

Remove write-staleness-as-degraded signal. Poll staleness is the only reliable indicator of Kafka connectivity failure. Introduce **caught-up idle** as a HEALTHY sub-state (`idle=True`): consumer previously wrote, polls are fresh, writes are stale (LAG=0, nothing new to write).

**Health classification after this fix:**
| State | Status | HTTP |
|-------|--------|------|
| Not running | UNHEALTHY | 503 |
| Poll stale/missing | DEGRADED | 503 |
| Polling OK, writing | HEALTHY (idle=False) | 200 |
| Polling OK, no new events | HEALTHY (idle=True) | 200 |

### Changed Files

- `src/omnibase_infra/services/observability/skill_lifecycle/consumer.py` — updated `_build_health_response` health classification logic and docstring
- `tests/unit/services/observability/skill_lifecycle/test_consumer.py` — replaced `test_degraded_when_stale_writes` with `test_healthy_when_caught_up_idle` (30/30 tests pass)

### Definition of Done

- [x] Health endpoint returns 200 on readiness probe (fix deployed to k8s will resolve `0/1` → `1/1 Ready`)
- [x] Root cause documented: write-staleness false-positive in `_build_health_response` (not missing secret, not Kafka topic issue — topics existed and were fully consumed)
- [x] Fix applied with updated unit tests
- [x] All 66 unit tests pass, all pre-commit hooks pass, mypy passes

### TCB Notes

No TCB suggestions used (fresh investigation via SSM/kubectl directly on the failing pod).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced health status reporting with explicit classifications and idle state indicators for improved service observability.

* **Bug Fixes**
  * Improved health determination logic to better detect connectivity issues through poll-based monitoring.
  * Write staleness is now tracked separately for observability without affecting overall health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->