### PR TITLE
fix(deploy): add migration scripts rsync to deploy-runtime.sh [OMN-5627]

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -859,6 +859,16 @@ sync_files() {
         --exclude='/overrides/' \
         "${repo_root}/docker/" "${deploy_target}/docker/"
 
+    # 5. Migration scripts (bind-mounted by docker-compose.infra.yml)
+    log_info "Syncing migration scripts..."
+    mkdir -p "${deploy_target}/scripts"
+    rsync -a \
+        --include='run-forward-migrations.sh' \
+        --include='check_migrations_complete.sh' \
+        --include='run-intelligence-migrations.sh' \
+        --exclude='*' \
+        "${repo_root}/scripts/" "${deploy_target}/scripts/"
+
     log_info "Sync complete."
 }
 


### PR DESCRIPTION
## Summary
- Add 5th rsync step to `sync_files()` in `deploy-runtime.sh` that copies migration scripts to the deployment target
- Includes `run-forward-migrations.sh`, `check_migrations_complete.sh`, and `run-intelligence-migrations.sh`
- These scripts are bind-mounted by `docker-compose.infra.yml` but were previously missing from the deploy rsync

## Test plan
- [x] Verify rsync step uses include/exclude pattern to copy only the 3 migration scripts
- [x] Verify `mkdir -p` creates the scripts directory if missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process to ensure migration scripts are properly transferred during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->