### PR TITLE
chore: wire no-bare-feature-flags pre-commit hook [OMN-5585]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,11 @@ repos:
   # Hardcoded topic guard — sourced from onex_change_control (OMN-5256/OMN-5259)
   # Pre-existing violations excluded pending migration to canonical constants (OMN-5259)
   - repo: https://github.com/OmniNode-ai/onex_change_control
-    rev: 1b0d2f0374bca1f39d9bab22a02251208cdce196 # pragma: allowlist secret
+    rev: a3d309f216f29f7ff3a4d992478cecf61274002a # pragma: allowlist secret
     hooks:
       - id: no-hardcoded-topics
         exclude: ^(src/omnibase_infra/(enums/generated|cli|tui|models/registration/model_event_bus_topic_entry\.py|nodes/.*/handlers|nodes/.*/services|runtime/contract_registration_event_router\.py|services/observability|services/service_timeout_emitter\.py|validation)|contracts/|scripts/|tests/)
+      - id: no-bare-feature-flags
   # YAML formatting (standard across ecosystem)
   - repo: https://github.com/google/yamlfmt
     rev: v0.17.2

--- a/src/omnibase_infra/runtime/protocol_domain_plugin.py
+++ b/src/omnibase_infra/runtime/protocol_domain_plugin.py
@@ -207,7 +207,7 @@ class ProtocolDomainPlugin(Protocol):
                 return "my-domain"
 
             def should_activate(self, config: ModelDomainPluginConfig) -> bool:
-                return bool(os.getenv("MY_DOMAIN_ENABLED"))
+                return bool(os.getenv("MY_DOMAIN_ENABLED"))  # ONEX_FLAG_EXEMPT: docstring example
 
             async def initialize(
                 self, config: ModelDomainPluginConfig


### PR DESCRIPTION
## Summary
- Wire `no-bare-feature-flags` hook from onex_change_control into omnibase_infra
- Bump onex_change_control rev to include the new validator (OMN-5573)
- 1 pre-existing exemption (docstring example in `protocol_domain_plugin.py`)
- Baseline: 1 exemption, 0 violations

## Test plan
- [x] `pre-commit run no-bare-feature-flags --all-files` passes
- [x] All pre-commit hooks pass

Closes OMN-5585 (omnibase_infra portion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hooks configuration to include an additional code quality check

* **Documentation**
  * Updated module documentation examples with clarification comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->