### PR TITLE
fix(ci): add SUFFIX_* export completeness test [OMN-6814]

### DIFF
--- a/tests/unit/topics/test_suffix_export_completeness.py
+++ b/tests/unit/topics/test_suffix_export_completeness.py
@@ -24,7 +24,7 @@ _INIT_MODULE = _TOPICS_PKG / "__init__.py"
 
 def _extract_suffix_names(path: Path) -> set[str]:
     """Return all module-level names starting with ``SUFFIX_`` from *path*."""
-    tree = ast.parse(path.read_text())
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     names: set[str] = set()
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign):
@@ -39,7 +39,7 @@ def _extract_suffix_names(path: Path) -> set[str]:
 
 def _extract_init_imports(path: Path) -> set[str]:
     """Return all names imported from platform_topic_suffixes in __init__.py."""
-    tree = ast.parse(path.read_text())
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     names: set[str] = set()
     for node in ast.walk(tree):
         if (
@@ -55,7 +55,7 @@ def _extract_init_imports(path: Path) -> set[str]:
 
 def _extract_init_all(path: Path) -> set[str]:
     """Return all SUFFIX_* entries in __all__ from __init__.py."""
-    tree = ast.parse(path.read_text())
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     names: set[str] = set()
 
     def _collect_from_list(value: ast.expr) -> None:


### PR DESCRIPTION
## Summary

- Adds a unit test (`test_suffix_export_completeness.py`) that verifies all `SUFFIX_*` constants from `platform_topic_suffixes.py` are properly imported and exported in `topics/__init__.py`
- Catches the recurring bug (third occurrence) where constants were defined but not re-exported, causing `ImportError` at runtime in downstream repos
- Three checks: all defined suffixes are imported, all imports appear in `__all__`, no stale entries in `__all__`

## Test plan

- [x] `uv run pytest tests/unit/topics/test_suffix_export_completeness.py -v` — all 3 tests pass
- [x] `uv run pre-commit run --all-files` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests that validate consistency of topic suffix exports across modules, improving reliability by detecting missing, incomplete, or stale export entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->