### PR TITLE
fix: add top-level input key to build_loop_workflow.yaml [OMN-7744]

### DIFF
--- a/src/omnibase_infra/workflows/build_loop_workflow.yaml
+++ b/src/omnibase_infra/workflows/build_loop_workflow.yaml
@@ -13,6 +13,9 @@ description: >
 
 initial_command: onex.cmd.omnibase-infra.build-loop-start.v1
 terminal_event: onex.evt.omnibase-infra.build-loop-cycle-completed.v1
+input:
+  class: ModelLoopStartCommand
+  module: omnibase_infra.nodes.node_autonomous_loop_orchestrator.models.model_loop_start_command
 handler:
   class: HandlerLoopOrchestrator
   module: omnibase_infra.nodes.node_autonomous_loop_orchestrator.handlers.handler_loop_orchestrator


### PR DESCRIPTION
## Summary

- Adds top-level `input` key to `build_loop_workflow.yaml` so `RuntimeLocal._run_single_handler()` can properly instantiate the `ModelLoopStartCommand` payload
- Without this, the handler receives `None` and crashes with `AttributeError: 'NoneType' object has no attribute 'correlation_id'`
- Root cause: runtime reads `contract.get("input", {})` but YAML only had it under `handler.input_model`

## Test plan

- [ ] Run `uv run onex run src/omnibase_infra/workflows/build_loop_workflow.yaml` — should no longer crash with NoneType error
- [ ] Verify `ModelLoopStartCommand` is properly instantiated with defaults (correlation_id, max_cycles, etc.)

Closes OMN-7744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The `build_loop` workflow contract now includes explicit input type declarations at the workflow level, providing clearer interface definitions for workflow invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->