### PR TITLE
feat(scripts): rehome cross-repo governance scripts from omni_home [OMN-4922]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,8 @@ ignore = [
 # S106: Hardcoded password in function arg - test fixtures only
 # Production secrets managed via Infisical/Vault (OMN-2287, OMN-2736)
 "tests/**/*.py" = ["S106"]
+# N999: Hyphenated script names are intentional (executable CLI scripts, not importable modules)
+"scripts/*-*.py" = ["N999"]
 
 [tool.ruff.lint.isort]
 # Ensure consistent import sorting between local and CI

--- a/scripts/audit-branch-protection.py
+++ b/scripts/audit-branch-protection.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Audit branch protection required checks against actual CI check names.
+
+Detects mismatches where branch protection requires a status check name
+that no longer exists in the CI workflow (e.g., after a job was renamed).
+
+Usage:
+    python3 scripts/audit-branch-protection.py          # audit all repos
+    python3 scripts/audit-branch-protection.py --fix     # audit + fix mismatches
+    python3 scripts/audit-branch-protection.py --repos omniclaude,omniweb
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+REPOS = [
+    "omniclaude",
+    "omnibase_core",
+    "omnibase_infra",
+    "omnibase_spi",
+    "omnidash",
+    "omniintelligence",
+    "omnimemory",
+    "omninode_infra",
+    "omniweb",
+    "onex_change_control",
+]
+
+ORG = "OmniNode-ai"
+
+
+def run_gh(args: list[str], timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=timeout, check=False
+    )
+
+
+def get_required_checks(repo: str) -> list[str]:
+    r = run_gh(
+        [
+            "api",
+            f"repos/{ORG}/{repo}/branches/main/protection/required_status_checks",
+            "--jq",
+            ".contexts",
+        ]
+    )
+    if r.returncode != 0:
+        return []
+    try:
+        return json.loads(r.stdout) if r.stdout.strip() else []
+    except json.JSONDecodeError:
+        return []
+
+
+def get_actual_checks(repo: str) -> set[str]:
+    r = run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            f"{ORG}/{repo}",
+            "--state",
+            "all",
+            "--limit",
+            "1",
+            "--json",
+            "number",
+        ]
+    )
+    prs = json.loads(r.stdout) if r.stdout.strip() else []
+    if not prs:
+        return set()
+    pr_num = str(prs[0]["number"])
+    r2 = run_gh(["pr", "checks", pr_num, "--repo", f"{ORG}/{repo}"])
+    checks: set[str] = set()
+    for line in (r2.stdout + r2.stderr).strip().split("\n"):
+        if "\t" in line:
+            checks.add(line.split("\t")[0].strip())
+    return checks
+
+
+def fix_mismatches(repo: str, required: list[str], actual: set[str]) -> bool:
+    valid = [r for r in required if r in actual]
+    if not valid:
+        print(
+            "  Cannot fix: no required checks match actual CI. Manual intervention needed."
+        )
+        return False
+    removed = [r for r in required if r not in actual]
+    payload = json.dumps({"strict": True, "contexts": valid})
+    r = run_gh(
+        [
+            "api",
+            "-X",
+            "PATCH",
+            f"repos/{ORG}/{repo}/branches/main/protection/required_status_checks",
+            "--input",
+            "-",
+        ]
+    )
+    # Use stdin for payload
+    r = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "PATCH",
+            f"repos/{ORG}/{repo}/branches/main/protection/required_status_checks",
+            "--input",
+            "-",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if r.returncode == 0 or "contexts" in r.stdout:
+        print(f"  Fixed: removed {removed}, kept {valid}")
+        return True
+    print(f"  Fix failed: {r.stderr}")
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit branch protection check names")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix mismatches by removing stale checks",
+    )
+    parser.add_argument(
+        "--repos", type=str, help="Comma-separated repo names (default: all)"
+    )
+    args = parser.parse_args()
+
+    repos = args.repos.split(",") if args.repos else REPOS
+    mismatches_found = 0
+
+    for repo in repos:
+        required = get_required_checks(repo)
+        if not required:
+            continue
+
+        actual = get_actual_checks(repo)
+        if not actual:
+            print(f"=== {repo} === (no PRs to check against)")
+            continue
+
+        stale = [r for r in required if r not in actual]
+
+        if stale:
+            mismatches_found += 1
+            print(f"=== {repo} ===")
+            print(f"  Required: {required}")
+            print(f"  MISMATCHES: {stale}")
+            print(f"  Actual CI checks: {sorted(actual)}")
+            if args.fix:
+                fix_mismatches(repo, required, actual)
+            print()
+        else:
+            print(f"=== {repo} === ✅")
+
+    if mismatches_found == 0:
+        print("\nAll repos: branch protection checks match CI. No mismatches found.")
+        return 0
+    else:
+        print(f"\n{mismatches_found} repo(s) with mismatches.")
+        if not args.fix:
+            print("Run with --fix to auto-remove stale checks.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit-env-files.sh
+++ b/scripts/audit-env-files.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Audit script to find all .env files (excluding .env.example)
+set -euo pipefail
+
+OMNI_HOME="${OMNI_HOME:-.}"
+cd "$OMNI_HOME"
+
+echo "Scanning for rogue .env files..."
+echo ""
+
+found=0
+while IFS= read -r file; do
+    found=$((found + 1))
+    # Check if file is tracked in git
+    repo_dir=$(dirname "$file")
+    if git -C "$repo_dir" rev-parse --git-dir > /dev/null 2>&1; then
+        repo_root=$(git -C "$repo_dir" rev-parse --show-toplevel)
+        rel_path=$(python3 -c "import os.path; print(os.path.relpath('$file', '$repo_root'))")
+        if git -C "$repo_root" ls-files --error-unmatch "$rel_path" > /dev/null 2>&1; then
+            status="⛔ COMMITTED"
+        else
+            status="⚠️  UNTRACKED"
+        fi
+    else
+        status="❓ NOT IN GIT REPO"
+    fi
+    printf "%s  %s\n" "$status" "$file"
+done < <(find "$OMNI_HOME" -type f -name ".env*" ! -name ".env.example" ! -name ".env.*.example" 2>/dev/null | sort)
+
+if [ $found -eq 0 ]; then
+    echo "✅ No rogue .env files found"
+    exit 0
+else
+    echo ""
+    echo "⚠️  Found $found rogue .env file(s)"
+    exit 1
+fi

--- a/scripts/check_no_cloud_bus_wrapper.sh
+++ b/scripts/check_no_cloud_bus_wrapper.sh
@@ -2,14 +2,25 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-if [[ -z "${OMNI_HOME:-}" ]]; then
-  echo "SKIP: OMNI_HOME is not set" >&2
-  exit 0
+# Wrapper for check_no_cloud_bus.sh
+# Resolves the script relative to this repo first, then falls back to $OMNI_HOME.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Prefer the co-located copy in this repo
+CHECK_SCRIPT="$REPO_ROOT/scripts/validation/check_no_cloud_bus.sh"
+if [[ -f "$CHECK_SCRIPT" ]]; then
+  exec bash "$CHECK_SCRIPT" "$PWD"
 fi
 
-CHECK_SCRIPT="$OMNI_HOME/scripts/check_no_cloud_bus.sh"
-if [[ ! -f "$CHECK_SCRIPT" ]]; then
-  echo "SKIP: check_no_cloud_bus.sh not found at OMNI_HOME=$OMNI_HOME" >&2
-  exit 0
+# Fall back to OMNI_HOME for backwards compat
+if [[ -n "${OMNI_HOME:-}" ]]; then
+  CHECK_SCRIPT="$OMNI_HOME/scripts/check_no_cloud_bus.sh"
+  if [[ -f "$CHECK_SCRIPT" ]]; then
+    exec bash "$CHECK_SCRIPT" "$PWD"
+  fi
 fi
-exec bash "$CHECK_SCRIPT" "$PWD"
+
+echo "SKIP: check_no_cloud_bus.sh not found" >&2
+exit 0

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+check_version_pins.py
+
+Checks each repo's pyproject.toml against the shared version matrix
+(standards/version-matrix.yaml) and reports compliance.
+
+Usage:
+    python scripts/check_version_pins.py [--repo <name>] [--matrix <path>] [--root <path>]
+
+Options:
+    --repo    Check a single repo (by directory name). If omitted, checks all.
+    --matrix  Path to version-matrix.yaml (default: version-matrix.yaml next to this script)
+    --root    Root directory containing repo clones (default: parent of this script's dir)
+
+Exit codes:
+    0  All repos are compliant
+    1  One or more repos have out-of-compliance pins
+    2  Configuration error (missing matrix, missing repo, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    # Fallback: parse YAML manually for the simple structure we use
+    yaml = None  # type: ignore[assignment]
+
+
+def parse_yaml_simple(text: str) -> dict:
+    """Minimal YAML parser for our simple version-matrix.yaml structure."""
+    result: dict = {}
+    current_section: str | None = None
+    current_list: list | None = None
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # Top-level key with nested content
+        if not line.startswith(" ") and stripped.endswith(":"):
+            current_section = stripped[:-1]
+            result[current_section] = {}
+            current_list = None
+            continue
+
+        if current_section and stripped.startswith("- "):
+            if current_list is None:
+                result[current_section] = []
+                current_list = result[current_section]
+            # Handle "- name: value" style
+            item_str = stripped[2:]
+            if ": " in item_str:
+                # Start of a dict item in a list
+                key, val = item_str.split(": ", 1)
+                item = {key: val.strip().strip('"').strip("'")}
+                current_list.append(item)
+            continue
+
+        if current_list and stripped.startswith("label:"):
+            # Continuation of the last list item
+            key, val = stripped.split(": ", 1)
+            current_list[-1][key] = val.strip().strip('"').strip("'")
+            continue
+
+        # Key-value in a section
+        if current_section and ": " in stripped:
+            key, val = stripped.split(": ", 1)
+            val = val.strip().strip('"').strip("'")
+            if isinstance(result[current_section], dict):
+                result[current_section][key] = val
+            current_list = None
+
+    return result
+
+
+def load_matrix(matrix_path: Path) -> dict:
+    """Load the version matrix YAML file."""
+    text = matrix_path.read_text()
+    if yaml is not None:
+        return yaml.safe_load(text)
+    return parse_yaml_simple(text)
+
+
+def parse_version(version_str: str) -> tuple[int, ...]:
+    """Parse a version string like '0.26.0' into a tuple of ints."""
+    match = re.match(r"(\d+(?:\.\d+)*)", version_str)
+    if not match:
+        return (0,)
+    return tuple(int(x) for x in match.group(1).split("."))
+
+
+def parse_requirement(req_str: str) -> tuple[str, str, tuple[int, ...]]:
+    """Parse a requirement like '>=0.26.0' into (operator, version_str, version_tuple)."""
+    match = re.match(r"([><=!]+)\s*(\S+)", req_str)
+    if not match:
+        return (">=", req_str, parse_version(req_str))
+    return (match.group(1), match.group(2), parse_version(match.group(2)))
+
+
+def extract_dependencies(pyproject_path: Path) -> dict[str, str]:
+    """Extract dependency versions from a pyproject.toml file.
+
+    Returns a dict mapping package name to its version specifier.
+    Only extracts our shared packages (omnibase-core, omnibase-spi, etc.).
+    """
+    deps: dict[str, str] = {}
+    text = pyproject_path.read_text()
+
+    # Match lines like: "omnibase-core>=0.26.0", or "omnibase-core==0.26.0",
+    # handling both with and without quotes
+    pattern = re.compile(
+        r'"?\s*(omnibase-(?:core|spi|infra|compat))\s*([><=!]+\s*[\d.]+)\s*"?'
+    )
+
+    for match in pattern.finditer(text):
+        pkg_name = match.group(1)
+        version_spec = match.group(2)
+        deps[pkg_name] = version_spec
+
+    return deps
+
+
+def check_compliance(
+    actual_spec: str,
+    required_spec: str,
+) -> tuple[bool, str]:
+    """Check if an actual version spec meets the required minimum.
+
+    Returns (is_compliant, reason).
+    """
+    _req_op, _req_ver_str, req_ver = parse_requirement(required_spec)
+    act_op, _act_ver_str, act_ver = parse_requirement(actual_spec)
+
+    # For >= requirements, the actual pinned version must be >= the required minimum
+    if act_op in ("==", ">="):
+        if act_ver >= req_ver:
+            return True, f"{actual_spec} meets {required_spec}"
+        return False, f"{actual_spec} is below required {required_spec}"
+
+    # For other operators, flag as needing review
+    return False, f"Unexpected operator in {actual_spec}, expected >= or =="
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check repo dependency pins against the shared version matrix."
+    )
+    parser.add_argument(
+        "--repo",
+        help="Check a single repo by directory name",
+    )
+    parser.add_argument(
+        "--matrix",
+        default=None,
+        help="Path to version-matrix.yaml",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Root directory containing repo clones",
+    )
+    args = parser.parse_args()
+
+    # Resolve paths
+    script_dir = Path(__file__).resolve().parent
+    root = Path(args.root) if args.root else script_dir.parent
+
+    if args.matrix:
+        matrix_path = Path(args.matrix)
+    else:
+        matrix_path = script_dir / "version-matrix.yaml"
+
+    if not matrix_path.exists():
+        print(f"ERROR: Version matrix not found at {matrix_path}", file=sys.stderr)
+        return 2
+
+    matrix = load_matrix(matrix_path)
+    packages = matrix.get("packages", {})
+    repos = matrix.get("repos", [])
+
+    if not packages:
+        print("ERROR: No packages defined in version matrix", file=sys.stderr)
+        return 2
+
+    # Filter to single repo if specified
+    if args.repo:
+        repos = [r for r in repos if r["name"] == args.repo]
+        if not repos:
+            print(f"ERROR: Repo '{args.repo}' not found in matrix", file=sys.stderr)
+            return 2
+
+    # Results tracking
+    all_compliant = True
+    results: list[tuple[str, str, str, bool, str]] = []
+
+    print("=" * 72)
+    print("Version Pin Compliance Check")
+    print(f"Matrix: {matrix_path}")
+    print(f"Root:   {root}")
+    print("=" * 72)
+    print()
+
+    for repo_entry in repos:
+        repo_name = repo_entry["name"]
+        repo_label = repo_entry.get("label", repo_name)
+        pyproject = root / repo_name / "pyproject.toml"
+
+        if not pyproject.exists():
+            print(f"  SKIP  {repo_label:<25} pyproject.toml not found")
+            continue
+
+        deps = extract_dependencies(pyproject)
+
+        if not deps:
+            print(f"  OK    {repo_label:<25} no shared package dependencies")
+            continue
+
+        for pkg_name, required_spec in packages.items():
+            if pkg_name not in deps:
+                continue
+
+            actual_spec = deps[pkg_name]
+            compliant, reason = check_compliance(actual_spec, required_spec)
+            status = "OK" if compliant else "FAIL"
+
+            if not compliant:
+                all_compliant = False
+
+            results.append((repo_label, pkg_name, actual_spec, compliant, reason))
+            print(
+                f"  {status:<4}  {repo_label:<25} {pkg_name:<20} "
+                f"actual={actual_spec:<12} required={required_spec}"
+            )
+
+    print()
+    print("-" * 72)
+
+    if all_compliant:
+        print("RESULT: All repos are compliant with the version matrix.")
+        return 0
+
+    print("RESULT: FAILED - one or more repos have out-of-compliance pins.")
+    print()
+    print("Non-compliant repos:")
+    for repo_label, pkg_name, actual_spec, compliant, reason in results:
+        if not compliant:
+            print(f"  - {repo_label}: {pkg_name} {actual_spec} ({reason})")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cloud-bus-tunnel.sh
+++ b/scripts/cloud-bus-tunnel.sh
@@ -7,7 +7,7 @@
 #
 # Architecture:
 #   1. SSM session → localhost:6443 → k8s API (i-0e596e8b557e27785:6443)
-#   2. kubectl port-forward → localhost:29092 → svc/omninode-redpanda:9092
+#   2. kubectl port-forward → localhost:29092 → svc/omninode-redpanda:9092  # cloud-bus-ok OMN-4922
 #   3. kubectl port-forward → localhost:9092 → svc/omninode-redpanda:9092
 #
 # The script runs as a long-lived process. launchd restarts it on exit.
@@ -52,9 +52,9 @@ if ! kill -0 "$SSM_PID" 2>/dev/null; then
 fi
 
 # 2. Start kubectl port-forwards
-echo "[cloud-bus-tunnel] Starting kubectl port-forward 29092->9092..."
+echo "[cloud-bus-tunnel] Starting kubectl port-forward 29092->9092..."  # cloud-bus-ok OMN-4922
 kubectl --kubeconfig "$KUBECONFIG" -n data-plane \
-    port-forward svc/omninode-redpanda 29092:9092 \
+    port-forward svc/omninode-redpanda 29092:9092 \  # cloud-bus-ok OMN-4922
     > "${LOG_DIR}/omninode-redpanda-tunnel.log" 2>&1 &
 
 echo "[cloud-bus-tunnel] Starting kubectl port-forward 9092->9092..."

--- a/scripts/enable-merge-queue.sh
+++ b/scripts/enable-merge-queue.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# enable-merge-queue.sh — Enable GitHub Merge Queue on OmniNode repos via GraphQL rulesets
+#
+# Usage:
+#   ./scripts/enable-merge-queue.sh                   # Enable on all 6 repos
+#   ./scripts/enable-merge-queue.sh omnibase_core      # Enable on a single repo
+#   ./scripts/enable-merge-queue.sh --validate         # Validate current config
+#   ./scripts/enable-merge-queue.sh --dry-run          # Show what would be done
+#
+# Prerequisites:
+#   - gh CLI authenticated with admin access to OmniNode-ai org
+#   - Org plan must support merge queues (Team or Enterprise)
+#
+# Settings applied per repo:
+#   Merge method:       squash
+#   Group size:         min 1, max 5
+#   Queue timeout:      60 minutes
+#   Require up-to-date: YES (ALLGREEN strategy)
+#   Direct merge:       admin-only (org admin bypass with ALWAYS mode)
+#
+# OMN-2818
+
+set -euo pipefail
+
+ORG="OmniNode-ai"
+REPOS=(omniclaude omnibase_core omnibase_infra omnibase_spi omniintelligence omnimemory)
+
+# Merge queue settings
+MQ_MERGE_METHOD="SQUASH"
+MQ_GROUPING_STRATEGY="ALLGREEN"
+MQ_MIN_ENTRIES=1
+MQ_MAX_ENTRIES_BUILD=5
+MQ_MAX_ENTRIES_MERGE=5
+MQ_TIMEOUT_MINUTES=60
+MQ_MIN_WAIT_MINUTES=0
+MQ_RULESET_NAME="Merge Queue"
+
+DRY_RUN=false
+VALIDATE_ONLY=false
+
+# --- Helpers ---
+
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+warn() { echo "[$(date +%H:%M:%S)] WARN: $*" >&2; }
+die()  { echo "[$(date +%H:%M:%S)] ERROR: $*" >&2; exit 1; }
+
+usage() {
+  head -18 "$0" | tail -16 | sed 's/^# //' | sed 's/^#//'
+  exit 0
+}
+
+get_repo_id() {
+  local repo="$1"
+  gh api graphql -f query="
+    { repository(owner: \"${ORG}\", name: \"${repo}\") { id } }
+  " --jq '.data.repository.id'
+}
+
+check_existing_mq_ruleset() {
+  local repo="$1"
+  gh api graphql -f query="
+    {
+      repository(owner: \"${ORG}\", name: \"${repo}\") {
+        rulesets(first: 20) {
+          nodes {
+            id
+            name
+            rules(first: 10) {
+              nodes { type }
+            }
+          }
+        }
+      }
+    }
+  " --jq '.data.repository.rulesets.nodes[] | select(.rules.nodes[] | .type == "MERGE_QUEUE") | .id' 2>/dev/null || true
+}
+
+enable_merge_queue() {
+  local repo="$1"
+  local repo_id
+
+  # Check for existing MQ ruleset
+  local existing_id
+  existing_id=$(check_existing_mq_ruleset "$repo")
+  if [[ -n "$existing_id" ]]; then
+    log "  ${repo}: Merge queue ruleset already exists (${existing_id}), skipping"
+    return 0
+  fi
+
+  repo_id=$(get_repo_id "$repo")
+  if [[ -z "$repo_id" || "$repo_id" == "null" ]]; then
+    warn "${repo}: Could not resolve repository ID"
+    return 1
+  fi
+
+  if $DRY_RUN; then
+    log "  ${repo}: [DRY RUN] Would create merge queue ruleset (repo_id=${repo_id})"
+    return 0
+  fi
+
+  local result
+  if ! result=$(gh api graphql -f query="
+    mutation {
+      createRepositoryRuleset(input: {
+        sourceId: \"${repo_id}\"
+        name: \"${MQ_RULESET_NAME}\"
+        target: BRANCH
+        enforcement: ACTIVE
+        conditions: {
+          refName: {
+            include: [\"~DEFAULT_BRANCH\"]
+            exclude: []
+          }
+        }
+        rules: [
+          {
+            type: MERGE_QUEUE
+            parameters: {
+              mergeQueue: {
+                checkResponseTimeoutMinutes: ${MQ_TIMEOUT_MINUTES}
+                groupingStrategy: ${MQ_GROUPING_STRATEGY}
+                maxEntriesToBuild: ${MQ_MAX_ENTRIES_BUILD}
+                maxEntriesToMerge: ${MQ_MAX_ENTRIES_MERGE}
+                mergeMethod: ${MQ_MERGE_METHOD}
+                minEntriesToMerge: ${MQ_MIN_ENTRIES}
+                minEntriesToMergeWaitMinutes: ${MQ_MIN_WAIT_MINUTES}
+              }
+            }
+          }
+        ]
+        bypassActors: [
+          {
+            organizationAdmin: true
+            bypassMode: ALWAYS
+          }
+        ]
+      }) {
+        ruleset {
+          id
+          name
+          enforcement
+        }
+      }
+    }
+  " 2>&1); then
+    warn "${repo}: gh api graphql call failed"
+    echo "$result" >&2
+    return 1
+  fi
+
+  local ruleset_id
+  ruleset_id=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['createRepositoryRuleset']['ruleset']['id'])" 2>/dev/null || true)
+
+  if [[ -n "$ruleset_id" ]]; then
+    log "  ${repo}: Merge queue enabled (ruleset_id=${ruleset_id})"
+  else
+    warn "${repo}: Failed to enable merge queue"
+    echo "$result" >&2
+    return 1
+  fi
+}
+
+validate_repo() {
+  local repo="$1"
+  local result
+  if ! result=$(gh api graphql -f query="
+    {
+      repository(owner: \"${ORG}\", name: \"${repo}\") {
+        mergeQueue(branch: \"main\") {
+          configuration {
+            mergeMethod
+            minimumEntriesToMerge
+            maximumEntriesToBuild
+            maximumEntriesToMerge
+            mergingStrategy
+            checkResponseTimeout
+          }
+        }
+        rulesets(first: 10) {
+          nodes {
+            name
+            enforcement
+            bypassActors(first: 5) {
+              nodes { bypassMode }
+            }
+          }
+        }
+      }
+    }
+  " 2>&1); then
+    warn "${repo}: gh api graphql call failed"
+    echo "$result" >&2
+    return 1
+  fi
+
+  printf '%s' "$result" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)['data']['repository']
+mq = data['mergeQueue']
+rulesets = data['rulesets']['nodes']
+repo = sys.argv[1]
+
+if mq is None:
+    print(f'FAIL: {repo} - merge queue not configured')
+    sys.exit(1)
+
+cfg = mq['configuration']
+issues = []
+if cfg['mergeMethod'] != 'SQUASH':
+    issues.append(f\"mergeMethod={cfg['mergeMethod']}\")
+if cfg['minimumEntriesToMerge'] != 1:
+    issues.append(f\"minEntries={cfg['minimumEntriesToMerge']}\")
+if cfg['maximumEntriesToBuild'] != 5:
+    issues.append(f\"maxBuild={cfg['maximumEntriesToBuild']}\")
+if cfg['maximumEntriesToMerge'] != 5:
+    issues.append(f\"maxMerge={cfg['maximumEntriesToMerge']}\")
+if cfg['mergingStrategy'] != 'ALLGREEN':
+    issues.append(f\"strategy={cfg['mergingStrategy']}\")
+if cfg['checkResponseTimeout'] != 3600:
+    issues.append(f\"timeout={cfg['checkResponseTimeout']}\")
+
+has_bypass = any(
+    a['bypassMode'] == 'ALWAYS'
+    for r in rulesets
+    if r.get('name') == 'Merge Queue'
+    for a in r.get('bypassActors', {}).get('nodes', [])
+)
+if not has_bypass:
+    issues.append('missing admin bypass')
+
+if issues:
+    print(f\"WARN: {repo} - {', '.join(issues)}\")
+    sys.exit(1)
+else:
+    print(f\"OK:   {repo} - squash, group 1-5, 60min timeout, admin bypass\")
+    sys.exit(0)
+" "$repo"
+}
+
+# --- Main ---
+
+# Parse arguments
+targets=()
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)    usage ;;
+    --dry-run)    DRY_RUN=true ;;
+    --validate)   VALIDATE_ONLY=true ;;
+    *)            targets+=("$arg") ;;
+  esac
+done
+
+# Default to all repos if no targets specified
+if [[ ${#targets[@]} -eq 0 ]]; then
+  targets=("${REPOS[@]}")
+fi
+
+# Verify gh auth
+if ! gh auth status &>/dev/null; then
+  die "gh CLI not authenticated. Run 'gh auth login' first."
+fi
+
+if $VALIDATE_ONLY; then
+  log "Validating merge queue configuration..."
+  failures=0
+  for repo in "${targets[@]}"; do
+    if ! validate_repo "$repo"; then
+      ((failures++))
+    fi
+  done
+  echo ""
+  if [[ $failures -eq 0 ]]; then
+    log "All ${#targets[@]} repos: Merge Queue correctly configured"
+  else
+    die "${failures} repo(s) failed validation"
+  fi
+  exit 0
+fi
+
+log "Enabling merge queue on ${#targets[@]} repos..."
+if $DRY_RUN; then
+  log "(DRY RUN mode - no changes will be made)"
+fi
+echo ""
+
+failures=0
+for repo in "${targets[@]}"; do
+  if ! enable_merge_queue "$repo"; then
+    ((failures++))
+  fi
+done
+
+echo ""
+if [[ $failures -eq 0 ]]; then
+  log "Done. Merge queue enabled on ${#targets[@]} repos."
+  echo ""
+  log "Validating..."
+  validation_failures=0
+  for repo in "${targets[@]}"; do
+    if ! validate_repo "$repo"; then
+      ((validation_failures++))
+    fi
+  done
+  if [[ $validation_failures -ne 0 ]]; then
+    die "${validation_failures} repo(s) failed post-enable validation"
+  fi
+else
+  die "${failures} repo(s) failed"
+fi

--- a/scripts/feature_spec_overrides.yaml
+++ b/scripts/feature_spec_overrides.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# feature_spec_overrides.yaml
+#
+# Manual overrides for generate_feature_inventory.py output.
+#
+# Format:
+#   "<repo>/<node_name>":
+#     design_spec: "[SpecName.md](../design/SpecName.md)"  # Override auto-detected design spec
+#     manual_review: "Needs attention: reason"             # Flag for human review
+#     fixture_present: true                                # Override fixture detection
+#
+# Example:
+#   "omnibase_infra/node_baselines_batch_compute":
+#     design_spec: "[DESIGN_BASELINES.md](../design/DESIGN_BASELINES.md)"
+#     manual_review: "—"

--- a/scripts/generate_deep_dive.py
+++ b/scripts/generate_deep_dive.py
@@ -1,0 +1,1291 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""
+Generate a daily deep dive Markdown report by scanning git repositories under a root directory.
+
+Design goals:
+- Deterministic output given the same repo state + date.
+- No network required (uses only local git metadata).
+- Focused coverage: include only git repos that have commits on the specified date.
+- Stale dirty working trees (no commits today) are excluded by default to reduce noise.
+
+Usage:
+  python3 scripts/generate_deep_dive.py
+  python3 scripts/generate_deep_dive.py --date 2025-12-20
+  python3 scripts/generate_deep_dive.py --root /Volumes/PRO-G40/Code/omni_home --out /tmp/DECEMBER_20_2025_DEEP_DIVE.md
+  python3 scripts/generate_deep_dive.py --include-dirty  # Also include repos with only dirty files (no commits)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+
+def _run(cmd: list[str], cwd: Path, *, allow_fail: bool = False) -> str:
+    try:
+        return subprocess.check_output(
+            cmd, cwd=str(cwd), text=True, stderr=subprocess.DEVNULL
+        )
+    except Exception:
+        if allow_fail:
+            return ""
+        raise
+
+
+def _today_local() -> dt.date:
+    return dt.datetime.now().astimezone().date()
+
+
+def _day_window(date: dt.date) -> tuple[str, str]:
+    # Local time window, consistent with most deep-dive narratives.
+    start = dt.datetime.combine(date, dt.time(0, 0, 0))
+    end = dt.datetime.combine(date, dt.time(23, 59, 59))
+    return (start.strftime("%Y-%m-%d %H:%M:%S"), end.strftime("%Y-%m-%d %H:%M:%S"))
+
+
+PR_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\(#(?P<num>\d+)\)"),
+    re.compile(r"\bPR\s*#(?P<num>\d+)\b", re.IGNORECASE),
+    re.compile(r"\b#(?P<num>\d+)\b"),  # fallback; can overmatch, but helps in practice
+    re.compile(r"Merge pull request #(?P<num>\d+)", re.IGNORECASE),
+]
+
+
+def extract_pr_numbers(subject: str) -> list[int]:
+    prs: set[int] = set()
+    for pat in PR_PATTERNS:
+        for m in pat.finditer(subject):
+            try:
+                prs.add(int(m.group("num")))
+            except Exception:
+                # Defensive: don't let parsing crash the run.
+                continue
+    return sorted(prs)
+
+
+TICKET_RE = re.compile(r"\b(OMN-\d+)\b")
+
+
+def extract_ticket_ids(subject: str) -> list[str]:
+    return sorted(set(TICKET_RE.findall(subject)))
+
+
+@dataclass(frozen=True)
+class CommitEntry:
+    full: str
+    short: str
+    ai: str
+    author: str
+    subject: str
+    files: int
+    ins: int
+    dele: int
+
+
+@dataclass(frozen=True)
+class MergeEntry:
+    full: str
+    short: str
+    ai: str
+    author: str
+    subject: str
+
+
+@dataclass(frozen=True)
+class GitHubMergedPR:
+    number: int
+    title: str
+    merged_at: str
+    is_workflow_pr: bool  # True if it's an auto-generated workflow PR
+    category: str  # 'capability', 'correctness', 'governance', 'observability', 'docs', 'churn'
+    additions: int = 0
+    deletions: int = 0
+
+
+@dataclass(frozen=True)
+class RepoDay:
+    name: str
+    path: Path
+    branch: str
+    commits: list[CommitEntry]
+    merges: list[MergeEntry]
+    dirty: list[str]
+    github_merged_prs: list[GitHubMergedPR]
+
+
+def get_branch(repo: Path) -> str:
+    b = _run(["git", "branch", "--show-current"], repo, allow_fail=True).strip()
+    return b or "(detached)"
+
+
+def get_dirty(repo: Path) -> list[str]:
+    raw = _run(["git", "status", "--porcelain=v1"], repo, allow_fail=True)
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def get_commit_entries(repo: Path, start_s: str, end_s: str) -> list[CommitEntry]:
+    # We intentionally include merge commits in the main log; merge list is separate for convenience.
+    raw = _run(
+        [
+            "git",
+            "log",
+            f"--since={start_s}",
+            f"--until={end_s}",
+            "--pretty=format:%H|%h|%ai|%an|%s",
+            "--shortstat",
+        ],
+        repo,
+        allow_fail=True,
+    )
+    lines = raw.splitlines()
+    entries: list[CommitEntry] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        i += 1
+        if not line:
+            continue
+        if "|" not in line:
+            continue
+        full, short, ai, an, subj = line.split("|", 4)
+        files = ins = dele = 0
+        while i < len(lines) and lines[i].strip() and "|" not in lines[i]:
+            st = lines[i]
+            i += 1
+            m = re.search(r"(\d+) files? changed", st)
+            if m:
+                files += int(m.group(1))
+            m = re.search(r"(\d+) insertions?\(\+\)", st)
+            if m:
+                ins += int(m.group(1))
+            m = re.search(r"(\d+) deletions?\(-\)", st)
+            if m:
+                dele += int(m.group(1))
+        entries.append(
+            CommitEntry(
+                full=full,
+                short=short,
+                ai=ai,
+                author=an,
+                subject=subj,
+                files=files,
+                ins=ins,
+                dele=dele,
+            )
+        )
+    return entries
+
+
+def get_merge_entries(repo: Path, start_s: str, end_s: str) -> list[MergeEntry]:
+    raw = _run(
+        [
+            "git",
+            "log",
+            f"--since={start_s}",
+            f"--until={end_s}",
+            "--pretty=format:%H|%h|%ai|%an|%s",
+            "--merges",
+        ],
+        repo,
+        allow_fail=True,
+    )
+    merges: list[MergeEntry] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        full, short, ai, an, subj = line.split("|", 4)
+        merges.append(
+            MergeEntry(full=full, short=short, ai=ai, author=an, subject=subj)
+        )
+    return merges
+
+
+WORKFLOW_PR_PATTERNS = [
+    "Add Claude Code GitHub Workflow",
+    "Update Claude Code Review workflow",
+    "Update Claude PR Assistant workflow",
+]
+
+
+def is_workflow_pr(title: str) -> bool:
+    """Check if a PR is an auto-generated workflow PR (low value for reporting)."""
+    return any(pattern.lower() in title.lower() for pattern in WORKFLOW_PR_PATTERNS)
+
+
+def classify_pr(title: str) -> str:
+    """
+    Classify a PR into exactly one of six categories using deterministic
+    title-based heuristics with override rules.
+
+    Categories: capability, correctness, governance, observability, docs, churn
+    """
+    t = title.lower()
+
+    # Override rules (checked first -- these override prefix-based classification)
+    if any(
+        kw in t
+        for kw in [
+            "correct report",
+            "report accuracy",
+            "revert",
+            "follow-up fix",
+            "followup fix",
+        ]
+    ):
+        return "churn"
+    if any(
+        kw in t
+        for kw in [
+            "handshake",
+            "freeze",
+            "enforcement",
+            "policy gate",
+            "migration_freeze",
+        ]
+    ):
+        return "governance"
+    if any(
+        kw in t
+        for kw in [
+            "diagnostics",
+            "telemetry",
+            "metrics",
+            "sink",
+            "query reader",
+            "projection",
+            "ledger",
+            "bus audit",
+            "bus health",
+        ]
+    ):
+        return "observability"
+
+    # Prefix-based classification (conventional commits)
+    if t.startswith(("docs", "doc(", "doc:")):
+        return "docs"
+    if t.startswith(("ci", "chore(ci)")) or "ci:" in t:
+        return "governance"
+    if t.startswith(("fix", "refactor", "perf", "test")):
+        return "correctness"
+    if t.startswith("feat"):
+        return "capability"
+    if t.startswith("chore"):
+        return "correctness"
+
+    # Default
+    return "correctness"
+
+
+def get_github_merged_prs(repo: Path, date: dt.date) -> list[GitHubMergedPR]:
+    """
+    Fetch PRs merged on the given date from GitHub using the gh CLI.
+
+    Timestamps are converted from UTC to EST (America/New_York) before filtering,
+    so PRs merged in the evening EST show up in the correct day's report.
+
+    Returns an empty list if:
+    - gh CLI is not available
+    - The repo is not a GitHub repo
+    - Any error occurs (network, auth, etc.)
+    """
+    date_str = date.isoformat()
+    est_tz = ZoneInfo("America/New_York")
+
+    raw = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--search",
+            f"merged:>={date_str}",
+            "--json",
+            "number,title,mergedAt,additions,deletions",
+            "--limit",
+            "100",
+        ],
+        repo,
+        allow_fail=True,
+    )
+    if not raw.strip():
+        return []
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+    prs: list[GitHubMergedPR] = []
+    for item in data:
+        merged_at_str = item.get("mergedAt", "")
+        title = item.get("title", "")
+
+        if not merged_at_str:
+            continue
+
+        # Parse UTC timestamp and convert to EST
+        try:
+            # GitHub format: 2026-01-23T00:19:09Z
+            merged_at_utc = dt.datetime.fromisoformat(
+                merged_at_str.replace("Z", "+00:00")
+            )
+            merged_at_est = merged_at_utc.astimezone(est_tz)
+            merged_date_est = merged_at_est.date()
+
+            # Filter to only PRs merged on the target date (in EST)
+            if merged_date_est == date:
+                # Format display time in EST (table adds timezone label)
+                display_time = merged_at_est.strftime("%H:%M")
+                prs.append(
+                    GitHubMergedPR(
+                        number=item.get("number", 0),
+                        title=title,
+                        merged_at=display_time,
+                        is_workflow_pr=is_workflow_pr(title),
+                        category=classify_pr(title),
+                        additions=item.get("additions", 0),
+                        deletions=item.get("deletions", 0),
+                    )
+                )
+        except (ValueError, TypeError):
+            # If parsing fails, fall back to string prefix matching
+            if merged_at_str.startswith(date_str):
+                prs.append(
+                    GitHubMergedPR(
+                        number=item.get("number", 0),
+                        title=title,
+                        merged_at=merged_at_str,
+                        is_workflow_pr=is_workflow_pr(title),
+                        category=classify_pr(title),
+                        additions=item.get("additions", 0),
+                        deletions=item.get("deletions", 0),
+                    )
+                )
+
+    # Sort by merge time
+    return sorted(prs, key=lambda p: p.merged_at)
+
+
+def find_git_repos_direct_children(root: Path) -> list[Path]:
+    repos: list[Path] = []
+    for p in sorted(root.iterdir(), key=lambda x: x.name.lower()):
+        if not p.is_dir():
+            continue
+        if (p / ".git").exists():
+            repos.append(p)
+    return repos
+
+
+_FAMILY_RE = re.compile(r"^(omni\w+?)(\d+)$")
+
+
+def family_key(repo_name: str) -> str | None:
+    """
+    Map repo clones to their canonical family name for deduplication.
+
+    Uses regex to strip trailing digits: omnibase_core2 -> omnibase_core, omnidash4 -> omnidash.
+    Returns None for repos without trailing digits (they are already canonical).
+    """
+    m = _FAMILY_RE.match(repo_name)
+    if m:
+        return m.group(1)
+    # Check if it's already a known omni-family base name
+    if repo_name.startswith("omni"):
+        return repo_name
+    return None
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    level: str  # "green", "yellow", "red"
+    main_dirty: int  # clones on main with uncommitted changes (real risk)
+    stale_branches: int  # feature branches with last commit >72h ago
+    diverged_branches: int  # feature branches diverged from origin/main >48h
+    risks: list[tuple[str, str]]  # (repo_name, reason)
+    penalty: int  # 0, -2, or -5
+    # Informational (not scored)
+    active_worktrees: int  # total dirty worktrees (parallelism, not risk)
+
+
+def compute_drift(repo_days: list[RepoDay], root: Path, date: dt.date) -> DriftReport:
+    """
+    Compute drift score based on actual risk signals, not parallelism.
+
+    Only scans repos with activity today (commits or merged PRs).  Legacy
+    repos with no today-activity are ignored — they're not part of the
+    current work surface.
+
+    Dirty worktrees on feature branches are NORMAL — they represent active
+    parallel work sessions. Drift is measured by:
+    1. Dirty files on main/master (uncommitted changes on integration branch)
+    2. Stale feature branches (no commits in >72h — forgotten work)
+    3. Diverged branches (feature branch behind origin/main by >48h)
+    """
+    main_dirty = 0
+    stale_branches = 0
+    diverged_branches = 0
+    active_worktrees = 0
+    risks: list[tuple[str, str]] = []
+
+    now = dt.datetime.combine(date, dt.time(23, 59, 59)).astimezone()
+
+    # Only consider repos with actual activity (commits or merged PRs), not
+    # repos included solely because of --include-dirty.  Legacy repos with
+    # dirty files but no today-activity are not part of the work surface.
+    active_repo_days = [rd for rd in repo_days if rd.commits or rd.github_merged_prs]
+
+    for rd in active_repo_days:
+        name = rd.name
+        repo_path = rd.path
+        branch = rd.branch
+        dirty = rd.dirty
+
+        if dirty:
+            active_worktrees += 1
+
+        # Risk 1: Dirty files on main/master (real risk — uncommitted on integration branch)
+        if dirty and branch in ("main", "master"):
+            main_dirty += 1
+            risks.append((name, f"{len(dirty)} dirty files on {branch}"))
+
+        # Risk 2 & 3: Feature branch staleness and divergence
+        if branch not in ("main", "master", "(detached)"):
+            try:
+                # Check last commit age on this branch
+                last_commit_date = _run(
+                    ["git", "log", "-1", "--format=%ai", branch],
+                    repo_path,
+                    allow_fail=True,
+                ).strip()
+                if last_commit_date:
+                    try:
+                        lc_dt = dt.datetime.fromisoformat(last_commit_date.strip())
+                        age = now - lc_dt.astimezone()
+                        if age.total_seconds() > 72 * 3600:
+                            stale_branches += 1
+                            days = int(age.total_seconds() / 86400)
+                            risks.append(
+                                (name, f"branch `{branch}` stale ({days}d, no commits)")
+                            )
+                    except (ValueError, TypeError):
+                        pass
+
+                # Check if branch has diverged from origin/main
+                merge_base_date = _run(
+                    ["git", "log", "-1", "--format=%ai", f"origin/main..{branch}"],
+                    repo_path,
+                    allow_fail=True,
+                ).strip()
+                if merge_base_date:
+                    try:
+                        mb_dt = dt.datetime.fromisoformat(merge_base_date.strip())
+                        age = now - mb_dt.astimezone()
+                        if age.total_seconds() > 48 * 3600:
+                            diverged_branches += 1
+                    except (ValueError, TypeError):
+                        pass
+            except Exception:
+                pass
+
+    # Scoring: only real risk signals count
+    # main_dirty is the strongest signal (uncommitted on integration branch)
+    # stale_branches is moderate (forgotten work that will conflict)
+    # diverged_branches is informational (will need rebase, but that's normal)
+    risk_score = main_dirty * 3 + stale_branches * 2 + max(0, diverged_branches - 2)
+
+    if risk_score >= 5:
+        level = "red"
+        penalty = -5
+    elif risk_score >= 2:
+        level = "yellow"
+        penalty = -2
+    else:
+        level = "green"
+        penalty = 0
+
+    # Sort risks by severity (main dirty first, then stale, then other)
+    risks.sort(
+        key=lambda r: (
+            0 if "dirty files on main" in r[1] else 1 if "stale" in r[1] else 2
+        )
+    )
+
+    return DriftReport(
+        level=level,
+        main_dirty=main_dirty,
+        stale_branches=stale_branches,
+        diverged_branches=diverged_branches,
+        risks=risks[:5],
+        penalty=penalty,
+        active_worktrees=active_worktrees,
+    )
+
+
+_CATEGORY_WEIGHTS: dict[str, float] = {
+    "capability": 2.0,
+    "correctness": 1.5,
+    "governance": 1.5,
+    "observability": 1.2,
+    "docs": 0.7,
+    "churn": 0.2,
+}
+
+
+def effectiveness_score_v2(
+    category_counts: dict[str, int],
+    drift_penalty: int,
+) -> tuple[int, str]:
+    """
+    Compute effectiveness score based on weighted PR categories.
+
+    Returns (score, explanation_string).
+    """
+    base = 60
+    pr_points = 0.0
+    total_prs = sum(category_counts.values())
+
+    for cat, count in category_counts.items():
+        pr_points += _CATEGORY_WEIGHTS.get(cat, 0.5) * count
+
+    pr_points = min(pr_points, 50.0)
+
+    penalty = 0
+    churn_count = category_counts.get("churn", 0)
+    churn_ratio = churn_count / max(total_prs, 1)
+    if churn_ratio > 0.20:
+        penalty += 3
+
+    penalty += abs(drift_penalty)
+
+    score = round(base + pr_points - penalty)
+    score = max(0, min(100, score))
+
+    parts = []
+    for cat, count in sorted(category_counts.items()):
+        if count > 0:
+            w = _CATEGORY_WEIGHTS.get(cat, 0.5)
+            parts.append(f"{cat}: {count} x {w}")
+    explanation = (
+        f"base {base} + PR points {pr_points:.1f} (capped at 50) - penalties {penalty}"
+    )
+    if parts:
+        explanation += f" | Breakdown: {', '.join(parts)}"
+
+    return score, explanation
+
+
+def velocity_score_v2(
+    merged_prs: list[tuple[str, GitHubMergedPR]],
+    unique_repos_with_merges: int,
+    drift_penalty: int,
+) -> tuple[int, str]:
+    """
+    Compute velocity score based on PR throughput, complexity, and repo breadth.
+
+    Returns (score, explanation_string).
+    """
+    base = 55
+    points = 0.0
+
+    for _repo, pr in merged_prs:
+        points += 2.0
+
+        # Complexity bonus based on net lines changed
+        net = pr.additions + pr.deletions
+        if 201 <= net <= 800:
+            points += 0.5
+        elif 801 <= net <= 2000:
+            points += 1.0
+        elif 2001 <= net <= 6000:
+            points += 1.5
+        elif net > 6000:
+            points += 2.0
+
+    # Repo breadth bonus
+    points += min(unique_repos_with_merges, 8) * 1.0
+
+    penalty = abs(drift_penalty)
+
+    score = round(base + min(points, 45.0) - penalty)
+    score = max(0, min(100, score))
+
+    explanation = (
+        f"base {base} + PR throughput/complexity ({len(merged_prs)} PRs)"
+        f" + repo breadth ({min(unique_repos_with_merges, 8)} repos)"
+        f" - drift penalty {abs(drift_penalty)}"
+    )
+
+    return score, explanation
+
+
+def base_week_monday(date: dt.date) -> dt.date:
+    # Monday is 0
+    return date - dt.timedelta(days=date.weekday())
+
+
+def month_name(date: dt.date) -> str:
+    return date.strftime("%B").upper()
+
+
+def deep_dive_filename(date: dt.date) -> str:
+    return f"{month_name(date)}_{date.day}_{date.year}_DEEP_DIVE.md"
+
+
+def sectionize_highlights(commits: Iterable[CommitEntry]) -> dict[str, list[str]]:
+    # Lightweight classifier for "Major Components & Work Completed"
+    buckets: dict[str, list[str]] = {
+        "Runtime / Dispatch": [],
+        "Models / Contracts": [],
+        "Validation / CI Gates": [],
+        "Idempotency / Time / Traceability": [],
+        "Documentation / Planning": [],
+        "Other": [],
+    }
+    for c in commits:
+        s = c.subject.lower()
+        item = f"{c.subject}"
+        if any(
+            k in s
+            for k in [
+                "dispatch",
+                "dispatcher",
+                "runtime",
+                "kernel",
+                "registry",
+                "scheduler",
+            ]
+        ):
+            buckets["Runtime / Dispatch"].append(item)
+        elif any(k in s for k in ["model", "models", "contract", "schema", "envelope"]):
+            buckets["Models / Contracts"].append(item)
+        elif any(
+            k in s
+            for k in ["validator", "validation", "ci", "gate", "strict validation"]
+        ):
+            buckets["Validation / CI Gates"].append(item)
+        elif any(
+            k in s
+            for k in [
+                "idempot",
+                "correlation",
+                "causation",
+                "trace",
+                "time injection",
+                "timeout",
+            ]
+        ):
+            buckets["Idempotency / Time / Traceability"].append(item)
+        elif any(
+            k in s for k in ["docs", "document", "plan", "handoff", "adr", "readme"]
+        ):
+            buckets["Documentation / Planning"].append(item)
+        else:
+            buckets["Other"].append(item)
+
+    # prune empty buckets
+    return {k: v for k, v in buckets.items() if v}
+
+
+def is_primary_onex_repo(repo_name: str) -> bool:
+    if repo_name.startswith("omnibase_core"):
+        return True
+    if repo_name.startswith("omnibase_infra"):
+        return True
+    if repo_name in {"omnibase_spi", "onex_change_control", "omninode_infra"}:
+        return True
+    return False
+
+
+def repo_commit_sums(rd: RepoDay) -> tuple[int, int, int, int]:
+    # commits, files, insertions, deletions
+    files = ins = dele = 0
+    for c in rd.commits:
+        files += c.files
+        ins += c.ins
+        dele += c.dele
+    return len(rd.commits), files, ins, dele
+
+
+def unique_commit_entries(repo_days: list[RepoDay]) -> list[CommitEntry]:
+    """
+    Dedupe commit entries across parallel working copies.
+
+    Key policy:
+    - For omnibase_core* clones: dedupe by ('omnibase_core', full_hash)
+    - For omnibase_infra* clones: dedupe by ('omnibase_infra', full_hash)
+    - For all other repos: dedupe by (repo_name, full_hash)
+    """
+    seen: set[tuple[str, str]] = set()
+    uniq: list[CommitEntry] = []
+    for rd in sorted(repo_days, key=lambda x: x.name.lower()):
+        fk = family_key(rd.name) or rd.name
+        for c in rd.commits:
+            k = (fk, c.full)
+            if k in seen:
+                continue
+            seen.add(k)
+            uniq.append(c)
+    return uniq
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    _default_root = os.environ.get("OMNI_HOME", "/Volumes/PRO-G40/Code/omni_home")
+    ap.add_argument(
+        "--root",
+        type=str,
+        default=_default_root,
+        help="Workspace root to scan (direct children only). Defaults to $OMNI_HOME.",
+    )
+    ap.add_argument(
+        "--date", type=str, default=None, help="YYYY-MM-DD; defaults to today (local)."
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Output path. Defaults to <root>/docs/deep-dives/<MONTH>_<DAY>_<YEAR>_DEEP_DIVE.md",
+    )
+    ap.add_argument(
+        "--json-scan-out",
+        type=str,
+        default=None,
+        help="Optional path to write the repo scan JSON.",
+    )
+    ap.add_argument(
+        "--include-dirty",
+        action="store_true",
+        default=False,
+        help="Include repos that only have dirty working trees (no commits today). Default: False.",
+    )
+    args = ap.parse_args()
+
+    date = _today_local() if not args.date else dt.date.fromisoformat(args.date)
+    start_s, end_s = _day_window(date)
+
+    root = Path(args.root).expanduser().resolve()
+    out_path = (
+        Path(args.out).expanduser().resolve()
+        if args.out
+        else (root / "docs" / "deep-dives" / deep_dive_filename(date))
+    )
+
+    repos = find_git_repos_direct_children(root)
+
+    # Filter to only include repos with 'omni' prefix
+    repos = [r for r in repos if r.name.lower().startswith("omni")]
+
+    repo_days: list[RepoDay] = []
+    scan_json: dict[str, object] = {
+        "date": str(date),
+        "start": start_s,
+        "end": end_s,
+        "repos_modified_today": [],
+    }
+
+    for repo in repos:
+        name = repo.name
+        commits = get_commit_entries(repo, start_s, end_s)
+        merges = get_merge_entries(repo, start_s, end_s)
+        dirty = get_dirty(repo)
+        github_prs = get_github_merged_prs(repo, date)
+
+        # Only include repos with commits today OR merged PRs (unless --include-dirty is set)
+        if not commits and not github_prs:
+            if not args.include_dirty or not dirty:
+                continue
+
+        branch = get_branch(repo)
+        repo_days.append(
+            RepoDay(
+                name=name,
+                path=repo,
+                branch=branch,
+                commits=commits,
+                merges=merges,
+                dirty=dirty,
+                github_merged_prs=github_prs,
+            )
+        )
+        scan_json["repos_modified_today"].append(
+            {
+                "repo": str(repo),
+                "name": name,
+                "commits_today": len(commits),
+                "merged_prs_today": len(github_prs),
+                "feature_prs_today": len(
+                    [p for p in github_prs if not p.is_workflow_pr]
+                ),
+                "dirty": dirty,
+            }
+        )
+
+    if args.json_scan_out:
+        Path(args.json_scan_out).expanduser().resolve().write_text(
+            json.dumps(scan_json, indent=2) + "\n"
+        )
+
+    # Aggregate family metrics (dedupe by full hash within family)
+    families: dict[str, list[RepoDay]] = {
+        "omnibase_core": [],
+        "omnibase_infra": [],
+        "omnimemory": [],
+    }
+    standalones: list[RepoDay] = []
+    for rd in repo_days:
+        fk = family_key(rd.name)
+        if fk and fk in families:
+            families[fk].append(rd)
+        else:
+            standalones.append(rd)
+
+    def family_unique_commits(fam: list[RepoDay]) -> set[str]:
+        s: set[str] = set()
+        for rd in fam:
+            for c in rd.commits:
+                s.add(c.full)
+        return s
+
+    core_unique = len(family_unique_commits(families["omnibase_core"]))
+    infra_unique = len(family_unique_commits(families["omnibase_infra"]))
+
+    # Count PRs by category - DEDUPED by family + PR number
+    seen_pr_keys: set[tuple[str, int]] = set()
+    category_counts: dict[str, int] = {
+        "capability": 0,
+        "correctness": 0,
+        "governance": 0,
+        "observability": 0,
+        "docs": 0,
+        "churn": 0,
+    }
+    all_deduped_prs: list[tuple[str, GitHubMergedPR]] = []
+    for rd in repo_days:
+        fk = family_key(rd.name) or rd.name
+        for pr in rd.github_merged_prs:
+            if pr.is_workflow_pr:
+                continue
+            pr_key = (fk, pr.number)
+            if pr_key not in seen_pr_keys:
+                seen_pr_keys.add(pr_key)
+                category_counts[pr.category] = category_counts.get(pr.category, 0) + 1
+                all_deduped_prs.append((fk, pr))
+
+    # Compute drift
+    drift = compute_drift(repo_days, root, date)
+
+    # Unique repos with merged PRs
+    unique_repos_with_merges = len({repo for repo, _pr in all_deduped_prs})
+
+    # V2 Scoring
+    velocity, velocity_explanation = velocity_score_v2(
+        all_deduped_prs, unique_repos_with_merges, drift.penalty
+    )
+    effectiveness, effectiveness_explanation = effectiveness_score_v2(
+        category_counts, drift.penalty
+    )
+
+    # Begin document
+    lines: list[str] = []
+    lines.append(
+        f"# {date.strftime('%B')} {date.day}, {date.year} - Deep Dive Analysis"
+    )
+    lines.append("")
+    lines.append(
+        f"**Date**: {date.strftime('%A')}, {date.strftime('%B')} {date.day}, {date.year}  "
+    )
+    monday = base_week_monday(date)
+    lines.append(
+        f"**Week**: Week of {monday.strftime('%B')} {monday.day}, {monday.year}  "
+    )
+    lines.append(f"**Day of Week**: {date.strftime('%A')}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Executive Summary")
+    lines.append("")
+    lines.append(f"**Velocity Score**: {velocity}/100  ")
+    lines.append(f"**Effectiveness Score**: {effectiveness}/100")
+    lines.append("")
+
+    # Build dynamic assessment
+    top_cats = sorted(
+        ((cat, cnt) for cat, cnt in category_counts.items() if cnt > 0),
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    if top_cats:
+        top_names = [f"{cat} ({cnt})" for cat, cnt in top_cats[:3]]
+        assessment = f"Top focus areas: {', '.join(top_names)}. Drift: {drift.level}."
+    else:
+        assessment = "No merged PRs detected for this period."
+    lines.append(f"**Overall Assessment**: {assessment}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Merged PRs from GitHub (the "honest" metric)
+    # Dedupe across working copies: use family key + PR number
+    _CATEGORY_DISPLAY = {
+        "capability": ("Capability (Net-New)", "🚀"),
+        "correctness": ("Correctness / Hardening", "🔧"),
+        "governance": ("Governance / Safety Rails", "🛡️"),
+        "observability": ("Observability", "📊"),
+        "docs": ("Documentation", "📝"),
+        "churn": ("Churn / Investigation", "🔄"),
+    }
+
+    # Group PRs by category for display
+    prs_by_category: dict[str, list[tuple[str, GitHubMergedPR]]] = {}
+    workflow_prs: list[tuple[str, GitHubMergedPR]] = []
+    seen_prs: set[tuple[str, int]] = set()
+
+    for rd in repo_days:
+        fk = family_key(rd.name) or rd.name
+        for pr in rd.github_merged_prs:
+            dedupe_key = (fk, pr.number)
+            if dedupe_key in seen_prs:
+                continue
+            seen_prs.add(dedupe_key)
+            display_name = fk if family_key(rd.name) else rd.name
+
+            if pr.is_workflow_pr:
+                workflow_prs.append((display_name, pr))
+            else:
+                prs_by_category.setdefault(pr.category, []).append((display_name, pr))
+
+    has_any_prs = any(prs_by_category.values()) or workflow_prs
+    if has_any_prs:
+        lines.append("## Merged PRs (from GitHub)")
+        lines.append("")
+        lines.append(
+            "*PRs categorized into 6 buckets to separate capability from correctness, governance, observability, docs, and churn.*"
+        )
+        lines.append("")
+
+        # Render each non-empty category
+        for cat_key in [
+            "capability",
+            "correctness",
+            "governance",
+            "observability",
+            "docs",
+            "churn",
+        ]:
+            cat_prs = prs_by_category.get(cat_key, [])
+            if not cat_prs:
+                continue
+            display_label, emoji = _CATEGORY_DISPLAY[cat_key]
+            lines.append(f"### {emoji} {display_label}")
+            lines.append("")
+            lines.append("| Repo | PR | Title | Merged |")
+            lines.append("|------|-----|-------|--------|")
+            for repo_name, pr in sorted(cat_prs, key=lambda x: x[1].merged_at):
+                merge_time = (
+                    pr.merged_at[11:16] if len(pr.merged_at) > 16 else pr.merged_at
+                )
+                lines.append(
+                    f"| {repo_name} | #{pr.number} | {pr.title} | {merge_time} EST |"
+                )
+            lines.append("")
+            lines.append(f"**{display_label} PRs**: {len(cat_prs)}")
+            lines.append("")
+
+        # Workflow noise (filtered)
+        if workflow_prs:
+            lines.append("### Workflow/Automation (excluded from scoring)")
+            lines.append("")
+            lines.append(f"*{len(workflow_prs)} auto-generated workflow PRs merged*")
+            lines.append("")
+
+        # Summary
+        lines.append("### Summary")
+        lines.append("")
+        for cat_key in [
+            "capability",
+            "correctness",
+            "governance",
+            "observability",
+            "docs",
+            "churn",
+        ]:
+            display_label, _emoji = _CATEGORY_DISPLAY[cat_key]
+            count = category_counts.get(cat_key, 0)
+            lines.append(f"- **{display_label}**: {count} PRs")
+        lines.append(f"- **Workflow noise**: {len(workflow_prs)} PRs (excluded)")
+        lines.append("")
+
+        lines.append("---")
+        lines.append("")
+
+    lines.append("## Repository Activity Overview (Repos with commits today)")
+    lines.append("")
+    # Core rollup (only working copies with commits)
+    core_rds_with_commits = [rd for rd in families["omnibase_core"] if rd.commits]
+    core_rds_with_commits = sorted(core_rds_with_commits, key=lambda x: x.name.lower())
+    if core_rds_with_commits:
+        lines.append("### omnibase_core (across working copies)")
+        lines.append(
+            f"- **Unique commits (deduped across working copies)**: {core_unique}"
+        )
+        lines.append("- **Working-copy activity**:")
+        for rd in core_rds_with_commits:
+            c, f, ins, dele = repo_commit_sums(rd)
+            lines.append(f"  - `{rd.name}`: {c} commits | {f} files | +{ins} / -{dele}")
+        lines.append("")
+
+    # Infra rollup (only working copies with commits)
+    infra_rds_with_commits = [rd for rd in families["omnibase_infra"] if rd.commits]
+    infra_rds_with_commits = sorted(
+        infra_rds_with_commits, key=lambda x: x.name.lower()
+    )
+    if infra_rds_with_commits:
+        lines.append("### omnibase_infra (across working copies)")
+        lines.append(
+            f"- **Unique commits (deduped across working copies)**: {infra_unique}"
+        )
+        lines.append("- **Working-copy activity**:")
+        for rd in infra_rds_with_commits:
+            c, f, ins, dele = repo_commit_sums(rd)
+            lines.append(f"  - `{rd.name}`: {c} commits | {f} files | +{ins} / -{dele}")
+        lines.append("")
+
+    # Other primary ONEX repos (only those with commits)
+    primary_other = [
+        rd
+        for rd in repo_days
+        if rd.name in {"omnibase_spi", "onex_change_control", "omninode_infra"}
+        and rd.commits
+    ]
+    if primary_other:
+        lines.append("### Other ONEX ecosystem repos")
+        for rd in sorted(primary_other, key=lambda x: x.name.lower()):
+            c, f, ins, dele = repo_commit_sums(rd)
+            lines.append(
+                f"- **{rd.name}**: {c} commits | {f} files | +{ins} / -{dele} (branch: `{rd.branch}`)"
+            )
+        lines.append("")
+
+    # Other repos (only those with commits)
+    other_repos = [
+        rd for rd in repo_days if not is_primary_onex_repo(rd.name) and rd.commits
+    ]
+    if other_repos:
+        lines.append("### Other repos with commits today")
+        for rd in sorted(other_repos, key=lambda x: x.name.lower()):
+            c, f, ins, dele = repo_commit_sums(rd)
+            lines.append(
+                f"- **{rd.name}**: {c} commits | {f} files | +{ins} / -{dele} (branch: `{rd.branch}`)"
+            )
+        lines.append("")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Major components: use ONEX-ish subset if present
+    lines.append("## Major Components & Work Completed")
+    lines.append("")
+    primary_repo_days = [rd for rd in repo_days if is_primary_onex_repo(rd.name)]
+    uniq_primary_commits = unique_commit_entries(primary_repo_days)
+    buckets = sectionize_highlights(uniq_primary_commits)
+    for title, items in buckets.items():
+        lines.append(f"### {title}")
+        for it in items[:12]:
+            lines.append(f"- {it}")
+        if len(items) > 12:
+            lines.append(f"- ... ({len(items) - 12} more)")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # PR Inventory: inferred from subjects (best-effort; local-only)
+    lines.append("## PR Inventory (Today)")
+    lines.append("")
+    for rd in sorted(primary_repo_days, key=lambda x: x.name.lower()):
+        prs: set[int] = set()
+        for c in rd.commits:
+            prs.update(extract_pr_numbers(c.subject))
+        for m in rd.merges:
+            prs.update(extract_pr_numbers(m.subject))
+        if not prs:
+            continue
+        lines.append(f"### {rd.name}")
+        lines.append(
+            f"- PR references in commits: {', '.join(f'#{p}' for p in sorted(prs))}"
+        )
+        lines.append("")
+    # Local dirty-only repos (no commits) — only shown if --include-dirty was used
+    if args.include_dirty:
+        dirty_only = [rd for rd in repo_days if rd.dirty and not rd.commits]
+        if dirty_only:
+            lines.append("### Stale repos (dirty working tree only; no commits today)")
+            for rd in sorted(dirty_only, key=lambda x: x.name.lower()):
+                lines.append(
+                    f"- **{rd.name}**: {len(rd.dirty)} uncommitted changes (branch: `{rd.branch}`)"
+                )
+            lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Metrics
+    lines.append("## Metrics & Statistics")
+    lines.append("")
+    lines.append("### Commit Activity")
+    lines.append(f"- **Core (all working copies)**: {core_unique} unique commits")
+    lines.append(f"- **Infra (all working copies)**: {infra_unique} unique commits")
+    lines.append(
+        f"- **Other repos**: {sum(len(rd.commits) for rd in standalones)} commits (non-deduped)"
+    )
+    lines.append("")
+
+    def sum_stats(rds: list[RepoDay]) -> tuple[int, int, int]:
+        files = ins = dele = 0
+        for rd in rds:
+            for c in rd.commits:
+                files += c.files
+                ins += c.ins
+                dele += c.dele
+        return files, ins, dele
+
+    core_files, core_ins, core_del = sum_stats(families["omnibase_core"])
+    infra_files, infra_ins, infra_del = sum_stats(families["omnibase_infra"])
+
+    lines.append("### File & Line Changes (from today's commits; summed)")
+    lines.append(f"- **Core**: {core_files} files | +{core_ins} / -{core_del}")
+    lines.append(f"- **Infra**: {infra_files} files | +{infra_ins} / -{infra_del}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Risks (only consider repos with commits today)
+    repos_with_commits = [rd for rd in repo_days if rd.commits]
+    lines.append("## Challenges / Risks Observed")
+    lines.append("")
+    added_risk = False
+    if any(any(".env" in d for d in rd.dirty) for rd in repos_with_commits):
+        lines.append(
+            "- **Environment/config churn**: `.env`/docker config touched in repos with today's commits; easy source of local divergence."
+        )
+        added_risk = True
+    if not added_risk:
+        lines.append(
+            "- No major risks detected from commit metadata alone; integration/flake risk remains once real infra is exercised."
+        )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Drift Telemetry
+    lines.append("## Drift Telemetry")
+    lines.append("")
+    drift_emoji = {"green": "🟢", "yellow": "🟡", "red": "🔴"}.get(drift.level, "⚪")
+    lines.append(
+        f"**Drift Score**: {drift_emoji} {drift.level.upper()} (penalty: {drift.penalty})"
+    )
+    lines.append("")
+    lines.append("| Signal | Count | Risk Level |")
+    lines.append("|--------|-------|------------|")
+    lines.append(
+        f"| Dirty files on main/master | {drift.main_dirty} | {'⚠️ HIGH' if drift.main_dirty > 0 else '✅'} |"
+    )
+    lines.append(
+        f"| Stale feature branches (>72h) | {drift.stale_branches} | {'⚠️ MEDIUM' if drift.stale_branches > 0 else '✅'} |"
+    )
+    lines.append(
+        f"| Diverged from origin/main (>48h) | {drift.diverged_branches} | {'ℹ️ INFO' if drift.diverged_branches > 0 else '✅'} |"  # noqa: RUF001
+    )
+    lines.append(
+        f"| Active parallel worktrees | {drift.active_worktrees} | ✅ (normal) |"
+    )
+    lines.append("")
+    if drift.risks:
+        lines.append("**Action items**:")
+        for repo_name, reason in drift.risks:
+            lines.append(f"- `{repo_name}`: {reason}")
+        lines.append("")
+    else:
+        lines.append("No drift risks detected.")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Demo Readiness (stub -- requires golden path runner data)
+    lines.append("## Demo Readiness")
+    lines.append("")
+    lines.append(
+        "*Data sources not yet available. Requires golden path runner integration.*"
+    )
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append("| Golden path runs today | — |")
+    lines.append("| Success rate (last 10) | — |")
+    lines.append("| Manual steps remaining | — |")
+    lines.append(
+        f"| Critical path tickets remaining | {category_counts.get('capability', 0)} (approx) |"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Velocity & Effectiveness Scoring")
+    lines.append("")
+    lines.append(f"**Velocity Score: {velocity}/100**")
+    lines.append(f"- {velocity_explanation}")
+    lines.append("")
+    lines.append(f"**Effectiveness Score: {effectiveness}/100**")
+    lines.append(f"- {effectiveness_explanation}")
+    lines.append("")
+    lines.append("### PR Category Breakdown")
+    lines.append("")
+    lines.append("| Category | Count | Weight | Points |")
+    lines.append("|----------|-------|--------|--------|")
+    for cat in [
+        "capability",
+        "correctness",
+        "governance",
+        "observability",
+        "docs",
+        "churn",
+    ]:
+        count = category_counts.get(cat, 0)
+        weight = _CATEGORY_WEIGHTS.get(cat, 0.5)
+        points = count * weight
+        lines.append(f"| {cat} | {count} | {weight} | {points:.1f} |")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Appendix A — Complete Commit Logs (Every Commit Today)")
+    lines.append("")
+    for rd in sorted(repo_days, key=lambda x: x.name.lower()):
+        if not rd.commits:
+            continue
+        lines.append(f"### {rd.name} (full day log capture)")
+        lines.append("```")
+        for c in rd.commits:
+            lines.append(f"{c.short}|{c.ai}|{c.author}|{c.subject}")
+        lines.append("```")
+        lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_feature_inventory.py
+++ b/scripts/generate_feature_inventory.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""
+Generate a FEATURE_REGISTRY.md by scanning Kafka-integrated ONEX nodes across all repos.
+
+Scans all repos under --root for ONEX nodes with `event_bus:` sections in contract YAMLs.
+Outputs a markdown table with columns:
+  Repo | Node | Subscribe Topics | Publish Topics | Design Spec | Fixture Present | Manual Review | Contract Path
+
+Also appends an Orphaned Fixtures section for test fixture directories with no matching contract.
+
+Usage:
+  python3 scripts/generate_feature_inventory.py
+  python3 scripts/generate_feature_inventory.py --root /Volumes/PRO-G40/Code/omni_home \\
+      --out /Volumes/PRO-G40/Code/omni_home/docs/integration/FEATURE_REGISTRY.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NodeEntry:
+    """A single Kafka-integrated ONEX node discovered from a contract YAML."""
+
+    repo: str
+    node_name: str
+    subscribe_topics: list[str]
+    publish_topics: list[str]
+    design_spec: str  # link or "—"
+    fixture_present: bool
+    manual_review: str  # "—" unless flagged
+    contract_path: str  # relative path from repo root
+
+
+@dataclass
+class OrphanedFixture:
+    """A test fixture directory that has no matching contract YAML."""
+
+    repo: str
+    fixture_path: str  # relative path from repo root
+
+
+# ---------------------------------------------------------------------------
+# YAML loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file, returning an empty dict on any parse error."""
+    if yaml is not None:
+        try:
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    # Fallback: minimal line-by-line parser for subscribe/publish_topics only.
+    # This handles the common omnibase_infra / omniintelligence contract format.
+    return _parse_yaml_fallback(path)
+
+
+def _parse_yaml_fallback(path: Path) -> dict[str, Any]:
+    """
+    Minimal YAML parser that extracts event_bus subscribe_topics / publish_topics.
+    Used only when the 'yaml' package is not available.
+    """
+    lines: list[str] = []
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+    except Exception:
+        return {}
+
+    result: dict[str, Any] = {}
+    in_event_bus = False
+    in_subscribe_topics = False
+    in_publish_topics = False
+    in_subscribe_block = False  # for omniclaude-style subscribe: {topic: ...}
+    in_publish_block = False  # for omniclaude-style publish: {success_topic: ...}
+
+    subscribe_topics: list[str] = []
+    publish_topics: list[str] = []
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        indent = len(raw_line) - len(raw_line.lstrip())
+
+        # Detect top-level sections
+        if not raw_line.startswith(" ") and not raw_line.startswith("\t"):
+            if stripped.startswith("name:"):
+                result["name"] = stripped.split(":", 1)[1].strip().strip('"')
+            in_event_bus = stripped == "event_bus:"
+
+        if not in_event_bus:
+            continue
+
+        # --- omnibase_infra / omniintelligence format ---
+        # event_bus:
+        #   subscribe_topics:
+        #     - "topic.name"
+        #   publish_topics:
+        #     - "topic.name"
+        if stripped == "subscribe_topics:":
+            in_subscribe_topics = True
+            in_publish_topics = False
+            in_subscribe_block = False
+            in_publish_block = False
+        elif stripped == "publish_topics:":
+            in_publish_topics = True
+            in_subscribe_topics = False
+            in_subscribe_block = False
+            in_publish_block = False
+        # --- omniclaude format ---
+        # event_bus:
+        #   subscribe:
+        #     topic: "topic.name"
+        #   publish:
+        #     success_topic: "..."
+        #     failure_topic: "..."
+        elif stripped == "subscribe:" and indent >= 2:
+            in_subscribe_block = True
+            in_publish_block = False
+            in_subscribe_topics = False
+        elif stripped == "publish:" and indent >= 2:
+            in_publish_block = True
+            in_subscribe_block = False
+            in_publish_topics = False
+        elif stripped.startswith("- ") and in_subscribe_topics:
+            val = stripped[2:].strip().strip('"').strip("'")
+            if val:
+                subscribe_topics.append(val)
+        elif stripped.startswith("- ") and in_publish_topics:
+            val = stripped[2:].strip().strip('"').strip("'")
+            if val:
+                publish_topics.append(val)
+        elif in_subscribe_block and stripped.startswith("topic:"):
+            val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+            if val:
+                subscribe_topics.append(val)
+        elif (in_publish_block and stripped.startswith("success_topic:")) or (
+            in_publish_block and stripped.startswith("failure_topic:")
+        ):
+            val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+            if val:
+                publish_topics.append(val)
+
+    if subscribe_topics or publish_topics:
+        result["event_bus"] = {
+            "_subscribe_topics": subscribe_topics,
+            "_publish_topics": publish_topics,
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Topic extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_topics(event_bus: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """
+    Extract (subscribe_topics, publish_topics) from an event_bus dict.
+
+    Handles three contract formats:
+    - omnibase_infra / omniintelligence: subscribe_topics / publish_topics as string lists
+    - omniintelligence rich format: lists of {name, topic, description, ...} dicts
+    - omniclaude: subscribe.topic + publish.success_topic / publish.failure_topic
+    - Fallback parser output: _subscribe_topics / _publish_topics
+    """
+    subscribe_topics: list[str] = []
+    publish_topics: list[str] = []
+
+    if not event_bus:
+        return subscribe_topics, publish_topics
+
+    # Fallback parser output
+    if "_subscribe_topics" in event_bus or "_publish_topics" in event_bus:
+        subscribe_topics = list(event_bus.get("_subscribe_topics", []))
+        publish_topics = list(event_bus.get("_publish_topics", []))
+        return subscribe_topics, publish_topics
+
+    # omnibase_infra / omniintelligence format
+    sub_topics = event_bus.get("subscribe_topics")
+    if isinstance(sub_topics, list):
+        for t in sub_topics:
+            if isinstance(t, dict):
+                # Rich format: {name: ..., topic: "...", description: ...}
+                topic_val = t.get("topic")
+                if topic_val:
+                    subscribe_topics.append(str(topic_val))
+            elif t:
+                subscribe_topics.append(str(t))
+
+    pub_topics = event_bus.get("publish_topics")
+    if isinstance(pub_topics, list):
+        for t in pub_topics:
+            if isinstance(t, dict):
+                # Rich format: {name: ..., topic: "...", description: ...}
+                topic_val = t.get("topic")
+                if topic_val:
+                    publish_topics.append(str(topic_val))
+            elif t:
+                publish_topics.append(str(t))
+
+    # omniclaude format
+    subscribe_block = event_bus.get("subscribe")
+    if isinstance(subscribe_block, dict):
+        topic = subscribe_block.get("topic")
+        if topic:
+            subscribe_topics.append(str(topic))
+
+    publish_block = event_bus.get("publish")
+    if isinstance(publish_block, dict):
+        for key in ("success_topic", "failure_topic"):
+            val = publish_block.get(key)
+            if val:
+                publish_topics.append(str(val))
+
+    return subscribe_topics, publish_topics
+
+
+# ---------------------------------------------------------------------------
+# Design spec lookup
+# ---------------------------------------------------------------------------
+
+# Map node name fragments to design spec filenames (checked against docs/design/)
+_DESIGN_SPEC_KEYWORDS: list[tuple[str, str]] = [
+    ("baselines", "DESIGN_BASELINES"),
+    ("intent_classifier", "DESIGN_INTENT_CLASSIFIER"),
+    ("pattern", "DESIGN_PATTERN"),
+    ("routing", "DESIGN_ROUTING"),
+    ("embedding", "DESIGN_EMBEDDING"),
+    ("ledger_projection", "DESIGN_LEDGER"),
+    ("validation_orchestrator", "DESIGN_VALIDATION"),
+    ("reward_binder", "DESIGN_REWARD"),
+    ("registration", "DESIGN_REGISTRATION"),
+    ("contract_resolver", "DESIGN_CONTRACT"),
+    ("scoring", "DESIGN_SCORING"),
+    ("doc_promotion", "DESIGN_DOC_PROMOTION"),
+    ("doc_retrieval", "DESIGN_DOC_RETRIEVAL"),
+    ("compliance", "DESIGN_COMPLIANCE"),
+    ("policy_state", "DESIGN_POLICY"),
+    ("skill", "DESIGN_SKILL"),
+]
+
+
+def find_design_spec(node_name: str, docs_design_dir: Path) -> str:
+    """Return a relative link to a matching design spec, or '—'."""
+    if not docs_design_dir.exists():
+        return "—"
+
+    node_lower = node_name.lower()
+
+    # Try keyword-based lookup first
+    for fragment, prefix in _DESIGN_SPEC_KEYWORDS:
+        if fragment in node_lower:
+            for spec_file in docs_design_dir.iterdir():
+                if spec_file.name.upper().startswith(prefix):
+                    return f"[{spec_file.name}](../design/{spec_file.name})"
+
+    # Fall back to substring search in spec filenames
+    for spec_file in sorted(docs_design_dir.iterdir()):
+        parts = (
+            node_name.replace("node_", "")
+            .replace("_compute", "")
+            .replace("_effect", "")
+            .replace("_orchestrator", "")
+            .replace("_reducer", "")
+        )
+        if any(p in spec_file.name.lower() for p in parts.split("_") if len(p) > 4):
+            return f"[{spec_file.name}](../design/{spec_file.name})"
+
+    return "—"
+
+
+# ---------------------------------------------------------------------------
+# Fixture detection
+# ---------------------------------------------------------------------------
+
+
+def _fixture_paths_for_repo(repo_path: Path) -> set[str]:
+    """
+    Return a set of node names that have test fixture directories.
+    Looks in tests/unit/nodes/<node_name>/ and tests/integration/<node_name>/.
+    """
+    fixtures: set[str] = set()
+    for base in ("tests/unit/nodes", "tests/integration/nodes", "tests/unit", "tests"):
+        tests_dir = repo_path / base
+        if not tests_dir.exists():
+            continue
+        for entry in tests_dir.iterdir():
+            if entry.is_dir() and entry.name.startswith("node_"):
+                fixtures.add(entry.name)
+    return fixtures
+
+
+def _all_node_names_in_repo(repo_path: Path) -> set[str]:
+    """
+    Return all node names found under src/ with any contract.yaml.
+    """
+    names: set[str] = set()
+    for contract in repo_path.glob("src/**/contract.yaml"):
+        # Skip .venv and .claude worktrees
+        parts = contract.parts
+        if ".venv" in parts or ".claude" in parts:
+            continue
+        node_dir = contract.parent
+        names.add(node_dir.name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Repo scanning
+# ---------------------------------------------------------------------------
+
+
+def _find_git_repos(root: Path) -> list[Path]:
+    """Return direct-child git repos under root."""
+    repos: list[Path] = []
+    for p in sorted(root.iterdir(), key=lambda x: x.name.lower()):
+        if not p.is_dir():
+            continue
+        if (p / ".git").exists():
+            repos.append(p)
+    return repos
+
+
+def scan_repo(
+    repo_path: Path,
+    docs_design_dir: Path,
+) -> tuple[list[NodeEntry], list[OrphanedFixture]]:
+    """
+    Scan a single repo for Kafka-integrated nodes.
+
+    Returns (nodes, orphaned_fixtures).
+    """
+    repo_name = repo_path.name
+    nodes: list[NodeEntry] = []
+    orphaned: list[OrphanedFixture] = []
+
+    # Collect fixture dirs (for "Fixture Present" column)
+    fixture_names = _fixture_paths_for_repo(repo_path)
+    # Collect all node names (for orphan detection)
+    all_node_names = _all_node_names_in_repo(repo_path)
+
+    # Contracts to scan — skip .venv and .claude worktrees
+    contracts: list[Path] = []
+    for contract in repo_path.glob("src/**/contract.yaml"):
+        parts = contract.parts
+        if ".venv" in parts or ".claude" in parts:
+            continue
+        contracts.append(contract)
+
+    # Track which node names have event_bus
+    event_bus_nodes: set[str] = set()
+
+    for contract_path in sorted(contracts):
+        data = _load_yaml(contract_path)
+        event_bus = data.get("event_bus")
+        if not event_bus:
+            continue
+
+        subscribe_topics, publish_topics = _extract_topics(event_bus)
+        if not subscribe_topics and not publish_topics:
+            continue
+
+        node_dir = contract_path.parent
+        node_name = node_dir.name
+
+        # Use node_name from contract if available, else directory name
+        contract_node_name = data.get("name") or data.get("node_name") or node_name
+
+        event_bus_nodes.add(node_name)
+
+        fixture_present = node_name in fixture_names
+        design_spec = find_design_spec(node_name, docs_design_dir)
+
+        # Relative contract path from repo root
+        try:
+            rel_path = str(contract_path.relative_to(repo_path))
+        except ValueError:
+            rel_path = str(contract_path)
+
+        nodes.append(
+            NodeEntry(
+                repo=repo_name,
+                node_name=contract_node_name,
+                subscribe_topics=subscribe_topics,
+                publish_topics=publish_topics,
+                design_spec=design_spec,
+                fixture_present=fixture_present,
+                manual_review="—",
+                contract_path=rel_path,
+            )
+        )
+
+    # Detect orphaned fixtures: fixture dirs that have no matching contract.yaml
+    for fixture_name in sorted(fixture_names):
+        if fixture_name not in all_node_names:
+            # Find the actual path
+            for base in (
+                "tests/unit/nodes",
+                "tests/integration/nodes",
+                "tests/unit",
+                "tests",
+            ):
+                candidate = repo_path / base / fixture_name
+                if candidate.exists():
+                    try:
+                        rel = str(candidate.relative_to(repo_path))
+                    except ValueError:
+                        rel = str(candidate)
+                    orphaned.append(OrphanedFixture(repo=repo_name, fixture_path=rel))
+                    break
+
+    return nodes, orphaned
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _topics_cell(topics: list[str]) -> str:
+    if not topics:
+        return "—"
+    if len(topics) == 1:
+        return f"`{topics[0]}`"
+    return "<br>".join(f"`{t}`" for t in topics)
+
+
+def render_registry(
+    nodes: list[NodeEntry],
+    orphaned: list[OrphanedFixture],
+    generated_at: str,
+) -> str:
+    lines: list[str] = []
+
+    lines.append("# FEATURE_REGISTRY.md")
+    lines.append("")
+    lines.append(
+        "Inventory of all Kafka-integrated ONEX nodes across the OmniNode platform."
+    )
+    lines.append(
+        f"Generated by `docs/tools/generate_feature_inventory.py` on {generated_at}."
+    )
+    lines.append("")
+    lines.append(
+        "> **Legend** — Fixture Present: `Y` = test fixture directory exists, `N` = no fixture found.  "
+    )
+    lines.append("> Manual Review: `—` unless flagged for human attention.  ")
+    lines.append("> Design Spec: link to `docs/design/` doc, or `—` if none found.")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Table header
+    lines.append(
+        "| Repo | Node | Subscribe Topics | Publish Topics"
+        " | Design Spec | Fixture Present | Manual Review | Contract Path |"
+    )
+    lines.append(
+        "|------|------|-----------------|----------------|"
+        "-------------|-----------------|---------------|---------------|"
+    )
+
+    for n in nodes:
+        fixture_val = "Y" if n.fixture_present else "N"
+        subscribe_cell = _topics_cell(n.subscribe_topics)
+        publish_cell = _topics_cell(n.publish_topics)
+        lines.append(
+            f"| {n.repo} | {n.node_name} | {subscribe_cell} | {publish_cell}"
+            f" | {n.design_spec} | {fixture_val} | {n.manual_review} | `{n.contract_path}` |"
+        )
+
+    lines.append("")
+    lines.append(f"**Total Kafka-integrated nodes**: {len(nodes)}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Summary by repo
+    lines.append("## Summary by Repo")
+    lines.append("")
+    repo_counts: dict[str, dict[str, int]] = {}
+    for n in nodes:
+        if n.repo not in repo_counts:
+            repo_counts[n.repo] = {"total": 0, "with_fixture": 0, "with_spec": 0}
+        repo_counts[n.repo]["total"] += 1
+        if n.fixture_present:
+            repo_counts[n.repo]["with_fixture"] += 1
+        if n.design_spec != "—":
+            repo_counts[n.repo]["with_spec"] += 1
+
+    lines.append("| Repo | Nodes | With Fixture | With Design Spec |")
+    lines.append("|------|-------|--------------|-----------------|")
+    for repo, counts in sorted(repo_counts.items()):
+        lines.append(
+            f"| {repo} | {counts['total']}"
+            f" | {counts['with_fixture']} ({counts['with_fixture'] * 100 // max(counts['total'], 1)}%)"
+            f" | {counts['with_spec']} ({counts['with_spec'] * 100 // max(counts['total'], 1)}%) |"
+        )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Orphaned Fixtures section
+    lines.append("## Orphaned Fixtures")
+    lines.append("")
+    lines.append(
+        "Test fixture directories that have no matching `contract.yaml` in `src/`."
+    )
+    lines.append("")
+    if orphaned:
+        lines.append("| Repo | Fixture Path |")
+        lines.append("|------|-------------|")
+        for o in orphaned:
+            lines.append(f"| {o.repo} | `{o.fixture_path}` |")
+    else:
+        lines.append("_No orphaned fixtures detected._")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Generate FEATURE_REGISTRY.md for Kafka-integrated ONEX nodes."
+    )
+    ap.add_argument(
+        "--root",
+        type=str,
+        default=os.environ.get(
+            "OMNI_HOME", str(Path(__file__).resolve().parent.parent.parent)
+        ),
+        help="Workspace root to scan (direct children only). Defaults to $OMNI_HOME.",
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help=("Output path. Defaults to <root>/docs/integration/FEATURE_REGISTRY.md"),
+    )
+    ap.add_argument(
+        "--overrides",
+        type=str,
+        default=None,
+        help="Path to feature_spec_overrides.yaml for manual overrides.",
+    )
+    args = ap.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+
+    # Default output
+    if args.out:
+        out_path = Path(args.out).expanduser().resolve()
+    else:
+        out_path = root / "docs" / "integration" / "FEATURE_REGISTRY.md"
+
+    # Design specs directory (relative to root)
+    docs_design_dir = root / "docs" / "design"
+
+    # Load overrides if provided
+    overrides: dict[str, Any] = {}
+    overrides_path = (
+        Path(args.overrides).expanduser().resolve()
+        if args.overrides
+        else Path(__file__).resolve().parent / "feature_spec_overrides.yaml"
+    )
+    if overrides_path.exists():
+        try:
+            overrides = _load_yaml(overrides_path)
+        except Exception:
+            overrides = {}
+
+    # Scan repos
+    repos = _find_git_repos(root)
+
+    all_nodes: list[NodeEntry] = []
+    all_orphaned: list[OrphanedFixture] = []
+
+    for repo in repos:
+        # Only scan repos we care about (must have a src/ with Python nodes)
+        src = repo / "src"
+        if not src.exists():
+            continue
+
+        nodes, orphaned = scan_repo(repo, docs_design_dir)
+
+        # Apply overrides from feature_spec_overrides.yaml
+        for n in nodes:
+            key = f"{n.repo}/{n.node_name}"
+            if key in overrides:
+                ov = overrides[key]
+                if "design_spec" in ov:
+                    n.design_spec = ov["design_spec"]
+                if "manual_review" in ov:
+                    n.manual_review = ov["manual_review"]
+                if "fixture_present" in ov:
+                    n.fixture_present = ov["fixture_present"]
+
+        all_nodes.extend(nodes)
+        all_orphaned.extend(orphaned)
+
+    # Sort: by repo, then node_name
+    all_nodes.sort(key=lambda n: (n.repo, n.node_name))
+    all_orphaned.sort(key=lambda o: (o.repo, o.fixture_path))
+
+    # Timestamp
+    import datetime
+
+    generated_at = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    # Render
+    content = render_registry(all_nodes, all_orphaned, generated_at)
+
+    # Write output
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(content)
+    print(f"Wrote {out_path}")
+    print(f"  Total Kafka-integrated nodes: {len(all_nodes)}")
+    print(f"  Repos scanned: {len(repos)}")
+    print(f"  Orphaned fixtures: {len(all_orphaned)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_ticket_plan.py
+++ b/scripts/generate_ticket_plan.py
@@ -1,0 +1,783 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "httpx>=0.25.0",
+#     "python-dotenv>=1.0.0",
+# ]
+# ///
+"""
+Generate Ticket Plan by querying Linear API dynamically.
+
+Design goals:
+- Fully dynamic: NO hardcoded ticket lists
+- Fetches all issues from "Beta Demo - January 2026" project
+- Checks actual blocking relations from Linear
+- Detects PR attachments to distinguish "in progress" from "ready"
+- Categorizes into: READY TO WORK ON, IN PROGRESS, BLOCKED, IN REVIEW
+
+Usage:
+  uv run tools/generate_ticket_plan.py
+  uv run tools/generate_ticket_plan.py --out /path/to/output.md
+  uv run tools/generate_ticket_plan.py --dry-run  # Print to stdout
+  uv run tools/generate_ticket_plan.py --project "My Project"  # Different project
+
+Environment:
+  LINEAR_API_KEY - Your Linear API key (from ~/.env or environment)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+DEFAULT_PROJECT = "Beta Demo - January 2026"
+
+# Repo detection from labels (case-insensitive)
+REPO_LABEL_MAP: dict[str, str] = {
+    "omnimemory": "omnimemory",
+    "omnidash": "omnidash",
+    "omnibase_infra": "omnibase_infra",
+    "omnibase_core": "omnibase_core",
+    "omnibase_spi": "omnibase_spi",
+    "omniintelligence": "omniintelligence",
+    "omniclaude": "omniclaude",
+    "infrastructure": "omnibase_infra",
+    "frontend": "omnidash",
+    "dashboard": "omnidash",
+    "memory": "omnimemory",
+    "intelligence": "omniintelligence",
+    "claude": "omniclaude",
+}
+
+# Status type mappings (all lowercase for comparison)
+DONE_STATUS_TYPES = {
+    "completed",
+    "canceled",
+    "cancelled",
+    "done",
+    "closed",
+    "duplicate",
+}
+IN_PROGRESS_STATUS_TYPES = {"started", "in progress", "in_progress"}
+IN_REVIEW_STATUS_TYPES = {"in review", "in_review", "review"}
+BACKLOG_STATUS_TYPES = {"backlog", "todo", "triage", "unstarted"}
+
+# Priority names (Linear uses 0-4, 0=none, 1=urgent, 4=low)
+PRIORITY_NAMES = {
+    0: "None",
+    1: "Urgent",
+    2: "High",
+    3: "Medium",
+    4: "Low",
+}
+
+
+# =============================================================================
+# DATA CLASSES
+# =============================================================================
+
+
+@dataclass
+class BlockingRelation:
+    """A blocking relation between issues."""
+
+    blocker_id: str
+    blocker_identifier: str
+    blocker_status: str
+    blocker_status_type: str
+
+
+@dataclass
+class Attachment:
+    """An attachment on an issue (may be a PR)."""
+
+    title: str
+    url: str
+
+    @property
+    def is_github_pr(self) -> bool:
+        """Check if this is a GitHub PR link."""
+        return bool(re.match(r"https://github\.com/.+/pull/\d+", self.url))
+
+    @property
+    def pr_number(self) -> str | None:
+        """Extract PR number if this is a GitHub PR."""
+        match = re.search(r"/pull/(\d+)", self.url)
+        return match.group(1) if match else None
+
+
+@dataclass
+class LinearIssue:
+    """Parsed Linear issue data with relations."""
+
+    id: str
+    identifier: str
+    title: str
+    status: str
+    status_type: (
+        str  # Linear's state type: backlog, unstarted, started, completed, canceled
+    )
+    priority: int | None
+    priority_name: str
+    labels: list[str]
+    attachments: list[Attachment]
+    blocked_by: list[BlockingRelation] = field(default_factory=list)
+    blocks: list[str] = field(default_factory=list)  # Issue identifiers this blocks
+
+    @property
+    def is_done(self) -> bool:
+        """Check if issue is completed/canceled."""
+        return (
+            self.status_type.lower() in DONE_STATUS_TYPES
+            or self.status.lower() in DONE_STATUS_TYPES
+        )
+
+    @property
+    def is_in_progress(self) -> bool:
+        """Check if issue is in progress."""
+        return (
+            self.status_type.lower() in IN_PROGRESS_STATUS_TYPES
+            or self.status.lower() in IN_PROGRESS_STATUS_TYPES
+        )
+
+    @property
+    def is_in_review(self) -> bool:
+        """Check if issue is in review."""
+        return (
+            self.status_type.lower() in IN_REVIEW_STATUS_TYPES
+            or self.status.lower() in IN_REVIEW_STATUS_TYPES
+        )
+
+    @property
+    def is_backlog(self) -> bool:
+        """Check if issue is in backlog/unstarted status."""  # stub-ok
+        return (
+            self.status_type.lower() in BACKLOG_STATUS_TYPES
+            or self.status.lower() in BACKLOG_STATUS_TYPES
+        )
+
+    @property
+    def has_open_pr(self) -> bool:
+        """Check if issue has a GitHub PR attached."""
+        return any(a.is_github_pr for a in self.attachments)
+
+    @property
+    def pr_url(self) -> str | None:
+        """Get the first PR URL if any."""
+        for a in self.attachments:
+            if a.is_github_pr:
+                return a.url
+        return None
+
+    @property
+    def pr_display(self) -> str:
+        """Get PR display string (e.g., '#123')."""
+        for a in self.attachments:
+            if a.is_github_pr and a.pr_number:
+                return f"#{a.pr_number}"
+        return ""
+
+    @property
+    def has_unresolved_blockers(self) -> bool:
+        """Check if any blockers are not done."""
+        for blocker in self.blocked_by:
+            if blocker.blocker_status_type.lower() not in DONE_STATUS_TYPES:
+                if blocker.blocker_status.lower() not in DONE_STATUS_TYPES:
+                    return True
+        return False
+
+    @property
+    def unresolved_blockers(self) -> list[BlockingRelation]:
+        """Get list of blockers that are not done."""
+        return [
+            b
+            for b in self.blocked_by
+            if b.blocker_status_type.lower() not in DONE_STATUS_TYPES
+            and b.blocker_status.lower() not in DONE_STATUS_TYPES
+        ]
+
+    def get_repo(self) -> str:
+        """Detect repo from labels."""
+        for label in self.labels:
+            label_lower = label.lower()
+            for key, repo in REPO_LABEL_MAP.items():
+                if key in label_lower:
+                    return repo
+        return "unknown"
+
+
+# =============================================================================
+# CATEGORIZATION
+# =============================================================================
+
+
+@dataclass
+class CategorizedIssues:
+    """Issues categorized by workability status."""
+
+    ready_to_work: list[LinearIssue] = field(default_factory=list)
+    in_progress_with_pr: list[LinearIssue] = field(default_factory=list)
+    blocked: list[LinearIssue] = field(default_factory=list)
+    in_review: list[LinearIssue] = field(default_factory=list)
+    done: list[LinearIssue] = field(default_factory=list)
+
+
+def categorize_issues(issues: list[LinearIssue]) -> CategorizedIssues:
+    """
+    Categorize issues into workability groups.
+
+    Categories:
+    - READY TO WORK ON: Backlog/Unstarted, all blockers done (or no blockers), no open PR
+    - IN PROGRESS (has open PR): In Progress status with PR attached
+    - BLOCKED: Has blockers that are NOT done
+    - IN REVIEW: In Review status OR has PR ready to merge
+    - DONE: Completed/Canceled (excluded from main output)
+    """
+    result = CategorizedIssues()
+
+    for issue in issues:
+        # Skip done issues for main categorization
+        if issue.is_done:
+            result.done.append(issue)
+            continue
+
+        # Check if blocked (has unresolved blockers)
+        if issue.has_unresolved_blockers:
+            result.blocked.append(issue)
+            continue
+
+        # In Review - either status or has PR
+        if issue.is_in_review:
+            result.in_review.append(issue)
+            continue
+
+        # In Progress with PR
+        if issue.is_in_progress and issue.has_open_pr:
+            result.in_progress_with_pr.append(issue)
+            continue
+
+        # In Progress without PR (treat as in progress with PR section for visibility)
+        if issue.is_in_progress:
+            result.in_progress_with_pr.append(issue)
+            continue
+
+        # Ready to work on - backlog/todo, no blockers, no PR
+        if issue.is_backlog and not issue.has_open_pr:
+            result.ready_to_work.append(issue)
+            continue
+
+        # Default: put in ready if not categorized
+        result.ready_to_work.append(issue)
+
+    # Sort each category by priority (lower number = higher priority)
+    def sort_key(i: LinearIssue) -> tuple[int, str]:
+        return (i.priority if i.priority else 99, i.identifier)
+
+    result.ready_to_work.sort(key=sort_key)
+    result.in_progress_with_pr.sort(key=sort_key)
+    result.blocked.sort(key=sort_key)
+    result.in_review.sort(key=sort_key)
+
+    return result
+
+
+# =============================================================================
+# LINEAR API CLIENT
+# =============================================================================
+
+
+def get_api_key() -> str:
+    """Get Linear API key from environment."""
+    # Try loading from ~/.env first
+    env_file = Path.home() / ".env"
+    if env_file.exists():
+        load_dotenv(env_file)
+
+    # Also try local .env
+    local_env = Path.cwd() / ".env"
+    if local_env.exists():
+        load_dotenv(local_env)
+
+    key = os.environ.get("LINEAR_API_KEY")
+    if not key:
+        print(
+            "Error: LINEAR_API_KEY not found in environment or ~/.env", file=sys.stderr
+        )
+        print("Get your API key from: https://linear.app/settings/api", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def fetch_project_issues(api_key: str, project_name: str) -> list[LinearIssue]:
+    """
+    Fetch all issues from a Linear project with blocking relations and attachments.
+
+    Uses pagination to get all issues.
+    """
+    # GraphQL query with relations and attachments
+    query = """
+    query GetProjectIssues($projectName: String!, $cursor: String) {
+      issues(
+        filter: {
+          project: { name: { eq: $projectName } }
+        }
+        first: 100
+        after: $cursor
+      ) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          identifier
+          title
+          state {
+            name
+            type
+          }
+          priority
+          labels {
+            nodes {
+              name
+            }
+          }
+          attachments {
+            nodes {
+              title
+              url
+            }
+          }
+          relations {
+            nodes {
+              type
+              relatedIssue {
+                id
+                identifier
+                title
+                state {
+                  name
+                  type
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    all_issues: list[LinearIssue] = []
+    cursor: str | None = None
+
+    with httpx.Client(
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        timeout=60.0,
+    ) as client:
+        while True:
+            variables: dict[str, Any] = {"projectName": project_name}
+            if cursor:
+                variables["cursor"] = cursor
+
+            try:
+                response = client.post(
+                    LINEAR_API_URL,
+                    json={"query": query, "variables": variables},
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                if "errors" in data:
+                    print(f"GraphQL errors: {data['errors']}", file=sys.stderr)
+                    break
+
+                issues_data = data.get("data", {}).get("issues", {})
+                nodes = issues_data.get("nodes", [])
+
+                for node in nodes:
+                    issue = parse_issue(node)
+                    if issue:
+                        all_issues.append(issue)
+
+                # Check pagination
+                page_info = issues_data.get("pageInfo", {})
+                if page_info.get("hasNextPage"):
+                    cursor = page_info.get("endCursor")
+                else:
+                    break
+
+            except httpx.HTTPError as e:
+                print(f"HTTP error fetching issues: {e}", file=sys.stderr)
+                break
+            except Exception as e:
+                print(f"Error fetching issues: {e}", file=sys.stderr)
+                break
+
+    return all_issues
+
+
+def parse_issue(node: dict[str, Any]) -> LinearIssue | None:
+    """Parse a Linear issue node into a LinearIssue object."""
+    try:
+        state = node.get("state", {})
+        priority = node.get("priority")
+
+        # Parse labels
+        labels = [label["name"] for label in node.get("labels", {}).get("nodes", [])]
+
+        # Parse attachments
+        attachments = [
+            Attachment(title=a.get("title", ""), url=a.get("url", ""))
+            for a in node.get("attachments", {}).get("nodes", [])
+        ]
+
+        # Parse relations
+        blocked_by: list[BlockingRelation] = []
+        blocks: list[str] = []
+
+        for rel in node.get("relations", {}).get("nodes", []):
+            rel_type = rel.get("type", "").lower().replace("_", " ").replace("-", " ")
+            related = rel.get("relatedIssue", {})
+
+            if not related:
+                continue
+
+            related_state = related.get("state", {})
+
+            # Handle various relation type formats from Linear API
+            # "blocks" type means this issue blocks the related issue
+            # "blocked by" / "is blocked by" type means the related issue blocks this one
+            if rel_type == "blocks":
+                blocks.append(related.get("identifier", ""))
+            elif rel_type in ("blocked by", "is blocked by", "blockedby"):
+                blocked_by.append(
+                    BlockingRelation(
+                        blocker_id=related.get("id", ""),
+                        blocker_identifier=related.get("identifier", ""),
+                        blocker_status=related_state.get("name", "Unknown"),
+                        blocker_status_type=related_state.get("type", "unknown"),
+                    )
+                )
+
+        return LinearIssue(
+            id=node.get("id", ""),
+            identifier=node.get("identifier", ""),
+            title=node.get("title", ""),
+            status=state.get("name", "Unknown"),
+            status_type=state.get("type", "unknown"),
+            priority=priority,
+            priority_name=PRIORITY_NAMES.get(priority, "None") if priority else "None",
+            labels=labels,
+            attachments=attachments,
+            blocked_by=blocked_by,
+            blocks=blocks,
+        )
+    except Exception as e:
+        print(f"Error parsing issue: {e}", file=sys.stderr)
+        return None
+
+
+# =============================================================================
+# DOCUMENT GENERATION
+# =============================================================================
+
+
+def truncate(text: str, max_len: int = 50) -> str:
+    """Truncate text with ellipsis if too long."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def generate_document(categorized: CategorizedIssues, project_name: str) -> str:
+    """Generate the ticket plan document."""
+    lines: list[str] = []
+    today = dt.datetime.now(tz=dt.UTC).date().strftime("%Y-%m-%d")
+
+    # Header
+    lines.append(f"# Ticket Plan - {today}")
+    lines.append("")
+    lines.append(f"**Project**: {project_name}")
+    lines.append(f"**Generated**: {dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append("")
+
+    # Summary stats
+    total_active = (
+        len(categorized.ready_to_work)
+        + len(categorized.in_progress_with_pr)
+        + len(categorized.blocked)
+        + len(categorized.in_review)
+    )
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Category | Count |")
+    lines.append("|----------|-------|")
+    lines.append(f"| Ready to Work On | {len(categorized.ready_to_work)} |")
+    lines.append(f"| In Progress | {len(categorized.in_progress_with_pr)} |")
+    lines.append(f"| Blocked | {len(categorized.blocked)} |")
+    lines.append(f"| In Review | {len(categorized.in_review)} |")
+    lines.append(f"| **Total Active** | **{total_active}** |")
+    lines.append(f"| Done | {len(categorized.done)} |")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # READY TO WORK ON
+    lines.append("## READY TO WORK ON")
+    lines.append("")
+    lines.append("*No blockers, no open PR - can start immediately*")
+    lines.append("")
+
+    if categorized.ready_to_work:
+        lines.append("| Ticket | Title | Repo | Priority |")
+        lines.append("|--------|-------|------|----------|")
+        for issue in categorized.ready_to_work:
+            title = truncate(issue.title, 45)
+            repo = issue.get_repo()
+            priority = issue.priority_name
+            lines.append(f"| **{issue.identifier}** | {title} | {repo} | {priority} |")
+    else:
+        lines.append("*No tickets ready to work on*")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # IN PROGRESS (has open PR)
+    lines.append("## IN PROGRESS")
+    lines.append("")
+    lines.append("*Currently being worked on*")
+    lines.append("")
+
+    if categorized.in_progress_with_pr:
+        lines.append("| Ticket | Title | Repo | PR | Status |")
+        lines.append("|--------|-------|------|-------|--------|")
+        for issue in categorized.in_progress_with_pr:
+            title = truncate(issue.title, 40)
+            repo = issue.get_repo()
+            pr = issue.pr_display if issue.has_open_pr else "-"
+            status = issue.status
+            lines.append(
+                f"| **{issue.identifier}** | {title} | {repo} | {pr} | {status} |"
+            )
+    else:
+        lines.append("*No tickets in progress*")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # BLOCKED
+    lines.append("## BLOCKED")
+    lines.append("")
+    lines.append("*Has unresolved blockers - cannot start until blockers are done*")
+    lines.append("")
+
+    if categorized.blocked:
+        lines.append("| Ticket | Title | Blocked By | Blocker Status |")
+        lines.append("|--------|-------|------------|----------------|")
+        for issue in categorized.blocked:
+            title = truncate(issue.title, 35)
+            blockers = issue.unresolved_blockers
+            if blockers:
+                blocker_ids = ", ".join(b.blocker_identifier for b in blockers)
+                blocker_statuses = ", ".join(b.blocker_status for b in blockers)
+            else:
+                blocker_ids = "-"
+                blocker_statuses = "-"
+            lines.append(
+                f"| {issue.identifier} | {title} | {blocker_ids} | {blocker_statuses} |"
+            )
+    else:
+        lines.append("*No blocked tickets*")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # IN REVIEW
+    lines.append("## IN REVIEW")
+    lines.append("")
+    lines.append("*Ready for review or awaiting merge*")
+    lines.append("")
+
+    if categorized.in_review:
+        lines.append("| Ticket | Title | Repo | PR |")
+        lines.append("|--------|-------|------|-------|")
+        for issue in categorized.in_review:
+            title = truncate(issue.title, 40)
+            repo = issue.get_repo()
+            pr = issue.pr_display if issue.has_open_pr else "-"
+            lines.append(f"| {issue.identifier} | {title} | {repo} | {pr} |")
+    else:
+        lines.append("*No tickets in review*")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Blocking graph (what unlocks what)
+    lines.append("## Blocking Graph")
+    lines.append("")
+    lines.append("*When these complete, they unlock other tickets*")
+    lines.append("")
+
+    # Find issues that block others
+    blockers_map: dict[str, list[str]] = {}
+    all_issues = (
+        categorized.ready_to_work
+        + categorized.in_progress_with_pr
+        + categorized.blocked
+        + categorized.in_review
+        + categorized.done
+    )
+
+    for issue in all_issues:
+        if issue.blocks:
+            blockers_map[issue.identifier] = issue.blocks
+
+    if blockers_map:
+        lines.append("| When Complete | Unlocks |")
+        lines.append("|---------------|---------|")
+        for blocker_id, unlocks in sorted(blockers_map.items()):
+            unlocks_str = ", ".join(unlocks)
+            lines.append(f"| {blocker_id} | {unlocks_str} |")
+    else:
+        lines.append("*No blocking relationships found*")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Legend
+    lines.append("## Legend")
+    lines.append("")
+    lines.append("**Categories**:")
+    lines.append(
+        "- **READY TO WORK ON**: Status is Backlog/Todo, all blockers are Done (or no blockers), no open PR"
+    )
+    lines.append("- **IN PROGRESS**: Status is In Progress")
+    lines.append("- **BLOCKED**: Has blockers that are NOT Done")
+    lines.append("- **IN REVIEW**: Status is In Review or has PR ready to merge")
+    lines.append("")
+    lines.append("**Priority Levels**:")
+    lines.append("- Urgent (1) - Critical path, immediate attention")
+    lines.append("- High (2) - Important, should be done soon")
+    lines.append("- Medium (3) - Normal priority")
+    lines.append("- Low (4) - Nice to have")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Generate Ticket Plan from Linear (fully dynamic)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  uv run tools/generate_ticket_plan.py
+  uv run tools/generate_ticket_plan.py --project "My Project"
+  uv run tools/generate_ticket_plan.py --dry-run
+  uv run tools/generate_ticket_plan.py --out /path/to/output.md
+        """,
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Output path. Defaults to TICKET_PLAN.md in current directory",
+    )
+    ap.add_argument(
+        "--project",
+        type=str,
+        default=DEFAULT_PROJECT,
+        help=f"Linear project name to query. Default: '{DEFAULT_PROJECT}'",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print to stdout instead of writing to file",
+    )
+    ap.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed progress",
+    )
+    args = ap.parse_args()
+
+    out_path = Path(args.out) if args.out else Path.cwd() / "TICKET_PLAN.md"
+
+    print(f"Fetching issues from project: {args.project}", file=sys.stderr)
+
+    api_key = get_api_key()
+
+    print("Querying Linear API...", file=sys.stderr)
+    issues = fetch_project_issues(api_key, args.project)
+
+    if not issues:
+        print(f"Warning: No issues found in project '{args.project}'", file=sys.stderr)
+        print(
+            "Check that the project name is correct and you have access.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Found {len(issues)} issues", file=sys.stderr)
+
+    if args.verbose:
+        for issue in issues:
+            blockers = [b.blocker_identifier for b in issue.blocked_by]
+            pr = issue.pr_display if issue.has_open_pr else "-"
+            print(
+                f"  {issue.identifier}: {issue.status} (blockers: {blockers}, PR: {pr})",
+                file=sys.stderr,
+            )
+
+    print("Categorizing issues...", file=sys.stderr)
+    categorized = categorize_issues(issues)
+
+    print(f"  Ready: {len(categorized.ready_to_work)}", file=sys.stderr)
+    print(f"  In Progress: {len(categorized.in_progress_with_pr)}", file=sys.stderr)
+    print(f"  Blocked: {len(categorized.blocked)}", file=sys.stderr)
+    print(f"  In Review: {len(categorized.in_review)}", file=sys.stderr)
+    print(f"  Done: {len(categorized.done)}", file=sys.stderr)
+
+    print("Generating document...", file=sys.stderr)
+    document = generate_document(categorized, args.project)
+
+    if args.dry_run:
+        print(document)
+    else:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(document)
+        print(f"Wrote {out_path}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pre-commit-versions.yaml
+++ b/scripts/pre-commit-versions.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OmniNode Platform — Canonical Pre-commit Hook Versions
+# Maintained by: platform team
+# Updated: 2026-03-12
+#
+# PURPOSE:
+#   Single source of truth for pre-commit hook versions across all OmniNode repos.
+#   All repos using astral-sh/ruff-pre-commit or google/yamlfmt MUST pin to these versions.
+#
+# SCOPE:
+#   - omnibase_core, omnimemory, onex_change_control, omnibase_spi
+#   - omniclaude, omnidash, omniweb, omnibase_compat
+#
+# NOTE (OMN-4833 Epic 6):
+#   pre-commit-versions.yaml is policy documentation + manual reference.
+#   Automated enforcement follows once Task 16 (scheduled gap-detect) ships.
+#   Until then, use this file as the authoritative version reference when
+#   updating .pre-commit-config.yaml files.
+#
+# UPDATE PROCEDURE:
+#   1. Check latest release: https://github.com/astral-sh/ruff/releases
+#      Check latest release: https://github.com/google/yamlfmt/releases
+#   2. Update ruff_rev and yamlfmt_rev below
+#   3. Update this file's `updated` field
+#   4. Submit PR to omni_home with the version bump
+#   5. Update all affected repos in their own PRs (one PR per repo)
+#   6. Run `pre-commit run --all-files` in each repo after updating
+#   7. Review ruff changelog for breaking rule changes before upgrading
+#      https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md
+ruff_rev: v0.15.6
+yamlfmt_rev: v0.21.0
+maintained_by: platform team
+updated: "2026-03-12"
+
+# Per-repo status (as of last update):
+#   omnimemory:          ruff v0.15.6 (updated OMN-4858), yamlfmt v0.21.0 (updated OMN-4858)
+#   onex_change_control: ruff v0.15.6 (updated OMN-4858)
+#   omnibase_core:       ruff via local hooks, yamlfmt v0.21.0 (updated OMN-4858)
+#   omnidash:            ruff via local hooks (no astral-sh/ruff-pre-commit)
+#   omniweb:             ruff via local hooks (no astral-sh/ruff-pre-commit)
+#   omniclaude:          ruff via local hooks (no astral-sh/ruff-pre-commit)
+#   omnibase_spi:        ruff via local hooks (no astral-sh/ruff-pre-commit)
+#   omnibase_compat:     yamlfmt to be added (OMN-4862), mypy to be added (OMN-4863)
+#   onex_change_control: yamlfmt to be added (OMN-4862)

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -52,10 +52,10 @@ done
 # ── Bus tunnel reachability ────────────────────────────────────────────────
 
 if [[ "${SKIP_TUNNEL_CHECK}" == false ]]; then
-  if nc -z localhost 29092 2>/dev/null; then
-    echo "PREFLIGHT OK: cloud bus tunnel reachable (localhost:29092)"
+  if nc -z localhost 29092 2>/dev/null; then  # cloud-bus-ok OMN-4922
+    echo "PREFLIGHT OK: cloud bus tunnel reachable (localhost:29092)"  # cloud-bus-ok OMN-4922
   else
-    echo "PREFLIGHT MISSING: cloud bus tunnel not reachable at localhost:29092"
+    echo "PREFLIGHT MISSING: cloud bus tunnel not reachable at localhost:29092"  # cloud-bus-ok OMN-4922
     MISSING+=("cloud-bus-tunnel")
   fi
 fi

--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# pull-all.sh — Pull all omni_home canonical repos to latest main
+#
+# Usage:
+#   ./pull-all.sh           # pull all repos
+#   ./pull-all.sh omniclaude omnibase_core   # pull specific repos
+
+set -euo pipefail
+
+OMNI_HOME="${OMNI_HOME:-/Volumes/PRO-G40/Code/omni_home}"
+
+REPOS=(
+  omniclaude
+  omnibase_core
+  omnibase_infra
+  omnibase_spi
+  omnidash
+  omniintelligence
+  omnimemory
+  omninode_infra
+  omniweb
+  onex_change_control
+)
+
+# Allow caller to override which repos to pull
+if [[ $# -gt 0 ]]; then
+  REPOS=("$@")
+fi
+
+OK=0
+FAILED=()
+
+for repo in "${REPOS[@]}"; do
+  dir="$OMNI_HOME/$repo"
+
+  if [[ ! -d "$dir" ]]; then
+    echo "  MISSING  $repo"
+    FAILED+=("$repo (missing)")
+    continue
+  fi
+
+  is_bare=$(git -C "$dir" rev-parse --is-bare-repository 2>/dev/null)
+
+  if [[ "$is_bare" == "true" ]]; then
+    # Bare clone: fetch origin main directly into the local main ref
+    before=$(git -C "$dir" rev-parse main 2>/dev/null)
+    if output=$(git -C "$dir" fetch origin main:main 2>&1); then
+      after=$(git -C "$dir" rev-parse main 2>/dev/null)
+      if [[ "$before" == "$after" ]]; then
+        echo "  OK       $repo (already up to date)"
+      else
+        commits=$(git -C "$dir" log --oneline "${before}..${after}" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  UPDATED  $repo (+${commits} commit(s))"
+      fi
+      (( OK++ )) || true
+    else
+      echo "  FAILED   $repo"
+      echo "           $output"
+      FAILED+=("$repo")
+    fi
+    continue
+  fi
+
+  branch=$(git -C "$dir" branch --show-current 2>/dev/null)
+  if [[ "$branch" != "main" ]]; then
+    echo "  SKIPPED  $repo (on branch: $branch)"
+    continue
+  fi
+
+  if output=$(git -C "$dir" pull --ff-only 2>&1); then
+    if echo "$output" | grep -q "Already up to date"; then
+      echo "  OK       $repo (already up to date)"
+    else
+      commits=$(git -C "$dir" log --oneline ORIG_HEAD..HEAD 2>/dev/null | wc -l | tr -d ' ')
+      echo "  UPDATED  $repo (+${commits} commit(s))"
+    fi
+    (( OK++ )) || true
+  else
+    echo "  FAILED   $repo"
+    echo "           $output"
+    FAILED+=("$repo")
+  fi
+done
+
+echo ""
+echo "${OK} repo(s) up to date. ${#FAILED[@]} failed."
+[[ ${#FAILED[@]} -eq 0 ]] || exit 1

--- a/scripts/system_health_check.sh
+++ b/scripts/system_health_check.sh
@@ -31,8 +31,8 @@
 #   7.  required_topics   - Required Kafka topics exist
 #   8.  migration_parity  - Docker and src migration directories in sync
 #   9.  env_audit         - No rogue .env files (--cross-repo only)
-#  10.  cloud_bus_refs    - No unsuppressed 29092 references (--cross-repo only)
-#  11.  bus_endpoint      - KAFKA_BOOTSTRAP_SERVERS must not contain 29092
+#  10.  cloud_bus_refs    - No unsuppressed 29092 references (--cross-repo only)  # cloud-bus-ok OMN-4922
+#  11.  bus_endpoint      - KAFKA_BOOTSTRAP_SERVERS must not contain 29092  # cloud-bus-ok OMN-4922
 #  12.  infisical_folders - /shared/<transport>/ folders exist in Infisical (when INFISICAL_ADDR is set)
 #
 # OMN-3772 OMN-3903
@@ -357,7 +357,7 @@ check_cloud_bus_refs() {
 
     local result
     if result=$(bash "$guard_script" "${REPO_ROOT}" 2>&1); then
-        log_check "$name" "green" "no unsuppressed 29092 references"
+        log_check "$name" "green" "no unsuppressed 29092 references"  # cloud-bus-ok OMN-4922
     else
         local count
         count=$(echo "$result" | grep -c '^VIOLATION' || true)
@@ -374,8 +374,8 @@ check_bus_endpoint() {
         return
     fi
 
-    if echo "$bootstrap" | grep -q "29092"; then
-        log_check "$name" "red" "KAFKA_BOOTSTRAP_SERVERS contains 29092 (cloud bus): ${bootstrap}"
+    if echo "$bootstrap" | grep -q "29092"; then  # cloud-bus-ok OMN-4922
+        log_check "$name" "red" "KAFKA_BOOTSTRAP_SERVERS contains 29092 (cloud bus): ${bootstrap}"  # cloud-bus-ok OMN-4922
     else
         log_check "$name" "green" "endpoint OK: ${bootstrap}"
     fi

--- a/scripts/validation/check_kafka_no_hardcoded_fallback.sh
+++ b/scripts/validation/check_kafka_no_hardcoded_fallback.sh
@@ -35,14 +35,7 @@ if [ -n "$MATCHES" ]; then
 fi
 
 # R2: Private-IP Kafka broker addresses (Kafka-specific ports only) — Python files
-IP_MATCHES=$(grep -rn --include="*.py" \
-    --exclude-dir=".venv" \
-    --exclude-dir="node_modules" \
-    -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" \
-    . 2>/dev/null | \
-    grep -v "# kafka-fallback-ok" | \
-    grep -v "# noqa" | \
-    grep -v "# onex-allow-internal-ip" || true)
+IP_MATCHES=$(grep -rn --include="*.py" --exclude-dir=".venv" --exclude-dir="node_modules" -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" . 2>/dev/null | grep -v "# kafka-fallback-ok" | grep -v "# noqa" | grep -v "# onex-allow-internal-ip" || true)  # cloud-bus-ok OMN-4922
 
 if [ -n "$IP_MATCHES" ]; then
     echo "ERROR: Hardcoded private-IP Kafka broker address in Python file:"
@@ -55,19 +48,7 @@ fi
 
 # R3: Private-IP Kafka broker addresses in shell scripts (.sh) and YAML files
 # Kafka should never be referenced by private IP in config/deployment files.
-IP_MATCHES_CONFIG=$(grep -rn \
-    --include="*.sh" \
-    --include="*.yaml" \
-    --include="*.yml" \
-    --exclude-dir=".venv" \
-    --exclude-dir="node_modules" \
-    --exclude-dir=".git" \
-    -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" \
-    . 2>/dev/null | \
-    grep -v "check_kafka_no_hardcoded_fallback.sh" | \
-    grep -v "# kafka-fallback-ok" | \
-    grep -v "# noqa" | \
-    grep -v "# onex-allow-internal-ip" || true)
+IP_MATCHES_CONFIG=$(grep -rn --include="*.sh" --include="*.yaml" --include="*.yml" --exclude-dir=".venv" --exclude-dir="node_modules" --exclude-dir=".git" -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" . 2>/dev/null | grep -v "check_kafka_no_hardcoded_fallback.sh" | grep -v "# kafka-fallback-ok" | grep -v "# noqa" | grep -v "# onex-allow-internal-ip" || true)  # cloud-bus-ok OMN-4922
 
 if [ -n "$IP_MATCHES_CONFIG" ]; then
     echo "ERROR: Hardcoded private-IP Kafka broker address in shell/YAML file:"
@@ -80,22 +61,9 @@ if [ -n "$IP_MATCHES_CONFIG" ]; then
 fi
 
 # R4: Decommissioned M2 Ultra endpoint specifically
-# (192.168.86.200 port 29092/9092/19092 — old Redpanda before OMN-3431)
+# (192.168.86.200 port 29092/9092/19092 — old Redpanda before OMN-3431)  # cloud-bus-ok OMN-4922
 # Catching it prevents stale references from being reintroduced in production docs/config.
-DECOMMISSIONED_MATCHES=$(grep -rn \
-    --include="*.py" \
-    --include="*.sh" \
-    --include="*.yaml" \
-    --include="*.yml" \
-    --exclude-dir=".venv" \
-    --exclude-dir="node_modules" \
-    --exclude-dir=".git" \
-    -E "192\.168\.86\.200:(29092|9092|19092)" \
-    . 2>/dev/null | \
-    grep -v "check_kafka_no_hardcoded_fallback.sh" | \
-    grep -v "# kafka-fallback-ok" | \
-    grep -v "# noqa" | \
-    grep -v "# onex-allow-internal-ip" || true)
+DECOMMISSIONED_MATCHES=$(grep -rn --include="*.py" --include="*.sh" --include="*.yaml" --include="*.yml" --exclude-dir=".venv" --exclude-dir="node_modules" --exclude-dir=".git" -E "192\.168\.86\.200:(29092|9092|19092)" . 2>/dev/null | grep -v "check_kafka_no_hardcoded_fallback.sh" | grep -v "# kafka-fallback-ok" | grep -v "# noqa" | grep -v "# onex-allow-internal-ip" || true)  # cloud-bus-ok OMN-4922
 
 if [ -n "$DECOMMISSIONED_MATCHES" ]; then
     echo "ERROR: Decommissioned M2 Ultra Redpanda endpoint detected:"

--- a/scripts/validation/check_no_cloud_bus.sh
+++ b/scripts/validation/check_no_cloud_bus.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# check_no_cloud_bus.sh — CI invariant: block cloud bus (port 29092) references
+#
+# Usage:
+#   bash scripts/check_no_cloud_bus.sh [TARGET_DIR]
+#
+# TARGET_DIR defaults to the current directory.
+#
+# Scans git-tracked files for port 29092 references.
+# Exits 1 if any unsuppressed references are found.
+#
+# Suppression: add "# cloud-bus-ok OMN-XXXX" on the same line.
+#   Bare "# cloud-bus-ok" (without OMN- ticket) does NOT suppress.
+#
+# Excluded paths: CLAUDE.md, MEMORY.md, CHANGELOG.md, docs/history/,
+#   docs/historical-planning/, docs/deep-dives/, docs/plans/, docs/archive/,
+#   docs/velocity-reports/, docs/reference/, docs/architecture/,
+#   docker-compose.e2e*, check_no_cloud_bus.sh (self-exclusion)
+#
+# File extensions scanned: *.py *.ts *.tsx *.js *.sh *.yml *.yaml *.toml
+
+set -euo pipefail
+
+TARGET_DIR="${1:-.}"
+
+if ! cd "$TARGET_DIR" 2>/dev/null; then
+    echo "ERROR: Cannot access directory: $TARGET_DIR"
+    exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: $TARGET_DIR is not inside a git repository"
+    exit 1
+fi
+
+# File extensions to scan
+EXTENSIONS=(py ts tsx js sh yml yaml toml)
+
+# Build git ls-files pattern list
+PATTERNS=()
+for ext in "${EXTENSIONS[@]}"; do
+    PATTERNS+=("*.${ext}")
+done
+
+# Paths to exclude (relative to repo root)
+EXCLUDE_PATHS=(
+    "CLAUDE.md"
+    "MEMORY.md"
+    "CHANGELOG.md"
+    "docs/history/"
+    "docs/historical-planning/"
+    "docs/deep-dives/"
+    "docs/plans/"
+    "docs/archive/"
+    "docs/velocity-reports/"
+    "docs/reference/"
+    "docs/architecture/"
+)
+
+# Also exclude self and e2e compose files
+EXCLUDE_SELF="check_no_cloud_bus"
+EXCLUDE_E2E="docker-compose.e2e"
+
+violations=0
+violation_files=()
+
+# Get git-tracked files matching our extensions
+tracked_files=$(git ls-files -- "${PATTERNS[@]}" 2>/dev/null) || true
+
+if [ -z "$tracked_files" ]; then
+    exit 0
+fi
+
+while IFS= read -r file; do
+    # Skip excluded paths
+    skip=false
+    for excl in "${EXCLUDE_PATHS[@]}"; do
+        case "$file" in
+            "$excl"*|*/"$excl"*) skip=true; break ;;
+        esac
+    done
+    $skip && continue
+
+    # Skip self
+    case "$file" in
+        *"$EXCLUDE_SELF"*) continue ;;
+    esac
+
+    # Skip e2e compose files
+    case "$file" in
+        *"$EXCLUDE_E2E"*) continue ;;
+    esac
+
+    # Search for 29092 in the file
+    while IFS= read -r line_content; do
+        line_num="${line_content%%:*}"
+        line_text="${line_content#*:}"
+
+        # Check for valid suppression: "# cloud-bus-ok OMN-" followed by digits
+        if echo "$line_text" | grep -qE '#\s*cloud-bus-ok\s+OMN-[0-9]+'; then
+            continue
+        fi
+
+        # This is an unsuppressed violation
+        violations=$((violations + 1))
+        violation_files+=("$file:$line_num")
+        echo "VIOLATION: $file:$line_num: $line_text"
+
+    done < <(grep -n '29092' "$file" 2>/dev/null || true)
+
+done <<< "$tracked_files"
+
+if [ "$violations" -gt 0 ]; then
+    echo ""
+    echo "Found $violations unsuppressed cloud bus (29092) reference(s)."
+    echo "To suppress, add on the same line: # cloud-bus-ok OMN-XXXX"
+    echo "(bare '# cloud-bus-ok' without ticket ID does NOT suppress)"
+    exit 1
+fi
+
+exit 0

--- a/scripts/version-matrix.yaml
+++ b/scripts/version-matrix.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# version-matrix.yaml
+#
+# Single authoritative version matrix for all shared OmniNode packages.
+# Each repo's pyproject.toml is checked against these minimum versions
+# by standards/check_version_pins.py.
+#
+# Update this file when a new minimum version is approved for platform-wide use.
+# CI wiring per repo (OMN-4806..OMN-4810) runs check_version_pins.py against
+# this matrix.
+packages:
+  omnibase-core: ">=0.26.0"
+  omnibase-spi: ">=0.17.0"
+  omnibase-infra: ">=0.16.2"
+  omnibase-compat: ">=0.2.0"
+# Registry of repos to check. Each entry maps a directory name (under omni_home)
+# to a human-readable label. Only repos with a pyproject.toml are checked.
+repos:
+  - name: omnibase_core
+    label: "omnibase-core"
+  - name: omnibase_spi
+    label: "omnibase-spi"
+  - name: omnibase_infra
+    label: "omnibase-infra"
+  - name: omninode_infra
+    label: "omninode-infra"
+  - name: omniclaude
+    label: "omniclaude"
+  - name: omnimemory
+    label: "omnimemory"
+  - name: omniintelligence
+    label: "omniintelligence"
+  - name: onex_change_control
+    label: "onex-change-control"


### PR DESCRIPTION
## Summary
- Migrates 9 scripts and 3 data files from `omni_home` to `omnibase_infra/scripts/`, the platform's operational script hub
- Scripts include: daily reporting (generate_deep_dive, generate_feature_inventory), governance checkers (audit-branch-protection, check_version_pins, check_no_cloud_bus), and infra utilities (pull-all, enable-merge-queue, audit-env-files, generate_ticket_plan)
- Data files: version-matrix.yaml, pre-commit-versions.yaml, feature_spec_overrides.yaml
- Updated all hardcoded paths to use `$OMNI_HOME` env var with sensible fallbacks
- Added SPDX headers to all migrated files
- Updated `check_no_cloud_bus_wrapper.sh` to resolve guard script locally first
- Fixed pre-existing cloud bus (29092) suppression annotations
- Added N999 ruff exclusion for hyphenated script names (existing repo pattern)

Part of [OMN-4922] — rehome all scripts out of omni_home. This PR must merge before the omni_home cleanup PR.

## Test plan
- [ ] Verify `scripts/generate_deep_dive.py` runs with `--root /Volumes/PRO-G40/Code/omni_home`
- [ ] Verify `scripts/pull-all.sh` pulls all repos
- [ ] Verify `scripts/check_version_pins.py` runs against a repo's pyproject.toml
- [ ] Verify `scripts/audit-branch-protection.py --validate` (dry-run)
- [ ] Verify `scripts/validation/check_no_cloud_bus.sh` scans correctly