### PR TITLE
fix(ci): add continue-on-error to auto-merge step [OMN-6489]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,7 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'jonahgabriel'
     steps:
+      # continue-on-error: merge queue re-triggers this workflow, and
+      # gh pr merge fails with "already enqueued" — that is expected.
       - name: Enable auto-merge (squash)
+        continue-on-error: true
         run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the "Enable auto-merge (squash)" step in the auto-merge workflow
- When a PR is already in the merge queue, `gh pr merge --auto --squash` fails with "already enqueued", marking the check as FAILED and causing UNSTABLE merge state
- This is an expected failure that should not block the workflow

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Confirm PRs entering the merge queue no longer show FAILED auto-merge check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced auto-merge workflow resilience by allowing the merge process to continue gracefully when re-enqueue scenarios occur, with clarifying documentation of expected behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->