### PR TITLE
feat(lint): reject topic strings missing producer segment (OMN-8507)

### DIFF
--- a/scripts/validation/lint_topic_names.py
+++ b/scripts/validation/lint_topic_names.py
@@ -62,6 +62,22 @@ _VALID_SEGMENT_PATTERN = re.compile(r"^[a-z0-9._-]+$")
 _VALID_PRODUCER_PATTERN = re.compile(r"^[a-z0-9-]+$")
 _VALID_VERSION_PATTERN = re.compile(r"^v[1-9]\d*$|^v1$")
 
+# Allowlist of known producer segments — must match the emitting repo (OMN-8507).
+# Any structurally-valid producer not in this set is rejected with "unknown producer".
+_KNOWN_PRODUCERS: frozenset[str] = frozenset(
+    {
+        "omnimarket",
+        "omnibase-infra",
+        "omniclaude",
+        "omniintelligence",
+        "omnimemory",
+        "omninode",
+        "omnibase-compat",
+        "github",
+        "platform",
+    }
+)
+
 # Regex to detect strings that look like complete ONEX topic names (for Python
 # scanning).  We require the string to start with 'onex.' AND end with a version
 # suffix (e.g. '.v1', '.v12').  This excludes partial-prefix strings like
@@ -137,6 +153,12 @@ def lint_topic(raw: str) -> LintResult:
         violations.append(
             f"invalid producer {producer!r} in topic {raw!r}; "
             f"must match ^[a-z0-9-]+$ (no underscores)"
+        )
+    elif producer not in _KNOWN_PRODUCERS:
+        violations.append(
+            f"unknown producer {producer!r} in topic {raw!r}; "
+            f"must be one of {sorted(_KNOWN_PRODUCERS)}. "
+            f"Did you mean the repo name (e.g. 'omnimarket' not {producer!r})?"
         )
 
     if not _VALID_SEGMENT_PATTERN.match(event_name):

--- a/scripts/validation/topic_naming_baseline.txt
+++ b/scripts/validation/topic_naming_baseline.txt
@@ -18,3 +18,51 @@ onex.int.platform.runtime-tick.v1
 onex.contract.resolve.completed
 onex.contract.resolve.requested
 onex.snapshot.platform.registration-snapshots.v1
+
+# Producer-segment violations discovered by OMN-8507 (W6.10) allowlist check.
+# TODO(OMN-8507): artifact producer should be omnibase-infra
+onex.cmd.artifact.reconcile.v1
+onex.evt.artifact.change-detected.v1
+onex.evt.artifact.impact-analyzed.v1
+onex.evt.artifact.pr-comment-posted.v1
+onex.evt.artifact.update-plan-created.v1
+onex.evt.artifact.update-plan-emitted.v1
+# TODO(OMN-8507): router producer should be omnibase-infra
+onex.cmd.router.route-request.v1
+onex.evt.router.health-snapshot.v1
+onex.evt.router.routing-complete.v1
+onex.evt.router.routing-failed.v1
+onex.evt.router.routing-outcome.v1
+onex.evt.router.scoring-decision.v1
+# TODO(OMN-8507): rsd producer should be omnibase-infra
+onex.cmd.rsd.score.v1
+onex.evt.rsd.data-fetched.v1
+onex.evt.rsd.score-complete.v1
+onex.evt.rsd.score-failed.v1
+onex.evt.rsd.scores-calculated.v1
+onex.evt.rsd.scores-stored.v1
+# TODO(OMN-8507): runtime producer should be omnibase-infra
+onex.evt.runtime.tick.v1
+# TODO(OMN-8507): skill producer should be omnimarket or omnibase-infra
+onex.cmd.skill.merge-sweep.v1
+onex.cmd.skill.scope-check.v1
+onex.evt.skill.merge-sweep-auto-merged.v1
+onex.evt.skill.merge-sweep-classified.v1
+onex.evt.skill.merge-sweep-complete.v1
+onex.evt.skill.merge-sweep-failed.v1
+onex.evt.skill.merge-sweep-pr-list.v1
+onex.evt.skill.scope-check-complete.v1
+onex.evt.skill.scope-check-failed.v1
+onex.evt.skill.scope-extracted.v1
+onex.evt.skill.scope-file-read.v1
+onex.evt.skill.scope-manifest-written.v1
+# TODO(OMN-8507): validation producer should be omnibase-infra
+onex.evt.validation.cross-repo-run-completed.v1
+onex.evt.validation.cross-repo-run-started.v1
+onex.evt.validation.cross-repo-violations-batch.v1
+# TODO(OMN-8507): git/linear/deploy/pattern/omniweb producers found in Python source
+onex.evt.git.hook.v1
+onex.evt.linear.snapshot.v1
+onex.cmd.deploy.rebuild-requested.v1
+onex.evt.pattern.discovered.v1
+onex.evt.omniweb.waitlist-signup.v1

--- a/tests/unit/scripts/validation/test_lint_topic_names.py
+++ b/tests/unit/scripts/validation/test_lint_topic_names.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from scripts.validation.lint_topic_names import LintResult, lint_topic, scan_contracts
+from scripts.validation.lint_topic_names import (
+    _KNOWN_PRODUCERS,
+    LintResult,
+    lint_topic,
+    scan_contracts,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -132,6 +137,63 @@ def test_scan_wrong_prefix_caught(tmp_path: Path) -> None:
 
     violations = scan_contracts(contracts_dir)
     assert len(violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Producer allowlist (OMN-8507)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unknown_producer_rejected() -> None:
+    """Linter must reject topic strings with producer not in the known-repos allowlist."""
+    result = lint_topic("onex.evt.review-bot.foo.v1")
+    assert not result.is_valid
+    assert any("unknown producer" in v for v in result.violations)
+    assert any("review-bot" in v for v in result.violations)
+
+
+@pytest.mark.unit
+def test_producer_with_underscore_rejected() -> None:
+    """Producer with underscore fails both producer-pattern and allowlist checks."""
+    result = lint_topic("onex.evt.review_bot.foo.v1")
+    assert not result.is_valid
+
+
+@pytest.mark.unit
+def test_known_producer_accepted() -> None:
+    """Linter must accept topic strings with producer in the known-repos allowlist."""
+    result = lint_topic("onex.evt.omnimarket.review-bot-foo.v1")
+    assert result.is_valid, f"Expected valid but got violations: {result.violations}"
+
+
+@pytest.mark.unit
+def test_all_known_producers_accepted() -> None:
+    """All entries in _KNOWN_PRODUCERS must produce valid 5-segment topics."""
+    for producer in _KNOWN_PRODUCERS:
+        result = lint_topic(f"onex.evt.{producer}.test-event.v1")
+        assert result.is_valid, (
+            f"Producer {producer!r} unexpectedly rejected: {result.violations}"
+        )
+
+
+@pytest.mark.unit
+def test_known_producers_allowlist_complete() -> None:
+    """_KNOWN_PRODUCERS contains all expected canonical producer segments."""
+    expected = {
+        "omnimarket",
+        "omnibase-infra",
+        "omniclaude",
+        "omniintelligence",
+        "omnimemory",
+        "omninode",
+        "omnibase-compat",
+        "github",
+        "platform",
+    }
+    assert expected.issubset(_KNOWN_PRODUCERS), (
+        f"Missing producers: {expected - _KNOWN_PRODUCERS}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_KNOWN_PRODUCERS` frozenset to `lint_topic_names.py` with 9 canonical producer segments
- Any structurally-valid producer not in the allowlist now produces an `unknown producer` violation
- Pre-existing violations (46 contract + 7 Python source) seeded into `topic_naming_baseline.txt`
- 5 new tests (TDD-first): `test_unknown_producer_rejected`, `test_known_producer_accepted`, `test_all_known_producers_accepted`, `test_known_producers_allowlist_complete`, `test_producer_with_underscore_rejected`

## Related

- Ticket: OMN-8507 (Wave 6.10 — parent OMN-8442)
- Sub-task for PR #209 violation: OMN-8508
- Companion PR: omnimarket (wire hook + CI job)

## Test plan

- [x] `uv run pytest tests/unit/scripts/validation/test_lint_topic_names.py` — 15 passed
- [x] `uv run python scripts/validation/lint_topic_names.py --scan-contracts src/omnibase_infra/nodes` — clean (46 suppressed by baseline)
- [x] `uv run ruff check scripts/validation/lint_topic_names.py` — passed
- [x] pre-commit hooks — all passed on commit