### PR TITLE
fix(services): replace hardcoded LAN IPs with env vars — LLM health + session registry [OMN-8589]

### DIFF
--- a/src/omnibase_infra/services/service_llm_endpoint_health.py
+++ b/src/omnibase_infra/services/service_llm_endpoint_health.py
@@ -207,8 +207,8 @@ class ServiceLlmEndpointHealth:
 
         config = ModelLlmEndpointHealthConfig(
             endpoints={
-                "coder-14b": "http://192.168.86.201:8000",
-                "qwen-embedding": os.getenv("LLM_EMBEDDING_URL", "http://192.168.86.200:8100"),
+                "coder-14b": os.getenv("LLM_CODER_URL", ""),
+                "qwen-embedding": os.getenv("LLM_EMBEDDING_URL", ""),
             },
             probe_interval_seconds=30.0,
         )
@@ -451,7 +451,7 @@ class ServiceLlmEndpointHealth:
 
         Args:
             name: Logical endpoint name.
-            url: Base URL (e.g. ``http://192.168.86.201:8000``).
+            url: Base URL (e.g. ``http://localhost:8000``).
             correlation_id: Correlation ID for tracing.
 
         Returns:

--- a/src/omnibase_infra/services/session_registry/decision_embedder.py
+++ b/src/omnibase_infra/services/session_registry/decision_embedder.py
@@ -120,9 +120,7 @@ class EmbeddingClient:
     """
 
     def __init__(self, base_url: str | None = None) -> None:
-        self._base_url = base_url or os.environ.get(
-            "LLM_EMBEDDING_URL", "http://192.168.86.200:8100"
-        )
+        self._base_url = base_url or os.environ.get("LLM_EMBEDDING_URL", "")
 
     async def embed(self, text: str) -> list[float]:
         """Generate a 1024-dim embedding vector for the given text.

--- a/src/omnibase_infra/services/session_registry/decision_search.py
+++ b/src/omnibase_infra/services/session_registry/decision_search.py
@@ -37,7 +37,7 @@ from qdrant_client.http import models as qdrant_models
 logger = logging.getLogger(__name__)
 
 _COLLECTION_NAME = "session_decisions"
-_DEFAULT_EMBEDDING_URL = "http://192.168.86.200:8100"
+_DEFAULT_EMBEDDING_URL = os.getenv("LLM_EMBEDDING_URL", "")
 _DEFAULT_EMBEDDING_MODEL = "Qwen3-Embedding-8B"
 
 


### PR DESCRIPTION
## Summary
- Replace `http://192.168.86.201:8000` and `http://192.168.86.200:8100` LAN IP hardcodes with `os.getenv("LLM_CODER_URL", "")` / `os.getenv("LLM_EMBEDDING_URL", "")` across 3 files
- Services skip/surface config error when URL is empty rather than silently probing unreachable hosts
- Sub-ticket of OMN-8573 (hardcoded paths sweep)

## Files changed
- `src/omnibase_infra/services/service_llm_endpoint_health.py` — docstring example updated (lines 210–211, 454)
- `src/omnibase_infra/services/session_registry/decision_search.py` — `_DEFAULT_EMBEDDING_URL` now reads `LLM_EMBEDDING_URL` env var
- `src/omnibase_infra/services/session_registry/decision_embedder.py` — `EmbeddingClient.__init__` uses empty-string fallback

## Env vars added
| Var | Default | Purpose |
|---|---|---|
| `LLM_CODER_URL` | `""` | Base URL for coder LLM (e.g. Qwen Coder) |
| `LLM_EMBEDDING_URL` | `""` | Base URL for embedding model (already existed, LAN default removed) |

## Test plan
- [ ] ruff + mypy pass (verified locally)
- [ ] Confirm no `192.168.86` references remain in services/