### PR TITLE
fix: replace "dev" default and wrong ENVIRONMENT env var [OMN-5219]

### DIFF
--- a/src/omnibase_infra/enums/enum_environment.py
+++ b/src/omnibase_infra/enums/enum_environment.py
@@ -26,9 +26,15 @@ class EnumEnvironment(str, Enum):
     and configuration management. Each environment has different security
     postures and permitted capabilities.
 
+    Note:
+        The canonical ONEX_ENVIRONMENT values are ``local``, ``staging``,
+        ``production``, and ``ci``.  Legacy code that used ``"dev"`` as a
+        default should be migrated to ``"local"`` (see OMN-5204).
+
     Attributes:
         DEVELOPMENT: Local development environment.
             Most permissive, allows debugging features and relaxed security.
+            Legacy references to ``"dev"`` should use ``"local"`` instead.
         STAGING: Pre-production testing environment.
             Production-like but allows some testing features.
         PRODUCTION: Live production environment.

--- a/src/omnibase_infra/nodes/node_rrh_emit_effect/handlers/handler_runtime_target_collect.py
+++ b/src/omnibase_infra/nodes/node_rrh_emit_effect/handlers/handler_runtime_target_collect.py
@@ -51,7 +51,7 @@ class HandlerRuntimeTargetCollect:
             Populated ``ModelRRHRuntimeTarget``.
         """
         return ModelRRHRuntimeTarget(
-            environment=environment or os.environ.get("ENVIRONMENT", "dev"),
+            environment=environment or os.environ.get("ONEX_ENVIRONMENT", "local"),
             kafka_broker=kafka_broker or os.environ.get("KAFKA_BOOTSTRAP_SERVERS", ""),
             kubernetes_context=kubernetes_context
             or os.environ.get("KUBECONFIG_CONTEXT", ""),

--- a/tests/unit/nodes/test_node_rrh_emit_effect.py
+++ b/tests/unit/nodes/test_node_rrh_emit_effect.py
@@ -205,7 +205,7 @@ class TestHandlerRuntimeTargetCollect:
     async def test_falls_back_to_env(
         self, handler: HandlerRuntimeTargetCollect
     ) -> None:
-        with patch.dict("os.environ", {"ENVIRONMENT": "ci"}, clear=False):
+        with patch.dict("os.environ", {"ONEX_ENVIRONMENT": "ci"}, clear=False):
             result = await handler.handle()
         assert result.environment == "ci"
 


### PR DESCRIPTION
## Summary

- Changed `os.environ.get("ENVIRONMENT", "dev")` to `os.environ.get("ONEX_ENVIRONMENT", "local")` in `handler_runtime_target_collect.py` — fixes both the wrong env var name (`ENVIRONMENT` should be `ONEX_ENVIRONMENT`) and the wrong default value (`dev` should be `local`)
- Added docstring to `EnumEnvironment` clarifying that `"dev"` is legacy terminology; prefer `"local"` per OMN-5204
- Updated unit test to use `ONEX_ENVIRONMENT` instead of `ENVIRONMENT`

Part of epic OMN-5204 (env-var audit).

## Test plan

- [x] `grep -rn 'getenv.*"dev"' src/omnibase_infra/` returns zero results
- [x] `grep -rn 'environ.get("ENVIRONMENT"' src/omnibase_infra/` returns zero results
- [x] `uv run pytest tests/unit/nodes/test_node_rrh_emit_effect.py -x` passes (13/13)
- [x] All pre-commit hooks pass
- [x] All pre-push hooks pass (mypy + architecture validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Environment variable key updated from `ENVIRONMENT` to `ONEX_ENVIRONMENT`
  * Default environment value changed from "dev" to "local"
  * Documented canonical environment values: local, staging, production, ci

* **Documentation**
  * Added migration guidance for legacy environment references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->