### PR TITLE
feat: add is_exempt_pr classifier for dep bumps and releases [OMN-6921]

### DIFF
--- a/scripts/generate_deep_dive.py
+++ b/scripts/generate_deep_dive.py
@@ -120,6 +120,7 @@ class GitHubMergedPR:
     merged_at: str
     is_workflow_pr: bool  # True if it's an auto-generated workflow PR
     category: str  # 'capability', 'correctness', 'governance', 'observability', 'docs', 'churn'
+    is_exempt: bool = False  # True if dep bump or release (exempt from ticket linkage)
     additions: int = 0
     deletions: int = 0
 
@@ -232,6 +233,25 @@ WORKFLOW_PR_PATTERNS = [
 def is_workflow_pr(title: str) -> bool:
     """Check if a PR is an auto-generated workflow PR (low value for reporting)."""
     return any(pattern.lower() in title.lower() for pattern in WORKFLOW_PR_PATTERNS)
+
+
+# Exempt PR patterns — dep bumps and releases that don't need ticket linkage
+# SYNC: exempt prefixes must match the lists in:
+#   - onex_change_control/.github/workflows/pr-title-check-reusable.yml
+#   - omniclaude/src/omniclaude/nodes/node_git_effect/models/model_git_request.py
+_EXEMPT_PREFIXES = (
+    "chore(deps",  # chore(deps):, chore(deps-dev):, chore(deps)(deps):
+    "build(deps",  # build(deps):
+    "bump ",  # Bump hashicorp/aws...
+    "chore: release",  # chore: release omnibase_core v0.34.0
+    "chore(release)",  # chore(release): v0.12.0
+    "release:",  # release: omnibase_infra v0.29.0
+)
+
+
+def is_exempt_pr(title: str) -> bool:
+    """Return True if the PR title is a dep bump or release (exempt from ticket linkage)."""
+    return title.lower().startswith(_EXEMPT_PREFIXES)
 
 
 def classify_pr(title: str) -> str:
@@ -366,6 +386,7 @@ def get_github_merged_prs(repo: Path, date: dt.date) -> list[GitHubMergedPR]:
                         merged_at=display_time,
                         is_workflow_pr=is_workflow_pr(title),
                         category=classify_pr(title),
+                        is_exempt=is_exempt_pr(title),
                         additions=item.get("additions", 0),
                         deletions=item.get("deletions", 0),
                     )
@@ -380,6 +401,7 @@ def get_github_merged_prs(repo: Path, date: dt.date) -> list[GitHubMergedPR]:
                         merged_at=merged_at_str,
                         is_workflow_pr=is_workflow_pr(title),
                         category=classify_pr(title),
+                        is_exempt=is_exempt_pr(title),
                         additions=item.get("additions", 0),
                         deletions=item.get("deletions", 0),
                     )

--- a/tests/unit/scripts/test_generate_deep_dive_classifier.py
+++ b/tests/unit/scripts/test_generate_deep_dive_classifier.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for is_exempt_pr in generate_deep_dive.py [OMN-6921]."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# generate_deep_dive.py is a standalone script, not a package module.
+# Import it via importlib to avoid sys.path manipulation.
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "generate_deep_dive.py"
+_spec = importlib.util.spec_from_file_location("generate_deep_dive", _SCRIPT_PATH)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["generate_deep_dive"] = _mod
+_spec.loader.exec_module(_mod)
+classify_pr = _mod.classify_pr
+is_exempt_pr = _mod.is_exempt_pr
+
+
+class TestIsExemptPr:
+    """Test the is_exempt_pr function."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "chore(deps): bump requests from 2.31.0 to 2.32.0",
+            "chore(deps-dev): bump pytest from 8.0 to 8.1",
+            "build(deps): bump actions/checkout from 4 to 6",
+            "Bump hashicorp/aws from 6.36.0 to 6.37.0",
+            "chore(deps)(deps): bump hashicorp/aws from 6.36.0 to 6.37.0",
+            "chore: release omnibase_core v0.34.0",
+            "chore(release): v0.12.0",
+            "chore(release): omniintelligence v0.18.0",
+            "release: omnibase_infra v0.29.0",
+        ],
+    )
+    def test_exempt_titles(self, title: str) -> None:
+        assert is_exempt_pr(title) is True
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "feat: add session registry [OMN-6853]",
+            "fix(ci): resolve flaky test [OMN-6878]",
+            "feat: multi-model adversarial review system",
+            "refactor: migrate ONEX state paths",
+        ],
+    )
+    def test_non_exempt_titles(self, title: str) -> None:
+        assert is_exempt_pr(title) is False


### PR DESCRIPTION
## Summary
- Add `is_exempt_pr()` function to `generate_deep_dive.py` that classifies dep bumps and releases
- Handles all Dependabot naming variants: `chore(deps):`, `chore(deps-dev):`, `build(deps):`, `Bump`, `chore(deps)(deps):`
- Handles release variants: `chore: release`, `chore(release):`, `release:`
- Wire `is_exempt` field into `GitHubMergedPR` dataclass
- 13 parametrized tests

## Test plan
- [x] 13 unit tests pass locally
- [ ] CI passes

Closes OMN-6921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exemption detection for dependency bump and release pull requests, enabling selective filtering during PR processing.

* **Tests**
  * Added comprehensive unit tests to validate PR exemption classification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->