### PR TITLE
feat: auto-refresh plugin cache after omniclaude pull [F58]

### DIFF
--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -97,6 +97,37 @@ for repo in "${REPOS[@]}"; do
   fi
 done
 
+# === Plugin cache refresh (Layer 2) ===
+# When omniclaude was updated, refresh the Claude Code plugin cache.
+_omniclaude_dir="$OMNI_HOME/omniclaude"
+_plugin_cache="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "${_plugin_cache}" ]]; then
+  # Try default plugin cache path
+  _plugin_cache=$(find "${HOME}/.claude/plugins/cache" -maxdepth 3 -name "skills" -type d 2>/dev/null | head -1)
+  [[ -n "${_plugin_cache}" ]] && _plugin_cache=$(dirname "${_plugin_cache}")
+fi
+
+if [[ -n "${_plugin_cache}" && -d "${_omniclaude_dir}" && -d "${_plugin_cache}/skills" ]]; then
+  _current=$(git -C "${_omniclaude_dir}" rev-parse HEAD 2>/dev/null)
+  _deployed=""
+  [[ -f "${_plugin_cache}/.deployed-commit" ]] && _deployed=$(cat "${_plugin_cache}/.deployed-commit" 2>/dev/null)
+
+  if [[ "${_current}" != "${_deployed}" && -n "${_current}" ]]; then
+    echo ""
+    echo "Refreshing Claude Code plugin cache (${_deployed:-none} → ${_current:0:8})..."
+    _tmpdir=$(mktemp -d)
+    if git -C "${_omniclaude_dir}" archive HEAD plugins/onex/skills/ 2>/dev/null | tar -x -C "${_tmpdir}" 2>/dev/null; then
+      cp -r "${_tmpdir}/plugins/onex/skills/"* "${_plugin_cache}/skills/" 2>/dev/null
+      echo "${_current}" > "${_plugin_cache}/.deployed-commit"
+      echo "Plugin cache refreshed."
+    else
+      echo "WARN: Plugin cache refresh failed (git archive error)."
+    fi
+    rm -rf "${_tmpdir}"
+  fi
+fi
+# === End plugin cache refresh ===
+
 echo ""
 echo "${OK} repo(s) up to date. ${#FAILED[@]} failed."
 [[ ${#FAILED[@]} -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
Layer 2 of plugin freshness fix. pull-all.sh now refreshes the Claude Code plugin cache when omniclaude has new commits.

## Why
Bare clones have no working tree. Code merges to main but the plugin cache is a separate disk path that was never refreshed automatically.

## Test plan
- [ ] Run pull-all.sh when omniclaude has new commits → plugin cache updated
- [ ] Run pull-all.sh when omniclaude is current → no-op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized plugin cache refresh mechanism to automatically detect and apply updates when changes are identified
  * Enhanced error handling ensures reliable completion of cache updates even if individual steps encounter issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->