### PR TITLE
fix: strip v-prefix in plugin pin cascade verification [OMN-6717]

### DIFF
--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -93,12 +93,18 @@ jobs:
         # the requested version. If PyPI propagation lag caused update-plugin-pins.py
         # to fetch an older version, fail loudly rather than silently succeed with
         # stale data.
+        #
+        # The dispatched version may carry a 'v' prefix (e.g. v0.15.0 from the
+        # release tag) while the Dockerfile pin is bare (0.15.0). Strip the prefix
+        # before comparing.
         run: |
           PKG="${{ steps.inputs.outputs.package }}"
           EXPECTED_VER="${{ steps.inputs.outputs.version }}"
+          # Strip leading 'v' prefix if present (e.g. v0.15.0 → 0.15.0)
+          EXPECTED_VER="${EXPECTED_VER#v}"
           ACTUAL=$(grep -oP "(?<=${PKG}==)[0-9]+\.[0-9]+\.[0-9]+" docker/Dockerfile.runtime || true)
           if [ "$ACTUAL" != "$EXPECTED_VER" ]; then
-            echo "ERROR: Dockerfile pin for ${PKG} did not reach expected version ${EXPECTED_VER} — PyPI propagation lag. Re-run workflow after 60s." >&2
+            echo "ERROR: Dockerfile pin for ${PKG} did not reach expected version ${EXPECTED_VER} (actual: ${ACTUAL}) — PyPI propagation lag. Re-run workflow after 60s." >&2
             exit 1
           fi
           echo "Pin confirmed: ${PKG}==${ACTUAL}"


### PR DESCRIPTION
## Summary

- Verification step now strips leading `v` prefix from dispatched version before comparing to Dockerfile pin
- Release workflows dispatch versions like `v0.15.0` but Dockerfile pins are bare `0.15.0`
- Also improved error message to show actual vs expected version

Closes OMN-6717

## Test plan

- [ ] CI passes
- [ ] Manual workflow_dispatch with version `v0.15.0` passes verification
- [ ] Bare version `0.15.0` still works (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal version verification robustness with enhanced error messaging and normalization for better build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->