### PR TITLE
fix: populate introspection node_name from contract [OMN-6405]

### DIFF
--- a/src/omnibase_infra/services/service_node_introspection.py
+++ b/src/omnibase_infra/services/service_node_introspection.py
@@ -217,12 +217,19 @@ class ServiceNodeIntrospection(MixinNodeIntrospection):
         contract, event_bus_sub = _try_load_contract(contracts_dir)
 
         # Extract metadata from contract Pydantic model if available
+        # OMN-6405: Also extract name from contract so introspection events
+        # carry the contract-defined node name instead of the runtime config
+        # name (e.g., "node_registration_orchestrator" not "runtime_config").
         description = None
+        effective_node_name = node_name
         version = "1.0.0"
         node_type = EnumNodeKind.ORCHESTRATOR
 
         if contract is not None:
             description = getattr(contract, "description", None)
+            contract_name = getattr(contract, "name", None)
+            if isinstance(contract_name, str) and contract_name:
+                effective_node_name = contract_name
             contract_version = getattr(contract, "contract_version", None)
             if contract_version is not None:
                 version = (
@@ -244,6 +251,9 @@ class ServiceNodeIntrospection(MixinNodeIntrospection):
                     pass  # Keep it
                 else:
                     description = None
+                raw_name = raw_yaml.get("name")
+                if isinstance(raw_name, str) and raw_name:
+                    effective_node_name = raw_name
                 raw_nt = raw_yaml.get("node_type")
                 if raw_nt is not None:
                     node_type = _map_node_type(raw_nt)
@@ -253,7 +263,7 @@ class ServiceNodeIntrospection(MixinNodeIntrospection):
 
         return cls.from_kernel_config(
             event_bus=event_bus,
-            node_name=node_name,
+            node_name=effective_node_name,
             node_id=node_id,
             node_type=node_type,
             version=version,

--- a/tests/unit/services/test_service_node_introspection.py
+++ b/tests/unit/services/test_service_node_introspection.py
@@ -127,6 +127,63 @@ class TestServiceNodeIntrospectionContractDir:
         assert service._introspection_contract is not None
         assert getattr(service._introspection_contract, "name", None) == "test_node"
 
+    def test_node_name_from_contract(self, tmp_path: Path) -> None:
+        """OMN-6405: node_name is populated from contract name, not caller arg."""
+        contract_file = tmp_path / "contract.yaml"
+        contract_file.write_text(yaml.dump(MINIMAL_CONTRACT_YAML))
+
+        service = ServiceNodeIntrospection.from_contract_dir(
+            contracts_dir=tmp_path,
+            event_bus=None,
+            node_name="runtime_config",  # caller passes generic config name
+            node_id=TEST_NODE_ID,
+        )
+        # Should use contract name, not the caller-provided "runtime_config"
+        assert service._introspection_node_name == "test_node"
+
+    @pytest.mark.asyncio
+    async def test_introspection_event_node_name_from_contract(
+        self, tmp_path: Path
+    ) -> None:
+        """OMN-6405: introspection event carries contract node_name, not None."""
+        contract_file = tmp_path / "contract.yaml"
+        contract_file.write_text(yaml.dump(MINIMAL_CONTRACT_YAML))
+
+        service = ServiceNodeIntrospection.from_contract_dir(
+            contracts_dir=tmp_path,
+            event_bus=None,
+            node_name="runtime_config",
+            node_id=TEST_NODE_ID,
+        )
+        event = await service.get_introspection_data()
+        assert event.node_name is not None
+        assert event.node_name == "test_node"
+
+    def test_node_name_from_raw_yaml_fallback(self, tmp_path: Path) -> None:
+        """OMN-6405: node_name extracted from raw YAML when Pydantic parsing fails."""
+        # Write a contract with extra fields that cause ModelContractBase to reject it
+        raw_yaml = {
+            "name": "my_custom_node",
+            "contract_version": {"major": 1, "minor": 0, "patch": 0},
+            "node_type": "EFFECT_GENERIC",
+            "description": "Test effect node",
+            "input_model": "omnibase_core.models.events.ModelEventEnvelope",
+            "output_model": "omnibase_core.models.events.ModelEventEnvelope",
+            "performance": {"single_operation_max_ms": 5000},
+            "unknown_field_that_breaks_pydantic": True,
+        }
+        contract_file = tmp_path / "contract.yaml"
+        contract_file.write_text(yaml.dump(raw_yaml))
+
+        service = ServiceNodeIntrospection.from_contract_dir(
+            contracts_dir=tmp_path,
+            event_bus=None,
+            node_name="runtime_config",
+            node_id=TEST_NODE_ID,
+        )
+        # Contract parsing fails, but raw YAML fallback should extract the name
+        assert service._introspection_node_name == "my_custom_node"
+
     def test_graceful_fallback_no_contract(self, tmp_path: Path) -> None:
         """Falls back gracefully when no contract.yaml exists."""
         service = ServiceNodeIntrospection.from_contract_dir(
@@ -137,6 +194,8 @@ class TestServiceNodeIntrospectionContractDir:
         )
         assert service is not None
         assert service._introspection_contract is None
+        # Without contract, caller-provided node_name is used
+        assert service._introspection_node_name == "test-service"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Root cause**: `ServiceNodeIntrospection.from_contract_dir()` used the caller-provided `node_name` (from `runtime_config.yaml` `name` field = `"runtime_config"`) instead of extracting the actual node name from the contract YAML. This caused introspection events to carry a generic config identifier rather than the contract-defined node name (e.g., `"node_registration_orchestrator"`), which then appeared as UUIDs or wrong names in the omnidash registry.
- **Fix**: Extract `name` from the contract Pydantic model (or raw YAML fallback when Pydantic parsing fails due to `extra="forbid"`), following the same pattern already used for `description`, `version`, and `node_type` extraction. Falls back to caller-provided `node_name` when no contract is available.
- **Tests**: Added 3 new tests verifying contract name extraction via Pydantic model, raw YAML fallback, and no-contract graceful degradation.

## Test plan

- [x] `test_node_name_from_contract` — verifies `_introspection_node_name` comes from contract, not caller
- [x] `test_introspection_event_node_name_from_contract` — verifies the published event carries the contract name
- [x] `test_node_name_from_raw_yaml_fallback` — verifies raw YAML fallback when Pydantic rejects the contract
- [x] `test_graceful_fallback_no_contract` — verifies caller-provided name is used when no contract exists
- [x] All 22 tests in `test_service_node_introspection.py` pass
- [x] All 7528 unit tests pass (1 pre-existing failure in unrelated `test_node_rrh_emit_effect.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Service node introspection now correctly derives node names from contract configuration files when available, rather than solely relying on runtime arguments. Includes graceful fallback when contracts are unavailable or unparseable.

* **Tests**
  * Added unit tests validating node name derivation from contract configurations and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->