### PR TITLE
fix(ci): auto-tag workflow matches chore: release PR titles [OMN-6909]

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -9,7 +9,9 @@ jobs:
     if: >-
       github.event.pull_request.merged == true &&
       (contains(github.event.pull_request.labels.*.name, 'release') ||
-       startsWith(github.event.pull_request.title, 'release:'))
+       startsWith(github.event.pull_request.title, 'release:') ||
+       startsWith(github.event.pull_request.title, 'chore: release') ||
+       startsWith(github.event.pull_request.title, 'chore(release)'))
     uses: OmniNode-ai/omnibase_core/.github/workflows/auto-tag-reusable.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Auto-tag workflow only matched PRs with a `release` label or title starting with `release:`. It missed `chore: release` and `chore(release)` title patterns, causing release cascade stalls.
- Adds `startsWith` checks for `chore: release` and `chore(release)` patterns.

## Test plan
- [x] Verify the `if` condition syntax is valid YAML and valid GitHub Actions expressions
- [ ] Merge a PR with title `chore: release ...` and confirm auto-tag fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automatic tagging conditions for release pull requests to recognize additional title formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->