### PR TITLE
fix(health): readiness probe 503 — tuple vs list in required_topics (OMN-4910)

### DIFF
--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -4380,7 +4380,7 @@ class RuntimeHostProcess:
                 getattr(self._event_bus, "get_readiness_status", None)
             ):
                 readiness = await self._event_bus.get_readiness_status()
-                event_bus_readiness = readiness.model_dump()
+                event_bus_readiness = readiness.model_dump(mode="json")
                 event_bus_ready = readiness.is_ready
             else:
                 # Event bus doesn't support readiness (treat as ready if healthy)

--- a/tests/unit/runtime/models/test_model_health_check_response.py
+++ b/tests/unit/runtime/models/test_model_health_check_response.py
@@ -218,6 +218,80 @@ class TestModelHealthCheckResponseImmutability:
         assert isinstance(hash_value, int)
 
 
+class TestModelHealthCheckResponseReadinessIntegration:
+    """Regression tests for readiness details in health check responses (OMN-4910).
+
+    The /ready endpoint nests ModelEventBusReadiness.model_dump(mode="json")
+    inside ModelHealthCheckResponse.details. Before the fix, model_dump()
+    without mode="json" produced tuples for tuple fields, which Pydantic
+    strict mode rejected during JSON serialization.
+    """
+
+    def test_readiness_details_with_list_topics_serializes(self) -> None:
+        """Test that readiness details with list required_topics serializes correctly.
+
+        This is the post-fix path: model_dump(mode="json") converts tuples to lists.
+        """
+        readiness_details: dict[str, object] = {
+            "is_ready": True,
+            "consumers_started": True,
+            "assignments": {"topic-a": [0, 1]},
+            "consume_tasks_alive": {"topic-a": True},
+            "required_topics": ["topic-a"],  # list (from mode="json")
+            "required_topics_ready": True,
+            "last_error": "",
+        }
+        resp = ModelHealthCheckResponse.success(
+            status="healthy",
+            version="1.0.0",
+            details={"ready": True, "event_bus_readiness": readiness_details},
+        )
+        json_str = resp.model_dump_json(exclude_none=True)
+        assert '"required_topics":["topic-a"]' in json_str
+
+    def test_readiness_details_roundtrip(self) -> None:
+        """Test JSON roundtrip with nested readiness details."""
+        readiness_details: dict[str, object] = {
+            "is_ready": False,
+            "consumers_started": True,
+            "assignments": {},
+            "consume_tasks_alive": {},
+            "required_topics": ["topic-a", "topic-b"],
+            "required_topics_ready": False,
+            "last_error": "",
+        }
+        original = ModelHealthCheckResponse.success(
+            status="unhealthy",
+            version="1.0.0",
+            details={
+                "ready": False,
+                "event_bus_readiness": readiness_details,
+            },
+        )
+        json_str = original.model_dump_json()
+        restored = ModelHealthCheckResponse.model_validate_json(json_str)
+        assert original == restored
+
+    def test_empty_required_topics_serializes(self) -> None:
+        """Test that empty required_topics list serializes correctly."""
+        readiness_details: dict[str, object] = {
+            "is_ready": True,
+            "consumers_started": True,
+            "assignments": {},
+            "consume_tasks_alive": {},
+            "required_topics": [],
+            "required_topics_ready": True,
+            "last_error": "",
+        }
+        resp = ModelHealthCheckResponse.success(
+            status="healthy",
+            version="1.0.0",
+            details={"ready": True, "event_bus_readiness": readiness_details},
+        )
+        json_str = resp.model_dump_json(exclude_none=True)
+        assert '"required_topics":[]' in json_str
+
+
 class TestModelHealthCheckResponseEquality:
     """Tests for ModelHealthCheckResponse equality comparison."""
 


### PR DESCRIPTION
## Summary

- Fix `/ready` endpoint returning 503 on all runtime pods due to Pydantic validation error
- `ModelEventBusReadiness.model_dump()` produces `tuple` for `required_topics`, but `ModelHealthCheckResponse` with `strict=True` rejects tuples during JSON serialization
- Changed to `model_dump(mode="json")` which converts tuples to lists, matching JSON semantics

## Root Cause

In `service_runtime_host_process.py` line 4383, `readiness.model_dump()` was called without `mode="json"`. The `ModelEventBusReadiness` model declares `required_topics: tuple[str, ...]`, so `model_dump()` preserves the tuple type. When this dict is nested inside `ModelHealthCheckResponse.details` and serialized via `model_dump_json()`, Pydantic strict mode rejects the tuple where a JSON-compatible type (list) is expected.

## Fix

```python
# Before (produces tuple)
event_bus_readiness = readiness.model_dump()

# After (converts tuple to list for JSON compatibility)
event_bus_readiness = readiness.model_dump(mode="json")
```

## Test Plan

- [x] 3 new regression tests in `test_model_health_check_response.py`:
  - `test_readiness_details_with_list_topics_serializes` — verifies list topics serialize
  - `test_readiness_details_roundtrip` — JSON roundtrip with nested readiness
  - `test_empty_required_topics_serializes` — edge case: empty topics list
- [x] All 231 existing unit tests pass (runtime models + event bus readiness)
- [x] Pre-commit hooks pass (all 30+ hooks)

Closes OMN-4910