### PR TITLE
feat(infra): add savings estimation compute handler with tiered attribution [OMN-5547]

### DIFF
--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/__init__.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Node Savings Estimation Compute -- tiered attribution.
+
+This package provides the NodeSavingsEstimationCompute, a compute node
+that estimates how much token spend the ONEX platform saved in a session
+by comparing actual costs against a counterfactual reference model.
+
+Capabilities:
+    - savings.estimate: Compute tiered token savings attribution
+
+Available Exports:
+    - NodeSavingsEstimationCompute: The declarative compute node
+    - ModelSavingsInput: Input model for session signals
+    - HandlerSavingsEstimator: Handler for savings computation
+    - RegistryInfraSavingsEstimation: DI registry
+
+Tracking:
+    - OMN-5547: Create HandlerSavingsEstimator compute handler
+"""
+
+from omnibase_infra.nodes.node_savings_estimation_compute.handlers import (
+    HandlerSavingsEstimator,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models import (
+    ModelSavingsInput,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.node import (
+    NodeSavingsEstimationCompute,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.registry import (
+    RegistryInfraSavingsEstimation,
+)
+
+__all__: list[str] = [
+    "HandlerSavingsEstimator",
+    "ModelSavingsInput",
+    "NodeSavingsEstimationCompute",
+    "RegistryInfraSavingsEstimation",
+]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/contract.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+#
+# ONEX Node Contract
+# Node: NodeSavingsEstimationCompute
+#
+# Tiered token savings attribution compute node.
+# Computes how much token spend the ONEX platform saved per session
+# by comparing actual costs against a counterfactual reference model.
+#
+# Related Tickets:
+#   - OMN-5547: Create HandlerSavingsEstimator compute handler
+# Contract identifiers
+name: "node_savings_estimation_compute"
+contract_name: "node_savings_estimation_compute"
+node_name: "node_savings_estimation_compute"
+contract_version:
+  major: 0
+  minor: 1
+  patch: 0
+node_version:
+  major: 0
+  minor: 1
+  patch: 0
+# Node type
+node_type: "COMPUTE_GENERIC"
+# Description
+description: >
+  Compute node for tiered token savings attribution. Takes session LLM call records, injection signals, validator catches, and baseline config, then computes savings across 5 categories (local routing, pattern injection, agent delegation, memory/RAG, validator catches) with two tiers (direct/heuristic). Produces a ContractSavingsEstimate wire-format dict.
+
+# Strongly typed I/O models
+input_model:
+  name: "ModelSavingsInput"
+  module: "omnibase_infra.nodes.node_savings_estimation_compute.models"
+  description: "Session signals and baseline config for savings estimation."
+output_model:
+  name: "dict"
+  module: "builtins"
+  description: "ContractSavingsEstimate wire-format dict."
+# Capability declaration
+capabilities:
+  - name: "savings.estimate"
+    description: "Compute tiered token savings attribution for a session"
+# Handler routing
+handler_routing:
+  routing_strategy: "operation_match"
+  handlers:
+    - operation: "savings.estimate"
+      handler_class: "HandlerSavingsEstimator"
+      handler_module: "omnibase_infra.nodes.node_savings_estimation_compute.handlers.handler_savings_estimator"
+      description: "Compute tiered savings from session signals and pricing table"
+      input_model:
+        name: "ModelSavingsInput"
+        module: "omnibase_infra.nodes.node_savings_estimation_compute.models"
+        description: "Session signals for savings estimation."
+# Error handling
+error_handling:
+  retry_policy:
+    max_retries: 0
+    initial_delay_ms: 0
+    max_delay_ms: 0
+    exponential_base: 1
+    retry_on: []
+  error_types:
+    - name: "SavingsEstimationError"
+      description: "Failed to compute savings estimate"
+      recoverable: false
+    - name: "PricingLookupError"
+      description: "Reference model not found in pricing table"
+      recoverable: false
+# Health check
+health_check:
+  enabled: true
+  endpoint: "/health"
+  interval_seconds: 30
+  checks:
+    - name: "savings_handler_loaded"
+      type: "handler"
+      critical: true
+# Metadata
+metadata:
+  author: "OmniNode Team"
+  license: "MIT"
+  created: "2026-03-19"
+  tags:
+    - compute
+    - savings
+    - estimation
+    - attribution
+    - pricing
+    - cost
+  related_tickets:
+    - "OMN-5547"

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/handlers/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Handlers for the savings estimation compute node."""
+
+from omnibase_infra.nodes.node_savings_estimation_compute.handlers.handler_savings_estimator import (
+    HandlerSavingsEstimator,
+)
+
+__all__: list[str] = ["HandlerSavingsEstimator"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/handlers/handler_savings_estimator.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/handlers/handler_savings_estimator.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Handler for computing tiered token savings attribution.
+
+Computes how much token spend the ONEX platform saved in a session by
+comparing actual costs against a counterfactual reference model.
+
+Savings are broken into 5 categories across two tiers:
+
+Tier A (direct, high confidence):
+    1. Local routing -- calls routed to $0 local models instead of paid APIs.
+
+Tier B (heuristic, varying confidence):
+    2. Pattern injection -- learned patterns injected into prompts.
+    3. Agent delegation -- avoided unnecessary subagent calls (Phase A: 0).
+    4. Memory/RAG -- retrieval avoiding regeneration (Phase A: 0).
+    5. Validator catches -- errors caught before reaching LLM regen cycles.
+
+Related Tickets:
+    - OMN-5547: Create HandlerSavingsEstimator compute handler
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from omnibase_infra.enums import (
+    EnumHandlerType,
+    EnumHandlerTypeCategory,
+)
+from omnibase_infra.models.pricing.model_pricing_table import ModelPricingTable
+from omnibase_infra.nodes.node_savings_estimation_compute.models import (
+    ModelSavingsInput,
+    ModelValidatorCatchSignal,
+)
+
+logger = logging.getLogger(__name__)
+
+# Confidence values for validator catch categories
+_CATCH_CONFIDENCE: dict[str, float] = {
+    "error_poly_enforcer": 0.9,
+    "error_pre_commit": 0.7,
+    "error_ci": 0.7,
+    "error_code_review": 0.7,
+    "warning_pre_commit": 0.5,
+    "warning_code_review": 0.5,
+}
+_DEFAULT_CATCH_CONFIDENCE: float = 0.5
+
+
+class SavingsCategoryResult:
+    """Internal accumulator for a single savings category."""
+
+    __slots__ = (
+        "category",
+        "confidence",
+        "cost_saved_usd",
+        "evidence",
+        "method",
+        "tier",
+        "tokens_saved",
+    )
+
+    def __init__(
+        self,
+        category: str,
+        tier: str,
+        tokens_saved: int,
+        cost_saved_usd: float,
+        confidence: float,
+        method: str,
+        # ONEX_EXCLUDE: any_type - dict[str, ...] for flexible evidence payload
+        evidence: dict[str, object],
+    ) -> None:
+        self.category = category
+        self.tier = tier
+        self.tokens_saved = tokens_saved
+        self.cost_saved_usd = cost_saved_usd
+        self.confidence = confidence
+        self.method = method
+        self.evidence = evidence
+
+
+class HandlerSavingsEstimator:
+    """Compute tiered token savings attribution for a session.
+
+    Stateless handler. Receives session signals and a pricing table,
+    computes savings across 5 categories, and returns a structured
+    estimate matching the ContractSavingsEstimate wire format.
+    """
+
+    def __init__(self, pricing_table: ModelPricingTable) -> None:
+        self._pricing_table = pricing_table
+
+    @property
+    def handler_id(self) -> str:
+        return "handler-savings-estimator"
+
+    @property
+    def handler_type(self) -> EnumHandlerType:
+        return EnumHandlerType.INFRA_HANDLER
+
+    @property
+    def handler_category(self) -> EnumHandlerTypeCategory:
+        return EnumHandlerTypeCategory.NONDETERMINISTIC_COMPUTE
+
+    # ONEX_EXCLUDE: any_type - dict[str, Any] return for SPI contract wire format
+    async def handle(self, savings_input: ModelSavingsInput) -> dict[str, object]:
+        """Compute savings estimate from session signals.
+
+        Returns a dict matching the ContractSavingsEstimate wire format.
+        """
+        config = savings_input.baseline_config
+        categories: list[SavingsCategoryResult] = []
+        has_unknown_model = False
+
+        # --- Category 1: Local routing (Tier A) ---
+        cat1 = self._compute_local_routing(savings_input)
+        if cat1.tokens_saved > 0 or savings_input.llm_calls:
+            categories.append(cat1)
+        if any(
+            not self._pricing_table.has_model(c.model_id)
+            for c in savings_input.llm_calls
+        ):
+            has_unknown_model = True
+
+        # --- Category 2: Pattern injection (Tier B) ---
+        cat2 = self._compute_pattern_injection(savings_input)
+        if cat2.tokens_saved > 0:
+            categories.append(cat2)
+
+        # --- Category 3: Agent delegation (Tier B, Phase A: 0) ---
+        cat3 = self._compute_delegation(savings_input)
+        categories.append(cat3)
+
+        # --- Category 4: Memory/RAG (Tier B, Phase A: 0) ---
+        cat4 = self._compute_rag(savings_input)
+        categories.append(cat4)
+
+        # --- Category 5: Validator catches (Tier B) ---
+        cat5 = self._compute_validator_catches(savings_input)
+        if cat5.tokens_saved > 0:
+            categories.append(cat5)
+
+        # Aggregate
+        direct_cats = [c for c in categories if c.tier == "direct"]
+        heuristic_cats = [
+            c for c in categories if c.tier == "heuristic" and c.confidence > 0.0
+        ]
+
+        direct_savings_usd = sum(c.cost_saved_usd for c in direct_cats)
+        direct_tokens_saved = sum(c.tokens_saved for c in direct_cats)
+        total_savings_usd = sum(c.cost_saved_usd for c in categories)
+        total_tokens_saved = sum(c.tokens_saved for c in categories)
+
+        direct_confidence = direct_cats[0].confidence if direct_cats else 0.0
+        if heuristic_cats:
+            total_heuristic_cost = sum(c.cost_saved_usd for c in heuristic_cats)
+            if total_heuristic_cost > 0:
+                heuristic_confidence_avg = (
+                    sum(c.confidence * c.cost_saved_usd for c in heuristic_cats)
+                    / total_heuristic_cost
+                )
+            else:
+                heuristic_confidence_avg = sum(
+                    c.confidence for c in heuristic_cats
+                ) / len(heuristic_cats)
+        else:
+            heuristic_confidence_avg = 0.0
+
+        # Actual session totals
+        actual_total_tokens = sum(
+            c.prompt_tokens + c.completion_tokens for c in savings_input.llm_calls
+        )
+        actual_cost_usd = 0.0
+        for call in savings_input.llm_calls:
+            est = self._pricing_table.estimate_cost(
+                call.model_id, call.prompt_tokens, call.completion_tokens
+            )
+            if est.estimated_cost_usd is not None:
+                actual_cost_usd += est.estimated_cost_usd
+
+        completeness_status = "complete"
+        if has_unknown_model:
+            completeness_status = "partial"
+        elif not savings_input.delegation_signals and not savings_input.rag_signals:
+            completeness_status = "phase_limited"
+
+        actual_model_ids = list({c.model_id for c in savings_input.llm_calls})
+
+        logger.info(
+            "Savings estimate: session=%s direct=%.4f heuristic=%.4f total=%.4f",
+            savings_input.session_id,
+            direct_savings_usd,
+            total_savings_usd - direct_savings_usd,
+            total_savings_usd,
+        )
+
+        return {
+            "schema_version": "1.0",
+            "session_id": savings_input.session_id,
+            "correlation_id": savings_input.correlation_id,
+            "timestamp_iso": datetime.now(tz=UTC).isoformat(),
+            "actual_total_tokens": actual_total_tokens,
+            "actual_cost_usd": round(actual_cost_usd, 10),
+            "actual_model_id": actual_model_ids[0] if actual_model_ids else "",
+            "counterfactual_model_id": config.reference_model_id,
+            "direct_savings_usd": round(direct_savings_usd, 10),
+            "direct_tokens_saved": direct_tokens_saved,
+            "estimated_total_savings_usd": round(total_savings_usd, 10),
+            "estimated_total_tokens_saved": total_tokens_saved,
+            "categories": [
+                {
+                    "category": c.category,
+                    "tier": c.tier,
+                    "tokens_saved": c.tokens_saved,
+                    "cost_saved_usd": round(c.cost_saved_usd, 10),
+                    "confidence": c.confidence,
+                    "method": c.method,
+                    "evidence": c.evidence,
+                }
+                for c in categories
+            ],
+            "direct_confidence": direct_confidence,
+            "heuristic_confidence_avg": round(heuristic_confidence_avg, 4),
+            "estimation_method": "tiered_attribution_v1",
+            "treatment_group": savings_input.treatment_group,
+            "is_measured": False,
+            "measurement_basis": "",
+            "baseline_session_id": "",
+            "pricing_manifest_version": config.pricing_manifest_version,
+            "completeness_status": completeness_status,
+            "extensions": {},
+        }
+
+    # ------------------------------------------------------------------
+    # Category computation methods
+    # ------------------------------------------------------------------
+
+    def _compute_local_routing(
+        self, savings_input: ModelSavingsInput
+    ) -> SavingsCategoryResult:
+        """Category 1: Local routing savings (Tier A, confidence 1.0)."""
+        config = savings_input.baseline_config
+        total_tokens_saved = 0
+        total_cost_saved = 0.0
+        call_count = 0
+
+        for call in savings_input.llm_calls:
+            entry = self._pricing_table.get_entry(call.model_id)
+            if entry is None:
+                continue
+            if entry.input_cost_per_1k == 0.0 and entry.output_cost_per_1k == 0.0:
+                # Local model -- compute what reference model would have cost
+                ref_estimate = self._pricing_table.estimate_cost(
+                    config.reference_model_id,
+                    call.prompt_tokens,
+                    call.completion_tokens,
+                )
+                if ref_estimate.estimated_cost_usd is not None:
+                    total_cost_saved += ref_estimate.estimated_cost_usd
+                    total_tokens_saved += call.prompt_tokens + call.completion_tokens
+                    call_count += 1
+
+        return SavingsCategoryResult(
+            category="local_routing",
+            tier="direct",
+            tokens_saved=total_tokens_saved,
+            cost_saved_usd=total_cost_saved,
+            confidence=1.0 if call_count > 0 else 0.0,
+            method="reference_pricing_delta",
+            evidence={
+                "evidence_type": "local_routing",
+                "reference_model_id": config.reference_model_id,
+                "reference_cost_usd": round(total_cost_saved, 10),
+                "actual_model_id": "local_mix",
+                "actual_cost_usd": 0.0,
+                "call_count": call_count,
+            },
+        )
+
+    def _compute_pattern_injection(
+        self, savings_input: ModelSavingsInput
+    ) -> SavingsCategoryResult:
+        """Category 2: Pattern injection savings (Tier B, confidence 0.8)."""
+        config = savings_input.baseline_config
+        total_tokens_saved = 0
+        total_cost_saved = 0.0
+        patterns_injected = 0
+        tokens_injected = 0
+
+        for signal in savings_input.injection_signals:
+            saved = int(signal.tokens_injected * config.regen_multiplier)
+            total_tokens_saved += saved
+            patterns_injected += signal.patterns_count
+            tokens_injected += signal.tokens_injected
+
+            ref_estimate = self._pricing_table.estimate_cost(
+                config.reference_model_id, saved, 0
+            )
+            if ref_estimate.estimated_cost_usd is not None:
+                total_cost_saved += ref_estimate.estimated_cost_usd
+
+        return SavingsCategoryResult(
+            category="pattern_injection",
+            tier="heuristic",
+            tokens_saved=total_tokens_saved,
+            cost_saved_usd=total_cost_saved,
+            confidence=0.8 if savings_input.injection_signals else 0.0,
+            method="regen_multiplier",
+            evidence={
+                "evidence_type": "pattern_injection",
+                "patterns_injected": patterns_injected,
+                "tokens_injected": tokens_injected,
+                "regen_multiplier": config.regen_multiplier,
+            },
+        )
+
+    def _compute_delegation(
+        self, savings_input: ModelSavingsInput
+    ) -> SavingsCategoryResult:
+        """Category 3: Agent delegation savings (Tier B, Phase A: 0)."""
+        return SavingsCategoryResult(
+            category="agent_delegation",
+            tier="heuristic",
+            tokens_saved=0,
+            cost_saved_usd=0.0,
+            confidence=0.0,
+            method="delegation_avoidance",
+            evidence={
+                "evidence_type": "agent_delegation",
+                "subagent_calls_avoided": 0,
+                "avg_tokens_per_call": savings_input.baseline_config.avg_tokens_per_subagent_call,
+                "baseline_version": savings_input.baseline_config.baseline_version,
+            },
+        )
+
+    def _compute_rag(self, savings_input: ModelSavingsInput) -> SavingsCategoryResult:
+        """Category 4: Memory/RAG savings (Tier B, Phase A: 0)."""
+        return SavingsCategoryResult(
+            category="memory_rag",
+            tier="heuristic",
+            tokens_saved=0,
+            cost_saved_usd=0.0,
+            confidence=0.0,
+            method="rag_regen_avoidance",
+            evidence={
+                "evidence_type": "memory_rag",
+                "tokens_retrieved": 0,
+                "regen_tokens_estimate": 0,
+                "regen_multiplier": savings_input.baseline_config.rag_regen_multiplier,
+                "baseline_version": savings_input.baseline_config.baseline_version,
+            },
+        )
+
+    def _compute_validator_catches(
+        self, savings_input: ModelSavingsInput
+    ) -> SavingsCategoryResult:
+        """Category 5: Validator catch savings (Tier B, severity-weighted)."""
+        config = savings_input.baseline_config
+        total_tokens_saved = 0
+        total_cost_saved = 0.0
+        catches_by_severity: dict[str, int] = {}
+        catches_by_type: dict[str, int] = {}
+        weighted_confidence_sum = 0.0
+        catch_count = 0
+
+        for catch in savings_input.validator_catches:
+            key = f"{catch.severity}_{catch.validator_type}"
+            tokens = config.tokens_per_fix_cycle_by_severity.get(key, 0)
+            total_tokens_saved += tokens
+            catch_count += 1
+
+            catches_by_severity[catch.severity] = (
+                catches_by_severity.get(catch.severity, 0) + 1
+            )
+            catches_by_type[catch.validator_type] = (
+                catches_by_type.get(catch.validator_type, 0) + 1
+            )
+
+            confidence = _CATCH_CONFIDENCE.get(key, _DEFAULT_CATCH_CONFIDENCE)
+            weighted_confidence_sum += confidence * tokens
+
+            ref_estimate = self._pricing_table.estimate_cost(
+                config.reference_model_id, tokens, 0
+            )
+            if ref_estimate.estimated_cost_usd is not None:
+                total_cost_saved += ref_estimate.estimated_cost_usd
+
+        avg_confidence = (
+            weighted_confidence_sum / total_tokens_saved
+            if total_tokens_saved > 0
+            else 0.0
+        )
+
+        return SavingsCategoryResult(
+            category="validator_catches",
+            tier="heuristic",
+            tokens_saved=total_tokens_saved,
+            cost_saved_usd=total_cost_saved,
+            confidence=round(avg_confidence, 4) if catch_count > 0 else 0.0,
+            method="severity_weighted_fix_cycles",
+            evidence={
+                "evidence_type": "validator_catches",
+                "catch_count": catch_count,
+                "catches_by_severity": catches_by_severity,
+                "catches_by_type": catches_by_type,
+                "tokens_per_fix_cycle_weighted": (
+                    total_tokens_saved // catch_count if catch_count > 0 else 0
+                ),
+                "fix_cycle_baseline_version": config.baseline_version,
+            },
+        )
+
+    @staticmethod
+    def _catch_confidence(catch: ModelValidatorCatchSignal) -> float:
+        """Get confidence for a validator catch based on severity and type."""
+        key = f"{catch.severity}_{catch.validator_type}"
+        return _CATCH_CONFIDENCE.get(key, _DEFAULT_CATCH_CONFIDENCE)
+
+
+__all__: list[str] = ["HandlerSavingsEstimator"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/__init__.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/__init__.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Models for the savings estimation compute node."""
+
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_delegation_signal import (
+    ModelDelegationSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_injection_signal import (
+    ModelInjectionSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_llm_call_record import (
+    ModelLlmCallRecord,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_rag_signal import (
+    ModelRagSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_savings_baseline_config import (
+    ModelSavingsBaselineConfig,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_savings_input import (
+    ModelSavingsInput,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_validator_catch_signal import (
+    ModelValidatorCatchSignal,
+)
+
+__all__: list[str] = [
+    "ModelDelegationSignal",
+    "ModelInjectionSignal",
+    "ModelLlmCallRecord",
+    "ModelRagSignal",
+    "ModelSavingsBaselineConfig",
+    "ModelSavingsInput",
+    "ModelValidatorCatchSignal",
+]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_delegation_signal.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_delegation_signal.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Delegation signal model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelDelegationSignal(BaseModel):
+    """Signal from avoided subagent delegation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    subagent_calls_avoided: int
+
+
+__all__: list[str] = ["ModelDelegationSignal"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_injection_signal.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_injection_signal.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Injection signal model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelInjectionSignal(BaseModel):
+    """Signal from pattern injection into a prompt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tokens_injected: int
+    patterns_count: int
+
+
+__all__: list[str] = ["ModelInjectionSignal"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_llm_call_record.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_llm_call_record.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""LLM call record model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelLlmCallRecord(BaseModel):
+    """Record of a single LLM call with token counts and model info."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # ONEX_EXCLUDE: pattern_validator - model_id is a human-readable model name, not a UUID
+    model_id: str
+    prompt_tokens: int
+    completion_tokens: int
+
+
+__all__: list[str] = ["ModelLlmCallRecord"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_rag_signal.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_rag_signal.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""RAG signal model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelRagSignal(BaseModel):
+    """Signal from memory/RAG retrieval avoiding regeneration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tokens_retrieved: int
+    regen_tokens_estimate: int
+
+
+__all__: list[str] = ["ModelRagSignal"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_baseline_config.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_baseline_config.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Baseline configuration model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelSavingsBaselineConfig(BaseModel):
+    """Baseline configuration for counterfactual cost estimation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # ONEX_EXCLUDE: pattern_validator - reference_model_id is a human-readable model name, not a UUID
+    reference_model_id: str = "claude-opus-4-6"
+    regen_multiplier: float = 3.0
+    # ONEX_EXCLUDE: any_type - dict[str, int] needed for severity->token mapping
+    tokens_per_fix_cycle_by_severity: dict[str, int] = Field(
+        default_factory=lambda: {
+            "error_pre_commit": 15000,
+            "error_ci": 30000,
+            "error_poly_enforcer": 10000,
+            "error_code_review": 25000,
+            "warning_pre_commit": 3000,
+            "warning_code_review": 5000,
+        }
+    )
+    avg_tokens_per_subagent_call: int = 20000
+    rag_regen_multiplier: float = 2.0
+    baseline_version: str = "v1.0"
+    pricing_manifest_version: str = ""
+
+
+__all__: list[str] = ["ModelSavingsBaselineConfig"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_input.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_input.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Top-level input model for the savings estimation compute handler."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_delegation_signal import (
+    ModelDelegationSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_injection_signal import (
+    ModelInjectionSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_llm_call_record import (
+    ModelLlmCallRecord,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_rag_signal import (
+    ModelRagSignal,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_savings_baseline_config import (
+    ModelSavingsBaselineConfig,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models.model_validator_catch_signal import (
+    ModelValidatorCatchSignal,
+)
+
+
+class ModelSavingsInput(BaseModel):
+    """Input for the savings estimation compute handler."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # ONEX_EXCLUDE: pattern_validator - session_id is a wire-format string, not a UUID
+    session_id: str
+    # ONEX_EXCLUDE: pattern_validator - correlation_id is a wire-format string, not a UUID
+    correlation_id: str
+    llm_calls: list[ModelLlmCallRecord] = Field(default_factory=list)
+    treatment_group: str
+    injection_signals: list[ModelInjectionSignal] = Field(default_factory=list)
+    validator_catches: list[ModelValidatorCatchSignal] = Field(default_factory=list)
+    delegation_signals: list[ModelDelegationSignal] = Field(default_factory=list)
+    rag_signals: list[ModelRagSignal] = Field(default_factory=list)
+    baseline_config: ModelSavingsBaselineConfig = Field(
+        default_factory=ModelSavingsBaselineConfig
+    )
+
+
+__all__: list[str] = ["ModelSavingsInput"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_validator_catch_signal.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_validator_catch_signal.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Validator catch signal model for savings estimation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelValidatorCatchSignal(BaseModel):
+    """Signal from a validator catching an error before LLM regen."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    validator_type: str
+    severity: str
+
+
+__all__: list[str] = ["ModelValidatorCatchSignal"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/node.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/node.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Node Savings Estimation Compute -- tiered attribution.
+
+Declarative compute node for token savings estimation. All behavior
+is defined in contract.yaml and implemented through handlers.
+
+Tracking:
+    - OMN-5547: Create HandlerSavingsEstimator compute handler
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.nodes.node_compute import NodeCompute
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class NodeSavingsEstimationCompute(NodeCompute):
+    """Compute node for tiered token savings attribution.
+
+    Capability: savings.estimate
+
+    Takes session LLM call records, injection signals, validator catches,
+    and baseline config, then computes savings across 5 categories with
+    two tiers (direct/heuristic).
+    """
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        super().__init__(container)
+
+
+__all__: list[str] = ["NodeSavingsEstimationCompute"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/registry/__init__.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/registry/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Registry for savings estimation compute node."""
+
+from omnibase_infra.nodes.node_savings_estimation_compute.registry.registry_infra_savings_estimation import (
+    RegistryInfraSavingsEstimation,
+)
+
+__all__: list[str] = ["RegistryInfraSavingsEstimation"]

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/registry/registry_infra_savings_estimation.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/registry/registry_infra_savings_estimation.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Registry for NodeSavingsEstimationCompute dependencies."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+    from omnibase_infra.nodes.node_savings_estimation_compute.node import (
+        NodeSavingsEstimationCompute,
+    )
+
+
+class RegistryInfraSavingsEstimation:
+    """Registry for NodeSavingsEstimationCompute dependency injection."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        self._container = container
+
+    def create_compute(self) -> NodeSavingsEstimationCompute:
+        from omnibase_infra.nodes.node_savings_estimation_compute.node import (
+            NodeSavingsEstimationCompute,
+        )
+
+        return NodeSavingsEstimationCompute(self._container)
+
+
+__all__: list[str] = ["RegistryInfraSavingsEstimation"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2733,6 +2733,44 @@ pattern_exemptions:
     documentation:
       - omnidash worker-health consumer contract
     ticket: OMN-5184
+  # ==========================================================================
+  # Savings Estimation Model Exemptions (OMN-5547)
+  # ==========================================================================
+  # model_id and reference_model_id are human-readable LLM model names
+  # (e.g., "claude-opus-4-6", "qwen3-coder-30b-a3b"), not UUID entity references.
+  # session_id and correlation_id are wire-format strings matching SPI contracts.
+  - file_pattern: 'model_llm_call_record\.py'
+    violation_pattern: "Field 'model_id' should use UUID"
+    reason: >
+      model_id is a human-readable LLM model name (e.g., "claude-opus-4-6"), not a UUID entity reference.
+
+    documentation:
+      - configs/pricing_manifest.yaml (model ID examples)
+    ticket: OMN-5547
+  - file_pattern: 'model_savings_baseline_config\.py'
+    violation_pattern: "Field 'reference_model_id' should use UUID"
+    reason: >
+      reference_model_id is a human-readable LLM model name for counterfactual pricing, not a UUID.
+
+    documentation:
+      - configs/pricing_manifest.yaml (model ID examples)
+    ticket: OMN-5547
+  - file_pattern: 'model_savings_input\.py'
+    violation_pattern: "Field 'session_id' should use UUID"
+    reason: >
+      session_id is a wire-format string matching the SPI ContractSavingsEstimate contract.
+
+    documentation:
+      - omnibase_spi contracts/measurement/contract_savings_estimate.py
+    ticket: OMN-5547
+  - file_pattern: 'model_savings_input\.py'
+    violation_pattern: "Field 'correlation_id' should use UUID"
+    reason: >
+      correlation_id is a wire-format string matching the SPI ContractSavingsEstimate contract.
+
+    documentation:
+      - omnibase_spi contracts/measurement/contract_savings_estimate.py
+    ticket: OMN-5547
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/unit/nodes/node_savings_estimation_compute/__init__.py
+++ b/tests/unit/nodes/node_savings_estimation_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_savings_estimation_compute/test_handler_savings_estimator.py
+++ b/tests/unit/nodes/node_savings_estimation_compute/test_handler_savings_estimator.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Tests for HandlerSavingsEstimator compute handler.
+
+Covers all 5 savings categories, tier separation, missing signals,
+and unknown model handling.
+
+Tracking:
+    - OMN-5547: Create HandlerSavingsEstimator compute handler
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.models.pricing.model_pricing_table import ModelPricingTable
+from omnibase_infra.nodes.node_savings_estimation_compute.handlers.handler_savings_estimator import (
+    HandlerSavingsEstimator,
+)
+from omnibase_infra.nodes.node_savings_estimation_compute.models import (
+    ModelInjectionSignal,
+    ModelLlmCallRecord,
+    ModelSavingsBaselineConfig,
+    ModelSavingsInput,
+    ModelValidatorCatchSignal,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PRICING_DATA = {
+    "schema_version": "1.0.0",
+    "models": {
+        "claude-opus-4-6": {
+            "input_cost_per_1k": 0.015,
+            "output_cost_per_1k": 0.075,
+            "effective_date": "2026-02-01",
+        },
+        "qwen3-coder-30b-a3b": {
+            "input_cost_per_1k": 0.0,
+            "output_cost_per_1k": 0.0,
+            "effective_date": "2026-03-19",
+        },
+        "qwen3-14b": {
+            "input_cost_per_1k": 0.0,
+            "output_cost_per_1k": 0.0,
+            "effective_date": "2026-03-19",
+        },
+    },
+}
+
+
+@pytest.fixture
+def pricing_table() -> ModelPricingTable:
+    return ModelPricingTable.from_dict(_PRICING_DATA)
+
+
+@pytest.fixture
+def handler(pricing_table: ModelPricingTable) -> HandlerSavingsEstimator:
+    return HandlerSavingsEstimator(pricing_table)
+
+
+# ---------------------------------------------------------------------------
+# Category 1: Local routing → exact reference pricing delta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_local_routing_savings(handler: HandlerSavingsEstimator) -> None:
+    """Local model calls produce direct savings equal to reference model cost."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-1",
+        correlation_id="corr-1",
+        treatment_group="treatment",
+        llm_calls=[
+            ModelLlmCallRecord(
+                model_id="qwen3-coder-30b-a3b",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+        ],
+    )
+
+    result = await handler.handle(savings_input)
+
+    # Reference cost = (1000/1000 * 0.015) + (500/1000 * 0.075) = 0.015 + 0.0375 = 0.0525
+    assert result["direct_savings_usd"] == pytest.approx(0.0525, abs=1e-6)
+    assert result["direct_tokens_saved"] == 1500
+
+    # Find local_routing category
+    local_cats = [c for c in result["categories"] if c["category"] == "local_routing"]
+    assert len(local_cats) == 1
+    assert local_cats[0]["tier"] == "direct"
+    assert local_cats[0]["confidence"] == 1.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_multiple_local_calls(handler: HandlerSavingsEstimator) -> None:
+    """Multiple local model calls accumulate savings."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-2",
+        correlation_id="corr-2",
+        treatment_group="treatment",
+        llm_calls=[
+            ModelLlmCallRecord(
+                model_id="qwen3-coder-30b-a3b",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+            ModelLlmCallRecord(
+                model_id="qwen3-14b", prompt_tokens=2000, completion_tokens=1000
+            ),
+        ],
+    )
+
+    result = await handler.handle(savings_input)
+
+    # Call 1: (1000/1000*0.015) + (500/1000*0.075) = 0.0525
+    # Call 2: (2000/1000*0.015) + (1000/1000*0.075) = 0.03 + 0.075 = 0.105
+    # Total: 0.1575
+    assert result["direct_savings_usd"] == pytest.approx(0.1575, abs=1e-6)
+    assert result["direct_tokens_saved"] == 4500
+
+
+# ---------------------------------------------------------------------------
+# Category 2: Injection signal → multiplier applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pattern_injection_savings(handler: HandlerSavingsEstimator) -> None:
+    """Injection signals produce heuristic savings via regen multiplier."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-3",
+        correlation_id="corr-3",
+        treatment_group="treatment",
+        injection_signals=[
+            ModelInjectionSignal(tokens_injected=500, patterns_count=2),
+        ],
+        baseline_config=ModelSavingsBaselineConfig(regen_multiplier=3.0),
+    )
+
+    result = await handler.handle(savings_input)
+
+    # tokens_saved = 500 * 3.0 = 1500 (input tokens at reference price)
+    # cost = 1500/1000 * 0.015 = 0.0225
+    injection_cats = [
+        c for c in result["categories"] if c["category"] == "pattern_injection"
+    ]
+    assert len(injection_cats) == 1
+    assert injection_cats[0]["tokens_saved"] == 1500
+    assert injection_cats[0]["cost_saved_usd"] == pytest.approx(0.0225, abs=1e-6)
+    assert injection_cats[0]["confidence"] == 0.8
+    assert injection_cats[0]["tier"] == "heuristic"
+
+
+# ---------------------------------------------------------------------------
+# Category 5: Mixed severity catches → severity-weighted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validator_catches_severity_weighted(
+    handler: HandlerSavingsEstimator,
+) -> None:
+    """Validator catches produce severity-weighted heuristic savings."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-5",
+        correlation_id="corr-5",
+        treatment_group="treatment",
+        validator_catches=[
+            ModelValidatorCatchSignal(validator_type="pre_commit", severity="error"),
+            ModelValidatorCatchSignal(validator_type="poly_enforcer", severity="error"),
+            ModelValidatorCatchSignal(validator_type="code_review", severity="warning"),
+        ],
+    )
+
+    result = await handler.handle(savings_input)
+
+    # error_pre_commit: 15000 tokens, confidence 0.7
+    # error_poly_enforcer: 10000 tokens, confidence 0.9
+    # warning_code_review: 5000 tokens, confidence 0.5
+    # total tokens: 30000
+    catch_cats = [
+        c for c in result["categories"] if c["category"] == "validator_catches"
+    ]
+    assert len(catch_cats) == 1
+    assert catch_cats[0]["tokens_saved"] == 30000
+    assert catch_cats[0]["tier"] == "heuristic"
+
+    # Weighted confidence = (0.7*15000 + 0.9*10000 + 0.5*5000) / 30000
+    # = (10500 + 9000 + 2500) / 30000 = 22000 / 30000 = 0.7333...
+    assert catch_cats[0]["confidence"] == pytest.approx(0.7333, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Tier separation: direct_savings only includes Category 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tier_separation(handler: HandlerSavingsEstimator) -> None:
+    """direct_savings_usd only includes Tier A (local routing)."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-6",
+        correlation_id="corr-6",
+        treatment_group="treatment",
+        llm_calls=[
+            ModelLlmCallRecord(
+                model_id="qwen3-coder-30b-a3b",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+        ],
+        injection_signals=[
+            ModelInjectionSignal(tokens_injected=500, patterns_count=1),
+        ],
+        validator_catches=[
+            ModelValidatorCatchSignal(validator_type="pre_commit", severity="error"),
+        ],
+    )
+
+    result = await handler.handle(savings_input)
+
+    # Direct savings = only local routing
+    assert result["direct_savings_usd"] == pytest.approx(0.0525, abs=1e-6)
+    # Total includes heuristic categories too
+    assert result["estimated_total_savings_usd"] > result["direct_savings_usd"]
+
+
+# ---------------------------------------------------------------------------
+# Missing signals: absent categories report zero with confidence 0.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_signals_zero_confidence(
+    handler: HandlerSavingsEstimator,
+) -> None:
+    """Absent categories report zero savings and 0.0 confidence."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-7",
+        correlation_id="corr-7",
+        treatment_group="treatment",
+    )
+
+    result = await handler.handle(savings_input)
+
+    assert result["direct_savings_usd"] == 0.0
+    assert result["estimated_total_savings_usd"] == 0.0
+    assert result["direct_confidence"] == 0.0
+    assert result["heuristic_confidence_avg"] == 0.0
+    assert result["completeness_status"] == "phase_limited"
+
+    # Delegation and RAG categories present with 0 confidence
+    delegation_cats = [
+        c for c in result["categories"] if c["category"] == "agent_delegation"
+    ]
+    assert len(delegation_cats) == 1
+    assert delegation_cats[0]["confidence"] == 0.0
+    assert delegation_cats[0]["tokens_saved"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Unknown model: returns completeness_status="partial"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unknown_model_partial_completeness(
+    handler: HandlerSavingsEstimator,
+) -> None:
+    """Unknown model in LLM calls sets completeness_status to 'partial'."""
+    savings_input = ModelSavingsInput(
+        session_id="sess-8",
+        correlation_id="corr-8",
+        treatment_group="treatment",
+        llm_calls=[
+            ModelLlmCallRecord(
+                model_id="unknown-model-xyz", prompt_tokens=1000, completion_tokens=500
+            ),
+        ],
+    )
+
+    result = await handler.handle(savings_input)
+
+    assert result["completeness_status"] == "partial"


### PR DESCRIPTION
## Summary
- Create `node_savings_estimation_compute` with `HandlerSavingsEstimator` that computes token savings across 5 categories:
  - **Tier A (direct)**: Local routing -- calls to $0 local models vs counterfactual reference cost
  - **Tier B (heuristic)**: Pattern injection (regen multiplier), agent delegation (Phase A: 0), memory/RAG (Phase A: 0), validator catches (severity-weighted fix cycles)
- 7 model files following one-model-per-file convention, with validation exemptions for wire-format string IDs
- Full ONEX node structure: contract.yaml, handlers, models, registry, node

## Test plan
- [x] 7 unit tests covering all categories, tier separation, missing signals, unknown models
- [x] All pre-commit hooks pass (architecture, pattern, naming, contract, topic drift)
- [x] mypy type checking passes

Closes OMN-5547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new compute node that estimates token and cost savings from session optimizations across multiple categories: routing efficiency, content injection, task delegation, retrieval augmentation, and validation improvements. Provides detailed savings breakdowns with confidence metrics and completeness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->