### PR TITLE
fix(runtime): parse legacy handler: contract key in auto-wiring discovery (OMN-8512)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -250,11 +250,15 @@ def _parse_contract(
             publish_topics=tuple(eb_raw.get("publish_topics", [])),
         )
 
-    # Extract handler routing
+    # Extract handler routing — new format (handler_routing:) or legacy (handler:)
     handler_routing: ModelHandlerRouting | None = None
     hr_raw = raw.get("handler_routing")
     if isinstance(hr_raw, dict):
         handler_routing = _parse_handler_routing(hr_raw)
+    else:
+        h_raw = raw.get("handler")
+        if isinstance(h_raw, dict):
+            handler_routing = _parse_legacy_handler(h_raw)
 
     return ModelDiscoveredContract(
         name=raw.get("name", entry_point_name),
@@ -301,4 +305,43 @@ def _parse_handler_routing(hr_raw: dict) -> ModelHandlerRouting:
     return ModelHandlerRouting(
         routing_strategy=hr_raw.get("routing_strategy", "unknown"),
         handlers=tuple(entries),
+    )
+
+
+def _parse_legacy_handler(h_raw: dict) -> ModelHandlerRouting | None:
+    """Synthesize a ModelHandlerRouting from the legacy handler: key.
+
+    Legacy format:
+        handler:
+          module: some.module.path
+          class: HandlerClassName
+          input_model: some.module.path.ModelClassName   # optional
+
+    Maps to payload_type_match routing with a single handler entry.
+    Returns None if the required module/class fields are missing.
+    """
+    module = h_raw.get("module", "")
+    class_name = h_raw.get("class", "")
+    if not module or not class_name:
+        return None
+
+    handler_ref = ModelHandlerRef(name=class_name, module=module)
+
+    event_model: ModelHandlerRef | None = None
+    input_model_str = h_raw.get("input_model")
+    if isinstance(input_model_str, str) and "." in input_model_str:
+        last_dot = input_model_str.rfind(".")
+        event_model = ModelHandlerRef(
+            name=input_model_str[last_dot + 1 :],
+            module=input_model_str[:last_dot],
+        )
+
+    entry = ModelHandlerRoutingEntry(
+        handler=handler_ref,
+        event_model=event_model,
+        operation=None,
+    )
+    return ModelHandlerRouting(
+        routing_strategy="payload_type_match",
+        handlers=(entry,),
     )


### PR DESCRIPTION
## Summary

- 56 of 83 omnimarket nodes use the legacy `handler:` contract key (module + class) instead of `handler_routing:`. The auto-wiring discovery in `discovery.py` only read `handler_routing:`, silently skipping all 56 nodes — their Kafka consumer groups never registered at runtime startup.
- Added `_parse_legacy_handler()` that synthesizes a `ModelHandlerRouting` (payload_type_match, single entry) from the `handler:` block, including optional `input_model` → `event_model` parsing.
- All 109 auto-wiring unit tests pass. mypy strict + all pre-commit hooks pass.

## Root cause

`discovery.py:255` only checks `raw.get("handler_routing")`. Nodes using `handler:` (the original contract schema) got `handler_routing=None` → `_wire_single_contract` returned SKIPPED with "No handler_routing declared in contract" → no Kafka subscription → consumer group never created.

## Nodes unblocked after redeploy

**Projection nodes** (critical path — delegation + session observability):
- `projection_delegation` — `onex.evt.omniclaude.task-delegated.v1`
- `projection_session_outcome`, `projection_savings`, `projection_baselines`, `projection_registration`, `projection_llm_cost`, `log_projection`

**Orchestration nodes**: `close_out`, `build_loop`, `merge_sweep`, `overnight`, `nightly_loop_controller`, `session_bootstrap`, `platform_diagnostics`

**Effect/compute nodes**: `pr_polish`, `pr_review_bot`, `ci_watch`, `aislop_sweep`, `baseline_capture/compare`, `coderabbit_triage`, `compliance_sweep`, `contract_sweep`, `coverage_sweep`, `create_ticket`, `dashboard_sweep`, `data_flow_sweep`, `data_verification`, `database_sweep`, `doc_freshness_sweep`, `dod_verify`, `duplication_sweep`, `emit_daemon`, `environment_health_scanner`, `golden_chain_sweep`, `hostile_reviewer`, `linear_triage`, `local_review`, `onboarding`, `overseer_verifier`, `plan_to_tickets`, `platform_readiness`, `pr_health_monitor`, `pr_lifecycle_fix_effect`, `pr_lifecycle_merge_effect`, `pr_snapshot_effect`, `process_watchdog`, `redeploy`, `release`, `retention_cleanup`, `runtime_sweep`, `session_post_mortem`, `ticket_pipeline`, `ticket_work`, `verify_effect`, `design_to_plan`

Existing `handler_routing:` nodes are unaffected (pr_lifecycle_orchestrator and all node_pr_lifecycle_* nodes continue to work).

Parent: OMN-8512

## Test plan
- [ ] 109 auto-wiring unit tests pass (`tests/unit/runtime/auto_wiring/`)
- [ ] mypy strict passes on `discovery.py`
- [ ] Pre-commit hooks all pass
- [ ] Post-redeploy: `rpk group list | grep omnimarket` shows consumer groups for projection_delegation and other legacy-format nodes