### PR TITLE
fix(redpanda): raise topic_partitions_per_shard to 7000 [OMN-7302]

### DIFF
--- a/docker/catalog/services/redpanda.yaml
+++ b/docker/catalog/services/redpanda.yaml
@@ -35,6 +35,8 @@ command:
   - --memory ${REDPANDA_MEMORY:-8G}
   - --default-log-level=warn
   - --set redpanda.kafka_batch_max_bytes=4194304
+  # OMN-7302: raise partition cap to prevent "Not enough resources" errors
+  - --set topic_partitions_per_shard=7000
 labels:
   com.omninode.service: redpanda
   com.omninode.layer: infrastructure

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -265,6 +265,10 @@ services:
       # Admin API defaults to 0.0.0.0:9644 in dev-container mode; port mapping
       # in ports: section is sufficient for external access.
       - --default-log-level=warn
+      # OMN-7302: raise partition cap from default 1000 to 7000 to prevent
+      # "Not enough resources" failures when topic count × partitions exceeds
+      # the per-shard limit.
+      - --set topic_partitions_per_shard=7000
     ports:
       - "${REDPANDA_EXTERNAL_PORT:-19092}:19092"
       # Pandaproxy (REST API for Kafka)


### PR DESCRIPTION
## Summary

- Raises Redpanda `topic_partitions_per_shard` from default 1000 to 7000 in both `docker-compose.infra.yml` and the service catalog manifest (`docker/catalog/services/redpanda.yaml`)
- Prevents "Not enough resources" errors when total topic × partition count exceeds the per-shard limit
- Fix also applied live on .201 via `rpk cluster config set`; 4 missing DLQ topics created on .201 (`agent-actions-dlq.v1`, `agent-observability-dlq.v1`, `fix-transition.v1`, `context-audit-dlq.v1`)

## Test plan

- [ ] `infra-up` starts Redpanda without errors
- [ ] `rpk cluster config get topic_partitions_per_shard` returns 7000 after container recreation
- [ ] Existing topics remain intact after restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redpanda service configuration to enhance message queue capacity management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->