### PR TITLE
fix(llm_openai_compat): propagate timeout_seconds in _execute_with_auth (OMN-8434)

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -597,6 +597,7 @@ class HandlerLlmOpenaiCompatible:
                 url=url,
                 payload=payload,
                 correlation_id=correlation_id,
+                timeout_seconds=timeout_seconds,
             )
 
         # Lock lives on the transport so that ALL handler instances sharing
@@ -633,6 +634,7 @@ class HandlerLlmOpenaiCompatible:
                     url=url,
                     payload=payload,
                     correlation_id=correlation_id,
+                    timeout_seconds=timeout_seconds,
                 )
             finally:
                 self._transport._http_client = original_client

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible.py
@@ -1295,3 +1295,59 @@ class TestParseUsage:
         )
         assert usage.tokens_input == 0
         assert usage.tokens_output == 0
+
+
+@pytest.mark.unit
+class TestTimeoutPropagation:
+    """Regression tests: timeout_seconds from the request must reach _execute_llm_http_call.
+
+    Root cause (2026-04-11): _execute_with_auth() called _execute_llm_http_call()
+    without forwarding timeout_seconds when api_key=None and extra_headers=None.
+    The transport's 30.0s default was used regardless of the per-model config,
+    causing ONEX_CORE_092_TIMEOUT_ERROR on slow local LLMs (qwen3-coder=120s,
+    deepseek-r1=300s).
+    """
+
+    @pytest.mark.asyncio
+    async def test_custom_timeout_forwarded_to_transport_no_auth(self) -> None:
+        """timeout_seconds=120.0 must reach _execute_llm_http_call when api_key=None."""
+        transport = _make_transport()
+        transport._execute_llm_http_call.return_value = _make_openai_chat_response(
+            content="ok", finish_reason="stop", prompt_tokens=5, completion_tokens=2
+        )
+        handler = _make_handler(transport)
+
+        request = _make_chat_request(timeout_seconds=120.0)
+        await handler.handle(request, correlation_id=_CORRELATION_ID)
+
+        call_kwargs = transport._execute_llm_http_call.call_args
+        assert call_kwargs is not None, "_execute_llm_http_call was not called"
+        # timeout_seconds should be passed as keyword arg
+        actual_timeout = call_kwargs.kwargs.get("timeout_seconds")
+        assert actual_timeout == 120.0, (
+            f"Expected timeout_seconds=120.0 forwarded to _execute_llm_http_call, "
+            f"got {actual_timeout!r}. The transport's 30.0s default is being used "
+            f"instead of the per-model config value."
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_forwarded_to_transport(self) -> None:
+        """Default timeout_seconds must still reach _execute_llm_http_call."""
+        transport = _make_transport()
+        transport._execute_llm_http_call.return_value = _make_openai_chat_response(
+            content="ok", finish_reason="stop", prompt_tokens=5, completion_tokens=2
+        )
+        handler = _make_handler(transport)
+
+        request = _make_chat_request()  # uses ModelLlmInferenceRequest default
+        default_timeout = request.timeout_seconds
+
+        await handler.handle(request, correlation_id=_CORRELATION_ID)
+
+        call_kwargs = transport._execute_llm_http_call.call_args
+        assert call_kwargs is not None
+        actual_timeout = call_kwargs.kwargs.get("timeout_seconds")
+        assert actual_timeout == default_timeout, (
+            f"Expected timeout_seconds={default_timeout} forwarded to transport, "
+            f"got {actual_timeout!r}."
+        )


### PR DESCRIPTION
## Summary
Fixes `HandlerLlmOpenaiCompatible._execute_with_auth()` dropping `timeout_seconds` when calling `_execute_llm_http_call`, causing the mixin's hardcoded 30s default to override per-model configs (qwen3-coder 120s, deepseek-r1 300s).

## Blast radius
Blocks all `/onex:hostile_reviewer` runs on prompts >12KB. Every architecture design adversarial review gate has been broken because of this. Two independent workers (architect-executor, hostile-infra-debug) converged on the same root cause with the same fix.

## Fix
Two one-line additions: pass `timeout_seconds=timeout_seconds` in both `_execute_llm_http_call` call sites (no-auth and auth-client paths).

## Tests
`TestTimeoutPropagation` class added in `test_handler_llm_openai_compatible.py`. TDD-first: tests written before fix, confirmed fail, fix applied, 69/69 pass.

## Bootstrap review
Because the `/onex:hostile_reviewer` skill IS what this PR fixes, running the mandatory gate via the skill would require the skill to work. We bootstrap by running the review via **direct vLLM API calls** (the same pattern `architect-executor` and `architect-validation` used today on their designs): qwen3-coder-30b @ `.201:8000` + deepseek-r1-14b @ `.201:8001`, diff fed as review input, findings posted as a PR comment. This is the bootstrap-only exception documented in the session handoff.

## Post-merge
Plugin redeploy required: `claude plugin marketplace update && claude plugin uninstall onex@omninode-tools && claude plugin install onex@omninode-tools`. The fix is in a handler imported by hook + skill code — the plugin must reload to pick it up. Coordinate with the plugin runtime architecture plan before redeploying (live-patched LLM vars on .201 are fragile per the OMN-8430 note).

## Ticket
OMN-8434 — Urgent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout handling in LLM API requests to properly respect per-request timeout settings instead of defaulting to transport defaults. Custom timeout values are now correctly propagated through both standard and authenticated API calls.

* **Tests**
  * Added comprehensive test coverage for timeout propagation across different authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->