### PR TITLE
fix(deploy): guard contracts/ rsync for missing directory [OMN-5630]

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -837,11 +837,15 @@ sync_files() {
     rsync -a --delete \
         "${repo_root}/src/" "${deploy_target}/src/"
 
-    # 3. Contracts
-    log_info "Syncing contracts/..."
-    log_cmd "rsync -a --delete contracts/ -> deployed"
-    rsync -a --delete \
-        "${repo_root}/contracts/" "${deploy_target}/contracts/"
+    # 3. Contracts (if directory exists)
+    if [[ -d "${repo_root}/contracts/" ]]; then
+        log_info "Syncing contracts/..."
+        log_cmd "rsync -a --delete contracts/ -> deployed"
+        rsync -a --delete \
+            "${repo_root}/contracts/" "${deploy_target}/contracts/"
+    else
+        log_info "No contracts/ directory present, skipping contracts sync."
+    fi
 
     # 4. Docker files -- with preserve allowlist
     #    .env, .env.local, certs/, overrides/ survive --delete


### PR DESCRIPTION
## Summary
- Wrap the `contracts/` rsync step in `deploy-runtime.sh` with a directory existence guard
- Deployments no longer fail when `contracts/` directory hasn't been created yet
- Logs a skip message when the directory is absent

## Test plan
- [x] Verify guard uses `[[ -d ... ]]` test before rsync
- [x] Verify else branch logs informational skip message
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment script robustness by gracefully handling missing deployment directories instead of failing, with informational logging for transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->