### PR TITLE
feat(db): add omniweb database to Docker init [OMN-5324]

### DIFF
--- a/docker/migrations/forward/000_create_multiple_databases.sh
+++ b/docker/migrations/forward/000_create_multiple_databases.sh
@@ -12,6 +12,7 @@
 #
 # Additional databases (infrastructure):
 #   infisical_db  (Infisical secrets management)
+#   omniweb       (OmniWeb landing page — OMN-5324)
 #
 # Per-service roles:
 #   role_omnibase, role_omniintelligence, role_omniclaude,
@@ -44,7 +45,7 @@ SERVICE_DB_MAP=(
 )
 
 # Additional databases without dedicated roles (managed by superuser)
-INFRA_DATABASES=("infisical_db")
+INFRA_DATABASES=("infisical_db" "omniweb")
 
 # =============================================================================
 # Helper functions


### PR DESCRIPTION
## Summary

- Add omniweb to INFRA_DATABASES in 000_create_multiple_databases.sh
- Database created during PostgreSQL container initialization
- Companion PR in omniweb updates connection string to OMNIWEB_DB_URL

## Test plan

- [ ] Run infra-down && infra-up and verify omniweb database is created
- [ ] Verify waitlist_signups table can be created in omniweb DB