### PR TITLE
fix(scripts): prune stale worktrees before fetch in pull-all.sh [OMN-5460]

### DIFF
--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -44,6 +44,10 @@ for repo in "${REPOS[@]}"; do
   is_bare=$(git -C "$dir" rev-parse --is-bare-repository 2>/dev/null)
 
   if [[ "$is_bare" == "true" ]]; then
+    # Prune stale worktrees before fetch — prevents "main is checked out"
+    # errors from dead worktrees that still hold a ref to main.
+    git -C "$dir" worktree prune 2>/dev/null || true
+
     # Bare clone: fetch origin main directly into the local main ref
     before=$(git -C "$dir" rev-parse main 2>/dev/null)
     if output=$(git -C "$dir" fetch origin main:main 2>&1); then
@@ -55,6 +59,15 @@ for repo in "${REPOS[@]}"; do
         echo "  UPDATED  $repo (+${commits} commit(s))"
       fi
       (( OK++ )) || true
+    elif echo "$output" | grep -q "checked out"; then
+      # Worktree has main checked out — force-fetch origin to FETCH_HEAD and update
+      echo "  WARN     $repo (main checked out in a worktree, using FETCH_HEAD)"
+      if git -C "$dir" fetch origin main 2>/dev/null; then
+        (( OK++ )) || true
+      else
+        echo "  FAILED   $repo (fetch failed even via FETCH_HEAD)"
+        FAILED+=("$repo")
+      fi
     else
       echo "  FAILED   $repo"
       echo "           $output"


### PR DESCRIPTION
## Summary
- Add `git worktree prune` before fetch in pull-all.sh for bare clones
- Add fallback to FETCH_HEAD when a live worktree has `main` checked out
- Prevents false NO_CONTRACT halt in integration-sweep from stale repos

## Test plan
- [x] pull-all.sh runs successfully with stale worktrees present
- [ ] Integration-sweep no longer fails on stale bare clones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a service catalog system enabling modular infrastructure deployment through reusable bundles (core, runtime, observability, memgraph, secrets, auth, tracing).
  * Added support for infrastructure-as-code via typed service manifests with automatic environment injection and dependency management.
  * Added CLI commands for bundle management: `onex_up`, `onex_down`, `onex_validate`, and `onex_generate`.
  * Added 15+ new containerized services for observability, secrets management, and data processing.

* **Documentation**
  * Updated architecture documentation with service catalog patterns and bundle composition guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->