### PR TITLE
fix(delegation): route ModelTaskDelegatedEvent through TOPIC constant (OMN-8532)

### DIFF
--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
@@ -28,6 +28,7 @@ from uuid import UUID
 from omnibase_infra.event_bus.topic_constants import (
     TOPIC_DELEGATION_COMPLETED,
     TOPIC_DELEGATION_FAILED,
+    TOPIC_DELEGATION_TASK_DELEGATED,
 )
 from omnibase_infra.nodes.node_delegation_orchestrator.enums import (
     EnumDelegationState,
@@ -293,7 +294,7 @@ class HandlerDelegationWorkflow:
 
         # Backward-compatible task-delegated.v1 event for omnidash (Task 12)
         compat_event = ModelTaskDelegatedEvent(
-            topic="onex.evt.omniclaude.task-delegated.v1",
+            topic=TOPIC_DELEGATION_TASK_DELEGATED,
             timestamp=datetime.now(UTC).isoformat(),
             correlation_id=cid,
             session_id=None,

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
@@ -293,6 +293,7 @@ class HandlerDelegationWorkflow:
 
         # Backward-compatible task-delegated.v1 event for omnidash (Task 12)
         compat_event = ModelTaskDelegatedEvent(
+            topic="onex.evt.omniclaude.task-delegated.v1",
             timestamp=datetime.now(UTC).isoformat(),
             correlation_id=cid,
             session_id=None,

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -18,8 +18,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from omnibase_infra.event_bus.topic_constants import TOPIC_DELEGATION_TASK_DELEGATED
-
 
 class ModelTaskDelegatedEvent(BaseModel):
     """Backward-compatible event payload for omnidash delegation projection.
@@ -32,7 +30,7 @@ class ModelTaskDelegatedEvent(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     topic: str = Field(
-        default=TOPIC_DELEGATION_TASK_DELEGATED,
+        ...,
         description="Kafka topic this event should be routed to.",
     )
     timestamp: str = Field(..., description="ISO-8601 timestamp.")

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from omnibase_infra.event_bus.topic_constants import TOPIC_DELEGATION_TASK_DELEGATED
+from omnibase_infra.enums.generated.enum_omniclaude_topic import EnumOmniclaudeTopic
 
 
 class ModelTaskDelegatedEvent(BaseModel):
@@ -32,7 +32,7 @@ class ModelTaskDelegatedEvent(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     topic: str = Field(
-        default=TOPIC_DELEGATION_TASK_DELEGATED,
+        default=EnumOmniclaudeTopic.EVT_TASK_DELEGATED_V1,
         description="Kafka topic this event should be routed to.",
     )
     timestamp: str = Field(..., description="ISO-8601 timestamp.")

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -18,6 +18,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_infra.event_bus.topic_constants import TOPIC_DELEGATION_TASK_DELEGATED
+
 
 class ModelTaskDelegatedEvent(BaseModel):
     """Backward-compatible event payload for omnidash delegation projection.
@@ -30,7 +32,7 @@ class ModelTaskDelegatedEvent(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     topic: str = Field(
-        ...,
+        default=TOPIC_DELEGATION_TASK_DELEGATED,
         description="Kafka topic this event should be routed to.",
     )
     timestamp: str = Field(..., description="ISO-8601 timestamp.")

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -18,6 +18,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_infra.event_bus.topic_constants import TOPIC_DELEGATION_TASK_DELEGATED
+
 
 class ModelTaskDelegatedEvent(BaseModel):
     """Backward-compatible event payload for omnidash delegation projection.
@@ -29,6 +31,10 @@ class ModelTaskDelegatedEvent(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
+    topic: str = Field(
+        default=TOPIC_DELEGATION_TASK_DELEGATED,
+        description="Kafka topic this event should be routed to.",
+    )
     timestamp: str = Field(..., description="ISO-8601 timestamp.")
     correlation_id: UUID = Field(..., description="Delegation correlation ID.")
     session_id: UUID | None = Field(default=None, description="Source session ID.")

--- a/tests/unit/delegation/test_delegation_orchestrator.py
+++ b/tests/unit/delegation/test_delegation_orchestrator.py
@@ -222,6 +222,7 @@ class TestHappyPath:
         assert intents[2].correlation_id == cid
         assert intents[2].quality_gate_passed is True
         assert intents[2].llm_call_id == "chatcmpl-abc123"
+        assert intents[2].topic == "onex.evt.omniclaude.task-delegated.v1"
 
     def test_completed_result_has_positive_latency(self) -> None:
         handler = HandlerDelegationWorkflow()
@@ -522,6 +523,83 @@ class TestConcurrentWorkflows:
 
         assert handler.workflows[cid2].state == EnumDelegationState.COMPLETED
         assert handler.workflows[cid1].state == EnumDelegationState.ROUTED
+
+
+# ---------------------------------------------------------------------------
+# Tests: Topic routing — ModelTaskDelegatedEvent carries topic field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTaskDelegatedEventTopicRouting:
+    """Verify ModelTaskDelegatedEvent carries the correct topic field.
+
+    The runtime kernel routes output_events by inspecting event.topic.
+    Without it, the compat event is silently dropped.
+    """
+
+    def test_compat_event_has_topic_on_gate_pass(self) -> None:
+        from omnibase_infra.event_bus.topic_constants import (
+            TOPIC_DELEGATION_TASK_DELEGATED,
+        )
+        from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+            ModelTaskDelegatedEvent,
+        )
+
+        handler = HandlerDelegationWorkflow()
+        cid = uuid4()
+
+        handler.handle_delegation_request(_make_request(correlation_id=cid))
+        handler.handle_routing_decision(_make_routing_decision(cid))
+        handler.handle_inference_response(
+            _make_inference_response(correlation_id=cid, content="def test_x(): pass")
+        )
+        events = handler.handle_gate_result(_make_gate_result(cid, passed=True))
+
+        compat_events = [e for e in events if isinstance(e, ModelTaskDelegatedEvent)]
+        assert len(compat_events) == 1
+        assert compat_events[0].topic == TOPIC_DELEGATION_TASK_DELEGATED
+
+    def test_compat_event_has_topic_on_gate_fail(self) -> None:
+        from omnibase_infra.event_bus.topic_constants import (
+            TOPIC_DELEGATION_TASK_DELEGATED,
+        )
+        from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+            ModelTaskDelegatedEvent,
+        )
+
+        handler = HandlerDelegationWorkflow()
+        cid = uuid4()
+
+        handler.handle_delegation_request(_make_request(correlation_id=cid))
+        handler.handle_routing_decision(_make_routing_decision(cid))
+        handler.handle_inference_response(
+            _make_inference_response(correlation_id=cid, content="I cannot help.")
+        )
+        events = handler.handle_gate_result(
+            _make_gate_result(cid, passed=False, failure_reasons=("REFUSAL",))
+        )
+
+        compat_events = [e for e in events if isinstance(e, ModelTaskDelegatedEvent)]
+        assert len(compat_events) == 1
+        assert compat_events[0].topic == TOPIC_DELEGATION_TASK_DELEGATED
+
+    def test_model_task_delegated_event_default_topic(self) -> None:
+        from omnibase_infra.event_bus.topic_constants import (
+            TOPIC_DELEGATION_TASK_DELEGATED,
+        )
+        from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+            ModelTaskDelegatedEvent,
+        )
+
+        event = ModelTaskDelegatedEvent(
+            timestamp="2026-04-12T00:00:00Z",
+            correlation_id=uuid4(),
+            task_type="test",
+            delegated_to="qwen3-coder",
+            quality_gate_passed=True,
+        )
+        assert event.topic == TOPIC_DELEGATION_TASK_DELEGATED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/delegation/test_delegation_orchestrator.py
+++ b/tests/unit/delegation/test_delegation_orchestrator.py
@@ -222,7 +222,11 @@ class TestHappyPath:
         assert intents[2].correlation_id == cid
         assert intents[2].quality_gate_passed is True
         assert intents[2].llm_call_id == "chatcmpl-abc123"
-        assert intents[2].topic == "onex.evt.omniclaude.task-delegated.v1"
+        from omnibase_infra.event_bus.topic_constants import (
+            TOPIC_DELEGATION_TASK_DELEGATED,
+        )
+
+        assert intents[2].topic == TOPIC_DELEGATION_TASK_DELEGATED
 
     def test_completed_result_has_positive_latency(self) -> None:
         handler = HandlerDelegationWorkflow()


### PR DESCRIPTION
## Summary

- Adds `topic` field to `ModelTaskDelegatedEvent` with default `TOPIC_DELEGATION_TASK_DELEGATED` (`onex.evt.omniclaude.task-delegated.v1`)
- The field was missing, meaning the compat event emitted by `handler_delegation_workflow.py:342` had no explicit topic and relied solely on the contract topic_router dict lookup — making the routing invisible and untestable
- This is a follow-up to OMN-8512, found by the delegation-soak probe (brief: `docs/briefs/delegation-e2e-2026-04-12.md`)

## Diff summary

**`model_task_delegated_event.py`**: add `topic: str = Field(default=TOPIC_DELEGATION_TASK_DELEGATED)` as first field; import `TOPIC_DELEGATION_TASK_DELEGATED` from `topic_constants`.

**`test_delegation_orchestrator.py`**: add `TestTaskDelegatedEventTopicRouting` (3 unit tests) asserting topic field on gate-pass, gate-fail, and direct construction. Extend existing happy-path test to assert `intents[2].topic == "onex.evt.omniclaude.task-delegated.v1"`.

## Test plan

- [x] 23/23 unit tests pass (`pytest tests/unit/delegation/test_delegation_orchestrator.py -m unit`)
- [x] `pre-commit run --all-files` — all hooks pass
- [x] mypy strict — passes

## Coordination

Complements `delegation-consumer-builder` (OMN-8532) which builds the consumer service. Together they close the delegation chain end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delegation events now include an explicit routing topic so delegated tasks are delivered reliably and routed correctly.

* **Tests**
  * Added unit tests to verify delegation event routing in success and failure flows and to ensure the routing topic is set by default on emitted events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->