### PR TITLE
fix(ci): skip infra-dependent scheduled jobs on ubuntu-latest [OMN-5776]

### DIFF
--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -39,7 +39,10 @@ env:
 jobs:
   baselines-compute:
     name: Baselines Batch Compute
-    # Self-hosted runner required: needs PostgreSQL and Kafka access
+    # Self-hosted runner required: needs PostgreSQL and Kafka access.
+    # When USE_SELF_HOSTED_RUNNERS is false, skip entirely — ubuntu-latest
+    # has no PostgreSQL and the OMNIBASE_INFRA_DB_URL secret is not configured.
+    if: vars.USE_SELF_HOSTED_RUNNERS == 'true'
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{

--- a/tests/integration/test_catalog_roundtrip.py
+++ b/tests/integration/test_catalog_roundtrip.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -14,9 +16,16 @@ from omnibase_infra.docker.catalog.resolver import CatalogResolver
 REPO_ROOT = str(Path(__file__).parent.parent.parent)
 CATALOG_DIR = str(Path(REPO_ROOT) / "docker" / "catalog")
 
+_HAS_DOCKER = shutil.which("docker") is not None
+_HAS_POSTGRES_PASSWORD = bool(os.environ.get("POSTGRES_PASSWORD"))
+
 
 @pytest.mark.integration
 @pytest.mark.slow
+@pytest.mark.skipif(
+    not _HAS_DOCKER or not _HAS_POSTGRES_PASSWORD,
+    reason="Requires Docker daemon and POSTGRES_PASSWORD env var",
+)
 def test_catalog_generates_and_starts_core_bundle() -> None:
     """Resolve core bundle, generate compose, start, health check, stop."""
     # Generate


### PR DESCRIPTION
## Summary

- **Baselines Scheduler**: Gate job with `if: vars.USE_SELF_HOSTED_RUNNERS == 'true'` so it skips cleanly on ubuntu-latest instead of timing out on unreachable PostgreSQL
- **Nightly Tests**: Add `skipif` to `test_catalog_generates_and_starts_core_bundle` when Docker or `POSTGRES_PASSWORD` is unavailable, since the test starts real Docker containers

Both failures stem from `USE_SELF_HOSTED_RUNNERS=false` routing scheduled jobs to ubuntu-latest which lacks PostgreSQL and Docker infrastructure.

## Test plan

- [ ] Verify baselines-scheduler workflow shows as skipped (not failed) on next scheduled run
- [ ] Verify nightly-tests workflow passes with the catalog roundtrip test skipped
- [ ] Manual workflow_dispatch of both workflows confirms green status

Fixes OMN-5776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline job execution with conditional deployment controls.
  * Enhanced test suite reliability with environment prerequisite validation to skip tests when required dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->