### PR TITLE
feat: add health-check for published_events_map [OMN-5159]

### DIFF
--- a/src/omnibase_infra/runtime/health/__init__.py
+++ b/src/omnibase_infra/runtime/health/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime health check functions."""

--- a/src/omnibase_infra/runtime/health/health_published_events_map.py
+++ b/src/omnibase_infra/runtime/health/health_published_events_map.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Health check for the published_events topic router map.
+
+Promotes the startup INFO/WARNING logs (OMN-5153/OMN-5154) to a health-check
+component so that an empty or missing map pages and blocks rollouts instead of
+silently degrading event routing.
+
+OMN-5159
+"""
+
+from __future__ import annotations
+
+from omnibase_infra.runtime.models.model_component_health import (
+    ModelComponentHealth,
+)
+
+
+def check_published_events_map_health(
+    published_events_map: dict[str, str] | None,
+    contract_path: str | None = None,
+) -> ModelComponentHealth:
+    """Check whether the published_events topic router map is populated.
+
+    Args:
+        published_events_map: The topic router dict mapping event class names
+            to Kafka topics (built from contract.yaml published_events).
+        contract_path: Optional path to the contract.yaml file for diagnostic
+            messages.
+
+    Returns:
+        ModelComponentHealth indicating healthy (map has entries) or unhealthy
+        (map is None or empty).
+    """
+    if not published_events_map:
+        error_msg = "published_events_map is empty or not loaded"
+        if contract_path:
+            error_msg += f" (contract: {contract_path})"
+        return ModelComponentHealth.unhealthy(
+            name="published_events_map",
+            error=error_msg,
+        )
+
+    return ModelComponentHealth.healthy(
+        name="published_events_map",
+        details={"entry_count": len(published_events_map)},
+    )
+
+
+__all__: list[str] = ["check_published_events_map_health"]

--- a/tests/unit/runtime/health/__init__.py
+++ b/tests/unit/runtime/health/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/health/test_health_published_events_map.py
+++ b/tests/unit/runtime/health/test_health_published_events_map.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for health_published_events_map health check function.
+
+OMN-5159
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.health.health_published_events_map import (
+    check_published_events_map_health,
+)
+
+
+@pytest.mark.unit
+class TestCheckPublishedEventsMapHealth:
+    """Tests for check_published_events_map_health."""
+
+    def test_returns_unhealthy_when_none(self) -> None:
+        result = check_published_events_map_health(None)
+        assert result.status == "unhealthy"
+        assert result.name == "published_events_map"
+        assert result.error is not None
+        assert "empty or not loaded" in result.error
+
+    def test_returns_unhealthy_when_empty(self) -> None:
+        result = check_published_events_map_health({})
+        assert result.status == "unhealthy"
+        assert result.name == "published_events_map"
+        assert result.error is not None
+        assert "empty or not loaded" in result.error
+
+    def test_returns_healthy_with_entries(self) -> None:
+        result = check_published_events_map_health(
+            {"ModelNodeRegistered": "onex.evt.platform.node-registered.v1"}
+        )
+        assert result.status == "healthy"
+        assert result.name == "published_events_map"
+        assert result.error is None
+        assert result.details is not None
+        assert result.details["entry_count"] == 1
+
+    def test_returns_healthy_with_multiple_entries(self) -> None:
+        result = check_published_events_map_health(
+            {
+                "ModelNodeRegistered": "onex.evt.platform.node-registered.v1",
+                "ModelNodeBecameActive": "onex.evt.platform.node-became-active.v1",
+                "ModelTopicCatalogResponse": "onex.evt.platform.topic-catalog-response.v1",
+            }
+        )
+        assert result.status == "healthy"
+        assert result.details is not None
+        assert result.details["entry_count"] == 3
+
+    def test_includes_contract_path_in_unhealthy_error(self) -> None:
+        result = check_published_events_map_health(
+            None, contract_path="/path/to/contract.yaml"
+        )
+        assert result.status == "unhealthy"
+        assert result.error is not None
+        assert "/path/to/contract.yaml" in result.error
+
+    def test_no_contract_path_in_unhealthy_error(self) -> None:
+        result = check_published_events_map_health(None, contract_path=None)
+        assert result.status == "unhealthy"
+        assert result.error is not None
+        assert "contract:" not in result.error


### PR DESCRIPTION
## Summary
- Adds `check_published_events_map_health()` function that returns unhealthy when the topic router map is empty/None
- Promotes OMN-5153 startup log-level signal to a health-check endpoint so it pages and blocks rollouts
- 6 unit tests covering None, empty, populated, and contract path error cases

## Test plan
- [ ] `uv run pytest tests/unit/runtime/health/test_health_published_events_map.py -v` passes
- [ ] `uv run mypy src/omnibase_infra/runtime/health/ --strict` passes
- [ ] Health endpoint returns published_events_map component when runtime is running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check validation for published events map configuration, returning status with entry counts and error details when unhealthy.

* **Tests**
  * Added comprehensive unit tests covering healthy and unhealthy scenarios, including validation of error messages with optional contract path information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->