### PR TITLE
fix(docker): add onex-change-control to Dockerfile.runtime before omnimarket install (OMN-8539)

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -195,6 +195,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "git+https://github.com/OmniNode-ai/omnibase_compat.git@main#egg=omnibase-compat"
 
+# Install onex_change_control before omnimarket — omnimarket's node_overseer_verifier
+# imports it at module level but omnimarket is installed --no-deps, so it must
+# be present first. Pinned to git main until PyPI publishing is automated.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --no-deps \
+    "git+https://github.com/OmniNode-ai/onex_change_control.git@main#egg=onex-change-control"
+
 # Install omnimarket from git main until PyPI releases are automated (OMN-7980).
 # Pinned to main so every image rebuild picks up the latest merged nodes.
 # Switch back to PyPI range pin once the auto-tag-on-merge release pipeline


### PR DESCRIPTION
## Summary

- `omnimarket`'s `node_overseer_verifier` handler imports `onex_change_control` at module level
- `omnimarket` is installed with `--no-deps` in the Dockerfile, so its declared dependency `onex-change-control>=0.5.0` was never installed
- Runtime startup failed with `ModuleNotFoundError: No module named 'onex_change_control'` on every boot
- Fix follows the existing `omnibase_compat` pattern: explicit `--no-deps` git install before the omnimarket install step

## Test plan

- [ ] Docker build completes without error
- [ ] `docker exec omninode-runtime python -c "import onex_change_control; print('OK')"` returns OK
- [ ] `overseer_verifier` contract wires successfully in runtime logs (no ModuleNotFoundError)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker runtime configuration for improved package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->