### PR TITLE
fix(ci): export PKG_HYPHEN in dependency cascade + relax auto-tag trigger

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   auto-tag:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: >-
+      github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'release') ||
+       startsWith(github.event.pull_request.title, 'release:'))
     uses: OmniNode-ai/omnibase_core/.github/workflows/auto-tag-reusable.yml@main
     permissions:
       contents: write

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -172,6 +172,7 @@ jobs:
           BUMP_PACKAGE: ${{ inputs.package }}
         run: |
           PKG_HYPHEN="${BUMP_PACKAGE//_/-}"
+          export PKG_HYPHEN
 
           RESOLVED=$(python3 - <<'PYEOF'
           import re, sys, os
@@ -188,7 +189,7 @@ jobs:
           PYEOF
           )
           echo "Resolved version for ${PKG_HYPHEN}: ${RESOLVED}"
-          export RESOLVED PKG_HYPHEN
+          export RESOLVED
 
           python3 - <<'PYEOF'
           import re, os


### PR DESCRIPTION
## Summary

- **Fixes dependency cascade `KeyError: 'PKG_HYPHEN'`**: The shell variable was not exported before being read by `os.environ` in a Python subprocess. This caused v0.26.0 cascade bumps to fail for omnimemory and omniclaude.
- **Relaxes auto-tag trigger**: Now matches PR titles starting with `release:` in addition to requiring the `release` label. This prevents missed tags when the label is not applied (as happened with #982).

## Root Cause

In the `Update pyproject.toml pin` step, `PKG_HYPHEN` was set as a shell variable but never exported. Python subprocesses inherit only exported environment variables, so `os.environ["PKG_HYPHEN"]` raised `KeyError`.

## Test plan

- [ ] CI passes
- [ ] Re-run dependency cascade for v0.26.0 after merge to verify omnimemory/omniclaude bumps succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release tagging workflow to support multiple trigger conditions
  * Improved environment variable management in dependency update automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->