### PR TITLE
feat(observability): add delegation projection consumer service (OMN-8532)

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -38,6 +38,7 @@ runtime:
     - waitlist-signup-notifier
     - savings-estimation-consumer
     - llm-cost-aggregation-consumer
+    - delegation-projection-consumer
     - consumer-health-projection
     - retry-worker
     - autoheal

--- a/docker/catalog/services/delegation-projection-consumer.yaml
+++ b/docker/catalog/services/delegation-projection-consumer.yaml
@@ -1,0 +1,48 @@
+name: delegation-projection-consumer
+description: Projects task-delegated events into delegation_events table for observability
+image: runtime:latest
+layer: runtime
+container_name: omninode-delegation-projection-consumer
+required_env:
+  - POSTGRES_PASSWORD
+hardcoded_env:
+  OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra'
+  OMNIBASE_INFRA_DELEGATION_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
+  OMNIBASE_INFRA_DELEGATION_HEALTH_CHECK_PORT: '8099'
+  OMNIBASE_INFRA_DELEGATION_HEALTH_CHECK_HOST: 0.0.0.0
+operational_defaults:
+  OMNIBASE_INFRA_DELEGATION_BATCH_SIZE: '100'
+  OMNIBASE_INFRA_DELEGATION_BATCH_TIMEOUT_MS: '1000'
+  ONEX_LOG_LEVEL: INFO
+  ONEX_ENVIRONMENT: local
+  OMNIMEMORY_ENABLED: 'false'
+ports:
+  external: 8099
+  internal: 8099
+healthcheck:
+  test: curl -sf http://localhost:8099/health
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 40
+depends_on:
+  - service: migration-gate
+    condition: service_healthy
+  - service: redpanda
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: '0.5'
+  memory: 256M
+  cpus_reservation: '0.1'
+  memory_reservation: 64M
+stop_grace_period: 60s
+command:
+  - python
+  - -m
+  - omnibase_infra.services.observability.delegation_projection.consumer
+labels:
+  com.omninode.service: delegation-projection-consumer
+  com.omninode.layer: runtime
+  com.omninode.version: ${RUNTIME_VERSION:-0.1.0}
+  autoheal: 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,7 @@ ignore = [
 "src/omnibase_infra/tools/contract_topic_extractor.py" = ["T201"]
 "src/omnibase_infra/scripts/verify_container_manifest.py" = ["T201"]
 "src/omnibase_infra/services/observability/llm_cost_aggregation/consumer.py" = ["T201"]
+"src/omnibase_infra/services/observability/delegation_projection/consumer.py" = ["T201"]
 # Intentional stdout sinks / fallback output
 "src/omnibase_infra/event_bus/service_topic_manager.py" = ["T201"]
 "src/omnibase_infra/observability/sinks/sink_logging_structured.py" = ["T201"]

--- a/src/omnibase_infra/services/observability/delegation_projection/__init__.py
+++ b/src/omnibase_infra/services/observability/delegation_projection/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Delegation projection consumer — projects task-delegated events to delegation_events."""
+
+from omnibase_infra.services.observability.delegation_projection.config import (
+    ConfigDelegationProjection,
+)
+from omnibase_infra.services.observability.delegation_projection.consumer import (
+    ServiceDelegationProjectionConsumer,
+)
+from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+    WriterDelegationProjectionPostgres,
+)
+
+__all__ = [
+    "ConfigDelegationProjection",
+    "ServiceDelegationProjectionConsumer",
+    "WriterDelegationProjectionPostgres",
+]

--- a/src/omnibase_infra/services/observability/delegation_projection/config.py
+++ b/src/omnibase_infra/services/observability/delegation_projection/config.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Configuration for delegation projection consumer.
+
+Loads from environment variables with OMNIBASE_INFRA_DELEGATION_ prefix.
+
+Related Tickets:
+    - OMN-8532: Add delegation projection consumer service
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Literal, Self
+from urllib.parse import urlparse
+
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigDelegationProjection(BaseSettings):
+    """Configuration for the delegation projection Kafka consumer.
+
+    Environment variables use the OMNIBASE_INFRA_DELEGATION_ prefix.
+    Example: OMNIBASE_INFRA_DELEGATION_KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="OMNIBASE_INFRA_DELEGATION_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # Kafka connection
+    kafka_bootstrap_servers: str = Field(
+        ...,
+        description=(
+            "Kafka bootstrap servers. Set via "
+            "OMNIBASE_INFRA_DELEGATION_KAFKA_BOOTSTRAP_SERVERS env var."
+        ),
+    )
+    kafka_group_id: str = Field(
+        default="delegation-projection-postgres",
+        description="Consumer group ID for offset tracking",
+    )
+
+    topics: list[str] = Field(
+        default_factory=lambda: [
+            "onex.evt.omniclaude.task-delegated.v1",
+        ],
+        description="Kafka topics to consume for delegation projection",
+    )
+
+    auto_offset_reset: Literal["earliest", "latest", "none"] = Field(
+        default="earliest",
+        description="Where to start consuming if no offset exists.",
+    )
+
+    session_timeout_ms: int = Field(
+        default=45000,
+        ge=6000,
+        le=300000,
+        description="Kafka session timeout in ms.",
+    )
+    heartbeat_interval_ms: int = Field(
+        default=15000,
+        ge=1000,
+        le=60000,
+        description="Kafka heartbeat interval in ms. Should be ~1/3 of session_timeout_ms.",
+    )
+    max_poll_interval_ms: int = Field(
+        default=300000,
+        ge=10000,
+        le=600000,
+        description="Max time between poll() calls in ms before consumer eviction.",
+    )
+
+    # PostgreSQL connection
+    postgres_dsn: str = Field(
+        ...,
+        repr=False,
+        exclude=True,
+        description="PostgreSQL connection string. Excluded from serialization.",
+    )
+
+    @field_validator("postgres_dsn")
+    @classmethod
+    def validate_postgres_dsn_scheme(cls, v: str) -> str:
+        if not v.startswith(("postgresql://", "postgres://")):
+            try:
+                parsed = urlparse(v)
+                safe_prefix = (
+                    f"{parsed.scheme}://..." if parsed.scheme else repr(v[:10])
+                )
+            except Exception:  # noqa: BLE001
+                safe_prefix = repr(v[:10])
+            raise ValueError(
+                f"postgres_dsn must start with 'postgresql://' or 'postgres://', "
+                f"got: {safe_prefix}."
+            )
+        return v
+
+    # Batch processing
+    batch_size: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Maximum records per batch write",
+    )
+    batch_timeout_ms: int = Field(
+        default=1000,
+        ge=100,
+        le=60000,
+        description="Timeout for batch accumulation in milliseconds",
+    )
+    poll_timeout_buffer_seconds: float = Field(
+        default=5.0,
+        ge=2.0,
+        le=30.0,
+        description="Additional buffer seconds for asyncio.wait_for timeout.",
+    )
+
+    # Connection pool
+    pool_min_size: int = Field(default=2, ge=1, le=20)
+    pool_max_size: int = Field(default=10, ge=1, le=50)
+
+    # Circuit breaker
+    circuit_breaker_threshold: int = Field(default=5, ge=1, le=100)
+    circuit_breaker_reset_timeout: float = Field(default=60.0, ge=1.0, le=3600.0)
+    circuit_breaker_half_open_successes: int = Field(default=1, ge=1, le=10)
+
+    # Health check
+    health_check_port: int = Field(
+        default=8099,
+        ge=1024,
+        le=65535,
+        description="Port for HTTP health check endpoint",
+    )
+    health_check_host: str = Field(
+        default="127.0.0.1",
+        description="Host for health check server binding.",
+    )
+    health_check_staleness_seconds: int = Field(default=300, ge=60, le=3600)
+    health_check_poll_staleness_seconds: int = Field(default=60, ge=10, le=300)
+    startup_grace_period_seconds: float = Field(default=60.0, ge=0.0, le=600.0)
+
+    @model_validator(mode="before")
+    @classmethod
+    # ONEX_EXCLUDE: any_type - dict[str, Any] required for pydantic mode="before" validator
+    def warn_unrecognized_env_vars(cls, data: dict[str, Any]) -> dict[str, Any]:
+        prefix = "OMNIBASE_INFRA_DELEGATION_"
+        known_fields = set(cls.model_fields.keys())
+        for env_key in os.environ:
+            if not env_key.upper().startswith(prefix):
+                continue
+            field_name = env_key[len(prefix) :].lower()
+            if field_name not in known_fields:
+                logger.warning(
+                    "Unrecognized environment variable '%s' has prefix '%s' "
+                    "but does not match any configuration field.",
+                    env_key,
+                    prefix,
+                )
+        return data
+
+    @model_validator(mode="after")
+    def validate_session_timeout_ratio(self) -> Self:
+        if self.heartbeat_interval_ms >= self.session_timeout_ms:
+            raise ValueError(
+                f"heartbeat_interval_ms ({self.heartbeat_interval_ms}) must be "
+                f"< session_timeout_ms ({self.session_timeout_ms})"
+            )
+        if self.max_poll_interval_ms < self.session_timeout_ms:
+            raise ValueError(
+                f"max_poll_interval_ms ({self.max_poll_interval_ms}) must be "
+                f">= session_timeout_ms ({self.session_timeout_ms})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_pool_size_relationship(self) -> Self:
+        if self.pool_min_size > self.pool_max_size:
+            from omnibase_infra.errors import ProtocolConfigurationError
+
+            raise ProtocolConfigurationError(
+                f"pool_min_size ({self.pool_min_size}) must not exceed "
+                f"pool_max_size ({self.pool_max_size})."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_topics_nonempty(self) -> Self:
+        if not self.topics:
+            from omnibase_infra.errors import ProtocolConfigurationError
+
+            raise ProtocolConfigurationError(
+                "No topics configured for delegation projection consumer."
+            )
+        return self

--- a/src/omnibase_infra/services/observability/delegation_projection/consumer.py
+++ b/src/omnibase_infra/services/observability/delegation_projection/consumer.py
@@ -1,0 +1,758 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Async Kafka consumer for delegation projection.
+
+ServiceDelegationProjectionConsumer consumes ``onex.evt.omniclaude.task-delegated.v1``
+events from Kafka and UPSERTs them into the ``delegation_events`` table.
+
+Topics consumed:
+    - onex.evt.omniclaude.task-delegated.v1
+
+Related Tickets:
+    - OMN-8532: delegation projector missing consumer service
+
+Example:
+    # Run as module:
+    # python -m omnibase_infra.services.observability.delegation_projection.consumer
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import asyncpg
+from aiohttp import web
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, TopicPartition
+from aiokafka.errors import KafkaError
+from aiokafka.structs import OffsetAndMetadata
+from pydantic import ValidationError
+
+from omnibase_core.errors import OnexError
+from omnibase_infra.event_bus.consumer_health_emitter import ConsumerHealthEmitter
+from omnibase_infra.event_bus.mixin_consumer_health import MixinConsumerHealth
+from omnibase_infra.services.observability.delegation_projection.config import (
+    ConfigDelegationProjection,
+)
+from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+    WriterDelegationProjectionPostgres,
+)
+
+if TYPE_CHECKING:
+    from aiokafka.structs import ConsumerRecord
+
+logger = logging.getLogger(__name__)
+
+_FATAL_COMMIT_ERROR_NAMES: frozenset[str] = frozenset(
+    {
+        "UnknownMemberIdError",
+        "RebalanceInProgressError",
+        "IllegalGenerationError",
+        "FencedInstanceIdError",
+    }
+)
+
+_CONSECUTIVE_TIMEOUT_LOG_INTERVAL: int = 5
+
+
+class EnumHealthStatus(StrEnum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    last_poll_at: datetime | None
+    last_successful_write_at: datetime | None
+    messages_received: int
+    started_at: datetime
+
+
+class ConsumerMetrics:
+    """Metrics tracking for the delegation projection consumer."""
+
+    def __init__(self) -> None:
+        self.messages_received: int = 0
+        self.messages_processed: int = 0
+        self.messages_failed: int = 0
+        self.messages_skipped: int = 0
+        self.batches_processed: int = 0
+        self.rows_written: int = 0
+        self.consecutive_commit_failures: int = 0
+        self.last_poll_at: datetime | None = None
+        self.last_successful_write_at: datetime | None = None
+        self.last_commit_failure_at: datetime | None = None
+        self.started_at: datetime = datetime.now(UTC)
+        self._lock = asyncio.Lock()
+
+    async def record_received(self, count: int = 1) -> None:
+        async with self._lock:
+            self.messages_received += count
+            self.last_poll_at = datetime.now(UTC)
+
+    async def record_processed(self, count: int = 1) -> None:
+        async with self._lock:
+            self.messages_processed += count
+            self.last_successful_write_at = datetime.now(UTC)
+
+    async def record_rows_written(self, count: int = 1) -> None:
+        async with self._lock:
+            self.rows_written += count
+
+    async def record_failed(self, count: int = 1) -> None:
+        async with self._lock:
+            self.messages_failed += count
+
+    async def record_skipped(self, count: int = 1) -> None:
+        async with self._lock:
+            self.messages_skipped += count
+
+    async def record_batch_processed(self) -> None:
+        async with self._lock:
+            self.batches_processed += 1
+
+    async def record_polled(self) -> None:
+        async with self._lock:
+            self.last_poll_at = datetime.now(UTC)
+
+    async def record_commit_failure(self) -> None:
+        async with self._lock:
+            self.consecutive_commit_failures += 1
+            self.last_commit_failure_at = datetime.now(UTC)
+
+    async def reset_consecutive_commit_failures(self) -> None:
+        async with self._lock:
+            self.consecutive_commit_failures = 0
+
+    async def snapshot(self) -> dict[str, object]:
+        async with self._lock:
+            return {
+                "messages_received": self.messages_received,
+                "messages_processed": self.messages_processed,
+                "messages_failed": self.messages_failed,
+                "messages_skipped": self.messages_skipped,
+                "batches_processed": self.batches_processed,
+                "rows_written": self.rows_written,
+                "consecutive_commit_failures": self.consecutive_commit_failures,
+                "last_poll_at": self.last_poll_at.isoformat()
+                if self.last_poll_at
+                else None,
+                "last_successful_write_at": (
+                    self.last_successful_write_at.isoformat()
+                    if self.last_successful_write_at
+                    else None
+                ),
+                "started_at": self.started_at.isoformat(),
+            }
+
+    async def health_snapshot(self) -> HealthSnapshot:
+        async with self._lock:
+            return HealthSnapshot(
+                last_poll_at=self.last_poll_at,
+                last_successful_write_at=self.last_successful_write_at,
+                messages_received=self.messages_received,
+                started_at=self.started_at,
+            )
+
+
+class ServiceDelegationProjectionConsumer(MixinConsumerHealth):
+    """Async Kafka consumer for delegation projection.
+
+    Consumes task-delegated events and UPSERTs them into delegation_events.
+    """
+
+    def __init__(self, config: ConfigDelegationProjection) -> None:
+        self._config = config
+        self._consumer: AIOKafkaConsumer | None = None
+        self._pool: asyncpg.Pool | None = None
+        self._writer: WriterDelegationProjectionPostgres | None = None
+        self._health_producer: AIOKafkaProducer | None = None
+        self._running = False
+        self._shutdown_event = asyncio.Event()
+
+        self._health_app: web.Application | None = None
+        self._health_runner: web.AppRunner | None = None
+        self._health_site: web.TCPSite | None = None
+
+        self.metrics = ConsumerMetrics()
+        self._consumer_id = f"delegation-projection-{uuid4().hex[:8]}"
+
+        logger.info(
+            "ServiceDelegationProjectionConsumer initialized",
+            extra={
+                "consumer_id": self._consumer_id,
+                "topics": self._config.topics,
+                "group_id": self._config.kafka_group_id,
+            },
+        )
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    @property
+    def consumer_id(self) -> str:
+        return self._consumer_id
+
+    async def start(self) -> None:
+        if self._running:
+            return
+
+        correlation_id = uuid4()
+        try:
+            self._pool = await asyncpg.create_pool(
+                dsn=self._config.postgres_dsn,
+                min_size=self._config.pool_min_size,
+                max_size=self._config.pool_max_size,
+            )
+
+            self._writer = WriterDelegationProjectionPostgres(
+                pool=self._pool,
+                circuit_breaker_threshold=self._config.circuit_breaker_threshold,
+                circuit_breaker_reset_timeout=self._config.circuit_breaker_reset_timeout,
+                circuit_breaker_half_open_successes=self._config.circuit_breaker_half_open_successes,
+            )
+
+            self._consumer = AIOKafkaConsumer(
+                *self._config.topics,
+                bootstrap_servers=self._config.kafka_bootstrap_servers,
+                group_id=self._config.kafka_group_id,
+                auto_offset_reset=self._config.auto_offset_reset,
+                enable_auto_commit=False,
+                session_timeout_ms=self._config.session_timeout_ms,
+                heartbeat_interval_ms=self._config.heartbeat_interval_ms,
+                max_poll_interval_ms=self._config.max_poll_interval_ms,
+                max_poll_records=self._config.batch_size,
+            )
+
+            await self._consumer.start()
+            await self._start_health_server()
+
+            self._running = True
+            self._shutdown_event.clear()
+
+            if ConsumerHealthEmitter.is_enabled():
+                self._health_producer = AIOKafkaProducer(
+                    bootstrap_servers=self._config.kafka_bootstrap_servers,
+                )
+                await self._health_producer.start()
+                self._init_health_emitter(
+                    self._health_producer,
+                    consumer_identity="delegation-projection-consumer",
+                    consumer_group=self._config.kafka_group_id,
+                    topic=",".join(self._config.topics),
+                    service_label="ServiceDelegationProjectionConsumer",
+                )
+
+            logger.info(
+                "ServiceDelegationProjectionConsumer started",
+                extra={
+                    "consumer_id": self._consumer_id,
+                    "correlation_id": str(correlation_id),
+                },
+            )
+
+        except Exception as e:
+            logger.exception(
+                "Failed to start consumer",
+                extra={"consumer_id": self._consumer_id, "error": str(e)},
+            )
+            await self._cleanup_resources(correlation_id)
+            raise
+
+    async def stop(self) -> None:
+        if not self._running:
+            return
+
+        correlation_id = uuid4()
+        self._running = False
+        self._shutdown_event.set()
+        await self._cleanup_resources(correlation_id)
+
+        metrics_snapshot = await self.metrics.snapshot()
+        logger.info(
+            "ServiceDelegationProjectionConsumer stopped",
+            extra={
+                "consumer_id": self._consumer_id,
+                "correlation_id": str(correlation_id),
+                "final_metrics": metrics_snapshot,
+            },
+        )
+
+    async def _cleanup_resources(self, correlation_id: UUID) -> None:
+        if self._health_site is not None:
+            await self._health_site.stop()
+            self._health_site = None
+
+        if self._health_runner is not None:
+            await self._health_runner.cleanup()
+            self._health_runner = None
+
+        self._health_app = None
+
+        if self._health_producer is not None:
+            try:
+                await self._health_producer.stop()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Error stopping health producer",
+                    extra={"consumer_id": self._consumer_id},
+                )
+            finally:
+                self._health_producer = None
+
+        if self._consumer is not None:
+            try:
+                await self._consumer.stop()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Error stopping Kafka consumer",
+                    extra={"consumer_id": self._consumer_id, "error": str(e)},
+                )
+            finally:
+                self._consumer = None
+
+        if self._pool is not None:
+            try:
+                await self._pool.close()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Error closing PostgreSQL pool",
+                    extra={"consumer_id": self._consumer_id, "error": str(e)},
+                )
+            finally:
+                self._pool = None
+
+        self._writer = None
+
+    async def run(self) -> None:
+        if not self._running or self._consumer is None:
+            raise OnexError("Consumer not started. Call start() before run().")
+        await self._consume_loop(uuid4())
+
+    async def __aenter__(self) -> ServiceDelegationProjectionConsumer:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        await self.stop()
+
+    async def _consume_loop(self, correlation_id: UUID) -> None:
+        if self._consumer is None:
+            return
+
+        batch_timeout_seconds = self._config.batch_timeout_ms / 1000.0
+        consecutive_timeouts: int = 0
+
+        try:
+            while self._running:
+                try:
+                    records = await asyncio.wait_for(
+                        self._consumer.getmany(
+                            timeout_ms=self._config.batch_timeout_ms,
+                            max_records=self._config.batch_size,
+                        ),
+                        timeout=batch_timeout_seconds
+                        + self._config.poll_timeout_buffer_seconds,
+                    )
+                except TimeoutError:
+                    consecutive_timeouts += 1
+                    if consecutive_timeouts % _CONSECUTIVE_TIMEOUT_LOG_INTERVAL == 0:
+                        logger.warning(
+                            "Kafka getmany() timed out %d consecutive times",
+                            consecutive_timeouts,
+                            extra={"consumer_id": self._consumer_id},
+                        )
+                    continue
+
+                consecutive_timeouts = 0
+                await self.metrics.record_polled()
+
+                if not records:
+                    continue
+
+                messages: list[ConsumerRecord] = []
+                for tp_messages in records.values():
+                    messages.extend(tp_messages)
+
+                if not messages:
+                    continue
+
+                await self.metrics.record_received(len(messages))
+
+                batch_correlation_id = uuid4()
+                successful_offsets = await self._process_batch(
+                    messages, batch_correlation_id
+                )
+
+                if successful_offsets:
+                    await self._commit_offsets(successful_offsets, batch_correlation_id)
+                    await self.metrics.record_batch_processed()
+
+        except asyncio.CancelledError:
+            logger.info(
+                "Consume loop cancelled", extra={"consumer_id": self._consumer_id}
+            )
+            raise
+        except KafkaError as e:
+            logger.exception(
+                "Kafka error in consume loop",
+                extra={"consumer_id": self._consumer_id, "error": str(e)},
+            )
+            raise
+        except Exception as e:
+            logger.exception(
+                "Unexpected error in consume loop",
+                extra={"consumer_id": self._consumer_id, "error": str(e)},
+            )
+            raise
+        finally:
+            logger.info(
+                "Consume loop exiting", extra={"consumer_id": self._consumer_id}
+            )
+
+    @staticmethod
+    def _track_skipped_offset(
+        skipped_offsets: dict[TopicPartition, int],
+        msg: ConsumerRecord,
+    ) -> None:
+        tp = TopicPartition(msg.topic, msg.partition)
+        current = skipped_offsets.get(tp, -1)
+        skipped_offsets[tp] = max(current, msg.offset)
+
+    async def _process_batch(
+        self,
+        messages: list[ConsumerRecord],
+        correlation_id: UUID,
+    ) -> dict[TopicPartition, int]:
+        if self._writer is None:
+            return {}
+
+        successful_offsets: dict[TopicPartition, int] = {}
+        skipped_offsets: dict[TopicPartition, int] = {}
+        parsed_skipped: int = 0
+
+        parsed_events: list[tuple[ConsumerRecord, dict[str, object]]] = []
+
+        for msg in messages:
+            if msg.value is None:
+                parsed_skipped += 1
+                self._track_skipped_offset(skipped_offsets, msg)
+                continue
+
+            try:
+                value = msg.value
+                if isinstance(value, bytes):
+                    try:
+                        value = value.decode("utf-8")
+                    except UnicodeDecodeError:
+                        parsed_skipped += 1
+                        self._track_skipped_offset(skipped_offsets, msg)
+                        continue
+
+                payload = json.loads(value)
+                if not isinstance(payload, dict):
+                    parsed_skipped += 1
+                    self._track_skipped_offset(skipped_offsets, msg)
+                    continue
+
+                parsed_events.append((msg, payload))
+
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Failed to decode JSON message",
+                    extra={
+                        "consumer_id": self._consumer_id,
+                        "topic": msg.topic,
+                        "partition": msg.partition,
+                        "offset": msg.offset,
+                    },
+                )
+                parsed_skipped += 1
+                self._track_skipped_offset(skipped_offsets, msg)
+
+        if parsed_skipped > 0:
+            await self.metrics.record_skipped(parsed_skipped)
+
+        if not parsed_events:
+            for tp, offset in skipped_offsets.items():
+                current = successful_offsets.get(tp, -1)
+                successful_offsets[tp] = max(current, offset)
+            return successful_offsets
+
+        event_dicts = [ev for _, ev in parsed_events]
+
+        try:
+            rows_written = await self._writer.write_events(event_dicts, correlation_id)
+
+            for msg, _ in parsed_events:
+                tp = TopicPartition(msg.topic, msg.partition)
+                current = successful_offsets.get(tp, -1)
+                successful_offsets[tp] = max(current, msg.offset)
+
+            await self.metrics.record_processed(len(parsed_events))
+            await self.metrics.record_rows_written(rows_written)
+
+        except Exception:
+            logger.exception(
+                "Failed to write delegation_events batch",
+                extra={
+                    "consumer_id": self._consumer_id,
+                    "correlation_id": str(correlation_id),
+                    "count": len(event_dicts),
+                },
+            )
+            await self.metrics.record_failed(len(event_dicts))
+
+        for tp, offset in skipped_offsets.items():
+            current = successful_offsets.get(tp, -1)
+            successful_offsets[tp] = max(current, offset)
+
+        return successful_offsets
+
+    async def _commit_offsets(
+        self,
+        offsets: dict[TopicPartition, int],
+        correlation_id: UUID,
+    ) -> None:
+        if not offsets or self._consumer is None:
+            return
+
+        commit_map: dict[TopicPartition, OffsetAndMetadata] = {
+            tp: OffsetAndMetadata(offset + 1, "") for tp, offset in offsets.items()
+        }
+
+        try:
+            await self._consumer.commit(commit_map)
+            await self.metrics.reset_consecutive_commit_failures()
+
+        except KafkaError as exc:
+            await self.metrics.record_commit_failure()
+            error_name = type(exc).__name__
+            is_fatal = error_name in _FATAL_COMMIT_ERROR_NAMES
+
+            if is_fatal:
+                logger.exception(
+                    "Fatal commit error (%s) -- consumer must rejoin group",
+                    error_name,
+                    extra={"consumer_id": self._consumer_id},
+                )
+                raise
+            logger.warning(
+                "Retriable commit error (%s), will retry on next batch",
+                error_name,
+                exc_info=True,
+                extra={"consumer_id": self._consumer_id},
+            )
+
+    async def _start_health_server(self) -> None:
+        from omnibase_infra.enums import EnumInfraTransportType
+        from omnibase_infra.errors import InfraConnectionError, ModelInfraErrorContext
+
+        self._health_app = web.Application()
+        self._health_app.router.add_get("/health", self._health_handler)
+        self._health_app.router.add_get("/health/live", self._liveness_handler)
+        self._health_app.router.add_get("/health/ready", self._readiness_handler)
+
+        self._health_runner = web.AppRunner(self._health_app)
+        await self._health_runner.setup()
+
+        self._health_site = web.TCPSite(
+            self._health_runner,
+            host=self._config.health_check_host,
+            port=self._config.health_check_port,
+        )
+
+        try:
+            await self._health_site.start()
+        except OSError as exc:
+            port = self._config.health_check_port
+            host = self._config.health_check_host
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation="start_health_server",
+            )
+            raise InfraConnectionError(
+                f"Health check port {port} already in use (host={host})",
+                context=context,
+            ) from exc
+
+    async def _determine_health_status(self) -> EnumHealthStatus:
+        if not self._running:
+            return EnumHealthStatus.UNHEALTHY
+
+        circuit_state = self._writer.get_circuit_breaker_state() if self._writer else {}
+        if circuit_state.get("state") in ("open", "half_open"):
+            return EnumHealthStatus.DEGRADED
+
+        snap = await self.metrics.health_snapshot()
+        now = datetime.now(UTC)
+
+        if snap.last_poll_at is not None:
+            poll_age = (now - snap.last_poll_at).total_seconds()
+            if poll_age > self._config.health_check_poll_staleness_seconds:
+                return EnumHealthStatus.DEGRADED
+
+        if snap.last_successful_write_at is None:
+            age = (now - snap.started_at).total_seconds()
+            if age <= self._config.startup_grace_period_seconds:
+                return EnumHealthStatus.HEALTHY
+            return EnumHealthStatus.DEGRADED
+
+        write_age = (now - snap.last_successful_write_at).total_seconds()
+        if (
+            write_age > self._config.health_check_staleness_seconds
+            and snap.messages_received > 0
+        ):
+            return EnumHealthStatus.DEGRADED
+
+        return EnumHealthStatus.HEALTHY
+
+    async def _health_handler(self, request: web.Request) -> web.Response:
+        metrics_snapshot = await self.metrics.snapshot()
+        circuit_state = self._writer.get_circuit_breaker_state() if self._writer else {}
+        status = await self._determine_health_status()
+
+        body = {
+            "status": status.value,
+            "consumer_running": self._running,
+            "consumer_id": self._consumer_id,
+            "last_poll_time": metrics_snapshot.get("last_poll_at"),
+            "last_successful_write": metrics_snapshot.get("last_successful_write_at"),
+            "circuit_breaker_state": circuit_state.get("state", "unknown"),
+            "messages_processed": metrics_snapshot.get("messages_processed", 0),
+            "messages_failed": metrics_snapshot.get("messages_failed", 0),
+            "rows_written": metrics_snapshot.get("rows_written", 0),
+        }
+        http_status = 200 if status != EnumHealthStatus.UNHEALTHY else 503
+        return web.json_response(body, status=http_status)
+
+    async def _liveness_handler(self, request: web.Request) -> web.Response:
+        body = {
+            "status": "alive" if self._running else "dead",
+            "consumer_id": self._consumer_id,
+        }
+        return web.json_response(body, status=200 if self._running else 503)
+
+    async def _readiness_handler(self, request: web.Request) -> web.Response:
+        deps = {
+            "postgres_pool": self._pool is not None,
+            "kafka_consumer": self._consumer is not None,
+            "writer": self._writer is not None,
+        }
+        circuit_state = self._writer.get_circuit_breaker_state() if self._writer else {}
+        deps["circuit_breaker"] = circuit_state.get("state") != "open"
+        all_ready = all(deps.values()) and self._running
+
+        body = {
+            "status": "ready" if all_ready else "not_ready",
+            "consumer_id": self._consumer_id,
+            "consumer_running": self._running,
+            "dependencies": deps,
+        }
+        return web.json_response(body, status=200 if all_ready else 503)
+
+    async def health_check(self) -> dict[str, object]:
+        metrics_snapshot = await self.metrics.snapshot()
+        circuit_state = self._writer.get_circuit_breaker_state() if self._writer else {}
+        status = await self._determine_health_status()
+        return {
+            "status": status.value,
+            "consumer_running": self._running,
+            "consumer_id": self._consumer_id,
+            "group_id": self._config.kafka_group_id,
+            "topics": self._config.topics,
+            "circuit_breaker_state": circuit_state,
+            "metrics": metrics_snapshot,
+        }
+
+
+async def _main() -> None:
+    from omnibase_infra.utils.util_consumer_restart import run_with_restart
+
+    try:
+        ConfigDelegationProjection()
+    except ValidationError as exc:
+        missing = [str(e["loc"][-1]) for e in exc.errors() if e["type"] == "missing"]
+        prefix = "OMNIBASE_INFRA_DELEGATION_"
+        if missing:
+            env_vars = ", ".join(f"{prefix}{f.upper()}" for f in missing)
+            print(
+                f"ERROR: Missing required configuration. "
+                f"Set the following environment variable(s): {env_vars}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"ERROR: Invalid configuration: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    shutdown_event = asyncio.Event()
+    active_consumer: list[ServiceDelegationProjectionConsumer | None] = [None]
+
+    def _on_signal() -> None:
+        shutdown_event.set()
+        if active_consumer[0] is not None:
+            asyncio.get_running_loop().create_task(active_consumer[0].stop())
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _on_signal)
+
+    async def _run_once() -> None:
+        config = ConfigDelegationProjection()
+        logger.info(
+            "Starting delegation projection consumer",
+            extra={
+                "topics": config.topics,
+                "bootstrap_servers": config.kafka_bootstrap_servers,
+                "group_id": config.kafka_group_id,
+                "health_port": config.health_check_port,
+            },
+        )
+        consumer = ServiceDelegationProjectionConsumer(config)
+        active_consumer[0] = consumer
+        try:
+            await consumer.start()
+            await consumer.run()
+        finally:
+            active_consumer[0] = None
+            try:
+                await asyncio.wait_for(consumer.stop(), timeout=10.0)
+            except TimeoutError:
+                logger.warning("consumer.stop() timed out after 10s")
+
+    await run_with_restart(
+        _run_once,
+        name="ServiceDelegationProjectionConsumer",
+        shutdown_event=shutdown_event,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    asyncio.run(_main())
+
+
+__all__ = [
+    "ConsumerMetrics",
+    "EnumHealthStatus",
+    "HealthSnapshot",
+    "ServiceDelegationProjectionConsumer",
+]

--- a/src/omnibase_infra/services/observability/delegation_projection/writer_postgres.py
+++ b/src/omnibase_infra/services/observability/delegation_projection/writer_postgres.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# no-migration: delegation_events table already exists via migration 0007_delegation_events.sql (OMN-8512)
+"""PostgreSQL writer for delegation projection.
+
+Writes task-delegated events to the delegation_events table with
+UPSERT-on-correlation_id semantics for idempotency.
+
+Related Tickets:
+    - OMN-8532: Add delegation projection consumer service
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import OrderedDict
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.mixins import MixinAsyncCircuitBreaker
+
+logger = logging.getLogger(__name__)
+
+_MAX_DEDUP_CACHE_SIZE: int = 50_000
+
+_UPSERT_SQL = """
+INSERT INTO delegation_events (
+    correlation_id,
+    session_id,
+    timestamp,
+    task_type,
+    delegated_to,
+    model_name,
+    delegated_by,
+    quality_gate_passed,
+    quality_gates_checked,
+    quality_gates_failed,
+    delegation_latency_ms,
+    repo,
+    is_shadow,
+    llm_call_id
+) VALUES (
+    $1, $2, $3::timestamptz, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11, $12, $13, $14
+)
+ON CONFLICT (correlation_id) DO UPDATE SET
+    session_id = EXCLUDED.session_id,
+    timestamp = EXCLUDED.timestamp,
+    task_type = EXCLUDED.task_type,
+    delegated_to = EXCLUDED.delegated_to,
+    model_name = EXCLUDED.model_name,
+    delegated_by = EXCLUDED.delegated_by,
+    quality_gate_passed = EXCLUDED.quality_gate_passed,
+    quality_gates_checked = EXCLUDED.quality_gates_checked,
+    quality_gates_failed = EXCLUDED.quality_gates_failed,
+    delegation_latency_ms = EXCLUDED.delegation_latency_ms,
+    repo = EXCLUDED.repo,
+    is_shadow = EXCLUDED.is_shadow,
+    llm_call_id = EXCLUDED.llm_call_id
+"""
+
+
+class WriterDelegationProjectionPostgres(MixinAsyncCircuitBreaker):
+    """PostgreSQL writer for delegation_events projection.
+
+    UPSERT on correlation_id for idempotency. In-memory dedup cache
+    bounds memory usage for replay scenarios.
+    """
+
+    DEFAULT_QUERY_TIMEOUT_SECONDS: float = 30.0
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        circuit_breaker_threshold: int = 5,
+        circuit_breaker_reset_timeout: float = 60.0,
+        circuit_breaker_half_open_successes: int = 1,
+        query_timeout: float = DEFAULT_QUERY_TIMEOUT_SECONDS,
+    ) -> None:
+        self._pool = pool
+        self._query_timeout = query_timeout
+        self._dedup_cache: OrderedDict[str, bool] = OrderedDict()
+
+        self._init_circuit_breaker(
+            threshold=circuit_breaker_threshold,
+            reset_timeout=circuit_breaker_reset_timeout,
+            service_name="delegation-projection-writer",
+            transport_type=EnumInfraTransportType.DATABASE,
+            half_open_successes=circuit_breaker_half_open_successes,
+        )
+
+    def _is_duplicate(self, correlation_id: str) -> bool:
+        if correlation_id in self._dedup_cache:
+            self._dedup_cache.move_to_end(correlation_id)
+            return True
+        return False
+
+    def _mark_seen(self, correlation_id: str) -> None:
+        self._dedup_cache[correlation_id] = True
+        while len(self._dedup_cache) > _MAX_DEDUP_CACHE_SIZE:
+            self._dedup_cache.popitem(last=False)
+
+    async def write_events(
+        self,
+        events: list[dict[str, object]],
+        correlation_id: UUID | None = None,
+    ) -> int:
+        """Write a batch of task-delegated events to delegation_events.
+
+        Returns number of rows upserted (skips in-memory duplicates).
+
+        Raises:
+            InfraUnavailableError: If the circuit breaker is open.
+        """
+        if not events:
+            return 0
+
+        if correlation_id is None:
+            correlation_id = uuid4()
+
+        async with self._circuit_breaker_lock:
+            await self._check_circuit_breaker("write_events", correlation_id)
+
+        unique_events: list[tuple[str, dict[str, object]]] = []
+        seen_in_batch: set[str] = set()
+        for event in events:
+            cid = str(event.get("correlation_id", ""))
+            if not cid:
+                continue
+            if not self._is_duplicate(cid) and cid not in seen_in_batch:
+                unique_events.append((cid, event))
+                seen_in_batch.add(cid)
+
+        if not unique_events:
+            return 0
+
+        written = 0
+        persisted_keys: list[str] = []
+        try:
+            async with self._pool.acquire() as conn:
+                async with conn.transaction():
+                    for cid, ev in unique_events:
+                        quality_gates_checked = ev.get("quality_gates_checked")
+                        quality_gates_failed = ev.get("quality_gates_failed")
+                        await conn.execute(
+                            _UPSERT_SQL,
+                            cid,
+                            ev.get("session_id"),
+                            ev.get("timestamp"),
+                            str(ev.get("task_type", "")),
+                            str(ev.get("delegated_to", "")),
+                            str(ev.get("model_name", "")),
+                            ev.get("delegated_by"),
+                            bool(ev.get("quality_gate_passed", False)),
+                            json.dumps(quality_gates_checked)
+                            if quality_gates_checked is not None
+                            else None,
+                            json.dumps(quality_gates_failed)
+                            if quality_gates_failed is not None
+                            else None,
+                            ev.get("delegation_latency_ms"),
+                            ev.get("repo"),
+                            bool(ev.get("is_shadow", False)),
+                            ev.get("llm_call_id") or None,
+                            timeout=self._query_timeout,
+                        )
+                        persisted_keys.append(cid)
+                        written += 1
+
+        except Exception:
+            logger.exception(
+                "Failed to write delegation_events batch",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "count": len(unique_events),
+                },
+            )
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure("write_events", correlation_id)
+            raise
+
+        for cid in persisted_keys:
+            self._mark_seen(cid)
+
+        async with self._circuit_breaker_lock:
+            await self._reset_circuit_breaker()
+
+        logger.debug(
+            "Wrote %d delegation_events rows",
+            written,
+            extra={"correlation_id": str(correlation_id)},
+        )
+        return written

--- a/tests/integration/observability/test_delegation_projection_e2e.py
+++ b/tests/integration/observability/test_delegation_projection_e2e.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: delegation projection consumer writes to delegation_events.
+
+Validates:
+  1. WriterDelegationProjectionPostgres UPSERTs a row into delegation_events
+  2. Deduplication skips re-processing same correlation_id in the same batch
+  3. Idempotent re-write updates the row, not duplicates
+  4. ServiceDelegationProjectionConsumer._process_batch() routes parsed events to writer
+
+Requires: live PostgreSQL at OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN or
+  OMNIBASE_INFRA_TEST_DB_DSN (falls back to OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN).
+Tests are skipped if DSN is not configured.
+
+Related Tickets:
+  - OMN-8532: delegation projector missing consumer service
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+POSTGRES_DSN = os.environ.get(
+    "OMNIBASE_INFRA_TEST_DB_DSN",
+    os.environ.get("OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN", ""),
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def sample_event() -> dict[str, object]:
+    return {
+        "correlation_id": str(uuid.uuid4()),
+        "session_id": "test-session-001",
+        "task_type": "code-review",
+        "delegated_to": "omninode-runner-1",
+        "model_name": "claude-opus-4-6",
+        "delegated_by": "team-lead",
+        "quality_gate_passed": True,
+        "quality_gates_checked": ["lint", "tests"],
+        "quality_gates_failed": [],
+        "delegation_latency_ms": 42,
+        "repo": "omnimarket",
+        "is_shadow": False,
+        "llm_call_id": str(uuid.uuid4()),
+        "timestamp": "2026-04-11T12:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Writer tests (unit-level, mock pool)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    """Mock asyncpg pool that records execute() calls."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="INSERT 0 1")
+
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+
+    acquire_ctx = AsyncMock()
+    acquire_ctx.__aenter__ = AsyncMock(return_value=conn)
+    acquire_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_ctx)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_writer_write_events_single(
+    mock_pool: MagicMock,
+    sample_event: dict[str, object],
+) -> None:
+    from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+        WriterDelegationProjectionPostgres,
+    )
+
+    writer = WriterDelegationProjectionPostgres(pool=mock_pool)
+    written = await writer.write_events([sample_event])
+    assert written == 1
+
+
+@pytest.mark.asyncio
+async def test_writer_deduplicates_same_correlation_id(
+    mock_pool: MagicMock,
+    sample_event: dict[str, object],
+) -> None:
+    from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+        WriterDelegationProjectionPostgres,
+    )
+
+    writer = WriterDelegationProjectionPostgres(pool=mock_pool)
+    # First write: inserts
+    written1 = await writer.write_events([sample_event])
+    assert written1 == 1
+    # Second write with same correlation_id: skipped by in-memory cache
+    written2 = await writer.write_events([sample_event])
+    assert written2 == 0
+
+
+@pytest.mark.asyncio
+async def test_writer_skips_events_missing_correlation_id(
+    mock_pool: MagicMock,
+) -> None:
+    from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+        WriterDelegationProjectionPostgres,
+    )
+
+    writer = WriterDelegationProjectionPostgres(pool=mock_pool)
+    bad_event: dict[str, object] = {
+        "task_type": "code-review",
+        "delegated_to": "agent-1",
+    }
+    written = await writer.write_events([bad_event])
+    assert written == 0
+
+
+@pytest.mark.asyncio
+async def test_writer_batch_multiple_events(
+    mock_pool: MagicMock,
+) -> None:
+    from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+        WriterDelegationProjectionPostgres,
+    )
+
+    writer = WriterDelegationProjectionPostgres(pool=mock_pool)
+    events = [
+        {
+            "correlation_id": str(uuid.uuid4()),
+            "task_type": "refactor",
+            "delegated_to": f"agent-{i}",
+        }
+        for i in range(5)
+    ]
+    written = await writer.write_events(events)
+    assert written == 5
+
+
+# ---------------------------------------------------------------------------
+# Consumer process_batch tests (mock writer + Kafka records)
+# ---------------------------------------------------------------------------
+
+
+def _make_kafka_record(payload: dict[str, object]) -> MagicMock:
+    record = MagicMock()
+    record.topic = "onex.evt.omniclaude.task-delegated.v1"
+    record.partition = 0
+    record.offset = 0
+    record.value = json.dumps(payload).encode()
+    return record
+
+
+@pytest.mark.asyncio
+async def test_consumer_process_batch_routes_to_writer(
+    sample_event: dict[str, object],
+) -> None:
+    from omnibase_infra.services.observability.delegation_projection.config import (
+        ConfigDelegationProjection,
+    )
+    from omnibase_infra.services.observability.delegation_projection.consumer import (
+        ServiceDelegationProjectionConsumer,
+    )
+
+    config = ConfigDelegationProjection(
+        kafka_bootstrap_servers="localhost:19092",
+        postgres_dsn="postgresql://postgres:test@localhost:5432/omnibase_infra",
+    )
+    consumer = ServiceDelegationProjectionConsumer(config)
+
+    mock_writer = AsyncMock()
+    mock_writer.write_events = AsyncMock(return_value=1)
+    consumer._writer = mock_writer
+    consumer._running = True
+
+    record = _make_kafka_record(sample_event)
+    offsets = await consumer._process_batch([record], uuid.uuid4())
+
+    assert len(offsets) == 1
+    mock_writer.write_events.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_consumer_process_batch_skips_null_value() -> None:
+    from omnibase_infra.services.observability.delegation_projection.config import (
+        ConfigDelegationProjection,
+    )
+    from omnibase_infra.services.observability.delegation_projection.consumer import (
+        ServiceDelegationProjectionConsumer,
+    )
+
+    config = ConfigDelegationProjection(
+        kafka_bootstrap_servers="localhost:19092",
+        postgres_dsn="postgresql://postgres:test@localhost:5432/omnibase_infra",
+    )
+    consumer = ServiceDelegationProjectionConsumer(config)
+    consumer._running = True
+
+    mock_writer = AsyncMock()
+    mock_writer.write_events = AsyncMock(return_value=0)
+    consumer._writer = mock_writer
+
+    record = MagicMock()
+    record.topic = "onex.evt.omniclaude.task-delegated.v1"
+    record.partition = 0
+    record.offset = 0
+    record.value = None
+
+    offsets = await consumer._process_batch([record], uuid.uuid4())
+    assert len(offsets) == 1
+    mock_writer.write_events.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Live DB integration (skipped if no DSN)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def live_pool() -> AsyncGenerator[object, None]:
+    if not POSTGRES_DSN:
+        pytest.skip("OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN not set")
+
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=POSTGRES_DSN, min_size=1, max_size=3)
+    yield pool
+    await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_writer_live_upsert(
+    live_pool: object, sample_event: dict[str, object]
+) -> None:
+    import asyncpg
+
+    from omnibase_infra.services.observability.delegation_projection.writer_postgres import (
+        WriterDelegationProjectionPostgres,
+    )
+
+    pool = live_pool
+    assert isinstance(pool, asyncpg.Pool)
+
+    writer = WriterDelegationProjectionPostgres(pool=pool)
+    written = await writer.write_events([sample_event])
+    assert written == 1
+
+    cid = str(sample_event["correlation_id"])
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT correlation_id, task_type, delegated_to FROM delegation_events WHERE correlation_id = $1",
+            cid,
+        )
+
+    assert row is not None
+    assert row["task_type"] == sample_event["task_type"]
+    assert row["delegated_to"] == sample_event["delegated_to"]
+
+    # Cleanup
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM delegation_events WHERE correlation_id = $1", cid
+        )


### PR DESCRIPTION
## Summary

- Adds `ServiceDelegationProjectionConsumer` — standalone async Kafka consumer subscribing to `onex.evt.omniclaude.task-delegated.v1`, UPSERTs rows into `delegation_events` via `WriterDelegationProjectionPostgres`
- Docker catalog entry `delegation-projection-consumer.yaml` (port 8099, runtime layer, autoheal enabled)
- Added to `runtime` bundle in `bundles.yaml` — compose now generates 26 services
- Follows exact sibling pattern from `llm_cost_aggregation` / `context_audit` consumers

## Root cause

`delegation_events` table had 0 rows post-OMN-8512 rebuild because no consumer process existed to consume the topic. The handler, contract, and entry point in omnimarket were complete; only the omnibase_infra consumer + catalog wiring was missing.

## Test plan

- [x] 6 integration tests pass (`test_delegation_projection_e2e.py`): writer batch write, dedup, missing-correlation_id skip, multi-event batch, consumer process_batch routing, null-value skip
- [x] Live DB UPSERT test included (skipped without DSN, runs in CI with `OMNIBASE_INFRA_DELEGATION_POSTGRES_DSN`)
- [x] All pre-commit hooks pass (including topic-naming-lint, writer-migration coupling check, mypy strict)
- [ ] Post-deploy: verify `rpk group list | grep delegation-projection-postgres` shows consumer group
- [ ] Post-deploy: verify `delegation_events` row count increases after delegation event fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added delegation projection consumer service that processes delegation events from Kafka and persists them to PostgreSQL
  * Includes health monitoring endpoints and batching capabilities for efficient event processing

* **Tests**
  * Added integration tests for event processing and database persistence workflows

* **Chores**
  * Updated service catalog configuration for deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->