### PR TITLE
fix(catalog): pre-cleanup dead containers before compose up [OMN-5468]

### DIFF
--- a/src/omnibase_infra/docker/catalog/cli.py
+++ b/src/omnibase_infra/docker/catalog/cli.py
@@ -118,6 +118,23 @@ def cmd_up(args: list[str]) -> int:
     if rc != 0:
         return rc
 
+    # Pre-cleanup: remove dead/exited containers to prevent restart delays (OMN-5468)
+    # and name collisions when core infra is already running (OMN-5469).
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            _DEFAULT_OUTPUT,
+            "rm",
+            "-f",
+            "--stop",
+        ],
+        cwd=str(_REPO_ROOT),
+        check=False,
+        capture_output=True,
+    )
+
     # Start
     proc = subprocess.run(
         ["docker", "compose", "-f", _DEFAULT_OUTPUT, "up", "-d"],


### PR DESCRIPTION
## Summary
- Add `docker compose rm -f --stop` before `up -d` in catalog CLI
- Removes dead/exited containers that block restarts for ~5 min (OMN-5468)
- Also prevents name collision errors when core infra already running (OMN-5469)

## Test plan
- [ ] Verify `infra-up` works after containers are in Dead state
- [ ] Verify runtime-only restart doesn't touch core services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker service catalog with composable infrastructure bundles (core, runtime, observability, memgraph, secrets, auth, tracing).
  * Added `onex` CLI tool for generating, validating, and managing containerized infrastructure.
  * Introduced bundle-based service selection with automatic transitive dependency resolution.

* **Documentation**
  * Added comprehensive Service Catalog Architecture documentation describing manifest-based deployment model and bundle composition.

* **Tests**
  * Added integration and unit test coverage for catalog resolution, bundle composition, and CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->