### PR TITLE
feat: semantic decision search via Qdrant [OMN-6864]

### DIFF
--- a/src/omnibase_infra/services/session_registry/decision_search.py
+++ b/src/omnibase_infra/services/session_registry/decision_search.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Semantic search over session decisions stored in Qdrant.
+
+Methods:
+  - search(query, limit, task_id) -> list[ModelDecisionSearchResult]
+    Embeds the query, searches Qdrant "session_decisions" collection.
+    Optional task_id filter to scope search to a specific task.
+
+  - search_related(task_id, limit) -> list[ModelDecisionSearchResult]
+    Finds decisions from OTHER tasks that are semantically similar to
+    decisions made in the given task.
+
+  - format_results(results) -> str
+    Human-readable formatted output for context injection.
+
+Collection: "session_decisions"
+Embedding: Qwen3-Embedding-8B on port 8100 via OpenAI-compatible API.
+
+Doctrine D7: Qdrant-based decision recall is enrichment only. It should
+not bloat default resume context unless it demonstrably improves real
+resume quality in measured use.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 14).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qdrant_models
+
+logger = logging.getLogger(__name__)
+
+_COLLECTION_NAME = "session_decisions"
+_DEFAULT_EMBEDDING_URL = "http://192.168.86.200:8100"
+_DEFAULT_EMBEDDING_MODEL = "Qwen3-Embedding-8B"
+
+
+class ModelDecisionSearchResult(BaseModel):
+    """A single decision search result from Qdrant.
+
+    Attributes:
+        task_id: The task that made this decision.
+        decision_text: The decision content.
+        context: Context in which the decision was made.
+        score: Similarity score (0.0 to 1.0).
+        timestamp: When the decision was recorded.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str = Field(  # onex:str-not-uuid — Linear ticket ID, not a UUID
+        ..., description="Task that made this decision"
+    )
+    decision_text: str = Field(..., description="Decision content")
+    context: str = Field(default="", description="Context of the decision")
+    score: float = Field(..., ge=0.0, le=1.0, description="Similarity score")
+    timestamp: str = Field(default="", description="When the decision was recorded")
+
+
+class DecisionSearchClient:
+    """Client for semantic search over session decisions in Qdrant.
+
+    Args:
+        qdrant: QdrantClient instance (None for format-only usage).
+        embedder: Callable that takes text and returns embedding vector.
+            If None, uses the default HTTP embedding client.
+    """
+
+    def __init__(
+        self,
+        qdrant: QdrantClient | None = None,
+        embedder: object | None = None,
+    ) -> None:
+        self._qdrant = qdrant
+        self._embedder = embedder
+
+    async def _embed(self, text: str) -> list[float]:
+        """Embed text using the configured embedding endpoint.
+
+        Falls back to the default Qwen3-Embedding-8B endpoint if no
+        custom embedder is provided.
+        """
+        if self._embedder is not None and callable(self._embedder):
+            result = self._embedder(text)
+            if isinstance(result, list):
+                return result
+            # Assume awaitable
+            return await result  # type: ignore[return-value]
+
+        base_url = os.getenv("LLM_EMBEDDING_URL", _DEFAULT_EMBEDDING_URL)
+        model = os.getenv("LLM_EMBEDDING_MODEL", _DEFAULT_EMBEDDING_MODEL)
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{base_url}/v1/embeddings",
+                json={"input": text, "model": model},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["data"][0]["embedding"]  # type: ignore[no-any-return]
+
+    async def search(
+        self,
+        query: str,
+        limit: int = 5,
+        task_id: str | None = None,
+    ) -> list[ModelDecisionSearchResult]:
+        """Search for decisions semantically similar to the query.
+
+        Args:
+            query: Natural language search query.
+            limit: Maximum number of results to return.
+            task_id: Optional filter to scope results to a specific task.
+
+        Returns:
+            List of decision search results ordered by similarity.
+        """
+        if self._qdrant is None:
+            logger.warning("Qdrant client not configured; returning empty results")
+            return []
+
+        vector = await self._embed(query)
+
+        query_filter = None
+        if task_id is not None:
+            query_filter = qdrant_models.Filter(
+                must=[
+                    qdrant_models.FieldCondition(
+                        key="task_id",
+                        match=qdrant_models.MatchValue(value=task_id),
+                    ),
+                ],
+            )
+
+        query_result = self._qdrant.query_points(
+            collection_name=_COLLECTION_NAME,
+            query=vector,
+            query_filter=query_filter,
+            limit=limit,
+        )
+
+        return [
+            ModelDecisionSearchResult(
+                task_id=str(pt.payload.get("task_id", "")) if pt.payload else "",
+                decision_text=str(pt.payload.get("decision_text", ""))
+                if pt.payload
+                else "",
+                context=str(pt.payload.get("context", "")) if pt.payload else "",
+                score=round(pt.score, 4),
+                timestamp=str(pt.payload.get("timestamp", "")) if pt.payload else "",
+            )
+            for pt in query_result.points
+        ]
+
+    async def search_related(
+        self,
+        task_id: str,
+        limit: int = 5,
+    ) -> list[ModelDecisionSearchResult]:
+        """Find decisions from OTHER tasks similar to a given task's decisions.
+
+        Retrieves decisions for the given task_id, then searches for
+        semantically similar decisions from other tasks.
+
+        Args:
+            task_id: The task whose decisions to find related matches for.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of related decisions from other tasks.
+        """
+        if self._qdrant is None:
+            logger.warning("Qdrant client not configured; returning empty results")
+            return []
+
+        # First, get decisions for the given task
+        task_filter = qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="task_id",
+                    match=qdrant_models.MatchValue(value=task_id),
+                ),
+            ],
+        )
+
+        task_decisions = self._qdrant.scroll(
+            collection_name=_COLLECTION_NAME,
+            scroll_filter=task_filter,
+            limit=10,
+            with_vectors=True,
+        )
+
+        points, _ = task_decisions
+        if not points:
+            logger.info("No decisions found for task %s", task_id)
+            return []
+
+        # Use the first decision's vector as the search query
+        # and exclude the source task from results
+        search_vector = points[0].vector
+        if not isinstance(search_vector, list):
+            logger.warning("Unexpected vector type for task %s", task_id)
+            return []
+
+        exclude_filter = qdrant_models.Filter(
+            must_not=[
+                qdrant_models.FieldCondition(
+                    key="task_id",
+                    match=qdrant_models.MatchValue(value=task_id),
+                ),
+            ],
+        )
+
+        query_result = self._qdrant.query_points(
+            collection_name=_COLLECTION_NAME,
+            query=search_vector,
+            query_filter=exclude_filter,
+            limit=limit,
+        )
+
+        return [
+            ModelDecisionSearchResult(
+                task_id=str(pt.payload.get("task_id", "")) if pt.payload else "",
+                decision_text=str(pt.payload.get("decision_text", ""))
+                if pt.payload
+                else "",
+                context=str(pt.payload.get("context", "")) if pt.payload else "",
+                score=round(pt.score, 4),
+                timestamp=str(pt.payload.get("timestamp", "")) if pt.payload else "",
+            )
+            for pt in query_result.points
+        ]
+
+    def format_results(self, results: list[ModelDecisionSearchResult]) -> str:
+        """Format search results as human-readable text for context injection.
+
+        Args:
+            results: List of decision search results to format.
+
+        Returns:
+            Formatted string suitable for injecting into agent context.
+        """
+        if not results:
+            return "No related decisions found."
+
+        lines: list[str] = ["--- RELATED DECISIONS ---"]
+        for r in results:
+            lines.append(f"[{r.task_id}] (score: {r.score}) {r.decision_text}")
+            if r.context:
+                lines.append(f"  Context: {r.context}")
+            if r.timestamp:
+                lines.append(f"  Timestamp: {r.timestamp}")
+            lines.append("")
+        lines.append("---")
+        return "\n".join(lines)
+
+
+__all__ = ["DecisionSearchClient", "ModelDecisionSearchResult"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2860,6 +2860,14 @@ pattern_exemptions:
       session_id is a CLI session identifier string, not a UUID. It comes from Claude Code hook events where session IDs are opaque strings.
 
     ticket: OMN-6863
+  - file_pattern: 'session_registry.*decision_search\.py'
+    violation_pattern: "Field 'task_id' should use UUID type instead of str"
+    reason: >
+      task_id in ModelDecisionSearchResult is a human-readable Linear ticket identifier (e.g., "OMN-1234"), not a UUID. Consistent with ModelSessionRegistryEntry in the same package. See plan Doctrine D2.
+
+    documentation:
+      - docs/plans/2026-03-27-multi-session-coordination.md (Doctrine D2)
+    ticket: OMN-6864
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/unit/services/session_registry/test_decision_search.py
+++ b/tests/unit/services/session_registry/test_decision_search.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for semantic decision search client.
+
+Part of the Multi-Session Coordination Layer (OMN-6850, Task 14).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.services.session_registry.decision_search import (
+    DecisionSearchClient,
+    ModelDecisionSearchResult,
+)
+
+
+@pytest.mark.unit
+class TestModelDecisionSearchResult:
+    """Tests for the ModelDecisionSearchResult Pydantic model."""
+
+    def test_search_result_model(self) -> None:
+        result = ModelDecisionSearchResult(
+            task_id="OMN-1234",
+            decision_text="Use Postgres for session state",
+            context="Multi-session coordination",
+            score=0.92,
+            timestamp="2026-03-27T14:00:00Z",
+        )
+        assert result.score == 0.92
+        assert result.task_id == "OMN-1234"
+        assert result.decision_text == "Use Postgres for session state"
+        assert result.context == "Multi-session coordination"
+        assert result.timestamp == "2026-03-27T14:00:00Z"
+
+    def test_search_result_frozen(self) -> None:
+        result = ModelDecisionSearchResult(
+            task_id="OMN-1234",
+            decision_text="Use Postgres",
+            score=0.5,
+        )
+        with pytest.raises(Exception):
+            result.score = 0.9  # type: ignore[misc]
+
+    def test_search_result_defaults(self) -> None:
+        result = ModelDecisionSearchResult(
+            task_id="OMN-1234",
+            decision_text="Use Postgres",
+            score=0.5,
+        )
+        assert result.context == ""
+        assert result.timestamp == ""
+
+    def test_search_result_score_bounds(self) -> None:
+        with pytest.raises(Exception):
+            ModelDecisionSearchResult(
+                task_id="OMN-1234",
+                decision_text="Test",
+                score=1.5,
+            )
+
+
+@pytest.mark.unit
+class TestDecisionSearchClientFormatResults:
+    """Tests for DecisionSearchClient.format_results()."""
+
+    def test_format_search_results(self) -> None:
+        results = [
+            ModelDecisionSearchResult(
+                task_id="OMN-1234",
+                decision_text="Use Postgres for session state",
+                context="coordination design",
+                score=0.92,
+                timestamp="2026-03-27T14:00:00Z",
+            ),
+            ModelDecisionSearchResult(
+                task_id="OMN-1230",
+                decision_text="Use Redis for caching",
+                context="performance optimization",
+                score=0.71,
+                timestamp="2026-03-26T10:00:00Z",
+            ),
+        ]
+        client = DecisionSearchClient(qdrant=None, embedder=None)
+        formatted = client.format_results(results)
+        assert "OMN-1234" in formatted
+        assert "0.92" in formatted
+        assert "OMN-1230" in formatted
+        assert "0.71" in formatted
+        assert "RELATED DECISIONS" in formatted
+        assert "Use Postgres for session state" in formatted
+        assert "coordination design" in formatted
+
+    def test_format_empty_results(self) -> None:
+        client = DecisionSearchClient(qdrant=None, embedder=None)
+        formatted = client.format_results([])
+        assert formatted == "No related decisions found."
+
+    def test_format_results_without_context(self) -> None:
+        results = [
+            ModelDecisionSearchResult(
+                task_id="OMN-5000",
+                decision_text="Skip integration tests",
+                score=0.88,
+            ),
+        ]
+        client = DecisionSearchClient(qdrant=None, embedder=None)
+        formatted = client.format_results(results)
+        assert "OMN-5000" in formatted
+        assert "Context:" not in formatted
+
+
+@pytest.mark.unit
+class TestDecisionSearchClientSearch:
+    """Tests for DecisionSearchClient.search() with mocked Qdrant."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_without_qdrant(self) -> None:
+        client = DecisionSearchClient(qdrant=None, embedder=None)
+        results = await client.search("test query")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_calls_qdrant(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_hit = MagicMock()
+        mock_hit.payload = {
+            "task_id": "OMN-1234",
+            "decision_text": "Use Kafka for events",
+            "context": "architecture",
+            "timestamp": "2026-03-27T10:00:00Z",
+        }
+        mock_hit.score = 0.95
+        mock_query_result = MagicMock()
+        mock_query_result.points = [mock_hit]
+        mock_qdrant.query_points.return_value = mock_query_result
+
+        embedder = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=embedder)
+        results = await client.search("event bus choice")
+
+        assert len(results) == 1
+        assert results[0].task_id == "OMN-1234"
+        assert results[0].score == 0.95
+        assert results[0].decision_text == "Use Kafka for events"
+        mock_qdrant.query_points.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_with_task_id_filter(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_query_result = MagicMock()
+        mock_query_result.points = []
+        mock_qdrant.query_points.return_value = mock_query_result
+
+        embedder = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=embedder)
+        await client.search("test", task_id="OMN-5555")
+
+        call_kwargs = mock_qdrant.query_points.call_args
+        assert call_kwargs.kwargs.get("query_filter") is not None
+
+
+@pytest.mark.unit
+class TestDecisionSearchClientSearchRelated:
+    """Tests for DecisionSearchClient.search_related() with mocked Qdrant."""
+
+    @pytest.mark.asyncio
+    async def test_search_related_returns_empty_without_qdrant(self) -> None:
+        client = DecisionSearchClient(qdrant=None, embedder=None)
+        results = await client.search_related("OMN-1234")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_related_empty_task(self) -> None:
+        mock_qdrant = MagicMock()
+        mock_qdrant.scroll.return_value = ([], None)
+
+        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=None)
+        results = await client.search_related("OMN-9999")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_related_finds_decisions(self) -> None:
+        mock_qdrant = MagicMock()
+
+        # Mock scroll to return a decision with a vector
+        mock_point = MagicMock()
+        mock_point.vector = [0.1, 0.2, 0.3]
+        mock_point.payload = {
+            "task_id": "OMN-1234",
+            "decision_text": "Use Kafka",
+        }
+        mock_qdrant.scroll.return_value = ([mock_point], None)
+
+        # Mock query_points to return a related decision from another task
+        mock_hit = MagicMock()
+        mock_hit.payload = {
+            "task_id": "OMN-5678",
+            "decision_text": "Use RabbitMQ for queues",
+            "context": "messaging",
+            "timestamp": "2026-03-20T10:00:00Z",
+        }
+        mock_hit.score = 0.85
+        mock_query_result = MagicMock()
+        mock_query_result.points = [mock_hit]
+        mock_qdrant.query_points.return_value = mock_query_result
+
+        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=None)
+        results = await client.search_related("OMN-1234")
+
+        assert len(results) == 1
+        assert results[0].task_id == "OMN-5678"
+        assert results[0].score == 0.85


### PR DESCRIPTION
## Summary

- Add `DecisionSearchClient` for semantic recall over session decisions stored in Qdrant (Task 14, OMN-6850 epic)
- `ModelDecisionSearchResult` frozen Pydantic model with task_id, decision_text, context, score, timestamp
- `search()`: embed query via Qwen3-Embedding-8B, search Qdrant `session_decisions` collection with optional task_id filter
- `search_related()`: find semantically similar decisions from OTHER tasks
- `format_results()`: human-readable output for context injection (Doctrine D7: enrichment only)
- 13 unit tests covering model validation, formatting, search, and search_related with mocked Qdrant
- Validation exemption for `task_id` str type (Linear ticket ID per Doctrine D2)

## Test plan

- [x] 13 unit tests pass (`pytest tests/unit/services/session_registry/test_decision_search.py`)
- [x] mypy strict passes
- [x] ruff check passes
- [x] All pre-commit hooks pass
- [ ] CI green

## Ticket

[OMN-6864](https://linear.app/omninode/issue/OMN-6864)
Part of epic [OMN-6850](https://linear.app/omninode/issue/OMN-6850)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic search for session decisions with similarity-ranked results, relevance scores, timestamps and context, plus a human-readable formatter for results.
* **Tests**
  * Added unit tests covering model validation, search behaviors, formatting, and edge cases (no-results, filtering).
* **Chores**
  * Added a validation exemption documenting task-id as a human-readable ticket identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->