### PR TITLE
ci: add PR title check caller workflow [OMN-6916]

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OMN-6912
+
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  pr-title:
+    uses: OmniNode-ai/onex_change_control/.github/workflows/pr-title-check-reusable.yml@main
+    permissions:
+      pull-requests: read


### PR DESCRIPTION
## Summary
- Add `pr-title-check.yml` caller workflow referencing reusable workflow from onex_change_control
- Enforces OMN-XXXX ticket linkage on all PR titles

## Test plan
- [ ] CI passes
- [ ] PR title check runs on this PR

Part of OMN-6916