### PR TITLE
feat: add omninode-intelligence to plugin pins + fix dependency cascade [OMN-5374] [OMN-5376]

### DIFF
--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -166,15 +166,52 @@ jobs:
             echo "Lockfile updated with new ${{ inputs.package }} version"
           fi
 
+      - name: Update pyproject.toml pin
+        if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
+        env:
+          BUMP_PACKAGE: ${{ inputs.package }}
+        run: |
+          PKG_HYPHEN="${BUMP_PACKAGE//_/-}"
+
+          RESOLVED=$(python3 - <<'PYEOF'
+          import re, sys, os
+          pkg = os.environ["PKG_HYPHEN"]
+          content = open("uv.lock").read()
+          m = re.search(
+              r'name\s*=\s*"' + re.escape(pkg) + r'".*?version\s*=\s*"([^"]+)"',
+              content, re.DOTALL
+          )
+          if m:
+              print(m.group(1))
+          else:
+              sys.exit(1)
+          PYEOF
+          )
+          echo "Resolved version for ${PKG_HYPHEN}: ${RESOLVED}"
+          export RESOLVED PKG_HYPHEN
+
+          python3 - <<'PYEOF'
+          import re, os
+          pkg = os.environ["PKG_HYPHEN"]
+          version = os.environ["RESOLVED"]
+          content = open("pyproject.toml").read()
+          updated = re.sub(
+              r'"' + re.escape(pkg) + r'==[0-9]+\.[0-9]+\.[0-9]+"',
+              f'"{pkg}=={version}"',
+              content,
+          )
+          open("pyproject.toml", "w").write(updated)
+          PYEOF
+
       - name: Commit and push
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add uv.lock
+          git add uv.lock pyproject.toml
           git commit -m "chore(deps): bump ${{ inputs.package }} to ${{ steps.vars.outputs.version }}
 
-          Automated dependency cascade from ${{ github.repository }} release ${{ inputs.version }}.
+          Automated dependency cascade — updates uv.lock and pyproject.toml pins.
 
           Triggered-by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           git push origin "${{ steps.vars.outputs.branch }}"
@@ -206,7 +243,7 @@ jobs:
           Automated dependency bump triggered by a new release of `${{ inputs.package }}` (${{ inputs.version }}).
 
           - Updates `uv.lock` via `uv lock --upgrade-package ${{ inputs.package }}`
-          - No source code changes -- lockfile only
+          - Updates `pyproject.toml` exact pins (`==X.Y.Z`) to match resolved version
 
           ## Triggered by
 

--- a/scripts/update-plugin-pins.py
+++ b/scripts/update-plugin-pins.py
@@ -7,7 +7,7 @@ Usage:
     update-plugin-pins.py [--dry-run] [--dockerfile PATH]
 
 Behaviour:
-    1. Fetch latest versions from PyPI for omninode-claude and omninode-memory.
+    1. Fetch latest versions from PyPI for omninode-claude, omninode-intelligence, and omninode-memory.
     2. Rewrite Dockerfile.runtime lines matching:
          RUN pip install omninode-claude==X.Y.Z
          RUN pip install omninode-memory==X.Y.Z
@@ -32,7 +32,7 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-PLUGINS = ["omninode-claude", "omninode-memory"]
+PLUGINS = ["omninode-claude", "omninode-intelligence", "omninode-memory"]
 
 # Default Dockerfile path relative to the repo root (two directories above
 # this script, which lives in <repo>/scripts/).
@@ -82,7 +82,7 @@ def fetch_latest_version(package: str) -> str:
 #   omninode-claude==1.2.3   (without quotes)
 #   omninode-claude>=1.0,<2.0  (without quotes)
 _PIN_RE = re.compile(
-    r'(?P<q>["\']?)(?P<pkg>omninode-(?:claude|memory))(?P<spec>[^\s"\'\\]+)(?P=q)'
+    r'(?P<q>["\']?)(?P<pkg>omninode-(?:claude|intelligence|memory))(?P<spec>[^\s"\'\\]+)(?P=q)'
 )
 
 

--- a/tests/unit/scripts/test_update_plugin_pins.py
+++ b/tests/unit/scripts/test_update_plugin_pins.py
@@ -65,6 +65,7 @@ CMD ["onex-runtime"]
 
 _VERSIONS = {
     "omninode-claude": "1.2.3",
+    "omninode-intelligence": "3.4.5",
     "omninode-memory": "2.3.4",
 }
 
@@ -160,3 +161,37 @@ def test_pypi_fetch_failure(tmp_path: Path) -> None:
     assert exit_code != 0
     # File must not have been modified
     assert dockerfile.read_text(encoding="utf-8") == _DOCKERFILE_RANGE_PINS
+
+
+# ---------------------------------------------------------------------------
+# test_intelligence_in_plugins_list (OMN-5374)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_intelligence_in_plugins_list() -> None:
+    """omninode-intelligence must be in the PLUGINS list."""
+    assert "omninode-intelligence" in _mod.PLUGINS
+
+
+@pytest.mark.unit
+def test_pin_re_matches_intelligence() -> None:
+    """_PIN_RE must match omninode-intelligence package references."""
+    line = 'RUN pip install "omninode-intelligence==0.5.0"'
+    m = _mod._PIN_RE.search(line)
+    assert m is not None
+    assert m.group("pkg") == "omninode-intelligence"
+
+
+@pytest.mark.unit
+def test_rewrite_updates_all_three_plugins() -> None:
+    """rewrite_content updates claude, intelligence, and memory pins."""
+    content = (
+        'RUN pip install "omninode-claude==0.1.0"\n'
+        'RUN pip install "omninode-intelligence==0.2.0"\n'
+        'RUN pip install "omninode-memory==0.3.0"\n'
+    )
+    result = rewrite_content(content, _VERSIONS)
+    assert '"omninode-claude==1.2.3"' in result
+    assert '"omninode-intelligence==3.4.5"' in result
+    assert '"omninode-memory==2.3.4"' in result


### PR DESCRIPTION
## Summary

- **OMN-5374**: Add `omninode-intelligence` to `PLUGINS` list and `_PIN_RE` regex in `update-plugin-pins.py` so Dockerfile.runtime pins include all three plugin packages
- **OMN-5376**: Fix `dependency-cascade.yml` to update `pyproject.toml` exact pins (`==X.Y.Z`) alongside `uv.lock` when a foundation package is released
- Adds 3 new unit tests for intelligence support in update-plugin-pins.py

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_update_plugin_pins.py -v` passes (7/7)
- [ ] CI passes