### PR TITLE
fix(scripts): replace hardcoded paths with OMNI_HOME env var [OMN-8588]

### DIFF
--- a/scripts/generate_deep_dive.py
+++ b/scripts/generate_deep_dive.py
@@ -879,7 +879,7 @@ def unique_commit_entries(repo_days: list[RepoDay]) -> list[CommitEntry]:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    _default_root = os.environ.get("OMNI_HOME", "/Volumes/PRO-G40/Code/omni_home")
+    _default_root = os.environ.get("OMNI_HOME", ".")
     ap.add_argument(
         "--root",
         type=str,

--- a/scripts/install-bare-clone-sync.sh
+++ b/scripts/install-bare-clone-sync.sh
@@ -56,7 +56,7 @@ if [[ ! -f "${PLIST_SRC}" ]]; then
 fi
 
 # Verify pull-all.sh exists at the path referenced in the plist
-PULL_ALL="/Volumes/PRO-G40/Code/omni_home/omnibase_infra/scripts/pull-all.sh"
+PULL_ALL="${OMNI_HOME}/omnibase_infra/scripts/pull-all.sh"
 if [[ ! -f "${PULL_ALL}" ]]; then
     echo "ERROR: pull-all.sh not found at ${PULL_ALL}" >&2
     echo "       The plist references this absolute path." >&2

--- a/scripts/validation/check_claudemd_references.py
+++ b/scripts/validation/check_claudemd_references.py
@@ -37,6 +37,8 @@ import re
 import sys
 from pathlib import Path
 
+_OMNI_HOME_DEFAULT = Path(os.environ.get("OMNI_HOME", "."))
+
 # Patterns to extract file paths from CLAUDE.md content
 BACKTICK_PATH = re.compile(r"`([^`]+)`")
 LINK_PATH = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
@@ -167,7 +169,6 @@ def check_claudemd(
 
 
 def main() -> int:
-    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Validate file path references in CLAUDE.md files"
     )
@@ -175,7 +176,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=_omni_home_default,
+        default=_OMNI_HOME_DEFAULT,
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_claudemd_references.py
+++ b/scripts/validation/check_claudemd_references.py
@@ -32,6 +32,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -173,7 +174,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path("/Users/jonah/Code/omni_home"),
+        default=Path(os.environ.get("OMNI_HOME", ".")),
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_claudemd_references.py
+++ b/scripts/validation/check_claudemd_references.py
@@ -167,6 +167,7 @@ def check_claudemd(
 
 
 def main() -> int:
+    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Validate file path references in CLAUDE.md files"
     )
@@ -174,7 +175,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path(os.environ.get("OMNI_HOME", ".")),
+        default=_omni_home_default,
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_migration_conflicts.py
+++ b/scripts/validation/check_migration_conflicts.py
@@ -32,6 +32,8 @@ import re
 import sys
 from pathlib import Path
 
+_OMNI_HOME_DEFAULT = Path(os.environ.get("OMNI_HOME", "."))
+
 MIGRATION_DIRS = [
     "migrations",
     "sql/migrations",
@@ -84,7 +86,6 @@ def extract_tables_from_sql(path: Path) -> list[str]:
 
 
 def main() -> int:
-    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Check for migration conflicts across repos"
     )
@@ -92,7 +93,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=_omni_home_default,
+        default=_OMNI_HOME_DEFAULT,
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_migration_conflicts.py
+++ b/scripts/validation/check_migration_conflicts.py
@@ -84,6 +84,7 @@ def extract_tables_from_sql(path: Path) -> list[str]:
 
 
 def main() -> int:
+    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Check for migration conflicts across repos"
     )
@@ -91,7 +92,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path(os.environ.get("OMNI_HOME", ".")),
+        default=_omni_home_default,
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_migration_conflicts.py
+++ b/scripts/validation/check_migration_conflicts.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -90,7 +91,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path("/Users/jonah/Code/omni_home"),
+        default=Path(os.environ.get("OMNI_HOME", ".")),
         help="Path to omni_home directory",
     )
     args = parser.parse_args()

--- a/scripts/validation/check_stale_todos.py
+++ b/scripts/validation/check_stale_todos.py
@@ -32,6 +32,8 @@ import re
 import sys
 from pathlib import Path
 
+_OMNI_HOME_DEFAULT = Path(os.environ.get("OMNI_HOME", "."))
+
 TODO_PATTERN = re.compile(r"TODO\s*\(?\s*(OMN-\d+)\s*\)?", re.IGNORECASE)
 
 SKIP_DIRS = {
@@ -108,7 +110,6 @@ def scan_repos(omni_home: Path) -> dict[str, list[tuple[Path, int, str]]]:
 
 
 def main() -> int:
-    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Scan for TODO(OMN-XXXX) references across omni_home repos"
     )
@@ -116,7 +117,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=_omni_home_default,
+        default=_OMNI_HOME_DEFAULT,
         help="Path to omni_home directory",
     )
     parser.add_argument(

--- a/scripts/validation/check_stale_todos.py
+++ b/scripts/validation/check_stale_todos.py
@@ -108,6 +108,7 @@ def scan_repos(omni_home: Path) -> dict[str, list[tuple[Path, int, str]]]:
 
 
 def main() -> int:
+    _omni_home_default = Path(os.environ.get("OMNI_HOME", "."))
     parser = argparse.ArgumentParser(
         description="Scan for TODO(OMN-XXXX) references across omni_home repos"
     )
@@ -115,7 +116,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path(os.environ.get("OMNI_HOME", ".")),
+        default=_omni_home_default,
         help="Path to omni_home directory",
     )
     parser.add_argument(

--- a/scripts/validation/check_stale_todos.py
+++ b/scripts/validation/check_stale_todos.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -114,7 +115,7 @@ def main() -> int:
         "omni_home",
         type=Path,
         nargs="?",
-        default=Path("/Users/jonah/Code/omni_home"),
+        default=Path(os.environ.get("OMNI_HOME", ".")),
         help="Path to omni_home directory",
     )
     parser.add_argument(

--- a/scripts/verify_error_triage_e2e.py
+++ b/scripts/verify_error_triage_e2e.py
@@ -26,11 +26,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+
+_OMNI_HOME = pathlib.Path(os.environ["OMNI_HOME"])
 
 
 @dataclass
@@ -428,7 +431,7 @@ def verify_begin_day_probes(report: VerificationReport) -> None:
         ("check-boundary-parity", ["uv", "run", "check-boundary-parity", "--json"]),
     ]:
         # Run from onex_change_control
-        occ_dir = "/Volumes/PRO-G40/Code/omni_home/onex_change_control"
+        occ_dir = str(_OMNI_HOME / "onex_change_control")
         try:
             result = subprocess.run(
                 cmd,
@@ -483,9 +486,7 @@ def verify_close_day_skill(report: VerificationReport) -> None:
     import pathlib
 
     # Check skill files exist
-    skill_dir = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omniclaude/plugins/onex/skills/close_day"
-    )
+    skill_dir = _OMNI_HOME / "omniclaude" / "plugins" / "onex" / "skills" / "close_day"
     for f in ["SKILL.md", "prompt.md", "topics.yaml"]:
         exists = (skill_dir / f).exists()
         report.add(
@@ -633,7 +634,7 @@ def verify_adversarial_6c_malformed(report: VerificationReport) -> None:
 
 def verify_adversarial_6d_regression(report: VerificationReport) -> None:
     """6d: Row count regression — verify check-omnidash-health detects it."""
-    occ_dir = "/Volumes/PRO-G40/Code/omni_home/onex_change_control"
+    occ_dir = str(_OMNI_HOME / "onex_change_control")
     # Just verify the script exists and can be invoked
     result = subprocess.run(
         ["uv", "run", "check-omnidash-health", "--help"],
@@ -667,7 +668,7 @@ def verify_adversarial_6d_regression(report: VerificationReport) -> None:
 
 def verify_adversarial_6e_boundary(report: VerificationReport) -> None:
     """6e: Boundary mismatch — verify check-boundary-parity detects it."""
-    occ_dir = "/Volumes/PRO-G40/Code/omni_home/onex_change_control"
+    occ_dir = str(_OMNI_HOME / "onex_change_control")
     result = subprocess.run(
         ["uv", "run", "check-boundary-parity", "--help"],
         capture_output=True,
@@ -699,7 +700,7 @@ def verify_adversarial_6f_dashboard(report: VerificationReport) -> None:
     """6f: Operator visibility — verify /runtime-errors page components exist."""
     import pathlib
 
-    omnidash = pathlib.Path("/Volumes/PRO-G40/Code/omni_home/omnidash")
+    omnidash = _OMNI_HOME / "omnidash"
 
     files = [
         ("client/src/pages/RuntimeErrorsDashboard.tsx", "Dashboard page"),
@@ -729,9 +730,7 @@ def verify_service_kernel_wiring(report: VerificationReport) -> None:
     """Verify HandlerRuntimeErrorTriage is wired in service_kernel.py."""
     import pathlib
 
-    kernel_path = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omnibase_infra/src/omnibase_infra/runtime/service_kernel.py"
-    )
+    kernel_path = _OMNI_HOME / "omnibase_infra" / "src" / "omnibase_infra" / "runtime" / "service_kernel.py"
     if not kernel_path.exists():
         report.add(
             VerificationResult(
@@ -769,9 +768,14 @@ def verify_contract(report: VerificationReport) -> None:
     """Verify NodeRuntimeErrorTriageEffect contract.yaml."""
     import pathlib
 
-    contract = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omnibase_infra/src/omnibase_infra/"
-        "nodes/node_runtime_error_triage_effect/contract.yaml"
+    contract = (
+        _OMNI_HOME
+        / "omnibase_infra"
+        / "src"
+        / "omnibase_infra"
+        / "nodes"
+        / "node_runtime_error_triage_effect"
+        / "contract.yaml"
     )
     if not contract.exists():
         report.add(
@@ -810,9 +814,13 @@ def verify_omnidash_projection_wiring(report: VerificationReport) -> None:
     """Verify omnidash projections are wired for runtime error topics."""
     import pathlib
 
-    proj_file = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omnidash/server/consumers/"
-        "read-model/omnibase-infra-projections.ts"
+    proj_file = (
+        _OMNI_HOME
+        / "omnidash"
+        / "server"
+        / "consumers"
+        / "read-model"
+        / "omnibase-infra-projections.ts"
     )
     if not proj_file.exists():
         report.add(
@@ -857,9 +865,7 @@ def verify_migrations(report: VerificationReport) -> None:
     import pathlib
 
     # omnibase_infra migrations
-    infra_migrations = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omnibase_infra/docker/migrations/forward"
-    )
+    infra_migrations = _OMNI_HOME / "omnibase_infra" / "docker" / "migrations" / "forward"
     migration_055 = list(infra_migrations.glob("055_*"))
     report.add(
         VerificationResult(
@@ -870,9 +876,7 @@ def verify_migrations(report: VerificationReport) -> None:
     )
 
     # omnidash migrations
-    omnidash_migrations = pathlib.Path(
-        "/Volumes/PRO-G40/Code/omni_home/omnidash/migrations"
-    )
+    omnidash_migrations = _OMNI_HOME / "omnidash" / "migrations"
     migration_0036 = list(omnidash_migrations.glob("0036_*"))
     migration_0039 = list(omnidash_migrations.glob("0039_*"))
     report.add(
@@ -902,7 +906,7 @@ def verify_unit_tests(report: VerificationReport) -> None:
         "tests/unit/scripts/test_monitor_logs_runtime_emit.py",
         "tests/unit/nodes/test_handler_runtime_error_triage.py",
     ]
-    infra_dir = "/Volumes/PRO-G40/Code/omni_home/omnibase_infra"
+    infra_dir = str(_OMNI_HOME / "omnibase_infra")
 
     for test_file in test_files:
         result = subprocess.run(
@@ -1023,7 +1027,7 @@ def main() -> None:
     # Write report to disk
     import pathlib
 
-    report_dir = pathlib.Path("/Volumes/PRO-G40/Code/omni_home/docs/tracking")
+    report_dir = _OMNI_HOME / "docs" / "tracking"
     report_dir.mkdir(parents=True, exist_ok=True)
     report_path = report_dir / "2026-04-02-omn-5656-e2e-verification-results.json"
     report_path.write_text(json.dumps(report.to_dict(), indent=2))


### PR DESCRIPTION
## Summary

- `verify_error_triage_e2e.py`: add `_OMNI_HOME = Path(os.environ["OMNI_HOME"])` at module top, replace all 12 `/Volumes/PRO-G40/...` string literals with `_OMNI_HOME / "<repo>/..."` expressions
- `install-bare-clone-sync.sh`: `PULL_ALL="${OMNI_HOME}/omnibase_infra/scripts/pull-all.sh"` — no more hardcoded absolute path
- `validation/check_{claudemd_references,migration_conflicts,stale_todos}.py`: argparse default changed to `Path(os.environ.get("OMNI_HOME", "."))`, added `import os`
- `generate_deep_dive.py`: remove `/Volumes/PRO-G40/...` fallback, use `"."` as fallback

Sub-ticket of OMN-8573.

## Test plan

- [ ] Run `OMNI_HOME=/Users/jonah/Code/omni_home uv run python scripts/verify_error_triage_e2e.py --skip-adversarial` — no path errors
- [ ] Confirm CI passes