### PR TITLE
fix(infra): point check-stale-images.sh at generated compose [OMN-7222]

### DIFF
--- a/scripts/check-stale-images.sh
+++ b/scripts/check-stale-images.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-COMPOSE_FILE="${1:-docker/docker-compose.infra.yml}"
+COMPOSE_FILE="${1:-docker/docker-compose.generated.yml}"
 PROFILE="${2:-runtime}"
 INFRA_DIR="${OMNIBASE_INFRA_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 


### PR DESCRIPTION
## Summary
- Fixed `scripts/check-stale-images.sh` default compose file path from `docker/docker-compose.infra.yml` (which no longer exists) to `docker/docker-compose.generated.yml` (the catalog-generated compose file)
- The PROFILE default (`runtime`) remains unchanged — it is a harmless no-op since the generated compose uses pre-built images with no Docker Compose profiles

## Test plan
- [x] Shell syntax check passes (`bash -n`)
- [ ] Verify script runs without error when generated compose file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Docker Compose configuration file path reference used in internal image scanning tools to align with current infrastructure organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->