### PR TITLE
feat: add integration catalog contract YAML [OMN-7239]

### DIFF
--- a/src/omnibase_infra/contracts/integrations/catalog.yaml
+++ b/src/omnibase_infra/contracts/integrations/catalog.yaml
@@ -22,8 +22,7 @@ integrations:
     type: webhook
     description: "Receives GitHub webhook events (PR merged, push, check suite) and publishes ONEX events"
     contract: "contracts/integrations/github_webhook/contract.yaml"
-    nodes:
-      - node_github_pr_poller_effect
+    nodes: []
     health_check:
       type: github_api
       endpoint: "https://api.github.com/orgs/OmniNode-ai"
@@ -66,6 +65,7 @@ integrations:
     env_vars:
       - GMAIL_CLIENT_ID
       - GMAIL_CLIENT_SECRET
+      - GMAIL_REFRESH_TOKEN
   - id: slack_alerter
     name: "Slack Alerter"
     type: outbound


### PR DESCRIPTION
## Summary
- Adds `contracts/integrations/catalog.yaml` — a declarative registry of all active platform integrations
- Lists 10 integrations: GitHub webhook, GitHub PR poller, Linear relay, Gmail intent poller, Slack alerter, Kafka, Qdrant, Infisical, PostgreSQL, Valkey
- Each entry includes: health check config, env var dependencies, ONEX node references, and contract pointers
- Consumed by omnidash `IntegrationCatalogDashboard` (see OmniNode-ai/omnidash#492)

Part of feature hookup Phase 3 (Tasks 7 + 8).

## Test plan
- [ ] Verify catalog.yaml is valid YAML and passes contract validation
- [ ] Verify omnidash integration-catalog-routes can load and parse this file
- [ ] Verify no hardcoded topic strings (enforced by pre-commit hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a centralized integration catalog documenting 10 integrations (GitHub webhook & PR poller, Linear, Gmail, Slack alerts, Kafka/Redpanda, Qdrant, Infisical, PostgreSQL, Valkey). Each entry includes an identifier, display name, type, description, health-check settings, implementing nodes, and required environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->