### PR TITLE
fix: add node_name to infra introspection event model [OMN-7088]

### DIFF
--- a/src/omnibase_infra/mixins/mixin_node_introspection.py
+++ b/src/omnibase_infra/mixins/mixin_node_introspection.py
@@ -1566,6 +1566,7 @@ class MixinNodeIntrospection:
         # Build event kwargs; resolved_feature_flags is optional (OMN-5577)
         event_kwargs: dict[str, object] = {
             "node_id": node_id_uuid,
+            "node_name": self._introspection_node_name,
             "node_type": node_type,
             "node_version": node_version,
             "declared_capabilities": self._introspection_declared_capabilities,

--- a/src/omnibase_infra/models/registration/model_node_introspection_event.py
+++ b/src/omnibase_infra/models/registration/model_node_introspection_event.py
@@ -92,6 +92,11 @@ class ModelNodeIntrospectionEvent(BaseModel):
 
     # Core identity (required, strongly typed)
     node_id: UUID = Field(..., description="Unique node identifier")
+    node_name: str | None = Field(
+        default=None,
+        description="Human-readable node name from contract metadata or snake_case class name. "
+        "None only as degraded fallback — UUID fallback in e2e is a regression.",
+    )
     node_type: EnumNodeKind = Field(..., description="ONEX node type")
     node_version: ModelSemVer = Field(
         default_factory=lambda: ModelSemVer(major=1, minor=0, patch=0),


### PR DESCRIPTION
## Summary
PR #766 added node_name extraction to omnibase_core, but the running nodes use the omnibase_infra mixin which builds Kafka payloads from ModelNodeIntrospectionEvent in this repo. That model had extra=forbid and no node_name field — the value was silently dropped.

- Adds node_name: str | None to ModelNodeIntrospectionEvent
- Passes self._introspection_node_name into event_kwargs

## Test plan
- Rebuild runtime, verify Kafka events contain node_name
- Verify Platform Registry shows human-readable names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node names are now included in introspection events, providing improved node identification and context. Names are sourced from contract metadata or automatically derived from the node's class name as a fallback when not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->