### PR TITLE
fix(ci): allowlist 6 handler contract compliance violations blocking main

### DIFF
--- a/arch-handler-contract-compliance-allowlist.yaml
+++ b/arch-handler-contract-compliance-allowlist.yaml
@@ -115,6 +115,30 @@ allowlisted_handlers:
     violations:
       - undeclared_transport
     ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_contract_loader_effect/handlers/handler_contract_scan.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_event_bus_wiring_effect/handlers/handler_event_bus_wiring.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config/bifrost_shadow.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config/model_shadow_decision_log.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_runtime_orchestrator/handlers/handler_runtime_lifecycle.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
+  - path: omnibase_infra/nodes/node_savings_estimation_compute/handlers/handler_savings_estimator.py
+    violations:
+      - missing_handler_routing
+    ticket: '# migration pending'
   - path: omnibase_infra/nodes/node_validation_executor/handlers/handler_run_checks.py
     violations:
       - missing_handler_routing


### PR DESCRIPTION
## Summary

- Adds 6 handlers to the `arch-handler-contract-compliance-allowlist.yaml` that were merged to main without `handler_routing` entries in their contracts
- These violations cause the Handler Contract Compliance CI check (and downstream Omni Standards Gate) to fail on **every PR**, blocking all 11 queued PRs
- Verified locally: `New violations: 0` after this change

## Handlers allowlisted

| Handler | Node |
|---------|------|
| `handler_contract_scan` | `node_contract_loader_effect` |
| `handler_event_bus_wiring` | `node_event_bus_wiring_effect` |
| `bifrost_shadow` | `node_llm_inference_effect` |
| `model_shadow_decision_log` | `node_llm_inference_effect` |
| `handler_runtime_lifecycle` | `node_runtime_orchestrator` |
| `handler_savings_estimator` | `node_savings_estimation_compute` |

## Test plan

- [ ] CI Handler Contract Compliance check passes (was failing on main)
- [ ] Omni Standards Gate passes (downstream of handler compliance)
- [ ] After merge, verify blocked PRs can pass CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal handler allowlist configuration to extend compliance tracking across additional handler paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->