### PR TITLE
fix(dockerfile): install omnibase_compat before omnimarket

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -181,6 +181,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "omninode-memory>=0.9.0,<2.0.0" \
     "omninode-intelligence>=0.15.0,<2.0.0"
 
+# Install omnibase_compat before omnimarket — omnimarket declares it as a
+# required dependency but we use --no-deps for the git install, so it must
+# be present first. Pinned to git main until PyPI publishing is automated.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --no-deps \
+    "git+https://github.com/OmniNode-ai/omnibase_compat.git@main#egg=omnibase-compat"
+
 # Install omnimarket from git main until PyPI releases are automated (OMN-7980).
 # Pinned to main so every image rebuild picks up the latest merged nodes.
 # Switch back to PyPI range pin once the auto-tag-on-merge release pipeline


### PR DESCRIPTION
## Summary
- omnimarket declares `omnibase-compat>=0.3.1` as a required dependency but the runtime image installs omnimarket with `--no-deps`, so `omnibase_compat` was never present in the container
- This caused `node_build_loop_orchestrator` entry point to fail to load at runtime: `No module named 'omnibase_compat'`
- The build loop handler never wired, so `onex.cmd.omnimarket.build-loop-orchestrator-start.v1` had no consumer and all build loop trigger commands were silently dropped

## Test plan
- [ ] Build new runtime image and verify `omnibase_compat` is importable: `docker exec omninode-runtime-effects /app/.venv/bin/python -c 'import omnibase_compat; print(omnibase_compat.__version__)'`
- [ ] Verify `node_build_loop_orchestrator` entry point loads: look for `Discovered contract: build_loop_orchestrator` in effects startup logs
- [ ] Fire build loop trigger and confirm consumer picks it up: `bash /home/jonah/.local/bin/onex-build-loop-trigger.sh`