### PR TITLE
fix(docker): upgrade PyJWT to clear CVE-2026-32597, add --no-cache build option [OMN-5136]

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -23,6 +23,12 @@ on:
       - 'uv.lock'
       - '.github/workflows/build-and-push-runtime.yml'
   workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Build with --no-cache to bust Docker layer cache (forces fresh foundation package install)'
+        required: false
+        default: 'false'
+        type: boolean
 
 concurrency:
   group: build-runtime-${{ github.ref }}
@@ -135,6 +141,7 @@ jobs:
           push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}
+          no-cache: ${{ inputs.no-cache == true }}
           build-args: |
             RUNTIME_VERSION=${{ github.ref_name }}
             BUILD_DATE=${{ steps.timestamp.outputs.build_date }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ dependencies = [
     "pydantic-settings>=2.2.1,<3.0.0", # Settings management
     "jsonschema>=4.20.0,<5.0.0", # JSON schema validation
     "watchdog>=4.0.0", # Filesystem event monitoring (HandlerContractFileWatcher, OMN-3940)
+    # Security: CVE-2026-32597 (HIGH) - PyJWT <2.12.0 accepts unknown `crit` header extensions.
+    # Transitive dependency (via mcp/httpx/authlib). Explicitly declared to enforce minimum version.
+    "pyjwt>=2.12.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -1916,6 +1916,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "qdrant-client" },
     { name = "redis" },
@@ -1986,6 +1987,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3.0.0" },
+    { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "qdrant-client", specifier = ">=1.16.0,<2.0.0" },
     { name = "redis", specifier = ">=6.0.0,<7.0.0" },
@@ -2612,11 +2614,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Upgrade PyJWT from 2.11.0 to 2.12.1 to fix CVE-2026-32597 (HIGH: accepts unknown `crit` header extensions). This unblocks the Trivy vulnerability scanner that has been failing on the runtime image build for the last 5+ runs.
- Add `no-cache` workflow_dispatch input to `build-and-push-runtime.yml` so operators can explicitly bust Docker layer cache when foundation packages need rebuilding from scratch.

## Context

OMN-5136: After the OMN-5095 dependency pin alignment epic, the runtime Docker image was rebuilt with correct plugin pins but foundation packages (omnibase-core, omnibase-spi, omnibase-infra) remained at old versions due to Docker layer cache. The Trivy scanner was independently blocking all runtime image pushes due to CVE-2026-32597 in PyJWT 2.11.0.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `pyjwt>=2.12.0` direct dependency for CVE-2026-32597 |
| `uv.lock` | Resolved PyJWT 2.11.0 -> 2.12.1 |
| `.github/workflows/build-and-push-runtime.yml` | Add `no-cache` workflow_dispatch input; pass to `docker/build-push-action` |

## Post-merge action required

After this PR merges, trigger a `--no-cache` rebuild via workflow_dispatch to align foundation packages:

```bash
gh workflow run "Build and push runtime image to ECR" \
  --repo OmniNode-ai/omnibase_infra \
  -f no-cache=true
```

Then trigger deploy-onex-dev from omninode_infra to roll out the new image.

## Test plan

- [x] Pre-commit hooks pass (all 38 hooks)
- [x] `uv lock` resolves cleanly (PyJWT 2.11.0 -> 2.12.1)
- [ ] CI passes (Trivy scan should now succeed)
- [ ] Post-merge: trigger `--no-cache` workflow_dispatch build
- [ ] Post-deploy: verify foundation package versions inside running containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to manually bypass Docker layer cache during builds for improved dependency freshness.

* **Chores**
  * Updated PyJWT dependency to version 2.12.0 or higher for security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->