### PR TITLE
chore: release v0.24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.24.0"
+version = "0.24.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Version bump 0.24.0 -> 0.24.1

## Changes since v0.24.0
- fix: add stale registration cleanup service and regression guard [OMN-5821]
- fix(infra): Infisical-first config -- eliminate localhost DB URL leakage [OMN-5831]
- fix(catalog): fix Docker healthcheck probes for Phoenix and Memgraph
- feat(topics): consolidate infra topic constants into DI-registered ProtocolTopicRegistry [OMN-5839]

## Test plan
- CI validates version consistency
- Auto-tag-on-merge creates GitHub release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.24.1 (patch release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->