### PR TITLE
fix(deps): break circular dependency infra ↔ omnimarket [OMN-8551]

### DIFF
--- a/src/omnibase_infra/plugins/plugin_emit_daemon.py
+++ b/src/omnibase_infra/plugins/plugin_emit_daemon.py
@@ -89,7 +89,9 @@ class PluginEmitDaemon:
             eps = entry_points(group="onex.nodes")
             emit_daemon_eps = [e for e in eps if e.name == "node_emit_daemon"]
             if not emit_daemon_eps:
-                raise ImportError("node_emit_daemon not found in onex.nodes entry points")
+                raise ImportError(
+                    "node_emit_daemon not found in onex.nodes entry points"
+                )
             node_entry = emit_daemon_eps[0].load()
             # Entry points load as classes, not modules. Resolve the defining module.
             node_module = (

--- a/src/omnibase_infra/plugins/plugin_emit_daemon.py
+++ b/src/omnibase_infra/plugins/plugin_emit_daemon.py
@@ -81,30 +81,40 @@ class PluginEmitDaemon:
         start_time = time.time()
 
         try:
-            from omnimarket.nodes.node_emit_daemon.event_queue import (
-                BoundedEventQueue,
-            )
-            from omnimarket.nodes.node_emit_daemon.event_registry import (
-                EventRegistry,
-            )
-            from omnimarket.nodes.node_emit_daemon.handlers.handler_emit_daemon import (
-                HandlerEmitDaemon,
-            )
-            from omnimarket.nodes.node_emit_daemon.publisher_loop import (
-                KafkaPublisherLoop,
-            )
-            from omnimarket.nodes.node_emit_daemon.socket_server import (
-                EmitSocketServer,
-            )
+            from importlib.metadata import entry_points
+
+            eps = entry_points(group="onex.nodes")
+            emit_daemon_eps = [e for e in eps if e.name == "node_emit_daemon"]
+            if not emit_daemon_eps:
+                raise ImportError("node_emit_daemon not found in onex.nodes entry points")
+            node_pkg = emit_daemon_eps[0].load()
+
+            import importlib
+
+            BoundedEventQueue = importlib.import_module(
+                f"{node_pkg.__name__}.event_queue"
+            ).BoundedEventQueue
+            EventRegistry = importlib.import_module(
+                f"{node_pkg.__name__}.event_registry"
+            ).EventRegistry
+            HandlerEmitDaemon = importlib.import_module(
+                f"{node_pkg.__name__}.handlers.handler_emit_daemon"
+            ).HandlerEmitDaemon
+            KafkaPublisherLoop = importlib.import_module(
+                f"{node_pkg.__name__}.publisher_loop"
+            ).KafkaPublisherLoop
+            EmitSocketServer = importlib.import_module(
+                f"{node_pkg.__name__}.socket_server"
+            ).EmitSocketServer
         except ImportError as e:
             duration = time.time() - start_time
             logger.warning(
-                "[EMIT-DAEMON] omnimarket not installed, cannot start emit daemon: %s",
+                "[EMIT-DAEMON] node_emit_daemon not available, cannot start emit daemon: %s",
                 e,
             )
             return ModelDomainPluginResult.failed(
                 plugin_id=self.plugin_id,
-                error_message=f"omnimarket not installed: {e}",
+                error_message=f"node_emit_daemon not available: {e}",
                 duration_seconds=duration,
             )
 
@@ -135,12 +145,10 @@ class PluginEmitDaemon:
         if registry_path_str:
             registry = EventRegistry.from_yaml(Path(registry_path_str))
         else:
-            # Try default claude_code registry from omnimarket
+            # Try default claude_code registry from the already-loaded node package
             try:
-                import omnimarket.nodes.node_emit_daemon as _pkg
-
                 default_registry = (
-                    Path(_pkg.__file__).parent / "registries" / "claude_code.yaml"
+                    Path(node_pkg.__file__).parent / "registries" / "claude_code.yaml"
                 )
                 if default_registry.exists():
                     registry = EventRegistry.from_yaml(default_registry)

--- a/src/omnibase_infra/plugins/plugin_emit_daemon.py
+++ b/src/omnibase_infra/plugins/plugin_emit_daemon.py
@@ -81,30 +81,42 @@ class PluginEmitDaemon:
         start_time = time.time()
 
         try:
+            import importlib
+            import inspect
+            import types
             from importlib.metadata import entry_points
 
             eps = entry_points(group="onex.nodes")
             emit_daemon_eps = [e for e in eps if e.name == "node_emit_daemon"]
             if not emit_daemon_eps:
                 raise ImportError("node_emit_daemon not found in onex.nodes entry points")
-            node_pkg = emit_daemon_eps[0].load()
-
-            import importlib
+            node_entry = emit_daemon_eps[0].load()
+            # Entry points load as classes, not modules. Resolve the defining module.
+            node_module = (
+                node_entry
+                if isinstance(node_entry, types.ModuleType)
+                else inspect.getmodule(node_entry)
+            )
+            if node_module is None or node_module.__file__ is None:
+                raise ImportError(
+                    "node_emit_daemon entry point did not resolve to an importable module"
+                )
+            node_package = node_module.__package__ or node_module.__name__
 
             BoundedEventQueue = importlib.import_module(
-                f"{node_pkg.__name__}.event_queue"
+                f"{node_package}.event_queue"
             ).BoundedEventQueue
             EventRegistry = importlib.import_module(
-                f"{node_pkg.__name__}.event_registry"
+                f"{node_package}.event_registry"
             ).EventRegistry
             HandlerEmitDaemon = importlib.import_module(
-                f"{node_pkg.__name__}.handlers.handler_emit_daemon"
+                f"{node_package}.handlers.handler_emit_daemon"
             ).HandlerEmitDaemon
             KafkaPublisherLoop = importlib.import_module(
-                f"{node_pkg.__name__}.publisher_loop"
+                f"{node_package}.publisher_loop"
             ).KafkaPublisherLoop
             EmitSocketServer = importlib.import_module(
-                f"{node_pkg.__name__}.socket_server"
+                f"{node_package}.socket_server"
             ).EmitSocketServer
         except ImportError as e:
             duration = time.time() - start_time
@@ -148,7 +160,9 @@ class PluginEmitDaemon:
             # Try default claude_code registry from the already-loaded node package
             try:
                 default_registry = (
-                    Path(node_pkg.__file__).parent / "registries" / "claude_code.yaml"
+                    Path(node_module.__file__).resolve().parent
+                    / "registries"
+                    / "claude_code.yaml"
                 )
                 if default_registry.exists():
                     registry = EventRegistry.from_yaml(default_registry)


### PR DESCRIPTION
## Summary
- Replaces 5 direct `from omnimarket.nodes.node_emit_daemon.*` imports in `PluginEmitDaemon.initialize()` with entry-point discovery via `importlib.metadata`
- Replaces `import omnimarket.nodes.node_emit_daemon as _pkg` (registry path lookup) with reuse of the already-loaded `node_pkg` reference
- Zero `from omnimarket` / `import omnimarket` live imports remain in `omnibase_infra/src/`

## Verification
```
grep -rn "from omnimarket\|import omnimarket" src/ --include="*.py"
# Returns only a comment line — zero live imports
```

## Test plan
- [x] 88 plugin unit tests pass
- [x] 878 broader unit tests pass (1 pre-existing DNS failure in unrelated CLI test)
- [x] `python -c "import omnibase_infra"` succeeds without omnimarket installed

Closes OMN-8551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin architecture for better modularity and flexibility in component discovery and loading mechanisms.
  * Enhanced fallback mechanisms for resource location to reduce direct dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->