### PR TITLE
feat: define session graph schema for Memgraph [OMN-6858]

### DIFF
--- a/src/omnibase_infra/migrations/memgraph/session_graph_001.cypher
+++ b/src/omnibase_infra/migrations/memgraph/session_graph_001.cypher
@@ -1,0 +1,16 @@
+// Session graph schema migration 001
+// Part of the Multi-Session Coordination Layer (OMN-6850, Task 8)
+//
+// Node labels: Session, Task, File, PullRequest, Repository
+// Relationships: WORKS_ON, TOUCHES, DEPENDS_ON, PRODUCED, BELONGS_TO
+
+// --- Uniqueness constraints ---
+CREATE CONSTRAINT ON (s:Session) ASSERT s.session_id IS UNIQUE;
+CREATE CONSTRAINT ON (t:Task) ASSERT t.task_id IS UNIQUE;
+CREATE CONSTRAINT ON (f:File) ASSERT f.path IS UNIQUE;
+CREATE CONSTRAINT ON (p:PullRequest) ASSERT p.pr_id IS UNIQUE;
+CREATE CONSTRAINT ON (r:Repository) ASSERT r.name IS UNIQUE;
+
+// --- Performance indexes ---
+CREATE INDEX ON :Task(status);
+CREATE INDEX ON :Session(last_activity);

--- a/src/omnibase_infra/services/session_registry/enum_node_label.py
+++ b/src/omnibase_infra/services/session_registry/enum_node_label.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Node label enum for session coordination graph.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 8).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumNodeLabel(StrEnum):
+    """Node labels for the session coordination graph.
+
+    Values:
+        SESSION: A Claude Code agent session.
+        TASK: A Linear ticket or pipeline task being worked on.
+        FILE: A source file touched by a task.
+        PULL_REQUEST: A GitHub pull request produced by a task.
+        REPOSITORY: A git repository that files and PRs belong to.
+    """
+
+    SESSION = "Session"
+    TASK = "Task"
+    FILE = "File"
+    PULL_REQUEST = "PullRequest"
+    REPOSITORY = "Repository"

--- a/src/omnibase_infra/services/session_registry/enum_relationship_type.py
+++ b/src/omnibase_infra/services/session_registry/enum_relationship_type.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Relationship type enum for session coordination graph.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 8).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumRelationshipType(StrEnum):
+    """Relationship types for the session coordination graph.
+
+    Values:
+        WORKS_ON: Session -> Task. A session is actively working on a task.
+        TOUCHES: Task -> File. A task modifies or reads a file.
+        DEPENDS_ON: Task -> Task. A task depends on another task.
+        PRODUCED: Task -> PullRequest. A task produced a pull request.
+        BELONGS_TO: File -> Repository or PullRequest -> Repository.
+    """
+
+    WORKS_ON = "WORKS_ON"
+    TOUCHES = "TOUCHES"
+    DEPENDS_ON = "DEPENDS_ON"
+    PRODUCED = "PRODUCED"
+    BELONGS_TO = "BELONGS_TO"

--- a/src/omnibase_infra/services/session_registry/graph_schema.py
+++ b/src/omnibase_infra/services/session_registry/graph_schema.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Session graph schema for Memgraph projection.
+
+Defines the Cypher DDL for the session coordination graph and re-exports
+node label and relationship type enums for convenience.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 8).
+"""
+
+from __future__ import annotations
+
+from omnibase_infra.services.session_registry.enum_node_label import (
+    EnumNodeLabel,
+)
+from omnibase_infra.services.session_registry.enum_relationship_type import (
+    EnumRelationshipType,
+)
+
+__all__ = [
+    "EnumNodeLabel",
+    "EnumRelationshipType",
+    "SESSION_GRAPH_SCHEMA",
+]
+
+SESSION_GRAPH_SCHEMA: str = """\
+CREATE CONSTRAINT ON (s:Session) ASSERT s.session_id IS UNIQUE;
+CREATE CONSTRAINT ON (t:Task) ASSERT t.task_id IS UNIQUE;
+CREATE CONSTRAINT ON (f:File) ASSERT f.path IS UNIQUE;
+CREATE CONSTRAINT ON (p:PullRequest) ASSERT p.pr_id IS UNIQUE;
+CREATE CONSTRAINT ON (r:Repository) ASSERT r.name IS UNIQUE;
+CREATE INDEX ON :Task(status);
+CREATE INDEX ON :Session(last_activity);
+"""

--- a/tests/unit/services/session_registry/test_session_graph_schema.py
+++ b/tests/unit/services/session_registry/test_session_graph_schema.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for session graph schema enums and Cypher DDL.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 8).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.services.session_registry.graph_schema import (
+    SESSION_GRAPH_SCHEMA,
+    EnumNodeLabel,
+    EnumRelationshipType,
+)
+
+
+@pytest.mark.unit
+class TestEnumNodeLabel:
+    """EnumNodeLabel must contain exactly the expected graph node labels."""
+
+    def test_member_count(self) -> None:
+        assert len(EnumNodeLabel) == 5
+
+    def test_expected_members(self) -> None:
+        expected = {"SESSION", "TASK", "FILE", "PULL_REQUEST", "REPOSITORY"}
+        assert set(EnumNodeLabel.__members__.keys()) == expected
+
+    @pytest.mark.parametrize(
+        ("member", "value"),
+        [
+            (EnumNodeLabel.SESSION, "Session"),
+            (EnumNodeLabel.TASK, "Task"),
+            (EnumNodeLabel.FILE, "File"),
+            (EnumNodeLabel.PULL_REQUEST, "PullRequest"),
+            (EnumNodeLabel.REPOSITORY, "Repository"),
+        ],
+    )
+    def test_values(self, member: EnumNodeLabel, value: str) -> None:
+        assert member.value == value
+
+    def test_is_str_enum(self) -> None:
+        for member in EnumNodeLabel:
+            assert isinstance(member, str)
+
+
+@pytest.mark.unit
+class TestEnumRelationshipType:
+    """EnumRelationshipType must contain exactly the expected relationship types."""
+
+    def test_member_count(self) -> None:
+        assert len(EnumRelationshipType) == 5
+
+    def test_expected_members(self) -> None:
+        expected = {"WORKS_ON", "TOUCHES", "DEPENDS_ON", "PRODUCED", "BELONGS_TO"}
+        assert set(EnumRelationshipType.__members__.keys()) == expected
+
+    @pytest.mark.parametrize(
+        ("member", "value"),
+        [
+            (EnumRelationshipType.WORKS_ON, "WORKS_ON"),
+            (EnumRelationshipType.TOUCHES, "TOUCHES"),
+            (EnumRelationshipType.DEPENDS_ON, "DEPENDS_ON"),
+            (EnumRelationshipType.PRODUCED, "PRODUCED"),
+            (EnumRelationshipType.BELONGS_TO, "BELONGS_TO"),
+        ],
+    )
+    def test_values(self, member: EnumRelationshipType, value: str) -> None:
+        assert member.value == value
+
+    def test_is_str_enum(self) -> None:
+        for member in EnumRelationshipType:
+            assert isinstance(member, str)
+
+
+@pytest.mark.unit
+class TestSessionGraphSchema:
+    """SESSION_GRAPH_SCHEMA DDL string must contain all constraints and indexes."""
+
+    def test_is_nonempty_string(self) -> None:
+        assert isinstance(SESSION_GRAPH_SCHEMA, str)
+        assert len(SESSION_GRAPH_SCHEMA) > 0
+
+    @pytest.mark.parametrize(
+        "label",
+        ["Session", "Task", "File", "PullRequest", "Repository"],
+    )
+    def test_constraint_for_each_node_label(self, label: str) -> None:
+        assert f":{label})" in SESSION_GRAPH_SCHEMA
+        assert "CREATE CONSTRAINT" in SESSION_GRAPH_SCHEMA
+
+    def test_uniqueness_constraint_count(self) -> None:
+        count = SESSION_GRAPH_SCHEMA.count("CREATE CONSTRAINT")
+        assert count == 5
+
+    def test_index_on_task_status(self) -> None:
+        assert "CREATE INDEX ON :Task(status)" in SESSION_GRAPH_SCHEMA
+
+    def test_index_on_session_last_activity(self) -> None:
+        assert "CREATE INDEX ON :Session(last_activity)" in SESSION_GRAPH_SCHEMA
+
+    def test_schema_matches_migration(self) -> None:
+        """Schema string must match the Cypher migration file content (DDL lines only)."""
+        from pathlib import Path
+
+        migration_path = (
+            Path(__file__).resolve().parents[4]
+            / "src"
+            / "omnibase_infra"
+            / "migrations"
+            / "memgraph"
+            / "session_graph_001.cypher"
+        )
+        if not migration_path.exists():
+            pytest.skip("Migration file not found at expected path")
+
+        migration_text = migration_path.read_text()
+        # Extract DDL lines (non-comment, non-empty) from migration
+        migration_ddl_lines = [
+            line.strip()
+            for line in migration_text.splitlines()
+            if line.strip() and not line.strip().startswith("//")
+        ]
+        schema_ddl_lines = [
+            line.strip() for line in SESSION_GRAPH_SCHEMA.splitlines() if line.strip()
+        ]
+        assert migration_ddl_lines == schema_ddl_lines


### PR DESCRIPTION
## Summary

- Add `EnumNodeLabel` (Session, Task, File, PullRequest, Repository) and `EnumRelationshipType` (WORKS_ON, TOUCHES, DEPENDS_ON, PRODUCED, BELONGS_TO) StrEnums for the session coordination graph
- Add `SESSION_GRAPH_SCHEMA` Cypher DDL string with uniqueness constraints and performance indexes
- Add Cypher migration file at `src/omnibase_infra/migrations/memgraph/session_graph_001.cypher`
- 26 unit tests covering enum members, values, DDL content, and migration-schema consistency

## Context

Task 8 of the Multi-Session Coordination Layer (OMN-6850). Defines the graph schema that the session graph projector (OMN-6859) will use to materialize session coordination data into Memgraph.

## Test plan

- [x] 26 unit tests pass (`uv run pytest tests/unit/services/session_registry/test_session_graph_schema.py`)
- [x] All pre-commit hooks pass
- [x] Pre-push mypy and architecture validation pass
- [x] One-enum-per-file convention satisfied