### PR TITLE
fix(test): isolate broker allowlist tests from host env [OMN-6878]

### DIFF
--- a/tests/unit/runtime/test_kafka_broker_allowlist.py
+++ b/tests/unit/runtime/test_kafka_broker_allowlist.py
@@ -24,6 +24,16 @@ from omnibase_infra.runtime.service_kernel import (
 class TestValidateKafkaBrokerAllowlist:
     """Tests for validate_kafka_broker_allowlist()."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_allowlist_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ensure KAFKA_BROKER_ALLOWLIST is unset for denylist-mode tests.
+
+        The host environment may have KAFKA_BROKER_ALLOWLIST=localhost: which
+        switches the validator into strict allowlist mode, causing denylist
+        tests to fail. Tests that need the allowlist explicitly patch it.
+        """
+        monkeypatch.delenv(ENV_KAFKA_BROKER_ALLOWLIST, raising=False)
+
     # ------------------------------------------------------------------
     # Rejected patterns — denylist enforcement
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add autouse fixture to clear `KAFKA_BROKER_ALLOWLIST` env var in broker allowlist test class
- Host environment sets `KAFKA_BROKER_ALLOWLIST=localhost:` which switches the validator into strict allowlist mode, causing 7 denylist tests to fail
- Tests that specifically test allowlist behavior already use `patch.dict` to set it

## Test plan
- [x] All 16 tests in `test_kafka_broker_allowlist.py` pass
- [x] Pre-commit passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring tests start with a clean environment state, preventing environment-specific failures in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->