### PR TITLE
feat: add bare-clone-sync launchd agent and install script [OMN-6908]

### DIFF
--- a/scripts/ai.omninode.bare-clone-sync.plist
+++ b/scripts/ai.omninode.bare-clone-sync.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.omninode.bare-clone-sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Volumes/PRO-G40/Code/omni_home/omnibase_infra/scripts/pull-all.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>1800</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/bare-clone-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/bare-clone-sync-error.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>OMNI_HOME</key>
+        <string>/Volumes/PRO-G40/Code/omni_home</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/install-bare-clone-sync.sh
+++ b/scripts/install-bare-clone-sync.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# install-bare-clone-sync.sh — Install the bare-clone-sync launchd agent
+#
+# This script installs a launchd user agent that runs pull-all.sh every
+# 30 minutes to keep bare clones in omni_home fresh.
+#
+# Usage:
+#   ./install-bare-clone-sync.sh           # Install and start
+#   ./install-bare-clone-sync.sh uninstall # Stop and remove
+#
+# Uninstall (manual):
+#   launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.omninode.bare-clone-sync.plist
+#   rm ~/Library/LaunchAgents/ai.omninode.bare-clone-sync.plist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLIST_NAME="ai.omninode.bare-clone-sync.plist"
+PLIST_SRC="${SCRIPT_DIR}/${PLIST_NAME}"
+PLIST_DST="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
+DOMAIN_TARGET="gui/$(id -u)"
+SERVICE_TARGET="${DOMAIN_TARGET}/${PLIST_NAME%.plist}"
+
+# ── Uninstall ────────────────────────────────────────────────────────
+if [[ "${1:-}" == "uninstall" ]]; then
+    echo "Uninstalling ${PLIST_NAME}..."
+
+    if launchctl print "${SERVICE_TARGET}" &>/dev/null; then
+        launchctl bootout "${DOMAIN_TARGET}" "${PLIST_DST}" 2>/dev/null || true
+        echo "  Service stopped."
+    else
+        echo "  Service not loaded (nothing to stop)."
+    fi
+
+    if [[ -f "${PLIST_DST}" ]]; then
+        rm -f "${PLIST_DST}"
+        echo "  Plist removed from ~/Library/LaunchAgents/."
+    else
+        echo "  Plist not found (already removed)."
+    fi
+
+    echo "Done. Bare-clone-sync uninstalled."
+    exit 0
+fi
+
+# ── Install ──────────────────────────────────────────────────────────
+echo "Installing ${PLIST_NAME}..."
+
+# Verify source plist exists
+if [[ ! -f "${PLIST_SRC}" ]]; then
+    echo "ERROR: Plist not found at ${PLIST_SRC}" >&2
+    exit 1
+fi
+
+# Verify pull-all.sh exists at the path referenced in the plist
+PULL_ALL="/Volumes/PRO-G40/Code/omni_home/omnibase_infra/scripts/pull-all.sh"
+if [[ ! -f "${PULL_ALL}" ]]; then
+    echo "ERROR: pull-all.sh not found at ${PULL_ALL}" >&2
+    echo "       The plist references this absolute path." >&2
+    exit 1
+fi
+
+# Create LaunchAgents directory if needed
+mkdir -p "${HOME}/Library/LaunchAgents"
+
+# Unload existing service if loaded
+if launchctl print "${SERVICE_TARGET}" &>/dev/null; then
+    echo "  Stopping existing service..."
+    launchctl bootout "${DOMAIN_TARGET}" "${PLIST_DST}" 2>/dev/null || true
+fi
+
+# Copy plist
+cp "${PLIST_SRC}" "${PLIST_DST}"
+echo "  Copied plist to ${PLIST_DST}"
+
+# Load service
+launchctl bootstrap "${DOMAIN_TARGET}" "${PLIST_DST}"
+echo "  Service loaded."
+
+# Validate service is running
+sleep 1
+if launchctl print "${SERVICE_TARGET}" &>/dev/null; then
+    echo "  Service is running."
+    echo ""
+    echo "Done. Bare clones will sync every 30 minutes."
+    echo "Logs: /tmp/bare-clone-sync.log"
+    echo "Errors: /tmp/bare-clone-sync-error.log"
+else
+    echo "WARNING: Service loaded but may not be running yet." >&2
+    echo "         Check: launchctl print ${SERVICE_TARGET}" >&2
+    exit 1
+fi

--- a/tests/unit/scripts/test_bare_clone_sync_plist.py
+++ b/tests/unit/scripts/test_bare_clone_sync_plist.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the bare-clone-sync launchd plist."""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import pytest
+
+PLIST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "ai.omninode.bare-clone-sync.plist"
+)
+
+
+@pytest.mark.unit
+class TestBareCloneSyncPlist:
+    """Validate the bare-clone-sync launchd plist."""
+
+    def test_plist_exists(self) -> None:
+        assert PLIST_PATH.exists(), f"Plist not found at {PLIST_PATH}"
+
+    def test_plist_is_well_formed_xml(self) -> None:
+        """Parse the plist with plistlib to verify well-formed XML."""
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        assert isinstance(data, dict), "Plist root must be a dict"
+
+    def test_label_matches_filename(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        assert data["Label"] == "ai.omninode.bare-clone-sync"
+
+    def test_program_arguments_uses_absolute_paths(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        args = data["ProgramArguments"]
+        assert len(args) == 2
+        assert args[0] == "/bin/bash"
+        assert args[1].startswith("/"), "pull-all.sh path must be absolute"
+        assert "pull-all.sh" in args[1]
+
+    def test_start_interval_is_30_minutes(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        assert data["StartInterval"] == 1800, "StartInterval should be 1800s (30 min)"
+
+    def test_run_at_load_enabled(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        assert data["RunAtLoad"] is True
+
+    def test_log_paths_configured(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        assert data["StandardOutPath"] == "/tmp/bare-clone-sync.log"  # noqa: S108
+        assert data["StandardErrorPath"] == "/tmp/bare-clone-sync-error.log"  # noqa: S108
+
+    def test_environment_variables_set(self) -> None:
+        data = plistlib.loads(PLIST_PATH.read_bytes())
+        env = data["EnvironmentVariables"]
+        assert "PATH" in env
+        assert "OMNI_HOME" in env
+        assert env["OMNI_HOME"] == "/Volumes/PRO-G40/Code/omni_home"


### PR DESCRIPTION
## Summary

- Adds `scripts/ai.omninode.bare-clone-sync.plist` -- launchd agent that runs `pull-all.sh` every 30 minutes with `RunAtLoad: true`, logging to `/tmp/bare-clone-sync.log`
- Adds `scripts/install-bare-clone-sync.sh` -- installer that copies plist to `~/Library/LaunchAgents/`, loads the service, validates it is running, and supports `uninstall` subcommand
- Adds 8 unit tests validating plist XML well-formedness, absolute paths, interval, label, and log paths

Resolves F66 friction from 2026-03-28 closeout where this script was referenced but did not exist.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_bare_clone_sync_plist.py -v` -- 8/8 pass
- [ ] CI passes
- [ ] Post-merge: run `./scripts/install-bare-clone-sync.sh` and verify `launchctl print gui/$(id -u)/ai.omninode.bare-clone-sync`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS launchd-based scheduled background job that runs automatically every 30 minutes with dedicated log output tracking.
  * Added installation script to set up and manage the background job lifecycle (install/uninstall modes).

* **Tests**
  * Added comprehensive unit tests validating background job configuration and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->