### PR TITLE
fix: Phoenix health check uses python3 instead of missing curl [OMN-6700]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1010,7 +1010,9 @@ services:
       - omnibase-infra-network
     healthcheck:
       !!merge <<: *healthcheck-defaults
-      test: ["CMD-SHELL", "curl -sf http://localhost:6006/healthz || exit 1"]
+      # OMN-6700: Phoenix slim image does not include curl. Use python3 urllib
+      # (always available in the Phoenix image) to probe the health endpoint.
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:6006/healthz')\" || exit 1"]
       start_period: 20s
     logging: *logging-defaults
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Phoenix container (arizephoenix/phoenix) is a slim image without curl
- Health check was always failing because curl binary is not present
- Switch to `python3 -c "import urllib.request; ..."` which is always available in the Phoenix image

## Test plan
- [ ] Run `infra-up-runtime` and verify Phoenix container reports healthy
- [ ] Verify `docker inspect omnibase-infra-phoenix` shows healthy status

Fixes OMN-6700
Parent: OMN-6697