### PR TITLE
feat: wire check_published_events_map_health into runtime health_check() [OMN-5164]

### DIFF
--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -169,6 +169,15 @@ class DispatchResultApplier:
         self._topic_router: dict[str, str] = topic_router or {}
         self._output_topic_map: dict[str, str] = output_topic_map or {}
 
+    @property
+    def published_events_map(self) -> dict[str, str]:
+        """Return the published_events topic routing map.
+
+        Exposes the output_topic_map for health check introspection (OMN-5164).
+        Returns the mapping of event_type names to their declared Kafka topics.
+        """
+        return self._output_topic_map
+
     def _resolve_partition_key(self, event: BaseModel) -> bytes | None:
         """Extract partition key from event model for per-entity ordering.
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -101,9 +101,15 @@ from omnibase_infra.runtime.envelope_validator import (
     validate_envelope,
 )
 from omnibase_infra.runtime.handler_registry import RegistryProtocolBinding
+from omnibase_infra.runtime.health.health_published_events_map import (
+    check_published_events_map_health,
+)
 from omnibase_infra.runtime.models import (
     ModelDuplicateResponse,
     ModelRuntimeContractConfig,
+)
+from omnibase_infra.runtime.models.model_component_health import (
+    ModelComponentHealth,
 )
 from omnibase_infra.runtime.models.model_materialized_resources import (
     ModelMaterializedResources,
@@ -4201,6 +4207,10 @@ class RuntimeHostProcess:
                   succeeded), "degraded_no_requirements" (INFISICAL_ADDR set
                   but zero contract requirements found),
                   "degraded_error" (prefetch raised an exception).
+                - components: List of ModelComponentHealth dicts for individual
+                  infrastructure components (OMN-5164). Currently includes
+                  ``published_events_map`` when a DispatchResultApplier is
+                  registered in the DI container.
 
         Health State Matrix:
             - healthy=True, degraded=False: Fully operational
@@ -4317,6 +4327,17 @@ class RuntimeHostProcess:
             for pool_type, pool in self._handler_pools.items():
                 pool_metrics[pool_type] = await pool.health_check()
 
+        # Check published_events_map health (OMN-5164)
+        # Resolve DispatchResultApplier from the DI container to inspect the
+        # topic routing map. An empty or missing map means output events will
+        # use the fallback topic, silently degrading event routing.
+        published_events_map_health = await self._check_published_events_map()
+        components: list[dict[str, object]] = []
+        if published_events_map_health is not None:
+            components.append(published_events_map_health.model_dump(mode="json"))
+            if published_events_map_health.status == "unhealthy":
+                healthy = False
+
         return {
             "healthy": healthy,
             "degraded": degraded,
@@ -4340,7 +4361,42 @@ class RuntimeHostProcess:
             "handler_pools": pool_metrics,
             "no_handlers_registered": no_handlers_registered,
             "config_prefetch_status": self._config_prefetch_status,
+            "components": components,
         }
+
+    async def _check_published_events_map(
+        self,
+    ) -> ModelComponentHealth | None:
+        """Resolve published_events_map from the DI container and check health.
+
+        Attempts to resolve ``DispatchResultApplier`` from the container's
+        service registry and inspects its ``published_events_map`` property.
+        Returns ``None`` when the container or service registry is unavailable
+        (e.g. in minimal test setups without domain plugins).
+
+        Returns:
+            ModelComponentHealth if the applier is resolvable, None otherwise.
+
+        OMN-5164
+        """
+        from omnibase_infra.runtime.service_dispatch_result_applier import (
+            DispatchResultApplier,
+        )
+
+        if self._container is None:
+            return None
+        registry = self._container.service_registry
+        if registry is None:
+            return None
+
+        applier = await registry.try_resolve_service(DispatchResultApplier)
+        if applier is None:
+            # DispatchResultApplier is not registered (no domain plugin wired).
+            # This is expected in lightweight runtimes without the registration
+            # orchestrator plugin.
+            return None
+
+        return check_published_events_map_health(applier.published_events_map)
 
     async def readiness_check(
         self, correlation_id: UUID | None = None

--- a/tests/unit/runtime/health/test_health_published_events_map_wiring.py
+++ b/tests/unit/runtime/health/test_health_published_events_map_wiring.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for published_events_map health check wiring into RuntimeHostProcess.
+
+Verifies that health_check() includes the published_events_map component
+when a DispatchResultApplier is registered in the DI container, and that
+an unhealthy map causes the overall health to report unhealthy.
+
+OMN-5164
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.runtime.service_dispatch_result_applier import (
+    DispatchResultApplier,
+)
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
+
+
+def _make_registry(
+    applier: DispatchResultApplier | None = None,
+) -> MagicMock:
+    """Create a mock service registry that resolves DispatchResultApplier.
+
+    Args:
+        applier: The applier to return from try_resolve_service. None means
+            the applier is not registered.
+
+    Returns:
+        MagicMock registry with async resolve methods.
+    """
+    registry = MagicMock()
+
+    async def try_resolve(interface: type, scope: object = None) -> object | None:
+        if applier is not None and interface is DispatchResultApplier:
+            return applier
+        return None
+
+    async def resolve(interface: type, scope: object = None) -> object:
+        result = await try_resolve(interface, scope)
+        if result is None:
+            raise KeyError(f"Service {interface} not registered")
+        return result
+
+    registry.try_resolve_service = AsyncMock(side_effect=try_resolve)
+    registry.resolve_service = AsyncMock(side_effect=resolve)
+    return registry
+
+
+def _make_container_with_applier(
+    output_topic_map: dict[str, str] | None = None,
+) -> MagicMock:
+    """Create a mock ONEX container with a DispatchResultApplier in its registry.
+
+    Args:
+        output_topic_map: The topic map to set on the applier. None means
+            the applier will have an empty map (default DispatchResultApplier
+            behavior converts None to {}).
+
+    Returns:
+        MagicMock container with service_registry configured.
+    """
+    applier = DispatchResultApplier(
+        event_bus=MagicMock(),
+        output_topic="fallback.topic",
+        output_topic_map=output_topic_map,
+    )
+
+    container = MagicMock()
+    container.service_registry = _make_registry(applier=applier)
+    return container
+
+
+def _make_container_without_applier() -> MagicMock:
+    """Create a mock ONEX container where DispatchResultApplier is not registered."""
+    container = MagicMock()
+    container.service_registry = _make_registry(applier=None)
+    return container
+
+
+@pytest.mark.unit
+class TestHealthCheckPublishedEventsMapWiring:
+    """Tests for published_events_map component in health_check()."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_includes_healthy_published_events_map(
+        self,
+    ) -> None:
+        """health_check() includes healthy published_events_map component."""
+        container = _make_container_with_applier(
+            output_topic_map={
+                "ModelNodeRegistered": "onex.evt.platform.node-registered.v1",
+            }
+        )
+        bus = EventBusInmemory()
+        process = RuntimeHostProcess(
+            container=container,
+            event_bus=bus,
+            config=make_runtime_config(),
+        )
+        seed_mock_handlers(process)
+        await process.start()
+        try:
+            health = await process.health_check()
+            components = health.get("components", [])
+            assert isinstance(components, list)
+            assert len(components) == 1
+
+            component = components[0]
+            assert component["name"] == "published_events_map"
+            assert component["status"] == "healthy"
+            assert component["details"]["entry_count"] == 1
+        finally:
+            await process.stop()
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_when_map_empty(self) -> None:
+        """health_check() reports unhealthy when published_events_map is empty."""
+        container = _make_container_with_applier(output_topic_map={})
+        bus = EventBusInmemory()
+        process = RuntimeHostProcess(
+            container=container,
+            event_bus=bus,
+            config=make_runtime_config(),
+        )
+        seed_mock_handlers(process)
+        await process.start()
+        try:
+            health = await process.health_check()
+            components = health.get("components", [])
+            assert len(components) == 1
+
+            component = components[0]
+            assert component["name"] == "published_events_map"
+            assert component["status"] == "unhealthy"
+            assert "empty or not loaded" in component["error"]
+
+            # Overall health should be False when map is unhealthy
+            assert health["healthy"] is False
+        finally:
+            await process.stop()
+
+    @pytest.mark.asyncio
+    async def test_health_check_no_components_without_applier(self) -> None:
+        """health_check() returns empty components when no applier is registered."""
+        container = _make_container_without_applier()
+        bus = EventBusInmemory()
+        process = RuntimeHostProcess(
+            container=container,
+            event_bus=bus,
+            config=make_runtime_config(),
+        )
+        seed_mock_handlers(process)
+        await process.start()
+        try:
+            health = await process.health_check()
+            components = health.get("components", [])
+            assert components == []
+        finally:
+            await process.stop()
+
+    @pytest.mark.asyncio
+    async def test_health_check_no_components_without_container(self) -> None:
+        """health_check() returns empty components when no container is provided."""
+        bus = EventBusInmemory()
+        process = RuntimeHostProcess(
+            event_bus=bus,
+            config=make_runtime_config(),
+        )
+        seed_mock_handlers(process)
+        await process.start()
+        try:
+            health = await process.health_check()
+            components = health.get("components", [])
+            assert components == []
+        finally:
+            await process.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_result_applier_published_events_map_property(
+        self,
+    ) -> None:
+        """DispatchResultApplier.published_events_map exposes the output_topic_map."""
+        topic_map = {
+            "ModelNodeRegistered": "onex.evt.platform.node-registered.v1",
+            "ModelNodeBecameActive": "onex.evt.platform.node-became-active.v1",
+        }
+        applier = DispatchResultApplier(
+            event_bus=MagicMock(),
+            output_topic="fallback.topic",
+            output_topic_map=topic_map,
+        )
+        assert applier.published_events_map == topic_map
+
+    @pytest.mark.asyncio
+    async def test_dispatch_result_applier_empty_map_by_default(self) -> None:
+        """DispatchResultApplier.published_events_map returns empty dict by default."""
+        applier = DispatchResultApplier(
+            event_bus=MagicMock(),
+            output_topic="fallback.topic",
+        )
+        assert applier.published_events_map == {}


### PR DESCRIPTION
## Summary

- Wires the `check_published_events_map_health()` function (created in OMN-5159/PR #848) into `RuntimeHostProcess.health_check()`
- Resolves `DispatchResultApplier` from the DI container to inspect the published_events topic routing map
- An empty or missing map now causes the `/health` endpoint to report unhealthy, preventing silent event routing degradation

## Changes

- **`service_dispatch_result_applier.py`**: Add `published_events_map` property exposing the `_output_topic_map` for health check introspection
- **`service_runtime_host_process.py`**: Add `_check_published_events_map()` async method that resolves the applier from the container and calls the health check function; include result in `components` list in health_check() response
- **`test_health_published_events_map_wiring.py`**: 6 unit tests covering healthy map, empty map, absent applier, absent container, and property behavior

## Test plan

- [x] All 12 health tests pass (6 existing OMN-5159 + 6 new wiring tests)
- [x] mypy --strict passes on both modified files
- [x] ruff check passes
- [x] All pre-commit hooks pass
- [ ] CI green
- [ ] After deploy: `curl localhost:8085/health | jq '.components'` shows `published_events_map` component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health checks now monitor and report published events map health as a component-level metric, providing detailed status information in health check responses.

* **Tests**
  * Added comprehensive unit tests validating published events map health check integration, covering various scenarios and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->