### PR TITLE
docs(registration): update stale workaround comment now that topic routing is fixed

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
@@ -317,8 +317,11 @@ class DispatcherNodeIntrospected(MixinAsyncCircuitBreaker):
 
             # Auto-ACK (Path B, OMN-3444): direct-publish ack when the reducer transitions
             # to AWAITING_ACK. Gate: ModelNodeRegistrationAccepted in output events.
-            # Published directly to _ACK_TOPIC (NOT in output_events — framework routes
-            # those to the wrong topic via single fixed output_topic).
+            # Published directly to _ACK_TOPIC as a command (not via output_events).
+            # This is intentional: ACK commands are not in published_events (they are commands,
+            # not events), so they are not routed by the topic_router. Direct publish is correct here.
+            # NOTE: The "wrong topic" routing bug (OMN-4880) has been fixed — output_events are
+            # now routed per-event-type via DispatchResultApplier.topic_router.
             if (
                 _auto_ack_enabled()
                 and self._event_bus is not None


### PR DESCRIPTION
Updates stale comment in dispatcher_node_introspected.py. Old comment said ACK was direct-published because 'framework routes those to the wrong topic via single fixed output_topic' — historically accurate but now misleading. New comment clarifies: direct publish is intentional (ACK commands are not in published_events), and notes the routing bug OMN-4880 is fixed. Both ACK dispatcher tests still pass. Fixes: OMN-4887, Epic: OMN-4880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how ACK commands are published and routed, emphasizing they are sent as commands and not via alternative event routing.
  * Noted that a prior routing mismatch has been resolved and documented for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->