### PR TITLE
fix(ci): prevent xdist race in topic pipeline E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,7 +604,7 @@ jobs:
             -m "not slow and not chaos and not kafka" \
             --splits 10 \
             --group ${{ matrix.split }} \
-            -n auto \
+            -n auto --dist loadgroup \
             --timeout=60 \
             --timeout-method=thread \
             --tb=short \

--- a/tests/integration/tools/test_topic_pipeline_e2e.py
+++ b/tests/integration/tools/test_topic_pipeline_e2e.py
@@ -37,7 +37,10 @@ import pytest
 
 from tests.helpers.path_utils import find_project_root
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.xdist_group("topic_pipeline_e2e"),
+]
 
 _REPO_ROOT = find_project_root(Path(__file__).resolve().parent)
 _SCRIPT = _REPO_ROOT / "scripts" / "generate_topic_enums.py"


### PR DESCRIPTION
## Summary

- Add `xdist_group("topic_pipeline_e2e")` marker to `TestTopicPipelineE2E` tests to serialize them on the same pytest-xdist worker
- Switch CI test runner from `--dist load` (implicit default) to `--dist loadgroup` so the `xdist_group` marker is honored

## Problem

PR #983 intermittently failed on Split 2/10 with `test_check_detects_stale_enum` reporting "CRITICAL P0 BUG: --check returned 0 instead of 1 on a corrupted generated file." The root cause was a pytest-xdist race condition: the four `TestTopicPipelineE2E` tests all mutate the shared generated enum directory (`src/omnibase_infra/enums/generated/`). When distributed across xdist workers, a `--generate` call from one test can overwrite the corrupted file before another test's `--check` runs, causing the check to see clean state instead of drift.

## Test plan

- [ ] CI passes with `--dist loadgroup` -- verify no test distribution regressions
- [ ] `test_check_detects_stale_enum` no longer flakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution distribution across parallel workers for more efficient test runs.
  * Updated test grouping configuration to optimize scheduling of integration tests.

* **Chores**
  * Enhanced CI workflow test distribution strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->