### PR TITLE
chore(release): v0.24.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.24.1"
+version = "0.24.2"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.24.2

### Changes
- fix(contracts): resolve ambiguous loader dirs and duplicate contracts [OMN-5964, OMN-5965]
- fix(runners): crash-loop fix for entrypoint.sh credential handling [OMN-5951]
- fix(ci): cap nightly xdist workers at 2 and add git-maintenance script [OMN-5957, OMN-5960]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->