### PR TITLE
feat(ci): add cross-repo migration conflict check [OMN-5772]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -711,6 +711,22 @@ jobs:
           fi
           echo "All 10 test splits passed"
 
+  # ============================================================================
+  # CROSS-REPO MIGRATION CONFLICT CHECK (OMN-5772)
+  # Validates migration schema conflicts against onex_change_control.
+  # warn-only until all violations fixed (see OMN-5775).
+  # ============================================================================
+
+  migration-conflict-check:
+    name: Cross-Repo Migration Conflicts
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@main
+        with:
+          checks: "migration-conflicts"
+          warn-only: "true"
+
   ci-summary:
     name: CI Summary
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together


### PR DESCRIPTION
## Summary

- Deploy `validate-boundaries` composite action from onex_change_control to omnibase_infra CI
- Runs `migration-conflicts` check with warn-only mode
- Added as `continue-on-error: true` until violations are fixed (OMN-5775)

## Dependencies

- Requires PR #88 in onex_change_control to be merged first (composite action definition)

## Ticket

OMN-5772

## Test plan

- [ ] CI pipeline runs migration-conflict-check job without blocking merge