### PR TITLE
fix(event_bus): wire retry_backoff_ms into AIOKafka constructors [OMN-5626]

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -658,8 +658,7 @@ class EventBusKafka(
                     bootstrap_servers=self._bootstrap_servers,
                     acks=self._config.acks_aiokafka,
                     enable_idempotence=self._config.enable_idempotence,
-                    reconnect_backoff_ms=self._config.reconnect_backoff_ms,
-                    reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
+                    retry_backoff_ms=self._config.reconnect_backoff_ms,
                     **self._build_auth_kwargs(),
                 )
 
@@ -983,8 +982,7 @@ class EventBusKafka(
                 bootstrap_servers=self._bootstrap_servers,
                 acks=self._config.acks_aiokafka,
                 enable_idempotence=self._config.enable_idempotence,
-                reconnect_backoff_ms=self._config.reconnect_backoff_ms,
-                reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
+                retry_backoff_ms=self._config.reconnect_backoff_ms,
                 **self._build_auth_kwargs(),
             )
 
@@ -1587,8 +1585,7 @@ class EventBusKafka(
             enable_auto_commit=self._config.enable_auto_commit,
             session_timeout_ms=self._config.session_timeout_ms,
             heartbeat_interval_ms=self._config.heartbeat_interval_ms,
-            reconnect_backoff_ms=self._config.reconnect_backoff_ms,
-            reconnect_backoff_max_ms=self._config.reconnect_backoff_max_ms,
+            retry_backoff_ms=self._config.reconnect_backoff_ms,
             **self._build_auth_kwargs(),
         )
 

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -362,7 +362,9 @@ class ModelKafkaEventBusConfig(BaseModel):
         description=(
             "Maximum reconnect backoff in milliseconds. Caps the exponential growth of "
             "reconnect delays. Must be >= reconnect_backoff_ms. "
-            "Override via KAFKA_RECONNECT_BACKOFF_MAX_MS."
+            "Override via KAFKA_RECONNECT_BACKOFF_MAX_MS. "
+            "NOTE: Not used by aiokafka 0.11.0 (no reconnect_backoff_max_ms parameter). "
+            "Retained in config model for forward-compatibility with future aiokafka versions."
         ),
         ge=0,
     )

--- a/tests/unit/event_bus/test_kafka_timeout_kwargs.py
+++ b/tests/unit/event_bus/test_kafka_timeout_kwargs.py
@@ -2,9 +2,13 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for EventBusKafka consumer/producer session timeout and reconnect kwargs (OMN-5445).
 
-Verifies that session_timeout_ms, heartbeat_interval_ms, reconnect_backoff_ms, and
-reconnect_backoff_max_ms are correctly passed from ModelKafkaEventBusConfig through
-to the AIOKafkaConsumer and AIOKafkaProducer constructors.
+Verifies that session_timeout_ms, heartbeat_interval_ms, and retry_backoff_ms are
+correctly passed from ModelKafkaEventBusConfig through to the AIOKafkaConsumer and
+AIOKafkaProducer constructors.
+
+Also verifies that reconnect_backoff_ms and reconnect_backoff_max_ms (config model
+fields) are NOT passed directly to aiokafka constructors, since aiokafka 0.11.0 uses
+retry_backoff_ms instead.
 """
 
 from __future__ import annotations
@@ -35,7 +39,7 @@ def bus(kafka_config: ModelKafkaEventBusConfig) -> EventBusKafka:
 
 
 class TestConsumerKwargs:
-    """Test that AIOKafkaConsumer receives session/heartbeat/reconnect kwargs."""
+    """Test that AIOKafkaConsumer receives session/heartbeat/retry kwargs."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -95,10 +99,10 @@ class TestConsumerKwargs:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_consumer_receives_reconnect_backoff_ms(
+    async def test_consumer_receives_retry_backoff_ms(
         self, bus: EventBusKafka, kafka_config: ModelKafkaEventBusConfig
     ) -> None:
-        """Consumer constructor must receive reconnect_backoff_ms from config."""
+        """Consumer constructor must receive retry_backoff_ms mapped from config.reconnect_backoff_ms."""
         mock_consumer = MagicMock()
         mock_consumer.start = AsyncMock()
 
@@ -119,14 +123,14 @@ class TestConsumerKwargs:
                 "test-topic", on_message=AsyncMock(), group_id="test-group"
             )
             call_kwargs = mock_consumer_cls.call_args
-            assert call_kwargs.kwargs["reconnect_backoff_ms"] == 3000
+            assert call_kwargs.kwargs["retry_backoff_ms"] == 3000
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_consumer_receives_reconnect_backoff_max_ms(
+    async def test_consumer_does_not_pass_reconnect_backoff_ms(
         self, bus: EventBusKafka, kafka_config: ModelKafkaEventBusConfig
     ) -> None:
-        """Consumer constructor must receive reconnect_backoff_max_ms from config."""
+        """Consumer constructor must NOT receive reconnect_backoff_ms (not a valid aiokafka kwarg)."""
         mock_consumer = MagicMock()
         mock_consumer.start = AsyncMock()
 
@@ -147,18 +151,19 @@ class TestConsumerKwargs:
                 "test-topic", on_message=AsyncMock(), group_id="test-group"
             )
             call_kwargs = mock_consumer_cls.call_args
-            assert call_kwargs.kwargs["reconnect_backoff_max_ms"] == 60000
+            assert "reconnect_backoff_ms" not in call_kwargs.kwargs
+            assert "reconnect_backoff_max_ms" not in call_kwargs.kwargs
 
 
 class TestProducerKwargs:
-    """Test that AIOKafkaProducer receives reconnect backoff kwargs."""
+    """Test that AIOKafkaProducer receives retry backoff kwargs."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_producer_start_receives_reconnect_backoff_ms(
+    async def test_producer_start_receives_retry_backoff_ms(
         self, bus: EventBusKafka
     ) -> None:
-        """Producer constructor in start() must receive reconnect_backoff_ms."""
+        """Producer constructor in start() must receive retry_backoff_ms mapped from config.reconnect_backoff_ms."""
         with patch(
             "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
         ) as mock_producer_cls:
@@ -168,14 +173,14 @@ class TestProducerKwargs:
             mock_producer_cls.return_value = mock_producer
             await bus.start()
             call_kwargs = mock_producer_cls.call_args
-            assert call_kwargs.kwargs["reconnect_backoff_ms"] == 3000
+            assert call_kwargs.kwargs["retry_backoff_ms"] == 3000
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_producer_start_receives_reconnect_backoff_max_ms(
+    async def test_producer_start_does_not_pass_reconnect_backoff_ms(
         self, bus: EventBusKafka
     ) -> None:
-        """Producer constructor in start() must receive reconnect_backoff_max_ms."""
+        """Producer constructor must NOT receive reconnect_backoff_ms or reconnect_backoff_max_ms."""
         with patch(
             "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
         ) as mock_producer_cls:
@@ -185,7 +190,8 @@ class TestProducerKwargs:
             mock_producer_cls.return_value = mock_producer
             await bus.start()
             call_kwargs = mock_producer_cls.call_args
-            assert call_kwargs.kwargs["reconnect_backoff_max_ms"] == 60000
+            assert "reconnect_backoff_ms" not in call_kwargs.kwargs
+            assert "reconnect_backoff_max_ms" not in call_kwargs.kwargs
 
 
 class TestDefaultValues:


### PR DESCRIPTION
## Summary
- Replace `reconnect_backoff_ms`/`reconnect_backoff_max_ms` with `retry_backoff_ms` in all 3 AIOKafka constructor sites (start, _ensure_producer, _start_consumer_for_topic)
- aiokafka 0.11.0 uses `retry_backoff_ms`, not `reconnect_backoff_ms`/`reconnect_backoff_max_ms` -- the old params were silently ignored
- Config model fields retained for forward-compatibility; `reconnect_backoff_max_ms` docstring updated with non-usage note

## Test plan
- [x] `uv run pytest tests/unit/event_bus/test_kafka_timeout_kwargs.py -v` -- 7 tests pass
- [x] Assert `retry_backoff_ms` IS present in mocked constructor kwargs
- [x] Assert `reconnect_backoff_ms` and `reconnect_backoff_max_ms` are NOT present in constructor kwargs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kafka event bus connection configuration to align with aiokafka v0.11.0 requirements. Adjusted retry backoff parameter handling for improved compatibility and forward compatibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->