### PR TITLE
feat: add post-release version verification script [OMN-5608]

### DIFF
--- a/scripts/verify_deployed_versions.py
+++ b/scripts/verify_deployed_versions.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env -S uv run python
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Post-release version verification for deployed runtime containers [OMN-5608].
+
+Verifies that the package versions installed inside running Docker containers
+match the expected release versions.  Designed to be called by the redeploy
+skill's VERIFY phase immediately after container restart.
+
+Usage:
+    # Verify specific versions (from redeploy --versions flag)
+    uv run python scripts/verify_deployed_versions.py \
+        --versions "omniintelligence=0.16.0,omninode-claude=0.4.0"
+
+    # Verify with explicit container name
+    uv run python scripts/verify_deployed_versions.py \
+        --versions "omniintelligence=0.16.0" \
+        --container omninode-runtime
+
+    # JSON output for machine consumption
+    uv run python scripts/verify_deployed_versions.py \
+        --versions "omniintelligence=0.16.0" --json
+
+Exit codes:
+    0 - All package versions match expectations
+    1 - One or more version mismatches detected
+    2 - Could not connect to container or run version check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# ─── Data structures ───────────────────────────────────────────────────────
+
+
+@dataclass
+class VersionCheckResult:
+    """Result of a single package version check."""
+
+    package: str
+    expected: str
+    actual: str | None
+    match: bool
+    error: str | None = None
+
+
+@dataclass
+class VerificationReport:
+    """Aggregate report of all version checks."""
+
+    container: str
+    results: list[VersionCheckResult] = field(default_factory=list)
+
+    @property
+    def all_match(self) -> bool:
+        """Return True only if every check passed with a matching version."""
+        return bool(self.results) and all(r.match for r in self.results)
+
+    @property
+    def mismatches(self) -> list[VersionCheckResult]:
+        """Return only the results that failed."""
+        return [r for r in self.results if not r.match]
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "container": self.container,
+            "all_match": self.all_match,
+            "results": [
+                {
+                    "package": r.package,
+                    "expected": r.expected,
+                    "actual": r.actual,
+                    "match": r.match,
+                    "error": r.error,
+                }
+                for r in self.results
+            ],
+        }
+
+
+# ─── Core verification logic ──────────────────────────────────────────────
+
+
+def get_installed_version(
+    container: str,
+    package: str,
+    *,
+    runner: object | None = None,
+) -> tuple[str | None, str | None]:
+    """Query the installed version of *package* inside *container*.
+
+    Args:
+        container: Docker container name or ID.
+        package: Python package name (pip-style, e.g. ``omniintelligence``).
+        runner: Optional callable ``(cmd: list[str]) -> subprocess.CompletedProcess``
+            for testing.  Defaults to ``subprocess.run``.
+
+    Returns:
+        ``(version_string, None)`` on success, or ``(None, error_message)`` on
+        failure.
+    """
+    cmd = [
+        "docker",
+        "exec",
+        container,
+        "uv",
+        "pip",
+        "show",
+        package,
+    ]
+    run_fn = runner or subprocess.run
+    try:
+        result = run_fn(  # type: ignore[operator]
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"Timed out querying {package} in {container}"
+    except FileNotFoundError:
+        return None, "docker command not found"
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else ""
+        return None, f"docker exec failed (exit {result.returncode}): {stderr}"
+
+    # Parse "Version: X.Y.Z" from pip show output
+    for line in result.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip(), None
+
+    return None, f"No 'Version:' line in output for {package}"
+
+
+def verify_versions(
+    container: str,
+    expected_versions: dict[str, str],
+    *,
+    runner: object | None = None,
+) -> VerificationReport:
+    """Verify that all *expected_versions* match what is deployed in *container*.
+
+    Args:
+        container: Docker container name or ID.
+        expected_versions: Mapping of ``{package_name: expected_version}``.
+        runner: Optional subprocess runner for testing.
+
+    Returns:
+        A :class:`VerificationReport` with per-package results.
+    """
+    report = VerificationReport(container=container)
+
+    for package, expected in sorted(expected_versions.items()):
+        actual, error = get_installed_version(container, package, runner=runner)
+
+        if error is not None:
+            report.results.append(
+                VersionCheckResult(
+                    package=package,
+                    expected=expected,
+                    actual=None,
+                    match=False,
+                    error=error,
+                )
+            )
+        else:
+            match = actual == expected
+            report.results.append(
+                VersionCheckResult(
+                    package=package,
+                    expected=expected,
+                    actual=actual,
+                    match=match,
+                )
+            )
+
+    return report
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────────
+
+
+def parse_versions_string(raw: str) -> dict[str, str]:
+    """Parse ``"pkg1=1.0.0,pkg2=2.0.0"`` into a dict.
+
+    Raises:
+        ValueError: If any token does not contain exactly one ``=``.
+    """
+    versions: dict[str, str] = {}
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            msg = f"Invalid version token (expected pkg=version): {token!r}"
+            raise ValueError(msg)
+        name, ver = token.split("=", 1)
+        versions[name.strip()] = ver.strip()
+    return versions
+
+
+def format_report_text(report: VerificationReport) -> str:
+    """Format a human-readable verification report."""
+    lines: list[str] = []
+    lines.append(f"Version verification for container: {report.container}")
+    lines.append("")
+
+    for r in report.results:
+        if r.match:
+            lines.append(f"  OK   {r.package}: {r.actual} (expected {r.expected})")
+        elif r.error:
+            lines.append(
+                f"  FAIL {r.package}: ERROR - {r.error} (expected {r.expected})"
+            )
+        else:
+            lines.append(f"  FAIL {r.package}: {r.actual} (expected {r.expected})")
+
+    lines.append("")
+    if report.all_match:
+        lines.append("Result: ALL VERSIONS MATCH")
+    else:
+        mismatch_count = len(report.mismatches)
+        lines.append(
+            f"Result: {mismatch_count} MISMATCH(ES) DETECTED -- "
+            f"deployed versions do not match expected release"
+        )
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.  Returns exit code (0=ok, 1=mismatch, 2=infra error)."""
+    parser = argparse.ArgumentParser(
+        description="Verify deployed package versions in Docker containers.",
+    )
+    parser.add_argument(
+        "--versions",
+        required=True,
+        help='Comma-separated pkg=version pairs, e.g. "omniintelligence=0.16.0,omninode-claude=0.4.0"',
+    )
+    parser.add_argument(
+        "--container",
+        default="omninode-runtime",
+        help="Docker container name (default: omninode-runtime)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        expected = parse_versions_string(args.versions)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    if not expected:
+        print("ERROR: No versions specified", file=sys.stderr)
+        return 2
+
+    report = verify_versions(args.container, expected)
+
+    if args.json_output:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(format_report_text(report))
+
+    if report.all_match:
+        return 0
+
+    # Distinguish between infra errors (couldn't check) and actual mismatches
+    has_infra_error = any(r.error is not None for r in report.mismatches)
+    has_version_mismatch = any(r.error is None and not r.match for r in report.results)
+
+    if has_version_mismatch:
+        return 1
+    if has_infra_error:
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_verify_deployed_versions.py
+++ b/tests/unit/test_verify_deployed_versions.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for scripts/verify_deployed_versions.py [OMN-5608].
+
+Tests the version verification logic using a mock subprocess runner
+so no Docker daemon is needed.
+"""
+
+from __future__ import annotations
+
+# Import the module under test by path -- the script lives under scripts/,
+# not in the installed package, so we import it via importlib.
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_deployed_versions.py"
+)
+_spec = importlib.util.spec_from_file_location("verify_deployed_versions", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["verify_deployed_versions"] = _mod
+_spec.loader.exec_module(_mod)
+
+VersionCheckResult = _mod.VersionCheckResult
+VerificationReport = _mod.VerificationReport
+verify_versions = _mod.verify_versions
+get_installed_version = _mod.get_installed_version
+parse_versions_string = _mod.parse_versions_string
+format_report_text = _mod.format_report_text
+main = _mod.main
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_runner(
+    outputs: dict[str, str],
+    returncode: int = 0,
+) -> Any:
+    """Create a mock subprocess runner that returns canned pip-show output.
+
+    Args:
+        outputs: Mapping of package name to ``uv pip show`` stdout text.
+        returncode: Exit code to return for all calls.
+    """
+
+    def runner(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        # cmd is: docker exec <container> uv pip show <package>
+        package = cmd[-1]
+        stdout = outputs.get(package, "")
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=returncode,
+            stdout=stdout,
+            stderr="",
+        )
+
+    return runner
+
+
+def _pip_show_output(name: str, version: str) -> str:
+    """Generate realistic ``uv pip show`` output."""
+    return (
+        f"Name: {name}\n"
+        f"Version: {version}\n"
+        f"Location: /usr/local/lib/python3.12/site-packages\n"
+    )
+
+
+# ─── Tests: parse_versions_string ──────────────────────────────────────────
+
+
+class TestParseVersionsString:
+    def test_simple(self) -> None:
+        result = parse_versions_string("omniintelligence=0.16.0")
+        assert result == {"omniintelligence": "0.16.0"}
+
+    def test_multiple(self) -> None:
+        result = parse_versions_string(
+            "omniintelligence=0.16.0,omninode-claude=0.4.0,omninode-memory=0.6.1"
+        )
+        assert result == {
+            "omniintelligence": "0.16.0",
+            "omninode-claude": "0.4.0",
+            "omninode-memory": "0.6.1",
+        }
+
+    def test_whitespace_tolerance(self) -> None:
+        result = parse_versions_string(" pkg=1.0.0 , other=2.0.0 ")
+        assert result == {"pkg": "1.0.0", "other": "2.0.0"}
+
+    def test_empty_string(self) -> None:
+        result = parse_versions_string("")
+        assert result == {}
+
+    def test_invalid_token(self) -> None:
+        with pytest.raises(ValueError, match="Invalid version token"):
+            parse_versions_string("no-equals-sign")
+
+
+# ─── Tests: get_installed_version ──────────────────────────────────────────
+
+
+class TestGetInstalledVersion:
+    def test_success(self) -> None:
+        runner = _make_runner(
+            {"omniintelligence": _pip_show_output("omniintelligence", "0.16.0")}
+        )
+        version, error = get_installed_version(
+            "test-container", "omniintelligence", runner=runner
+        )
+        assert version == "0.16.0"
+        assert error is None
+
+    def test_package_not_found(self) -> None:
+        runner = _make_runner({}, returncode=1)
+        version, error = get_installed_version(
+            "test-container", "nonexistent-pkg", runner=runner
+        )
+        assert version is None
+        assert error is not None
+        assert "docker exec failed" in error
+
+    def test_no_version_line(self) -> None:
+        runner = _make_runner({"pkg": "Name: pkg\nSummary: something\n"})
+        version, error = get_installed_version("test-container", "pkg", runner=runner)
+        assert version is None
+        assert error is not None
+        assert "No 'Version:' line" in error
+
+    def test_timeout(self) -> None:
+        def timeout_runner(cmd: list[str], **kwargs: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        version, error = get_installed_version(
+            "test-container", "pkg", runner=timeout_runner
+        )
+        assert version is None
+        assert error is not None
+        assert "Timed out" in error
+
+
+# ─── Tests: verify_versions ───────────────────────────────────────────────
+
+
+class TestVerifyVersions:
+    def test_all_match(self) -> None:
+        runner = _make_runner(
+            {
+                "omniintelligence": _pip_show_output("omniintelligence", "0.16.0"),
+                "omninode-claude": _pip_show_output("omninode-claude", "0.4.0"),
+            }
+        )
+        report = verify_versions(
+            "test-container",
+            {"omniintelligence": "0.16.0", "omninode-claude": "0.4.0"},
+            runner=runner,
+        )
+        assert report.all_match is True
+        assert len(report.results) == 2
+        assert len(report.mismatches) == 0
+
+    def test_version_mismatch(self) -> None:
+        """Core test for OMN-5608: mismatch detection path."""
+        runner = _make_runner(
+            {
+                "omniintelligence": _pip_show_output("omniintelligence", "0.15.0"),
+            }
+        )
+        report = verify_versions(
+            "test-container",
+            {"omniintelligence": "0.16.0"},
+            runner=runner,
+        )
+        assert report.all_match is False
+        assert len(report.mismatches) == 1
+
+        mismatch = report.mismatches[0]
+        assert mismatch.package == "omniintelligence"
+        assert mismatch.expected == "0.16.0"
+        assert mismatch.actual == "0.15.0"
+        assert mismatch.match is False
+        assert mismatch.error is None
+
+    def test_mixed_match_and_mismatch(self) -> None:
+        runner = _make_runner(
+            {
+                "omniintelligence": _pip_show_output("omniintelligence", "0.16.0"),
+                "omninode-claude": _pip_show_output("omninode-claude", "0.3.0"),
+            }
+        )
+        report = verify_versions(
+            "test-container",
+            {"omniintelligence": "0.16.0", "omninode-claude": "0.4.0"},
+            runner=runner,
+        )
+        assert report.all_match is False
+        assert len(report.mismatches) == 1
+        assert report.mismatches[0].package == "omninode-claude"
+
+    def test_container_unreachable(self) -> None:
+        runner = _make_runner({}, returncode=1)
+        report = verify_versions(
+            "nonexistent-container",
+            {"omniintelligence": "0.16.0"},
+            runner=runner,
+        )
+        assert report.all_match is False
+        assert report.results[0].error is not None
+
+    def test_empty_versions(self) -> None:
+        runner = _make_runner({})
+        report = verify_versions("test-container", {}, runner=runner)
+        assert report.all_match is False  # no results means not all_match
+        assert len(report.results) == 0
+
+
+# ─── Tests: format_report_text ─────────────────────────────────────────────
+
+
+class TestFormatReportText:
+    def test_all_match_output(self) -> None:
+        report = VerificationReport(
+            container="test",
+            results=[
+                VersionCheckResult("pkg", "1.0.0", "1.0.0", True),
+            ],
+        )
+        text = format_report_text(report)
+        assert "ALL VERSIONS MATCH" in text
+        assert "OK" in text
+
+    def test_mismatch_output(self) -> None:
+        report = VerificationReport(
+            container="test",
+            results=[
+                VersionCheckResult("pkg", "2.0.0", "1.0.0", False),
+            ],
+        )
+        text = format_report_text(report)
+        assert "MISMATCH" in text
+        assert "FAIL" in text
+        assert "expected 2.0.0" in text
+
+    def test_error_output(self) -> None:
+        report = VerificationReport(
+            container="test",
+            results=[
+                VersionCheckResult("pkg", "1.0.0", None, False, error="container down"),
+            ],
+        )
+        text = format_report_text(report)
+        assert "container down" in text
+
+
+# ─── Tests: main (CLI) ────────────────────────────────────────────────────
+
+
+class TestMainCLI:
+    def test_exit_0_on_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runner = _make_runner(
+            {"omniintelligence": _pip_show_output("omniintelligence", "0.16.0")}
+        )
+        monkeypatch.setattr(_mod, "subprocess", MagicMock())
+
+        # Patch verify_versions to use our runner
+        original_verify = _mod.verify_versions
+
+        def patched_verify(
+            container: str, expected: dict[str, str], **kwargs: Any
+        ) -> VerificationReport:
+            return original_verify(container, expected, runner=runner)
+
+        monkeypatch.setattr(_mod, "verify_versions", patched_verify)
+        exit_code = main(["--versions", "omniintelligence=0.16.0"])
+        assert exit_code == 0
+
+    def test_exit_1_on_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runner = _make_runner(
+            {"omniintelligence": _pip_show_output("omniintelligence", "0.15.0")}
+        )
+        original_verify = _mod.verify_versions
+
+        def patched_verify(
+            container: str, expected: dict[str, str], **kwargs: Any
+        ) -> VerificationReport:
+            return original_verify(container, expected, runner=runner)
+
+        monkeypatch.setattr(_mod, "verify_versions", patched_verify)
+        exit_code = main(["--versions", "omniintelligence=0.16.0"])
+        assert exit_code == 1
+
+    def test_exit_2_on_infra_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runner = _make_runner({}, returncode=1)
+        original_verify = _mod.verify_versions
+
+        def patched_verify(
+            container: str, expected: dict[str, str], **kwargs: Any
+        ) -> VerificationReport:
+            return original_verify(container, expected, runner=runner)
+
+        monkeypatch.setattr(_mod, "verify_versions", patched_verify)
+        exit_code = main(["--versions", "omniintelligence=0.16.0"])
+        assert exit_code == 2
+
+
+# ─── Tests: VerificationReport serialization ───────────────────────────────
+
+
+class TestVerificationReportSerialization:
+    def test_to_dict(self) -> None:
+        report = VerificationReport(
+            container="test",
+            results=[
+                VersionCheckResult("pkg", "1.0.0", "1.0.0", True),
+                VersionCheckResult("pkg2", "2.0.0", "1.9.0", False),
+            ],
+        )
+        d = report.to_dict()
+        assert d["container"] == "test"
+        assert d["all_match"] is False
+        assert len(d["results"]) == 2  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Add `scripts/verify_deployed_versions.py` that queries package versions inside running Docker containers via `docker exec ... uv pip show` and compares against expected release versions
- Exit codes: 0 (all match), 1 (version mismatch), 2 (infra error / container unreachable)
- Supports `--json` output for machine consumption and `--container` override
- 21 unit tests covering mismatch detection, infra errors, CLI exit codes, report formatting, and version parsing

## Context

During OMN-5500, runtime containers were found running omniintelligence v0.15.0 when v0.16.0 was required -- discovered only by manual inspection. This script automates that check as part of the redeploy skill's VERIFY phase.

## Test plan

- [x] 21 unit tests pass (`uv run pytest tests/unit/test_verify_deployed_versions.py -v`)
- [x] Tests use mock subprocess runner -- no Docker daemon required
- [x] Covers: version match, version mismatch, container unreachable, timeout, malformed output
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a post-deployment verification tool to validate Python package versions installed in Docker containers, supporting customizable container targets and flexible output formats (human-readable and JSON).

* **Tests**
  * Added comprehensive unit test coverage for the new verification tool, validating core functionality and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->