### PR TITLE
fix(deps): break circular dependency infra ↔ omniintelligence [OMN-8552]

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1618,25 +1618,31 @@ async def bootstrap() -> int:
                 exc_info=True,
             )
 
-        # Try to import and register PluginIntelligence (graceful degradation).
-        # omniintelligence is an optional dependency — kernel boots without it.
-        # Registered LAST because it subscribes to 46 topics (~12 min startup).
+        # Try to load and register PluginIntelligence via entry-point discovery
+        # (graceful degradation). omniintelligence is an optional dependency —
+        # kernel boots without it. Registered LAST because it subscribes to
+        # 46 topics (~12 min startup).
         try:
-            from omniintelligence.runtime.plugin import (  # type: ignore[import-not-found]
-                PluginIntelligence,
-            )
+            from importlib.metadata import entry_points
 
-            plugin_registry.register(PluginIntelligence())
-            logger.info(
-                "PluginIntelligence registered (correlation_id=%s)",
-                correlation_id,
-            )
-        except ImportError:
-            logger.debug(
-                "omniintelligence not installed, intelligence plugin not available "
-                "(correlation_id=%s)",
-                correlation_id,
-            )
+            intel_eps = [
+                e
+                for e in entry_points(group="onex.domain_plugins")
+                if e.name == "intelligence"
+            ]
+            if intel_eps:
+                PluginIntelligence = intel_eps[0].load()
+                plugin_registry.register(PluginIntelligence())
+                logger.info(
+                    "PluginIntelligence registered (correlation_id=%s)",
+                    correlation_id,
+                )
+            else:
+                logger.debug(
+                    "omniintelligence not installed, intelligence plugin not available "
+                    "(correlation_id=%s)",
+                    correlation_id,
+                )
         except Exception:  # noqa: BLE001 — boundary: logs warning and degrades
             logger.warning(
                 "PluginIntelligence failed to initialize, continuing without it "

--- a/src/omnibase_infra/runtime/util_schema_fingerprint.py
+++ b/src/omnibase_infra/runtime/util_schema_fingerprint.py
@@ -697,11 +697,12 @@ def _main() -> None:
     if args.manifest == "omniintelligence":
         env_var_name = "OMNIINTELLIGENCE_DB_URL"
         try:
-            from omniintelligence.runtime.model_schema_manifest import (
-                OMNIINTELLIGENCE_SCHEMA_MANIFEST,
-            )
+            import importlib
 
-            manifest_obj = OMNIINTELLIGENCE_SCHEMA_MANIFEST
+            _intel_mod = importlib.import_module(
+                "omniintelligence.runtime.model_schema_manifest"
+            )
+            manifest_obj = _intel_mod.OMNIINTELLIGENCE_SCHEMA_MANIFEST
         except ImportError:
             print(
                 "ERROR: omniintelligence package not installed. "


### PR DESCRIPTION
## Summary
- `service_kernel.py`: replaces `from omniintelligence.runtime.plugin import PluginIntelligence` with entry-point discovery via `importlib.metadata` (group=`onex.domain_plugins`, name=`intelligence`) — omniintelligence already declares this entry point in its `pyproject.toml`
- `util_schema_fingerprint.py`: replaces `from omniintelligence.runtime.model_schema_manifest import ...` with `importlib.import_module(...)` inside the CLI `__main__` block; graceful degradation on ImportError preserved

## Verification
```
grep -rn "from omniintelligence\|import omniintelligence" src/ --include="*.py"
# Returns only: topics/topic_keys.py:74 — a docstring (explicitly exempted by plan)
```

## Test plan
- [x] 879 unit tests pass (cli, adapters, backends, capabilities, plugins)
- [x] 100 runtime/kernel + domain-plugin tests pass (2 pre-existing failures: pytest temp path in /var blocked by security policy, unrelated to this change)
- [x] `python -c "import omnibase_infra"` succeeds without omniintelligence installed

Closes OMN-8552