### PR TITLE
fix(runtime): add omnimemory to trusted plugin namespace prefixes [OMN-6829]

### DIFF
--- a/src/omnibase_infra/runtime/constants_security.py
+++ b/src/omnibase_infra/runtime/constants_security.py
@@ -51,6 +51,9 @@ Example:
 
 .. versionchanged:: 0.6.0
     Added omniclaude. to TRUSTED_PLUGIN_NAMESPACE_PREFIXES (OMN-2047).
+
+.. versionchanged:: 0.8.0
+    Added omnimemory. to TRUSTED_PLUGIN_NAMESPACE_PREFIXES (OMN-6829).
 """
 
 from __future__ import annotations
@@ -98,12 +101,20 @@ TRUSTED_HANDLER_NAMESPACE_PREFIXES: Final[tuple[str, ...]] = (
 # - Without this prefix, discover_from_entry_points() rejects it (OMN-2192)
 # - omniintelligence is a first-party package in the OmniNode ecosystem
 #
+# Why omnimemory. is included:
+# - omnimemory provides PluginMemory, a first-party domain plugin registered
+#   via pyproject.toml entry_points (onex.domain_plugins group)
+# - Without this prefix, discover_from_entry_points() rejects the entry point
+#   with status namespace_rejected (OMN-6829)
+# - omnimemory is a first-party package in the OmniNode ecosystem
+#
 # Third-party plugin namespaces must be explicitly configured via security config file.
 TRUSTED_PLUGIN_NAMESPACE_PREFIXES: Final[tuple[str, ...]] = (
     "omnibase_core.",
     "omnibase_infra.",
     "omniclaude.",
     "omniintelligence.",
+    "omnimemory.",
 )
 
 # PEP 621 entry_points group name for domain plugin discovery.

--- a/tests/unit/runtime/test_constants_security.py
+++ b/tests/unit/runtime/test_constants_security.py
@@ -44,6 +44,14 @@ class TestTrustedPluginNamespacePrefixes:
         """Test that omniclaude is a trusted plugin namespace (OMN-2047)."""
         assert "omniclaude." in TRUSTED_PLUGIN_NAMESPACE_PREFIXES
 
+    def test_contains_omniintelligence_namespace(self) -> None:
+        """Test that omniintelligence is a trusted plugin namespace (OMN-2192)."""
+        assert "omniintelligence." in TRUSTED_PLUGIN_NAMESPACE_PREFIXES
+
+    def test_contains_omnimemory_namespace(self) -> None:
+        """Test that omnimemory is a trusted plugin namespace (OMN-6829)."""
+        assert "omnimemory." in TRUSTED_PLUGIN_NAMESPACE_PREFIXES
+
     def test_is_tuple(self) -> None:
         """Test that the constant is a tuple (immutable), not a list."""
         assert isinstance(TRUSTED_PLUGIN_NAMESPACE_PREFIXES, tuple)
@@ -81,12 +89,15 @@ class TestPluginHandlerNamespaceRelationship:
     def test_plugin_prefixes_include_extra_namespaces(self) -> None:
         """Plugin prefixes include namespaces not in handler prefixes.
 
-        omniclaude. provides domain plugins but not handler implementations.
+        omniclaude, omniintelligence, and omnimemory provide domain plugins
+        but not handler implementations.
         """
         extra = set(TRUSTED_PLUGIN_NAMESPACE_PREFIXES) - set(
             TRUSTED_HANDLER_NAMESPACE_PREFIXES
         )
         assert "omniclaude." in extra
+        assert "omniintelligence." in extra
+        assert "omnimemory." in extra
 
 
 class TestDomainPluginEntryPointGroup:


### PR DESCRIPTION
## Summary

- Add `"omnimemory."` to `TRUSTED_PLUGIN_NAMESPACE_PREFIXES` in `constants_security.py`
- The omnimemory `PluginMemory` domain plugin was rejected at runtime boot because its module path (`omnimemory.runtime.plugin`) was not in the namespace allowlist
- Add tests for `omnimemory.` and backfill missing `omniintelligence.` test coverage

## Test plan

- [x] `test_contains_omnimemory_namespace` — verifies `omnimemory.` is in the allowlist
- [x] `test_contains_omniintelligence_namespace` — backfills coverage for existing entry
- [x] `test_plugin_prefixes_include_extra_namespaces` — asserts all 3 plugin-only namespaces
- [x] All 13 tests in `test_constants_security.py` pass
- [x] Pre-commit hooks pass (all 43 hooks)

Closes OMN-6829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended trusted plugin namespaces to support omnimemory, enabling new memory-based plugin loading and functionality.

* **Tests**
  * Added unit tests to verify proper recognition and validation of the new trusted namespace in the plugin allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->