### PR TITLE
fix: deploy-runtime.sh copies omnibase_core runtime contracts [OMN-6698]

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -853,6 +853,7 @@ sync_files() {
     # from the installed omnibase_core package (contracts/runtime_data/), but
     # the bind-mount hides them. We must copy them into the deployed contracts/
     # directory so they survive the bind-mount override.
+    check_command python3 "locating omnibase_core runtime contracts"
     local core_contracts_dir
     core_contracts_dir="$(python3 -c "
 import importlib.util, pathlib
@@ -870,6 +871,7 @@ if spec and spec.origin:
     if [[ -n "${core_contracts_dir}" && -d "${core_contracts_dir}" ]]; then
         log_info "Copying omnibase_core runtime contracts from ${core_contracts_dir}..."
         mkdir -p "${deploy_target}/contracts/runtime"
+        local expected_core_runtime_count=5
         local yaml_count=0
         for yaml_file in "${core_contracts_dir}"/*.yaml; do
             if [[ -f "${yaml_file}" ]]; then
@@ -877,8 +879,8 @@ if spec and spec.origin:
                 yaml_count=$((yaml_count + 1))
             fi
         done
-        if (( yaml_count == 0 )); then
-            log_error "No runtime contract YAMLs found in ${core_contracts_dir}."
+        if (( yaml_count < expected_core_runtime_count )); then
+            log_error "Expected at least ${expected_core_runtime_count} runtime contract YAMLs in ${core_contracts_dir}, found ${yaml_count}."
             log_error "Aborting deployment to avoid runtime startup failure."
             exit 1
         fi


### PR DESCRIPTION
## Summary
- After rsync of `contracts/`, copy omnibase_core runtime contract YAMLs from the installed package into `contracts/runtime/`
- The bind-mount `../contracts:/app/contracts:ro` overrides the Dockerfile's baked-in contracts, causing crash-loops when core contracts are missing
- Locates omnibase_core via `importlib.util.find_spec` and copies all `.yaml` files from `contracts/runtime_data/`

## Test plan
- [ ] Run `deploy-runtime.sh --execute` and verify contracts/runtime/ contains all 7 YAML files (2 from omnibase_infra + 5 from omnibase_core)
- [ ] Verify runtime starts without crash-loop after redeploy

Fixes OMN-6698
Parent: OMN-6697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now gathers runtime contract configuration files from installed runtime packages to ensure runtime configs are complete.
  * New validations enforce a minimum set of runtime YAMLs; deployment will log errors and stop if required files are missing.
  * Deployment will create the runtime target directory automatically when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->