### PR TITLE
feat(infra): parameterize skills volume mount for remote deployment [OMN-6053]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -163,7 +163,8 @@ x-runtime-env: &runtime-env
   # nodes at the site-packages path below.
   OMNICLAUDE_CONTRACTS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/nodes
   # OMN-4622: Skills root for topic provisioning (flat-list topics.yaml manifests)
-  OMNICLAUDE_SKILLS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/plugins/onex/skills
+  # Overrideable for remote deployments where skills are mounted from host (e.g. OMNICLAUDE_SKILLS_ROOT=/app/skills)
+  OMNICLAUDE_SKILLS_ROOT: ${OMNICLAUDE_SKILLS_ROOT:-/app/.venv/lib/python3.12/site-packages/omniclaude/plugins/onex/skills}
   # --- Infisical config store ---
   INFISICAL_ADDR: ${INFISICAL_ADDR:-}
   INFISICAL_CLIENT_ID: ${INFISICAL_CLIENT_ID:-}
@@ -575,6 +576,7 @@ services:
       - runtime_logs:/app/logs
       - runtime_data:/app/data
       - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s
@@ -619,6 +621,7 @@ services:
       - effects_logs:/app/logs
       - effects_data:/app/data
       - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s
@@ -658,6 +661,7 @@ services:
     volumes:
       - worker_logs:/app/logs
       - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s
@@ -973,6 +977,7 @@ services:
     volumes:
       - contract_resolver_logs:/app/logs
       - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8091/health"]
       interval: 30s

--- a/scripts/omnidash-lifecycle.sh
+++ b/scripts/omnidash-lifecycle.sh
@@ -40,14 +40,7 @@ _resolve_omnidash_dir() {
     fi
   fi
 
-  # Hardcoded fallback
-  local fallback="/Volumes/PRO-G40/Code/omni_home/omnidash"
-  if [[ -f "${fallback}/package.json" ]]; then
-    echo "${fallback}"
-    return 0
-  fi
-
-  echo "[omnidash] ERROR: Cannot find omnidash directory. Set OMNIDASH_DIR." >&2
+  echo "[omnidash] ERROR: Cannot find omnidash directory. Set OMNIDASH_DIR or OMNIBASE_INFRA_DIR." >&2
   return 1
 }
 


### PR DESCRIPTION
## Summary

- Make `OMNICLAUDE_SKILLS_ROOT` overrideable via env var in `x-runtime-env` (defaults to venv path; remote hosts can set `/app/skills`)
- Add `${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro` volume mount to `omninode-runtime`, `runtime-effects`, `runtime-worker`, and `contract-resolver`
- Remove hardcoded `/Volumes/PRO-G40` fallback from `omnidash-lifecycle.sh`; derive from `OMNIBASE_INFRA_DIR` only, error clearly if unset

## Context

Part of the `.201` migration — these changes allow the remote host to mount skills from a host-specific path without local code modifications, replacing the 3 manual edits that existed on `.201`.

## Test plan

- [ ] `pre-commit run --all-files` passes
- [ ] On .201: set `OMNICLAUDE_SKILLS_DIR` and `OMNICLAUDE_SKILLS_ROOT` in `.env`, rebuild, verify runtime healthy
- [ ] `grep -r '/Volumes/PRO-G40' scripts/omnidash-lifecycle.sh` returns no results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced runtime environment configuration to support environment variable overrides for skills directory paths.
  * Improved directory resolution error handling with clearer messaging when required configuration is not properly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->