### PR TITLE
fix(docker): increase health check start_period to stop autoheal restart loop [OMN-5095]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -642,6 +642,11 @@ services:
   # ONEX Runtime - Workers (Runtime Profile)
   # ==========================================================================
   # Scalable worker containers for parallel compute operations.
+  # OMN-5095: Workers have an extended start_period (120s) and retries (5)
+  # because plugin initialization (intelligence DB ownership, schema fingerprint,
+  # message type registration) must complete before /health returns 200.
+  # Unhealthy detection latency = start_period + (interval * retries) = 120s + 150s = 270s.
+  # AUTOHEAL_START_PERIOD (180s) must exceed start_period to avoid premature restarts.
   runtime-worker:
     !!merge <<: *runtime-base
     profiles: ["runtime", "full"]


### PR DESCRIPTION
## Summary

- Runtime-worker containers accumulated 4+ restarts within minutes despite clean logs (successful plugin wiring, handshake attestation passing) because autoheal restarted them before plugin initialization could complete and `/health` could transition from "starting" to "healthy"
- Root cause: `AUTOHEAL_START_PERIOD` (60s) was measured from when autoheal itself started, not from each container's start time, so workers that started later (due to `depends_on: omninode-runtime`) had less effective grace time
- Bumped `start_period` on all runtime services (main: 40s->90s, effects: 40s->90s, worker: 60s->120s) and `AUTOHEAL_START_PERIOD` from 60s to 180s

## Changes

| Service | `start_period` before | `start_period` after | `retries` |
|---------|----------------------|---------------------|-----------|
| omninode-runtime | 40s | 90s | 3 (unchanged) |
| runtime-effects | 40s | 90s | 3 (unchanged) |
| runtime-worker | 60s | 120s | 3 -> 5 |
| autoheal `AUTOHEAL_START_PERIOD` | 60s | 180s | n/a |

## Why these values

- Workers do the most work at startup: intelligence plugin DB ownership validation, schema fingerprint verification, message type registration — all before `/health` returns 200
- Workers start last (depend on `omninode-runtime` being healthy first, which itself can take 30-40s)
- `AUTOHEAL_START_PERIOD=180s` ensures autoheal never interferes with any container still in its Docker health check `start_period`

## Test plan

- [ ] `infra-up-runtime` and verify no restart loop on workers (`docker inspect --format='{{.RestartCount}}' omnibase-infra-runtime-runtime-worker-1`)
- [ ] Verify all runtime containers reach "healthy" status within their start_period
- [ ] Verify autoheal still restarts genuinely unhealthy containers after the grace window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended health-check grace periods and increased retry counts for runtime services to improve startup tolerance and reduce false-positive failures.
  * Increased autoheal startup window to avoid premature restarts during container initialization and plugin startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->