### PR TITLE
fix(infra): expose Redpanda Admin API port 9644 [OMN-4959]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -269,6 +269,7 @@ services:
       - --mode dev-container
       - --smp 1
       - --memory ${REDPANDA_MEMORY:-8G}
+      - --admin-addr 0.0.0.0:9644
       - --default-log-level=warn
     ports:
       - "${REDPANDA_EXTERNAL_PORT:-19092}:19092"
@@ -276,6 +277,8 @@ services:
       - "${REDPANDA_PANDAPROXY_PORT:-18082}:18082"
       # Schema Registry
       - "${REDPANDA_SCHEMA_REGISTRY_PORT:-18081}:18081"
+      # OMN-4959: Admin API (used by omnidash event-bus-health-poller)
+      - "${REDPANDA_ADMIN_PORT:-9644}:9644"
     volumes:
       - redpanda_data:/var/lib/redpanda/data
     networks:


### PR DESCRIPTION
## Summary

- Add `--admin-addr 0.0.0.0:9644` to Redpanda command args in `docker-compose.infra.yml`
- Expose port 9644 externally via `REDPANDA_ADMIN_PORT` env var (default: 9644)

## Context

Part of epic OMN-4956 (Omnidash Dashboard Health), Wave 0 / Phase 1: Foundation.

Redpanda Admin API port 9644 was not exposed, causing omnidash `event-bus-health-poller.ts` to fail with connection refused every 30 seconds.

## Test plan

- [ ] `docker port omnibase-infra-redpanda` output includes 9644
- [ ] `curl http://localhost:9644/v1/brokers` returns JSON broker list
- [ ] omnidash health poller stops logging connection errors
- [ ] Existing Redpanda produce/consume on 19092 unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to expose an admin API port for service health monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->