### PR TITLE
fix(registration): wire topic_router into DispatchResultApplier from contract published_events

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -63,9 +63,22 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
+from omnibase_infra.runtime.contract_topic_router import (
+    build_topic_router_from_contract,
+)
 from omnibase_infra.runtime.models.model_postgres_pool_config import (
     ModelPostgresPoolConfig,
 )
+
+# Build topic router from contract published_events at module import time.
+# This maps Python event class names to their declared Kafka topics so that
+# DispatchResultApplier can publish each output event to the correct topic
+# instead of the single fallback output_topic. (OMN-4881/OMN-4883)
+_CONTRACT_PATH = Path(__file__).parent / "contract.yaml"
+_CONTRACT_DATA: dict[str, object] = yaml.safe_load(_CONTRACT_PATH.read_text())
+_TOPIC_ROUTER: dict[str, str] = build_topic_router_from_contract(_CONTRACT_DATA)
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -1073,6 +1086,7 @@ class PluginRegistration:
                 event_bus=config.event_bus,  # type: ignore[arg-type]
                 output_topic=config.output_topic,
                 intent_executor=intent_executor,
+                topic_router=_TOPIC_ROUTER,
             )
 
             # Register DispatchResultApplier in the DI container for the same

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_topic_router.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_topic_router.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Tests verifying that the registration orchestrator plugin wires topic_router correctly.
+
+Two-level proof:
+1. The contract.yaml published_events section contains the expected event-to-topic mappings.
+2. The plugin module exposes _TOPIC_ROUTER built from the contract, and passes it to
+   DispatchResultApplier via topic_router=_TOPIC_ROUTER.
+
+OMN-4883 / OMN-4880
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.runtime.contract_topic_router import (
+    build_topic_router_from_contract,
+)
+
+_CONTRACT_PATH = (
+    Path(__file__).parents[4]
+    / "src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml"
+)
+
+
+@pytest.mark.unit
+def test_contract_published_events_produces_expected_router_entries() -> None:
+    """The registration orchestrator contract produces a router with all declared events."""
+    contract_data = yaml.safe_load(_CONTRACT_PATH.read_text())
+    router = build_topic_router_from_contract(contract_data)
+    # Must contain the core events declared in published_events
+    assert "ModelNodeRegistrationAccepted" in router
+    assert "ModelNodeBecameActive" in router
+    assert "ModelNodeLivenessExpired" in router
+    assert "ModelNodeRegistrationRejected" in router
+    # Must not contain spurious entries (count matches contract)
+    expected_count = len(
+        [
+            e
+            for e in contract_data.get("published_events", [])
+            if e.get("event_type") and e.get("topic")
+        ]
+    )
+    assert len(router) == expected_count
+
+
+@pytest.mark.unit
+def test_contract_router_contains_registration_accepted_topic() -> None:
+    """ModelNodeRegistrationAccepted must map to the correct declared topic."""
+    contract_data = yaml.safe_load(_CONTRACT_PATH.read_text())
+    router = build_topic_router_from_contract(contract_data)
+    assert router.get("ModelNodeRegistrationAccepted") == (
+        "onex.evt.platform.node-registration-accepted.v1"
+    )
+
+
+@pytest.mark.unit
+def test_plugin_topic_router_constant_matches_contract_and_is_wired() -> None:
+    """Two-part wiring proof.
+
+    Part A: plugin._TOPIC_ROUTER matches build_topic_router_from_contract output.
+    Part B: plugin source contains topic_router=_TOPIC_ROUTER at the DispatchResultApplier
+            construction site.
+    """
+    import omnibase_infra.nodes.node_registration_orchestrator.plugin as plugin_module
+
+    # Part A: module constant shape matches contract
+    contract_data = yaml.safe_load(_CONTRACT_PATH.read_text())
+    expected_router = build_topic_router_from_contract(contract_data)
+    assert expected_router == plugin_module._TOPIC_ROUTER, (
+        "plugin._TOPIC_ROUTER does not match what build_topic_router_from_contract produces. "
+        "Re-check the module-level initialization."
+    )
+
+    # Part B: plugin source passes _TOPIC_ROUTER to DispatchResultApplier
+    plugin_source = Path(plugin_module.__file__).read_text()
+    assert "topic_router=_TOPIC_ROUTER" in plugin_source, (
+        "plugin.py does not pass topic_router=_TOPIC_ROUTER to DispatchResultApplier. "
+        "The router is built but not wired."
+    )


### PR DESCRIPTION
## Summary

- Adds `_CONTRACT_PATH`, `_CONTRACT_DATA`, `_TOPIC_ROUTER` module-level constants to `node_registration_orchestrator/plugin.py`
- `_TOPIC_ROUTER` is built at import time from `contract.yaml` via `build_topic_router_from_contract()`
- Passes `topic_router=_TOPIC_ROUTER` to `DispatchResultApplier` at construction
- **Root cause fix**: `ModelNodeRegistrationAccepted` and other output events now route to their declared per-type Kafka topics instead of the fallback `"responses"` topic

## Test plan

- [x] `test_contract_published_events_produces_expected_router_entries` — contract has all expected entries
- [x] `test_contract_router_contains_registration_accepted_topic` — correct topic mapping
- [x] `test_plugin_topic_router_constant_matches_contract_and_is_wired` — Part A: constant correct, Part B: source grep confirms wiring
- [x] All pre-commit hooks pass
- [x] mypy --strict clean

## Tickets

- Fixes: OMN-4883
- Epic: OMN-4880
- Depends on: OMN-4881 (PR #810), OMN-4882 (PR #811)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented contract-driven Kafka topic routing: output events now route to topics based on event type and contract configuration, with fallback to default topic if unmapped.

* **Tests**
  * Added comprehensive unit tests validating topic router construction, event type routing, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->