### PR TITLE
chore(deps): bump omnibase-core to 0.35.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_core` (v0.35.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_core`
- No source code changes -- lockfile only

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_core/actions/runs/23768418225

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version