### PR TITLE
feat(ci): add auto-merge-on-open workflow [OMN-6571]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-6571: Automatically enable auto-merge (squash) on every PR opened
+# by jonahgabriel. Ensures PRs do not sit idle in the merge queue waiting
+# for manual enrollment.
+name: Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'jonahgabriel'
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-merge.yml` that automatically enables auto-merge (squash) on every PR opened by `jonahgabriel`
- Triggers on `pull_request` events: opened, reopened, ready_for_review
- Prevents PRs from sitting idle waiting for manual auto-merge enrollment

## Test plan

- [ ] Workflow file is valid YAML and uses correct GitHub Actions syntax
- [ ] `if: github.actor == 'jonahgabriel'` correctly filters to repo owner PRs only
- [ ] `gh pr merge --auto --squash` enables squash auto-merge without blocking CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request merge automation in the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->