### PR TITLE
feat: add entry-point generation and drift-validation script (OMN-8546)

### DIFF
--- a/scripts/generate_entry_points.py
+++ b/scripts/generate_entry_points.py
@@ -87,8 +87,6 @@ def _replace_entry_point_section(current: str, new_section: str) -> str:
     Replaces the entire [project.entry-points."onex.nodes"] block if it exists,
     otherwise appends it before the next [section] or at end of file.
     """
-    section_header = '[project.entry-points."onex.nodes"]'
-
     # Pattern: match the header line through the next blank line followed by [
     # or end of file. We use a non-greedy match per line.
     pattern = re.compile(

--- a/scripts/generate_entry_points.py
+++ b/scripts/generate_entry_points.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Entry-point generation and drift-validation script.
+
+Usage:
+    # Generate mode (default) — scan node dirs, write to pyproject.toml
+    uv run python scripts/generate_entry_points.py omnimarket
+
+    # Check mode — exit 0 if clean, exit 1 with diff if drifted
+    uv run python scripts/generate_entry_points.py omnimarket --check
+
+    # Exclude nodes already migrated to another repo (e.g. omnimemory → omnimarket)
+    uv run python scripts/generate_entry_points.py omnimemory --exclude-migrated omnimarket
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Core helpers (imported by tests)
+# ---------------------------------------------------------------------------
+
+
+def collect_node_dirs(
+    repo_root: Path,
+    package_name: str,
+    exclude: set[str] | None = None,
+) -> list[Path]:
+    """Return sorted list of node_* directories under <repo_root>/src/<package>/nodes/.
+
+    Args:
+        repo_root: Root directory of the repository.
+        package_name: Python package name (e.g. "omnimarket").
+        exclude: Optional set of node directory names to skip.
+
+    Returns:
+        Sorted list of Path objects for each node_* directory.
+    """
+    nodes_dir = repo_root / "src" / package_name / "nodes"
+    if not nodes_dir.is_dir():
+        return []
+
+    exclude_set = exclude or set()
+    result = [
+        p
+        for p in nodes_dir.iterdir()
+        if p.is_dir() and p.name.startswith("node_") and p.name not in exclude_set
+    ]
+    return sorted(result, key=lambda p: p.name)
+
+
+def build_entry_point_section(node_dirs: list[Path], package_name: str) -> str:
+    """Build the [project.entry-points."onex.nodes"] TOML section string.
+
+    Args:
+        node_dirs: List of node directory Paths (as returned by collect_node_dirs).
+        package_name: Python package name (e.g. "omnimarket").
+
+    Returns:
+        TOML string for the entry-points section, ready to splice into pyproject.toml.
+    """
+    lines = ['[project.entry-points."onex.nodes"]']
+    for node_dir in node_dirs:
+        name = node_dir.name
+        lines.append(f'{name} = "{package_name}.nodes.{name}"')
+    return "\n".join(lines) + "\n"
+
+
+def _read_pyproject(repo_root: Path) -> str:
+    """Read pyproject.toml content."""
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject}")
+    return pyproject.read_text(encoding="utf-8")
+
+
+def _replace_entry_point_section(current: str, new_section: str) -> str:
+    """Replace or append the onex.nodes entry-points section in pyproject.toml content.
+
+    Replaces the entire [project.entry-points."onex.nodes"] block if it exists,
+    otherwise appends it before the next [section] or at end of file.
+    """
+    section_header = '[project.entry-points."onex.nodes"]'
+
+    # Pattern: match the header line through the next blank line followed by [
+    # or end of file. We use a non-greedy match per line.
+    pattern = re.compile(
+        r'(\[project\.entry-points\."onex\.nodes"\]\n(?:[^\[]*\n)*)',
+        re.MULTILINE,
+    )
+    if pattern.search(current):
+        return pattern.sub(new_section + "\n", current)
+
+    # Section not present — append before next top-level section after [project]
+    # or at the end.
+    return current.rstrip() + "\n\n" + new_section + "\n"
+
+
+def check_mode(repo_root: Path, package_name: str, node_dirs: list[Path]) -> int:
+    """Compare generated entry-point section against current pyproject.toml.
+
+    Returns:
+        0 if the pyproject.toml is in sync with the filesystem.
+        1 if it has drifted, printing a diff to stdout.
+    """
+    generated = build_entry_point_section(node_dirs, package_name)
+
+    try:
+        current = _read_pyproject(repo_root)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    # Extract the existing entry-points section from pyproject.toml for comparison.
+    pattern = re.compile(
+        r'(\[project\.entry-points\."onex\.nodes"\]\n(?:[^\[]*\n)*)',
+        re.MULTILINE,
+    )
+    match = pattern.search(current)
+    existing_section = match.group(1) if match else ""
+
+    if existing_section.rstrip("\n") == generated.rstrip("\n"):
+        return 0
+
+    diff = list(
+        difflib.unified_diff(
+            existing_section.splitlines(keepends=True),
+            generated.splitlines(keepends=True),
+            fromfile="pyproject.toml (current)",
+            tofile="pyproject.toml (generated)",
+        )
+    )
+    print("".join(diff))
+    return 1
+
+
+def generate_mode(repo_root: Path, package_name: str, node_dirs: list[Path]) -> None:
+    """Write the generated entry-point section into pyproject.toml (idempotent)."""
+    new_section = build_entry_point_section(node_dirs, package_name)
+    current = _read_pyproject(repo_root)
+    updated = _replace_entry_point_section(current, new_section)
+
+    pyproject = repo_root / "pyproject.toml"
+    pyproject.write_text(updated, encoding="utf-8")
+    print(f"Written {len(node_dirs)} entry points to {pyproject}")
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _resolve_repo(repo_arg: str) -> tuple[Path, str]:
+    """Resolve repo name/path to (repo_root, package_name).
+
+    Accepts either:
+    - A bare repo name like "omnimarket" (resolved relative to OMNI_HOME or cwd parent)
+    - An absolute path
+    """
+    p = Path(repo_arg)
+    if p.is_absolute() and p.is_dir():
+        return p, p.name
+
+    # Try OMNI_HOME env var first, then cwd's parent (typical omni_home layout)
+    omni_home_candidates = []
+    omni_home_env = os.environ.get("OMNI_HOME")
+    if omni_home_env:
+        omni_home_candidates.append(Path(omni_home_env))
+
+    # The script lives in omnibase_infra/scripts/; omni_home is two levels up
+    script_dir = Path(__file__).parent
+    omni_home_candidates.append(script_dir.parent.parent)
+
+    for omni_home in omni_home_candidates:
+        candidate = omni_home / repo_arg
+        if candidate.is_dir():
+            # Package name is the top-level dir under src/
+            src = candidate / "src"
+            if src.is_dir():
+                subdirs = [
+                    d
+                    for d in src.iterdir()
+                    if d.is_dir() and not d.name.startswith("_")
+                ]
+                if subdirs:
+                    return candidate, subdirs[0].name
+            return candidate, repo_arg.replace("-", "_")
+
+    raise ValueError(
+        f"Cannot resolve repo '{repo_arg}'. Set OMNI_HOME or pass an absolute path."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate or validate onex.nodes entry points in pyproject.toml"
+    )
+    parser.add_argument("repo", help="Repo name (e.g. omnimarket) or absolute path")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validation mode: exit 0 if clean, exit 1 with diff if drifted",
+    )
+    parser.add_argument(
+        "--exclude-migrated",
+        metavar="OTHER_REPO",
+        help="Skip nodes already registered in another repo (e.g. for omnimemory migration)",
+    )
+    args = parser.parse_args()
+
+    repo_root, package_name = _resolve_repo(args.repo)
+
+    exclude: set[str] | None = None
+    if args.exclude_migrated:
+        other_root, other_pkg = _resolve_repo(args.exclude_migrated)
+        other_dirs = collect_node_dirs(other_root, other_pkg)
+        exclude = {d.name for d in other_dirs}
+        print(f"Excluding {len(exclude)} nodes already in {args.exclude_migrated}")
+
+    node_dirs = collect_node_dirs(repo_root, package_name, exclude=exclude)
+    print(
+        f"Found {len(node_dirs)} node directories in {repo_root / 'src' / package_name / 'nodes'}"
+    )
+
+    if args.check:
+        return check_mode(repo_root, package_name, node_dirs)
+
+    generate_mode(repo_root, package_name, node_dirs)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_entry_points.py
+++ b/scripts/generate_entry_points.py
@@ -164,7 +164,15 @@ def _resolve_repo(repo_arg: str) -> tuple[Path, str]:
     """
     p = Path(repo_arg)
     if p.is_absolute() and p.is_dir():
-        return p, p.name
+        src = p / "src"
+        if src.is_dir():
+            subdirs = [d for d in src.iterdir() if d.is_dir() and not d.name.startswith("_")]
+            if subdirs:
+                return p, subdirs[0].name
+        raise ValueError(
+            f"Cannot determine package name for absolute path '{p}': "
+            f"no src/ subdirectory with a package found."
+        )
 
     # Try OMNI_HOME env var first, then cwd's parent (typical omni_home layout)
     omni_home_candidates = []

--- a/tests/scripts/test_generate_entry_points.py
+++ b/tests/scripts/test_generate_entry_points.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the generate_entry_points.py script."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — import the functions under test from the script
+# ---------------------------------------------------------------------------
+
+
+def _import_script() -> object:
+    """Import generate_entry_points as a module (scripts/ is not a package)."""
+    import importlib.util
+    import sys
+
+    scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+    script_path = scripts_dir / "generate_entry_points.py"
+    spec = importlib.util.spec_from_file_location("generate_entry_points", script_path)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_entry_points"] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def script():  # type: ignore[return]
+    return _import_script()
+
+
+# ---------------------------------------------------------------------------
+# collect_node_dirs()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_collect_node_dirs_returns_node_dirs(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """collect_node_dirs() should return directories matching node_* pattern."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_alpha").mkdir()
+    (nodes_dir / "node_beta").mkdir()
+    (nodes_dir / "__pycache__").mkdir()
+    (nodes_dir / "helpers").mkdir()
+
+    result = script.collect_node_dirs(tmp_path, "mypkg")
+    names = [p.name for p in result]
+
+    assert "node_alpha" in names
+    assert "node_beta" in names
+    assert "__pycache__" not in names
+    assert "helpers" not in names
+
+
+@pytest.mark.unit
+def test_collect_node_dirs_empty_when_no_nodes(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """collect_node_dirs() returns empty list when nodes/ dir has no node_ dirs."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "helpers").mkdir()
+
+    result = script.collect_node_dirs(tmp_path, "mypkg")
+    assert result == []
+
+
+@pytest.mark.unit
+def test_collect_node_dirs_sorted(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """collect_node_dirs() should return directories in sorted order."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_z").mkdir()
+    (nodes_dir / "node_a").mkdir()
+    (nodes_dir / "node_m").mkdir()
+
+    result = script.collect_node_dirs(tmp_path, "mypkg")
+    names = [p.name for p in result]
+    assert names == sorted(names)
+
+
+@pytest.mark.unit
+def test_collect_node_dirs_exclude_migrated(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """collect_node_dirs() with exclude set should omit those node names."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_alpha").mkdir()
+    (nodes_dir / "node_beta").mkdir()
+    (nodes_dir / "node_gamma").mkdir()
+
+    result = script.collect_node_dirs(
+        tmp_path, "mypkg", exclude={"node_beta", "node_gamma"}
+    )
+    names = [p.name for p in result]
+
+    assert names == ["node_alpha"]
+
+
+# ---------------------------------------------------------------------------
+# build_entry_point_section()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_entry_point_section_format(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """build_entry_point_section() should produce correct TOML entry-points block."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_alpha").mkdir()
+    (nodes_dir / "node_beta").mkdir()
+
+    node_dirs = script.collect_node_dirs(tmp_path, "mypkg")
+    section = script.build_entry_point_section(node_dirs, "mypkg")
+
+    assert '[project.entry-points."onex.nodes"]' in section
+    assert 'node_alpha = "mypkg.nodes.node_alpha"' in section
+    assert 'node_beta = "mypkg.nodes.node_beta"' in section
+
+
+@pytest.mark.unit
+def test_build_entry_point_section_empty(script) -> None:  # type: ignore[no-untyped-def]
+    """build_entry_point_section() with empty dirs list produces header-only section."""
+    section = script.build_entry_point_section([], "mypkg")
+    assert '[project.entry-points."onex.nodes"]' in section
+    # No entries after the header
+    lines = [line.strip() for line in section.splitlines() if line.strip()]
+    assert len(lines) == 1
+
+
+@pytest.mark.unit
+def test_build_entry_point_section_matches_omnimarket_format(
+    script, tmp_path: Path
+) -> None:  # type: ignore[no-untyped-def]
+    """Entry lines must follow the exact omnimarket format: name = "pkg.nodes.name"."""
+    nodes_dir = tmp_path / "src" / "omnimarket" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_merge_sweep").mkdir()
+
+    node_dirs = script.collect_node_dirs(tmp_path, "omnimarket")
+    section = script.build_entry_point_section(node_dirs, "omnimarket")
+
+    assert 'node_merge_sweep = "omnimarket.nodes.node_merge_sweep"' in section
+
+
+# ---------------------------------------------------------------------------
+# check mode (integration-ish, but uses only tmp dirs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_check_mode_exits_0_when_clean(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """check_mode() should return 0 when pyproject.toml entry points are up to date."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_alpha").mkdir()
+
+    node_dirs = script.collect_node_dirs(tmp_path, "mypkg")
+    section = script.build_entry_point_section(node_dirs, "mypkg")
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f'[project]\nname = "mypkg"\n\n{section}\n')
+
+    result = script.check_mode(tmp_path, "mypkg", node_dirs)
+    assert result == 0
+
+
+@pytest.mark.unit
+def test_check_mode_exits_1_when_drifted(script, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """check_mode() should return 1 when pyproject.toml is missing an entry."""
+    nodes_dir = tmp_path / "src" / "mypkg" / "nodes"
+    nodes_dir.mkdir(parents=True)
+    (nodes_dir / "node_alpha").mkdir()
+    (nodes_dir / "node_beta").mkdir()
+
+    # pyproject only has node_alpha, missing node_beta
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mypkg"\n\n'
+        '[project.entry-points."onex.nodes"]\n'
+        'node_alpha = "mypkg.nodes.node_alpha"\n'
+    )
+
+    node_dirs = script.collect_node_dirs(tmp_path, "mypkg")
+    result = script.check_mode(tmp_path, "mypkg", node_dirs)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# omnimarket smoke-test (real repo)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_omnimarket_collect_and_build_smoke(script) -> None:  # type: ignore[no-untyped-def]
+    """collect_node_dirs + build_entry_point_section work against the real omnimarket repo."""
+    try:
+        omnimarket_root, pkg = script._resolve_repo("omnimarket")
+    except ValueError:
+        pytest.skip("omnimarket not resolvable from this environment")
+
+    if not omnimarket_root.exists():
+        pytest.skip("omnimarket not found")
+
+    node_dirs = script.collect_node_dirs(omnimarket_root, pkg)
+    # omnimarket has many nodes — ensure we found a reasonable number
+    assert len(node_dirs) > 50, f"Expected >50 nodes, found {len(node_dirs)}"
+
+    section = script.build_entry_point_section(node_dirs, pkg)
+    assert '[project.entry-points."onex.nodes"]' in section
+    # Every found dir must have a corresponding entry line
+    for nd in node_dirs:
+        assert f'{nd.name} = "{pkg}.nodes.{nd.name}"' in section

--- a/tests/scripts/test_generate_entry_points.py
+++ b/tests/scripts/test_generate_entry_points.py
@@ -196,15 +196,15 @@ def test_check_mode_exits_1_when_drifted(script, tmp_path: Path) -> None:  # typ
 @pytest.mark.unit
 def test_omnimarket_collect_and_build_smoke(script) -> None:  # type: ignore[no-untyped-def]
     """collect_node_dirs + build_entry_point_section work against the real omnimarket repo."""
-    omnimarket_root: Path
-    pkg: str
     try:
         omnimarket_root, pkg = script._resolve_repo("omnimarket")
     except ValueError:
         pytest.skip("omnimarket not resolvable from this environment")
+        return  # unreachable; satisfies static analysis
 
     if not omnimarket_root.exists():
         pytest.skip("omnimarket not found")
+        return  # unreachable; satisfies static analysis
 
     node_dirs = script.collect_node_dirs(omnimarket_root, pkg)
     # omnimarket has many nodes — ensure we found a reasonable number

--- a/tests/scripts/test_generate_entry_points.py
+++ b/tests/scripts/test_generate_entry_points.py
@@ -194,9 +194,7 @@ def test_check_mode_exits_1_when_drifted(script, tmp_path: Path) -> None:  # typ
 
 
 @pytest.mark.unit
-def test_resolve_repo_absolute_path_uses_src_subdir(
-    script, tmp_path: Path
-) -> None:
+def test_resolve_repo_absolute_path_uses_src_subdir(script, tmp_path: Path) -> None:
     """_resolve_repo with an absolute path derives package name from src/, not dir name."""
     repo_root = tmp_path / "my-repo-with-hyphens"
     src = repo_root / "src" / "my_package"
@@ -208,9 +206,7 @@ def test_resolve_repo_absolute_path_uses_src_subdir(
 
 
 @pytest.mark.unit
-def test_resolve_repo_absolute_path_no_src_raises(
-    script, tmp_path: Path
-) -> None:
+def test_resolve_repo_absolute_path_no_src_raises(script, tmp_path: Path) -> None:
     """_resolve_repo raises ValueError for absolute path with no src/ package."""
     repo_root = tmp_path / "empty-repo"
     repo_root.mkdir()

--- a/tests/scripts/test_generate_entry_points.py
+++ b/tests/scripts/test_generate_entry_points.py
@@ -3,7 +3,6 @@
 
 """Tests for the generate_entry_points.py script."""
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -197,6 +196,8 @@ def test_check_mode_exits_1_when_drifted(script, tmp_path: Path) -> None:  # typ
 @pytest.mark.unit
 def test_omnimarket_collect_and_build_smoke(script) -> None:  # type: ignore[no-untyped-def]
     """collect_node_dirs + build_entry_point_section work against the real omnimarket repo."""
+    omnimarket_root: Path
+    pkg: str
     try:
         omnimarket_root, pkg = script._resolve_repo("omnimarket")
     except ValueError:

--- a/tests/scripts/test_generate_entry_points.py
+++ b/tests/scripts/test_generate_entry_points.py
@@ -189,6 +189,37 @@ def test_check_mode_exits_1_when_drifted(script, tmp_path: Path) -> None:  # typ
 
 
 # ---------------------------------------------------------------------------
+# _resolve_repo() — absolute path mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_repo_absolute_path_uses_src_subdir(
+    script, tmp_path: Path
+) -> None:
+    """_resolve_repo with an absolute path derives package name from src/, not dir name."""
+    repo_root = tmp_path / "my-repo-with-hyphens"
+    src = repo_root / "src" / "my_package"
+    src.mkdir(parents=True)
+
+    resolved_root, pkg = script._resolve_repo(str(repo_root))
+    assert resolved_root == repo_root
+    assert pkg == "my_package"
+
+
+@pytest.mark.unit
+def test_resolve_repo_absolute_path_no_src_raises(
+    script, tmp_path: Path
+) -> None:
+    """_resolve_repo raises ValueError for absolute path with no src/ package."""
+    repo_root = tmp_path / "empty-repo"
+    repo_root.mkdir()
+
+    with pytest.raises(ValueError, match="Cannot determine package name"):
+        script._resolve_repo(str(repo_root))
+
+
+# ---------------------------------------------------------------------------
 # omnimarket smoke-test (real repo)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `scripts/generate_entry_points.py` — scans `<repo>/src/<pkg>/nodes/node_*/` directories and generates the `[project.entry-points."onex.nodes"]` section in `pyproject.toml`
- Generate mode (default): writes entry points idempotently into pyproject.toml
- Check mode (`--check`): exits 0 if in sync, exits 1 with a unified diff if drifted
- `--exclude-migrated <other_repo>`: skips nodes already registered in another repo (supports the omnimemory → omnimarket migration)
- Adds 10 unit tests covering `collect_node_dirs()`, `build_entry_point_section()`, `check_mode()`, and a real-repo smoke test against omnimarket

## Test plan

- [ ] `uv run pytest tests/scripts/test_generate_entry_points.py -v -m unit` — all 10 pass
- [ ] `uv run python scripts/generate_entry_points.py omnimarket --check` — exits 1 (expected: omnimarket pyproject needs regeneration)
- [ ] `uv run python scripts/generate_entry_points.py omnimarket` then `--check` — exits 0

Prereq for Tasks 1–4 (omniintelligence, omnibase_infra, omnimemory, omniclaude entry-point wiring).

Closes OMN-8546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated entry-point generator that discovers package node directories, updates or appends the project's onex.nodes entry-point block in pyproject.toml, supports a dry-run/check mode that validates configuration, and can exclude nodes migrated from another repository (with repository resolution).
* **Tests**
  * Added tests for node discovery, entry-point block generation, check vs generate behavior, exclusion handling, and an optional integration smoke test against a real repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->