### PR TITLE
feat: omnidash lifecycle script + container error scanner [OMN-5141]

### DIFF
--- a/scripts/container-error-to-linear.py
+++ b/scripts/container-error-to-linear.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""
+container-error-to-linear.py — Scan Docker containers for persistent errors
+and optionally create Linear tickets for them.
+
+Usage:
+    uv run python scripts/container-error-to-linear.py [--execute] [--team-id TEAM_ID]
+
+Modes:
+    (default)   Dry-run: scan containers, print findings, create no tickets.
+    --execute   Create Linear tickets via the Linear MCP server for persistent errors.
+    --team-id   Linear team ID (required for --execute).
+
+Container selection:
+    Scans all containers in the omnibase-infra Docker compose project.
+    Filters for containers that are in restart loop or have repeated error log lines.
+
+Error detection heuristics:
+    1. Container restart count > 3 (restart loop)
+    2. OOMKilled flag set
+    3. Exit code != 0 with repeated restarts
+    4. Repeated ERROR/FATAL log lines in the last 100 log lines
+
+Output:
+    JSON array of detected issues, each with:
+      - container_name
+      - error_type: restart_loop | oom_killed | crash_loop | log_errors
+      - details: human-readable description
+      - log_sample: last relevant log lines (truncated)
+      - suggested_ticket_title
+      - suggested_ticket_body
+
+[OMN-5150]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class ContainerIssue:
+    container_name: str
+    error_type: str  # restart_loop | oom_killed | crash_loop | log_errors
+    details: str
+    log_sample: list[str]
+    suggested_ticket_title: str
+    suggested_ticket_body: str
+
+
+def run_cmd(cmd: list[str], *, timeout: int = 30) -> str:
+    """Run a command and return stdout. Returns empty string on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+
+
+def get_infra_containers() -> list[dict]:
+    """Get all containers from the omnibase-infra project."""
+    output = run_cmd(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=com.docker.compose.project=omnibase-infra",
+            "--format",
+            "{{.Names}}",
+        ]
+    )
+    if not output:
+        return []
+
+    containers = []
+    for name in output.splitlines():
+        name = name.strip()
+        if not name:
+            continue
+        inspect_json = run_cmd(["docker", "inspect", name])
+        if inspect_json:
+            try:
+                data = json.loads(inspect_json)
+                if data:
+                    containers.append(data[0])
+            except json.JSONDecodeError:
+                pass
+    return containers
+
+
+def get_container_logs(name: str, tail: int = 100) -> list[str]:
+    """Get the last N log lines from a container."""
+    output = run_cmd(["docker", "logs", "--tail", str(tail), name])
+    return output.splitlines() if output else []
+
+
+def detect_issues(containers: list[dict]) -> list[ContainerIssue]:
+    """Scan containers for persistent error conditions."""
+    issues: list[ContainerIssue] = []
+
+    for container in containers:
+        name = container.get("Name", "").lstrip("/")
+        state = container.get("State", {})
+        restart_count = state.get("RestartCount", 0)
+        oom_killed = state.get("OOMKilled", False)
+        exit_code = state.get("ExitCode", 0)
+        status = state.get("Status", "")
+
+        # Check for OOM kills
+        if oom_killed:
+            logs = get_container_logs(name, tail=50)
+            issues.append(
+                ContainerIssue(
+                    container_name=name,
+                    error_type="oom_killed",
+                    details=f"Container was OOM killed. Restart count: {restart_count}.",
+                    log_sample=logs[-20:] if logs else [],
+                    suggested_ticket_title=f"fix(infra): {name} OOMKilled — increase memory limit",
+                    suggested_ticket_body=(
+                        f"## Problem\n"
+                        f"Container `{name}` was OOM killed.\n"
+                        f"- Restart count: {restart_count}\n"
+                        f"- Status: {status}\n\n"
+                        f"## Suggested Fix\n"
+                        f"Increase memory limit in docker-compose.yml or optimize memory usage.\n\n"
+                        f"## Log Sample\n```\n{''.join(ln + chr(10) for ln in logs[-10:])}\n```"
+                    ),
+                )
+            )
+            continue
+
+        # Check for restart loops
+        if restart_count > 3:
+            logs = get_container_logs(name, tail=50)
+            issues.append(
+                ContainerIssue(
+                    container_name=name,
+                    error_type="restart_loop",
+                    details=f"Container in restart loop. Restart count: {restart_count}, exit code: {exit_code}.",
+                    log_sample=logs[-20:] if logs else [],
+                    suggested_ticket_title=f"fix(infra): {name} restart loop (exit {exit_code}, {restart_count} restarts)",
+                    suggested_ticket_body=(
+                        f"## Problem\n"
+                        f"Container `{name}` is in a restart loop.\n"
+                        f"- Restart count: {restart_count}\n"
+                        f"- Exit code: {exit_code}\n"
+                        f"- Status: {status}\n\n"
+                        f"## Log Sample\n```\n{''.join(ln + chr(10) for ln in logs[-10:])}\n```"
+                    ),
+                )
+            )
+            continue
+
+        # Check for crash loop (exited with non-zero, not running)
+        if status != "running" and exit_code != 0 and restart_count > 0:
+            logs = get_container_logs(name, tail=50)
+            issues.append(
+                ContainerIssue(
+                    container_name=name,
+                    error_type="crash_loop",
+                    details=f"Container exited with code {exit_code}. Restart count: {restart_count}.",
+                    log_sample=logs[-20:] if logs else [],
+                    suggested_ticket_title=f"fix(infra): {name} crash loop (exit {exit_code})",
+                    suggested_ticket_body=(
+                        f"## Problem\n"
+                        f"Container `{name}` is crashing.\n"
+                        f"- Exit code: {exit_code}\n"
+                        f"- Restart count: {restart_count}\n"
+                        f"- Status: {status}\n\n"
+                        f"## Log Sample\n```\n{''.join(ln + chr(10) for ln in logs[-10:])}\n```"
+                    ),
+                )
+            )
+            continue
+
+        # Check running containers for repeated errors in logs
+        if status == "running":
+            logs = get_container_logs(name, tail=100)
+            error_lines = [
+                line
+                for line in logs
+                if any(
+                    kw in line.upper()
+                    for kw in ["ERROR", "FATAL", "PANIC", "EXCEPTION"]
+                )
+            ]
+            # Only flag if there are many repeated errors (>5 in last 100 lines)
+            if len(error_lines) > 5:
+                # Deduplicate by taking unique error messages
+                unique_errors = list(dict.fromkeys(error_lines))[:5]
+                issues.append(
+                    ContainerIssue(
+                        container_name=name,
+                        error_type="log_errors",
+                        details=f"Container has {len(error_lines)} error lines in last 100 log lines.",
+                        log_sample=unique_errors,
+                        suggested_ticket_title=f"fix(infra): {name} persistent log errors ({len(error_lines)} errors)",
+                        suggested_ticket_body=(
+                            f"## Problem\n"
+                            f"Container `{name}` is running but logging persistent errors.\n"
+                            f"- Error lines in last 100 log lines: {len(error_lines)}\n"
+                            f"- Unique error patterns: {len(unique_errors)}\n\n"
+                            f"## Sample Errors\n```\n{''.join(ln + chr(10) for ln in unique_errors)}\n```"
+                        ),
+                    )
+                )
+
+    return issues
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scan containers for persistent errors"
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Create Linear tickets (default: dry-run)",
+    )
+    parser.add_argument(
+        "--team-id", type=str, help="Linear team ID for ticket creation"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    if args.execute and not args.team_id:
+        print("ERROR: --team-id is required when using --execute", file=sys.stderr)
+        sys.exit(1)
+
+    print("[container-error-to-linear] Scanning Docker containers...", file=sys.stderr)
+    containers = get_infra_containers()
+    if not containers:
+        print(
+            "[container-error-to-linear] No omnibase-infra containers found.",
+            file=sys.stderr,
+        )
+        if args.json:
+            print("[]")
+        sys.exit(0)
+
+    print(
+        f"[container-error-to-linear] Found {len(containers)} containers.",
+        file=sys.stderr,
+    )
+
+    issues = detect_issues(containers)
+
+    if args.json:
+        print(json.dumps([asdict(i) for i in issues], indent=2))
+    elif not issues:
+        print("[container-error-to-linear] No persistent errors detected.")
+    else:
+        print(f"\n[container-error-to-linear] Found {len(issues)} issue(s):\n")
+        for issue in issues:
+            print(f"  [{issue.error_type}] {issue.container_name}")
+            print(f"    {issue.details}")
+            print(f"    Ticket: {issue.suggested_ticket_title}")
+            print()
+
+    if args.execute and issues:
+        print(
+            "[container-error-to-linear] --execute: Linear ticket creation not yet implemented.",
+            file=sys.stderr,
+        )
+        print(
+            "[container-error-to-linear] Ticket data is available in --json output for manual creation.",
+            file=sys.stderr,
+        )
+        # Future: integrate with Linear MCP tools or API
+        # For now, dry-run outputs the ticket data so it can be piped to the Linear MCP
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/omnidash-lifecycle.sh
+++ b/scripts/omnidash-lifecycle.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# omnidash-lifecycle.sh — start, stop, restart, and status for the local omnidash dev server.
+#
+# Usage:
+#   omnidash-lifecycle.sh start   [--bus local|cloud]  # Start omnidash (kills any prior instance first)
+#   omnidash-lifecycle.sh stop                          # Stop omnidash gracefully
+#   omnidash-lifecycle.sh restart [--bus local|cloud]  # Stop then start
+#   omnidash-lifecycle.sh status                        # Check if omnidash is running and healthy
+#
+# Environment:
+#   OMNIDASH_DIR    Override omnidash repo path (default: sibling of OMNIBASE_INFRA_DIR or /Volumes/PRO-G40/Code/omni_home/omnidash)
+#   OMNIDASH_PORT   Override port (default: 3000)
+#
+# The script sources ~/.omnibase/.env for platform config. Bus mode can be
+# overridden with --bus local|cloud (maps to npm run dev:local / dev:cloud / dev).
+#
+# [OMN-5142]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve omnidash directory
+_resolve_omnidash_dir() {
+  if [[ -n "${OMNIDASH_DIR:-}" ]] && [[ -d "${OMNIDASH_DIR}" ]]; then
+    echo "${OMNIDASH_DIR}"
+    return 0
+  fi
+
+  # Derive from OMNIBASE_INFRA_DIR (sibling repo)
+  if [[ -n "${OMNIBASE_INFRA_DIR:-}" ]]; then
+    local candidate
+    candidate="$(dirname "${OMNIBASE_INFRA_DIR}")/omnidash"
+    if [[ -d "${candidate}/package.json" ]] || [[ -f "${candidate}/package.json" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  fi
+
+  # Hardcoded fallback
+  local fallback="/Volumes/PRO-G40/Code/omni_home/omnidash"
+  if [[ -f "${fallback}/package.json" ]]; then
+    echo "${fallback}"
+    return 0
+  fi
+
+  echo "[omnidash] ERROR: Cannot find omnidash directory. Set OMNIDASH_DIR." >&2
+  return 1
+}
+
+OMNIDASH_PORT="${OMNIDASH_PORT:-3000}"
+
+cmd_start() {
+  local bus_mode=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bus) bus_mode="$2"; shift 2 ;;
+      *) echo "[omnidash] Unknown option: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local omnidash_dir
+  omnidash_dir="$(_resolve_omnidash_dir)" || return 1
+
+  echo "[omnidash] Starting omnidash from: ${omnidash_dir}"
+
+  # Kill any existing instance first (using omnidash's own kill-server.sh)
+  if [[ -f "${omnidash_dir}/scripts/kill-server.sh" ]]; then
+    PORT="${OMNIDASH_PORT}" bash "${omnidash_dir}/scripts/kill-server.sh" 2>/dev/null || true
+  fi
+
+  # Determine npm script based on bus mode
+  local npm_script="dev"
+  case "${bus_mode}" in
+    local)  npm_script="dev:local" ;;
+    cloud)  npm_script="dev:cloud" ;;
+    "")     npm_script="dev" ;;
+    *)      echo "[omnidash] Unknown bus mode: ${bus_mode}. Use 'local' or 'cloud'." >&2; return 1 ;;
+  esac
+
+  echo "[omnidash] npm run ${npm_script} (port ${OMNIDASH_PORT})"
+
+  # Start in background, redirect output to log file
+  local log_file="${omnidash_dir}/.omnidash-server.log"
+  cd "${omnidash_dir}"
+  nohup npm run "${npm_script}" > "${log_file}" 2>&1 &
+  local server_pid=$!
+  echo "[omnidash] Server starting (PID ${server_pid})"
+
+  # Wait for server to become responsive (up to 30s)
+  local max_wait=30
+  local elapsed=0
+  while ! curl -sf "http://localhost:${OMNIDASH_PORT}/api/health-probe" > /dev/null 2>&1; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    if [[ ${elapsed} -ge ${max_wait} ]]; then
+      echo "[omnidash] WARNING: Server not responding after ${max_wait}s. Check ${log_file}" >&2
+      echo "[omnidash] PID ${server_pid} may still be starting up." >&2
+      return 0  # Non-fatal — server may still be loading
+    fi
+  done
+
+  echo "[omnidash] Server healthy on port ${OMNIDASH_PORT} (startup took ~${elapsed}s)"
+}
+
+cmd_stop() {
+  local omnidash_dir
+  omnidash_dir="$(_resolve_omnidash_dir)" || return 1
+
+  echo "[omnidash] Stopping omnidash..."
+
+  if [[ -f "${omnidash_dir}/scripts/kill-server.sh" ]]; then
+    PORT="${OMNIDASH_PORT}" bash "${omnidash_dir}/scripts/kill-server.sh" 2>/dev/null || true
+  else
+    # Fallback: kill anything on the port
+    local port_pids
+    port_pids=$(lsof -ti:"${OMNIDASH_PORT}" 2>/dev/null || true)
+    if [[ -n "${port_pids}" ]]; then
+      echo "${port_pids}" | xargs kill -TERM 2>/dev/null || true
+      sleep 2
+      echo "${port_pids}" | xargs kill -9 2>/dev/null || true
+    fi
+  fi
+
+  echo "[omnidash] Stopped."
+}
+
+cmd_restart() {
+  cmd_stop
+  cmd_start "$@"
+}
+
+cmd_status() {
+  local omnidash_dir
+  omnidash_dir="$(_resolve_omnidash_dir)" || return 1
+
+  # Check if port is in use
+  local port_pids
+  port_pids=$(lsof -ti:"${OMNIDASH_PORT}" 2>/dev/null || true)
+
+  if [[ -z "${port_pids}" ]]; then
+    echo "[omnidash] Status: NOT RUNNING (port ${OMNIDASH_PORT} not in use)"
+    return 1
+  fi
+
+  # Check health endpoint
+  local health_response
+  if health_response=$(curl -sf "http://localhost:${OMNIDASH_PORT}/api/health-probe" 2>/dev/null); then
+    echo "[omnidash] Status: RUNNING on port ${OMNIDASH_PORT}"
+    echo "[omnidash] Health: ${health_response}"
+
+    # Check build info if available
+    local build_info
+    if build_info=$(curl -sf "http://localhost:${OMNIDASH_PORT}/api/build-info" 2>/dev/null); then
+      echo "[omnidash] Build:  ${build_info}"
+    fi
+    return 0
+  else
+    echo "[omnidash] Status: PORT IN USE (port ${OMNIDASH_PORT}) but health probe failed"
+    echo "[omnidash] PIDs on port: ${port_pids}"
+    return 2
+  fi
+}
+
+# Dispatch subcommand
+case "${1:-}" in
+  start)   shift; cmd_start "$@" ;;
+  stop)    cmd_stop ;;
+  restart) shift; cmd_restart "$@" ;;
+  status)  cmd_status ;;
+  *)
+    echo "Usage: omnidash-lifecycle.sh {start|stop|restart|status} [--bus local|cloud]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- **omnidash-lifecycle.sh** (OMN-5142): Start/stop/restart/status shell script for the local omnidash dev server with health check polling and bus mode selection. Shell function wrappers (`omnidash-start`, `omnidash-stop`, `omnidash-restart`, `omnidash-status`) added to `~/.zshrc`.
- **container-error-to-linear.py** (OMN-5150): Scan Docker containers for persistent errors (restart loops, OOM kills, crash loops, repeated log errors) and output structured findings suitable for Linear ticket creation. Dry-run by default.

## Test plan
- [ ] Run `omnidash-lifecycle.sh status` to verify status check
- [ ] Run `omnidash-lifecycle.sh start` to verify server startup
- [ ] Run `container-error-to-linear.py --json` to verify container scanning
- [ ] Verify shell functions load via `source ~/.zshrc && omnidash-status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container error detection: new tool to scan and identify container issues with error reporting capabilities
  * Development server management: new lifecycle commands (start, stop, restart, status) for local development server with health monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->