### PR TITLE
chore(deps): bump omnibase-core to 0.28.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1954,7 +1954,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=23.2.1,<24.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiokafka", specifier = ">=0.11.0,<0.12.0" },
-    { name = "asyncpg", specifier = ">=0.29.0,<0.30.0" },
+    { name = "asyncpg", specifier = ">=0.29.0,<0.32.0" },
     { name = "circuitbreaker", specifier = ">=2.0.0,<3.0.0" },
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "confluent-kafka", specifier = ">=2.12.0,<3.0.0" },
@@ -1979,7 +1979,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-kafka-python", specifier = ">=0.48b0,<0.49" },
     { name = "opentelemetry-instrumentation-redis", specifier = ">=0.48b0,<0.49" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0,<2.0.0" },
-    { name = "prometheus-client", specifier = ">=0.19.0,<0.20.0" },
+    { name = "prometheus-client", specifier = ">=0.19.0,<0.25.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3.0.0" },
@@ -1987,7 +1987,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "qdrant-client", specifier = ">=1.16.0,<2.0.0" },
     { name = "redis", specifier = ">=6.0.0,<7.0.0" },
-    { name = "rich", specifier = ">=13.7.0,<14.0.0" },
+    { name = "rich", specifier = ">=13.7.0,<15.0.0" },
     { name = "slowapi", specifier = ">=0.1.9,<0.2.0" },
     { name = "sqlparse", specifier = ">=0.4.4,<0.6.0" },
     { name = "structlog", specifier = ">=23.2.0,<24.0.0" },
@@ -2006,8 +2006,8 @@ dev = [
     { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
     { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
     { name = "pytest", specifier = ">=8.4.0,<9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.25.0,<0.26.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0,<1.4.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<8.0.0" },
     { name = "pytest-httpserver", specifier = ">=1.1.0,<2.0.0" },
     { name = "pytest-mock", specifier = ">=3.11.0,<4.0.0" },
     { name = "pytest-split", specifier = ">=0.10.0,<0.11.0" },


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_core` (v0.28.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_core`
- No source code changes -- lockfile only

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_core/actions/runs/23144285409

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version