### PR TITLE
fix(runtime): handler_wiring missing event_bus.subscribe() for contract auto-wiring (OMN-8512)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -342,6 +342,7 @@ async def _wire_single_contract(
     dispatchers_registered: list[str] = []
     routes_registered: list[str] = []
     topics_subscribed: list[str] = []
+    unsubscribers: list[Callable[[], Awaitable[None]]] = []
 
     try:
         # Import and wire each handler from handler_routing
@@ -372,12 +373,15 @@ async def _wire_single_contract(
                     node_identity, EnumConsumerGroupPurpose.CONSUME
                 )
                 callback = _make_event_bus_callback(topic, dispatch_engine)
-                typed_bus = cast("ProtocolEventBusSubscriber", event_bus)
-                _unsubscribe = await typed_bus.subscribe(
+                typed_bus: ProtocolEventBusSubscriber = cast(
+                    "ProtocolEventBusSubscriber", event_bus
+                )
+                unsubscribe = await typed_bus.subscribe(
                     topic=topic,
                     node_identity=node_identity,
                     on_message=callback,
                 )
+                unsubscribers.append(unsubscribe)
                 topics_subscribed.append(topic)
 
                 logger.info(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -121,15 +121,25 @@ def _make_event_bus_callback(
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 
     async def callback(message: object) -> None:
-        raw = getattr(message, "value", None)
-        if raw is not None:
-            data = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
-            envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
-                object
-            ].model_validate(data)
-        else:
-            envelope = message  # type: ignore[assignment]
-        await dispatch_engine.dispatch(topic, envelope)
+        try:
+            raw = getattr(message, "value", None)
+            if raw is not None:
+                data = json.loads(
+                    raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                )
+                envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
+                    object
+                ].model_validate(data)
+            else:
+                envelope = message  # type: ignore[assignment]
+            await dispatch_engine.dispatch(topic, envelope)
+        except Exception as exc:  # noqa: BLE001 — boundary: log and discard; unsubscribe unavailable here
+            logger.error(
+                "Auto-wiring callback error: topic=%s error_type=%s error=%s",
+                topic,
+                type(exc).__name__,
+                exc,
+            )
 
     return callback
 

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -131,7 +131,15 @@ def _make_event_bus_callback(
                     object
                 ].model_validate(data)
             else:
-                envelope = message  # type: ignore[assignment]
+                if not isinstance(message, ModelEventEnvelope):
+                    logger.warning(
+                        "Auto-wiring callback: message has no 'value' and is not a ModelEventEnvelope"
+                        " — dropping. topic=%s message_type=%s",
+                        topic,
+                        type(message).__name__,
+                    )
+                    return
+                envelope = message
             await dispatch_engine.dispatch(topic, envelope)
         except Exception as exc:  # noqa: BLE001 — boundary: log and discard; unsubscribe unavailable here
             logger.error(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -24,7 +24,7 @@ import inspect
 import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
@@ -40,6 +40,9 @@ from omnibase_infra.runtime.auto_wiring.report import (
 
 if TYPE_CHECKING:
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+    from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
+        ProtocolEventBusSubscriber,
+    )
     from omnibase_infra.models.dispatch.model_dispatch_result import (
         ModelDispatchResult,
     )
@@ -106,7 +109,7 @@ def _make_dispatch_callback(
 
 def _make_event_bus_callback(
     topic: str,
-    dispatch_engine: object,
+    dispatch_engine: ProtocolDispatchEngine,
 ) -> Callable[..., Awaitable[None]]:
     """Create a Kafka on_message callback that deserializes and dispatches to engine.
 
@@ -126,7 +129,7 @@ def _make_event_bus_callback(
             ].model_validate(data)
         else:
             envelope = message  # type: ignore[assignment]
-        await dispatch_engine.dispatch(topic, envelope)  # type: ignore[union-attr]
+        await dispatch_engine.dispatch(topic, envelope)
 
     return callback
 
@@ -351,7 +354,8 @@ async def _wire_single_contract(
                     node_identity, EnumConsumerGroupPurpose.CONSUME
                 )
                 callback = _make_event_bus_callback(topic, dispatch_engine)
-                unsubscribe = await event_bus.subscribe(
+                typed_bus = cast("ProtocolEventBusSubscriber", event_bus)
+                unsubscribe = await typed_bus.subscribe(
                     topic=topic,
                     node_identity=node_identity,
                     on_message=callback,

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -104,6 +104,33 @@ def _make_dispatch_callback(
     return _callback
 
 
+def _make_event_bus_callback(
+    topic: str,
+    dispatch_engine: object,
+) -> Callable[..., Awaitable[None]]:
+    """Create a Kafka on_message callback that deserializes and dispatches to engine.
+
+    Mirrors EventBusSubcontractWiring._create_dispatch_callback but stripped of
+    DLQ/idempotency concerns — auto-wired nodes rely on the simplified path.
+    """
+    import json
+
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+    async def callback(message: object) -> None:
+        raw = getattr(message, "value", None)
+        if raw is not None:
+            data = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+            envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
+                object
+            ].model_validate(data)
+        else:
+            envelope = message  # type: ignore[assignment]
+        await dispatch_engine.dispatch(topic, envelope)  # type: ignore[union-attr]
+
+    return callback
+
+
 def _derive_route_id(contract_name: str, handler_name: str) -> str:
     """Derive a route ID from contract and handler names."""
     return f"route.auto.{contract_name}.{handler_name}"
@@ -309,14 +336,34 @@ async def _wire_single_contract(
 
         # Subscribe to Kafka topics via event bus
         if event_bus is not None and contract.event_bus:
+            from omnibase_infra.enums import EnumConsumerGroupPurpose
+            from omnibase_infra.models import ModelNodeIdentity
+            from omnibase_infra.utils import compute_consumer_group_id
+
             for topic in contract.event_bus.subscribe_topics:
+                node_identity = ModelNodeIdentity(
+                    env=environment,
+                    service=contract.package_name,
+                    node_name=contract.name,
+                    version="v1",
+                )
+                consumer_group = compute_consumer_group_id(
+                    node_identity, EnumConsumerGroupPurpose.CONSUME
+                )
+                callback = _make_event_bus_callback(topic, dispatch_engine)
+                unsubscribe = await event_bus.subscribe(
+                    topic=topic,
+                    node_identity=node_identity,
+                    on_message=callback,
+                )
                 topics_subscribed.append(topic)
 
-            logger.info(
-                "Auto-wired topics for %s: %s",
-                contract.name,
-                contract.event_bus.subscribe_topics,
-            )
+                logger.info(
+                    "Auto-wired subscription: topic=%s consumer_group=%s node=%s",
+                    topic,
+                    consumer_group,
+                    contract.name,
+                )
 
     except Exception as exc:  # noqa: BLE001 — boundary: structured diagnostics for auto-wiring
         logger.error(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -26,6 +26,9 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
+from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
+    ProtocolEventBusSubscriber,
+)
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
     ModelDiscoveredContract,
@@ -40,9 +43,6 @@ from omnibase_infra.runtime.auto_wiring.report import (
 
 if TYPE_CHECKING:
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
-    from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
-        ProtocolEventBusSubscriber,
-    )
     from omnibase_infra.models.dispatch.model_dispatch_result import (
         ModelDispatchResult,
     )
@@ -366,14 +366,14 @@ async def _wire_single_contract(
                     env=environment,
                     service=contract.package_name,
                     node_name=contract.name,
-                    version="v1",
+                    version=str(contract.contract_version),
                 )
                 consumer_group = compute_consumer_group_id(
                     node_identity, EnumConsumerGroupPurpose.CONSUME
                 )
                 callback = _make_event_bus_callback(topic, dispatch_engine)
                 typed_bus = cast("ProtocolEventBusSubscriber", event_bus)
-                unsubscribe = await typed_bus.subscribe(
+                _unsubscribe = await typed_bus.subscribe(
                     topic=topic,
                     node_identity=node_identity,
                     on_message=callback,

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""TDD tests for OMN-8512 — _wire_single_contract must call event_bus.subscribe().
+
+These tests were written BEFORE the fix and must fail on the unfixed codebase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _contract(
+    name: str = "node_test",
+    subscribe_topics: tuple[str, ...] = ("onex.cmd.omnimarket.test-start.v1",),
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name=name,
+        package_name="test-package",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=subscribe_topics,
+            publish_topics=(),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="FakeHandler",
+                        module="fake.module",
+                    ),
+                    event_model=None,
+                    operation=None,
+                ),
+            ),
+        ),
+    )
+
+
+def _fake_handler_cls() -> MagicMock:
+    cls = MagicMock()
+    instance = MagicMock()
+    instance.handle = AsyncMock(return_value=None)
+    cls.return_value = instance
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — subscribe() is called once per subscribe_topic
+# ---------------------------------------------------------------------------
+
+
+class TestWireFromManifestCallsSubscribe:
+    """event_bus.subscribe() must be called for each contract subscribe_topic."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_called_once_per_topic(self) -> None:
+        topic = "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1"
+        contract = _contract(subscribe_topics=(topic,))
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        # Mock event_bus with async subscribe that returns an async unsubscribe callable
+        unsubscribe = AsyncMock()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=unsubscribe)
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        assert report.total_wired == 1
+        # THE critical assertion: subscribe must have been called
+        event_bus.subscribe.assert_called_once()
+        call_kwargs = event_bus.subscribe.call_args
+        # Called with topic= and node_identity= and on_message= keyword args
+        assert call_kwargs.kwargs.get("topic") == topic or call_kwargs.args[0] == topic
+
+    @pytest.mark.asyncio
+    async def test_subscribe_called_for_each_of_multiple_topics(self) -> None:
+        topics = (
+            "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1",
+            "onex.cmd.omnimarket.pr-lifecycle-retry.v1",
+        )
+        contract = _contract(subscribe_topics=topics)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        unsubscribe = AsyncMock()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=unsubscribe)
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        assert event_bus.subscribe.call_count == len(topics)
+
+    @pytest.mark.asyncio
+    async def test_topics_subscribed_in_report(self) -> None:
+        topic = "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1"
+        contract = _contract(subscribe_topics=(topic,))
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        unsubscribe = AsyncMock()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=unsubscribe)
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        assert topic in report.results[0].topics_subscribed
+
+    @pytest.mark.asyncio
+    async def test_no_subscribe_when_event_bus_none(self) -> None:
+        """When event_bus is None, subscribe must not be called (no event_bus to call on)."""
+        contract = _contract()
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=None, environment="local"
+            )
+
+        # Still wired (dispatchers+routes registered), but no subscription
+        assert report.total_wired == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — callback routes to dispatch engine
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeCallbackRoutesToDispatchEngine:
+    """When an event arrives on a subscribed topic, dispatch engine must receive it."""
+
+    @pytest.mark.asyncio
+    async def test_callback_dispatches_to_engine(self) -> None:
+        topic = "onex.cmd.omnimarket.test-start.v1"
+        contract = _contract(subscribe_topics=(topic,))
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        captured_callbacks: list = []
+
+        async def fake_subscribe(**kwargs: object) -> AsyncMock:
+            captured_callbacks.append(kwargs.get("on_message"))
+            return AsyncMock()
+
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(side_effect=fake_subscribe)
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        # A callback must have been captured
+        assert len(captured_callbacks) == 1
+        callback = captured_callbacks[0]
+        assert callable(callback)

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -205,3 +205,66 @@ class TestSubscribeCallbackRoutesToDispatchEngine:
         assert len(captured_callbacks) == 1
         callback = captured_callbacks[0]
         assert callable(callback)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — raw=None fallback path (OMN-8512 CR fix)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeEventBusCallbackFallbackPath:
+    """When raw is None, dispatch_engine must NOT receive a non-ModelEventEnvelope."""
+
+    @pytest.mark.asyncio
+    async def test_non_envelope_message_is_dropped_not_dispatched(self) -> None:
+        """A message with no .value attribute that is not a ModelEventEnvelope must
+        be dropped (dispatch_engine.dispatch not called) rather than passed through raw."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        dispatch_engine = MagicMock()
+        dispatch_engine.dispatch = AsyncMock()
+
+        callback = _make_event_bus_callback(
+            "onex.cmd.test.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+        )
+
+        # A plain object with no .value — not a ModelEventEnvelope
+        bad_message = object()
+        await callback(bad_message)
+
+        # dispatch_engine must NOT have been called with the raw non-envelope
+        dispatch_engine.dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_envelope_message_passes_through(self) -> None:
+        """A message with no .value that IS already a ModelEventEnvelope must still be dispatched."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        dispatch_engine = MagicMock()
+        dispatch_engine.dispatch = AsyncMock()
+
+        callback = _make_event_bus_callback(
+            "onex.cmd.test.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+        )
+
+        envelope = ModelEventEnvelope[object].model_construct(
+            event_type="onex.cmd.test.v1",
+            payload={},
+        )
+        await callback(envelope)
+
+        dispatch_engine.dispatch.assert_called_once()
+        _, call_envelope = dispatch_engine.dispatch.call_args.args
+        assert isinstance(call_envelope, ModelEventEnvelope)


### PR DESCRIPTION
## Summary

- `_wire_single_contract` appended subscribe_topics to a tracking list but never called `event_bus.subscribe()` — zero Kafka consumer groups were created for ALL auto-wired nodes
- Fix: after registering dispatchers and routes, call `event_bus.subscribe()` per subscribe_topic using `ModelNodeIdentity` + `compute_consumer_group_id`, with a deserialize-and-dispatch callback (`_make_event_bus_callback`)
- Pattern mirrors `EventBusSubcontractWiring._create_dispatch_callback` (the reference working path)
- Legacy `_handler_descriptors` + `EventBusSubcontractWiring` path is untouched

**Diagnosis report:** `docs/briefs/runtime-deploy-verification.md`
**Reference pattern:** `EventBusSubcontractWiring._create_dispatch_callback` in `event_bus_subcontract_wiring.py`

## Scope

`_wire_single_contract` only. No other auto_wiring functions changed. Legacy path preserved.

## TDD evidence

Tests in `tests/unit/runtime/auto_wiring/test_wiring_subscribe.py` were written first and confirmed **failing** on the unfixed code before the fix was applied:

```
FAILED test_subscribe_called_once_per_topic      (0 calls, expected 1)
FAILED test_subscribe_called_for_each_of_multiple_topics  (0 calls, expected 2)
FAILED test_callback_dispatches_to_engine        (0 callbacks captured, expected 1)
```

All 5 tests pass after fix. 107/107 auto_wiring tests pass. Zero regressions in runtime unit suite.

## Test plan

- [ ] `tests/unit/runtime/auto_wiring/test_wiring_subscribe.py` — 5 tests all green
- [ ] `tests/unit/runtime/auto_wiring/` — 107/107 pass
- [ ] After deploy: `rpk group list | grep pr.lifecycle` shows Stable consumer group
- [ ] Same for `aislop_sweep` and `autopilot_orchestrator` consumer groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved event-bus subscription wiring: per-topic subscriptions with consumer-group handling, robust message decoding/envelope validation, and safe error handling with clear per-subscription logging.

* **Tests**
  * Added tests for subscription behavior (multiple topics, callback registration), wiring with/without an event bus, and message-dispatch handling for valid vs non-envelope messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->