### PR TITLE
fix(infra): Redpanda advertised host hardcodes localhost [OMN-7223]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -246,9 +246,9 @@ services:
       - redpanda
       - start
       - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
-      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:${REDPANDA_EXTERNAL_PORT:-19092}
+      - --advertise-kafka-addr internal://redpanda:9092,external://${REDPANDA_ADVERTISE_HOST:-localhost}:${REDPANDA_EXTERNAL_PORT:-19092}
       - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
-      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:${REDPANDA_PANDAPROXY_PORT:-18082}
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://${REDPANDA_ADVERTISE_HOST:-localhost}:${REDPANDA_PANDAPROXY_PORT:-18082}
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
       - --rpc-addr redpanda:33145
       - --advertise-rpc-addr redpanda:33145


### PR DESCRIPTION
## Summary
- Replace hardcoded `localhost` in Redpanda `--advertise-kafka-addr` and `--advertise-pandaproxy-addr` with `${REDPANDA_ADVERTISE_HOST:-localhost}` env var
- Defaults to `localhost` for backwards compatibility; remote clients can override via env

## Test plan
- [ ] Verify `infra-up` still works with no env var set (defaults to localhost)
- [ ] Verify setting `REDPANDA_ADVERTISE_HOST=<ip>` advertises the correct host to remote Kafka clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redpanda infrastructure configuration to support dynamic external host address configuration via environment variable, enabling flexible deployments across different network environments while maintaining `localhost` as the default fallback. Internal address routing remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->