### PR TITLE
feat: add activation section to handler contracts [OMN-5355]

### DIFF
--- a/src/omnibase_infra/contracts/handlers/db/contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/db/contract.yaml
@@ -58,6 +58,8 @@ operation_bindings:
       - parameter_name: "parameters"
         expression: "${payload.parameters}"
         required: false
+activation:
+  optional: false
 metadata:
   handler_id: "db-handler"
   handler_type: "infra_handler"

--- a/src/omnibase_infra/contracts/handlers/graph/contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/graph/contract.yaml
@@ -105,6 +105,10 @@ operation_bindings:
       - parameter_name: "filters"
         expression: "${payload.filters}"
         required: false
+activation:
+  optional: true
+  required_env:
+    - OMNIMEMORY_MEMGRAPH_HOST
 metadata:
   handler_id: "graph-handler"
   handler_type: "infra_handler"

--- a/src/omnibase_infra/contracts/handlers/http/contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/http/contract.yaml
@@ -56,6 +56,8 @@ operation_bindings:
       - parameter_name: "body"
         expression: "${payload.body}"
         required: false
+activation:
+  optional: false
 metadata:
   handler_id: "http-handler"
   handler_type: "infra_handler"

--- a/src/omnibase_infra/contracts/handlers/intent/contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/intent/contract.yaml
@@ -53,6 +53,8 @@ operation_bindings:
         required: true
     # No payload bindings required - aggregates all intents by type (read-only)
     "intent.query_distribution": []
+activation:
+  optional: false
 metadata:
   handler_id: "intent-handler"
   handler_type: "intent_handler"

--- a/src/omnibase_infra/contracts/handlers/mcp/contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/mcp/contract.yaml
@@ -51,6 +51,8 @@ operation_bindings:
         required: false
     # No payload bindings required - returns MCP server capabilities
     "mcp.describe": []
+activation:
+  optional: false
 metadata:
   handler_id: "mcp-handler"
   handler_type: "infra_handler"


### PR DESCRIPTION
## Summary
- Add `activation` section to all 5 handler contract YAMLs
- Graph handler: `optional: true`, `required_env: [OMNIMEMORY_MEMGRAPH_HOST]`
- DB, HTTP, intent, MCP handlers: `optional: false` (always registered)

## Test plan
- [ ] All contract YAMLs parse with `yaml.safe_load()` without error
- [ ] No other fields in the contracts are modified
- [ ] CI passes

Closes OMN-5355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit activation controls across handler contracts for enhanced operational governance.
  * Expanded handler metadata with newly visible fields including category, transport type, and feature documentation.

* **Security**
  * Enhanced security features specification with comprehensive tool execution timeout enforcement, request size limits, and circuit breaker protection documentation.

* **Chores**
  * Updated handler contract bounds and resilience feature documentation across database, graph, HTTP, intent, and message protocol handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->