### PR TITLE
fix(migrations): create role_omniweb with DML grants for omniweb tables [OMN-4700]

### DIFF
--- a/docker/migrations/forward/052_create_role_omniweb.sql
+++ b/docker/migrations/forward/052_create_role_omniweb.sql
@@ -2,7 +2,7 @@
 -- MIGRATION: Create role_omniweb and grant table permissions
 -- =============================================================================
 -- Ticket: OMN-4700 (omniweb-migrate P0 connectivity fix)
--- Version: 1.0.0
+-- Version: 1.1.0
 --
 -- PURPOSE:
 --   omniweb-migrate currently uses the postgres superuser from
@@ -15,6 +15,14 @@
 --      (kubectl patch — see PR description for the operator command)
 --   2. Update omniweb-migrate.yaml to use role_omniweb instead of postgres
 --      (done in the companion omninode_infra PR)
+--
+-- NOTE ON TABLE GRANTS:
+--   waitlist_signups and admin_events_log are managed by omniweb's own
+--   migrations (not omnibase_infra). The GRANTs are wrapped in conditional
+--   DO blocks so this migration is safe to run even when those tables do not
+--   yet exist (e.g. in a fresh CI test database that only applies
+--   omnibase_infra migrations). In production the tables already exist and
+--   the GRANTs apply immediately.
 --
 -- ROLLBACK:
 --   DROP ROLE role_omniweb;  (after revoking grants)
@@ -29,15 +37,31 @@ BEGIN
 END;
 $$;
 
--- Grant DML on omniweb tables in the omnibase_infra DB.
--- These are the only tables omniweb migrations touch.
-GRANT INSERT, SELECT, UPDATE, DELETE
-  ON TABLE public.waitlist_signups
-  TO role_omniweb;
-
-GRANT INSERT, SELECT, UPDATE, DELETE
-  ON TABLE public.admin_events_log
-  TO role_omniweb;
-
 -- Grant usage on the schema so the role can resolve objects.
 GRANT USAGE ON SCHEMA public TO role_omniweb;
+
+-- Grant DML on omniweb tables in the omnibase_infra DB.
+-- These are the only tables omniweb migrations touch.
+-- Wrapped in DO blocks so the migration is safe when tables do not yet exist
+-- (e.g. CI test DB that only runs omnibase_infra migrations).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'waitlist_signups'
+  ) THEN
+    EXECUTE 'GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.waitlist_signups TO role_omniweb';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'admin_events_log'
+  ) THEN
+    EXECUTE 'GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.admin_events_log TO role_omniweb';
+  END IF;
+END;
+$$;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:5752f37bf905313ecee40558580a5d0abd419cd1c4c30f3e609230328d2e5a5e
-generated_at: 2026-03-09T15:57:35Z
-migration_file_count: 29
+sha256:d593a1fe951066fde8ff224a3d314d5283ce8977390f0afb7f73e8dd89d31dc1
+generated_at: 2026-03-12T18:15:34Z
+migration_file_count: 30


### PR DESCRIPTION
## Summary

- Adds migration `051_create_role_omniweb.sql` to create a least-privilege `role_omniweb` database role
- Grants `INSERT, SELECT, UPDATE, DELETE` on `waitlist_signups` and `admin_events_log` tables to `role_omniweb`
- This unblocks `omniweb-migrate` Job which was failing because the `postgres` superuser key was removed from `per-service-db-credentials` when the per-service role strategy was implemented

## Emergency Unblock (before PR merges)

Check if the `postgres` key is present in the secret:

```bash
aws ssm send-command --instance-ids i-0e596e8b557e27785 --region us-east-1 \
  --document-name "AWS-RunShellScript" \
  --parameters 'commands=["kubectl get secret per-service-db-credentials -n data-plane -o jsonpath={.data.postgres} | base64 -d | wc -c"]'
```

If output is `0`: restore the postgres key temporarily to unblock the pipeline while this PR is in review.

## Operator Actions Required After Merge

1. Apply migration 051 (runs automatically via omnibase_infra migration Job)
2. Add `role_omniweb` password to `per-service-db-credentials`:

```bash
# Get the role_omniweb password from postgres (set during role creation)
kubectl exec -n data-plane deploy/omninode-postgres -- \
  psql -U postgres -tAc "SELECT pg_catalog.pg_get_userbyid(r.oid) FROM pg_catalog.pg_roles r WHERE r.rolname='role_omniweb'"

# Patch the secret (replace PASSWORD with actual password)
kubectl patch secret per-service-db-credentials -n data-plane \
  --type='json' \
  -p='[{"op":"add","path":"/data/role_omniweb","value":"'$(echo -n "PASSWORD" | base64)'"}]'
```

## Companion PR

`omninode_infra` PR updates `omniweb-migrate.yaml` to use `role_omniweb`. Both PRs must be deployed together.

## Risk

LOW — migration is idempotent (IF NOT EXISTS guard on role creation). The role grants DML only on the specific tables omniweb uses.

## Rollback

`DROP ROLE role_omniweb` after revoking grants. Restore `postgres` key to secret if needed.

Linear: OMN-4700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied database migration to update schema and implement new role-based access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->