### PR TITLE
chore(docker): bump plugin pins in Dockerfile.runtime [OMN-5328]

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -172,9 +172,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # in a separate step so plugins have their required third-party libraries.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "omninode-claude==0.7.2" \
-    "omninode-memory==0.7.2" \
-    "omninode-intelligence==0.13.3"
+    "omninode-claude==0.8.0" \
+    "omninode-memory==0.8.0" \
+    "omninode-intelligence==0.14.0"
 
 # Install CPU-only PyTorch (~2GB savings over CUDA wheels).
 # K8s runtime has no GPU; inference offloads to LLM servers via HTTP.


### PR DESCRIPTION
## Summary

- Bump Dockerfile.runtime plugin pins to latest published versions:
  - omninode-claude 0.7.2 -> 0.8.0
  - omninode-memory 0.7.2 -> 0.8.0
  - omninode-intelligence 0.13.3 -> 0.14.0
- Part of coordinated pin alignment (OMN-5328 / OMN-5319 stabilization)

## Test plan

- [ ] Docker Integration Tests pass with new pins
- [ ] `docker build -f docker/Dockerfile.runtime .` succeeds