### PR TITLE
feat(kafka): add max_request_size config + broker default 4MB [OMN-6341]

### DIFF
--- a/docker/catalog/services/redpanda.yaml
+++ b/docker/catalog/services/redpanda.yaml
@@ -34,6 +34,7 @@ command:
   - --smp 1
   - --memory ${REDPANDA_MEMORY:-8G}
   - --default-log-level=warn
+  - --set redpanda.kafka_batch_max_bytes=4194304
 labels:
   com.omninode.service: redpanda
   com.omninode.layer: infrastructure

--- a/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
+++ b/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
@@ -91,3 +91,6 @@ acks: "${KAFKA_ACKS:-all}"
 # Enable idempotent producer to prevent duplicate messages
 # Recommended for exactly-once semantics
 enable_idempotence: ${KAFKA_ENABLE_IDEMPOTENCE:-true}
+# Maximum size in bytes for a Kafka produce request (passed to AIOKafkaProducer)
+# Must align with broker-side max.message.bytes
+max_request_size: ${KAFKA_MAX_REQUEST_SIZE:-4194304}

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -658,6 +658,7 @@ class EventBusKafka(
                     bootstrap_servers=self._bootstrap_servers,
                     acks=self._config.acks_aiokafka,
                     enable_idempotence=self._config.enable_idempotence,
+                    max_request_size=self._config.max_request_size,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
                     **self._build_auth_kwargs(),
                 )
@@ -982,6 +983,7 @@ class EventBusKafka(
                 bootstrap_servers=self._bootstrap_servers,
                 acks=self._config.acks_aiokafka,
                 enable_idempotence=self._config.enable_idempotence,
+                max_request_size=self._config.max_request_size,
                 retry_backoff_ms=self._config.reconnect_backoff_ms,
                 **self._build_auth_kwargs(),
             )

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -277,6 +277,17 @@ class ModelKafkaEventBusConfig(BaseModel):
         default=True,
         description="Enable producer idempotence for exactly-once semantics",
     )
+    max_request_size: int = Field(
+        default=4 * 1024 * 1024,  # 4 MB
+        description=(
+            "Maximum size in bytes for a Kafka produce request. "
+            "Passed to AIOKafkaProducer(max_request_size=...). "
+            "Must also align with broker-side max.message.bytes. "
+            "Override via KAFKA_MAX_REQUEST_SIZE."
+        ),
+        ge=1024,  # 1 KB minimum
+        le=52428800,  # 50 MB maximum
+    )
 
     # Kafka consumer settings
     auto_offset_reset: str = Field(
@@ -821,6 +832,7 @@ class ModelKafkaEventBusConfig(BaseModel):
             "KAFKA_SSL_CA_FILE": "ssl_ca_file",
             "KAFKA_RECONNECT_BACKOFF_MS": "reconnect_backoff_ms",
             "KAFKA_RECONNECT_BACKOFF_MAX_MS": "reconnect_backoff_max_ms",
+            "KAFKA_MAX_REQUEST_SIZE": "max_request_size",
         }
 
         # Integer fields for type conversion
@@ -833,6 +845,7 @@ class ModelKafkaEventBusConfig(BaseModel):
             "session_timeout_ms",
             "heartbeat_interval_ms",
             "max_poll_interval_ms",
+            "max_request_size",
         }
 
         # Float fields for type conversion

--- a/tests/unit/event_bus/test_kafka_config_max_request_size.py
+++ b/tests/unit/event_bus/test_kafka_config_max_request_size.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for max_request_size field on ModelKafkaEventBusConfig."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.event_bus.models.config.model_kafka_event_bus_config import (
+    ModelKafkaEventBusConfig,
+)
+
+
+@pytest.mark.unit
+class TestMaxRequestSizeConfig:
+    """Tests for max_request_size config field."""
+
+    def test_max_request_size_default(self) -> None:
+        """max_request_size defaults to 4MB."""
+        config = ModelKafkaEventBusConfig()
+        assert config.max_request_size == 4 * 1024 * 1024  # 4,194,304
+
+    def test_max_request_size_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """KAFKA_MAX_REQUEST_SIZE env var overrides default."""
+        monkeypatch.setenv("KAFKA_MAX_REQUEST_SIZE", "8388608")
+        config = ModelKafkaEventBusConfig().apply_environment_overrides()
+        assert config.max_request_size == 8388608
+
+    def test_max_request_size_validation_minimum(self) -> None:
+        """max_request_size rejects values below 1KB."""
+        with pytest.raises(ValidationError):
+            ModelKafkaEventBusConfig(max_request_size=500)
+
+    def test_max_request_size_validation_maximum(self) -> None:
+        """max_request_size rejects values above 50MB."""
+        with pytest.raises(ValidationError):
+            ModelKafkaEventBusConfig(max_request_size=60_000_000)
+
+    def test_max_request_size_custom_value(self) -> None:
+        """max_request_size accepts valid custom values."""
+        config = ModelKafkaEventBusConfig(max_request_size=2_000_000)
+        assert config.max_request_size == 2_000_000

--- a/tests/unit/event_bus/test_kafka_producer_max_request_size.py
+++ b/tests/unit/event_bus/test_kafka_producer_max_request_size.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests that max_request_size is passed to AIOKafkaProducer (OMN-6346)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+
+
+@pytest.mark.unit
+class TestProducerMaxRequestSize:
+    """Verify AIOKafkaProducer receives max_request_size from config."""
+
+    @pytest.mark.asyncio
+    async def test_producer_receives_max_request_size_default(self) -> None:
+        """AIOKafkaProducer gets default max_request_size (4MB) from config."""
+        config = ModelKafkaEventBusConfig()
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            await bus.start()
+
+            call_kwargs = mock_producer_cls.call_args.kwargs
+            assert call_kwargs["max_request_size"] == 4 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_producer_receives_custom_max_request_size(self) -> None:
+        """AIOKafkaProducer gets custom max_request_size from config."""
+        config = ModelKafkaEventBusConfig(max_request_size=5_000_000)
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            await bus.start()
+
+            call_kwargs = mock_producer_cls.call_args.kwargs
+            assert call_kwargs["max_request_size"] == 5_000_000


### PR DESCRIPTION
## Summary

- Add `max_request_size` field to `ModelKafkaEventBusConfig` (default 4MB, range 1KB-50MB)
- Add `KAFKA_MAX_REQUEST_SIZE` env var override in `apply_environment_overrides()`
- Pass `max_request_size` to both `AIOKafkaProducer` init sites (primary + reconnect)
- Set `kafka_batch_max_bytes=4194304` in Redpanda broker config (`redpanda.yaml`)
- Add YAML config entry for `max_request_size`

Fixes the producer-side and broker-side of the Kafka MessageSizeTooLarge error on pattern projection snapshots. The defense-in-depth truncation fix is in the companion omniintelligence PR.

## Test plan

- [x] 5 config field tests (default, env override, min/max validation, custom value)
- [x] 2 producer kwarg tests (default + custom max_request_size passed to AIOKafkaProducer)
- [x] Full event_bus test suite (420 tests) passes with no regressions
- [ ] Manual: After deploy, run `rpk topic alter-config onex.evt.omniintelligence.pattern-projection.v1 --set max.message.bytes=4194304`

## Tickets

OMN-6345, OMN-6346, OMN-6348 (children of OMN-6341)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kafka maximum request size setting with a default of 4 MB, adjustable between 1 KB and 50 MB via the `KAFKA_MAX_REQUEST_SIZE` environment variable.

* **Tests**
  * Added comprehensive unit tests validating request size configuration, environment variable overrides, and boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->