### PR TITLE
feat(consumer): add learning extraction consumer entrypoint stub [OMN-7251]

### DIFF
--- a/src/omnibase_infra/services/agent_learning_extraction/entrypoint.py
+++ b/src/omnibase_infra/services/agent_learning_extraction/entrypoint.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Entrypoint for the agent learning extraction consumer.
+
+Consumes session-ended and tool-executed events from Kafka.
+For SUCCESS sessions, extracts learning records and stores them
+in Postgres + Qdrant.
+
+Run as a standalone consumer:
+    uv run python -m omnibase_infra.services.agent_learning_extraction.entrypoint
+
+Wiring contract:
+    Topics:
+        - onex.evt.session.ended.v1 (trigger: session completed)
+        - onex.evt.tool.executed.v1 (buffered per session_id)
+    Consumer group: agent-learning-extraction
+    Processing pipeline:
+        1. Buffer tool-executed events keyed by session_id
+        2. On session-ended (SUCCESS): collect buffered tool events
+        3. Extract error signatures from failed tool outputs
+        4. Generate resolution summary via LLM (Qwen3-14B)
+        5. Build ModelAgentLearning record
+        6. Store metadata in Postgres (agent_learnings table)
+        7. Embed and store vectors in Qdrant (error_signatures + task_context collections)
+
+Follows the SessionEventConsumer pattern from
+omnibase_infra/services/session/consumer.py:
+    - MixinConsumerHealth for resilience
+    - At-least-once delivery with manual offset commits
+    - Circuit breaker for downstream writes
+    - Graceful shutdown with drain
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def run_consumer() -> None:
+    """Main consumer loop (placeholder for wiring).
+
+    Full implementation wires together:
+    1. Kafka consumer subscribing to session-ended + tool-executed topics
+    2. In-memory buffer for tool events keyed by session_id
+    3. On session-ended (SUCCESS): extract errors, generate summary, build record, store
+    """
+    logger.info("Agent learning extraction consumer starting...")
+    # Implementation follows the SessionEventConsumer pattern from
+    # omnibase_infra/services/session/consumer.py:
+    # - MixinConsumerHealth for resilience
+    # - async for message in event_bus.consume(topic)
+    # - Manual offset commits after successful processing
+    logger.info(
+        "Consumer placeholder — full implementation requires Kafka event bus wiring"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_consumer())


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_infra/services/agent_learning_extraction/entrypoint.py` — a stub entrypoint for the Kafka consumer that will extract learning records from successful agent sessions
- Documents the full wiring contract (topics, consumer group, processing pipeline) in the module docstring
- Placeholder `run_consumer()` async function and `__main__` block for standalone execution

This is explicitly a **stub** (Phase 1D of the cross-agent memory fabric plan). Full Kafka consumption, event buffering, LLM summarization, embedding, and dual Postgres+Qdrant writes are deferred to a follow-up ticket.

## Test plan

- [x] Pre-commit hooks pass (all 40+ checks)
- [x] ruff format/check clean
- [ ] CI passes