### PR TITLE
docs(env): document OMNICLAUDE_SKILLS_ROOT in env-example-full.txt [OMN-4599]

### DIFF
--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -231,6 +231,15 @@ POSTGRES_ADAPTER_PORT=18085
 # Example: ./contracts, /app/contracts, /etc/onex/contracts
 # ONEX_CONTRACTS_DIR=./contracts
 
+# Path to omniclaude skills root for cross-repo topic discovery (OMN-4597)
+# When set, TopicProvisioner scans topics.yaml files under this path and merges
+# the discovered skill topics into the provisioned topic set at runtime startup.
+# Default: unset (skill-manifest discovery disabled)
+# Local dev example: /Volumes/PRO-G40/Code/omni_home/omniclaude/plugins/onex/skills
+# Docker example: /app/omniclaude/plugins/onex/skills (if omniclaude is volume-mounted)
+# Leave unset if omniclaude is not co-located or skill topics are not needed.
+# OMNICLAUDE_SKILLS_ROOT=/path/to/omniclaude/plugins/onex/skills
+
 # Environment name: local, development, staging, production
 # Default: local
 # Example: local (development), staging (pre-prod), production (live)


### PR DESCRIPTION
## Summary

Adds documentation for `OMNICLAUDE_SKILLS_ROOT` to `docs/env-example-full.txt` — the env var wired in OMN-4597 that enables cross-repo skill topic discovery at runtime.

Placed alongside `ONEX_CONTRACTS_DIR` for discoverability.

## Test plan

- [ ] `docs/env-example-full.txt` contains `OMNICLAUDE_SKILLS_ROOT` with example values and description
- [ ] pre-commit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional environment variable enabling cross-repository skill topic discovery during startup
  * Provides configuration examples for both local and Docker deployments
  * Feature disabled by default with optional setup

* **Documentation**
  * Expanded environment configuration documentation with new variable specifications and usage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->