### PR TITLE
fix(runners): crash-loop fix for entrypoint.sh credential handling [OMN-5951]

### DIFF
--- a/docker/runners/entrypoint.sh
+++ b/docker/runners/entrypoint.sh
@@ -227,7 +227,7 @@ while true; do
     if [[ ${exit_code} -eq 0 ]]; then
         # GitHub runner exits 0 even when registration is server-side deleted
         # ("no retry needed" from its perspective). Check log for this case.
-        if echo "${log_content}" | grep -qi "registration has been deleted"; then
+        if echo "${log_content}" | grep -qiE "registration has been deleted|Not configured"; then
             echo "[entrypoint] Runner registration was deleted by GitHub (exit 0 but stale)."
             echo "[entrypoint] Clearing cached credentials and will re-register on next attempt."
             _clear_cached_creds

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -123,10 +123,12 @@ run_local() {
 
 fetch_registration_token() {
     log "Fetching GitHub Actions registration token for org ${RUNNER_ORG}..."
+    # Separate declaration from assignment so set -e catches gh api failures
     local token
-    token=$(gh api "/orgs/${RUNNER_ORG}/actions/runners/registration-token" --jq .token)
+    token=$(gh api --method POST "/orgs/${RUNNER_ORG}/actions/runners/registration-token" --jq .token) \
+        || err "gh api failed. Check gh auth and org admin permissions (need admin:org scope)."
     if [[ -z "${token}" ]]; then
-        err "Failed to fetch registration token. Check gh auth and org admin permissions."
+        err "Registration token is empty. Check gh auth and org admin permissions."
     fi
     echo "${token}"
 }
@@ -137,7 +139,8 @@ fetch_registration_token() {
 
 encode_token() {
     local token="${1}"
-    echo -n "${token}" | base64
+    # -w 0 prevents line wrapping (macOS base64 wraps at 76 chars by default)
+    echo -n "${token}" | base64 -w 0 2>/dev/null || echo -n "${token}" | base64 -b 0 2>/dev/null || echo -n "${token}" | base64
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the runner entrypoint crash-loop that caused 9 of 10 self-hosted runners to fail on restart.

- **OMN-5952**: Fix credential cache directory check (`-f` to `-d`) -- `_restore_cached_creds` checked for a regular file but the cache path is a directory
- **OMN-5953**: Add in-place credential detection for container restarts -- Docker restart preserves the filesystem, so credentials are already present in RUNNER_HOME
- **OMN-5954**: Make RUNNER_TOKEN optional -- only needed for first-time registration; guard `_deregister` against missing token

## Root Cause

`_restore_cached_creds` used `-f` (is regular file?) to check for cached credentials, but the cache key path is a **directory** containing `.runner`, `.credentials`, `.credentials_rsaparams`. This caused every container restart to skip cached credentials and attempt re-registration, which fails when RUNNER_TOKEN is expired (tokens last 1 hour).

## Test plan

- [ ] Deploy to CI host via `scripts/deploy-runners.sh`
- [ ] Verify all 10 runners report online in GitHub API
- [ ] Verify all 10 containers show `Up` (not `Restarting`) in `docker ps`
- [ ] Restart one runner and confirm it comes back online without RUNNER_TOKEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Registration token is optional for subsequent runs when cached or in-place credentials exist.
  * Cached credential detection/restore refined to avoid unnecessary re-registration.
  * Startup and retry flow updated to handle deleted registrations, clear credentials, and require token only for first-time registration.
  * De-registration is skipped when no token is provided.

* **New Features**
  * Added a "soft" deploy mode to update runner artifacts and restart runners with minimal disruption; CLI and startup logs reflect soft mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->