### PR TITLE
fix(docker): add LLM_* env vars to runtime-env anchor [OMN-7979]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -200,6 +200,15 @@ x-runtime-env: &runtime-env
   # Auto-ACK local/internal nodes after introspection. Never set in production —
   # external nodes send their own ack. Must be explicitly set to true or false.
   ONEX_REGISTRATION_AUTO_ACK: ${ONEX_REGISTRATION_AUTO_ACK:?ONEX_REGISTRATION_AUTO_ACK must be set in ~/.omnibase/.env (true or false)}
+  # --- LLM endpoints (OMN-7979) ---
+  # PluginLlm.should_activate() reads these from os.environ. Without them in
+  # the container, the LLM plugin skips activation and LlmCallerDelegation
+  # wires with llm_caller=None, breaking the delegation pipeline.
+  # Values come from ~/.omnibase/.env (or Infisical in managed deployments).
+  LLM_CODER_URL: ${LLM_CODER_URL:?LLM_CODER_URL required for PluginLlm activation}
+  LLM_CODER_FAST_URL: ${LLM_CODER_FAST_URL:?LLM_CODER_FAST_URL required for PluginLlm activation}
+  LLM_EMBEDDING_URL: ${LLM_EMBEDDING_URL:?LLM_EMBEDDING_URL required for PluginLlm activation}
+  LLM_DEEPSEEK_R1_URL: ${LLM_DEEPSEEK_R1_URL:?LLM_DEEPSEEK_R1_URL required for PluginLlm activation}
   # --- OpenTelemetry (OMN-5382: removed from base env — injected per-bundle) ---
   # OTEL vars are only present when the tracing bundle is selected.
   # OTEL_SERVICE_NAME is set per-service (already done in service blocks).

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -201,9 +201,11 @@ x-runtime-env: &runtime-env
   # external nodes send their own ack. Must be explicitly set to true or false.
   ONEX_REGISTRATION_AUTO_ACK: ${ONEX_REGISTRATION_AUTO_ACK:?ONEX_REGISTRATION_AUTO_ACK must be set in ~/.omnibase/.env (true or false)}
   # --- LLM endpoints (OMN-7979) ---
-  # PluginLlm.should_activate() reads these from os.environ. Without them in
-  # the container, the LLM plugin skips activation and LlmCallerDelegation
-  # wires with llm_caller=None, breaking the delegation pipeline.
+  # PluginLlm.should_activate() returns true when any LLM_*_URL in
+  # _LLM_URL_ENV_VARS is set (e.g. LLM_SMALL_URL, LLM_GLM_URL,
+  # LLM_OPENROUTER_URL, or the four below). This compose contract requires
+  # these four baseline endpoints so delegation wiring is consistently
+  # available; without at least one, LlmCallerDelegation wires llm_caller=None.
   # Values come from ~/.omnibase/.env (or Infisical in managed deployments).
   LLM_CODER_URL: ${LLM_CODER_URL:?LLM_CODER_URL required for PluginLlm activation}
   LLM_CODER_FAST_URL: ${LLM_CODER_FAST_URL:?LLM_CODER_FAST_URL required for PluginLlm activation}

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -110,6 +110,13 @@ LOCAL_ONLY_KEYS: frozenset[str] = frozenset(
         "OMNIBASE_INFRA_DIR",
         # OmniMemory crawl path — local server path, has no k8s equivalent
         "OMNIMEMORY_CRAWL_PATH_PREFIXES",
+        # LLM endpoints — lab-local GPU servers (192.168.86.*); k8s onex-dev
+        # routes to cluster-internal or public model endpoints via a different
+        # mechanism (tracked: OMN-7979). In local docker these activate PluginLlm.
+        "LLM_CODER_URL",
+        "LLM_CODER_FAST_URL",
+        "LLM_EMBEDDING_URL",
+        "LLM_DEEPSEEK_R1_URL",
     }
 )
 

--- a/tests/integration/docker/test_docker_integration.py
+++ b/tests/integration/docker/test_docker_integration.py
@@ -1092,6 +1092,12 @@ class TestDockerComposeProfiles:
                 "ONEX_REGISTRATION_AUTO_ACK": "true",
                 "ONEX_SERVICE_CLIENT_SECRET": "test-service-secret",
                 "LINEAR_API_KEY": "test-linear-api-key",
+                # OMN-7979: LLM endpoint URLs added with :? fail-fast to
+                # activate PluginLlm in runtime containers.
+                "LLM_CODER_URL": "http://llm-coder.test:8000",
+                "LLM_CODER_FAST_URL": "http://llm-coder-fast.test:8001",
+                "LLM_EMBEDDING_URL": "http://llm-embed.test:8100",
+                "LLM_DEEPSEEK_R1_URL": "http://llm-r1.test:8101",
             }
         )
 


### PR DESCRIPTION
## Summary
- PR #1227 added LLM_* vars to the catalog manifests, but the live deployment on .201 uses `docker/docker-compose.infra.yml` directly — the catalog manifests are an unused parallel path
- Without LLM_* vars in the actual compose, `PluginLlm.should_activate()` returns False and `LlmCallerDelegation` wires with `llm_caller=None`, breaking the delegation pipeline
- Add the four vars to the `*runtime-env` anchor so all runtime services inherit them

## Why the previous fix did not take effect
`docker inspect omninode-runtime-effects` confirmed the running container had no `LLM_*` env vars even after PR #1227 merged and the service was recreated. The catalog-generated compose and the hand-written `docker-compose.infra.yml` are not the same file. The canonical deploy uses the latter.

## Test plan
- [x] `docker inspect omninode-runtime-effects` shows all four LLM_* vars after redeploy
- [x] runtime-effects logs show `PluginLlm: activating with 4 endpoints`
- [x] delegation orchestrator logs show `DelegationIntentBridge wired llm_caller=<AdapterModelRouter...>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added four required LLM endpoint environment variables to the Docker runtime, making them mandatory for container config/startup and updating the runtime contract for LLM behavior.
* **Tests**
  * Updated environment-parity and Docker integration tests to include the new LLM environment keys so test expectations match the updated runtime requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->