### PR TITLE
fix(docker): extend runtime-effects healthcheck timing [OMN-5637]

### DIFF
--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -42,8 +42,8 @@ healthcheck:
   test: curl -sf http://localhost:8085/health
   interval_s: 30
   timeout_s: 10
-  retries: 3
-  start_period_s: 90
+  retries: 5
+  start_period_s: 120
 volumes:
   - effects_logs:/app/logs
   - effects_data:/app/data

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -591,6 +591,12 @@ services:
   # ONEX Runtime - Effects Handler (Runtime Profile)
   # ==========================================================================
   # Handles effect nodes for external service interactions.
+  # OMN-5637: Effects has an extended start_period (120s) and retries (5)
+  # because plugin initialization (1950+ Kafka consumer subscriptions,
+  # intelligence DB ownership, schema fingerprint, message type registration)
+  # must complete before /health returns 200.
+  # Unhealthy detection latency = start_period + (interval * retries) = 120s + 150s = 270s.
+  # AUTOHEAL_START_PERIOD (180s) must exceed start_period to avoid premature restarts.
   runtime-effects:
     !!merge <<: *runtime-base
     container_name: omninode-runtime-effects
@@ -618,8 +624,8 @@ services:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 90s
+      retries: 5
+      start_period: 120s
     labels:
       - "com.omninode.service=runtime-effects"
       - "com.omninode.layer=runtime"


### PR DESCRIPTION
## Summary
- Extend runtime-effects healthcheck `start_period` from 90s to 120s and `retries` from 3 to 5
- Effects container runs 1950+ Kafka consumer subscriptions during init; 90s was insufficient
- Updates both docker-compose.infra.yml and catalog manifest

## Test plan
- [ ] `docker compose up` with runtime profile — effects container reaches "healthy" status
- [ ] No premature autoheal restarts during initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container healthcheck configuration for improved service reliability. Extended the startup grace period from 90 to 120 seconds to allow additional initialization time, and increased retry attempts from 3 to 5 before marking the container as unhealthy. These adjustments provide more stable container behavior during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->