### PR TITLE
release: omnibase_infra v0.25.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.24.2"
+version = "0.25.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1880,7 +1880,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.24.2"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump omnibase_infra from 0.24.2 to 0.25.0
- Updates pyproject.toml and uv.lock

## Changelog since 0.24.2

- feat(runner-health): Runner Health Monitoring MVP [OMN-6075] (#961)
- fix(deps): update stale omnibase-core and spi version pins [OMN-6112] (#963)
- fix(contracts): resolve ambiguous loader dirs and duplicate contracts [OMN-5964, OMN-5965] (#959)
- fix(runners): crash-loop fix for entrypoint.sh credential handling [OMN-5951] (#957)
- fix(ci): cap nightly xdist workers at 2 and add git-maintenance script [OMN-5957, OMN-5960] (#958)

## Test plan

- [x] pre-commit hooks pass
- [x] uv lock resolves cleanly
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.25.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->