### PR TITLE
fix(migrations): backfill NULL checksums + enforce NOT NULL on schema_migrations [OMN-4701]

### DIFF
--- a/docker/migrations/forward/051_backfill_schema_migration_checksums.sql
+++ b/docker/migrations/forward/051_backfill_schema_migration_checksums.sql
@@ -2,10 +2,10 @@
 -- MIGRATION: Backfill NULL checksums and enforce NOT NULL on schema_migrations
 -- =============================================================================
 -- Ticket: OMN-4701 (OMN-4653 root cause fix)
--- Version: 1.0.0
+-- Version: 1.1.0
 --
 -- PURPOSE:
---   The live omnibase_infra DB has 22 NULL checksum rows in schema_migrations.
+--   The live omnibase_infra DB has NULL checksum rows in schema_migrations.
 --   These rows were applied before checksum tracking was implemented (the bash
 --   runner used nullable DDL, contradicting the Python runner's NOT NULL spec).
 --
@@ -14,22 +14,50 @@
 --      identifiable as pre-checksum-era rows.
 --   2. Enforces NOT NULL on the checksum column to prevent future nulls.
 --
+-- SCHEMA COMPATIBILITY NOTE:
+--   The live DB (created by the bash runner) uses column "version" as PK.
+--   The CI test DB (which applies all migrations in order) uses "migration_id"
+--   as PK, per migration 036_create_schema_migrations.sql.
+--   This migration adapts to whichever column name is present.
+--
 -- SAFETY:
 --   Wrapped in a transaction. Idempotent: UPDATE only touches NULL rows.
 --   ALTER TABLE SET NOT NULL is safe once all rows have a non-null checksum.
 --
 -- ROLLBACK:
---   See rollback/rollback_045_backfill_schema_migration_checksums.sql
+--   See rollback/rollback_051_backfill_schema_migration_checksums.sql
 -- =============================================================================
 
 BEGIN;
 
 -- Step 1: Backfill all NULL checksum rows with a stable sentinel value.
 -- The prefix "backfilled:pre-checksum-era:" identifies rows patched by
--- this migration. The suffix is the version for traceability.
-UPDATE public.schema_migrations
-SET checksum = 'backfilled:pre-checksum-era:' || version
-WHERE checksum IS NULL;
+-- this migration. Handles both "version" (bash runner schema) and
+-- "migration_id" (migration 036 schema) column names.
+DO $$
+DECLARE
+  id_col TEXT;
+BEGIN
+  -- Detect which primary key column name this schema uses.
+  SELECT column_name INTO id_col
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name   = 'schema_migrations'
+    AND column_name IN ('version', 'migration_id')
+  LIMIT 1;
+
+  IF id_col IS NULL THEN
+    RAISE NOTICE 'schema_migrations has neither version nor migration_id column — skipping backfill';
+  ELSE
+    EXECUTE format(
+      'UPDATE public.schema_migrations SET checksum = ''backfilled:pre-checksum-era:'' || %I WHERE checksum IS NULL',
+      id_col
+    );
+    GET DIAGNOSTICS id_col = ROW_COUNT;
+    RAISE NOTICE 'Backfilled % NULL checksum rows', id_col;
+  END IF;
+END;
+$$;
 
 -- Step 2: Enforce NOT NULL now that all rows have a value.
 ALTER TABLE public.schema_migrations

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:43b9fbed216c09dbca71ea5897fd8851c8da03be45fab8f7066c798865bc212d
-generated_at: 2026-03-12T18:50:43Z
+sha256:d12dbb972f08bb7f9ede1eaba37f9a65d442e049e0f01937af349dc63c96007c
+generated_at: 2026-03-12T18:50:48Z
 migration_file_count: 31


### PR DESCRIPTION
## Summary

- Adds migration `051_backfill_schema_migration_checksums.sql` to backfill 22 NULL `checksum` rows in the live `omnibase_infra.schema_migrations` table
- Enforces `NOT NULL` on the `checksum` column after backfill
- Root cause: bash runner used nullable DDL; Python runner spec says `NOT NULL` — this migration closes the gap

### What the migration does

1. `UPDATE ... SET checksum = 'backfilled:pre-checksum-era:' || migration_id WHERE checksum IS NULL` — idempotent sentinel prefix
2. `ALTER TABLE ... ALTER COLUMN checksum SET NOT NULL` — enforces the contract going forward
3. Adds `COMMENT` documenting backfill date and ticket

## Dependency

Must land **before** OMN-4702 (DDL standardization / bash runner NOT NULL enforcement).

## Risk

LOW — wrapped in a transaction, idempotent UPDATE, no schema changes that affect runtime behavior. The `schema_migrations` table is internal bookkeeping only.

## Test Evidence

Pre-commit hooks pass (migration sequence check, freeze check, writer-migration coupling).

## Rollback

See `rollback/rollback_051_backfill_schema_migration_checksums.sql` (to be added if needed — the backfill is safe to leave in place even if this ticket is reverted, as it only affects NULL rows).

Linear: OMN-4701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backfilled missing migration checksum values for legacy records and enforced checksums as required for all recorded migrations.
  * Added documentation describing the checksum contract, backfill context, and rollback/safety notes.
  * Updated migration metadata fingerprint, migration count, and generation timestamp to reflect the new migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->