### PR TITLE
release: omnibase_infra v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## v0.20.0 (2026-03-13)
+
+### Features
+- feat(scripts): rehome cross-repo governance scripts from omni_home [OMN-4922] (#820)
+- feat(runtime): add build_topic_router_from_contract() utility for per-event topic routing (#811)
+- feat(runtime): add topic_router to DispatchResultApplier for per-event-type topic routing (#810)
+
+### Bug Fixes
+- fix(infra): expose Redpanda Admin API port 9644 in docker-compose [OMN-4959] (#819)
+- fix(docker): bump Dockerfile.runtime plugin pins to latest releases (#818)
+- fix(registration): wire topic_router into DispatchResultApplier from contract published_events (#812)
+- fix(registration): short-circuit handler_node_heartbeat for terminal states (OMN-4824) (#799)
+- fix(health): use mode="json" in readiness model_dump to convert tuples to lists (OMN-4910) (#815)
+- fix(cleanup): purge dead endpoints and add skip markers (#805)
+- fix(registration): add terminal-state guard to decide_heartbeat (OMN-4822) (#797)
+- fix(runtime): eradicate inmemory default from ModelEventBusConfig and kernel (#809)
+- fix(consul): remove Consul handler and add recurrence-prevention [OMN-4857] (#804)
+- feat(cleanup): remove Ollama handlers, registries, and adapter (OMN-4849 Phase 2a) (#808)
+
+### Other Changes
+- docs(linear-relay): add activation guide for Linear snapshot automation [OMN-4973] (#823)
+- docs(pr-poller): add activation guide for GitHub PR poller effect node [OMN-4972] (#822)
+- docs(validation): add activation guide for validation orchestrator [OMN-4971] (#824)
+- docs(registration): update stale workaround comment now that topic routing is fixed (#814)
+- test(registration): add regression test asserting ModelNodeRegistrationAccepted routes to correct topic (#813)
+- ci: add published_events consistency checker to pre-commit and CI (#816)
+- ci(standards): add version pin compliance check [OMN-4807] (#803)
+- test(registration): integration test for liveness expiry -> heartbeat race (OMN-4825) (#800)
+
 ## v0.19.0 (2026-03-13)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.19.0"
+version = "0.20.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{name = "OmniNode Team", email = "team@omninode.ai"}]
 license = {text = "MIT"}
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core==0.26.0",
+    "omnibase-core==0.27.0",
     "omnibase-spi==0.16.1",
     # ============================================================================
     # External Dependency Security Guidance

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -167,8 +167,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.26.0",
-        max_version="0.27.0",
+        min_version="0.27.0",
+        max_version="0.28.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/uv.lock
+++ b/uv.lock
@@ -1859,7 +1859,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.26.0"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1874,14 +1874,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/2bbc00abdcab28ac37fc5eebe8301ffbcfaa11de9a69b01f2aba2145dcc1/omnibase_core-0.26.0.tar.gz", hash = "sha256:6352356afa7bfe9c2bf6a10cad5d2eac067033575aa5c83ed5becd5ec02c1675", size = 8464492, upload-time = "2026-03-13T12:22:29.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/96/195b61a63a5aceefb3d97ce90ee3db2cac151bf7f25abe25d2c5fe6553f3/omnibase_core-0.27.0.tar.gz", hash = "sha256:406feb4e61488e5cad67807b5e99bb1057f2d526f9f0c51cd36e7442710ccafa", size = 8466845, upload-time = "2026-03-13T23:57:17.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/02/4f3e7b31ebf641ccbf51f79aff3312359b742fe24d01a296422e88366174/omnibase_core-0.26.0-py3-none-any.whl", hash = "sha256:0e3d5e37fa131bb16d7039cb358d17e3265deadf4d9883ebd9c038f69bebb13b", size = 5170062, upload-time = "2026-03-13T12:22:33.146Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/df/76cdd282ebadbdaf0a951253e199965a5675d4678e6703419a98e63c26f8/omnibase_core-0.27.0-py3-none-any.whl", hash = "sha256:b6ec4364388f82c28819bda3d2adf881b7bf826e0284373ce7bad08a25331de5", size = 5169449, upload-time = "2026-03-13T23:57:20.285Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1970,7 +1970,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<6.0.0" },
-    { name = "omnibase-core", specifier = "==0.26.0" },
+    { name = "omnibase-core", specifier = "==0.27.0" },
     { name = "omnibase-spi", specifier = "==0.16.1" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Release: omnibase_infra v0.20.0

**Bump**: minor (0.19.0 -> 0.20.0)
**Dependency pin**: omnibase-core==0.27.0

### Changes since v0.19.0 (21 commits)

#### Features
- feat(scripts): rehome cross-repo governance scripts from omni_home [OMN-4922] (#820)
- feat(runtime): add build_topic_router_from_contract() utility (#811)
- feat(runtime): add topic_router to DispatchResultApplier (#810)
- feat(cleanup): remove Ollama handlers, registries, and adapter (OMN-4849 Phase 2a) (#808)

#### Bug Fixes
- fix(infra): expose Redpanda Admin API port 9644 [OMN-4959] (#819)
- fix(docker): bump Dockerfile.runtime plugin pins (#818)
- fix(registration): wire topic_router into DispatchResultApplier (#812)
- fix(registration): short-circuit handler_node_heartbeat for terminal states (OMN-4824) (#799)
- fix(health): use mode="json" in readiness model_dump (OMN-4910) (#815)
- fix(cleanup): purge dead endpoints and add skip markers (#805)
- fix(registration): add terminal-state guard to decide_heartbeat (OMN-4822) (#797)
- fix(runtime): eradicate inmemory default from ModelEventBusConfig (#809)
- fix(consul): remove Consul handler and add recurrence-prevention [OMN-4857] (#804)

#### Other
- docs: activation guides for Linear relay, PR poller, validation orchestrator (#822-824)
- ci: published_events consistency checker, version pin compliance (#803, #816)
- test: registration regression tests (#800, #813)

---
Part of coordinated release `release-20260313-7f74bc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.20.0

* **New Features**
  * Added runtime scripting capabilities
  * Enhanced topic routing utilities

* **Bug Fixes**
  * Fixed issues in infrastructure, registration, and health systems
  * Improved CI/test processes

* **Documentation**
  * Updated documentation to reflect new features and improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->