### PR TITLE
feat(watchdog): add CAIA session watchdog for continuous pipeline [OMN-7288]

### DIFF
--- a/scripts/ai.omninode.caia-watchdog.plist
+++ b/scripts/ai.omninode.caia-watchdog.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CAIA Watchdog — macOS LaunchAgent
+
+  Monitors for session checkpoint files and relaunches claude -p when
+  limits reset. Uses WatchPaths for efficient detection (triggers on
+  checkpoint creation) plus a KeepAlive fallback for the long-running loop.
+
+  Install:
+    bash scripts/install-watchdog.sh
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/ai.omninode.caia-watchdog.plist
+    rm ~/Library/LaunchAgents/ai.omninode.caia-watchdog.plist
+
+  Logs:
+    ~/.onex_state/orchestrator/watchdog.log
+    /tmp/caia-watchdog-stderr.log  (launchd-level errors only)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.omninode.caia-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Volumes/PRO-G40/Code/omni_home/omnibase_infra/scripts/caia-watchdog.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>HOME</key>
+        <string>/Users/jonah</string>
+    </dict>
+
+    <!-- Start immediately on load -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart automatically if the process exits -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Wait 60s before restarting after exit (avoids tight loops) -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <!-- Also trigger when checkpoint file is created/modified -->
+    <key>WatchPaths</key>
+    <array>
+        <string>/Users/jonah/.onex_state/orchestrator</string>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/caia-watchdog-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/caia-watchdog-stderr.log</string>
+</dict>
+</plist>

--- a/scripts/caia-watchdog.sh
+++ b/scripts/caia-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# caia-watchdog.sh — CAIA session watchdog
+#
+# Monitors for session checkpoints written by the checkpoint skill and
+# relaunches `claude -p` when the reset time arrives.
+#
+# Checkpoint file: ~/.onex_state/orchestrator/checkpoint.yaml
+# Log file:        ~/.onex_state/orchestrator/watchdog.log
+#
+# Managed by launchd plist ai.omninode.caia-watchdog.
+# The script runs as a long-lived process; launchd restarts it on exit.
+
+set -euo pipefail
+
+CHECKPOINT_DIR="${HOME}/.onex_state/orchestrator"
+CHECKPOINT_FILE="${CHECKPOINT_DIR}/checkpoint.yaml"
+LOG_FILE="${CHECKPOINT_DIR}/watchdog.log"
+ARCHIVE_DIR="${CHECKPOINT_DIR}/archive"
+POLL_INTERVAL="${CAIA_WATCHDOG_POLL_SECONDS:-300}"  # 5 minutes default
+
+mkdir -p "$CHECKPOINT_DIR"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG_FILE"; }
+
+log "Watchdog started. Polling ${CHECKPOINT_FILE} every ${POLL_INTERVAL}s"
+
+while true; do
+    if [[ -f "$CHECKPOINT_FILE" ]]; then
+        log "Checkpoint found"
+
+        # Parse YAML fields using python3 (available on macOS)
+        RESET_AT=$(python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('$CHECKPOINT_FILE'))
+    print(d.get('reset_at', '') or '')
+except Exception as e:
+    print('', file=sys.stderr)
+    print('')
+" 2>>"$LOG_FILE")
+
+        RESUME_PROMPT=$(python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('$CHECKPOINT_FILE'))
+    print(d.get('resume_prompt', '') or '')
+except Exception as e:
+    print('', file=sys.stderr)
+    print('')
+" 2>>"$LOG_FILE")
+
+        # Validate that we got a resume prompt
+        if [[ -z "$RESUME_PROMPT" ]]; then
+            log "ERROR: checkpoint has no resume_prompt, removing"
+            rm -f "$CHECKPOINT_FILE"
+            sleep "$POLL_INTERVAL"
+            continue
+        fi
+
+        # If reset_at is set, sleep until that time
+        if [[ -n "$RESET_AT" ]]; then
+            # Parse ISO-8601 timestamp to epoch (macOS date -j)
+            # Strip fractional seconds and timezone suffix for date parsing
+            CLEAN_TS=$(echo "$RESET_AT" | sed 's/\.[0-9]*//; s/Z$//; s/+00:00$//')
+            RESET_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$CLEAN_TS" "+%s" 2>/dev/null || echo 0)
+            NOW_EPOCH=$(date "+%s")
+            SLEEP_SECS=$(( RESET_EPOCH - NOW_EPOCH ))
+
+            if [[ $SLEEP_SECS -gt 0 ]]; then
+                log "Sleeping ${SLEEP_SECS}s until reset at ${RESET_AT}"
+                sleep "$SLEEP_SECS"
+            else
+                log "Reset time already passed (${RESET_AT}), launching immediately"
+            fi
+        fi
+
+        # Archive checkpoint before launch
+        mkdir -p "$ARCHIVE_DIR"
+        cp "$CHECKPOINT_FILE" "${ARCHIVE_DIR}/checkpoint-$(date +%s).yaml"
+        rm -f "$CHECKPOINT_FILE"
+
+        log "Launching claude -p with resume prompt"
+
+        # Launch claude -p — run in foreground so launchd tracks the process
+        ONEX_RUN_ID="watchdog-$(date +%s)" \
+        claude -p "$RESUME_PROMPT" \
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep,mcp__linear-server__*" \
+            >> "$LOG_FILE" 2>&1 || log "claude -p exited with code $?"
+
+        log "claude -p session completed"
+    fi
+
+    sleep "$POLL_INTERVAL"
+done

--- a/scripts/install-watchdog.sh
+++ b/scripts/install-watchdog.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# install-watchdog.sh — Install the CAIA watchdog launchd agent
+#
+# Usage:
+#   bash scripts/install-watchdog.sh          # Install and load
+#   bash scripts/install-watchdog.sh --uninstall  # Unload and remove
+
+set -euo pipefail
+
+LABEL="ai.omninode.caia-watchdog"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLIST_SRC="${SCRIPT_DIR}/ai.omninode.caia-watchdog.plist"
+PLIST_DST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+CHECKPOINT_DIR="${HOME}/.onex_state/orchestrator"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+    echo "Uninstalling ${LABEL}..."
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+    rm -f "$PLIST_DST"
+    echo "Done. Watchdog uninstalled."
+    exit 0
+fi
+
+echo "Installing ${LABEL}..."
+
+# Ensure checkpoint directory exists (WatchPaths needs it)
+mkdir -p "$CHECKPOINT_DIR"
+
+# Ensure LaunchAgents directory exists
+mkdir -p "${HOME}/Library/LaunchAgents"
+
+# Make watchdog script executable
+chmod +x "${SCRIPT_DIR}/caia-watchdog.sh"
+
+# Unload existing if present (safe to fail)
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+
+# Copy plist
+cp "$PLIST_SRC" "$PLIST_DST"
+
+# Load the agent
+launchctl load "$PLIST_DST"
+
+echo "Done. Watchdog installed and running."
+echo "  Plist:      ${PLIST_DST}"
+echo "  Script:     ${SCRIPT_DIR}/caia-watchdog.sh"
+echo "  Log:        ${CHECKPOINT_DIR}/watchdog.log"
+echo "  Checkpoint: ${CHECKPOINT_DIR}/checkpoint.yaml"
+echo ""
+echo "To uninstall: bash ${SCRIPT_DIR}/install-watchdog.sh --uninstall"

--- a/tests/unit/scripts/test_watchdog_checkpoint.py
+++ b/tests/unit/scripts/test_watchdog_checkpoint.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for CAIA watchdog checkpoint YAML parsing.
+
+Validates that the watchdog shell script's Python-based YAML parsing
+handles valid, incomplete, and malformed checkpoint files correctly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+class TestWatchdogCheckpointParsing:
+    """Validate checkpoint YAML parsing used by caia-watchdog.sh."""
+
+    def _parse_field(self, checkpoint_path: Path, field: str) -> str:
+        """Simulate the Python one-liner the watchdog uses to extract a field."""
+        result = subprocess.run(
+            [
+                "python3",
+                "-c",
+                f"import yaml; d=yaml.safe_load(open('{checkpoint_path}')); "
+                f"print(d.get('{field}', '') or '')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        return result.stdout.strip()
+
+    def test_parse_valid_checkpoint(self, tmp_path: Path) -> None:
+        """Full checkpoint with all fields parses correctly."""
+        checkpoint = {
+            "schema_version": "1.0.0",
+            "session_id": "test-session-123",
+            "checkpoint_reason": "context_limit",
+            "created_at": "2026-04-02T10:00:00Z",
+            "reset_at": "2026-04-02T11:00:00Z",
+            "resume_prompt": "Continue ticket-pipeline for OMN-7300",
+            "active_epic": "OMN-7299",
+            "active_tickets": ["OMN-7300", "OMN-7301"],
+            "active_prs": ["omniclaude#1070"],
+            "pipeline_state": "ticket-pipeline:implement",
+            "context_percent": 87,
+            "session_percent": 45,
+            "weekly_percent": 20,
+        }
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text(yaml.dump(checkpoint, default_flow_style=False))
+
+        assert self._parse_field(cp_file, "reset_at") == "2026-04-02T11:00:00Z"
+        assert (
+            self._parse_field(cp_file, "resume_prompt")
+            == "Continue ticket-pipeline for OMN-7300"
+        )
+        assert self._parse_field(cp_file, "checkpoint_reason") == "context_limit"
+
+    def test_parse_checkpoint_missing_reset_at(self, tmp_path: Path) -> None:
+        """Checkpoint without reset_at returns empty string."""
+        checkpoint = {
+            "schema_version": "1.0.0",
+            "session_id": "test-session-456",
+            "checkpoint_reason": "explicit",
+            "created_at": "2026-04-02T10:00:00Z",
+            "resume_prompt": "Resume the close-out pipeline",
+        }
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text(yaml.dump(checkpoint, default_flow_style=False))
+
+        assert self._parse_field(cp_file, "reset_at") == ""
+        assert (
+            self._parse_field(cp_file, "resume_prompt")
+            == "Resume the close-out pipeline"
+        )
+
+    def test_parse_checkpoint_missing_resume_prompt(self, tmp_path: Path) -> None:
+        """Checkpoint without resume_prompt returns empty string."""
+        checkpoint = {
+            "schema_version": "1.0.0",
+            "session_id": "test-session-789",
+            "checkpoint_reason": "session_limit",
+            "created_at": "2026-04-02T10:00:00Z",
+            "reset_at": "2026-04-02T12:00:00Z",
+        }
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text(yaml.dump(checkpoint, default_flow_style=False))
+
+        assert self._parse_field(cp_file, "resume_prompt") == ""
+        assert self._parse_field(cp_file, "reset_at") == "2026-04-02T12:00:00Z"
+
+    def test_parse_checkpoint_null_reset_at(self, tmp_path: Path) -> None:
+        """Checkpoint with explicit null reset_at returns empty string."""
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text(
+            textwrap.dedent("""\
+                schema_version: "1.0.0"
+                session_id: test-null
+                checkpoint_reason: weekly_limit
+                created_at: "2026-04-02T10:00:00Z"
+                reset_at: null
+                resume_prompt: "Resume after weekly reset"
+            """)
+        )
+
+        assert self._parse_field(cp_file, "reset_at") == ""
+        assert (
+            self._parse_field(cp_file, "resume_prompt") == "Resume after weekly reset"
+        )
+
+    def test_parse_malformed_yaml(self, tmp_path: Path) -> None:
+        """Malformed YAML does not crash the parser — returns empty string."""
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text("this is not: valid: yaml: [[[")
+
+        # The Python one-liner catches exceptions and returns empty
+        result = subprocess.run(
+            [
+                "python3",
+                "-c",
+                f"import yaml, sys\n"
+                f"try:\n"
+                f"    d=yaml.safe_load(open('{cp_file}'))\n"
+                f"    print(d.get('reset_at', '') or '')\n"
+                f"except Exception:\n"
+                f"    print('')\n",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert result.stdout.strip() == ""
+
+    def test_parse_empty_file(self, tmp_path: Path) -> None:
+        """Empty file does not crash — returns empty string."""
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text("")
+
+        result = subprocess.run(
+            [
+                "python3",
+                "-c",
+                f"import yaml, sys\n"
+                f"try:\n"
+                f"    d=yaml.safe_load(open('{cp_file}'))\n"
+                f"    print((d or {{}}).get('reset_at', '') or '')\n"
+                f"except Exception:\n"
+                f"    print('')\n",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert result.stdout.strip() == ""
+
+    def test_checkpoint_yaml_roundtrip(self, tmp_path: Path) -> None:
+        """Checkpoint written as YAML can be read back with all fields intact."""
+        checkpoint = {
+            "schema_version": "1.0.0",
+            "session_id": "roundtrip-test",
+            "checkpoint_reason": "context_limit",
+            "created_at": "2026-04-02T10:00:00Z",
+            "reset_at": "2026-04-02T11:30:00Z",
+            "resume_prompt": "Continue epic-team for OMN-7280",
+            "active_tickets": ["OMN-7300"],
+            "active_prs": [],
+            "context_percent": 92,
+        }
+        cp_file = tmp_path / "checkpoint.yaml"
+        cp_file.write_text(yaml.dump(checkpoint, default_flow_style=False))
+
+        loaded = yaml.safe_load(cp_file.read_text())
+        assert loaded["session_id"] == "roundtrip-test"
+        assert loaded["reset_at"] == "2026-04-02T11:30:00Z"
+        assert loaded["context_percent"] == 92
+        assert loaded["active_tickets"] == ["OMN-7300"]


### PR DESCRIPTION
## Summary

- Add `scripts/caia-watchdog.sh` — shell script that polls for session checkpoint files at `~/.onex_state/orchestrator/checkpoint.yaml`, sleeps until the `reset_at` timestamp, and relaunches `claude -p` with the stored resume prompt
- Add `scripts/ai.omninode.caia-watchdog.plist` — launchd agent with WatchPaths for efficient checkpoint detection plus KeepAlive for resilience
- Add `scripts/install-watchdog.sh` — installation helper that copies the plist, loads the agent, and supports `--uninstall`
- Add `tests/unit/scripts/test_watchdog_checkpoint.py` — 7 unit tests validating YAML checkpoint parsing (valid, missing fields, null, malformed, empty, roundtrip)

## Context

Phase 1B of the CAIA platform roadmap. Enables continuous autonomous pipeline operation by bridging the gap between Claude Code session limit hits and limit resets. When the checkpoint skill writes a checkpoint file, the watchdog detects it and relaunches a new session at the appropriate time.

## Test plan

- [x] All 7 unit tests pass (`uv run pytest tests/unit/scripts/test_watchdog_checkpoint.py -v`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] CI passes on this PR
- [ ] Manual verification: write a test checkpoint, confirm watchdog detects and archives it