### PR TITLE
release: omnibase_infra v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v0.24.0 (2026-03-22)
+
+### Added
+- feat: verify_container_manifest.py + CLI entry point [OMN-5796] (#947)
+- feat(ci): add cross-repo migration conflict check [OMN-5772] (#943)
+- feat(monitor): emit runtime errors to Kafka [OMN-5649] (#934)
+- feat(contracts): create service-level feature flag contracts [OMN-5628] (#926)
+- feat(introspection): wire contract data into introspection emission path [OMN-5609] (#923)
+- feat(scripts): add post-release version verification script [OMN-5608] (#922)
+
+### Fixed
+- fix(ci): skip infra-dependent scheduled jobs on ubuntu-latest [OMN-5776] (#945)
+- fix(deep-dive): include onex repos and add ticket summary section [OMN-5647] (#933)
+- fix(docker): extend runtime-effects healthcheck timing to prevent false unhealthy [OMN-5637] (#931)
+- fix(deploy): guard contracts/ rsync for missing directory [OMN-5630] (#928)
+- fix(topics): register 5 missing Kafka topics in services manifest [OMN-5633] (#929)
+- fix(deploy): add migration scripts rsync to deploy-runtime.sh [OMN-5627] (#925)
+- fix(event_bus): wire retry_backoff_ms into AIOKafka constructors [OMN-5626] (#924)
+
+### Changed
+- ci: deploy TODO enforcement hooks and workflows [OMN-5694, OMN-5695] (#941)
+- chore: remove stale/canceled TODOs [OMN-5690] (#937, #939)
+- chore: re-tag deferred and unfinished TODOs [OMN-5691, OMN-5692] (#940)
+- chore: delete orphaned handler contract scaffolds [OMN-5698] (#936)
+- chore: update exemption markers to ONEX_FLAG_EXEMPT [OMN-5629] (#927)
+
 ## v0.23.0 (2026-03-20)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.23.1"
+version = "0.24.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/dispatchers/dispatcher_node_introspected.py
@@ -248,7 +248,7 @@ class DispatcherNodeIntrospected(MixinAsyncCircuitBreaker):
         """
         # NOTE: Both started_at and handler 'now' use direct datetime.now(UTC)
         # instead of ModelDispatchContext.now due to protocol signature limitation.
-        # See TODO(OMN-5738) below for details.
+        # See OMN-5738 below for details.
         started_at = datetime.now(UTC)
 
         correlation_id, raw_payload = extract_envelope_fields(envelope)

--- a/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
+++ b/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
@@ -121,7 +121,7 @@ def _check_file_size(contract_path: Path, operation: str) -> None:
         )
 
 
-def _load_and_validate_contract_yaml(  # stub-ok: has tracked TODO
+def _load_and_validate_contract_yaml(  # stub-ok: tracked in OMN-41
     contract_path: Path,
     operation: str,
 ) -> tuple[dict, dict]:

--- a/src/omnibase_infra/runtime/handler_registry.py
+++ b/src/omnibase_infra/runtime/handler_registry.py
@@ -242,7 +242,7 @@ def get_event_bus_class(bus_kind: str) -> type[ProtocolEventBus]:
     return get_event_bus_registry().get(bus_kind)
 
 
-def register_handlers_from_config(  # stub-ok: has tracked TODO
+def register_handlers_from_config(  # stub-ok: tracked in OMN-41
     runtime: object,  # Will be BaseRuntimeHostProcess
     protocol_configs: list[ModelProtocolRegistrationConfig],
 ) -> None:

--- a/tests/integration/test_runtime_log_bridge_pipeline.py
+++ b/tests/integration/test_runtime_log_bridge_pipeline.py
@@ -28,6 +28,9 @@ from uuid import uuid4
 
 import pytest
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+
+# ONEX_FLAG_EXEMPT: test fixture — env var toggled in tests below
+_FLAG = "ENABLE_RUNTIME_LOG_BRIDGE"
 from aiokafka.structs import ConsumerRecord
 
 from omnibase_infra.event_bus.topic_constants import TOPIC_RUNTIME_ERROR
@@ -75,11 +78,11 @@ class _EnableBridgeCtx:
     """Context manager to enable the runtime log bridge feature flag."""
 
     def __enter__(self) -> _EnableBridgeCtx:
-        os.environ["ENABLE_RUNTIME_LOG_BRIDGE"] = "true"
+        os.environ[_FLAG] = "true"
         return self
 
     def __exit__(self, *args: object) -> None:
-        os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+        os.environ.pop(_FLAG, None)
 
 
 class TestRuntimeLogBridgeIntegration:
@@ -92,7 +95,7 @@ class TestRuntimeLogBridgeIntegration:
         kafka_consumer: AIOKafkaConsumer,
     ) -> None:
         """Verify an ERROR log record flows through the bridge to Kafka."""
-        os.environ["ENABLE_RUNTIME_LOG_BRIDGE"] = "true"
+        os.environ[_FLAG] = "true"
         try:
             bridge = RuntimeLogEventBridge(
                 producer=kafka_producer,
@@ -132,7 +135,7 @@ class TestRuntimeLogBridgeIntegration:
             bridge.detach_from_loggers([test_logger_name])
             await bridge.stop()
         finally:
-            os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+            os.environ.pop(_FLAG, None)
 
     @pytest.mark.asyncio
     async def test_circular_logging_prevention(
@@ -140,7 +143,7 @@ class TestRuntimeLogBridgeIntegration:
         kafka_producer: AIOKafkaProducer,
     ) -> None:
         """Verify the bridge does not capture its own log records."""
-        os.environ["ENABLE_RUNTIME_LOG_BRIDGE"] = "true"
+        os.environ[_FLAG] = "true"
         try:
             bridge = RuntimeLogEventBridge(
                 producer=kafka_producer,
@@ -172,7 +175,7 @@ class TestRuntimeLogBridgeIntegration:
             )
             await bridge.stop()
         finally:
-            os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+            os.environ.pop(_FLAG, None)
 
     @pytest.mark.asyncio
     async def test_rate_limiting(
@@ -180,7 +183,7 @@ class TestRuntimeLogBridgeIntegration:
         kafka_producer: AIOKafkaProducer,
     ) -> None:
         """Verify rate limiter suppresses duplicate log events."""
-        os.environ["ENABLE_RUNTIME_LOG_BRIDGE"] = "true"
+        os.environ[_FLAG] = "true"
         try:
             bridge = RuntimeLogEventBridge(
                 producer=kafka_producer,
@@ -207,7 +210,7 @@ class TestRuntimeLogBridgeIntegration:
             bridge.detach_from_loggers([test_logger_name])
             await bridge.stop()
         finally:
-            os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+            os.environ.pop(_FLAG, None)
 
     @pytest.mark.asyncio
     async def test_bridge_disabled_by_default(
@@ -215,7 +218,7 @@ class TestRuntimeLogBridgeIntegration:
         kafka_producer: AIOKafkaProducer,
     ) -> None:
         """Verify bridge is a no-op when feature flag is off."""
-        os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+        os.environ.pop(_FLAG, None)
 
         bridge = RuntimeLogEventBridge(
             producer=kafka_producer,
@@ -241,7 +244,7 @@ class TestRuntimeLogBridgeIntegration:
         kafka_producer: AIOKafkaProducer,
     ) -> None:
         """Verify bridge self-metrics track correctly."""
-        os.environ["ENABLE_RUNTIME_LOG_BRIDGE"] = "true"
+        os.environ[_FLAG] = "true"
         try:
             bridge = RuntimeLogEventBridge(
                 producer=kafka_producer,
@@ -269,7 +272,7 @@ class TestRuntimeLogBridgeIntegration:
             bridge.detach_from_loggers([test_logger_name])
             await bridge.stop()
         finally:
-            os.environ.pop("ENABLE_RUNTIME_LOG_BRIDGE", None)
+            os.environ.pop(_FLAG, None)
 
 
 async def _get_one_message(

--- a/tests/unit/topics/test_platform_topic_suffixes.py
+++ b/tests/unit/topics/test_platform_topic_suffixes.py
@@ -8,6 +8,9 @@ import os
 
 import pytest
 
+# ONEX_FLAG_EXEMPT: test fixture — env var checked in tests below
+_OMNIMEMORY_FLAG = "OMNIMEMORY_ENABLED"
+
 from omnibase_core.validation import validate_topic_suffix
 from omnibase_infra.topics import (
     ALL_INTELLIGENCE_TOPIC_SPECS,
@@ -409,7 +412,7 @@ class TestProvisionedTopicSpecs:
     def test_provisioned_contains_all_omnimemory(self) -> None:
         """ALL_PROVISIONED_SUFFIXES includes OmniMemory suffixes iff OMNIMEMORY_ENABLED is truthy."""
         omnimemory_suffixes = {spec.suffix for spec in ALL_OMNIMEMORY_TOPIC_SPECS}
-        enabled = os.environ.get("OMNIMEMORY_ENABLED", "").strip().lower() in {
+        enabled = os.environ.get(_OMNIMEMORY_FLAG, "").strip().lower() in {
             "1",
             "true",
             "yes",
@@ -428,7 +431,7 @@ class TestProvisionedTopicSpecs:
 
     def test_provisioned_count(self) -> None:
         """Combined provisioned specs count reflects whether OMNIMEMORY_ENABLED is set."""
-        enabled = os.environ.get("OMNIMEMORY_ENABLED", "").strip().lower() in {
+        enabled = os.environ.get(_OMNIMEMORY_FLAG, "").strip().lower() in {
             "1",
             "true",
             "yes",
@@ -618,7 +621,7 @@ class TestOmnimemoryEnabledGating:
         try:
             os.environ.clear()
             os.environ.update(old_env)
-            for key in ["OMNIMEMORY_ENABLED"]:
+            for key in [_OMNIMEMORY_FLAG]:
                 os.environ.pop(key, None)
             os.environ.update(env)
 
@@ -653,7 +656,7 @@ class TestOmnimemoryEnabledGating:
 
     def test_omnimemory_topics_excluded_when_false(self) -> None:
         """When OMNIMEMORY_ENABLED=false, omnimemory topics must not be provisioned."""
-        _specs, suffixes = self._reload_specs({"OMNIMEMORY_ENABLED": "false"})
+        _specs, suffixes = self._reload_specs({_OMNIMEMORY_FLAG: "false"})
         omnimemory_suffixes = {spec.suffix for spec in ALL_OMNIMEMORY_TOPIC_SPECS}
         for suffix in omnimemory_suffixes:
             assert suffix not in suffixes, (
@@ -662,7 +665,7 @@ class TestOmnimemoryEnabledGating:
 
     def test_omnimemory_topics_included_when_true(self) -> None:
         """When OMNIMEMORY_ENABLED=true, omnimemory topics must be provisioned."""
-        _specs, suffixes = self._reload_specs({"OMNIMEMORY_ENABLED": "true"})
+        _specs, suffixes = self._reload_specs({_OMNIMEMORY_FLAG: "true"})
         omnimemory_suffixes = {spec.suffix for spec in ALL_OMNIMEMORY_TOPIC_SPECS}
         for suffix in omnimemory_suffixes:
             assert suffix in suffixes, (

--- a/uv.lock
+++ b/uv.lock
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.23.1"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Release omnibase_infra v0.24.0 (minor bump from v0.23.1).

Covers all commits since v0.23.0 (including the unlogged v0.23.1 patch):

### Added
- verify_container_manifest.py + CLI entry point [OMN-5796]
- Cross-repo migration conflict check [OMN-5772]
- Emit runtime errors to Kafka [OMN-5649]
- Service-level feature flag contracts [OMN-5628]
- Wire contract data into introspection emission [OMN-5609]
- Post-release version verification script [OMN-5608]

### Fixed
- Skip infra-dependent scheduled jobs on ubuntu-latest [OMN-5776]
- Deep-dive report: include onex repos + ticket summary [OMN-5647]
- Runtime-effects healthcheck timing [OMN-5637]
- Deploy: guard contracts/ rsync, add migration scripts rsync [OMN-5630, OMN-5627]
- Register 5 missing Kafka topics [OMN-5633]
- Wire retry_backoff_ms into AIOKafka constructors [OMN-5626]

### Housekeeping
- Fix pre-existing pre-commit violations (bare feature flags, bare TODOs, markdown links)
- TODO enforcement hooks and workflows [OMN-5694, OMN-5695]
- Delete orphaned handler contract scaffolds [OMN-5698]

## Test plan
- [x] All 40 pre-commit hooks pass
- [x] uv lock resolves cleanly
- [x] version_compatibility.py fallback matrix matches pyproject.toml
- [ ] CI checks pass on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.24.0

* **New Features**
  * Added container manifest verification CLI tool
  * Introduced service-level feature flag contracts
  * Enhanced Kafka runtime error emission capabilities

* **Bug Fixes**
  * Fixed Docker healthcheck timing to prevent false unhealthy states
  * Improved CI cross-repo migration conflict detection
  * Corrected Kafka topic registration handling
  * Enhanced scheduled job configuration for CI environments

* **Chores**
  * Updated internal tracking references and test flag handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->