### PR TITLE
fix(tooling): add cache-bust headers to PyPI requests [OMN-6811]

### DIFF
--- a/scripts/update-plugin-pins.py
+++ b/scripts/update-plugin-pins.py
@@ -49,12 +49,22 @@ DEFAULT_DOCKERFILE = _REPO_ROOT / "docker" / "Dockerfile.runtime"
 def fetch_latest_version(package: str) -> str:
     """Return the latest stable version of *package* from PyPI.
 
+    Sends cache-bust headers to avoid stale index pages from HTTP caches
+    (OMN-6811).
+
     Raises:
         RuntimeError: if the HTTP request fails or the JSON is malformed.
     """
     url = f"https://pypi.org/pypi/{package}/json"
+    req = urllib.request.Request(  # noqa: S310
+        url,
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+        },
+    )
     try:
-        with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
             data = json.loads(resp.read())
     except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
         raise RuntimeError(

--- a/tests/unit/scripts/test_update_plugin_pins.py
+++ b/tests/unit/scripts/test_update_plugin_pins.py
@@ -183,6 +183,29 @@ def test_pin_re_matches_intelligence() -> None:
 
 
 @pytest.mark.unit
+def test_fetch_sends_cache_bust_headers() -> None:
+    """fetch_latest_version must send Cache-Control and Pragma headers (OMN-6811)."""
+    import urllib.request
+
+    captured_request: list[urllib.request.Request] = []
+    original_urlopen = urllib.request.urlopen
+
+    def mock_urlopen(req: urllib.request.Request, **kwargs: object) -> object:  # type: ignore[override]
+        captured_request.append(req)
+        raise urllib.error.URLError("test — not a real request")
+
+    with patch.object(urllib.request, "urlopen", side_effect=mock_urlopen):
+        with pytest.raises(RuntimeError):
+            fetch_latest_version("omninode-claude")
+
+    assert len(captured_request) == 1
+    req = captured_request[0]
+    assert isinstance(req, urllib.request.Request)
+    assert "no-cache" in req.get_header("Cache-control")
+    assert req.get_header("Pragma") == "no-cache"
+
+
+@pytest.mark.unit
 def test_rewrite_updates_all_three_plugins() -> None:
     """rewrite_content updates claude, intelligence, and memory pins."""
     content = (


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: no-cache, no-store, must-revalidate` and `Pragma: no-cache` headers to PyPI JSON API requests in `update-plugin-pins.py`
- Prevents stale HTTP cache from returning outdated package version info (friction F50)

## Test plan
- [x] New test `test_fetch_sends_cache_bust_headers` verifies `Request` object contains cache-bust headers
- [x] All existing tests continue to pass (8/8)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin version checking to provide more reliable and consistent retrieval of the latest available version information, ensuring users receive accurate version data on each check.

* **Tests**
  * Added unit tests for the plugin version checking system to validate proper behavior and verify the reliability of the version retrieval mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->