### PR TITLE
fix(catalog): use Docker-internal addresses for DB URLs [OMN-5831]

### DIFF
--- a/docker/catalog/services/agent-actions-consumer.yaml
+++ b/docker/catalog/services/agent-actions-consumer.yaml
@@ -4,8 +4,9 @@ image: runtime:latest
 layer: runtime
 container_name: omninode-agent-actions-consumer
 required_env:
-  - OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN
+  - POSTGRES_PASSWORD
 hardcoded_env:
+  OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
   OMNIBASE_INFRA_AGENT_ACTIONS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   OMNIBASE_INFRA_AGENT_ACTIONS_HEALTH_CHECK_PORT: '8087'
   OMNIBASE_INFRA_AGENT_ACTIONS_HEALTH_CHECK_HOST: 0.0.0.0

--- a/docker/catalog/services/context-audit-consumer.yaml
+++ b/docker/catalog/services/context-audit-consumer.yaml
@@ -4,8 +4,9 @@ image: runtime:latest
 layer: runtime
 container_name: omninode-context-audit-consumer
 required_env:
-  - OMNIBASE_INFRA_CONTEXT_AUDIT_POSTGRES_DSN
+  - POSTGRES_PASSWORD
 hardcoded_env:
+  OMNIBASE_INFRA_CONTEXT_AUDIT_POSTGRES_DSN: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
   OMNIBASE_INFRA_CONTEXT_AUDIT_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   OMNIBASE_INFRA_CONTEXT_AUDIT_HEALTH_CHECK_PORT: '8093'
   OMNIBASE_INFRA_CONTEXT_AUDIT_HEALTH_CHECK_HOST: 0.0.0.0

--- a/docker/catalog/services/contract-resolver.yaml
+++ b/docker/catalog/services/contract-resolver.yaml
@@ -5,13 +5,13 @@ layer: runtime
 container_name: omninode-contract-resolver
 required_env:
   - POSTGRES_PASSWORD
-  - OMNIBASE_INFRA_DB_URL
   - VALKEY_PASSWORD
-  - OMNIINTELLIGENCE_DB_URL
   - KEYCLOAK_ADMIN_CLIENT_SECRET
   - ONEX_SERVICE_CLIENT_SECRET
   - ONEX_REGISTRATION_AUTO_ACK
 hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
+  OMNIINTELLIGENCE_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence"
   KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
   BUS_ID: local

--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -5,13 +5,13 @@ layer: runtime
 container_name: omninode-runtime
 required_env:
   - POSTGRES_PASSWORD
-  - OMNIBASE_INFRA_DB_URL
   - VALKEY_PASSWORD
-  - OMNIINTELLIGENCE_DB_URL
   - KEYCLOAK_ADMIN_CLIENT_SECRET
   - ONEX_SERVICE_CLIENT_SECRET
   - ONEX_REGISTRATION_AUTO_ACK
 hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
+  OMNIINTELLIGENCE_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence"
   KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
   BUS_ID: local

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -5,13 +5,13 @@ layer: runtime
 container_name: omninode-runtime-effects
 required_env:
   - POSTGRES_PASSWORD
-  - OMNIBASE_INFRA_DB_URL
   - VALKEY_PASSWORD
-  - OMNIINTELLIGENCE_DB_URL
   - KEYCLOAK_ADMIN_CLIENT_SECRET
   - ONEX_SERVICE_CLIENT_SECRET
   - ONEX_REGISTRATION_AUTO_ACK
 hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
+  OMNIINTELLIGENCE_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence"
   KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
   BUS_ID: local

--- a/docker/catalog/services/runtime-worker.yaml
+++ b/docker/catalog/services/runtime-worker.yaml
@@ -5,13 +5,13 @@ layer: runtime
 container_name: null
 required_env:
   - POSTGRES_PASSWORD
-  - OMNIBASE_INFRA_DB_URL
   - VALKEY_PASSWORD
-  - OMNIINTELLIGENCE_DB_URL
   - KEYCLOAK_ADMIN_CLIENT_SECRET
   - ONEX_SERVICE_CLIENT_SECRET
   - ONEX_REGISTRATION_AUTO_ACK
 hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
+  OMNIINTELLIGENCE_DB_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence"
   KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
   BUS_ID: local

--- a/docker/catalog/services/skill-lifecycle-consumer.yaml
+++ b/docker/catalog/services/skill-lifecycle-consumer.yaml
@@ -4,8 +4,9 @@ image: runtime:latest
 layer: runtime
 container_name: omninode-skill-lifecycle-consumer
 required_env:
-  - OMNIBASE_INFRA_SKILL_LIFECYCLE_POSTGRES_DSN
+  - POSTGRES_PASSWORD
 hardcoded_env:
+  OMNIBASE_INFRA_SKILL_LIFECYCLE_POSTGRES_DSN: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra"
   OMNIBASE_INFRA_SKILL_LIFECYCLE_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   OMNIBASE_INFRA_SKILL_LIFECYCLE_HEALTH_CHECK_PORT: '8092'
   OMNIBASE_INFRA_SKILL_LIFECYCLE_HEALTH_CHECK_HOST: 0.0.0.0

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -8,10 +8,30 @@ from __future__ import annotations
 # instead of dict[str, Any] to satisfy the ONEX Any-type ban.
 from omnibase_infra.docker.catalog.enum_infra_layer import EnumInfraLayer
 from omnibase_infra.docker.catalog.resolver import ResolvedStack
+from omnibase_infra.docker.catalog.validator import (
+    validate_no_localhost_in_container_env,
+)
 
 
 def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
-    """Generate a docker-compose dict from a resolved stack."""
+    """Generate a docker-compose dict from a resolved stack.
+
+    Raises:
+        ValueError: If any manifest contains localhost in env vars that will
+            be set inside Docker containers.  DB URLs and broker addresses
+            must use Docker DNS names (e.g. ``postgres:5432``).
+    """
+    # Pre-generation validation: reject localhost in container env vars
+    violations = validate_no_localhost_in_container_env(resolved.manifests)
+    if violations:
+        details = "; ".join(
+            f"{v.service}.{v.env_section}.{v.var_name}={v.value!r}" for v in violations
+        )
+        raise ValueError(
+            f"localhost detected in Docker container env vars — use Docker "
+            f"DNS names (e.g. postgres:5432, redpanda:9092) instead: {details}"
+        )
+
     services: dict[str, dict[str, object]] = {}
     all_volumes: set[str] = set()
 

--- a/src/omnibase_infra/docker/catalog/validator.py
+++ b/src/omnibase_infra/docker/catalog/validator.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
+
+from omnibase_infra.docker.catalog.manifest_schema import CatalogManifest
 
 
 @dataclass(frozen=True)
@@ -16,7 +19,71 @@ class ValidationResult:
     missing: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class LocalhostViolation:
+    """A single localhost violation found in a catalog manifest."""
+
+    service: str
+    env_section: str  # hardcoded_env | operational_defaults | catalog_env
+    var_name: str
+    value: str
+
+
+# Pattern that matches localhost in URLs/connection strings.
+# Matches "localhost" as a hostname component (preceded by @, //, or start-of-string
+# followed by optional port).  Does NOT flag localhost in healthcheck commands or
+# CORS origins (those are container-internal and correct).
+_LOCALHOST_DB_URL_RE = re.compile(r"(?:@|//)localhost(?::\d+)?(?:/|$)", re.IGNORECASE)
+
+# Env var names that are exempt from the localhost check because they are
+# container-internal (e.g. CORS origins listing browser-accessible URLs,
+# Keycloak issuer URLs resolved by the browser, not the container).
+_LOCALHOST_EXEMPT_PATTERNS: set[str] = {
+    "CORS_ORIGINS",
+    "KEYCLOAK_ISSUER",
+}
+
+
 def validate_env(required: set[str]) -> ValidationResult:
     """Check that all required env vars are set in the current environment."""
     missing = [var for var in sorted(required) if not os.environ.get(var)]
     return ValidationResult(ok=len(missing) == 0, missing=missing)
+
+
+def validate_no_localhost_in_container_env(
+    manifests: dict[str, CatalogManifest],
+) -> list[LocalhostViolation]:
+    """Reject localhost in env vars that will be set inside Docker containers.
+
+    DB URLs, Kafka brokers, and other service addresses must use Docker DNS
+    names (e.g. ``postgres:5432``, ``redpanda:9092``), never ``localhost``.
+
+    Only checks ``hardcoded_env``, ``operational_defaults``, and ``catalog_env``
+    -- these are literal values baked into the compose file.  ``required_env``
+    vars are passthrough references (``${VAR:?...}``) and are not checked here
+    since their values come from the host environment at compose-up time.
+
+    Returns a list of violations (empty means clean).
+    """
+    violations: list[LocalhostViolation] = []
+
+    for name, manifest in manifests.items():
+        for section_name, section_dict in [
+            ("hardcoded_env", manifest.hardcoded_env),
+            ("operational_defaults", manifest.operational_defaults),
+            ("catalog_env", manifest.catalog_env),
+        ]:
+            for var_name, value in section_dict.items():
+                if var_name in _LOCALHOST_EXEMPT_PATTERNS:
+                    continue
+                if _LOCALHOST_DB_URL_RE.search(value):
+                    violations.append(
+                        LocalhostViolation(
+                            service=name,
+                            env_section=section_name,
+                            var_name=var_name,
+                            value=value,
+                        )
+                    )
+
+    return violations

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -80,3 +80,59 @@ def test_generated_compose_includes_network_and_volumes() -> None:
     compose = generate_compose(resolved)
     assert "omnibase-infra-network" in compose["networks"]
     assert "postgres_data" in compose.get("volumes", {})
+
+
+@pytest.mark.unit
+def test_generated_compose_db_urls_use_docker_dns() -> None:
+    """DB URLs in the runtime bundle must use Docker-internal addresses."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    # generate_compose will raise ValueError if localhost is detected
+    compose = generate_compose(resolved)
+    # Also verify the actual URL values in the generated compose
+    rt_env = compose["services"]["omninode-runtime"]["environment"]
+    assert "postgres:5432" in rt_env["OMNIBASE_INFRA_DB_URL"]
+    assert "localhost" not in rt_env["OMNIBASE_INFRA_DB_URL"]
+    assert "postgres:5432" in rt_env["OMNIINTELLIGENCE_DB_URL"]
+    assert "localhost" not in rt_env["OMNIINTELLIGENCE_DB_URL"]
+
+
+@pytest.mark.unit
+def test_generated_compose_consumer_dsn_uses_docker_dns() -> None:
+    """Consumer DSN vars must use Docker-internal addresses."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+    aac_env = compose["services"]["agent-actions-consumer"]["environment"]
+    assert "postgres:5432" in aac_env["OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN"]
+    assert "localhost" not in aac_env["OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN"]
+
+
+@pytest.mark.unit
+def test_generator_rejects_localhost_in_db_url() -> None:
+    """Generator must raise ValueError if a manifest has localhost in a DB URL."""
+    from omnibase_infra.docker.catalog.manifest_schema import CatalogManifest
+    from omnibase_infra.docker.catalog.resolver import ResolvedStack
+
+    bad_manifest = CatalogManifest(
+        name="bad-svc",
+        description="test",
+        image="test:latest",
+        layer="runtime",
+        required_env=["POSTGRES_PASSWORD"],
+        hardcoded_env={
+            "DB_URL": "postgresql://postgres:pw@localhost:5436/mydb",
+        },
+        operational_defaults={},
+        ports=None,
+        healthcheck=None,
+        volumes=[],
+        depends_on=[],
+    )
+    resolved = ResolvedStack(
+        manifests={"bad-svc": bad_manifest},
+        required_env={"POSTGRES_PASSWORD"},
+        injected_env={},
+    )
+    with pytest.raises(ValueError, match="localhost detected"):
+        generate_compose(resolved)

--- a/tests/unit/infra/test_catalog_validator.py
+++ b/tests/unit/infra/test_catalog_validator.py
@@ -6,7 +6,35 @@ from __future__ import annotations
 
 import pytest
 
-from omnibase_infra.docker.catalog.validator import validate_env
+from omnibase_infra.docker.catalog.enum_infra_layer import EnumInfraLayer
+from omnibase_infra.docker.catalog.manifest_schema import CatalogManifest
+from omnibase_infra.docker.catalog.validator import (
+    validate_env,
+    validate_no_localhost_in_container_env,
+)
+
+
+def _make_manifest(
+    name: str = "test-svc",
+    hardcoded_env: dict[str, str] | None = None,
+    operational_defaults: dict[str, str] | None = None,
+    catalog_env: dict[str, str] | None = None,
+) -> CatalogManifest:
+    """Create a minimal manifest for testing."""
+    return CatalogManifest(
+        name=name,
+        description="test",
+        image="test:latest",
+        layer=EnumInfraLayer.RUNTIME,
+        required_env=["POSTGRES_PASSWORD"],
+        hardcoded_env=hardcoded_env or {},
+        operational_defaults=operational_defaults or {},
+        ports=None,
+        healthcheck=None,
+        volumes=[],
+        depends_on=[],
+        catalog_env=catalog_env or {},
+    )
 
 
 @pytest.mark.unit
@@ -25,3 +53,113 @@ def test_validator_fails_when_required_missing(monkeypatch: pytest.MonkeyPatch) 
     result = validate_env(required={"VALKEY_PASSWORD"})
     assert not result.ok
     assert "VALKEY_PASSWORD" in result.missing
+
+
+# --- localhost validation tests ---
+
+
+@pytest.mark.unit
+def test_localhost_rejected_in_hardcoded_db_url() -> None:
+    """DB URLs with localhost must be rejected in hardcoded_env."""
+    manifest = _make_manifest(
+        hardcoded_env={
+            "OMNIBASE_INFRA_DB_URL": "postgresql://postgres:pw@localhost:5436/omnibase_infra",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert len(violations) == 1
+    assert violations[0].var_name == "OMNIBASE_INFRA_DB_URL"
+    assert violations[0].env_section == "hardcoded_env"
+
+
+@pytest.mark.unit
+def test_localhost_rejected_in_operational_defaults() -> None:
+    """DB URLs with localhost must be rejected in operational_defaults too."""
+    manifest = _make_manifest(
+        operational_defaults={
+            "SOME_DB_URL": "postgresql://user:pass@localhost:5432/mydb",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert len(violations) == 1
+    assert violations[0].env_section == "operational_defaults"
+
+
+@pytest.mark.unit
+def test_localhost_rejected_in_catalog_env() -> None:
+    """DB URLs with localhost must be rejected in catalog_env too."""
+    manifest = _make_manifest(
+        catalog_env={
+            "DB_URL": "postgresql://u:p@localhost/db",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert len(violations) == 1
+    assert violations[0].env_section == "catalog_env"
+
+
+@pytest.mark.unit
+def test_docker_dns_url_passes() -> None:
+    """Docker-internal URLs (postgres:5432) must be accepted."""
+    manifest = _make_manifest(
+        hardcoded_env={
+            "OMNIBASE_INFRA_DB_URL": "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra",
+            "KAFKA_BOOTSTRAP_SERVERS": "redpanda:9092",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_cors_origins_exempt_from_localhost_check() -> None:
+    """CORS_ORIGINS legitimately contains localhost (browser URLs)."""
+    manifest = _make_manifest(
+        operational_defaults={
+            "CORS_ORIGINS": "http://localhost:3000,http://localhost:3001",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_keycloak_issuer_exempt_from_localhost_check() -> None:
+    """KEYCLOAK_ISSUER is browser-resolved, localhost is correct."""
+    manifest = _make_manifest(
+        operational_defaults={
+            "KEYCLOAK_ISSUER": "http://localhost:28080/realms/omninode",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_multiple_violations_reported() -> None:
+    """All violations across services and sections should be reported."""
+    m1 = _make_manifest(
+        name="svc-a",
+        hardcoded_env={"DB_URL": "postgresql://u:p@localhost:5436/db"},
+    )
+    m2 = _make_manifest(
+        name="svc-b",
+        operational_defaults={"OTHER_URL": "http://localhost:9999/api"},
+    )
+    violations = validate_no_localhost_in_container_env({"svc-a": m1, "svc-b": m2})
+    assert len(violations) == 2
+    services_hit = {v.service for v in violations}
+    assert services_hit == {"svc-a", "svc-b"}
+
+
+@pytest.mark.unit
+def test_non_url_localhost_not_flagged() -> None:
+    """Plain string values that happen to contain 'localhost' without URL
+    patterns should not be flagged (no @localhost or //localhost)."""
+    manifest = _make_manifest(
+        hardcoded_env={
+            "SOME_FLAG": "localhost_mode",
+        },
+    )
+    violations = validate_no_localhost_in_container_env({"svc": manifest})
+    assert violations == []


### PR DESCRIPTION
## Summary

- Move `OMNIBASE_INFRA_DB_URL`, `OMNIINTELLIGENCE_DB_URL`, and `*_POSTGRES_DSN` vars from `required_env` (host passthrough with `localhost:5436`) to `hardcoded_env` with Docker-internal addresses (`postgres:5432`), following the same pattern already used for Kafka (`redpanda:9092`) and Keycloak (`jdbc:postgresql://postgres:5432/keycloak`)
- Password still resolved from host via `${POSTGRES_PASSWORD}` compose interpolation
- Add generator-level localhost validation that rejects `localhost` in any env var baked into Docker containers (`hardcoded_env`, `operational_defaults`, `catalog_env`), with exemptions for browser-resolved vars (`CORS_ORIGINS`, `KEYCLOAK_ISSUER`)

## Services updated (7)

| Service | Var moved to `hardcoded_env` |
|---------|------------------------------|
| `omninode-runtime` | `OMNIBASE_INFRA_DB_URL`, `OMNIINTELLIGENCE_DB_URL` |
| `runtime-effects` | `OMNIBASE_INFRA_DB_URL`, `OMNIINTELLIGENCE_DB_URL` |
| `runtime-worker` | `OMNIBASE_INFRA_DB_URL`, `OMNIINTELLIGENCE_DB_URL` |
| `contract-resolver` | `OMNIBASE_INFRA_DB_URL`, `OMNIINTELLIGENCE_DB_URL` |
| `agent-actions-consumer` | `OMNIBASE_INFRA_AGENT_ACTIONS_POSTGRES_DSN` |
| `skill-lifecycle-consumer` | `OMNIBASE_INFRA_SKILL_LIFECYCLE_POSTGRES_DSN` |
| `context-audit-consumer` | `OMNIBASE_INFRA_CONTEXT_AUDIT_POSTGRES_DSN` |

## Regression guard

`validate_no_localhost_in_container_env()` in `validator.py` is called by `generate_compose()` before producing any compose output. If a manifest introduces `localhost` in a DB URL, the generator raises `ValueError`.

## Test plan

- [x] 10 new validator unit tests (localhost rejection, exemptions, non-URL patterns)
- [x] 3 new generator tests (Docker DNS verification, consumer DSN, rejection integration)
- [x] All 30 existing catalog tests pass
- [x] All 42 pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified database configuration across multiple services by consolidating password-based connection string construction
  * Added validation to prevent misconfigured database connections and ensure proper deployment setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->