### PR TITLE
fix(OMN-8025): add OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS to runtime hardcoded_env

### DIFF
--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -14,6 +14,7 @@ hardcoded_env:
   OMNIINTELLIGENCE_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence'
   KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
+  OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   BUS_ID: local
   ONEX_CONTRACTS_DIR: /app/contracts
   VALKEY_HOST: valkey


### PR DESCRIPTION
## Summary

- `ConfigSavingsEstimation` uses `env_prefix="OMNIBASE_INFRA_SAVINGS_"` so it reads `OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS`, not the generic `KAFKA_BOOTSTRAP_SERVERS` that is already in the runtime container
- Without this var, the in-kernel savings estimation consumer silently fails to start at runtime: `Failed to start savings estimation consumer, continuing without it`
- This is a `hardcoded_env` fix (container-to-container address `redpanda:9092`, per CLAUDE.md rule: container-to-container addresses must live in `hardcoded_env`)

## Test plan

- [ ] Verify `omninode-runtime` logs show `Savings estimation consumer started` after redeploy
- [ ] Emit `{"session_id":"e2e-test-savings-xxx",...}` to `onex.evt.omniclaude.session-ended.v1` and verify row appears in `omnidash_analytics.savings_estimates`
- [ ] Check `/api/savings/summary` returns non-null total

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kafka connectivity configuration for the runtime infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->