### PR TITLE
feat: decision projector consumes Kafka events into Qdrant [OMN-6863]

### DIFF
--- a/src/omnibase_infra/services/session_registry/decision_embedder.py
+++ b/src/omnibase_infra/services/session_registry/decision_embedder.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Decision embedding models and utilities for Qdrant semantic retrieval.
+
+Embeds decision records and stores them in Qdrant for semantic retrieval.
+
+Collection: "session_decisions"
+Vector: 1024-dim from Qwen3-Embedding-8B (LLM_EMBEDDING_URL)
+Payload: task_id, session_id, decision_text, context, timestamp
+
+Embedding text format:
+  "Task {task_id}: {decision_text}. Context: {context}"
+
+Uses EmbeddingClient pattern (async httpx to port 8100).
+Uses qdrant_client for storage.
+
+Point ID: uuid5(NAMESPACE_DNS, f"{task_id}:{decision_hash}")
+  - Dedup key: same decision text under same task_id -> same point ID (idempotent upsert)
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 12).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from uuid import UUID, uuid5
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qdrant_models
+
+logger = logging.getLogger(__name__)
+
+# Qdrant collection name for decision vectors.
+COLLECTION_NAME = "session_decisions"
+
+# Vector dimension for Qwen3-Embedding-8B.
+VECTOR_DIM = 1024
+
+# Namespace UUID for deterministic point ID generation.
+_NAMESPACE = UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # NAMESPACE_DNS
+
+
+class ModelDecisionRecord(BaseModel):
+    """A single architectural or design decision made during a task.
+
+    Immutable record capturing a decision for embedding and semantic search.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str = Field(  # onex:str-not-uuid — Linear ticket ID, not a UUID
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Linear ticket ID (e.g., 'OMN-1234').",
+    )
+    session_id: str = Field(  # onex:str-not-uuid — CLI session ID, not a UUID
+        ...,
+        min_length=1,
+        description="CLI session ID that recorded the decision.",
+    )
+    decision_text: str = Field(
+        ...,
+        min_length=1,
+        description="The decision text.",
+    )
+    context: str = Field(
+        default="",
+        description="Additional context around the decision.",
+    )
+    timestamp: str = Field(
+        default="",
+        description="ISO 8601 timestamp of when the decision was made.",
+    )
+
+
+def build_embedding_text(record: ModelDecisionRecord) -> str:
+    """Build embedding text from a decision record.
+
+    Format: "Task {task_id}: {decision_text}. Context: {context}"
+
+    Args:
+        record: The decision record to embed.
+
+    Returns:
+        Formatted text suitable for embedding generation.
+    """
+    parts = [f"Task {record.task_id}: {record.decision_text}"]
+    if record.context:
+        parts.append(f"Context: {record.context}")
+    return ". ".join(parts)
+
+
+def decision_point_id(task_id: str, decision_text: str) -> str:
+    """Generate a deterministic UUID for deduplication.
+
+    Same task_id + decision_text always produces the same point ID,
+    enabling idempotent upserts.
+
+    Args:
+        task_id: The ticket ID.
+        decision_text: The decision text.
+
+    Returns:
+        A UUID string for use as the Qdrant point ID.
+    """
+    decision_hash = hashlib.sha256(decision_text.encode()).hexdigest()[:16]
+    return str(uuid5(_NAMESPACE, f"{task_id}:{decision_hash}"))
+
+
+class EmbeddingClient:
+    """Async HTTP client for generating embeddings via OpenAI-compatible API.
+
+    Calls POST {base_url}/v1/embeddings with the standard request format.
+    Default base_url is read from LLM_EMBEDDING_URL env var.
+    """
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self._base_url = base_url or os.environ.get(
+            "LLM_EMBEDDING_URL", "http://192.168.86.200:8100"
+        )
+
+    async def embed(self, text: str) -> list[float]:
+        """Generate a 1024-dim embedding vector for the given text.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            A list of floats representing the embedding vector.
+
+        Raises:
+            httpx.HTTPStatusError: If the embedding API returns an error.
+        """
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self._base_url}/v1/embeddings",
+                json={"input": text, "model": "embedding"},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["data"][0]["embedding"]
+
+
+class DecisionEmbedderWriter:
+    """Writes decision embeddings to Qdrant.
+
+    Thin wrapper around QdrantClient for upserting decision vectors
+    into the session_decisions collection.
+    """
+
+    def __init__(self, qdrant: QdrantClient) -> None:
+        self._qdrant = qdrant
+
+    def ensure_collection(self) -> None:
+        """Create the session_decisions collection if it does not exist."""
+        collections = self._qdrant.get_collections().collections
+        existing = {c.name for c in collections}
+        if COLLECTION_NAME not in existing:
+            self._qdrant.create_collection(
+                collection_name=COLLECTION_NAME,
+                vectors_config=qdrant_models.VectorParams(
+                    size=VECTOR_DIM,
+                    distance=qdrant_models.Distance.COSINE,
+                ),
+            )
+            logger.info("Created Qdrant collection %s", COLLECTION_NAME)
+
+    def upsert(
+        self,
+        record: ModelDecisionRecord,
+        vector: list[float],
+    ) -> None:
+        """Upsert a decision embedding into Qdrant.
+
+        Uses deterministic point ID for idempotent upserts.
+
+        Args:
+            record: The decision record metadata.
+            vector: The embedding vector (1024-dim).
+        """
+        point_id = decision_point_id(record.task_id, record.decision_text)
+        self._qdrant.upsert(
+            collection_name=COLLECTION_NAME,
+            points=[
+                qdrant_models.PointStruct(
+                    id=point_id,
+                    vector=vector,
+                    payload={
+                        "task_id": record.task_id,
+                        "session_id": record.session_id,
+                        "decision_text": record.decision_text,
+                        "context": record.context,
+                        "timestamp": record.timestamp,
+                    },
+                ),
+            ],
+        )
+
+
+__all__ = [
+    "COLLECTION_NAME",
+    "DecisionEmbedderWriter",
+    "EmbeddingClient",
+    "ModelDecisionRecord",
+    "VECTOR_DIM",
+    "build_embedding_text",
+    "decision_point_id",
+]

--- a/src/omnibase_infra/services/session_registry/decision_projector.py
+++ b/src/omnibase_infra/services/session_registry/decision_projector.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka consumer that projects decision events into Qdrant.
+
+Subscribes to: onex.evt.omniintelligence.decision-recorded.v1
+Consumer group: omnibase_infra.session_registry.decision_project.v1
+
+For each event:
+  1. Extract ModelDecisionRecord from payload
+  2. Build embedding text via build_embedding_text()
+  3. Call EmbeddingClient to get 1024-dim vector
+  4. Upsert into Qdrant "session_decisions" collection
+
+Also indexes decisions from coordination signals:
+  - PR_MERGED with rationale -> "Decided to merge PR #N: {rationale}"
+  - TICKET_COMPLETED with summary -> "Completed OMN-XXXX: {summary}"
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 13).
+
+Architecture:
+    Kafka (onex.evt.omniintelligence.decision-recorded.v1)
+           |
+           v
+    DecisionProjector.extract_decision()
+           |
+           v
+    EmbeddingClient.embed() -> 1024-dim vector
+           |
+           v
+    DecisionEmbedderWriter.upsert() -> Qdrant
+
+Design decisions:
+    - Pure function extraction: extract_decision() and
+      extract_decision_from_coordination() are pure functions that
+      return ModelDecisionRecord from raw event dicts. This enables
+      unit testing without Kafka, Qdrant, or embedding dependencies.
+    - Events without task_id are silently skipped.
+    - Coordination signals (PR_MERGED, TICKET_COMPLETED) are converted
+      into synthetic decision records for semantic recall.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from omnibase_infra.services.session_registry.decision_embedder import (
+    DecisionEmbedderWriter,
+    EmbeddingClient,
+    ModelDecisionRecord,
+    build_embedding_text,
+)
+from omnibase_infra.topics.platform_topic_suffixes import (
+    SUFFIX_INTELLIGENCE_DECISION_RECORDED_EVT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Consumer group for the decision projector.
+CONSUMER_GROUP = "omnibase_infra.session_registry.decision_project.v1"
+
+# Kafka topic for decision recorded events (from canonical topic registry).
+DECISION_RECORDED_TOPIC = SUFFIX_INTELLIGENCE_DECISION_RECORDED_EVT
+
+# Coordination signal types that produce synthetic decisions.
+_COORDINATION_SIGNAL_TYPES = frozenset({"PR_MERGED", "TICKET_COMPLETED"})
+
+
+class DecisionProjector:
+    """Projects decision events from Kafka into Qdrant via embeddings.
+
+    The projector has two extraction paths:
+
+    1. ``extract_decision()`` -- extracts from decision.recorded events
+    2. ``extract_decision_from_coordination()`` -- extracts from
+       coordination signals (PR_MERGED, TICKET_COMPLETED)
+
+    Both return ModelDecisionRecord or None (skip).
+
+    The ``project()`` method orchestrates the full pipeline:
+    extract -> embed -> upsert.
+    """
+
+    def __init__(
+        self,
+        embedder: EmbeddingClient | None,
+        qdrant: DecisionEmbedderWriter | None,
+    ) -> None:
+        self._embedder = embedder
+        self._qdrant = qdrant
+
+    def extract_decision(
+        self,
+        event: dict[str, object],
+    ) -> ModelDecisionRecord | None:
+        """Extract a decision record from a decision.recorded event.
+
+        Returns None if the event has no task_id or is malformed.
+        Never raises -- all errors are logged and swallowed to preserve
+        projector liveness.
+
+        Args:
+            event: Raw deserialized Kafka event dict.
+
+        Returns:
+            A ModelDecisionRecord, or None if the event should be skipped.
+        """
+        try:
+            payload = event.get("payload")
+            if isinstance(payload, dict):
+                source = payload
+            else:
+                source = event
+
+            task_id = source.get("task_id")
+            if not task_id or not isinstance(task_id, str):
+                return None
+
+            decision_text = source.get("decision_text", "")
+            if not isinstance(decision_text, str) or not decision_text:
+                return None
+
+            session_id = str(source.get("session_id", "unknown"))
+            rationale = source.get("rationale", "")
+            context = str(rationale) if rationale else ""
+            emitted_at = str(source.get("emitted_at", ""))
+
+            return ModelDecisionRecord(
+                task_id=task_id,
+                session_id=session_id,
+                decision_text=decision_text,
+                context=context,
+                timestamp=emitted_at,
+            )
+
+        except Exception:
+            logger.exception("Failed to extract decision from event")
+            return None
+
+    def extract_decision_from_coordination(
+        self,
+        signal: dict[str, object],
+    ) -> ModelDecisionRecord | None:
+        """Extract a synthetic decision from a coordination signal.
+
+        Coordination signals like PR_MERGED and TICKET_COMPLETED carry
+        implicit decisions that are useful for semantic recall.
+
+        Formats:
+            PR_MERGED: "Decided to merge PR #{pr_number}: {rationale}"
+            TICKET_COMPLETED: "Completed {task_id}: {summary}"
+
+        Args:
+            signal: Raw coordination signal dict with signal_type, task_id, etc.
+
+        Returns:
+            A ModelDecisionRecord, or None if the signal should be skipped.
+        """
+        try:
+            signal_type = signal.get("signal_type")
+            if not isinstance(signal_type, str):
+                return None
+            if signal_type not in _COORDINATION_SIGNAL_TYPES:
+                return None
+
+            task_id = signal.get("task_id")
+            if not task_id or not isinstance(task_id, str):
+                return None
+
+            session_id = str(signal.get("session_id", "unknown"))
+            emitted_at = str(signal.get("emitted_at", ""))
+
+            if signal_type == "PR_MERGED":
+                pr_number = signal.get("pr_number", "?")
+                rationale = signal.get("rationale", "")
+                decision_text = f"Decided to merge PR #{pr_number}: {rationale}"
+                context = "coordination:pr_merged"
+            elif signal_type == "TICKET_COMPLETED":
+                summary = signal.get("summary", "")
+                decision_text = f"Completed {task_id}: {summary}"
+                context = "coordination:ticket_completed"
+            else:
+                return None
+
+            return ModelDecisionRecord(
+                task_id=task_id,
+                session_id=session_id,
+                decision_text=decision_text,
+                context=context,
+                timestamp=emitted_at,
+            )
+
+        except Exception:
+            logger.exception("Failed to extract decision from coordination signal")
+            return None
+
+    async def project(self, event: dict[str, object]) -> bool:
+        """Full projection pipeline: extract -> embed -> upsert.
+
+        Args:
+            event: Raw deserialized Kafka event dict.
+
+        Returns:
+            True if the event was successfully projected, False if skipped.
+        """
+        if self._embedder is None or self._qdrant is None:
+            logger.warning("DecisionProjector not fully initialized (embedder/qdrant)")
+            return False
+
+        # Try decision.recorded extraction first.
+        record = self.extract_decision(event)
+
+        # Fall back to coordination signal extraction.
+        if record is None:
+            record = self.extract_decision_from_coordination(event)
+
+        if record is None:
+            return False
+
+        try:
+            text = build_embedding_text(record)
+            vector = await self._embedder.embed(text)
+            self._qdrant.upsert(record, vector)
+            logger.info(
+                "Projected decision for task=%s text=%s",
+                record.task_id,
+                record.decision_text[:50],
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "Failed to project decision for task=%s",
+                record.task_id,
+            )
+            return False
+
+
+__all__ = [
+    "CONSUMER_GROUP",
+    "DECISION_RECORDED_TOPIC",
+    "DecisionProjector",
+]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2843,6 +2843,23 @@ pattern_exemptions:
     documentation:
       - docs/plans/2026-03-27-multi-session-coordination.md (Doctrine D2)
     ticket: OMN-6853
+  # ==========================================================================
+  # ModelDecisionRecord task_id / session_id Exemptions (OMN-6863)
+  # ==========================================================================
+  # task_id is a Linear ticket ID ("OMN-1234"), session_id is a CLI session
+  # identifier — neither are UUIDs. Same reasoning as ModelSessionRegistryEntry.
+  - file_pattern: 'session_registry.*decision_embedder\.py'
+    violation_pattern: "Field 'task_id' should use UUID type instead of str"
+    reason: >
+      task_id is a human-readable Linear ticket identifier (e.g., "OMN-1234"), not a UUID. See plan Doctrine D2.
+
+    ticket: OMN-6863
+  - file_pattern: 'session_registry.*decision_embedder\.py'
+    violation_pattern: "Field 'session_id' should use UUID type instead of str"
+    reason: >
+      session_id is a CLI session identifier string, not a UUID. It comes from Claude Code hook events where session IDs are opaque strings.
+
+    ticket: OMN-6863
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/unit/services/session_registry/test_decision_embedder.py
+++ b/tests/unit/services/session_registry/test_decision_embedder.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for decision embedding models and utilities.
+
+Tests ModelDecisionRecord creation, embedding text generation,
+and deterministic point ID generation.
+
+Part of OMN-6850, Task 12/13.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.services.session_registry.decision_embedder import (
+    ModelDecisionRecord,
+    build_embedding_text,
+    decision_point_id,
+)
+
+
+@pytest.mark.unit
+class TestModelDecisionRecord:
+    """Tests for ModelDecisionRecord Pydantic model."""
+
+    def test_decision_record_creation(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-1234",
+            session_id="session-abc",
+            decision_text="Chose approach B: extend ModelFoo rather than creating ModelBar",
+            context="Working on auth middleware refactor",
+        )
+        assert record.task_id == "OMN-1234"
+        assert record.session_id == "session-abc"
+        assert "approach B" in record.decision_text
+
+    def test_decision_record_minimal(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-5678",
+            session_id="s1",
+            decision_text="Use Postgres",
+        )
+        assert record.context == ""
+        assert record.timestamp == ""
+
+    def test_decision_record_frozen(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-1234",
+            session_id="s1",
+            decision_text="Use Postgres",
+        )
+        with pytest.raises(Exception):
+            record.task_id = "OMN-9999"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestBuildEmbeddingText:
+    """Tests for build_embedding_text utility."""
+
+    def test_embedding_text_includes_context(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-1234",
+            session_id="s1",
+            decision_text="Use Postgres for session state",
+            context="Multi-session coordination design",
+        )
+        text = build_embedding_text(record)
+        assert "Use Postgres" in text
+        assert "Multi-session" in text
+        assert "OMN-1234" in text
+
+    def test_embedding_text_without_context(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-5678",
+            session_id="s1",
+            decision_text="Use Kafka for events",
+        )
+        text = build_embedding_text(record)
+        assert "Use Kafka" in text
+        assert "OMN-5678" in text
+        assert "Context" not in text
+
+    def test_embedding_text_format(self) -> None:
+        record = ModelDecisionRecord(
+            task_id="OMN-1",
+            session_id="s1",
+            decision_text="decision A",
+            context="ctx B",
+        )
+        text = build_embedding_text(record)
+        assert text == "Task OMN-1: decision A. Context: ctx B"
+
+
+@pytest.mark.unit
+class TestDecisionPointId:
+    """Tests for deterministic point ID generation."""
+
+    def test_deterministic(self) -> None:
+        id1 = decision_point_id("OMN-1234", "Use Postgres")
+        id2 = decision_point_id("OMN-1234", "Use Postgres")
+        assert id1 == id2
+
+    def test_different_text_different_id(self) -> None:
+        id1 = decision_point_id("OMN-1234", "Use Postgres")
+        id2 = decision_point_id("OMN-1234", "Use Redis")
+        assert id1 != id2
+
+    def test_different_task_different_id(self) -> None:
+        id1 = decision_point_id("OMN-1234", "Use Postgres")
+        id2 = decision_point_id("OMN-5678", "Use Postgres")
+        assert id1 != id2

--- a/tests/unit/services/session_registry/test_decision_projector.py
+++ b/tests/unit/services/session_registry/test_decision_projector.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for DecisionProjector.
+
+Tests extraction of decision records from decision.recorded events
+and coordination signals, plus the full projection pipeline with mocks.
+
+Part of OMN-6850, Task 13.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.services.session_registry.decision_projector import (
+    CONSUMER_GROUP,
+    DECISION_RECORDED_TOPIC,
+    DecisionProjector,
+)
+
+
+@pytest.mark.unit
+class TestDecisionProjectorExtraction:
+    """Tests for DecisionProjector.extract_decision()."""
+
+    def test_extracts_decision_from_decision_recorded_event(self) -> None:
+        event = {
+            "event_type": "decision.recorded",
+            "payload": {
+                "session_id": "s1",
+                "task_id": "OMN-1234",
+                "decision_text": "Use approach B for retry logic",
+                "rationale": "Approach A requires new dependency",
+                "emitted_at": "2026-03-27T14:00:00Z",
+            },
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision(event)
+        assert record is not None
+        assert record.decision_text == "Use approach B for retry logic"
+        assert record.task_id == "OMN-1234"
+        assert record.session_id == "s1"
+        assert record.context == "Approach A requires new dependency"
+
+    def test_skips_events_without_task_id(self) -> None:
+        event = {
+            "event_type": "decision.recorded",
+            "payload": {
+                "session_id": "s1",
+                "task_id": None,
+                "decision_text": "something",
+            },
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision(event)
+        assert record is None
+
+    def test_skips_events_without_decision_text(self) -> None:
+        event = {
+            "event_type": "decision.recorded",
+            "payload": {
+                "session_id": "s1",
+                "task_id": "OMN-1234",
+                "decision_text": "",
+            },
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision(event)
+        assert record is None
+
+    def test_extracts_from_flat_event(self) -> None:
+        """Events without a nested payload dict should still work."""
+        event = {
+            "event_type": "decision.recorded",
+            "task_id": "OMN-5678",
+            "session_id": "s2",
+            "decision_text": "Use Kafka for events",
+            "rationale": "",
+            "emitted_at": "2026-03-27T15:00:00Z",
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision(event)
+        assert record is not None
+        assert record.task_id == "OMN-5678"
+
+    def test_handles_malformed_event(self) -> None:
+        """Malformed events should return None, not raise."""
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision({})
+        assert record is None
+
+
+@pytest.mark.unit
+class TestDecisionProjectorCoordination:
+    """Tests for DecisionProjector.extract_decision_from_coordination()."""
+
+    def test_pr_merged_signal(self) -> None:
+        signal = {
+            "signal_type": "PR_MERGED",
+            "task_id": "OMN-1234",
+            "session_id": "s1",
+            "pr_number": 47,
+            "rationale": "All tests pass, approved by reviewer",
+            "emitted_at": "2026-03-27T16:00:00Z",
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision_from_coordination(signal)
+        assert record is not None
+        assert "merge PR #47" in record.decision_text
+        assert "All tests pass" in record.decision_text
+        assert record.context == "coordination:pr_merged"
+
+    def test_ticket_completed_signal(self) -> None:
+        signal = {
+            "signal_type": "TICKET_COMPLETED",
+            "task_id": "OMN-5678",
+            "session_id": "s1",
+            "summary": "Implemented retry logic with exponential backoff",
+            "emitted_at": "2026-03-27T17:00:00Z",
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision_from_coordination(signal)
+        assert record is not None
+        assert "Completed OMN-5678" in record.decision_text
+        assert "retry logic" in record.decision_text
+        assert record.context == "coordination:ticket_completed"
+
+    def test_skips_unknown_signal_type(self) -> None:
+        signal = {
+            "signal_type": "UNKNOWN",
+            "task_id": "OMN-1234",
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision_from_coordination(signal)
+        assert record is None
+
+    def test_skips_signal_without_task_id(self) -> None:
+        signal = {
+            "signal_type": "PR_MERGED",
+            "task_id": None,
+            "pr_number": 47,
+        }
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        record = projector.extract_decision_from_coordination(signal)
+        assert record is None
+
+
+@pytest.mark.unit
+class TestDecisionProjectorProject:
+    """Tests for the full projection pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_project_success(self) -> None:
+        mock_embedder = MagicMock()
+        mock_embedder.embed = AsyncMock(return_value=[0.1] * 1024)
+        mock_writer = MagicMock()
+
+        projector = DecisionProjector(embedder=mock_embedder, qdrant=mock_writer)
+        event = {
+            "event_type": "decision.recorded",
+            "payload": {
+                "session_id": "s1",
+                "task_id": "OMN-1234",
+                "decision_text": "Use Postgres",
+                "rationale": "Best fit for relational data",
+                "emitted_at": "2026-03-27T14:00:00Z",
+            },
+        }
+        result = await projector.project(event)
+        assert result is True
+        mock_embedder.embed.assert_awaited_once()
+        mock_writer.upsert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_project_skips_empty_event(self) -> None:
+        mock_embedder = MagicMock()
+        mock_writer = MagicMock()
+
+        projector = DecisionProjector(embedder=mock_embedder, qdrant=mock_writer)
+        result = await projector.project({})
+        assert result is False
+        mock_embedder.embed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_project_falls_back_to_coordination(self) -> None:
+        mock_embedder = MagicMock()
+        mock_embedder.embed = AsyncMock(return_value=[0.1] * 1024)
+        mock_writer = MagicMock()
+
+        projector = DecisionProjector(embedder=mock_embedder, qdrant=mock_writer)
+        signal = {
+            "signal_type": "PR_MERGED",
+            "task_id": "OMN-1234",
+            "session_id": "s1",
+            "pr_number": 47,
+            "rationale": "Tests pass",
+        }
+        result = await projector.project(signal)
+        assert result is True
+        mock_writer.upsert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_project_returns_false_when_uninitialized(self) -> None:
+        projector = DecisionProjector(embedder=None, qdrant=None)
+        event = {
+            "payload": {
+                "task_id": "OMN-1234",
+                "session_id": "s1",
+                "decision_text": "Use Postgres",
+            },
+        }
+        result = await projector.project(event)
+        assert result is False
+
+
+@pytest.mark.unit
+class TestDecisionProjectorConstants:
+    """Tests for module-level constants."""
+
+    def test_consumer_group(self) -> None:
+        assert CONSUMER_GROUP == "omnibase_infra.session_registry.decision_project.v1"
+
+    def test_topic(self) -> None:
+        assert (
+            DECISION_RECORDED_TOPIC == "onex.evt.omniintelligence.decision-recorded.v1"
+        )


### PR DESCRIPTION
## Summary

- Add `DecisionProjector` Kafka consumer that subscribes to `onex.evt.omniintelligence.decision-recorded.v1` and projects decision records into Qdrant `session_decisions` collection via embeddings
- Includes `ModelDecisionRecord`, `EmbeddingClient`, `DecisionEmbedderWriter` as dependency types (also needed by OMN-6862)
- Handles coordination signals (PR_MERGED, TICKET_COMPLETED) as synthetic decision records for semantic recall
- 24 unit tests covering extraction, coordination signals, and full projection pipeline

## Files Changed

- `src/omnibase_infra/services/session_registry/decision_embedder.py` — Decision record model, embedding text builder, Qdrant writer, embedding client
- `src/omnibase_infra/services/session_registry/decision_projector.py` — Kafka-to-Qdrant projector with dual extraction paths
- `tests/unit/services/session_registry/test_decision_embedder.py` — 9 tests for models and utilities
- `tests/unit/services/session_registry/test_decision_projector.py` — 15 tests for extraction, coordination, and projection
- `src/omnibase_infra/validation/validation_exemptions.yaml` — Pattern validation exemptions for str-typed task_id/session_id

## Test plan

- [x] 24 unit tests pass locally (`pytest -xvs`)
- [x] ruff check passes
- [x] mypy strict passes
- [x] All pre-commit hooks pass

Part of epic OMN-6850 (Multi-Session Coordination Layer), Task 13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added decision recording and embedding storage system for session events.
  * Introduced event processing capability to capture and embed decision records from messaging systems.
  * Automatic embedding generation and vector storage for decision data.

* **Tests**
  * Added comprehensive unit test coverage for decision recording and embedding utilities.
  * Added unit tests for decision event extraction and processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->