### PR TITLE
chore(deps): post-release uv.sources tag fixup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,8 +150,8 @@ dev = [
 ]
 
 [tool.uv.sources]
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "release/v0.29.0" }
-omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "release/v0.18.0" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", tag = "v0.29.0" }
+omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", tag = "v0.18.0" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1860,7 +1860,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.29.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=release%2Fv0.29.0#786df81e4107ad9bd46ec25e471a87554bf8f454" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.29.0#69348a3167a8c29164d142c72b1da9eadcfbf612" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1967,8 +1967,8 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<6.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=release%2Fv0.29.0" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=release%2Fv0.18.0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.29.0" },
+    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.18.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.48b0,<0.62" },
@@ -2022,7 +2022,7 @@ dev = [
 [[package]]
 name = "omnibase-spi"
 version = "0.18.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=release%2Fv0.18.0#dea7c4e2f5cdf4156c9f987e98f0f00d0464cf9b" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.18.0#9d8f29a814d0ae7850f41656663c697e61663ed6" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
Switch uv.sources from ephemeral release/* branches to published tags
(v0.29.0, v0.18.0) after successful PyPI release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency references to use stable git tags instead of branch pointers for improved version stability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->