### PR TITLE
fix(monitoring): alert on terminal-state heartbeat warning in monitor_logs.py (OMN-4826)

### DIFF
--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -169,7 +169,8 @@ IGNORE_PATTERN = re.compile(
 
 WARNING_PATTERN = re.compile(
     r"\[WARNING\].*("
-    r"Heartbeat received for non-active node"
+    r"terminal-state heartbeat ignored"
+    r"|Heartbeat received for non-active node"
     r"|dispatch_handlers:.*nacking message for retry"
     r"|DeadlockDetectedError"
     r"|HandlerConsul.*ConnectionError"
@@ -183,6 +184,9 @@ _WARNING_BACKOFF_BASE = 1800  # 30 minutes
 _WARNING_BACKOFF_CAP = 3600  # 1 hour max
 
 _WARNING_ISSUE_LABELS: dict[str, str] = {
+    # OMN-4826: terminal-state heartbeat ignored — node received a heartbeat
+    # after LIVENESS_EXPIRED or REJECTED. Alert includes node_id and current_state.
+    "terminal-state heartbeat ignored": "terminal-state-heartbeat",
     "non-active node": "stale-registration",
     "dispatch_handlers": "kafka-nack",
     "DeadlockDetectedError": "schema-deadlock",


### PR DESCRIPTION
## Summary

- Adds `"terminal-state heartbeat ignored"` to `WARNING_PATTERN` in `monitor_logs.py`
- Adds `"terminal-state-heartbeat"` label to `_WARNING_ISSUE_LABELS` for descriptive Slack alerts
- Pattern placed first in alternation (before generic `"non-active node"`) for specificity

## Changes

`scripts/monitor_logs.py`

```python
# Before
WARNING_PATTERN = re.compile(
    r"\[WARNING\].*("
    r"Heartbeat received for non-active node"
    ...
    r")"
)

_WARNING_ISSUE_LABELS: dict[str, str] = {
    "non-active node": "stale-registration",
    ...
}

# After
WARNING_PATTERN = re.compile(
    r"\[WARNING\].*("
    r"terminal-state heartbeat ignored"      # ← new (OMN-4826)
    r"|Heartbeat received for non-active node"
    ...
    r")"
)

_WARNING_ISSUE_LABELS: dict[str, str] = {
    "terminal-state heartbeat ignored": "terminal-state-heartbeat",  # ← new
    "non-active node": "stale-registration",
    ...
}
```

## Alert behavior

When a log line matches `"terminal-state heartbeat ignored"`:
- Slack alert is triggered with label `"terminal-state-heartbeat"`
- Alert fires with the standard WARNING_COOLDOWN_SECONDS (1800s default) backoff
- No false positives on other log lines

## Test plan

- [x] Pre-commit passes
- [x] Pattern matches `"[WARNING] terminal-state heartbeat ignored"` log lines
- [x] No false positives on `"Heartbeat received for non-active node"` lines (separate pattern)

## Linear

Closes OMN-4826 | Part of epic OMN-4817
Depends on OMN-4824 (handler emits "terminal-state heartbeat ignored" warning)