### PR TITLE
feat(capabilities): extract feature flags from contract YAML [OMN-5574]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", tag = "v0.29.0" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "jonahgabriel/omn-5566-contract-feature-flags" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", tag = "v0.18.0" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 

--- a/src/omnibase_infra/capabilities/contract_node_capability_extractor.py
+++ b/src/omnibase_infra/capabilities/contract_node_capability_extractor.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from pydantic import ValidationError
@@ -45,6 +46,9 @@ from pydantic import ValidationError
 from omnibase_infra.models.registration.model_node_capabilities import (
     ModelNodeCapabilities,
 )
+
+if TYPE_CHECKING:
+    from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +69,9 @@ class ContractNodeCapabilityExtractor:
         caps = extractor.extract_from_yaml(Path("contract.yaml"))
         assert caps.postgres is True
     """
+
+    def __init__(self) -> None:
+        self.last_validation_errors: list[str] = []
 
     def extract_from_yaml(self, contract_path: Path) -> ModelNodeCapabilities:
         """Extract node capabilities from a contract YAML file.
@@ -140,6 +147,109 @@ class ContractNodeCapabilityExtractor:
                 exc,
             )
             return ModelNodeCapabilities()
+
+    def extract_feature_flags_from_yaml(self, yaml_path: Path) -> ModelFeatureFlags:
+        """Extract feature flags from a contract YAML file.
+
+        Missing block -> empty ``ModelFeatureFlags()``.
+        Invalid block -> empty ``ModelFeatureFlags()`` + structured warning +
+        ``last_validation_errors`` populated.
+        Valid block -> ``ModelFeatureFlags.from_contract_declarations(parsed_list)``.
+
+        Args:
+            yaml_path: Path to the contract YAML file.
+
+        Returns:
+            ``ModelFeatureFlags`` populated from the ``feature_flags`` block,
+            or an empty instance if the block is absent or invalid.
+        """
+        from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
+
+        self.last_validation_errors = []
+
+        try:
+            raw = yaml_path.read_text(encoding="utf-8")
+            raw_data: object = yaml.safe_load(raw)
+        except (OSError, yaml.YAMLError) as exc:
+            logger.warning(
+                "Failed to parse contract YAML for feature flags: %s: %s",
+                yaml_path,
+                exc,
+            )
+            return ModelFeatureFlags()
+
+        if not isinstance(raw_data, dict):
+            return ModelFeatureFlags()
+
+        return self._parse_feature_flags_block(raw_data, str(yaml_path))
+
+    def extract_feature_flags_from_dict(
+        self, data: dict[str, object]
+    ) -> ModelFeatureFlags:
+        """Extract feature flags from an already-parsed contract dict.
+
+        Args:
+            data: Parsed YAML dict (top-level contract data).
+
+        Returns:
+            ``ModelFeatureFlags`` populated from the ``feature_flags`` block,
+            or an empty instance if the block is absent or invalid.
+        """
+        self.last_validation_errors = []
+        return self._parse_feature_flags_block(data, "<dict>")
+
+    def _parse_feature_flags_block(
+        self, data: dict[str, object], source: str
+    ) -> ModelFeatureFlags:
+        """Shared parsing logic for feature flags from a contract dict.
+
+        Args:
+            data: Top-level contract dict.
+            source: Human-readable source identifier for log messages.
+
+        Returns:
+            Parsed ``ModelFeatureFlags`` or empty on error.
+        """
+        from omnibase_core.models.contracts.model_contract_feature_flag import (
+            ModelContractFeatureFlag,
+        )
+        from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
+
+        flags_block = data.get("feature_flags")
+        if flags_block is None:
+            return ModelFeatureFlags()
+
+        if not isinstance(flags_block, list):
+            msg = (
+                f"feature_flags in {source} is not a list "
+                f"(got {type(flags_block).__name__})"
+            )
+            logger.warning(msg)
+            self.last_validation_errors.append(msg)
+            return ModelFeatureFlags()
+
+        declarations: list[ModelContractFeatureFlag] = []
+        for idx, entry in enumerate(flags_block):
+            if not isinstance(entry, dict):
+                msg = (
+                    f"feature_flags[{idx}] in {source} is not a mapping "
+                    f"(got {type(entry).__name__})"
+                )
+                logger.warning(msg)
+                self.last_validation_errors.append(msg)
+                continue
+
+            try:
+                declarations.append(ModelContractFeatureFlag(**entry))
+            except (TypeError, ValidationError) as exc:
+                msg = f"feature_flags[{idx}] in {source} failed validation: {exc}"
+                logger.warning(msg)
+                self.last_validation_errors.append(msg)
+
+        if self.last_validation_errors:
+            return ModelFeatureFlags()
+
+        return ModelFeatureFlags.from_contract_declarations(declarations)
 
 
 __all__ = [

--- a/tests/unit/capabilities/test_contract_capability_extractor_feature_flags.py
+++ b/tests/unit/capabilities/test_contract_capability_extractor_feature_flags.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for feature flag extraction in ContractNodeCapabilityExtractor.
+
+OMN-5574: Extend the capability extractor to extract feature flags from
+contract YAML ``feature_flags:`` blocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
+from omnibase_infra.capabilities.contract_node_capability_extractor import (
+    ContractNodeCapabilityExtractor,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def extractor() -> ContractNodeCapabilityExtractor:
+    """Provide a fresh extractor instance for each test."""
+    return ContractNodeCapabilityExtractor()
+
+
+class TestExtractFeatureFlagsFromYaml:
+    """Tests for extract_feature_flags_from_yaml."""
+
+    def test_extract_feature_flags_from_yaml(
+        self, extractor: ContractNodeCapabilityExtractor, tmp_path: Path
+    ) -> None:
+        """Valid YAML with feature_flags block extracts flags correctly."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(
+            dedent("""\
+            name: "test_node"
+            feature_flags:
+              - name: enable_caching
+                description: "Enable response caching"
+                default_value: true
+                env_var: ENABLE_CACHING
+                category: infrastructure
+                owner: infra-team
+              - name: debug_mode
+                description: "Enable debug logging"
+                default_value: false
+                category: observability
+            """)
+        )
+
+        result = extractor.extract_feature_flags_from_yaml(contract)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.is_enabled("enable_caching") is True
+        assert result.is_enabled("debug_mode") is False
+        assert result.get_flag_count() == 2
+        assert extractor.last_validation_errors == []
+
+    def test_missing_block_returns_empty(
+        self, extractor: ContractNodeCapabilityExtractor, tmp_path: Path
+    ) -> None:
+        """YAML without feature_flags block returns empty ModelFeatureFlags."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(
+            dedent("""\
+            name: "test_node"
+            node_type: "EFFECT_GENERIC"
+            """)
+        )
+
+        result = extractor.extract_feature_flags_from_yaml(contract)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+        assert extractor.last_validation_errors == []
+
+    def test_invalid_block_returns_empty_with_validation_error(
+        self, extractor: ContractNodeCapabilityExtractor, tmp_path: Path
+    ) -> None:
+        """feature_flags that is not a list returns empty + validation errors."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(
+            dedent("""\
+            name: "test_node"
+            feature_flags: not_a_list
+            """)
+        )
+
+        result = extractor.extract_feature_flags_from_yaml(contract)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+        assert len(extractor.last_validation_errors) > 0
+
+    def test_invalid_block_populates_validation_errors(
+        self, extractor: ContractNodeCapabilityExtractor, tmp_path: Path
+    ) -> None:
+        """Malformed entries populate last_validation_errors with structured messages."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(
+            dedent("""\
+            name: "test_node"
+            feature_flags:
+              - not_a_mapping
+              - name: valid_flag
+                default_value: true
+            """)
+        )
+
+        result = extractor.extract_feature_flags_from_yaml(contract)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+        assert len(extractor.last_validation_errors) > 0
+
+    def test_nonexistent_file_returns_empty(
+        self, extractor: ContractNodeCapabilityExtractor, tmp_path: Path
+    ) -> None:
+        """Nonexistent file returns empty ModelFeatureFlags."""
+        contract = tmp_path / "does_not_exist.yaml"
+
+        result = extractor.extract_feature_flags_from_yaml(contract)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+
+
+class TestExtractFeatureFlagsFromDict:
+    """Tests for extract_feature_flags_from_dict."""
+
+    def test_extract_feature_flags_from_dict(
+        self, extractor: ContractNodeCapabilityExtractor
+    ) -> None:
+        """Dict input with valid feature_flags list extracts correctly."""
+        data: dict[str, object] = {
+            "name": "test_node",
+            "feature_flags": [
+                {
+                    "name": "enable_caching",
+                    "description": "Enable response caching",
+                    "default_value": True,
+                    "env_var": "ENABLE_CACHING",
+                    "category": "infrastructure",
+                },
+                {
+                    "name": "debug_mode",
+                    "default_value": False,
+                },
+            ],
+        }
+
+        result = extractor.extract_feature_flags_from_dict(data)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.is_enabled("enable_caching") is True
+        assert result.is_enabled("debug_mode") is False
+        assert result.get_flag_count() == 2
+        assert extractor.last_validation_errors == []
+
+    def test_missing_block_returns_empty(
+        self, extractor: ContractNodeCapabilityExtractor
+    ) -> None:
+        """Dict without feature_flags key returns empty ModelFeatureFlags."""
+        data: dict[str, object] = {"name": "test_node"}
+
+        result = extractor.extract_feature_flags_from_dict(data)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+
+    def test_invalid_block_returns_empty_with_errors(
+        self, extractor: ContractNodeCapabilityExtractor
+    ) -> None:
+        """Dict with non-list feature_flags returns empty + errors."""
+        data: dict[str, object] = {
+            "name": "test_node",
+            "feature_flags": "not_a_list",
+        }
+
+        result = extractor.extract_feature_flags_from_dict(data)
+
+        assert isinstance(result, ModelFeatureFlags)
+        assert result.get_flag_count() == 0
+        assert len(extractor.last_validation_errors) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1860,7 +1860,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.29.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.29.0#69348a3167a8c29164d142c72b1da9eadcfbf612" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=jonahgabriel%2Fomn-5566-contract-feature-flags#49bd2cb252003257def8d9a1b811b5c7a7f9b9f7" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1967,7 +1967,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<6.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.29.0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=jonahgabriel%2Fomn-5566-contract-feature-flags" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.18.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- Extends `ContractNodeCapabilityExtractor` with `extract_feature_flags_from_yaml()` and `extract_feature_flags_from_dict()` methods
- Missing `feature_flags:` block returns empty `ModelFeatureFlags()`; invalid blocks log structured warnings and populate `last_validation_errors`; valid blocks delegate to `ModelFeatureFlags.from_contract_declarations()`
- Temporarily pins `omnibase-core` uv.sources to the feature branch (`jonahgabriel/omn-5566-contract-feature-flags`) that adds `ModelContractFeatureFlag` — revert to tag once omnibase_core PR #708 merges

## Test plan
- [x] 8 new unit tests covering valid extraction, missing blocks, invalid blocks, validation error population, and dict input
- [x] All 13 existing `ContractNodeCapabilityExtractor` tests still pass
- [x] All pre-commit hooks pass