### PR TITLE
feat: add GITHUB_WEBHOOK_SECRET Infisical contract [OMN-6723]

### DIFF
--- a/src/omnibase_infra/contracts/integrations/github_webhook/contract.yaml
+++ b/src/omnibase_infra/contracts/integrations/github_webhook/contract.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# GitHub Webhook Bridge Integration Contract [OMN-6723]
+#
+# Declares the GITHUB_WEBHOOK_SECRET env dependency so seed-infisical.py
+# discovers it and creates the Infisical key. The actual webhook endpoint
+# lives in omnidash (server/lib/github-webhook-signature.ts).
+name: "github_webhook_bridge"
+description: >
+  GitHub webhook integration bridge. Receives webhook events from GitHub, verifies HMAC-SHA256 signatures, and publishes normalized ONEX events to Kafka. The webhook secret is shared between GitHub org settings and the omnidash deployment.
+
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+dependencies:
+  - name: "GITHUB_WEBHOOK_SECRET"
+    type: "environment"
+    description: "HMAC-SHA256 shared secret for GitHub webhook signature verification"
+    required: true
+event_bus:
+  publish_topics:
+    - topic: "onex.evt.github.pr-merged.v1"
+      direction: "publish"
+      description: "Emitted when a GitHub PR is merged"
+    - topic: "onex.evt.github.push-to-main.v1"
+      direction: "publish"
+      description: "Emitted when code is pushed to the default branch"
+    - topic: "onex.evt.github.check-suite-completed.v1"
+      direction: "publish"
+      description: "Emitted when a GitHub check suite completes"


### PR DESCRIPTION
## Summary

- Register `GITHUB_WEBHOOK_SECRET` as an environment dependency in a new integration contract (`contracts/integrations/github_webhook/contract.yaml`)
- Declares three new GitHub webhook event topics in the contract's `event_bus.publish_topics` section
- Enables `seed-infisical.py` to discover and provision the key automatically

## Test plan

- [x] Pre-commit hooks pass (SPDX headers, yamlfmt, contract validation, topic naming lint)
- [ ] Run `seed-infisical.py --dry-run` to verify key appears in output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub webhook integration is now available. The integration processes GitHub events and publishes normalized event streams for pull request merges, pushes to the main branch, and check suite completions. Webhook authentication is secured for data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->