### PR TITLE
fix: infra-up-runtime auto-rebuilds stale images [OMN-7214]

### DIFF
--- a/scripts/check-stale-images.sh
+++ b/scripts/check-stale-images.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# check-stale-images.sh — detect when local Docker images are older than
+# the source code that produced them.
+#
+# Usage:
+#   scripts/check-stale-images.sh [compose-file] [profile]
+#
+# Prints image names that are stale (code is newer than image).
+# Exit 0 with output  = stale images found (rebuild recommended)
+# Exit 0 with no output = all images are current
+# Exit 1 = error
+
+set -euo pipefail
+
+COMPOSE_FILE="${1:-docker/docker-compose.infra.yml}"
+PROFILE="${2:-runtime}"
+INFRA_DIR="${OMNIBASE_INFRA_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Get the latest commit timestamp in the repo (epoch seconds)
+code_ts=$(git -C "${INFRA_DIR}" log -1 --format='%ct' 2>/dev/null || echo "0")
+if [[ "${code_ts}" == "0" ]]; then
+    echo "[check-stale-images] ERROR: Cannot determine git commit timestamp" >&2
+    exit 1
+fi
+
+# Get runtime-profiled service names from the compose file
+compose_path="${INFRA_DIR}/${COMPOSE_FILE}"
+if [[ ! -f "${compose_path}" ]]; then
+    # Try as absolute path
+    compose_path="${COMPOSE_FILE}"
+fi
+
+if [[ ! -f "${compose_path}" ]]; then
+    echo "[check-stale-images] ERROR: Compose file not found: ${COMPOSE_FILE}" >&2
+    exit 1
+fi
+
+# Extract images for services with the given profile that have a build context
+# (services using pre-built images like postgres/redpanda don't need rebuilding)
+service_images=$(docker compose -f "${compose_path}" --profile "${PROFILE}" config --format json 2>/dev/null \
+    | jq -r '.services | to_entries[]
+        | select(.value.profiles // [] | index("'"${PROFILE}"'"))
+        | select(.value.build != null)
+        | .value.image // .key' \
+    | sort -u)
+
+if [[ -z "${service_images}" ]]; then
+    # No buildable runtime services found — nothing to check
+    exit 0
+fi
+
+stale_found=0
+while IFS= read -r image; do
+    [[ -z "${image}" ]] && continue
+
+    # Get image creation timestamp (epoch seconds)
+    image_created=$(docker inspect --format '{{.Created}}' "${image}" 2>/dev/null || echo "")
+
+    if [[ -z "${image_created}" ]]; then
+        # Image doesn't exist locally — definitely needs building
+        echo "${image}"
+        stale_found=1
+        continue
+    fi
+
+    # Convert ISO 8601 timestamp to epoch seconds
+    # macOS date and GNU date handle this differently
+    if date --version &>/dev/null 2>&1; then
+        # GNU date
+        image_ts=$(date -d "${image_created}" +%s 2>/dev/null || echo "0")
+    else
+        # macOS date — parse ISO 8601
+        image_ts=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$(echo "${image_created}" | cut -c1-19)" +%s 2>/dev/null || echo "0")
+    fi
+
+    if [[ "${code_ts}" -gt "${image_ts}" ]]; then
+        echo "${image}"
+        stale_found=1
+    fi
+done <<< "${service_images}"
+
+exit 0

--- a/scripts/onex-cli.sh
+++ b/scripts/onex-cli.sh
@@ -11,12 +11,38 @@ set -euo pipefail
 INFRA_DIR="${OMNIBASE_INFRA_DIR:-$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")}"
 
 onex_up() {
-    local bundles="$*"
+    local force_build=0
+    local bundles=""
+    for arg in "$@"; do
+        if [[ "$arg" == "--build" ]]; then
+            force_build=1
+        else
+            bundles="${bundles:+$bundles }$arg"
+        fi
+    done
     if [ -z "$bundles" ]; then
         bundles=$(cd "$INFRA_DIR" && uv run python -m omnibase_infra.docker.catalog.cli read-stack)
     fi
-    # shellcheck disable=SC2086
-    (cd "$INFRA_DIR" && uv run python -m omnibase_infra.docker.catalog.cli up $bundles)
+
+    # Auto-detect stale images when not explicitly requesting --build
+    if [[ "$force_build" -eq 0 ]]; then
+        local stale
+        stale=$("${INFRA_DIR}/scripts/check-stale-images.sh" 2>/dev/null || true)
+        if [[ -n "$stale" ]]; then
+            echo "[onex] Stale images detected (code is newer than image):" >&2
+            echo "$stale" | sed 's/^/  /' >&2
+            echo "[onex] Auto-rebuilding..." >&2
+            force_build=1
+        fi
+    fi
+
+    if [[ "$force_build" -eq 1 ]]; then
+        # shellcheck disable=SC2086
+        (cd "$INFRA_DIR" && uv run python -m omnibase_infra.docker.catalog.cli up --build $bundles)
+    else
+        # shellcheck disable=SC2086
+        (cd "$INFRA_DIR" && uv run python -m omnibase_infra.docker.catalog.cli up $bundles)
+    fi
 }
 
 onex_down() {

--- a/src/omnibase_infra/docker/catalog/cli.py
+++ b/src/omnibase_infra/docker/catalog/cli.py
@@ -8,6 +8,7 @@ Usage:
     python -m omnibase_infra.docker.catalog.cli validate core
     python -m omnibase_infra.docker.catalog.cli up runtime
     python -m omnibase_infra.docker.catalog.cli up runtime --seed
+    python -m omnibase_infra.docker.catalog.cli up runtime --build
     python -m omnibase_infra.docker.catalog.cli down
     python -m omnibase_infra.docker.catalog.cli status
     python -m omnibase_infra.docker.catalog.cli seed
@@ -175,12 +176,14 @@ def cmd_seed(_args: list[str]) -> int:
 def cmd_up(args: list[str]) -> int:
     """Validate, generate, and start compose stack."""
     _load_omnibase_env()
-    # Parse --seed flag
+    # Parse flags
     run_seed = "--seed" in args
-    bundles = [a for a in args if a != "--seed"] if args else _load_stack()
+    force_build = "--build" in args
+    flag_args = {"--seed", "--build"}
+    bundles = [a for a in args if a not in flag_args] if args else _load_stack()
 
-    # Save stack selection
-    if args:
+    # Save stack selection (exclude flags from saved bundles)
+    if bundles:
         _save_stack(bundles)
 
     # Validate
@@ -214,6 +217,18 @@ def cmd_up(args: list[str]) -> int:
         check=False,
         capture_output=True,
     )
+
+    # Build if requested (OMN-7214)
+    if force_build:
+        print("Rebuilding images (--build)...")
+        build_proc = subprocess.run(
+            ["docker", "compose", "-f", _DEFAULT_OUTPUT, "build"],
+            cwd=str(_REPO_ROOT),
+            check=False,
+        )
+        if build_proc.returncode != 0:
+            print("Image build failed", file=sys.stderr)
+            return build_proc.returncode
 
     # Start
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

- Add `scripts/check-stale-images.sh` — compares `git log -1 --format=%ct` against `docker inspect --format '{{.Created}}'` for each runtime-profiled service with a build context
- Update `scripts/onex-cli.sh` `onex_up` to auto-detect stale images and pass `--build` when code is newer than the image
- Update `src/omnibase_infra/docker/catalog/cli.py` `cmd_up` to accept `--build` flag and run `docker compose build` before `up -d`
- The shell function `infra-up-runtime` already passes `"$@"` through, so `infra-up-runtime --build` works for explicit forced rebuilds

## Test plan

- [ ] Run `scripts/check-stale-images.sh` and verify it detects stale images
- [ ] Run `infra-up-runtime` after a code change and verify it auto-rebuilds
- [ ] Run `infra-up-runtime --build` to verify explicit forced rebuild
- [ ] Verify containers start with the new image after rebuild