### PR TITLE
docs: add INTELLIGENCE_SERVICE_URL to env-example-full.txt [OMN-6259]

### DIFF
--- a/docker/env-example-full.txt
+++ b/docker/env-example-full.txt
@@ -149,6 +149,12 @@ POSTGRES_PASSWORD=__REPLACE_WITH_SECURE_PASSWORD__
 # RUNTIME_BIND_HOST=0.0.0.0
 
 # =============================================================================
+# ONEX Platform Service URLs
+# =============================================================================
+# OmniIntelligence HTTP API (context injection, pattern discovery)
+# INTELLIGENCE_SERVICE_URL=http://localhost:8053
+
+# =============================================================================
 # Main Runtime Service Configuration
 # =============================================================================
 # Host port mapping for the main runtime service


### PR DESCRIPTION
## Summary
- Add `INTELLIGENCE_SERVICE_URL` to `docker/env-example-full.txt` so env audits and completeness checks include it

## Test plan
- [x] `grep -c INTELLIGENCE_SERVICE_URL docker/env-example-full.txt` returns 1
- [x] Pre-commit hooks pass

Closes OMN-6259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added platform service URL configuration example to environment settings file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->