### PR TITLE
chore: add slow marker to Docker integration tests [OMN-6467]

### DIFF
--- a/tests/integration/docker/test_docker_integration.py
+++ b/tests/integration/docker/test_docker_integration.py
@@ -40,6 +40,7 @@ import yaml
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.infrastructure,
+    pytest.mark.slow,
 ]
 
 # Container naming prefix for test isolation


### PR DESCRIPTION
## Summary

- Add `pytest.mark.slow` to Docker integration test module marks
- Investigation: tests have proper Docker availability detection and graceful skipping. No code fixes needed.
- Tests are already excluded from CI via `--ignore=tests/integration/docker`. The `slow` marker adds belt-and-suspenders filtering via `-m "not slow"`.

## Ticket

[OMN-6467](https://linear.app/omninode/issue/OMN-6467)
Parent epic: [OMN-6470](https://linear.app/omninode/issue/OMN-6470)

## Test plan

- [ ] Docker integration tests have `pytest.mark.slow` marker
- [ ] CI passes (tests remain excluded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Docker integration test categorization to mark tests as slow, improving test suite organization and execution management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->