### PR TITLE
feat(docker): bump runtime plugin pins + CI checks [OMN-5102][OMN-5108][OMN-5110]

### DIFF
--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Plugin Pin Cascade (OMN-5110)
+#
+# Automatically updates Dockerfile.runtime plugin pins when a plugin package
+# is released. Triggered by repository_dispatch from omniclaude,
+# omniintelligence, or omnimemory release workflows.
+#
+# Event payload:
+#   { "package": "omninode-claude", "version": "v0.7.2", ... }
+name: Plugin Pin Cascade
+
+on:
+  repository_dispatch:
+    types: [plugin-release]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Plugin package name (e.g. omninode-claude)'
+        required: true
+        type: string
+      version:
+        description: 'Released version (e.g. v0.7.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-dockerfile-pins:
+    name: Update Dockerfile.runtime Pins
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Extract event variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            PACKAGE="${{ github.event.client_payload.package }}"
+            VERSION="${{ github.event.client_payload.version }}"
+          else
+            PACKAGE="${{ inputs.package }}"
+            VERSION="${{ inputs.version }}"
+          fi
+          VERSION="${VERSION#v}"
+          echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=automation/bump-dockerfile-${PACKAGE}-${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Updating $PACKAGE to $VERSION in Dockerfile.runtime"
+
+      - name: Update Dockerfile.runtime pin
+        id: update
+        run: |
+          DOCKERFILE="docker/Dockerfile.runtime"
+          PACKAGE="${{ steps.vars.outputs.package }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+
+          if ! grep -q "\"${PACKAGE}==" "$DOCKERFILE"; then
+            echo "Package $PACKAGE not found in $DOCKERFILE — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Replace the exact pin for this package
+          sed -i "s/\"${PACKAGE}==[^\"]*\"/\"${PACKAGE}==${VERSION}\"/" "$DOCKERFILE"
+
+          if git diff --quiet "$DOCKERFILE"; then
+            echo "No changes — $PACKAGE already at $VERSION"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Updated $PACKAGE to $VERSION:"
+            git diff "$DOCKERFILE"
+          fi
+
+      - name: Create branch, commit, and open PR
+        if: steps.update.outputs.skip != 'true'
+        run: |
+          BRANCH="${{ steps.vars.outputs.branch }}"
+          PACKAGE="${{ steps.vars.outputs.package }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add docker/Dockerfile.runtime
+          git commit -m "chore(docker): bump ${PACKAGE} to ${VERSION} in Dockerfile.runtime
+
+          Automated plugin pin cascade triggered by ${PACKAGE} release.
+
+          Triggered-by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git push origin "$BRANCH"
+
+      - name: Open pull request
+        if: steps.update.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.vars.outputs.branch }}"
+          PACKAGE="${{ steps.vars.outputs.package }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+
+          # Dedup guard: check for existing PR
+          EXISTING=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "PR already exists for $BRANCH — skipping"
+            exit 0
+          fi
+
+          gh pr create \
+            --title "chore(docker): bump ${PACKAGE} to ${VERSION} in Dockerfile.runtime" \
+            --body "$(cat <<PREOF
+          ## Summary
+
+          Automated Dockerfile.runtime pin update triggered by a new release of \`${PACKAGE}\` (v${VERSION}).
+
+          - Updates \`docker/Dockerfile.runtime\` plugin pin
+          - No source code changes
+
+          ## Triggered by
+
+          Release event from \`${PACKAGE}\`
+
+          ## Test plan
+
+          - [ ] CI passes
+          - [ ] Docker build succeeds with new pin
+          PREOF
+          )" \
+            --head "$BRANCH" \
+            --base main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -537,15 +537,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout omni_home standards
+      - name: Checkout onex_change_control standards
         uses: actions/checkout@v4
         continue-on-error: true
         with:
-          repository: OmniNode-ai/omni_home
+          repository: OmniNode-ai/onex_change_control
           token: ${{ secrets.CROSS_REPO_PAT }}
-          path: omni_home
+          path: onex_change_control
           sparse-checkout: |
             standards/
+            scripts/
           sparse-checkout-cone-mode: false
 
       - name: Setup Python and uv
@@ -557,12 +558,23 @@ jobs:
 
       - name: Check version pin compliance
         run: |
-          SCRIPT="omni_home/standards/check_version_pins.py"
+          SCRIPT="onex_change_control/scripts/check_version_pins.py"
           if [ ! -f "$SCRIPT" ]; then
-            echo "::warning::$SCRIPT not found — skipping version pin check (depends on OMN-4803)"
+            echo "::warning::$SCRIPT not found — skipping version pin check"
             exit 0
           fi
-          python "$SCRIPT" --repo omnibase_infra --root omni_home
+          # The script scans root/*/pyproject.toml — create a temp workspace
+          # with a symlink so the scanner can find this repo's pyproject.toml.
+          WORKSPACE=$(mktemp -d)
+          ln -s "$GITHUB_WORKSPACE" "$WORKSPACE/omnibase_infra"
+          python "$SCRIPT" --root "$WORKSPACE"
+
+      - name: Check Dockerfile.runtime plugin pins
+        run: |
+          echo "================================================================"
+          echo "Dockerfile.runtime Plugin Pin Check (OMN-5108)"
+          echo "================================================================"
+          uv run python scripts/check_dockerfile_pins.py
 
   # ============================================================================
   # CI Tests Gate (aggregator for branch protection)

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -172,9 +172,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # in a separate step so plugins have their required third-party libraries.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "omninode-claude==0.7.1" \
-    "omninode-memory==0.7.1" \
-    "omninode-intelligence==0.13.1"
+    "omninode-claude==0.7.2" \
+    "omninode-memory==0.7.2" \
+    "omninode-intelligence==0.13.3"
 
 # Install CPU-only PyTorch (~2GB savings over CUDA wheels).
 # K8s runtime has no GPU; inference offloads to LLM servers via HTTP.


### PR DESCRIPTION
## Summary

- **OMN-5102**: Update Dockerfile.runtime plugin pins to match released versions:
  - `omninode-claude` 0.7.1 -> 0.7.2
  - `omninode-memory` 0.7.1 -> 0.7.2
  - `omninode-intelligence` 0.13.1 -> 0.13.3
- **OMN-5108**: Add `check_dockerfile_pins.py` step to CI version-pin-check job; update job to reference `onex_change_control` instead of removed `omni_home/standards/`
- **OMN-5110**: Add `plugin-pin-cascade.yml` workflow that auto-updates Dockerfile.runtime pins when plugin repos publish new releases via `repository_dispatch`

Part of OMN-5095 (dependency pin alignment epic).

## Test plan

- [ ] CI passes (including new Dockerfile pin check step)
- [ ] Docker build succeeds with updated pins
- [ ] plugin-pin-cascade.yml is syntactically valid