### PR TITLE
fix: increase runtime healthcheck start_period to 120s [OMN-7081]

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -355,9 +355,9 @@ EXPOSE 8085
 # Health check using the runtime's health endpoint
 # - interval: Check every 30 seconds
 # - timeout: Fail if check takes more than 10 seconds
-# - start-period: Allow 40 seconds for startup before checking
+# - start-period: Allow 120 seconds for startup (Kafka consumer init is slow)
 # - retries: Mark unhealthy after 3 consecutive failures
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl --fail --silent http://localhost:8085/health || exit 1
 
 # Use tini as init to properly handle signals (PID 1 problem)

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -580,7 +580,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 90s
+      start_period: 120s
     labels:
       - "com.omninode.service=runtime-main"
       - "com.omninode.layer=runtime"


### PR DESCRIPTION
## Summary
- Increase `start_period` from 90s to 120s for `omninode-runtime` in docker-compose.infra.yml (matching runtime-effects)
- Increase `start_period` from 40s to 120s in Dockerfile.runtime HEALTHCHECK instruction

## Why
Kafka consumer loop initialization takes longer than 90s on cold start, causing Docker to mark the container unhealthy and autoheal to SIGTERM it before it finishes starting.

## Test plan
- [ ] Verify runtime container reaches healthy status without restart after `infra-up-runtime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended health check grace period to 120 seconds to allow adequate startup time before health evaluation begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->