### PR TITLE
chore: register custom noqa codes as ruff external linters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,8 @@ line-ending = "auto"
 [tool.ruff.lint]
 # Matches omnibase_core settings for consistency across ONEX ecosystem
 select = ["E", "F", "W", "C90", "I", "N", "UP", "YTT", "S", "BLE", "FBT", "B", "A", "COM", "C4", "DTZ", "T10", "EM", "EXE", "ISC", "ICN", "G", "INP", "PIE", "T20", "PT", "Q", "RSE", "RET", "SLF", "SIM", "TID", "TCH", "ARG", "PTH", "ERA", "PD", "PGH", "PL", "TRY", "NPY", "RUF"]
+# Custom pre-commit hook codes — registered so ruff doesn't warn about unknown noqa directives
+external = ["model-dump-bare", "ONEX-PATTERN-PARAMS", "arch-topic-naming"]
 ignore = [
     # UP007 (Union[X, Y] -> X | Y) is NOT ignored — PEP 604 syntax enforced
     "S101",      # Allow assert statements in tests


### PR DESCRIPTION
## Summary
- Adds `external = ["model-dump-bare", "ONEX-PATTERN-PARAMS", "arch-topic-naming"]` to the ruff lint config in `pyproject.toml`
- Eliminates 13 ruff warnings about unrecognized `# noqa` directives that reference custom pre-commit hook codes
- No behavioral changes — existing noqa suppressions continue to work as before

## Test plan
- [x] `ruff check src/` passes with zero warnings (was 13 warnings before)
- [x] All pre-commit hooks pass
- [x] No source code changes — only `pyproject.toml` config addition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to ensure proper recognition of custom code quality standards and reduce unnecessary warnings during code reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->