### PR TITLE
test(registration): failing tests for decide_heartbeat terminal-state guard (OMN-4819)

### DIFF
--- a/tests/unit/nodes/node_registration_orchestrator/services/test_decide_heartbeat_terminal_state_guard.py
+++ b/tests/unit/nodes/node_registration_orchestrator/services/test_decide_heartbeat_terminal_state_guard.py
@@ -94,6 +94,10 @@ def make_ctx(now=None, correlation_id=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="OMN-4822 pending: decide_heartbeat does not yet guard terminal states",
+)
 class TestDecideHeartbeatTerminalStateGuard:
     """decide_heartbeat must return no_op immediately for terminal states.
 


### PR DESCRIPTION
## Summary

- Adds 5 failing unit tests in `TestDecideHeartbeatTerminalStateGuard` that assert `decide_heartbeat` returns `no_op` for all terminal registration states (`LIVENESS_EXPIRED`, `REJECTED`)
- Adds 1 passing regression guard confirming ACTIVE heartbeats still return `emit`
- All 5 terminal-state tests are intentionally RED — fix target is OMN-4822

## Test file

`tests/unit/nodes/node_registration_orchestrator/services/test_decide_heartbeat_terminal_state_guard.py`

## Why these tests fail

`decide_heartbeat` currently returns `action='emit'` with a PostgreSQL UPDATE intent for any non-None projection, regardless of whether the node is in a terminal state. This allows the handler to erroneously extend the liveness deadline for expired/rejected nodes, triggering spurious re-registration.

## What OMN-4822 will do

Add a terminal-state guard at the top of `decide_heartbeat`:
```python
if projection.current_state.is_terminal():
    return _no_op(f"Terminal state {projection.current_state} — heartbeat ignored")
```

## Test plan

- [x] 5 tests FAIL before OMN-4822 (confirmed: `assert 'emit' == 'no_op'`)
- [x] 1 regression test PASSES (ACTIVE state still processed correctly)
- [ ] All 6 tests GREEN after OMN-4822 fix is applied

## Linear

Closes OMN-4819 | Part of epic OMN-4817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for node heartbeat handling in terminal registration states (expired/rejected).
  * Introduced deterministic test helpers and a fixed test time for repeatable scenarios.
  * Parametric coverage across all terminal states, plus a regression test confirming non-terminal (active) behavior still emits an update.
  * Some tests are marked pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->