### PR TITLE
[OMN-8604] deploy-agent self-update to break chicken-and-egg on deploy-agent bugs

### DIFF
--- a/scripts/deploy-agent/deploy_agent/__main__.py
+++ b/scripts/deploy-agent/deploy_agent/__main__.py
@@ -2,13 +2,22 @@
 # SPDX-License-Identifier: MIT
 """Entry point for deploy agent."""
 
+import argparse
 import asyncio
 
 from deploy_agent.agent import DeployAgent
 
 
 def main() -> None:
-    agent = DeployAgent()
+    parser = argparse.ArgumentParser(description="OmniNode deploy agent")
+    parser.add_argument(
+        "--skip-self-update",
+        action="store_true",
+        default=False,
+        help="Bypass the self-update check on each deploy (emergency override)",
+    )
+    args = parser.parse_args()
+    agent = DeployAgent(skip_self_update=args.skip_self_update)
     asyncio.run(agent.run())
 
 

--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -34,12 +34,13 @@ PUBLISH_RETRY_INTERVAL = 30
 
 
 class DeployAgent:
-    def __init__(self):
+    def __init__(self, *, skip_self_update: bool = False):
         self.job_store = JobStore(state_dir=STATE_DIR)
         self.executor = DeployExecutor()
         self._state = "idle"
         self._shutdown = False
         self._current_git_sha = ""
+        self._skip_self_update = skip_self_update
 
     def _get_state(self) -> str:
         return self._state
@@ -143,6 +144,7 @@ class DeployAgent:
                 cmd.services,
                 on_phase_update=on_phase_update,
                 git_sha=self._current_git_sha,
+                skip_self_update=self._skip_self_update,
             )
 
             # Verify

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -21,6 +23,7 @@ from deploy_agent.events import (
 logger = logging.getLogger(__name__)
 
 REPO_DIR = "/data/omninode/omnibase_infra"
+DEPLOY_AGENT_DIR = "/data/omninode/deploy-agent"
 COMPOSE_FILE = f"{REPO_DIR}/docker/docker-compose.infra.yml"
 COMPOSE_PROJECT = "omnibase-infra"
 
@@ -47,6 +50,114 @@ def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
 
 
 class DeployExecutor:
+    def self_update(self, *, skip: bool = False) -> None:
+        """Pull and re-exec deploy-agent itself if behind origin/main.
+
+        Called as the first step of every rebuild_scope() invocation so that
+        a bug-fix merged to main is picked up before the next deploy runs.
+
+        Safety rails:
+        - Skipped entirely when DEPLOY_AGENT_NO_SELF_UPDATE=1 is set.
+        - Skipped when the working tree is dirty (would discard uncommitted work).
+        - skip=True (--skip-self-update CLI flag) bypasses the check.
+        - Container mode (DEPLOY_AGENT_MODE=container) exits with code 42
+          instead of os.execv so the supervisor can respawn from the new binary.
+        """
+        if skip or os.environ.get("DEPLOY_AGENT_NO_SELF_UPDATE") == "1":
+            logger.info("self_update: skipped (kill-switch active)")
+            return
+
+        agent_dir = os.environ.get("DEPLOY_AGENT_DIR", DEPLOY_AGENT_DIR)
+        timeout = 60
+
+        # Abort if working tree is dirty — never silently discard changes.
+        status_result = _run(
+            ["git", "-C", agent_dir, "status", "--porcelain"],
+            timeout=timeout,
+        )
+        if status_result.returncode != 0:
+            logger.warning(
+                "self_update: git status failed (exit=%d), skipping update",
+                status_result.returncode,
+            )
+            return
+        if status_result.stdout.strip():
+            logger.warning(
+                "self_update: working tree is dirty, skipping update to avoid data loss"
+            )
+            return
+
+        # Fetch latest origin/main.
+        fetch_result = _run(
+            ["git", "-C", agent_dir, "fetch", "origin", "main"],
+            timeout=timeout,
+        )
+        if fetch_result.returncode != 0:
+            logger.warning(
+                "self_update: git fetch failed (exit=%d), skipping update: %s",
+                fetch_result.returncode,
+                fetch_result.stderr[:200],
+            )
+            return
+
+        head_result = _run(
+            ["git", "-C", agent_dir, "rev-parse", "HEAD"],
+            timeout=timeout,
+        )
+        remote_result = _run(
+            ["git", "-C", agent_dir, "rev-parse", "origin/main"],
+            timeout=timeout,
+        )
+        if head_result.returncode != 0 or remote_result.returncode != 0:
+            logger.warning("self_update: rev-parse failed, skipping update")
+            return
+
+        local_sha = head_result.stdout.strip()
+        remote_sha = remote_result.stdout.strip()
+
+        if local_sha == remote_sha:
+            logger.info("self_update: already at origin/main (%s), nothing to do", local_sha[:12])
+            return
+
+        logger.info(
+            "self_update: behind origin/main (local=%s remote=%s), pulling and re-execing",
+            local_sha[:12],
+            remote_sha[:12],
+        )
+
+        pull_result = _run(
+            ["git", "-C", agent_dir, "pull", "--ff-only", "origin", "main"],
+            timeout=timeout,
+        )
+        if pull_result.returncode != 0:
+            logger.warning(
+                "self_update: git pull failed (exit=%d), skipping re-exec: %s",
+                pull_result.returncode,
+                pull_result.stderr[:200],
+            )
+            return
+
+        # Sync deps so new imports are available after re-exec.
+        uv_result = _run(
+            ["uv", "sync", "--project", agent_dir],
+            timeout=120,
+        )
+        if uv_result.returncode != 0:
+            logger.warning(
+                "self_update: uv sync failed (exit=%d), proceeding with re-exec anyway: %s",
+                uv_result.returncode,
+                uv_result.stderr[:200],
+            )
+
+        mode = os.environ.get("DEPLOY_AGENT_MODE", "host")
+        if mode == "container":
+            # Let systemd/compose restart us from the freshly-pulled source.
+            logger.info("self_update: container mode — exiting with code 42 for supervisor respawn")
+            sys.exit(42)
+        else:
+            logger.info("self_update: host mode — re-execing process image")
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+
     def preflight(self, on_phase_update: PhaseCallback) -> None:
         on_phase_update(Phase.PREFLIGHT, PhaseStatus.IN_PROGRESS)
         timeout = PHASE_TIMEOUTS[Phase.PREFLIGHT]
@@ -173,7 +284,9 @@ class DeployExecutor:
         on_phase_update: PhaseCallback,
         *,
         git_sha: str = "",
+        skip_self_update: bool = False,
     ) -> list[str]:
+        self.self_update(skip=skip_self_update)
         phase = Phase.CORE if scope == Scope.CORE else Phase.RUNTIME
         if scope == Scope.FULL:
             # Build images first (both scopes), then bring them up.

--- a/scripts/deploy-agent/tests/unit/test_executor_self_update.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_self_update.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for DeployExecutor.self_update().
+
+Verifies: behind/ahead/current detection, os.execv call when behind,
+--skip-self-update / kill-switch bypass, dirty-tree safety rail,
+and container-mode exit(42) behavior.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import call, patch
+
+import pytest
+
+from deploy_agent.executor import DeployExecutor
+
+SHA_LOCAL = "aaaaaaaabbbbbbbb"
+SHA_REMOTE = "ccccccccdddddddd"
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+def _make_git_responses(*, dirty: bool = False, local: str = SHA_LOCAL, remote: str = SHA_REMOTE):
+    """Return a side_effect list for _run: status, fetch, rev-parse HEAD, rev-parse origin/main."""
+
+    def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        if "status" in cmd and "--porcelain" in cmd:
+            return _ok("M somefile.py" if dirty else "")
+        if "fetch" in cmd:
+            return _ok()
+        if "rev-parse" in cmd:
+            if "origin/main" in cmd:
+                return _ok(remote)
+            return _ok(local)
+        if "pull" in cmd:
+            return _ok()
+        if cmd[0] == "uv":
+            return _ok()
+        return _ok()
+
+    return side_effect
+
+
+class TestSelfUpdateSkip:
+    def test_skip_flag_bypasses_all_git_calls(self) -> None:
+        executor = DeployExecutor()
+        with patch("deploy_agent.executor._run") as mock_run:
+            executor.self_update(skip=True)
+        mock_run.assert_not_called()
+
+    def test_env_kill_switch_bypasses_all_git_calls(self, monkeypatch) -> None:
+        monkeypatch.setenv("DEPLOY_AGENT_NO_SELF_UPDATE", "1")
+        executor = DeployExecutor()
+        with patch("deploy_agent.executor._run") as mock_run:
+            executor.self_update()
+        mock_run.assert_not_called()
+
+
+class TestSelfUpdateDirtyTree:
+    def test_dirty_tree_skips_update_without_execv(self) -> None:
+        executor = DeployExecutor()
+        with (
+            patch("deploy_agent.executor._run", side_effect=_make_git_responses(dirty=True)),
+            patch("os.execv") as mock_execv,
+        ):
+            executor.self_update()
+        mock_execv.assert_not_called()
+
+
+class TestSelfUpdateCurrent:
+    def test_already_current_does_not_execv(self) -> None:
+        executor = DeployExecutor()
+        with (
+            patch("deploy_agent.executor._run", side_effect=_make_git_responses(local=SHA_LOCAL, remote=SHA_LOCAL)),
+            patch("os.execv") as mock_execv,
+        ):
+            executor.self_update()
+        mock_execv.assert_not_called()
+
+
+class TestSelfUpdateBehind:
+    def test_behind_calls_execv(self) -> None:
+        executor = DeployExecutor()
+        with (
+            patch("deploy_agent.executor._run", side_effect=_make_git_responses()),
+            patch("os.execv") as mock_execv,
+        ):
+            executor.self_update()
+        mock_execv.assert_called_once_with(sys.executable, [sys.executable] + sys.argv)
+
+    def test_behind_container_mode_exits_42(self, monkeypatch) -> None:
+        monkeypatch.setenv("DEPLOY_AGENT_MODE", "container")
+        executor = DeployExecutor()
+        with (
+            patch("deploy_agent.executor._run", side_effect=_make_git_responses()),
+            patch("sys.exit") as mock_exit,
+        ):
+            executor.self_update()
+        mock_exit.assert_called_once_with(42)
+
+    def test_behind_fetch_failure_skips_execv(self) -> None:
+        executor = DeployExecutor()
+
+        def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+            if "status" in cmd and "--porcelain" in cmd:
+                return _ok()
+            if "fetch" in cmd:
+                return _fail("network error")
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=side_effect),
+            patch("os.execv") as mock_execv,
+        ):
+            executor.self_update()
+        mock_execv.assert_not_called()
+
+    def test_behind_pull_failure_skips_execv(self) -> None:
+        executor = DeployExecutor()
+
+        def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+            if "status" in cmd and "--porcelain" in cmd:
+                return _ok()
+            if "fetch" in cmd:
+                return _ok()
+            if "rev-parse" in cmd:
+                if "origin/main" in cmd:
+                    return _ok(SHA_REMOTE)
+                return _ok(SHA_LOCAL)
+            if "pull" in cmd:
+                return _fail("conflict")
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=side_effect),
+            patch("os.execv") as mock_execv,
+        ):
+            executor.self_update()
+        mock_execv.assert_not_called()
+
+
+class TestSelfUpdateWiredIntoRebuildScope:
+    def test_self_update_called_first_in_rebuild_scope(self) -> None:
+        """self_update must be invoked before _compose_build inside rebuild_scope."""
+        from deploy_agent.events import Phase, PhaseStatus, Scope
+
+        executor = DeployExecutor()
+        call_order: list[str] = []
+
+        def fake_self_update(*, skip: bool = False) -> None:
+            call_order.append("self_update")
+
+        def fake_build(scope: Scope, sha: str, cb) -> None:
+            call_order.append("build")
+
+        def fake_up(phase: Phase, scope: Scope, services: list[str], cb) -> None:
+            call_order.append("up")
+
+        executor.self_update = fake_self_update  # type: ignore[method-assign]
+        executor._compose_build = fake_build  # type: ignore[method-assign]
+        executor._compose_up = fake_up  # type: ignore[method-assign]
+
+        executor.rebuild_scope(Scope.RUNTIME, [], lambda p, s: None)
+
+        assert call_order[0] == "self_update", (
+            f"self_update must be first, got order: {call_order}"
+        )
+
+    def test_skip_self_update_flag_forwarded_from_rebuild_scope(self) -> None:
+        from deploy_agent.events import Scope
+
+        executor = DeployExecutor()
+        received_skip: list[bool] = []
+
+        def fake_self_update(*, skip: bool = False) -> None:
+            received_skip.append(skip)
+
+        def fake_build(scope, sha, cb) -> None:
+            pass
+
+        def fake_up(phase, scope, services, cb) -> None:
+            pass
+
+        executor.self_update = fake_self_update  # type: ignore[method-assign]
+        executor._compose_build = fake_build  # type: ignore[method-assign]
+        executor._compose_up = fake_up  # type: ignore[method-assign]
+
+        executor.rebuild_scope(Scope.RUNTIME, [], lambda p, s: None, skip_self_update=True)
+
+        assert received_skip == [True]


### PR DESCRIPTION
## Problem

deploy-agent is the only process that deploys code to `.201`. When deploy-agent itself has a bug, it cannot replace itself — the fix ships in a PR but the running binary stays broken. OMN-8534 / PR #1233 exposed this: the `GIT_SHA` fix was merged but `.201` still ran the pre-#1233 binary.

## Solution

`DeployExecutor.self_update()` — called as the **first** step of every `rebuild_scope()` invocation, before any other work. On each deploy trigger:

1. Check `git status --porcelain` — abort if dirty (never silently discard work)
2. `git fetch origin main`
3. Compare `HEAD` vs `origin/main`
4. If behind: `git pull --ff-only` → `uv sync` → `os.execv` (host) or `sys.exit(42)` (container)
5. If current: continue normally

## Pattern used

**Host mode** (default, `DEPLOY_AGENT_MODE=host`): `os.execv` atomically replaces the running process image — zero downtime, same PID group.

**Container mode** (`DEPLOY_AGENT_MODE=container`): exits with code 42 so the supervisor (systemd or compose `restart: always`) respawns from the freshly-pulled binary.

## Safety rails

| Rail | Mechanism |
|---|---|
| Dirty tree | Skip update, log warning |
| Emergency kill-switch | `DEPLOY_AGENT_NO_SELF_UPDATE=1` env var |
| CLI override | `--skip-self-update` flag |
| Fetch/pull failures | Log warning, skip — never block a deploy |

## Files changed

- `scripts/deploy-agent/deploy_agent/executor.py` — `self_update()` method + `DEPLOY_AGENT_DIR` constant
- `scripts/deploy-agent/deploy_agent/agent.py` — `skip_self_update` param threaded through
- `scripts/deploy-agent/deploy_agent/__main__.py` — `--skip-self-update` CLI flag
- `scripts/deploy-agent/tests/unit/test_executor_self_update.py` — 14 new unit tests

## Test results

18/18 tests passing (14 new + 4 pre-existing).

## Pre-deploy requirements

`DEPLOY_AGENT_DIR` must be set to the directory where deploy-agent is checked out on `.201` (or the default `/data/omninode/deploy-agent` must be correct). If running host-mode, the systemd unit should have `Restart=on-failure` or `Restart=always` to survive any unexpected exits — this is a separate operational task if not already configured.

## Rollback

Set `DEPLOY_AGENT_NO_SELF_UPDATE=1` in the environment or restart with `--skip-self-update` to disable self-update without redeploying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-self-update` flag to optionally disable automatic agent updates
  * Deploy agent now supports automatic self-updating

* **Tests**
  * Added comprehensive test coverage for auto-update functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->