### PR TITLE
feat(OMN-8029): wire LlmCallerDelegation — delegation pipeline routes to local models

### DIFF
--- a/src/omnibase_infra/adapters/llm/adapter_llm_caller_delegation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_caller_delegation.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""LlmCallerDelegation — ProtocolLlmCaller implementation for the delegation pipeline.
+
+Bridges ModelInferenceIntent (emitted by the delegation orchestrator) to the
+AdapterLlmProviderOpenai HTTP transport.  The routing reducer has already
+resolved the endpoint URL, model name, and generation parameters — this adapter
+simply executes the call and returns ModelInferenceResponseData.
+
+Design notes:
+    - A new AdapterLlmProviderOpenai is created per-call using intent.base_url.
+      The routing reducer owns endpoint selection; round-robin load balancing
+      (AdapterModelRouter) is intentionally bypassed here.
+    - The adapter is stateless and safe for concurrent async calls.
+    - system_prompt is prepended as a system message in the messages tuple via
+      the infra-layer ModelLlmInferenceRequest.
+
+Related:
+    - OMN-8029: Delegation pipeline — local→cheap-cloud→claude routing
+    - DelegationIntentBridge: consumes this adapter via ProtocolLlmCaller
+    - handler_delegation_routing.py: upstream — resolves intent.base_url
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from omnibase_infra.adapters.llm.adapter_llm_provider_openai import (
+    AdapterLlmProviderOpenai,
+)
+from omnibase_infra.adapters.llm.model_llm_adapter_request import (
+    ModelLlmAdapterRequest,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_intent import (
+    ModelInferenceIntent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_response_data import (
+    ModelInferenceResponseData,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LlmCallerDelegation:
+    """ProtocolLlmCaller implementation that calls the endpoint resolved by the routing reducer.
+
+    Accepts a ModelInferenceIntent, builds the prompt string (with system prompt
+    prepended when present), and calls AdapterLlmProviderOpenai pointed at
+    intent.base_url.  Returns ModelInferenceResponseData.
+
+    This class is intentionally stateless — no provider pool, no circuit breaker
+    at this layer (AdapterLlmProviderOpenai owns its own transport circuit breaker).
+    """
+
+    async def call(
+        self,
+        intent: ModelInferenceIntent,
+    ) -> ModelInferenceResponseData:
+        """Execute LLM inference for a delegation intent.
+
+        Args:
+            intent: Inference intent with resolved model, endpoint, and prompt.
+
+        Returns:
+            ModelInferenceResponseData with generated content and token counts.
+
+        Raises:
+            InfraConnectionError: If the provider endpoint cannot be reached.
+            InfraTimeoutError: If the request times out.
+            InfraUnavailableError: If the provider is unavailable.
+        """
+        # Build the full prompt: system prompt prepended to user prompt.
+        # AdapterLlmProviderOpenai._translate_request wraps the full prompt
+        # as a single user message.  For models that support a system role
+        # we could split them, but a combined prompt works universally.
+        if intent.system_prompt:
+            full_prompt = f"{intent.system_prompt}\n\n{intent.prompt}"
+        else:
+            full_prompt = intent.prompt
+
+        request = ModelLlmAdapterRequest(
+            prompt=full_prompt,
+            model_name=intent.model,
+            max_tokens=intent.max_tokens,
+            temperature=intent.temperature,
+        )
+
+        provider = AdapterLlmProviderOpenai(
+            base_url=intent.base_url,
+            default_model=intent.model,
+            provider_name=f"delegation-{intent.model}",
+            provider_type="local",
+        )
+
+        t0 = time.monotonic()
+        logger.info(
+            "LlmCallerDelegation: calling model=%s base_url=%s correlation_id=%s",
+            intent.model,
+            intent.base_url,
+            intent.correlation_id,
+        )
+
+        try:
+            response = await provider.generate_async(request)
+        finally:
+            await provider.close()
+
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        usage = response.usage_statistics or {}
+
+        logger.info(
+            "LlmCallerDelegation: completed model=%s latency=%dms correlation_id=%s",
+            intent.model,
+            latency_ms,
+            intent.correlation_id,
+        )
+
+        return ModelInferenceResponseData(
+            correlation_id=intent.correlation_id,
+            content=response.generated_text,
+            model_used=response.model_used or intent.model,
+            latency_ms=latency_ms,
+            prompt_tokens=int(usage.get("prompt_tokens", 0)),
+            completion_tokens=int(usage.get("completion_tokens", 0)),
+            total_tokens=int(usage.get("total_tokens", 0)),
+        )
+
+
+__all__: list[str] = ["LlmCallerDelegation"]

--- a/src/omnibase_infra/adapters/llm/adapter_llm_caller_delegation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_caller_delegation.py
@@ -112,6 +112,9 @@ class LlmCallerDelegation:
         latency_ms = int((time.monotonic() - t0) * 1000)
         usage = response.usage_statistics or {}
 
+        def _to_int(val: object) -> int:
+            return int(val) if isinstance(val, (int, float)) else 0
+
         logger.info(
             "LlmCallerDelegation: completed model=%s latency=%dms correlation_id=%s",
             intent.model,
@@ -124,9 +127,9 @@ class LlmCallerDelegation:
             content=response.generated_text,
             model_used=response.model_used or intent.model,
             latency_ms=latency_ms,
-            prompt_tokens=int(usage.get("prompt_tokens", 0)),
-            completion_tokens=int(usage.get("completion_tokens", 0)),
-            total_tokens=int(usage.get("total_tokens", 0)),
+            prompt_tokens=_to_int(usage.get("prompt_tokens")),
+            completion_tokens=_to_int(usage.get("completion_tokens")),
+            total_tokens=_to_int(usage.get("total_tokens")),
         )
 
 

--- a/src/omnibase_infra/adapters/llm/plugin_llm.py
+++ b/src/omnibase_infra/adapters/llm/plugin_llm.py
@@ -183,13 +183,44 @@ class PluginLlm:
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:
-        """Register LLM adapter in container for handler injection."""
+        """Register LLM adapter and DelegationIntentBridge in the container."""
         from omnibase_infra.runtime.models import ModelDomainPluginResult
 
-        if self._router is not None and config.container is not None:
+        services: list[str] = ["AdapterModelRouter"]
+
+        event_bus = getattr(config, "event_bus", None)
+        if event_bus is not None and config.container is not None:
+            from omnibase_core.enums import EnumInjectionScope
+            from omnibase_infra.adapters.llm.adapter_llm_caller_delegation import (
+                LlmCallerDelegation,
+            )
+            from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
+                DelegationIntentBridge,
+            )
+
+            bridge = DelegationIntentBridge(
+                event_bus=event_bus,
+                llm_caller=LlmCallerDelegation(),
+            )
+            if config.container.service_registry is not None:
+                await config.container.service_registry.register_instance(
+                    interface=DelegationIntentBridge,
+                    instance=bridge,
+                    scope=EnumInjectionScope.GLOBAL,
+                    metadata={
+                        "description": "Delegation intent bridge with local-model LLM caller",
+                    },
+                )
+            services.append("DelegationIntentBridge")
             logger.info(
-                "PluginLlm: AdapterModelRouter available for injection "
+                "PluginLlm: DelegationIntentBridge registered with LlmCallerDelegation "
                 "(correlation_id=%s)",
+                config.correlation_id,
+            )
+        else:
+            logger.debug(
+                "PluginLlm: skipping DelegationIntentBridge registration — "
+                "no event_bus or container (correlation_id=%s)",
                 config.correlation_id,
             )
 
@@ -197,7 +228,7 @@ class PluginLlm:
             plugin_id=self.plugin_id,
             success=True,
             message="LLM handlers wired",
-            services_registered=["AdapterModelRouter"],
+            services_registered=services,
         )
 
     async def wire_dispatchers(

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/delegation_intent_bridge.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/delegation_intent_bridge.py
@@ -98,6 +98,11 @@ class DelegationIntentBridge:
         self._event_bus: ProtocolEventBusLike = event_bus
         self._llm_caller = llm_caller
 
+    @property
+    def llm_caller(self) -> ProtocolLlmCaller | None:
+        """The LLM caller wired into this bridge, or None if not configured."""
+        return self._llm_caller
+
     async def handle_routing_intent(
         self, intent: ModelRoutingIntent
     ) -> ModelRoutingDecision:

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
@@ -338,16 +338,43 @@ class PluginDelegation:
                 node_name="delegation-orchestrator",
             )
 
+            from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
+                DelegationIntentBridge,
+            )
             from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
                 wire_delegation_bridge,
             )
 
+            # Resolve the bridge registered by PluginLlm (has real LlmCallerDelegation).
+            # Fall back to None so routing/quality-gate intents still work without LLM.
+            llm_caller = None
+            if config.container.service_registry is not None:
+                try:
+                    existing_bridge = (
+                        await config.container.service_registry.resolve_service(
+                            DelegationIntentBridge
+                        )
+                    )
+                    llm_caller = existing_bridge.llm_caller
+                    logger.info(
+                        "PluginDelegation: resolved LlmCallerDelegation from container "
+                        "(correlation_id=%s)",
+                        correlation_id,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "PluginDelegation: DelegationIntentBridge not in container — "
+                        "inference intents will be disabled (correlation_id=%s)",
+                        correlation_id,
+                    )
+
             bridge_result = await wire_delegation_bridge(
                 event_bus=config.event_bus,
-                llm_caller=None,
+                llm_caller=llm_caller,
             )
             logger.info(
-                "DelegationIntentBridge wired (correlation_id=%s): %s",
+                "DelegationIntentBridge wired llm_caller=%s (correlation_id=%s): %s",
+                type(llm_caller).__name__ if llm_caller else "None",
                 correlation_id,
                 bridge_result,
             )

--- a/tests/unit/delegation/test_llm_caller_delegation.py
+++ b/tests/unit/delegation/test_llm_caller_delegation.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for LlmCallerDelegation.
+
+Verifies the adapter correctly translates ModelInferenceIntent to
+ModelInferenceResponseData without hitting a real LLM endpoint.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.adapters.llm.adapter_llm_caller_delegation import (
+    LlmCallerDelegation,
+)
+from omnibase_infra.adapters.llm.model_llm_adapter_response import (
+    ModelLlmAdapterResponse,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_intent import (
+    ModelInferenceIntent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_response_data import (
+    ModelInferenceResponseData,
+)
+
+
+def _make_intent(
+    *,
+    model: str = "qwen3-coder-30b",
+    base_url: str = "http://192.168.86.201:8000/v1",
+    system_prompt: str = "You are a code generation assistant.",
+    prompt: str = "Write a pytest test for the add() function.",
+    max_tokens: int = 2048,
+    temperature: float = 0.3,
+) -> ModelInferenceIntent:
+    return ModelInferenceIntent(
+        base_url=base_url,
+        model=model,
+        system_prompt=system_prompt,
+        prompt=prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        correlation_id=uuid4(),
+    )
+
+
+def _make_adapter_response(
+    generated_text: str = "def test_add():\n    assert add(1, 2) == 3",
+    model_used: str = "qwen3-coder-30b",
+) -> ModelLlmAdapterResponse:
+    return ModelLlmAdapterResponse(
+        generated_text=generated_text,
+        model_used=model_used,
+        usage_statistics={
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+        },
+        finish_reason="stop",
+        response_metadata={"latency_ms": 42, "provider_id": "", "correlation_id": ""},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_returns_inference_response_data() -> None:
+    """LlmCallerDelegation.call() returns a well-formed ModelInferenceResponseData."""
+    intent = _make_intent()
+    adapter_response = _make_adapter_response()
+    caller = LlmCallerDelegation()
+
+    with patch(
+        "omnibase_infra.adapters.llm.adapter_llm_caller_delegation.AdapterLlmProviderOpenai"
+    ) as MockProvider:
+        instance = MagicMock()
+        instance.generate_async = AsyncMock(return_value=adapter_response)
+        instance.close = AsyncMock()
+        MockProvider.return_value = instance
+
+        result = await caller.call(intent)
+
+    assert isinstance(result, ModelInferenceResponseData)
+    assert result.correlation_id == intent.correlation_id
+    assert result.content == adapter_response.generated_text
+    assert result.model_used == adapter_response.model_used
+    assert result.prompt_tokens == 50
+    assert result.completion_tokens == 30
+    assert result.total_tokens == 80
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_prepends_system_prompt() -> None:
+    """System prompt is prepended to user prompt when calling the provider."""
+    intent = _make_intent(system_prompt="Be concise.", prompt="Write a function.")
+    adapter_response = _make_adapter_response()
+    caller = LlmCallerDelegation()
+
+    captured_request = {}
+
+    async def _capture(req: object) -> ModelLlmAdapterResponse:
+        captured_request["prompt"] = getattr(req, "prompt", "")
+        return adapter_response
+
+    with patch(
+        "omnibase_infra.adapters.llm.adapter_llm_caller_delegation.AdapterLlmProviderOpenai"
+    ) as MockProvider:
+        instance = MagicMock()
+        instance.generate_async = _capture
+        instance.close = AsyncMock()
+        MockProvider.return_value = instance
+
+        await caller.call(intent)
+
+    assert "Be concise." in captured_request["prompt"]
+    assert "Write a function." in captured_request["prompt"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_without_system_prompt() -> None:
+    """When system_prompt is empty, only the user prompt is sent."""
+    intent = _make_intent(system_prompt="", prompt="Just the user prompt.")
+    adapter_response = _make_adapter_response()
+    caller = LlmCallerDelegation()
+
+    captured_request = {}
+
+    async def _capture(req: object) -> ModelLlmAdapterResponse:
+        captured_request["prompt"] = getattr(req, "prompt", "")
+        return adapter_response
+
+    with patch(
+        "omnibase_infra.adapters.llm.adapter_llm_caller_delegation.AdapterLlmProviderOpenai"
+    ) as MockProvider:
+        instance = MagicMock()
+        instance.generate_async = _capture
+        instance.close = AsyncMock()
+        MockProvider.return_value = instance
+
+        await caller.call(intent)
+
+    assert captured_request["prompt"] == "Just the user prompt."
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_closed_after_call() -> None:
+    """Provider.close() is called even when generate_async raises."""
+    intent = _make_intent()
+    caller = LlmCallerDelegation()
+
+    with patch(
+        "omnibase_infra.adapters.llm.adapter_llm_caller_delegation.AdapterLlmProviderOpenai"
+    ) as MockProvider:
+        instance = MagicMock()
+        instance.generate_async = AsyncMock(side_effect=RuntimeError("timeout"))
+        instance.close = AsyncMock()
+        MockProvider.return_value = instance
+
+        with pytest.raises(RuntimeError, match="timeout"):
+            await caller.call(intent)
+
+        instance.close.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_constructed_with_correct_base_url() -> None:
+    """AdapterLlmProviderOpenai is constructed with intent.base_url."""
+    intent = _make_intent(
+        base_url="http://192.168.86.201:8001/v1", model="deepseek-r1-14b"
+    )
+    adapter_response = _make_adapter_response(model_used="deepseek-r1-14b")
+    caller = LlmCallerDelegation()
+
+    with patch(
+        "omnibase_infra.adapters.llm.adapter_llm_caller_delegation.AdapterLlmProviderOpenai"
+    ) as MockProvider:
+        instance = MagicMock()
+        instance.generate_async = AsyncMock(return_value=adapter_response)
+        instance.close = AsyncMock()
+        MockProvider.return_value = instance
+
+        await caller.call(intent)
+
+        MockProvider.assert_called_once()
+        call_kwargs = MockProvider.call_args.kwargs
+        assert call_kwargs["base_url"] == "http://192.168.86.201:8001/v1"
+        assert call_kwargs["default_model"] == "deepseek-r1-14b"


### PR DESCRIPTION
## Summary

- **Root cause**: `DelegationIntentBridge` was always constructed with `llm_caller=None`. The routing reducer correctly selected the local model endpoint (Qwen3-Coder-30B / DeepSeek-R1-14B on .201), but the inference call immediately raised `RuntimeError: No LLM caller configured`.
- **Fix**: Add `LlmCallerDelegation` adapter that implements `ProtocolLlmCaller` using `AdapterLlmProviderOpenai` pointed at `intent.base_url` (already resolved by the routing reducer). Wire it through `PluginLlm → DI container → PluginDelegation → wire_delegation_bridge`.
- **No routing config changes**: `routing_tiers.yaml` is already correct — set `LLM_CODER_URL` and `LLM_CODER_FAST_URL` in Infisical to activate local model routing.

## Changes

| File | Change |
|------|--------|
| `adapters/llm/adapter_llm_caller_delegation.py` | New — `LlmCallerDelegation` implements `ProtocolLlmCaller` |
| `adapters/llm/plugin_llm.py` | `wire_handlers()` registers `DelegationIntentBridge(llm_caller=LlmCallerDelegation())` in container |
| `nodes/node_delegation_orchestrator/plugin.py` | `start_consumers()` resolves bridge from container, passes `llm_caller` to `wire_delegation_bridge()` |
| `nodes/node_delegation_orchestrator/delegation_intent_bridge.py` | Add `llm_caller` property for clean container access |
| `tests/unit/delegation/test_llm_caller_delegation.py` | 5 unit tests |

## Degraded-mode safety

`PluginDelegation` falls back to `llm_caller=None` if `PluginLlm` is not active or the bridge is not in the container. Routing and quality-gate intents continue to work; only inference intents are disabled.

## Env vars needed on .201

```
LLM_CODER_URL=http://192.168.86.201:8000/v1      # Qwen3-Coder-30B — code_generation, test, refactor
LLM_CODER_FAST_URL=http://192.168.86.201:8001/v1 # DeepSeek-R1-14B — reasoning, planning, review
```

These are currently **not set** in the runtime containers. Seed them in Infisical to activate local routing.

## Test plan

- [x] 5 unit tests in `test_llm_caller_delegation.py` — all pass
- [x] Full delegation suite (52 tests) — all pass
- [x] Full unit suite (18044 tests) — 8 pre-existing failures, 0 regressions
- [x] All pre-commit hooks pass (ruff, mypy, arch validators)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM delegation handler for improved model routing and inference capabilities
  * Enhanced support for local model inference with automatic cleanup

* **Tests**
  * Added comprehensive unit test coverage for LLM delegation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->