### PR TITLE
feat(contracts): create service-level feature flag contracts [OMN-5628]

### DIFF
--- a/contracts/services/event_bus.contract.yaml
+++ b/contracts/services/event_bus.contract.yaml
@@ -1,0 +1,7 @@
+name: event_bus_service
+description: "Feature flags for Kafka event bus infrastructure services"
+feature_flags:
+  - name: "ENABLE_CONSUMER_HEALTH_EMITTER"
+    env_var: "ENABLE_CONSUMER_HEALTH_EMITTER"
+    default: "false"
+    description: "Gate for consumer health metric emission via Kafka events"

--- a/contracts/services/runtime.contract.yaml
+++ b/contracts/services/runtime.contract.yaml
@@ -1,0 +1,7 @@
+name: runtime_service
+description: "Feature flags for ONEX runtime services"
+feature_flags:
+  - name: "ENABLE_RUNTIME_LOG_BRIDGE"
+    env_var: "ENABLE_RUNTIME_LOG_BRIDGE"
+    default: "false"
+    description: "Gate for runtime log-to-Kafka event bridge"


### PR DESCRIPTION
## Summary
- Create `contracts/services/event_bus.contract.yaml` declaring `ENABLE_CONSUMER_HEALTH_EMITTER` feature flag
- Create `contracts/services/runtime.contract.yaml` declaring `ENABLE_RUNTIME_LOG_BRIDGE` feature flag
- Formalizes env var gates used in `consumer_health_emitter.py` and `runtime_log_event_bridge.py`

## Test plan
- [x] YAML files pass `yamlfmt` and ONEX Contract Validation pre-commit hooks
- [x] Contract fields (name, env_var, default, description) match actual usage in source code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consumer health metrics can now be emitted to Kafka events (configurable)
  * Runtime logs can now be bridged to Kafka events (configurable)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->