### PR TITLE
feat(systemd): ONEX timer units for overnight autonomy [OMN-8133]

### DIFF
--- a/scripts/deploy-timers.sh
+++ b/scripts/deploy-timers.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# deploy-timers.sh — Install and enable ONEX systemd timer units on .201
+#
+# Run as: ssh jonah@192.168.86.201 'bash /opt/omninode/scripts/deploy-timers.sh'
+#
+# Units installed:
+#   onex-build-loop.timer   — fires at 02:00, publishes to onex.cmd.build.loop-requested.v1
+#   onex-build-loop.service — oneshot service triggered by timer
+#   onex-nightly-sweep.timer   — fires at 03:00, publishes to onex.cmd.verification.sweep-requested.v1
+#   onex-nightly-sweep.service — oneshot service triggered by timer
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYSTEMD_SRC="$SCRIPT_DIR/systemd"
+SYSTEMD_DEST="/etc/systemd/system"
+
+UNITS=(
+    "onex-build-loop.timer"
+    "onex-build-loop.service"
+    "onex-nightly-sweep.timer"
+    "onex-nightly-sweep.service"
+)
+
+echo "==> Copying unit files to $SYSTEMD_DEST"
+for unit in "${UNITS[@]}"; do
+    src="$SYSTEMD_SRC/$unit"
+    if [[ ! -f "$src" ]]; then
+        echo "ERROR: source unit not found: $src" >&2
+        exit 1
+    fi
+    sudo cp "$src" "$SYSTEMD_DEST/$unit"
+    echo "    copied $unit"
+done
+
+echo "==> Reloading systemd daemon"
+sudo systemctl daemon-reload
+
+echo "==> Enabling and starting timers"
+sudo systemctl enable --now onex-build-loop.timer
+sudo systemctl enable --now onex-nightly-sweep.timer
+
+echo "==> Verifying timer state"
+systemctl list-timers --no-pager | grep -E "onex-(build-loop|nightly-sweep)" || {
+    echo "WARNING: timers not found in list-timers output" >&2
+}
+
+echo "==> Done. Active timer status:"
+systemctl is-enabled onex-build-loop.timer
+systemctl is-enabled onex-nightly-sweep.timer

--- a/scripts/systemd/onex-build-loop.service
+++ b/scripts/systemd/onex-build-loop.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=ONEX Build Loop — publishes loop-requested event to Kafka
+Documentation=https://github.com/OmniNode-ai/omnibase_infra/blob/main/systemd/onex-build-loop.service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=jonah
+Environment=KAFKA_BOOTSTRAP_SERVERS=localhost:19092
+ExecStart=/bin/bash -c '\
+  rpk topic produce onex.cmd.build.loop-requested.v1 <<< \
+  "{\"correlation_id\":\"timer-build-loop-$(date +%%Y%%m%%dT%%H%%M%%S)\",\"requested_by\":\"systemd-timer\",\"scope\":\"overnight\"}"'
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=onex-build-loop
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/onex-build-loop.timer
+++ b/scripts/systemd/onex-build-loop.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=ONEX Build Loop — daily 02:00 trigger
+Documentation=https://github.com/OmniNode-ai/omnibase_infra/blob/main/systemd/onex-build-loop.timer
+Requires=onex-build-loop.service
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+Unit=onex-build-loop.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/onex-nightly-sweep.service
+++ b/scripts/systemd/onex-nightly-sweep.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=ONEX Nightly Sweep — publishes sweep-requested event to Kafka
+Documentation=https://github.com/OmniNode-ai/omnibase_infra/blob/main/systemd/onex-nightly-sweep.service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=jonah
+Environment=KAFKA_BOOTSTRAP_SERVERS=localhost:19092
+ExecStart=/bin/bash -c '\
+  rpk topic produce onex.cmd.verification.sweep-requested.v1 <<< \
+  "{\"correlation_id\":\"timer-nightly-sweep-$(date +%%Y%%m%%dT%%H%%M%%S)\",\"requested_by\":\"systemd-timer\",\"scope\":\"full\"}"'
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=onex-nightly-sweep
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/onex-nightly-sweep.timer
+++ b/scripts/systemd/onex-nightly-sweep.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=ONEX Nightly Sweep — daily 03:00 trigger
+Documentation=https://github.com/OmniNode-ai/omnibase_infra/blob/main/systemd/onex-nightly-sweep.timer
+Requires=onex-nightly-sweep.service
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+Unit=onex-nightly-sweep.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- 4 systemd unit files committed to `scripts/systemd/`:
  - `onex-build-loop.timer` — fires at 02:00 daily
  - `onex-build-loop.service` — publishes `onex.cmd.build.loop-requested.v1` to Kafka via `rpk`
  - `onex-nightly-sweep.timer` — fires at 03:00 daily
  - `onex-nightly-sweep.service` — publishes `onex.cmd.verification.sweep-requested.v1` to Kafka
- `scripts/deploy-timers.sh` — copies units to `/etc/systemd/system/`, reloads daemon, enables and starts both timers

## Test plan
- [ ] After merge, run `ssh jonah@192.168.86.201 'bash /opt/omninode/scripts/deploy-timers.sh'`
- [ ] Verify `systemctl list-timers | grep onex` shows both timers with next-fire at 02:00 and 03:00
- [ ] Verify `systemctl is-enabled onex-build-loop.timer` → `enabled`
- [ ] Verify `systemctl is-enabled onex-nightly-sweep.timer` → `enabled`