### PR TITLE
feat(cli): add onex kafka produce subcommand (OMN-8435)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ onex-linear-relay = "omnibase_infra.cli.linear_relay:main"
 onex-status = "omnibase_infra.tui.__main__:run_status_tui"
 verify-container-manifest = "omnibase_infra.scripts.verify_container_manifest:main"
 
+[project.entry-points."onex.cli"]
+kafka = "omnibase_infra.cli.cli_kafka:kafka"
+
 [project.entry-points."onex.backends"]
 event_bus_kafka = "omnibase_infra.event_bus.event_bus_kafka:EventBusKafka"
 state_postgres = "omnibase_infra.backends.backend_probe:probe_postgres"

--- a/src/omnibase_infra/cli/cli_kafka.py
+++ b/src/omnibase_infra/cli/cli_kafka.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""onex kafka — local Kafka command topic publisher (OMN-8435).
+
+Eliminates the SSH+rpk ritual for publishing ONEX Kafka command topics from a
+dev machine. Registered into the onex CLI via the onex.cli entry-point group.
+
+Usage:
+    onex kafka produce <topic> --payload '<json>' [--dry-run] [--envelope]
+
+V1 limitation: PLAINTEXT auth only. Redpanda on LAN (.201) is unauthenticated
+from dev machines. SASL/TLS support is deferred to V2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import click
+from aiokafka import AIOKafkaProducer
+
+
+def _build_envelope(
+    payload_dict: dict[str, object], requested_by: str
+) -> dict[str, object]:
+    envelope: dict[str, object] = {
+        "correlation_id": str(uuid4()),
+        "requested_by": requested_by,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    envelope.update(payload_dict)
+    return envelope
+
+
+@click.group()
+def kafka() -> None:  # stub-ok: click group, subcommands via @kafka.command()
+    """Kafka utilities — publish to command topics without SSH."""
+
+
+@kafka.command()
+@click.argument("topic")
+@click.option(
+    "--payload",
+    "-p",
+    default=None,
+    help="JSON payload string. Reads from stdin if omitted.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print topic and payload without connecting to Kafka.",
+)
+@click.option(
+    "--envelope",
+    is_flag=True,
+    default=False,
+    help="Wrap payload in ONEX command envelope (correlation_id, requested_by, timestamp).",
+)
+@click.option(
+    "--requested-by",
+    default="onex-cli",
+    show_default=True,
+    help="Value for the requested_by field when --envelope is set.",
+)
+def produce(
+    topic: str,
+    payload: str | None,
+    dry_run: bool,
+    envelope: bool,
+    requested_by: str,
+) -> None:
+    """Publish a JSON payload to a Kafka topic.
+
+    TOPIC is the full Kafka topic name.
+
+    \b
+    Examples:
+        onex kafka produce onex.cmd.deploy.rebuild-requested.v1 \\
+            --payload '{"scope":"full","services":[],"git_ref":"origin/main"}' \\
+            --envelope
+
+        onex kafka produce onex.cmd.test.v1 --payload '{}' --dry-run
+    """
+    if payload is None:
+        if sys.stdin.isatty():
+            raise click.UsageError("--payload is required when stdin is a terminal.")
+        payload = sys.stdin.read().strip()
+
+    try:
+        payload_dict: dict[str, object] = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"Invalid JSON payload: {exc}") from exc
+
+    final_payload = (
+        _build_envelope(payload_dict, requested_by) if envelope else payload_dict
+    )
+    final_json = json.dumps(final_payload, indent=2)
+
+    click.echo(f"Topic:   {topic}")
+    click.echo(f"Payload: {final_json}")
+
+    if dry_run:
+        click.echo("(dry-run: skipping Kafka publish)")
+        return
+
+    bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "").strip()
+    if not bootstrap_servers:
+        raise click.ClickException(
+            "KAFKA_BOOTSTRAP_SERVERS is not set. "
+            "Set it to your Redpanda address, e.g. 192.168.86.201:19092"  # kafka-fallback-ok: example in error message, not used as default
+        )
+
+    async def _publish() -> None:
+        producer = AIOKafkaProducer(bootstrap_servers=bootstrap_servers, acks="all")
+        await producer.start()
+        try:
+            await producer.send_and_wait(topic, final_json.encode())
+        finally:
+            await producer.stop()
+
+    try:
+        asyncio.run(_publish())
+    except Exception as exc:
+        raise click.ClickException(f"Kafka publish failed: {exc}") from exc
+
+    click.echo(f"Published to {topic}")

--- a/tests/unit/cli/test_cli_kafka_produce.py
+++ b/tests/unit/cli/test_cli_kafka_produce.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for onex kafka produce CLI command (OMN-8435)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_infra.cli.cli_kafka import kafka
+
+pytestmark = pytest.mark.unit
+
+
+class TestKafkaProduceDryRun:
+    """Tests for --dry-run mode — no Kafka connection required."""
+
+    def test_dry_run_prints_topic_and_payload(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            [
+                "produce",
+                "onex.cmd.test.v1",
+                "--payload",
+                '{"key": "value"}',
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "onex.cmd.test.v1" in result.output
+        assert "key" in result.output
+
+    def test_dry_run_with_envelope_wraps_payload(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            [
+                "produce",
+                "onex.cmd.deploy.rebuild-requested.v1",
+                "--payload",
+                '{"scope": "full", "services": []}',
+                "--dry-run",
+                "--envelope",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        output_json = _extract_json(result.output)
+        assert output_json is not None, f"No JSON in output: {result.output}"
+        assert "correlation_id" in output_json
+        assert "requested_by" in output_json
+        assert "timestamp" in output_json
+        assert output_json.get("scope") == "full"
+
+    def test_dry_run_indicates_skipping_publish(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            ["produce", "onex.cmd.test.v1", "--payload", "{}", "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "dry-run" in result.output.lower() or "skipping" in result.output.lower()
+
+    def test_invalid_json_payload_fails(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            ["produce", "onex.cmd.test.v1", "--payload", "not-json", "--dry-run"],
+        )
+        assert result.exit_code != 0
+
+    def test_help_shows_produce_subcommand(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(kafka, ["--help"])
+        assert result.exit_code == 0
+        assert "produce" in result.output
+
+    def test_envelope_uses_custom_requested_by(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            [
+                "produce",
+                "onex.cmd.test.v1",
+                "--payload",
+                "{}",
+                "--dry-run",
+                "--envelope",
+                "--requested-by",
+                "my-agent",
+            ],
+        )
+        assert result.exit_code == 0
+        output_json = _extract_json(result.output)
+        assert output_json is not None
+        assert output_json.get("requested_by") == "my-agent"
+
+
+class TestKafkaProducePublish:
+    """Tests for actual publish path — Kafka producer mocked."""
+
+    def test_produce_calls_publisher_with_correct_topic(self) -> None:
+        published: list[dict[str, object]] = []
+
+        async def mock_send(topic: str, value: bytes) -> None:
+            published.append({"topic": topic, "payload": json.loads(value)})
+
+        mock_producer = MagicMock()
+        mock_producer.start = AsyncMock()
+        mock_producer.stop = AsyncMock()
+        mock_producer.send_and_wait = AsyncMock(side_effect=mock_send)
+
+        with patch(
+            "omnibase_infra.cli.cli_kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                kafka,
+                ["produce", "onex.cmd.test.v1", "--payload", '{"scope": "full"}'],
+                env={"KAFKA_BOOTSTRAP_SERVERS": "localhost:19092"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(published) == 1
+        assert published[0]["topic"] == "onex.cmd.test.v1"
+
+    def test_envelope_flag_produces_valid_envelope_shape(self) -> None:
+        published: list[dict[str, object]] = []
+
+        async def mock_send(topic: str, value: bytes) -> None:
+            published.append({"topic": topic, "payload": json.loads(value)})
+
+        mock_producer = MagicMock()
+        mock_producer.start = AsyncMock()
+        mock_producer.stop = AsyncMock()
+        mock_producer.send_and_wait = AsyncMock(side_effect=mock_send)
+
+        with patch(
+            "omnibase_infra.cli.cli_kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                kafka,
+                [
+                    "produce",
+                    "onex.cmd.deploy.rebuild-requested.v1",
+                    "--payload",
+                    '{"scope": "full", "services": [], "git_ref": "origin/main"}',
+                    "--envelope",
+                    "--requested-by",
+                    "test-agent",
+                ],
+                env={"KAFKA_BOOTSTRAP_SERVERS": "localhost:19092"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(published) == 1
+        env = published[0]["payload"]
+        assert "correlation_id" in env
+        assert env.get("requested_by") == "test-agent"
+        assert "timestamp" in env
+        assert env.get("scope") == "full"
+
+    def test_missing_bootstrap_servers_fails(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            kafka,
+            ["produce", "onex.cmd.test.v1", "--payload", "{}"],
+            env={"KAFKA_BOOTSTRAP_SERVERS": ""},
+        )
+        assert result.exit_code != 0
+
+
+def _extract_json(output: str) -> dict[str, object] | None:
+    brace_pos = output.find("{")
+    if brace_pos == -1:
+        return None
+    candidate = output[brace_pos:]
+    for end in range(len(candidate), 0, -1):
+        try:
+            result = json.loads(candidate[:end])
+            if isinstance(result, dict):
+                return result  # type: ignore[return-value]
+        except json.JSONDecodeError:
+            continue
+    return None


### PR DESCRIPTION
## Summary

- Adds `onex kafka produce <topic>` CLI command — eliminates the SSH+rpk ritual for publishing ONEX Kafka command topics from a dev machine
- Registered via `onex.cli` entry-point group (requires omnibase_core dynamic loader PR to be merged first)
- Supports `--dry-run`, `--envelope` (wraps payload in ONEX command envelope with correlation_id/requested_by/timestamp), `--requested-by`
- Reads `bootstrap_servers` from `KAFKA_BOOTSTRAP_SERVERS` env var
- V1: PLAINTEXT auth only (Redpanda on LAN is unauthenticated)

## Example

```bash
# Trigger a runtime rebuild without SSH
export KAFKA_BOOTSTRAP_SERVERS=192.168.86.201:19092
onex kafka produce onex.cmd.deploy.rebuild-requested.v1 \
  --payload '{"scope":"full","services":[],"git_ref":"origin/main"}' \
  --envelope
```

## Test plan

- [ ] `test_dry_run_prints_topic_and_payload`
- [ ] `test_dry_run_with_envelope_wraps_payload` — asserts correlation_id, requested_by, timestamp present
- [ ] `test_dry_run_indicates_skipping_publish`
- [ ] `test_invalid_json_payload_fails`
- [ ] `test_help_shows_produce_subcommand`
- [ ] `test_envelope_uses_custom_requested_by`
- [ ] `test_produce_calls_publisher_with_correct_topic` — mocked AIOKafkaProducer
- [ ] `test_envelope_flag_produces_valid_envelope_shape` — mocked, verifies full shape
- [ ] `test_missing_bootstrap_servers_fails`

## Related

- Linear: OMN-8435
- omnibase_core PR: dynamic onex.cli extension loader (must merge first)