### PR TITLE
fix(mypy): resolve 25 pre-existing mypy errors and make CI job fully blocking [OMN-5405]

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+name: Omni* Ecosystem Standards Compliance
+
+on:
+  push:
+    branches: [main, develop, "jonah/*", "jonahgabriel/*"]
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+  REPO_NAME: "omnibase_infra"
+
+jobs:
+  type-safety:
+    name: Type Safety Validation
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run MyPy type checking
+        run: |
+          if [ -f mypy.ini ]; then
+            uv run mypy src/ --config-file=mypy.ini
+          else
+            uv run mypy src/ --strict
+          fi
+
+  type-union-check:
+    name: PEP 604 Type Union Check (UP007)
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check for Optional/Union usage (PEP 604)
+        run: uv run ruff check src/ --select UP007,UP006
+
+  omni-standards-gate:
+    name: Omni Standards Gate
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    needs:
+      - type-safety
+      - type-union-check
+    if: always()
+    steps:
+      - name: Check standards results
+        run: |
+          FAILED=false
+          for check in \
+            "type-safety=${{ needs.type-safety.result }}" \
+            "type-union-check=${{ needs.type-union-check.result }}"; do
+            NAME="${check%%=*}"
+            RESULT="${check##*=}"
+            if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
+              echo "::error::$NAME failed (result: $RESULT)"
+              FAILED=true
+            else
+              echo "$NAME: $RESULT"
+            fi
+          done
+          if [ "$FAILED" = "true" ]; then
+            echo "Omni Standards Gate FAILED"
+            exit 1
+          fi
+          echo "Omni Standards Gate PASSED"

--- a/src/omnibase_infra/diagnostics/bus_audit.py
+++ b/src/omnibase_infra/diagnostics/bus_audit.py
@@ -39,13 +39,12 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING
 
 from confluent_kafka import Consumer, TopicPartition
-from confluent_kafka.admin import AdminClient  # type: ignore[attr-defined]
-
-if TYPE_CHECKING:
-    from confluent_kafka.admin import ClusterMetadata  # type: ignore[attr-defined]
+from confluent_kafka.admin import (  # type: ignore[attr-defined]
+    AdminClient,
+    ClusterMetadata,
+)
 from pydantic import BaseModel
 
 from omnibase_core.validation import validate_topic_suffix

--- a/src/omnibase_infra/event_bus/adapters/adapter_protocol_event_publisher_kafka.py
+++ b/src/omnibase_infra/event_bus/adapters/adapter_protocol_event_publisher_kafka.py
@@ -338,7 +338,7 @@ class AdapterProtocolEventPublisherKafka:
             Configured ModelEventEnvelope ready for serialization.
         """
         event_type = str(params["event_type"])
-        payload: JsonType = params["payload"]
+        payload = params["payload"]
         correlation_id = params.get("correlation_id")
         causation_id = params.get("causation_id")
         metadata = params.get("metadata")

--- a/src/omnibase_infra/event_bus/event_bus_inmemory.py
+++ b/src/omnibase_infra/event_bus/event_bus_inmemory.py
@@ -845,4 +845,4 @@ class EventBusInmemory:
             }
 
 
-__all__: list[str] = ["EventBusInmemory"]
+__all__: list[str] = ["EventBusInmemory", "ModelEventHeaders", "ModelEventMessage"]

--- a/src/omnibase_infra/event_bus/testing/adapter_protocol_event_publisher_inmemory.py
+++ b/src/omnibase_infra/event_bus/testing/adapter_protocol_event_publisher_inmemory.py
@@ -261,7 +261,7 @@ class AdapterProtocolEventPublisherInmemory:
             Configured ModelEventEnvelope ready for serialization.
         """
         event_type = str(params["event_type"])
-        payload: JsonType = params["payload"]
+        payload = params["payload"]
         correlation_id = params.get("correlation_id")
         causation_id = params.get("causation_id")
         metadata = params.get("metadata")

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
@@ -285,6 +285,7 @@ class DispatcherNodeIntrospected(MixinAsyncCircuitBreaker):
             # Type narrowing: the branch above guarantees payload is
             # ModelNodeIntrospectionEvent (isinstance returned True, or model_validate
             # succeeded, or we returned early).
+            assert isinstance(payload, ModelNodeIntrospectionEvent)
 
             # TODO(OMN-2050): Use injected time from ModelDispatchContext instead
             # of datetime.now(UTC). Currently, the ProtocolMessageDispatcher.handle()

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_registration_acked.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_registration_acked.py
@@ -253,6 +253,7 @@ class DispatcherNodeRegistrationAcked(MixinAsyncCircuitBreaker):
             # Type narrowing: the branch above guarantees payload is
             # ModelNodeRegistrationAcked (isinstance returned True, or model_validate
             # succeeded, or we returned early).
+            assert isinstance(payload, ModelNodeRegistrationAcked)
 
             # Get current time for handler
             now = datetime.now(UTC)

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_runtime_tick.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_runtime_tick.py
@@ -253,6 +253,7 @@ class DispatcherRuntimeTick(MixinAsyncCircuitBreaker):
             # Type narrowing: the branch above guarantees payload is
             # ModelRuntimeTick (isinstance returned True, or model_validate
             # succeeded, or we returned early).
+            assert isinstance(payload, ModelRuntimeTick)
 
             # Get current time for handler
             now = datetime.now(UTC)

--- a/src/omnibase_infra/nodes/node_registration_reducer/models/model_payload_postgres_update_registration.py
+++ b/src/omnibase_infra/nodes/node_registration_reducer/models/model_payload_postgres_update_registration.py
@@ -71,4 +71,6 @@ class ModelPayloadPostgresUpdateRegistration(BaseModel):
 
 __all__: list[str] = [
     "ModelPayloadPostgresUpdateRegistration",
+    "ModelRegistrationAckUpdate",
+    "ModelRegistrationHeartbeatUpdate",
 ]

--- a/src/omnibase_infra/observability/handlers/model_metrics_handler_response.py
+++ b/src/omnibase_infra/observability/handlers/model_metrics_handler_response.py
@@ -97,5 +97,6 @@ class ModelMetricsHandlerResponse(BaseModel):
 
 
 __all__: list[str] = [
+    "ModelMetricsHandlerPayload",
     "ModelMetricsHandlerResponse",
 ]

--- a/src/omnibase_infra/observability/sinks/sink_metrics_prometheus.py
+++ b/src/omnibase_infra/observability/sinks/sink_metrics_prometheus.py
@@ -256,8 +256,7 @@ class SinkMetricsPrometheus:
         # - Returns labels (possibly stripped) if allowed
         # - Returns None if metric should be dropped
         # - Raises ModelOnexError if on_violation=RAISE
-        result: dict[str, str] | None = self._policy.enforce_labels(labels)
-        return result
+        return self._policy.enforce_labels(labels)
 
     def _get_or_create_counter(
         self,

--- a/src/omnibase_infra/runtime/models/model_config_ref.py
+++ b/src/omnibase_infra/runtime/models/model_config_ref.py
@@ -327,5 +327,6 @@ ModelConfigRefParseResult.model_rebuild()
 
 
 __all__: list[str] = [
+    "EnumConfigRefScheme",
     "ModelConfigRef",
 ]

--- a/src/omnibase_infra/services/retry_worker/models/model_delivery_attempt.py
+++ b/src/omnibase_infra/services/retry_worker/models/model_delivery_attempt.py
@@ -81,4 +81,4 @@ class ModelDeliveryAttempt(BaseModel):
     )
 
 
-__all__ = ["ModelDeliveryAttempt"]
+__all__ = ["EnumDeliveryStatus", "ModelDeliveryAttempt"]


### PR DESCRIPTION
## Summary

- Fixes all 25 pre-existing mypy strict errors that were blocking the `type-safety` CI job from being fully enforced
- Removes `continue-on-error: true` from the `type-safety` job in `omni-standards-compliance.yml` and adds it to the gate enforcement
- `uv run mypy src/ --strict` now exits 0 with 0 errors

## Changes

### attr-defined errors (17 fixes)
- Add missing symbols to `__all__` in source modules: `model_topic_parser` (`TypeCacheInfo`), `model_node_event_bus_config` (`ModelEventBusTopicEntry`), `model_config_ref` (`EnumConfigRefScheme`), `binding_resolver` (4 constants), `model_delivery_attempt` (`EnumDeliveryStatus`), `model_metrics_handler_response` (`ModelMetricsHandlerPayload`), `event_bus_inmemory` (`ModelEventHeaders`, `ModelEventMessage`), `model_payload_postgres_update_registration` (2 models)
- Fix import sources: `sink_ledger_inmemory` → imports `EnumLedgerSinkDropPolicy` from `enums` (not `protocols`), `handler_plan_to_yaml` → imports `EnumArtifactTopic` directly from leaf module (not auto-generated `__init__`), `service_envelope_validator` → imports `InvalidSignature` from `cryptography.exceptions` directly
- Add `# type: ignore[attr-defined]` to `bus_audit.py` for `confluent_kafka.admin.ClusterMetadata` (missing stub)

### redundant-cast errors (8 fixes)
- Replace `cast("ModelRuntimeTick/ModelNodeRegistrationAcked/ModelNodeIntrospectionEvent", payload)` with `assert isinstance(payload, ...)` in 3 dispatcher files (type narrowing after isinstance branch)
- Remove `cast("JsonType", params["payload"])` in 2 event_bus adapters (TypedDict already types `payload` as `JsonType`)
- Replace `cast("object", input_data.get("json", {}))` with explicit annotation `json_data: object = ...` in 2 plugin examples
- Remove `cast("dict[str, str] | None", ...)` in `sink_metrics_prometheus` (mypy already infers return type)

### CI workflow
- Add `omni-standards-compliance.yml` (from `std-sweep-v2` branch) with `continue-on-error: true` removed from `type-safety` job
- Add `type-safety` to the `omni-standards-gate` enforcement check

## Test plan

- [ ] `uv run mypy src/ --strict` exits 0 with 0 errors
- [ ] `pre-commit run --all-files` passes all hooks
- [ ] CI green on PR (type-safety job now blocking)
- [ ] `omni-standards-gate` passes with both `type-safety` and `type-union-check` enforced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow to enforce code quality standards, including type safety checks and ecosystem compliance validation across pull requests.

* **Refactor**
  * Simplified internal type annotations and return logic for improved code maintainability.
  * Enhanced runtime error handling with additional validation assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->