### PR TITLE
fix(ci): enable cancel-in-progress for merge queue events [OMN-6488]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
   merge_group:
   workflow_dispatch:
 
-# Prevent auto-cancellation of running workflows when new commits are pushed
+# OMN-6488: cancel-in-progress for merge_group events only — re-enqueue should
+# cancel the previous run.  Regular PR pushes keep cancel-in-progress: false so
+# in-flight tests aren't killed when a new commit is pushed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 env:
   UV_VERSION: "0.6.14"


### PR DESCRIPTION
## Summary
- Updates CI concurrency to use `cancel-in-progress: true` for `merge_group` events only
- Uses PR number in concurrency group for better isolation
- Regular PR push events still use `cancel-in-progress: false`

## Test plan
- [ ] CI green
- [ ] Merge queue re-enqueue cancels the previous CI run

Fixes friction item F18 from 2026-03-24 close-out (infra part).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow concurrency handling to optimize build performance during pull request and merge operations. Workflow jobs are now more intelligently grouped and managed to improve overall build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->