### PR TITLE
chore(deps): bump omnibase-core to 0.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.30.2",
+    "omnibase-core>=0.31.0",
     "omnibase-spi>=0.19.1",
     # ============================================================================
     # External Dependency Security Guidance

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,8 +175,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.30.2",
-        max_version="0.31.0",
+        min_version="0.31.0",
+        max_version="0.32.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1971,7 +1971,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<6.0.0" },
-    { name = "omnibase-core", specifier = ">=0.30.2" },
+    { name = "omnibase-core", specifier = ">=0.31.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_core` (v0.31.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_core`
- No source code changes -- lockfile only

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_core/actions/runs/23509998722

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version constraints for omnibase-core dependency to support the latest compatible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->