### PR TITLE
fix: start health server before runtime.start() [OMN-7081]

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -584,8 +584,8 @@ async def bootstrap() -> int:
         8. Start HTTP health server for Docker/Kubernetes health probes
         9. Start runtime (Kafka consumer joins — may take 10+ min)
         10. Run runtime until shutdown signal received
-        10. Perform graceful shutdown with configurable timeout
-        11. Clean up resources in finally block to prevent resource leaks
+        11. Perform graceful shutdown with configurable timeout
+        12. Clean up resources in finally block to prevent resource leaks
 
     Error Handling:
         - Configuration errors: Logged with full context and correlation_id


### PR DESCRIPTION
## Summary

- Reorder `bootstrap()` in `service_kernel.py` so the HTTP health server (port 8085) starts **before** `runtime.start()`, not after
- `runtime.start()` takes 10+ min due to ~91 sequential Kafka consumer group joins; the health server was blocked behind this, causing Docker health checks to fail and autoheal to restart the container in a loop

## Root Cause

The bootstrap sequence was:
1. Step 8: `await runtime.start()` (10+ min Kafka consumer joins)
2. Step 9: Start health server on :8085

Docker health checks fire during step 8 → container marked unhealthy → autoheal kills it → restart loop.

## Fix

Swap the order:
1. Step 8: Start health server on :8085 (instant)
2. Step 9: `await runtime.start()` (slow, but health checks pass)

The health server has no dependency on `runtime.start()` completing.

## Test plan

- [ ] Pre-commit hooks pass (all 40+ checks)
- [ ] mypy strict passes
- [ ] Runtime container starts and becomes healthy within start_period
- [ ] Dependent containers (effects, workers, contract-resolver) cascade-start after runtime is healthy
- [ ] `curl -sf http://localhost:8085/health` returns 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Health/health-check server now starts earlier during application startup to improve probe responsiveness.
  * Added port validation with a fallback to a default port for invalid configurations.
  * Improved debug logging for health server startup and selected port.
  * Clarified behavior so health checks remain responsive during long background startup phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->