### PR TITLE
fix: health check graceful degradation and start_period increase [OMN-6565]

### DIFF
--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -40,10 +40,10 @@ ports:
   internal: 8085
 healthcheck:
   test: curl -sf http://localhost:8085/health
-  interval_s: 30
+  interval_s: 45
   timeout_s: 10
   retries: 5
-  start_period_s: 120
+  start_period_s: 480
 volumes:
   - effects_logs:/app/logs
   - effects_data:/app/data

--- a/src/omnibase_infra/observability/wiring_health/wiring_health_checker.py
+++ b/src/omnibase_infra/observability/wiring_health/wiring_health_checker.py
@@ -153,9 +153,24 @@ class WiringHealthChecker:
         """
         correlation_id = correlation_id or uuid4()
 
-        # Gather counts
-        emit_counts = self._emission_source.get_emission_counts()
-        consume_counts = self._consumption_source.get_consumption_counts()
+        # Gather counts — degrade gracefully if either source is unavailable
+        try:
+            emit_counts = self._emission_source.get_emission_counts()
+        except AttributeError:
+            _logger.warning(
+                "Emission source missing get_emission_counts — using empty counts",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            emit_counts = {}
+
+        try:
+            consume_counts = self._consumption_source.get_consumption_counts()
+        except AttributeError:
+            _logger.warning(
+                "Consumption source missing get_consumption_counts — using empty counts",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            consume_counts = {}
 
         # Compute metrics
         metrics = ModelWiringHealthMetrics.from_counts(

--- a/tests/unit/observability/wiring_health/test_wiring_health_checker.py
+++ b/tests/unit/observability/wiring_health/test_wiring_health_checker.py
@@ -47,6 +47,14 @@ class MockConsumptionSource:
         return dict(self._counts)
 
 
+class BrokenConsumptionSource:
+    """Mock source that raises AttributeError on get_consumption_counts."""
+
+
+class BrokenEmissionSource:
+    """Mock source that raises AttributeError on get_emission_counts."""
+
+
 class TestModelTopicWiringHealth:
     """Tests for ModelTopicWiringHealth."""
 
@@ -382,6 +390,51 @@ class TestWiringHealthChecker:
 
         assert alert is not None
         assert alert.correlation_id == correlation_id
+
+    def test_compute_health_consumption_source_attribute_error(
+        self, topic: str
+    ) -> None:
+        """Should degrade gracefully when consumption source raises AttributeError."""
+        emission_source = MockEmissionSource({topic: 100})
+        consumption_source = BrokenConsumptionSource()
+
+        handler = WiringHealthChecker(
+            emission_source=emission_source,
+            consumption_source=consumption_source,  # type: ignore[arg-type]
+            environment="dev",
+        )
+
+        # Should NOT raise — degrades gracefully
+        metrics = handler.compute_health()
+
+        # With empty consumption counts, all monitored topics show mismatch
+        # but the key point is: no crash
+        assert isinstance(metrics, ModelWiringHealthMetrics)
+
+    def test_compute_health_emission_only_mode(self, topic: str) -> None:
+        """Should return valid metrics when consumption source is unavailable.
+
+        In emission-only mode (consumption source broken), metrics should still
+        be computable — the health check reports degraded status but does not crash.
+        """
+        emission_source = MockEmissionSource({topic: 50})
+        consumption_source = BrokenConsumptionSource()
+
+        handler = WiringHealthChecker(
+            emission_source=emission_source,
+            consumption_source=consumption_source,  # type: ignore[arg-type]
+            environment="dev",
+        )
+
+        metrics = handler.compute_health()
+
+        # Metrics exist and contain topic data
+        assert isinstance(metrics, ModelWiringHealthMetrics)
+        assert metrics.topics is not None
+
+        # Response formatting should not crash either
+        response = handler.to_health_response(metrics)
+        assert "status" in response
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- WiringHealthChecker.compute_health() now catches AttributeError from either count source and falls back to empty counts with a warning log, preventing /health endpoint crashes
- Runtime-effects start_period increased from 120s to 480s (8 min) to accommodate 16+ sequential Kafka topic subscriptions (~7 min startup)
- Health check interval raised to 45s to reduce frequency during startup

## Test plan

- [x] 2 new unit tests: AttributeError fallback + emission-only health mode
- [x] All 24 existing wiring health tests pass
- [ ] Verify runtime-effects container stays healthy after deploy (8+ min startup)

Closes OMN-6565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health checker resilience to gracefully handle unavailable or invalid dependencies without raising errors.

* **Chores**
  * Updated container health check timing configuration (increased interval and startup period).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->