### PR TITLE
release: omnibase_infra v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.34.0 (2026-04-03)
+
+### Features
+- feat(routing): emit routing-decided events from model router [OMN-7443] (#1141)
+
+### Bug Fixes
+- fix: add consumers for context-enrichment and injection-recorded events [OMN-6158] (#1140)
+
 ## v0.32.0 (2026-04-03)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.33.0"
+version = "0.34.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/contract.yaml
@@ -23,10 +23,7 @@ node_version:
   patch: 0
 node_type: "ORCHESTRATOR_GENERIC"
 description: >
-  Orchestrator that coordinates the 6-phase autonomous build loop cycle.
-  Reacts to reducer-approved state transitions and bridges COMPUTE/EFFECT
-  node outputs to events for the reducer. Never independently decides
-  phase transitions.
+  Orchestrator that coordinates the 6-phase autonomous build loop cycle. Reacts to reducer-approved state transitions and bridges COMPUTE/EFFECT node outputs to events for the reducer. Never independently decides phase transitions.
 
 input_model:
   name: "ModelLoopStartCommand"

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/contracts/delegation_request_v1.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/contracts/delegation_request_v1.yaml
@@ -9,25 +9,20 @@ contract_version:
   minor: 0
   patch: 0
 node_type: "SCHEMA"
-
 topic: "onex.cmd.omnibase-infra.delegation-request.v1"
 schema_version: "1.0.0"
 ticket: "OMN-7360"
 description: >
-  Delegation request command emitted by omniclaude to delegate tasks (test, document,
-  research) to a local LLM via the ONEX runtime event bus. Prior incident: silent drops
-  caused by field name mismatches between producer and consumer.
+  Delegation request command emitted by omniclaude to delegate tasks (test, document, research) to a local LLM via the ONEX runtime event bus. Prior incident: silent drops caused by field name mismatches between producer and consumer.
 
 producer:
   repo: "omniclaude"
   file: "plugins/onex/hooks/lib/delegation_wrapper.py"
   function: "emit_delegation_request"
-
 consumer:
   repo: "omnibase_infra"
   file: "src/omnibase_infra/nodes/node_delegation_orchestrator/dispatchers/dispatcher_delegation_request.py"
   model: "ModelDelegationRequest"
-
 required_fields:
   - name: "prompt"
     type: "string"
@@ -43,7 +38,6 @@ required_fields:
   - name: "emitted_at"
     type: "datetime"
     description: "Timestamp when the request was created."
-
 optional_fields:
   - name: "source_session_id"
     type: "string"

--- a/src/omnibase_infra/services/observability/agent_actions/contracts/intelligence_hook_event_v1.yaml
+++ b/src/omnibase_infra/services/observability/agent_actions/contracts/intelligence_hook_event_v1.yaml
@@ -7,20 +7,16 @@ topic: "onex.cmd.omniintelligence.claude-hook-event.v1"
 schema_version: "1.0.0"
 ticket: "OMN-7360"
 description: >
-  Full Claude Code hook event sent to the intelligence pipeline for analysis.
-  Contains the complete prompt content (access-restricted topic). This is the
-  privacy-sensitive counterpart to the preview-safe evt topics.
+  Full Claude Code hook event sent to the intelligence pipeline for analysis. Contains the complete prompt content (access-restricted topic). This is the privacy-sensitive counterpart to the preview-safe evt topics.
 
 producer:
   repo: "omniclaude"
   file: "src/omniclaude/hooks/handler_event_emitter.py"
   function: "emit_intelligence_event"
-
 consumer:
   repo: "omniintelligence"
   file: "src/omniintelligence/consumers/hook_event_consumer.py"
   model: "ModelClaudeHookEvent"
-
 required_fields:
   - name: "session_id"
     type: "string"
@@ -34,7 +30,6 @@ required_fields:
   - name: "event_type"
     type: "string"
     description: "Hook event type (session_started, prompt_submitted, tool_executed, session_ended)."
-
 optional_fields:
   - name: "task_id"
     type: "string"

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2535,8 +2535,7 @@ pattern_exemptions:
   - file_pattern: 'model_context_enrichment\.py'
     violation_pattern: "Field 'model_name' might reference an entity"
     reason: >
-      model_name is a free-text LLM identifier string (e.g. "gpt-4o"), not an entity reference.
-      Matches the producer schema in omniclaude enrichment_observability_emitter.py.
+      model_name is a free-text LLM identifier string (e.g. "gpt-4o"), not an entity reference. Matches the producer schema in omniclaude enrichment_observability_emitter.py.
 
     documentation:
       - enrichment_observability_emitter.py (omniclaude)
@@ -3050,32 +3049,32 @@ pattern_exemptions:
     violation_pattern: "Field 'ticket_id' should use UUID type instead of str"
     reason: >
       ticket_id is a human-readable Linear identifier (e.g. "OMN-1234"), not a UUID.
-    ticket: OMN-5113
 
+    ticket: OMN-5113
   - file_pattern: 'model_ticket_for_classification\.py'
     violation_pattern: "Field 'ticket_id' should use UUID type instead of str"
     reason: >
       ticket_id is a human-readable Linear identifier (e.g. "OMN-1234"), not a UUID.
-    ticket: OMN-5113
 
+    ticket: OMN-5113
   - file_pattern: 'model_build_target\.py'
     violation_pattern: "Field 'ticket_id' should use UUID type instead of str"
     reason: >
       ticket_id is a human-readable Linear identifier (e.g. "OMN-1234"), not a UUID.
-    ticket: OMN-5113
 
+    ticket: OMN-5113
   - file_pattern: 'model_build_dispatch_outcome\.py'
     violation_pattern: "Field 'ticket_id' should use UUID type instead of str"
     reason: >
       ticket_id is a human-readable Linear identifier (e.g. "OMN-1234"), not a UUID.
-    ticket: OMN-5113
 
+    ticket: OMN-5113
   - file_pattern: 'model_scored_ticket\.py'
     violation_pattern: "Field 'ticket_id' should use UUID type instead of str"
     reason: >
       ticket_id is a human-readable Linear identifier (e.g. "OMN-1234"), not a UUID.
-    ticket: OMN-5113
 
+    ticket: OMN-5113
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/uv.lock
+++ b/uv.lock
@@ -1883,7 +1883,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.32.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release: omnibase_infra v0.34.0

Coordinated release run: `release-20260403-703e84`

### Changes
- feat(routing): emit routing-decided events from model router [OMN-7443] (#1141)
- fix: add consumers for context-enrichment and injection-recorded events [OMN-6158] (#1140)

### Release metadata
- Bump: minor
- Previous: v0.33.0
- Plan hash: sha256:1dbf46eccc70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event emission from the model router.

* **Bug Fixes**
  * Fixed event consumer registration for context enrichment and injection tracking.

* **Chores**
  * Bumped version to 0.34.0.
  * Reformatted documentation and configuration files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->