### PR TITLE
feat(OMN-8270): onboarding skill — infra layer (Tasks 1-3, 8, 10)

### DIFF
--- a/scripts/check_subscribe_wiring_health.py
+++ b/scripts/check_subscribe_wiring_health.py
@@ -151,6 +151,8 @@ _BASELINE_DEAD_LETTER_ALLOWLIST: dict[str, str] = {
     "onex.evt.skill.scope-manifest-written.v1": "Scope manifest write effect pending | owner: jonah | expiry: 2026-09-01",
     # Gmail archive cleanup — runtime tick published by scheduler
     "onex.int.platform.runtime-tick.v1": "Published by runtime scheduler | owner: jonah | expiry: 2026-09-01",
+    # Onboarding — triggered by omniclaude /onboarding skill, not Kafka publisher
+    "onex.cmd.omnibase-infra.onboarding-start.v1": "Triggered by /onboarding skill via claude -p, not Kafka | owner: jonah | expiry: 2026-12-01",
 }
 # fmt: on
 

--- a/scripts/check_subscribe_wiring_health.py
+++ b/scripts/check_subscribe_wiring_health.py
@@ -74,7 +74,7 @@ _EXTERNAL_PUBLISHER_ALLOWLIST: dict[str, str] = {
 # is the goal.
 #
 # Format: "topic": "reason | owner | expiry"
-# Current baseline: 2026-04-02 (44 entries)
+# Current baseline: 2026-04-10 (45 entries)
 # Target: 0 entries
 # ---------------------------------------------------------------------------
 # fmt: off

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -28,6 +28,7 @@ class EnumOmnibaseInfraTopic(str, Enum):
     CMD_LLM_COMPLETION_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-completion-request.v1"  # onex.cmd.omnibase-infra.llm-completion-request.v1
     CMD_LLM_EMBEDDING_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-embedding-request.v1"  # onex.cmd.omnibase-infra.llm-embedding-request.v1
     CMD_LLM_INFERENCE_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-inference-request.v1"  # onex.cmd.omnibase-infra.llm-inference-request.v1
+    CMD_ONBOARDING_START_V1 = "onex.cmd.omnibase-infra.onboarding-start.v1"  # onex.cmd.omnibase-infra.onboarding-start.v1
     CMD_VECTOR_STORE_REQUEST_V1 = "onex.cmd.omnibase-infra.vector-store-request.v1"  # onex.cmd.omnibase-infra.vector-store-request.v1
     EVT_BASELINES_COMPUTED_V1 = "onex.evt.omnibase-infra.baselines-computed.v1"  # onex.evt.omnibase-infra.baselines-computed.v1
     EVT_CHAIN_LEARN_COMPLETE_V1 = "onex.evt.omnibase-infra.chain-learn-complete.v1"  # onex.evt.omnibase-infra.chain-learn-complete.v1
@@ -46,6 +47,8 @@ class EnumOmnibaseInfraTopic(str, Enum):
     EVT_INFERENCE_RESPONSE_V1 = "onex.evt.omnibase-infra.inference-response.v1"  # onex.evt.omnibase-infra.inference-response.v1
     EVT_LLM_CALL_COMPLETED_V1 = "onex.evt.omnibase-infra.llm-call-completed.v1"  # onex.evt.omnibase-infra.llm-call-completed.v1
     EVT_LLM_COMPLETION_COMPLETED_V1 = "onex.evt.omnibase-infra.llm-completion-completed.v1"  # onex.evt.omnibase-infra.llm-completion-completed.v1
+    EVT_ONBOARDING_COMPLETED_V1 = "onex.evt.omnibase-infra.onboarding-completed.v1"  # onex.evt.omnibase-infra.onboarding-completed.v1
+    EVT_ONBOARDING_STEP_VERIFIED_V1 = "onex.evt.omnibase-infra.onboarding-step-verified.v1"  # onex.evt.omnibase-infra.onboarding-step-verified.v1
     EVT_QUALITY_GATE_RESULT_V1 = "onex.evt.omnibase-infra.quality-gate-result.v1"  # onex.evt.omnibase-infra.quality-gate-result.v1
     EVT_ROUTING_DECISION_V1 = "onex.evt.omnibase-infra.routing-decision.v1"  # onex.evt.omnibase-infra.routing-decision.v1
     EVT_ROW_COUNT_DIAGNOSTIC_V1 = "onex.evt.omnibase-infra.row-count-diagnostic.v1"  # onex.evt.omnibase-infra.row-count-diagnostic.v1

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/contract.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Ticket: OMN-8272
+name: "node_onboarding_orchestrator"
+node_type: "ORCHESTRATOR_GENERIC"
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+node_version: "1.0.0"
+description: >
+  Onboarding orchestrator — loads the canonical graph, resolves a policy to a minimal step set, executes verification for each step, and renders markdown output. Emits lifecycle events on completion. No result field (Invariant I5).
+
+input_model:
+  name: "ModelOnboardingInput"
+  module: "omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_input"
+  description: "Target capabilities to achieve, optional steps to skip, and failure behavior flag."
+output_model:
+  name: "ModelOnboardingOutput"
+  module: "omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_output"
+  description: "Step results, success flag, counts, and rendered markdown output."
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelOnboardingInput"
+        module: "omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_input"
+      handler:
+        name: "handle_onboarding"
+        module: "omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding"
+capabilities:
+  - "onboarding.orchestrate"
+  - "onboarding.policy.resolve"
+  - "onboarding.step.verify"
+  - "onboarding.output.render"
+event_bus:
+  subscribe_topics:
+    - "onex.cmd.omnibase-infra.onboarding-start.v1"
+  publish_topics:
+    - "onex.evt.omnibase-infra.onboarding-completed.v1"
+    - "onex.evt.omnibase-infra.onboarding-step-verified.v1"
+metadata:
+  description: "Onboarding orchestrator that loads the canonical graph, resolves policy, executes verifications, and renders markdown output"
+  ticket: "OMN-8272"

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/node.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/node.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Onboarding orchestrator node (OMN-8274).
+
+Declarative node — all behavior defined in contract.yaml.
+"""
+
+from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+from omnibase_core.nodes import NodeOrchestrator
+
+
+class NodeOnboardingOrchestrator(NodeOrchestrator):
+    """Declarative onboarding orchestrator — driven entirely by contract.yaml."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        super().__init__(container)
+
+
+__all__ = ["NodeOnboardingOrchestrator"]

--- a/src/omnibase_infra/onboarding/policies/new_employee.yaml
+++ b/src/omnibase_infra/onboarding/policies/new_employee.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+policy_name: "new_employee"
+description: "Full platform onboarding for new employees (target: ~45 min, unvalidated on fresh machine)"
+target_capabilities:
+  - "omnidash_running"
+  - "secrets_configured"
+  - "event_bus_connected"
+  - "first_node_running"
+max_estimated_minutes: 45

--- a/tests/ci/test_handler_architecture_invariants.py
+++ b/tests/ci/test_handler_architecture_invariants.py
@@ -122,6 +122,13 @@ _INV4_WIRING_EXEMPTIONS: frozenset[tuple[str, str]] = frozenset(
             "src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml",
             "HandlerDelegationRouting",
         ),
+        # OMN-8272: node_onboarding_orchestrator uses a module-level async function
+        # (handle_onboarding) invoked via asyncio.run() from omnimarket's HandlerOnboarding.
+        # It is not wired through the handler registry — invoked directly by callers.
+        (
+            "src/omnibase_infra/nodes/node_onboarding_orchestrator/contract.yaml",
+            "handle_onboarding",
+        ),
     }
 )
 

--- a/tests/unit/nodes/node_onboarding_orchestrator/test_node_onboarding_orchestrator_contract.py
+++ b/tests/unit/nodes/node_onboarding_orchestrator/test_node_onboarding_orchestrator_contract.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for node_onboarding_orchestrator contract.yaml structure and node.py (OMN-8280)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_NODE_DIR = (
+    Path(__file__).parents[4]
+    / "src"
+    / "omnibase_infra"
+    / "nodes"
+    / "node_onboarding_orchestrator"
+)
+_CONTRACT_FILE = _NODE_DIR / "contract.yaml"
+
+
+@pytest.fixture
+def contract_data() -> dict:
+    """Load the node contract as a dict."""
+    assert _CONTRACT_FILE.exists(), f"contract.yaml not found at {_CONTRACT_FILE}"
+    with _CONTRACT_FILE.open() as f:
+        return yaml.safe_load(f)
+
+
+class TestNodeOnboardingOrchestratorContract:
+    """Structural validation of contract.yaml and node.py for node_onboarding_orchestrator."""
+
+    def test_contract_file_exists(self) -> None:
+        """contract.yaml must exist in node directory."""
+        assert _CONTRACT_FILE.exists(), f"contract.yaml not found at {_CONTRACT_FILE}"
+
+    def test_required_fields_present(self, contract_data) -> None:
+        """Required top-level contract fields must all be present."""
+        required = {
+            "name",
+            "node_type",
+            "contract_version",
+            "node_version",
+            "input_model",
+            "output_model",
+        }
+        for field in required:
+            assert field in contract_data, (
+                f"Required field '{field}' missing from contract.yaml"
+            )
+
+    def test_node_type_is_orchestrator(self, contract_data) -> None:
+        """node_type must be ORCHESTRATOR_GENERIC."""
+        assert contract_data["node_type"] == "ORCHESTRATOR_GENERIC", (
+            f"Expected node_type 'ORCHESTRATOR_GENERIC', got '{contract_data['node_type']}'"
+        )
+
+    def test_event_bus_topics_non_empty(self, contract_data) -> None:
+        """event_bus must declare non-empty subscribe and publish topic lists."""
+        event_bus = contract_data.get("event_bus", {})
+        assert event_bus, "event_bus block missing from contract.yaml"
+        subscribe = event_bus.get("subscribe_topics", [])
+        publish = event_bus.get("publish_topics", [])
+        assert len(subscribe) > 0, "event_bus.subscribe_topics must be non-empty"
+        assert len(publish) > 0, "event_bus.publish_topics must be non-empty"
+
+    def test_input_model_fields(self, contract_data) -> None:
+        """input_model must declare name and module."""
+        im = contract_data.get("input_model", {})
+        assert "name" in im, "input_model.name missing"
+        assert "module" in im, "input_model.module missing"
+        assert im["name"] == "ModelOnboardingInput"
+
+    def test_output_model_fields(self, contract_data) -> None:
+        """output_model must declare name and module."""
+        om = contract_data.get("output_model", {})
+        assert "name" in om, "output_model.name missing"
+        assert "module" in om, "output_model.module missing"
+        assert om["name"] == "ModelOnboardingOutput"
+
+    def test_node_py_importable(self) -> None:
+        """NodeOnboardingOrchestrator must import cleanly from node.py."""
+        from omnibase_infra.nodes.node_onboarding_orchestrator.node import (
+            NodeOnboardingOrchestrator,
+        )
+
+        assert NodeOnboardingOrchestrator is not None
+
+    def test_node_extends_node_orchestrator(self) -> None:
+        """NodeOnboardingOrchestrator must subclass NodeOrchestrator."""
+        from omnibase_core.nodes import NodeOrchestrator
+        from omnibase_infra.nodes.node_onboarding_orchestrator.node import (
+            NodeOnboardingOrchestrator,
+        )
+
+        assert issubclass(NodeOnboardingOrchestrator, NodeOrchestrator), (
+            "NodeOnboardingOrchestrator must extend NodeOrchestrator"
+        )

--- a/tests/unit/onboarding/test_new_employee_policy.py
+++ b/tests/unit/onboarding/test_new_employee_policy.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for new_employee onboarding policy (OMN-8271)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.onboarding.loader import load_canonical_graph
+from omnibase_infra.onboarding.policy_resolver import (
+    load_builtin_policies,
+    resolve_policy,
+)
+
+# Path to the policies directory in this source tree (worktree-aware).
+_POLICIES_DIR = (
+    Path(__file__).parents[3] / "src" / "omnibase_infra" / "onboarding" / "policies"
+)
+_NEW_EMPLOYEE_POLICY_FILE = _POLICIES_DIR / "new_employee.yaml"
+
+
+@pytest.fixture
+def canonical_graph():
+    """Load the canonical graph for tests."""
+    return load_canonical_graph()
+
+
+@pytest.fixture
+def new_employee_policy_data() -> dict:
+    """Load new_employee policy directly from source tree (worktree-aware)."""
+    assert _NEW_EMPLOYEE_POLICY_FILE.exists(), (
+        f"new_employee.yaml not found at {_NEW_EMPLOYEE_POLICY_FILE}. "
+        "Run this test from the omnibase_infra worktree."
+    )
+    with _NEW_EMPLOYEE_POLICY_FILE.open() as f:
+        return yaml.safe_load(f)
+
+
+class TestNewEmployeePolicy:
+    """Tests for the new_employee onboarding policy."""
+
+    def test_policy_file_exists(self) -> None:
+        """new_employee.yaml must exist in the policies directory."""
+        assert _NEW_EMPLOYEE_POLICY_FILE.exists(), (
+            f"new_employee.yaml not found at {_NEW_EMPLOYEE_POLICY_FILE}"
+        )
+
+    def test_policy_name_is_new_employee(self, new_employee_policy_data) -> None:
+        """policy_name field must be 'new_employee'."""
+        assert new_employee_policy_data["policy_name"] == "new_employee"
+
+    def test_target_capabilities_present(self, new_employee_policy_data) -> None:
+        """Policy must declare target_capabilities as a non-empty list."""
+        caps = new_employee_policy_data.get("target_capabilities", [])
+        assert isinstance(caps, list)
+        assert len(caps) > 0
+
+    def test_all_target_capabilities_exist_in_canonical_graph(
+        self, new_employee_policy_data, canonical_graph
+    ) -> None:
+        """All target capabilities must exist as produces_capabilities entries in canonical.yaml."""
+        all_produced = set()
+        for step in canonical_graph.steps:
+            all_produced.update(step.produces_capabilities)
+
+        for cap in new_employee_policy_data["target_capabilities"]:
+            assert cap in all_produced, (
+                f"Capability '{cap}' declared in new_employee policy "
+                f"but not produced by any step in canonical.yaml. "
+                f"Available capabilities: {sorted(all_produced)}"
+            )
+
+    def test_resolve_policy_returns_non_empty_steps(
+        self, new_employee_policy_data, canonical_graph
+    ) -> None:
+        """resolve_policy() with new_employee targets must return at least 5 steps."""
+        target_capabilities = new_employee_policy_data["target_capabilities"]
+        steps = resolve_policy(canonical_graph, target_capabilities, None)
+        assert len(steps) >= 5, (
+            f"Expected at least 5 resolved steps for new_employee policy, got {len(steps)}: "
+            f"{[s.step_key for s in steps]}"
+        )
+
+    def test_all_existing_policies_still_load(self) -> None:
+        """Regression guard: all builtin policies must still load without error."""
+        policies = load_builtin_policies()
+        # At minimum the original 3 plus new_employee (4 total after merge)
+        assert len(policies) >= 3
+        for name in ["standalone_quickstart", "contributor_local", "full_platform"]:
+            assert name in policies, (
+                f"Existing policy '{name}' missing from load_builtin_policies()"
+            )
+
+    def test_resolve_policy_rejects_policy_name_as_positional_arg(
+        self, canonical_graph
+    ) -> None:
+        """resolve_policy() does not accept policy_name as a keyword argument.
+
+        This test enforces correct API usage: callers must call load_builtin_policies()
+        first to get target_capabilities, then pass those to resolve_policy().
+        """
+        with pytest.raises(TypeError):
+            resolve_policy(canonical_graph, policy_name="new_employee")  # type: ignore[call-arg]

--- a/tests/unit/onboarding/test_new_employee_policy.py
+++ b/tests/unit/onboarding/test_new_employee_policy.py
@@ -88,9 +88,14 @@ class TestNewEmployeePolicy:
     def test_all_existing_policies_still_load(self) -> None:
         """Regression guard: all builtin policies must still load without error."""
         policies = load_builtin_policies()
-        # At minimum the original 3 plus new_employee (4 total after merge)
-        assert len(policies) >= 3
-        for name in ["standalone_quickstart", "contributor_local", "full_platform"]:
+        # All 4 policies must be present: 3 original + new_employee
+        assert len(policies) >= 4
+        for name in [
+            "standalone_quickstart",
+            "contributor_local",
+            "full_platform",
+            "new_employee",
+        ]:
             assert name in policies, (
                 f"Existing policy '{name}' missing from load_builtin_policies()"
             )

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -103,10 +103,11 @@ class TestLoadBuiltinPolicies:
 
     def test_loads_three_policies(self) -> None:
         policies = load_builtin_policies()
-        assert len(policies) == 3
+        assert len(policies) == 4
         assert "standalone_quickstart" in policies
         assert "contributor_local" in policies
         assert "full_platform" in policies
+        assert "new_employee" in policies
 
     def test_standalone_targets(self) -> None:
         policies = load_builtin_policies()


### PR DESCRIPTION
## Summary

- Add `new_employee.yaml` policy targeting full platform onboarding (~45 min)
- Add `contract.yaml` for `node_onboarding_orchestrator` (makes existing node contract-compliant)
- Add `node.py` declarative class extending `NodeOrchestrator`
- Add unit tests: 7 policy resolver tests + 8 contract structure tests
- Regenerate topic enums for new onboarding topics

## Part of Epic

OMN-8270 (onboarding skill implementation — new employee starts 2026-04-13)

## Test Evidence

```
tests/unit/onboarding/test_new_employee_policy.py    7 passed
tests/unit/nodes/node_onboarding_orchestrator/test_node_onboarding_orchestrator_contract.py    8 passed
```

## Notes

- Topics use `omnibase-infra` (hyphenated) per naming convention
- Policy declares 4 target capabilities all verified in canonical.yaml
- `new_employee` duration is a target estimate (~45 min), not a confirmed SLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an onboarding orchestrator to manage onboarding workflows, policy resolution, step verification, and output rendering.
  * Added a "new_employee" onboarding policy with target capabilities and estimated duration.

* **Tests**
  * Added unit tests validating the orchestrator contract, policy resolution, and the new policy integration.

* **Chores**
  * Updated dead-letter allowlist to include the onboarding-start topic (baseline updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->