### PR TITLE
fix(runtime): enable include_installed_packages in TopicProvisioner

### DIFF
--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -127,7 +127,7 @@ class TopicProvisioner:
             ContractTopicExtractor,
         )
 
-        extractor = ContractTopicExtractor()
+        extractor = ContractTopicExtractor(include_installed_packages=True)
         contract_entries = extractor.extract_all(
             contracts_root=self._contracts_root,
             skill_manifests_root=self._skill_manifests_root,


### PR DESCRIPTION
## Summary

- `ContractTopicExtractor` in `service_topic_manager.py` was instantiated with `include_installed_packages=False` (the default), so omnimarket, omniintelligence, omnimemory, omniclaude, and other approved packages' node contracts were never scanned during runtime startup
- Topic provisioning silently relied on Redpanda's `auto_create_topics_enabled=true` as a fallback for any topics declared in installed packages
- This PR flips the flag to `True` so all topics from the approved package set are explicitly provisioned at startup

## Change

One-line change in `src/omnibase_infra/event_bus/service_topic_manager.py:130`:

```python
# Before
extractor = ContractTopicExtractor()

# After
extractor = ContractTopicExtractor(include_installed_packages=True)
```

Packages not installed are silently skipped (non-fatal, existing behavior from `extract_from_installed_packages`).

## Test plan

- [x] All 9 existing `TopicProvisioner` unit tests pass unchanged
- [x] All pre-commit hooks pass (ruff, mypy, architecture validators)
- [ ] Verify on .201: after runtime restart, previously missing `onex.cmd.omnimarket.*` topics should appear in `rpk topic list` as explicitly provisioned rather than auto-created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced topic provisioning to include installed packages for more comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->