### PR TITLE
fix(docker): bump runtime memory limits — workers crash-loop at 256MB [OMN-5140]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -117,7 +117,7 @@ x-runtime-base: &runtime-base
     resources:
       limits:
         cpus: '1.0'
-        memory: 512M
+        memory: 768M
       reservations:
         cpus: '0.25'
         memory: 128M
@@ -678,10 +678,10 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 256M
+          memory: 768M
         reservations:
           cpus: '0.1'
-          memory: 64M
+          memory: 128M
     labels:
       - "com.omninode.service=runtime-worker"
       - "com.omninode.layer=runtime"


### PR DESCRIPTION
## Summary

- `x-runtime-base`: 512M → 768M (all runtime containers were at 97% of 512M)
- `runtime-worker`: 256M → 768M (crash-looping at 99.95% — 146+ restarts)
- Worker reservation: 64M → 128M

## Root Cause

Runtime-workers override the base 512MB anchor with 256MB. The omniintelligence plugin's kernel boot sequence requires more than 256MB — workers crash before `wire_dispatchers()` runs, so pattern-learning dispatch handlers never register. 740 patterns stuck in `requested` lifecycle state, zero `pattern-lifecycle-transitioned` events produced.

Same class as OMN-5103 (skill-lifecycle-consumer 128MB → 256MB).

## Test plan

- [x] Verified all healthy containers are at 97-99% of 512MB (need headroom)
- [ ] Workers stable with 0 restarts for >5 min after bump
- [ ] `pattern-lifecycle-transitioned.v1` topic receives new events
- [ ] Patterns in DB progress past `requested` state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for runtime services to improve performance and stability. Runtime base memory increased to 768M, and runtime-worker memory limit raised to 768M with improved memory reservation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->