### PR TITLE
fix: wire event bus publisher and loosen ticket classifier for build loop [OMN-7569]

### DIFF
--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
@@ -21,6 +21,8 @@ from uuid import UUID
 
 from omnibase_core.enums import EnumInjectionScope, EnumMessageCategory
 
+from omnibase_infra.errors import ModelInfraErrorContext
+
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
     from omnibase_core.protocols.event_bus import ProtocolEventBusPublisher
@@ -113,10 +115,15 @@ async def wire_build_loop_handlers(
             )
             publisher_cb = _make_publisher(event_bus)
             logger.debug("Resolved ProtocolEventBusPublisher for build loop")
-        except Exception:  # noqa: BLE001 — degrade to filesystem fallback
+        except Exception as exc:  # noqa: BLE001 — degrade to filesystem fallback
+            _ctx = ModelInfraErrorContext.with_correlation(
+                operation="resolve_event_bus_publisher",
+            )
             logger.warning(
                 "Could not resolve ProtocolEventBusPublisher — "
-                "build loop will use filesystem fallback",
+                "build loop will use filesystem fallback "
+                "(context=%s)",
+                _ctx,
                 exc_info=True,
             )
 

--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, TypedDict
 from uuid import UUID
 
 from omnibase_core.enums import EnumInjectionScope, EnumMessageCategory
-
 from omnibase_infra.errors import ModelInfraErrorContext
 
 if TYPE_CHECKING:

--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
@@ -12,8 +12,10 @@ Related:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypedDict
 from uuid import UUID
 
@@ -21,11 +23,52 @@ from omnibase_core.enums import EnumInjectionScope, EnumMessageCategory
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
+    from omnibase_core.protocols.event_bus import ProtocolEventBusPublisher
     from omnibase_infra.runtime import MessageDispatchEngine
 
 logger = logging.getLogger(__name__)
 
 ROUTE_ID_BUILD_LOOP_START = "route.build-loop.build-loop-start"
+
+
+def _make_publisher(
+    event_bus: ProtocolEventBusPublisher,
+) -> Callable[..., Awaitable[bool]]:
+    """Create a publisher callback that bridges ProtocolEventBusPublisher to
+    the HandlerLoopOrchestrator's expected signature.
+
+    The orchestrator calls ``publisher(event_type=..., payload=...,
+    correlation_id=..., topic=...)`` and expects a ``bool`` return.
+    """
+
+    async def _publish(
+        *,
+        event_type: str,
+        payload: dict[str, object],
+        correlation_id: UUID,
+        topic: str,
+    ) -> bool:
+        try:
+            value = json.dumps(
+                {
+                    "event_type": event_type,
+                    "correlation_id": str(correlation_id),
+                    "payload": payload,
+                },
+            ).encode()
+            key = str(correlation_id).encode()
+            await event_bus.publish(topic, key, value)
+            return True
+        except Exception:  # noqa: BLE001 — caller logs the False return
+            logger.warning(
+                "Event bus publish failed (topic=%s, correlation_id=%s)",
+                topic,
+                correlation_id,
+                exc_info=True,
+            )
+            return False
+
+    return _publish
 
 
 class WiringResult(TypedDict):
@@ -47,6 +90,7 @@ async def wire_build_loop_handlers(
     Returns:
         WiringResult with list of registered service names.
     """
+    from omnibase_core.protocols.event_bus import ProtocolEventBusPublisher
     from omnibase_infra.nodes.node_autonomous_loop_orchestrator.handlers.handler_loop_orchestrator import (
         HandlerLoopOrchestrator,
     )
@@ -54,7 +98,30 @@ async def wire_build_loop_handlers(
     services_registered: list[str] = []
 
     linear_api_key = os.environ.get("LINEAR_API_KEY")
-    handler = HandlerLoopOrchestrator(linear_api_key=linear_api_key)
+
+    # Resolve event bus publisher so the orchestrator can publish delegation
+    # payloads to Kafka during the BUILD phase.
+    publisher_cb = None
+    if container.service_registry is not None:
+        try:
+            event_bus: ProtocolEventBusPublisher = (
+                await container.service_registry.resolve_service(
+                    ProtocolEventBusPublisher
+                )
+            )
+            publisher_cb = _make_publisher(event_bus)
+            logger.debug("Resolved ProtocolEventBusPublisher for build loop")
+        except Exception:  # noqa: BLE001 — degrade to filesystem fallback
+            logger.warning(
+                "Could not resolve ProtocolEventBusPublisher — "
+                "build loop will use filesystem fallback",
+                exc_info=True,
+            )
+
+    handler = HandlerLoopOrchestrator(
+        publisher=publisher_cb,
+        linear_api_key=linear_api_key,
+    )
 
     if container.service_registry is not None:
         await container.service_registry.register_instance(

--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
@@ -104,9 +104,11 @@ async def wire_build_loop_handlers(
     publisher_cb = None
     if container.service_registry is not None:
         try:
+            # NOTE: service_kernel registers the concrete EventBus under the
+            # ProtocolEventBusPublisher key; mypy cannot verify Protocol-based DI.
             event_bus: ProtocolEventBusPublisher = (
                 await container.service_registry.resolve_service(
-                    ProtocolEventBusPublisher
+                    ProtocolEventBusPublisher  # type: ignore[type-abstract]
                 )
             )
             publisher_cb = _make_publisher(event_bus)

--- a/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_autonomous_loop_orchestrator/wiring.py
@@ -62,10 +62,14 @@ def _make_publisher(
             await event_bus.publish(topic, key, value)
             return True
         except Exception:  # noqa: BLE001 — caller logs the False return
+            _ctx = ModelInfraErrorContext.with_correlation(
+                correlation_id=correlation_id,
+                operation="event_bus_publish",
+            )
             logger.warning(
-                "Event bus publish failed (topic=%s, correlation_id=%s)",
+                "Event bus publish failed (topic=%s, context=%s)",
                 topic,
-                correlation_id,
+                _ctx,
                 exc_info=True,
             )
             return False

--- a/src/omnibase_infra/nodes/node_ticket_classify_compute/handlers/handler_ticket_classify.py
+++ b/src/omnibase_infra/nodes/node_ticket_classify_compute/handlers/handler_ticket_classify.py
@@ -121,11 +121,19 @@ class HandlerTicketClassify:
     ) -> ModelTicketClassifyOutput:
         """Classify tickets by buildability.
 
-        Classification priority (first match wins):
+        Classification priority:
             1. SKIP — matches skip keywords or state is terminal
             2. BLOCKED — matches blocked keywords
-            3. NEEDS_ARCH_DECISION — matches architecture keywords
-            4. AUTO_BUILDABLE — matches buildable keywords (default)
+            3. AUTO_BUILDABLE — title contains buildable action verbs
+            4. NEEDS_ARCH_DECISION — arch keywords dominate AND no
+               buildable keywords in the title
+            5. AUTO_BUILDABLE — default fallback for unmatched tickets
+
+        The key insight: tickets whose *title* contains action verbs like
+        "add", "implement", "fix" are buildable even if the description
+        mentions "design" or "investigate".  NEEDS_ARCH_DECISION only wins
+        when the ticket has arch keywords but no buildable signal in the
+        title.
 
         Args:
             correlation_id: Cycle correlation ID.
@@ -149,7 +157,7 @@ class HandlerTicketClassify:
                 f"{ticket.title} {ticket.description} {' '.join(ticket.labels)}"
             )
 
-            # Priority order: SKIP > BLOCKED > NEEDS_ARCH > AUTO_BUILDABLE
+            # Priority order: SKIP > BLOCKED > (buildable vs arch) > default
             skip_matches = _match_keywords(combined_text, _SKIP_KEYWORDS)
             if skip_matches or ticket.state in ("Done", "Cancelled", "Duplicate"):
                 classifications.append(
@@ -182,8 +190,15 @@ class HandlerTicketClassify:
                 total_skipped += 1
                 continue
 
+            # Check both keyword sets before deciding.  Title-level buildable
+            # keywords override description-level arch keywords.
+            auto_matches = _match_keywords(combined_text, _AUTO_BUILDABLE_KEYWORDS)
+            title_auto_matches = _match_keywords(ticket.title, _AUTO_BUILDABLE_KEYWORDS)
             arch_matches = _match_keywords(combined_text, _ARCH_DECISION_KEYWORDS)
-            if arch_matches:
+
+            # Arch wins only when arch keywords present AND no buildable
+            # signal in the title.
+            if arch_matches and not title_auto_matches:
                 classifications.append(
                     ModelTicketClassification(
                         ticket_id=ticket.ticket_id,
@@ -197,7 +212,6 @@ class HandlerTicketClassify:
                 total_skipped += 1
                 continue
 
-            auto_matches = _match_keywords(combined_text, _AUTO_BUILDABLE_KEYWORDS)
             confidence = min(0.9, 0.3 + 0.1 * len(auto_matches))
             classifications.append(
                 ModelTicketClassification(


### PR DESCRIPTION
## Summary

- Wire `ProtocolEventBusPublisher` from the DI container into `HandlerLoopOrchestrator` so the BUILD phase can publish delegation payloads to Kafka instead of falling back to filesystem-only dispatch (`has_publisher=False` blocker)
- Fix ticket classifier producing 0 buildable targets: buildable keywords in the ticket title now take priority over arch-decision keywords in the description, preventing implementation tickets from being misclassified as `NEEDS_ARCH_DECISION`

## Test plan

- [x] All 379 unit tests pass (`uv run pytest tests/unit/ -k "build_loop or ticket_classify or loop_orchestrator or wiring"`)
- [x] All pre-commit hooks pass including mypy, ruff, ONEX arch validation
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestrator loop can publish structured JSON events to the centralized event bus; if the bus isn't available it falls back and logs a warning.

* **Bug Fixes**
  * Ticket classification now treats buildable signals found in the title as higher priority than architecture keywords, reducing incorrect NEEDS_ARCH_DECISION labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->