### PR TITLE
fix(runtime): include omnimarket in TopicProvisioner approved packages (OMN-8536)

### DIFF
--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -42,6 +42,7 @@ _APPROVED_PACKAGES: tuple[str, ...] = (
     "omniintelligence",
     "omnimemory",
     "omniclaude",
+    "omnimarket",
 )
 
 _VALID_KINDS: frozenset[str] = frozenset({"evt", "cmd", "intent"})

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -687,3 +687,39 @@ def test_extract_from_real_nodes_directory() -> None:
         assert entry.topic.startswith("onex.")
         assert len(entry.source_contracts) >= 1
         assert entry.version.startswith("v")
+
+
+@pytest.mark.unit
+def test_approved_packages_includes_omnimarket() -> None:
+    """omnimarket must be in _APPROVED_PACKAGES so its topics are provisioned on boot.
+
+    Without omnimarket in the approved list, ContractTopicExtractor skips all
+    omnimarket contracts even when include_installed_packages=True, leaving 41+
+    nodes with unprovisioned topics and InfraTimeoutError on every boot cycle.
+    """
+    from omnibase_infra.tools.contract_topic_extractor import _APPROVED_PACKAGES
+
+    assert "omnimarket" in _APPROVED_PACKAGES, (
+        "omnimarket must be in _APPROVED_PACKAGES — omitting it causes 41+ nodes "
+        "to fail with InfraTimeoutError on every boot cycle"
+    )
+
+
+@pytest.mark.unit
+def test_extract_from_installed_packages_discovers_omnimarket_topics() -> None:
+    """ContractTopicExtractor discovers omnimarket topics when omnimarket is installed."""
+    import importlib.util
+
+    if importlib.util.find_spec("omnimarket") is None:
+        pytest.skip(
+            "omnimarket not installed — skipping installed-packages discovery test"
+        )
+
+    extractor = ContractTopicExtractor(include_installed_packages=True)
+    entries = extractor.extract_from_installed_packages()
+
+    omnimarket_topics = [e.topic for e in entries if "omnimarket" in e.topic]
+    assert len(omnimarket_topics) > 0, (
+        "Expected at least one omnimarket topic from installed package scan; "
+        "got none — check that omnimarket is installed and in _APPROVED_PACKAGES"
+    )

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -718,8 +718,10 @@ def test_extract_from_installed_packages_discovers_omnimarket_topics() -> None:
     extractor = ContractTopicExtractor(include_installed_packages=True)
     entries = extractor.extract_from_installed_packages()
 
-    omnimarket_topics = [e.topic for e in entries if "omnimarket" in e.topic]
-    assert len(omnimarket_topics) > 0, (
-        "Expected at least one omnimarket topic from installed package scan; "
+    omnimarket_entries = [
+        e for e in entries if any("omnimarket" in str(p) for p in e.source_contracts)
+    ]
+    assert len(omnimarket_entries) > 0, (
+        "Expected at least one topic sourced from omnimarket contracts; "
         "got none — check that omnimarket is installed and in _APPROVED_PACKAGES"
     )


### PR DESCRIPTION
## Summary

- `omnimarket` was absent from `_APPROVED_PACKAGES` in `ContractTopicExtractor`
- `TopicProvisioner._build_topic_specs` already calls `ContractTopicExtractor(include_installed_packages=True)` but the list gating which packages are scanned excluded omnimarket
- All 41 omnimarket node topics were never provisioned in Redpanda on boot, causing each node to hit a 30s `InfraTimeoutError` on `aiokafka.subscribe()`
- The wiring loop burned 20+ min per boot cycle processing 41 sequential timeouts
- 25/72 nodes that worked only did so because their topics existed from prior boot cycles

## Change

Single-line addition: `"omnimarket"` added to `_APPROVED_PACKAGES` tuple in `contract_topic_extractor.py`.

## Tests

Two new `@pytest.mark.unit` tests added to `test_contract_topic_extractor.py`:
- `test_approved_packages_includes_omnimarket` — guards against regression
- `test_extract_from_installed_packages_discovers_omnimarket_topics` — verifies runtime discovery works end-to-end

## Investigation

Full root cause analysis: `omni_home/docs/briefs/orchestrator-wiring-investigation-2026-04-12.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contract extraction now includes the omnimarket package as an installed-package source.

* **Tests**
  * Added unit tests to verify omnimarket is recognized and that installed-package extraction returns omnimarket-related contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->