### PR TITLE
chore: remove stale/canceled TODOs (5 tickets) [OMN-5690]

### DIFF
--- a/src/omnibase_infra/event_bus/adapters/adapter_protocol_event_publisher_kafka.py
+++ b/src/omnibase_infra/event_bus/adapters/adapter_protocol_event_publisher_kafka.py
@@ -60,8 +60,6 @@ from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.types import JsonType
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import InfraUnavailableError
-
-# TODO: OMN-1767 - Move ModelPublisherMetrics out of testing/ directory
 from omnibase_infra.event_bus.testing.model_publisher_metrics import (
     ModelPublisherMetrics,
 )

--- a/src/omnibase_infra/models/dispatch/model_topic_parser.py
+++ b/src/omnibase_infra/models/dispatch/model_topic_parser.py
@@ -372,7 +372,7 @@ class ModelTopicParser:
         routing semantics.
 
         External Documentation:
-            - ONEX Topic Taxonomy: docs/architecture/TOPIC_TAXONOMY.md (TODO(OMN-981): create)
+            - ONEX Topic Taxonomy: docs/architecture/TOPIC_TAXONOMY.md
             - Environment-Aware Topics: docs/patterns/ENVIRONMENT_TOPICS.md
             - Message Categories: EnumMessageCategory in omnibase_infra.enums
     """

--- a/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
+++ b/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
@@ -136,13 +136,7 @@ def _load_and_validate_contract_yaml(  # stub-ok: has tracked TODO
 
     Note on direct file operations:
         This function uses direct file I/O rather than a FileRegistry abstraction.
-        See handler_contract_source.py for the same pattern and rationale:
-        - RegistryFileBased (FileRegistry) does not yet exist in omnibase_core
-        - Once available, this should be refactored for consistency
-        - See: docs/architecture/RUNTIME_HOST_IMPLEMENTATION_PLAN.md
-
-        TODO [OMN-1352]: Refactor to use RegistryFileBased once available in omnibase_core.
-        This will provide consistent file access patterns across all contract loaders.
+        See handler_contract_source.py for the same pattern and rationale.
 
     Security Note:
         File size is checked BEFORE YAML parsing (line 164) to prevent memory

--- a/src/omnibase_infra/runtime/handler_contract_source.py
+++ b/src/omnibase_infra/runtime/handler_contract_source.py
@@ -641,18 +641,6 @@ class HandlerContractSource(ProtocolContractSource):
             yaml.YAMLError: If YAML parsing fails.
             ValidationError: If contract validation fails.
         """
-        # TODO [OMN-1352]: Replace direct file I/O with FileRegistry abstraction
-        #
-        # Why direct file operations are used here:
-        #   RegistryFileBased (or FileRegistry) does not yet exist in omnibase_core.
-        #   This is a temporary implementation that will be replaced once the
-        #   registry abstraction is available, providing:
-        #   - Consistent file loading across the codebase
-        #   - Caching and performance optimizations
-        #   - Unified error handling for file operations
-        #
-        # See: docs/architecture/RUNTIME_HOST_IMPLEMENTATION_PLAN.md
-
         # Validate file size before reading to prevent memory exhaustion
         file_size = contract_path.stat().st_size
         if file_size > MAX_CONTRACT_SIZE:

--- a/src/omnibase_infra/runtime/service_message_dispatch_engine.py
+++ b/src/omnibase_infra/runtime/service_message_dispatch_engine.py
@@ -1072,12 +1072,9 @@ class MessageDispatchEngine:
         # Until it is, we trust the topic category as the source of truth for routing.
         # This is safe because the topic defines the message category, and handlers
         # are registered for specific categories - any mismatch would be a caller error.
-        # TODO(OMN-934): Re-enable envelope category validation when infer_category() is available
-        #
-        # The code below is disabled until infer_category() is available:
-        # envelope_category = envelope.infer_category()
-        # if envelope_category != topic_category:
-        #     ... (category mismatch handling with structured metrics)
+        # Envelope category validation is deferred: infer_category() exists but
+        # topic category is the source of truth for routing. Handlers are registered
+        # for specific categories, so mismatch would be a caller error.
 
         # Step 3: Get routing key from event_type (primary) or payload class name (fallback)
         #

--- a/src/omnibase_infra/runtime/util_container_wiring.py
+++ b/src/omnibase_infra/runtime/util_container_wiring.py
@@ -124,11 +124,8 @@ def _validate_service_registry(
         )
 
     if container.service_registry is None:
-        # TODO(OMN-1265): Request upstream API - add public method
-        # `container.initialize_service_registry(config)` in omnibase_core.
-        # Current behavior: service_registry returns None under several conditions, requiring
-        # downstream validation. Proposed improvement: provide a factory method or builder pattern
-        # that ensures service_registry is always initialized with clear diagnostics.
+        # service_registry returns None under several conditions, requiring
+        # downstream validation.
         raise ServiceRegistryUnavailableError(
             "Container service_registry is None",
             operation=operation,


### PR DESCRIPTION
## Summary
- Remove TODO comments for completed and canceled work across 5 tickets
- OMN-934: `infer_category()` exists, topic category is source of truth
- OMN-981: topic taxonomy doc creation (canceled)
- OMN-1265: `initialize_service_registry` API (completed)
- OMN-1352: `RegistryFileBased` abstraction (canceled, 2 occurrences)
- OMN-1767: `ModelPublisherMetrics` relocation (canceled)

## Context
Recreated from closed PR #937 which had diverged with unrelated service catalog commits causing merge conflicts.

## Test plan
- [ ] CI passes (no functional changes, only comment removal)