### PR TITLE
feat(topics): add extract_from_skill_manifests + extend extract_all [OMN-4593]

### DIFF
--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -384,31 +384,132 @@ class ContractTopicExtractor:
 
         return sorted(accumulated.values(), key=lambda e: e.topic)
 
+    def extract_from_skill_manifests(
+        self, skills_root: Path
+    ) -> list[ModelContractTopicEntry]:
+        """Extract topics from omniclaude skill topics.yaml manifests.
+
+        Recursively scans *skills_root* for ``topics.yaml`` files in direct
+        child directories (one level deep). Skip directories whose names start
+        with ``_`` or ``__`` (e.g. ``_lib``, ``_shared``, ``__pycache__``).
+
+        Each ``topics.yaml`` is expected to contain a ``topics:`` list of
+        ONEX topic strings. Malformed topics are warned and skipped (no crash).
+        Duplicate topics across multiple manifests are deduplicated (sources
+        merged).
+
+        Args:
+            skills_root: Path to the omniclaude ``plugins/onex/skills/`` directory.
+
+        Returns:
+            Sorted (by topic string), deduplicated list of
+            :class:`ModelContractTopicEntry` objects.
+
+        Raises:
+            RuntimeError: If the same topic string yields inconsistent parsed
+                components across files (implies a parser bug).
+
+        Ticket: OMN-4593
+        """
+        accumulated: dict[str, ModelContractTopicEntry] = {}
+
+        if not skills_root.is_dir():
+            _warn(
+                f"skills_root {skills_root} is not a directory — "
+                "extract_from_skill_manifests returns empty list"
+            )
+            return []
+
+        for skill_dir in sorted(skills_root.iterdir()):
+            # Only process direct child directories; skip _ / __ prefixes
+            if not skill_dir.is_dir():
+                continue
+            if skill_dir.name.startswith("_") or skill_dir.name.startswith("__"):
+                continue
+
+            topics_yaml = skill_dir / "topics.yaml"
+            if not topics_yaml.exists():
+                continue
+
+            try:
+                with topics_yaml.open(encoding="utf-8") as fh:
+                    data = yaml.safe_load(fh)
+            except Exception as exc:
+                _warn(f"Could not parse {topics_yaml}: {exc} — skipping")
+                continue
+
+            if not isinstance(data, dict):
+                _warn(f"topics.yaml is not a mapping: {topics_yaml} — skipping")
+                continue
+
+            raw_topics = data.get("topics")
+            if not isinstance(raw_topics, list):
+                _warn(f"topics.yaml missing 'topics' list: {topics_yaml} — skipping")
+                continue
+
+            for raw in raw_topics:
+                if not isinstance(raw, str) or not raw.strip():
+                    _warn(f"Skipping non-string or empty topic entry in {topics_yaml}")
+                    continue
+
+                entry = _parse_topic(raw.strip(), topics_yaml)
+                if entry is None:
+                    # Malformed — warned inside _parse_topic
+                    continue
+
+                if raw in accumulated:
+                    existing = accumulated[raw]
+                    if (
+                        existing.kind != entry.kind
+                        or existing.producer != entry.producer
+                        or existing.event_name != entry.event_name
+                        or existing.version != entry.version
+                    ):
+                        _error(
+                            f"Inconsistent parsed components for topic {raw!r}: "
+                            f"first seen in {existing.source_contracts[0]}, "
+                            f"now in {topics_yaml}. This implies a parser bug."
+                        )
+                    accumulated[raw] = existing.merge_sources(entry)
+                else:
+                    accumulated[raw] = entry
+
+        return sorted(accumulated.values(), key=lambda e: e.topic)
+
     def extract_all(
         self,
         contracts_root: Path,
         supplementary_sources: list[Path] | None = None,
+        skill_manifests_root: Path | None = None,
     ) -> list[ModelContractTopicEntry]:
-        """Extract topics from contracts AND supplementary Python sources.
+        """Extract topics from contracts AND supplementary Python sources AND skill manifests.
 
-        Combines results from contract.yaml scanning and Python source file
-        scanning into a single deduplicated list. Topics appearing in both
-        sources are merged (source_contracts combined).
+        Combines results from contract.yaml scanning, Python source file
+        scanning, and omniclaude skill manifest scanning into a single
+        deduplicated list. Topics appearing in multiple sources are merged
+        (source_contracts combined).
 
         This is the recommended entry point for the generation pipeline
-        (OMN-3254) to ensure all topics -- whether declared in contracts
-        or hardcoded in Python constants -- appear in the generated enums.
+        (OMN-3254, OMN-4593) to ensure all topics -- whether declared in
+        contracts, hardcoded in Python constants, or declared in skill
+        topics.yaml manifests -- appear in the generated enums.
 
         Args:
             contracts_root: Directory to scan for contract.yaml files.
             supplementary_sources: Optional list of Python files to scan
                 for additional topic constants.
+            skill_manifests_root: Optional path to omniclaude
+                ``plugins/onex/skills/`` directory. When set, skill
+                ``topics.yaml`` manifests are discovered and merged.
+                When ``None``, skill manifest discovery is skipped.
 
         Returns:
             Sorted, deduplicated list of ModelContractTopicEntry objects.
 
         Raises:
             RuntimeError: On inconsistent parsed components.
+
+        Ticket: OMN-4593
         """
         # Start with contract-derived topics
         contract_entries = self.extract(contracts_root)
@@ -416,7 +517,7 @@ class ContractTopicExtractor:
             e.topic: e for e in contract_entries
         }
 
-        # Merge supplementary sources
+        # Merge supplementary Python sources (legacy path, OMN-3254)
         if supplementary_sources:
             supplementary_entries = self.extract_from_python_sources(
                 supplementary_sources
@@ -424,7 +525,16 @@ class ContractTopicExtractor:
             for entry in supplementary_entries:
                 if entry.topic in accumulated:
                     existing = accumulated[entry.topic]
-                    # Same topic from both contract and Python source — merge sources
+                    accumulated[entry.topic] = existing.merge_sources(entry)
+                else:
+                    accumulated[entry.topic] = entry
+
+        # Merge skill manifest topics (OMN-4593)
+        if skill_manifests_root is not None:
+            skill_entries = self.extract_from_skill_manifests(skill_manifests_root)
+            for entry in skill_entries:
+                if entry.topic in accumulated:
+                    existing = accumulated[entry.topic]
                     accumulated[entry.topic] = existing.merge_sources(entry)
                 else:
                     accumulated[entry.topic] = entry

--- a/tests/unit/tools/test_contract_topic_extractor_yaml.py
+++ b/tests/unit/tools/test_contract_topic_extractor_yaml.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TDD tests for ContractTopicExtractor skill manifest support.
+
+Tests for:
+  - extract_from_skill_manifests(skills_root: Path) -> list[ModelContractTopicEntry]
+  - extract_all(contracts_root, skill_manifests_root=None) overload
+
+Ticket: OMN-4593
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.tools.contract_topic_extractor import (
+    ContractTopicExtractor,
+    ModelContractTopicEntry,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path) -> Path:
+    """Create a minimal fake skills root with topics.yaml files."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Skill A — 3 valid topics
+    skill_a = root / "epic-team"
+    skill_a.mkdir()
+    (skill_a / "topics.yaml").write_text(
+        textwrap.dedent(
+            """\
+            topics:
+              - onex.cmd.omniclaude.epic-team.v1
+              - onex.evt.omniclaude.epic-team-completed.v1
+              - onex.evt.omniclaude.epic-team-failed.v1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Skill B — 3 valid topics
+    skill_b = root / "ticket-pipeline"
+    skill_b.mkdir()
+    (skill_b / "topics.yaml").write_text(
+        textwrap.dedent(
+            """\
+            topics:
+              - onex.cmd.omniclaude.ticket-pipeline.v1
+              - onex.evt.omniclaude.ticket-pipeline-completed.v1
+              - onex.evt.omniclaude.ticket-pipeline-failed.v1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Skip dir — should be ignored
+    skip_lib = root / "_lib"
+    skip_lib.mkdir()
+    (skip_lib / "topics.yaml").write_text(
+        "topics:\n  - onex.cmd.omniclaude.should-not-appear.v1\n",
+        encoding="utf-8",
+    )
+
+    return root
+
+
+@pytest.fixture
+def skills_root_with_malformed(tmp_path: Path) -> Path:
+    """Skills root containing one malformed topic — should warn+skip, not crash."""
+    root = tmp_path / "skills_malformed"
+    root.mkdir()
+
+    skill = root / "good-skill"
+    skill.mkdir()
+    (skill / "topics.yaml").write_text(
+        textwrap.dedent(
+            """\
+            topics:
+              - onex.cmd.omniclaude.good-skill.v1
+              - onex.INVALID.omniclaude.good-skill-completed.v1
+              - onex.evt.omniclaude.good-skill-failed.v1
+            """
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Test 1: extract_from_skill_manifests returns correct entries from valid files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_from_skill_manifests_returns_valid_entries(skills_root: Path) -> None:
+    """extract_from_skill_manifests discovers topics.yaml in all non-skip skill dirs."""
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_skill_manifests(skills_root)
+
+    topics = {e.topic for e in entries}
+
+    # Should find 6 topics (3 per skill, 2 non-skip skills)
+    assert len(entries) == 6, (
+        f"Expected 6 entries, got {len(entries)}: {[e.topic for e in entries]}"
+    )
+
+    # Both skills present
+    assert "onex.cmd.omniclaude.epic-team.v1" in topics
+    assert "onex.evt.omniclaude.epic-team-completed.v1" in topics
+    assert "onex.evt.omniclaude.epic-team-failed.v1" in topics
+    assert "onex.cmd.omniclaude.ticket-pipeline.v1" in topics
+    assert "onex.evt.omniclaude.ticket-pipeline-completed.v1" in topics
+    assert "onex.evt.omniclaude.ticket-pipeline-failed.v1" in topics
+
+    # _lib topics must NOT appear
+    assert "onex.cmd.omniclaude.should-not-appear.v1" not in topics
+
+    # All entries have correct kind
+    for entry in entries:
+        assert entry.kind in ("cmd", "evt"), f"Unexpected kind {entry.kind!r}"
+        assert entry.producer == "omniclaude"
+
+    # Result is sorted by topic string
+    sorted_topics = sorted(e.topic for e in entries)
+    assert [e.topic for e in entries] == sorted_topics
+
+
+# ---------------------------------------------------------------------------
+# Test 2: malformed topics are warned and skipped, not raised
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_from_skill_manifests_warns_and_skips_malformed(
+    skills_root_with_malformed: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed topics in topics.yaml produce a WARNING on stderr and are skipped."""
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_skill_manifests(skills_root_with_malformed)
+
+    topics = {e.topic for e in entries}
+
+    # Valid topics should be present
+    assert "onex.cmd.omniclaude.good-skill.v1" in topics
+    assert "onex.evt.omniclaude.good-skill-failed.v1" in topics
+
+    # Malformed topic must be absent
+    assert not any("INVALID" in t for t in topics), "Malformed topic should be skipped"
+
+    # A warning should have been emitted
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err or "WARNING" in captured.out, (
+        "Expected a WARNING for the malformed topic"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: deduplication — same topic in multiple skills.yaml is merged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_from_skill_manifests_deduplicates(tmp_path: Path) -> None:
+    """Same topic string appearing in two skills is deduplicated into one entry."""
+    root = tmp_path / "skills_dup"
+    root.mkdir()
+
+    for skill_name in ("skill-a", "skill-b"):
+        d = root / skill_name
+        d.mkdir()
+        (d / "topics.yaml").write_text(
+            "topics:\n  - onex.cmd.omniclaude.shared-topic.v1\n",
+            encoding="utf-8",
+        )
+
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_skill_manifests(root)
+
+    shared = [e for e in entries if e.topic == "onex.cmd.omniclaude.shared-topic.v1"]
+    assert len(shared) == 1, "Duplicate topic should be deduplicated to 1 entry"
+    # Source contracts should reference both files
+    assert len(shared[0].source_contracts) == 2, (
+        "Deduplicated entry should have both source files"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: extract_all with skill_manifests_root combines contract + skill topics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_all_with_skill_manifests_root_combines_sources(
+    tmp_path: Path,
+    skills_root: Path,
+) -> None:
+    """extract_all(contracts_root, skill_manifests_root=...) unions both sources."""
+    # Create a minimal contracts_root with one contract.yaml
+    contracts_root = tmp_path / "nodes"
+    contracts_root.mkdir()
+    node_dir = contracts_root / "node_example_effect"
+    node_dir.mkdir()
+    (node_dir / "contract.yaml").write_text(
+        textwrap.dedent(
+            """\
+            event_bus:
+              publish_topics:
+                - onex.evt.platform.example-event.v1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_all(
+        contracts_root=contracts_root,
+        skill_manifests_root=skills_root,
+    )
+
+    topics = {e.topic for e in entries}
+
+    # Contract topic present
+    assert "onex.evt.platform.example-event.v1" in topics
+
+    # Skill manifest topics present (from skills_root fixture — 2 skills, 6 topics)
+    assert "onex.cmd.omniclaude.epic-team.v1" in topics
+    assert "onex.cmd.omniclaude.ticket-pipeline.v1" in topics
+
+    # _lib topic absent
+    assert "onex.cmd.omniclaude.should-not-appear.v1" not in topics
+
+    # Sorted and deduplicated
+    sorted_topics = sorted(e.topic for e in entries)
+    assert [e.topic for e in entries] == sorted_topics
+
+    # When skill_manifests_root=None, only contract topics returned
+    entries_no_skills = extractor.extract_all(
+        contracts_root=contracts_root,
+        skill_manifests_root=None,
+    )
+    topics_no_skills = {e.topic for e in entries_no_skills}
+    assert "onex.evt.platform.example-event.v1" in topics_no_skills
+    assert "onex.cmd.omniclaude.epic-team.v1" not in topics_no_skills


### PR DESCRIPTION
## Summary

- Adds `ContractTopicExtractor.extract_from_skill_manifests(skills_root: Path)` — scans `plugins/onex/skills/<skill>/topics.yaml` files, warns+skips malformed topics, deduplicates
- Extends `ContractTopicExtractor.extract_all()` with new optional `skill_manifests_root: Path | None` — combines contract + Python source + skill manifest topics into one deduplicated list
- Fully backwards-compatible: callers without the new `skill_manifests_root` arg get identical behavior

## TDD

All 4 tests written before implementation, verified failing, then passing:

```
tests/unit/tools/test_contract_topic_extractor_yaml.py::test_extract_from_skill_manifests_returns_valid_entries PASSED
tests/unit/tools/test_contract_topic_extractor_yaml.py::test_extract_from_skill_manifests_warns_and_skips_malformed PASSED
tests/unit/tools/test_contract_topic_extractor_yaml.py::test_extract_from_skill_manifests_deduplicates PASSED
tests/unit/tools/test_contract_topic_extractor_yaml.py::test_extract_all_with_skill_manifests_root_combines_sources PASSED
```

## Test plan

- [x] 4 new unit tests pass
- [x] Existing `extract()` and `extract_from_python_sources()` behavior unchanged
- [x] `pre-commit run --all-files` passes (all ONEX hooks including SPDX, arch validation, topic naming)
- [x] `extract_all(contracts_root, skill_manifests_root=None)` returns only contract topics (backwards compat)

## Related

- Part of epic OMN-4590 (Contract-Driven Topic Registry)
- Unblocks OMN-4594 (Wire TopicProvisioner)
- Unblocks OMN-4595 (--skills-root CLI flag)
- Unblocks OMN-4596 (Replace count-based tests)
- Unblocks OMN-4600 (CI parity gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Topic extraction pipeline now supports discovering and extracting topics from skill manifests alongside contracts and supplementary sources.

* **Tests**
  * Added comprehensive unit tests for skill manifest topic extraction, including malformed topic handling, deduplication across manifests, and integration with the overall extraction pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->