### PR TITLE
feat: add decision embedding pipeline for Qdrant [OMN-6862]

### DIFF
--- a/src/omnibase_infra/services/session_registry/decision_embedder.py
+++ b/src/omnibase_infra/services/session_registry/decision_embedder.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Decision embedding pipeline for Qdrant vector store.
+
+Embeds architectural and design decisions made during multi-session
+coordination into Qdrant for semantic recall. Each decision is a single
+text string embedded as one vector -- no chunking required.
+
+Doctrine D7: Decision recall is enrichment only -- does not bloat
+default resume context. Consumers pull from Qdrant on demand.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 12).
+
+Components:
+    - ModelDecisionRecord: Typed record for a single decision.
+    - build_embedding_text: Formats a decision record into embedding input.
+    - DecisionEmbedder: Async client that embeds and upserts to Qdrant.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import datetime
+from uuid import UUID, uuid5
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qdrant_models
+
+logger = logging.getLogger(__name__)
+
+# Qdrant collection configuration
+COLLECTION_NAME = "session_decisions"
+VECTOR_DIMENSION = 1024
+DISTANCE_METRIC = qdrant_models.Distance.COSINE
+
+# Namespace for deterministic point IDs (uuid5)
+_DECISION_NAMESPACE = UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # NAMESPACE_DNS
+
+# Default embedding endpoint
+_DEFAULT_EMBEDDING_URL = "http://192.168.86.200:8100"
+
+
+class ModelDecisionRecord(BaseModel):
+    """A single decision record for embedding into Qdrant.
+
+    Each record represents one architectural or design decision made
+    during task execution. The combination of task_id + decision_text
+    hash produces a deterministic point ID for idempotent upserts.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str = Field(  # onex:str-not-uuid — Linear ticket ID, not a UUID
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Linear ticket ID (e.g., 'OMN-1234').",
+    )
+    session_id: str = Field(  # onex:str-not-uuid — CLI session ID, not a UUID
+        ...,
+        min_length=1,
+        description="CLI session ID that produced this decision.",
+    )
+    decision_text: str = Field(
+        ...,
+        min_length=1,
+        description="The decision content.",
+    )
+    context: str = Field(
+        default="",
+        description="Additional context for the decision.",
+    )
+    timestamp: datetime = Field(
+        ...,
+        description="When the decision was made.",
+    )
+
+
+def build_embedding_text(record: ModelDecisionRecord) -> str:
+    """Format a decision record into a single string for embedding.
+
+    The format is designed to produce semantically meaningful vectors
+    that capture both the decision content and its task context.
+
+    Args:
+        record: The decision record to format.
+
+    Returns:
+        A formatted string suitable for embedding.
+    """
+    text = f"Task {record.task_id}: {record.decision_text}"
+    if record.context:
+        text += f". Context: {record.context}"
+    return text
+
+
+def _decision_point_id(task_id: str, decision_text: str) -> str:
+    """Compute a deterministic Qdrant point ID for a decision.
+
+    Uses uuid5(NAMESPACE_DNS, "{task_id}:{sha256_of_decision_text}")
+    so re-upserting the same decision is idempotent.
+
+    Args:
+        task_id: The Linear ticket ID.
+        decision_text: The raw decision text.
+
+    Returns:
+        A UUID string for the Qdrant point ID.
+    """
+    decision_hash = hashlib.sha256(decision_text.encode()).hexdigest()[:16]
+    return str(uuid5(_DECISION_NAMESPACE, f"{task_id}:{decision_hash}"))
+
+
+class DecisionEmbedder:
+    """Async client that embeds decision records and upserts to Qdrant.
+
+    Uses httpx for async embedding requests to the Qwen3-Embedding-8B
+    endpoint and qdrant-client for vector storage.
+
+    Usage::
+
+        embedder = DecisionEmbedder()
+        await embedder.ensure_collection()
+        await embedder.embed_and_upsert(record)
+    """
+
+    def __init__(
+        self,
+        *,
+        qdrant_url: str | None = None,
+        qdrant_port: int | None = None,
+        embedding_url: str | None = None,
+    ) -> None:
+        self._qdrant_url = qdrant_url or os.getenv(
+            "QDRANT_URL", "http://localhost:6333"
+        )
+        self._qdrant_port = qdrant_port or int(os.getenv("QDRANT_PORT", "6333"))
+        self._embedding_url = embedding_url or os.getenv(
+            "LLM_EMBEDDING_URL", _DEFAULT_EMBEDDING_URL
+        )
+        self._qdrant = QdrantClient(url=self._qdrant_url)
+
+    async def ensure_collection(self) -> None:
+        """Create the session_decisions collection if it does not exist."""
+        collections = self._qdrant.get_collections().collections
+        existing = {c.name for c in collections}
+        if COLLECTION_NAME not in existing:
+            self._qdrant.create_collection(
+                collection_name=COLLECTION_NAME,
+                vectors_config=qdrant_models.VectorParams(
+                    size=VECTOR_DIMENSION,
+                    distance=DISTANCE_METRIC,
+                ),
+            )
+            logger.info("Created Qdrant collection '%s'", COLLECTION_NAME)
+
+    async def _get_embedding(self, text: str) -> list[float]:
+        """Request an embedding vector from the embedding endpoint.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            A list of floats representing the embedding vector.
+
+        Raises:
+            httpx.HTTPStatusError: If the embedding request fails.
+        """
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self._embedding_url}/v1/embeddings",
+                json={"input": text, "model": "default"},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["data"][0]["embedding"]
+
+    async def embed_and_upsert(self, record: ModelDecisionRecord) -> str:
+        """Embed a decision record and upsert it into Qdrant.
+
+        Args:
+            record: The decision record to embed and store.
+
+        Returns:
+            The point ID (UUID string) of the upserted point.
+        """
+        text = build_embedding_text(record)
+        vector = await self._get_embedding(text)
+
+        point_id = _decision_point_id(record.task_id, record.decision_text)
+
+        self._qdrant.upsert(
+            collection_name=COLLECTION_NAME,
+            points=[
+                qdrant_models.PointStruct(
+                    id=point_id,
+                    vector=vector,
+                    payload={
+                        "task_id": record.task_id,
+                        "session_id": record.session_id,
+                        "decision_text": record.decision_text,
+                        "context": record.context,
+                        "timestamp": record.timestamp.isoformat(),
+                        "embedding_text": text,
+                    },
+                ),
+            ],
+        )
+        logger.info(
+            "Upserted decision for task %s (point_id=%s)", record.task_id, point_id
+        )
+        return point_id
+
+    async def search_similar(
+        self,
+        query_text: str,
+        *,
+        limit: int = 5,
+        task_id_filter: str | None = None,
+    ) -> list[qdrant_models.ScoredPoint]:
+        """Search for decisions similar to the query text.
+
+        Args:
+            query_text: The text to find similar decisions for.
+            limit: Maximum number of results.
+            task_id_filter: Optional filter to restrict results to a specific task.
+
+        Returns:
+            A list of scored points from Qdrant.
+        """
+        vector = await self._get_embedding(query_text)
+
+        query_filter = None
+        if task_id_filter:
+            query_filter = qdrant_models.Filter(
+                must=[
+                    qdrant_models.FieldCondition(
+                        key="task_id",
+                        match=qdrant_models.MatchValue(value=task_id_filter),
+                    ),
+                ],
+            )
+
+        return self._qdrant.query_points(
+            collection_name=COLLECTION_NAME,
+            query=vector,
+            query_filter=query_filter,
+            limit=limit,
+        ).points

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2843,6 +2843,36 @@ pattern_exemptions:
     documentation:
       - docs/plans/2026-03-27-multi-session-coordination.md (Doctrine D2)
     ticket: OMN-6853
+  # ==========================================================================
+  # Decision Embedder Exemptions (OMN-6862)
+  # ==========================================================================
+  # task_id and session_id in ModelDecisionRecord are human-readable string
+  # identifiers, not UUIDs. task_id is a Linear ticket ID (e.g., "OMN-1234")
+  # and session_id is a CLI session identifier string.
+  - file_pattern: 'decision_embedder\.py'
+    violation_pattern: "Field 'task_id' should use UUID"
+    reason: >
+      task_id is a human-readable Linear ticket identifier (e.g., "OMN-1234"), not a UUID. Matches ModelSessionRegistryEntry.task_id convention.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md
+    ticket: OMN-6862
+  - file_pattern: 'decision_embedder\.py'
+    violation_pattern: "Field 'session_id' should use UUID"
+    reason: >
+      session_id is a CLI session identifier string, not a UUID. Matches existing session_id conventions in the session registry.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md
+    ticket: OMN-6862
+  - file_pattern: 'decision_search\.py'
+    violation_pattern: "Field 'task_id' should use UUID"
+    reason: >
+      task_id is a human-readable Linear ticket identifier (e.g., "OMN-1234"), not a UUID. Part of the decision search query interface.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md
+    ticket: OMN-6864
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:
@@ -2952,7 +2982,29 @@ architecture_exemptions:
     documentation:
       - CLAUDE.md (Protocol File Naming - domain-grouping convention)
     ticket: OMN-5060
-# These handle complex union type violations
+    # These handle complex union type violations
+  # ==========================================================================
+  # Decision Embedder Exemptions (OMN-6862)
+  # ==========================================================================
+  # task_id and session_id in ModelDecisionRecord are human-readable string
+  # identifiers, not UUIDs. task_id is a Linear ticket ID (e.g., 'OMN-1234')
+  # and session_id is a CLI session identifier string.
+  - file_pattern: 'decision_embedder\.py'
+    violation_pattern: "Field 'task_id' should use UUID"
+    reason: >
+      task_id is a human-readable Linear ticket identifier (e.g., 'OMN-1234'), not a UUID. Matches ModelSessionRegistryEntry.task_id convention.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md
+    ticket: OMN-6862
+  - file_pattern: 'decision_embedder\.py'
+    violation_pattern: "Field 'session_id' should use UUID"
+    reason: >
+      session_id is a CLI session identifier string, not a UUID. Matches existing session_id conventions in the session registry.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md
+    ticket: OMN-6862
 union_exemptions:
   # ==========================================================================
   # ModelNodeCapabilities Config Field Exemption

--- a/tests/unit/services/session_registry/test_decision_embedder.py
+++ b/tests/unit/services/session_registry/test_decision_embedder.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the decision embedding pipeline for Qdrant.
+
+Tests ModelDecisionRecord creation, build_embedding_text formatting,
+deterministic point ID generation, and DecisionEmbedder methods with
+mocked Qdrant and embedding endpoints.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 12).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.services.session_registry.decision_embedder import (
+    COLLECTION_NAME,
+    VECTOR_DIMENSION,
+    DecisionEmbedder,
+    ModelDecisionRecord,
+    _decision_point_id,
+    build_embedding_text,
+)
+
+
+@pytest.fixture
+def sample_record() -> ModelDecisionRecord:
+    """Create a sample decision record for testing."""
+    return ModelDecisionRecord(
+        task_id="OMN-1234",
+        session_id="sess-abc-123",
+        decision_text="Use Kafka for async communication",
+        context="Existing Redpanda infra supports this pattern",
+        timestamp=datetime(2026, 3, 27, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def sample_record_no_context() -> ModelDecisionRecord:
+    """Create a sample decision record without context."""
+    return ModelDecisionRecord(
+        task_id="OMN-5678",
+        session_id="sess-def-456",
+        decision_text="Pin qdrant-client to v1.16+",
+        context="",
+        timestamp=datetime(2026, 3, 27, 14, 0, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.unit
+class TestModelDecisionRecord:
+    """Tests for ModelDecisionRecord validation."""
+
+    def test_valid_creation(self, sample_record: ModelDecisionRecord) -> None:
+        assert sample_record.task_id == "OMN-1234"
+        assert sample_record.session_id == "sess-abc-123"
+        assert sample_record.decision_text == "Use Kafka for async communication"
+
+    def test_frozen_immutability(self, sample_record: ModelDecisionRecord) -> None:
+        with pytest.raises(Exception):  # ValidationError for frozen model
+            sample_record.task_id = "OMN-9999"  # type: ignore[misc]
+
+    def test_forbids_extra_fields(self) -> None:
+        with pytest.raises(Exception):
+            ModelDecisionRecord(
+                task_id="OMN-1234",
+                session_id="sess-abc",
+                decision_text="test",
+                timestamp=datetime.now(tz=UTC),
+                unknown_field="bad",  # type: ignore[call-arg]
+            )
+
+    def test_requires_task_id(self) -> None:
+        with pytest.raises(Exception):
+            ModelDecisionRecord(
+                task_id="",
+                session_id="sess-abc",
+                decision_text="test",
+                timestamp=datetime.now(tz=UTC),
+            )
+
+    def test_requires_decision_text(self) -> None:
+        with pytest.raises(Exception):
+            ModelDecisionRecord(
+                task_id="OMN-1234",
+                session_id="sess-abc",
+                decision_text="",
+                timestamp=datetime.now(tz=UTC),
+            )
+
+
+@pytest.mark.unit
+class TestBuildEmbeddingText:
+    """Tests for build_embedding_text formatting."""
+
+    def test_with_context(self, sample_record: ModelDecisionRecord) -> None:
+        text = build_embedding_text(sample_record)
+        assert text == (
+            "Task OMN-1234: Use Kafka for async communication. "
+            "Context: Existing Redpanda infra supports this pattern"
+        )
+
+    def test_without_context(
+        self, sample_record_no_context: ModelDecisionRecord
+    ) -> None:
+        text = build_embedding_text(sample_record_no_context)
+        assert text == "Task OMN-5678: Pin qdrant-client to v1.16+"
+        assert "Context:" not in text
+
+    def test_preserves_task_id_prefix(self, sample_record: ModelDecisionRecord) -> None:
+        text = build_embedding_text(sample_record)
+        assert text.startswith("Task OMN-1234:")
+
+
+@pytest.mark.unit
+class TestDecisionPointId:
+    """Tests for deterministic point ID generation."""
+
+    def test_deterministic(self) -> None:
+        id1 = _decision_point_id("OMN-1234", "Use Kafka")
+        id2 = _decision_point_id("OMN-1234", "Use Kafka")
+        assert id1 == id2
+
+    def test_different_for_different_text(self) -> None:
+        id1 = _decision_point_id("OMN-1234", "Use Kafka")
+        id2 = _decision_point_id("OMN-1234", "Use RabbitMQ")
+        assert id1 != id2
+
+    def test_different_for_different_task(self) -> None:
+        id1 = _decision_point_id("OMN-1234", "Use Kafka")
+        id2 = _decision_point_id("OMN-5678", "Use Kafka")
+        assert id1 != id2
+
+    def test_returns_valid_uuid_string(self) -> None:
+        point_id = _decision_point_id("OMN-1234", "test")
+        # uuid5 returns a UUID with dashes
+        parts = point_id.split("-")
+        assert len(parts) == 5
+
+
+@pytest.mark.unit
+class TestDecisionEmbedderEnsureCollection:
+    """Tests for DecisionEmbedder.ensure_collection."""
+
+    @pytest.mark.asyncio
+    async def test_creates_collection_when_missing(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_qdrant.get_collections.return_value = MagicMock(collections=[])
+
+        with patch(
+            "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+            return_value=mock_qdrant,
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            await embedder.ensure_collection()
+
+        mock_qdrant.create_collection.assert_called_once()
+        call_kwargs = mock_qdrant.create_collection.call_args
+        assert call_kwargs.kwargs["collection_name"] == COLLECTION_NAME
+
+    @pytest.mark.asyncio
+    async def test_skips_creation_when_exists(self) -> None:
+        existing = MagicMock()
+        existing.name = COLLECTION_NAME
+        mock_qdrant = MagicMock()
+        mock_qdrant.get_collections.return_value = MagicMock(collections=[existing])
+
+        with patch(
+            "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+            return_value=mock_qdrant,
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            await embedder.ensure_collection()
+
+        mock_qdrant.create_collection.assert_not_called()
+
+
+@pytest.mark.unit
+class TestDecisionEmbedderEmbedAndUpsert:
+    """Tests for DecisionEmbedder.embed_and_upsert."""
+
+    @pytest.mark.asyncio
+    async def test_upserts_to_qdrant(self, sample_record: ModelDecisionRecord) -> None:
+        mock_qdrant = MagicMock()
+        fake_vector = [0.1] * VECTOR_DIMENSION
+
+        with (
+            patch(
+                "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+                return_value=mock_qdrant,
+            ),
+            patch.object(
+                DecisionEmbedder,
+                "_get_embedding",
+                new_callable=AsyncMock,
+                return_value=fake_vector,
+            ),
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            point_id = await embedder.embed_and_upsert(sample_record)
+
+        assert point_id is not None
+        mock_qdrant.upsert.assert_called_once()
+        call_kwargs = mock_qdrant.upsert.call_args
+        assert call_kwargs.kwargs["collection_name"] == COLLECTION_NAME
+
+    @pytest.mark.asyncio
+    async def test_idempotent_point_id(
+        self, sample_record: ModelDecisionRecord
+    ) -> None:
+        mock_qdrant = MagicMock()
+        fake_vector = [0.1] * VECTOR_DIMENSION
+
+        with (
+            patch(
+                "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+                return_value=mock_qdrant,
+            ),
+            patch.object(
+                DecisionEmbedder,
+                "_get_embedding",
+                new_callable=AsyncMock,
+                return_value=fake_vector,
+            ),
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            id1 = await embedder.embed_and_upsert(sample_record)
+            id2 = await embedder.embed_and_upsert(sample_record)
+
+        assert id1 == id2
+
+    @pytest.mark.asyncio
+    async def test_payload_contains_all_fields(
+        self, sample_record: ModelDecisionRecord
+    ) -> None:
+        mock_qdrant = MagicMock()
+        fake_vector = [0.1] * VECTOR_DIMENSION
+
+        with (
+            patch(
+                "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+                return_value=mock_qdrant,
+            ),
+            patch.object(
+                DecisionEmbedder,
+                "_get_embedding",
+                new_callable=AsyncMock,
+                return_value=fake_vector,
+            ),
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            await embedder.embed_and_upsert(sample_record)
+
+        call_kwargs = mock_qdrant.upsert.call_args
+        points = call_kwargs.kwargs["points"]
+        payload = points[0].payload
+        assert payload["task_id"] == "OMN-1234"
+        assert payload["session_id"] == "sess-abc-123"
+        assert payload["decision_text"] == "Use Kafka for async communication"
+        assert payload["context"] == "Existing Redpanda infra supports this pattern"
+        assert "timestamp" in payload
+        assert "embedding_text" in payload
+
+
+@pytest.mark.unit
+class TestDecisionEmbedderSearchSimilar:
+    """Tests for DecisionEmbedder.search_similar."""
+
+    @pytest.mark.asyncio
+    async def test_search_without_filter(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_qdrant.query_points.return_value = MagicMock(points=[])
+        fake_vector = [0.1] * VECTOR_DIMENSION
+
+        with (
+            patch(
+                "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+                return_value=mock_qdrant,
+            ),
+            patch.object(
+                DecisionEmbedder,
+                "_get_embedding",
+                new_callable=AsyncMock,
+                return_value=fake_vector,
+            ),
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            results = await embedder.search_similar("Kafka usage")
+
+        assert results == []
+        mock_qdrant.query_points.assert_called_once()
+        call_kwargs = mock_qdrant.query_points.call_args
+        assert call_kwargs.kwargs["query_filter"] is None
+        assert call_kwargs.kwargs["limit"] == 5
+
+    @pytest.mark.asyncio
+    async def test_search_with_task_filter(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_qdrant.query_points.return_value = MagicMock(points=[])
+        fake_vector = [0.1] * VECTOR_DIMENSION
+
+        with (
+            patch(
+                "omnibase_infra.services.session_registry.decision_embedder.QdrantClient",
+                return_value=mock_qdrant,
+            ),
+            patch.object(
+                DecisionEmbedder,
+                "_get_embedding",
+                new_callable=AsyncMock,
+                return_value=fake_vector,
+            ),
+        ):
+            embedder = DecisionEmbedder(qdrant_url="http://localhost:6333")
+            await embedder.search_similar("Kafka", task_id_filter="OMN-1234")
+
+        call_kwargs = mock_qdrant.query_points.call_args
+        assert call_kwargs.kwargs["query_filter"] is not None


### PR DESCRIPTION
## Summary

- Add `DecisionEmbedder` service for embedding architectural decisions into Qdrant vector store
- Implement `ModelDecisionRecord` Pydantic model with deterministic uuid5-based point IDs for idempotent upserts
- Add `search_similar()` method for semantic decision recall with optional task_id filtering

## Details

Part of Multi-Session Coordination Layer (OMN-6850, Task 12).

**Collection**: `session_decisions`, 1024-dim cosine vectors from Qwen3-Embedding-8B.

**Doctrine D7 compliance**: Decision recall is enrichment-only — consumers pull from Qdrant on demand, does not bloat default resume context.

**Not reusing HandlerQdrant** from omnimemory (that's for document chunking/crawling). Decision embedding is simpler: one text string = one vector, no chunking.

## Files

- `src/omnibase_infra/services/session_registry/decision_embedder.py` — New module
- `tests/unit/services/session_registry/test_decision_embedder.py` — 19 unit tests
- `src/omnibase_infra/validation/validation_exemptions.yaml` — Pattern exemptions for str IDs

## Test plan

- [x] 19 unit tests pass covering model validation, embedding text formatting, deterministic point IDs, collection creation, upsert, and search
- [x] mypy --strict passes
- [x] ruff check passes
- [x] All pre-commit hooks pass