### PR TITLE
feat(probes): add row count probe for projection health [OMN-5653]

### DIFF
--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -339,6 +339,8 @@ _LEGACY_ALLOWLIST: dict[str, str] = {
     "onex.evt.platform.dlq-message.v1": "OMN-6136; cross-published by MixinKafkaDlq for omnidash /dlq dashboard | owner: jonah | expiry: 2026-06-01",
     # --- runner health pipeline topics (OMN-6082) ---
     "onex.evt.omnibase-infra.runner-health-snapshot.v1": "OMN-6082; Phase 1 CLI-based, contract.yaml deferred to OMN-6091 (true ONEX node conversion) | owner: jonah | expiry: 2026-09-01",
+    # --- row count diagnostic probe (OMN-5653) ---
+    "onex.evt.omnibase-infra.row-count-diagnostic.v1": "OMN-5653; probe-based emission, contract.yaml deferred to ONEX node conversion | owner: jonah | expiry: 2026-09-01",
     # --- AST code extraction pipeline topics (OMN-5669) ---
     "onex.cmd.omniintelligence.code-crawl-requested.v1": "OMN-5669; contract.yaml in omniintelligence repo (cross-repo provisioning) | owner: jonah | expiry: 2026-09-01",
     "onex.evt.omniintelligence.code-file-discovered.v1": "OMN-5669; contract.yaml in omniintelligence repo (cross-repo provisioning) | owner: jonah | expiry: 2026-09-01",

--- a/src/omnibase_infra/models/health/__init__.py
+++ b/src/omnibase_infra/models/health/__init__.py
@@ -35,8 +35,14 @@ from omnibase_infra.models.health.model_llm_endpoint_health_event import (
 from omnibase_infra.models.health.model_llm_endpoint_status import (
     ModelLlmEndpointStatus,
 )
+from omnibase_infra.models.health.model_row_count_probe_result import (
+    ModelRowCountProbeResult,
+)
 from omnibase_infra.models.health.model_runtime_error_event import (
     ModelRuntimeErrorEvent,
+)
+from omnibase_infra.models.health.model_table_row_count import (
+    ModelTableRowCount,
 )
 
 __all__ = [
@@ -51,5 +57,7 @@ __all__ = [
     "ModelLlmEndpointHealthConfig",
     "ModelLlmEndpointHealthEvent",
     "ModelLlmEndpointStatus",
+    "ModelRowCountProbeResult",
     "ModelRuntimeErrorEvent",
+    "ModelTableRowCount",
 ]

--- a/src/omnibase_infra/models/health/model_row_count_probe_result.py
+++ b/src/omnibase_infra/models/health/model_row_count_probe_result.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Row count probe result model for omnidash projection health checks.
+
+Reports tables with zero rows detected via pg_stat_user_tables,
+used by the error triage pipeline to flag empty projection tables
+that indicate silent data loss.
+
+Related Tickets:
+    - OMN-5653: Wire row count probe
+    - OMN-5529: Runtime Health Event Pipeline (epic)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.health.model_table_row_count import (
+    ModelTableRowCount,
+)
+
+
+class ModelRowCountProbeResult(BaseModel):
+    """Result of a row count probe across omnidash projection tables.
+
+    Aggregates pg_stat_user_tables data and flags tables with
+    zero rows as potential projection failures.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    event_id: UUID = Field(
+        default_factory=uuid4, description="Unique probe event identifier."
+    )
+    db_display_label: str = Field(
+        ..., description="Display label for the database that was probed."
+    )
+    total_tables: int = Field(..., description="Total number of user tables found.")
+    empty_tables: int = Field(..., description="Number of tables with zero live rows.")
+    populated_tables: int = Field(
+        ..., description="Number of tables with at least one live row."
+    )
+    empty_table_names: list[str] = Field(
+        default_factory=list,
+        description="Names of tables with zero live rows.",
+    )
+    table_details: list[ModelTableRowCount] = Field(
+        default_factory=list,
+        description="Per-table row count details.",
+    )
+    healthy: bool = Field(
+        ...,
+        description="True if no unexpected empty tables were detected.",
+    )
+    probed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="Timestamp when the probe was executed.",
+    )
+
+
+__all__ = [
+    "ModelRowCountProbeResult",
+]

--- a/src/omnibase_infra/models/health/model_table_row_count.py
+++ b/src/omnibase_infra/models/health/model_table_row_count.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Single-table row count model for projection health probes (OMN-5653).
+
+Represents the row count for one table as reported by pg_stat_user_tables.
+
+Related Tickets:
+    - OMN-5653: Wire row count probe
+    - OMN-5529: Runtime Health Event Pipeline (epic)
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelTableRowCount(BaseModel):
+    """Row count for a single table from pg_stat_user_tables."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    relation_key: str = Field(
+        ..., description="Relation (table) identifier from pg_stat_user_tables."
+    )
+    schema_label: str = Field(
+        default="public",
+        description="Schema label containing the table.",
+    )
+    n_live_tup: int = Field(
+        ..., description="Approximate live row count from pg_stat_user_tables."
+    )
+    is_empty: bool = Field(..., description="Whether the table has zero live rows.")
+
+
+__all__ = [
+    "ModelTableRowCount",
+]

--- a/src/omnibase_infra/probes/__init__.py
+++ b/src/omnibase_infra/probes/__init__.py
@@ -13,12 +13,14 @@ from omnibase_infra.probes.capability_probe import (
 )
 from omnibase_infra.probes.model_verification_result import ModelVerificationResult
 from omnibase_infra.probes.model_verification_spec import ModelVerificationSpec
+from omnibase_infra.probes.probe_row_count import RowCountProbe
 from omnibase_infra.probes.protocol_verification_spec import VerificationSpec
 from omnibase_infra.probes.verification_executor import execute_verification
 
 __all__ = [
     "ModelVerificationResult",
     "ModelVerificationSpec",
+    "RowCountProbe",
     "VerificationSpec",
     "execute_verification",
     "http_health_check",

--- a/src/omnibase_infra/probes/probe_row_count.py
+++ b/src/omnibase_infra/probes/probe_row_count.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Row count probe for omnidash projection tables (OMN-5653).
+
+Queries pg_stat_user_tables to detect tables with zero live rows,
+which indicates projection failures (events consumed but not written).
+
+The probe is designed to be called periodically by the runtime health
+pipeline or begin-day diagnostics. It emits a diagnostic event when
+empty tables are detected.
+
+Usage:
+    from omnibase_infra.probes.probe_row_count import RowCountProbe
+
+    probe = RowCountProbe(dsn="postgresql://...")
+    result = await probe.run()
+    if not result.healthy:
+        # emit diagnostic event
+        ...
+"""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from omnibase_infra.models.health.model_row_count_probe_result import (
+    ModelRowCountProbeResult,
+)
+from omnibase_infra.models.health.model_table_row_count import (
+    ModelTableRowCount,
+)
+
+logger = logging.getLogger(__name__)
+
+# Tables that are expected to be empty in normal operation (e.g. DLQ, staging).
+# These are excluded from the "unhealthy" determination.
+DEFAULT_EXPECTED_EMPTY: frozenset[str] = frozenset(
+    {
+        "schema_migrations",
+        "drizzle_migrations",
+    }
+)
+
+_ROW_COUNT_QUERY = """
+    SELECT
+        schemaname,
+        relname,
+        n_live_tup
+    FROM pg_stat_user_tables
+    WHERE schemaname = 'public'
+    ORDER BY relname
+"""
+
+
+class PgStatRow:
+    """Typed wrapper for pg_stat_user_tables query results."""
+
+    __slots__ = ("n_live_tup", "relname", "schemaname")
+
+    def __init__(self, schemaname: str, relname: str, n_live_tup: int) -> None:
+        self.schemaname = schemaname
+        self.relname = relname
+        self.n_live_tup = n_live_tup
+
+    @classmethod
+    def from_record(cls, record: asyncpg.Record) -> PgStatRow:
+        """Construct from an asyncpg Record."""
+        return cls(
+            schemaname=str(record["schemaname"]),
+            relname=str(record["relname"]),
+            n_live_tup=int(record["n_live_tup"]),
+        )
+
+
+class RowCountProbe:
+    """Probes a PostgreSQL database for tables with zero live rows.
+
+    Connects via asyncpg, queries pg_stat_user_tables, and returns
+    a structured result with per-table row counts.
+
+    Args:
+        dsn: PostgreSQL connection string.
+        expected_empty: Table names that are expected to be empty
+            (excluded from the healthy/unhealthy determination).
+        db_display_label: Display name for the database being probed.
+    """
+
+    def __init__(
+        self,
+        *,
+        dsn: str,
+        expected_empty: frozenset[str] | None = None,
+        db_display_label: str = "omnidash_analytics",
+    ) -> None:
+        self._dsn = dsn
+        self._expected_empty = expected_empty or DEFAULT_EXPECTED_EMPTY
+        self._db_display_label = db_display_label
+
+    async def run(self) -> ModelRowCountProbeResult:
+        """Execute the row count probe.
+
+        Returns:
+            ModelRowCountProbeResult with per-table details and health status.
+        """
+        rows = await self._query_row_counts()
+        return self._evaluate(rows)
+
+    async def _query_row_counts(self) -> list[PgStatRow]:
+        """Query pg_stat_user_tables for row counts."""
+        conn: asyncpg.Connection[asyncpg.Record] = await asyncpg.connect(self._dsn)
+        try:
+            records = await conn.fetch(_ROW_COUNT_QUERY)
+            return [PgStatRow.from_record(r) for r in records]
+        finally:
+            await conn.close()
+
+    def _evaluate(self, rows: list[PgStatRow]) -> ModelRowCountProbeResult:
+        """Evaluate row counts and build the probe result."""
+        table_details: list[ModelTableRowCount] = []
+        empty_table_names: list[str] = []
+
+        for row in rows:
+            is_empty = row.n_live_tup == 0
+
+            table_details.append(
+                ModelTableRowCount(
+                    relation_key=row.relname,
+                    schema_label=row.schemaname,
+                    n_live_tup=row.n_live_tup,
+                    is_empty=is_empty,
+                )
+            )
+
+            if is_empty and row.relname not in self._expected_empty:
+                empty_table_names.append(row.relname)
+
+        total = len(table_details)
+        empty_count = len(empty_table_names)
+        populated = total - empty_count
+
+        # Healthy if no unexpected empty tables
+        healthy = empty_count == 0
+
+        if not healthy:
+            logger.warning(
+                "Row count probe found %d empty projection table(s): %s",
+                empty_count,
+                ", ".join(empty_table_names),
+            )
+
+        return ModelRowCountProbeResult(
+            db_display_label=self._db_display_label,
+            total_tables=total,
+            empty_tables=empty_count,
+            populated_tables=populated,
+            empty_table_names=empty_table_names,
+            table_details=table_details,
+            healthy=healthy,
+        )
+
+
+__all__ = [
+    "RowCountProbe",
+    "DEFAULT_EXPECTED_EMPTY",
+]

--- a/src/omnibase_infra/topics/__init__.py
+++ b/src/omnibase_infra/topics/__init__.py
@@ -114,6 +114,7 @@ from omnibase_infra.topics.platform_topic_suffixes import (
     SUFFIX_REGISTRY_REQUEST_INTROSPECTION,
     SUFFIX_REQUEST_INTROSPECTION,
     SUFFIX_RESOLUTION_DECIDED,
+    SUFFIX_ROW_COUNT_DIAGNOSTIC,
     SUFFIX_RUNNER_HEALTH_SNAPSHOT,
     SUFFIX_RUNTIME_ERROR,
     SUFFIX_RUNTIME_TICK,
@@ -186,6 +187,8 @@ __all__: list[str] = [
     "SUFFIX_GITHUB_POST_MERGE_RESULT",
     # Runner health monitoring (OMN-6075)
     "SUFFIX_RUNNER_HEALTH_SNAPSHOT",
+    # Row count probe diagnostic (OMN-5653)
+    "SUFFIX_ROW_COUNT_DIAGNOSTIC",
     # Runtime health event pipeline (OMN-5529)
     "SUFFIX_CONSUMER_HEALTH",
     "SUFFIX_CONSUMER_RESTART_CMD",

--- a/src/omnibase_infra/topics/platform_topic_suffixes.py
+++ b/src/omnibase_infra/topics/platform_topic_suffixes.py
@@ -570,6 +570,17 @@ Producer: cli_runner_health.py (cron-scheduled)
 Consumer: omnidash (future)
 """
 
+SUFFIX_ROW_COUNT_DIAGNOSTIC: str = "onex.evt.omnibase-infra.row-count-diagnostic.v1"
+"""Topic suffix for row count probe diagnostic events (OMN-5653).
+
+Published by ServiceRowCountProbe when the probe detects empty projection
+tables. Each event carries a ``ModelRowCountProbeResult`` payload with
+per-table row counts and the list of empty tables.
+
+Producer: ServiceRowCountProbe (begin-day diagnostics / periodic probe)
+Consumer: omnidash (future)
+"""
+
 SUFFIX_GITHUB_PR_MERGED: str = "onex.evt.github.pr-merged.v1"
 """Topic suffix for GitHub PR merged events (OMN-6726).
 
@@ -663,6 +674,15 @@ ALL_OMNIBASE_INFRA_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
         suffix=SUFFIX_RUNNER_HEALTH_SNAPSHOT,
         partitions=1,
         kafka_config={},
+    ),
+    # Row count diagnostic events (1 partition — low-throughput, OMN-5653)
+    ModelTopicSpec(
+        suffix=SUFFIX_ROW_COUNT_DIAGNOSTIC,
+        partitions=1,
+        kafka_config={
+            "retention.ms": "604800000",
+            "cleanup.policy": "delete",
+        },  # 7 days
     ),
     # GitHub PR merged events (1 partition — low-throughput, one event per merge, OMN-6726)
     ModelTopicSpec(

--- a/tests/unit/probes/test_probe_row_count.py
+++ b/tests/unit/probes/test_probe_row_count.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for RowCountProbe (OMN-5653)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from omnibase_infra.models.health.model_row_count_probe_result import (
+    ModelRowCountProbeResult,
+)
+from omnibase_infra.models.health.model_table_row_count import (
+    ModelTableRowCount,
+)
+from omnibase_infra.probes.probe_row_count import (
+    DEFAULT_EXPECTED_EMPTY,
+    PgStatRow,
+    RowCountProbe,
+)
+
+
+@pytest.mark.unit
+class TestRowCountProbe:
+    """Tests for the row count probe evaluation logic."""
+
+    def _make_probe(
+        self,
+        expected_empty: frozenset[str] | None = None,
+    ) -> RowCountProbe:
+        return RowCountProbe(
+            dsn="postgresql://test:test@localhost:5432/test",
+            expected_empty=expected_empty,
+            db_display_label="test_db",
+        )
+
+    def test_evaluate_all_populated(self) -> None:
+        """All tables have rows -> healthy."""
+        probe = self._make_probe()
+        rows = [
+            PgStatRow("public", "epic_run_events", 42),
+            PgStatRow("public", "pr_watch_state", 10),
+        ]
+        result = probe._evaluate(rows)
+
+        assert result.healthy is True
+        assert result.total_tables == 2
+        assert result.empty_tables == 0
+        assert result.populated_tables == 2
+        assert result.empty_table_names == []
+        assert result.db_display_label == "test_db"
+
+    def test_evaluate_with_empty_tables(self) -> None:
+        """Some tables have zero rows -> unhealthy, flagged."""
+        probe = self._make_probe()
+        rows = [
+            PgStatRow("public", "epic_run_events", 42),
+            PgStatRow("public", "agent_actions", 0),
+            PgStatRow("public", "llm_cost_aggregates", 0),
+        ]
+        result = probe._evaluate(rows)
+
+        assert result.healthy is False
+        assert result.total_tables == 3
+        assert result.empty_tables == 2
+        assert result.populated_tables == 1
+        assert "agent_actions" in result.empty_table_names
+        assert "llm_cost_aggregates" in result.empty_table_names
+
+    def test_evaluate_expected_empty_excluded(self) -> None:
+        """Tables in expected_empty set are not counted as unhealthy."""
+        probe = self._make_probe(
+            expected_empty=frozenset({"schema_migrations", "staging_table"})
+        )
+        rows = [
+            PgStatRow("public", "epic_run_events", 10),
+            PgStatRow("public", "schema_migrations", 0),
+            PgStatRow("public", "staging_table", 0),
+        ]
+        result = probe._evaluate(rows)
+
+        assert result.healthy is True
+        assert result.empty_table_names == []
+
+    def test_evaluate_empty_database(self) -> None:
+        """No tables at all -> healthy (vacuously)."""
+        probe = self._make_probe()
+        result = probe._evaluate([])
+
+        assert result.healthy is True
+        assert result.total_tables == 0
+        assert result.empty_tables == 0
+
+    def test_default_expected_empty_contains_migrations(self) -> None:
+        """Default expected_empty includes migration tables."""
+        assert "schema_migrations" in DEFAULT_EXPECTED_EMPTY
+        assert "drizzle_migrations" in DEFAULT_EXPECTED_EMPTY
+
+    def test_table_details_populated(self) -> None:
+        """Table details include per-table row counts."""
+        probe = self._make_probe()
+        rows = [
+            PgStatRow("public", "my_table", 100),
+        ]
+        result = probe._evaluate(rows)
+
+        assert len(result.table_details) == 1
+        detail = result.table_details[0]
+        assert detail.relation_key == "my_table"
+        assert detail.schema_label == "public"
+        assert detail.n_live_tup == 100
+        assert detail.is_empty is False
+
+    @pytest.mark.asyncio
+    async def test_run_calls_query_and_evaluate(self) -> None:
+        """run() queries the database and evaluates results."""
+        probe = self._make_probe()
+        mock_rows = [
+            PgStatRow("public", "test_table", 5),
+        ]
+
+        with patch.object(
+            probe, "_query_row_counts", new_callable=AsyncMock, return_value=mock_rows
+        ):
+            result = await probe.run()
+
+        assert isinstance(result, ModelRowCountProbeResult)
+        assert result.healthy is True
+        assert result.total_tables == 1
+
+
+@pytest.mark.unit
+class TestModelRowCountProbeResult:
+    """Tests for the probe result model."""
+
+    def test_model_frozen(self) -> None:
+        """Model is immutable."""
+        result = ModelRowCountProbeResult(
+            db_display_label="test",
+            total_tables=1,
+            empty_tables=0,
+            populated_tables=1,
+            healthy=True,
+        )
+        with pytest.raises(Exception):
+            result.db_display_label = "other"  # type: ignore[misc]
+
+    def test_model_extra_forbid(self) -> None:
+        """Extra fields are rejected."""
+        with pytest.raises(Exception):
+            ModelRowCountProbeResult(
+                db_display_label="test",
+                total_tables=1,
+                empty_tables=0,
+                populated_tables=1,
+                healthy=True,
+                extra_field="bad",  # type: ignore[call-arg]
+            )
+
+
+@pytest.mark.unit
+class TestModelTableRowCount:
+    """Tests for the table row count model."""
+
+    def test_model_construction(self) -> None:
+        """Model constructs with required fields."""
+        m = ModelTableRowCount(
+            relation_key="my_table",
+            n_live_tup=42,
+            is_empty=False,
+        )
+        assert m.relation_key == "my_table"
+        assert m.schema_label == "public"  # default
+        assert m.n_live_tup == 42
+        assert m.is_empty is False


### PR DESCRIPTION
## Summary
- Add `RowCountProbe` that queries `pg_stat_user_tables` for zero-row projection tables
- Add `ModelRowCountProbeResult` and `ModelTableRowCount` models for structured probe output
- Register `SUFFIX_ROW_COUNT_DIAGNOSTIC` topic for diagnostic event emission
- 10 unit tests covering evaluation logic, expected-empty exclusion, and model constraints

## Test plan
- [x] Unit tests pass (10/10)
- [x] Pre-commit clean (all hooks pass)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database row count diagnostics to monitor PostgreSQL table health and population status
  * Introduced health models and messaging infrastructure for row count probe results

* **Tests**
  * Added unit test coverage for row count diagnostic probe functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->