### PR TITLE
fix(infra): reroute LLM_DEEPSEEK_R1_URL to .201:8001, add endpoint health-check script [OMN-8488]

### DIFF
--- a/config/shared_key_registry.yaml
+++ b/config/shared_key_registry.yaml
@@ -73,7 +73,7 @@ shared:
     #   LLM_CODER_URL        — Qwen3-Coder-30B-A3B AWQ-4bit (RTX 5090, 64K ctx, port 8000)
     #   LLM_CODER_FAST_URL   — Qwen3-14B-AWQ (RTX 4090, 40K ctx, port 8001)
     #   LLM_EMBEDDING_URL    — Qwen3-Embedding-8B-4bit (M2 Ultra, port 8100)
-    #   LLM_DEEPSEEK_R1_URL  — DeepSeek-R1-Distill-Qwen-32B-bf16 (M2 Ultra, port 8101)
+    #   LLM_DEEPSEEK_R1_URL  — DeepSeek-R1-14B AWQ (RTX 4090, .201, port 8001) — .200:8101 down
     - LLM_CODER_URL
     - LLM_CODER_FAST_URL
     - LLM_EMBEDDING_URL

--- a/scripts/check_llm_endpoints.sh
+++ b/scripts/check_llm_endpoints.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check_llm_endpoints.sh — probe all known LLM inference endpoints.
+# Exits 0 if all required endpoints are healthy, non-zero otherwise.
+#
+# Required endpoints (must be reachable or script exits 1):
+#   LLM_CODER_URL       — Qwen3-Coder-30B (port 8000)
+#   LLM_DEEPSEEK_R1_URL — DeepSeek-R1-14B  (port 8001)
+#
+# Optional endpoints (failures are warned, not fatal):
+#   LLM_CODER_FAST_URL  — fast coder (port 8001 alias)
+#   LLM_EMBEDDING_URL   — embedding model
+#
+# Usage:
+#   bash scripts/check_llm_endpoints.sh
+#   TIMEOUT=5 bash scripts/check_llm_endpoints.sh
+
+set -euo pipefail
+
+TIMEOUT="${TIMEOUT:-5}"
+PASS=0
+FAIL=0
+WARN=0
+
+_probe() {
+  local label="$1"
+  local url="$2"
+  local required="${3:-true}"
+
+  # Try /health first, then /v1/models as fallback
+  local status
+  status=$(curl -sf --max-time "$TIMEOUT" -o /dev/null -w "%{http_code}" "${url%/}/health" 2>/dev/null || true)
+
+  if [[ "$status" =~ ^2 ]]; then
+    echo "  OK   ${label} — ${url} (/health HTTP ${status})"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+
+  status=$(curl -sf --max-time "$TIMEOUT" -o /dev/null -w "%{http_code}" "${url%/}/v1/models" 2>/dev/null || true)
+  if [[ "$status" =~ ^2 ]]; then
+    echo "  OK   ${label} — ${url} (/v1/models HTTP ${status})"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+
+  if [[ "$required" == "true" ]]; then
+    echo "  FAIL ${label} — ${url} (unreachable)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  WARN ${label} — ${url} (unreachable, optional)"
+    WARN=$((WARN + 1))
+  fi
+}
+
+echo "=== LLM endpoint health check ==="
+echo "    timeout: ${TIMEOUT}s"
+echo ""
+
+# Required endpoints — these must be set and healthy
+if [[ -z "${LLM_DEEPSEEK_R1_URL:-}" ]]; then
+  echo "  FAIL LLM_DEEPSEEK_R1_URL not set"
+  FAIL=$((FAIL + 1))
+else
+  _probe "deepseek-r1 (LLM_DEEPSEEK_R1_URL)" "$LLM_DEEPSEEK_R1_URL" true
+fi
+
+if [[ -z "${LLM_CODER_URL:-}" ]]; then
+  echo "  WARN LLM_CODER_URL not set (optional in CI)"
+  WARN=$((WARN + 1))
+else
+  _probe "coder (LLM_CODER_URL)" "$LLM_CODER_URL" false
+fi
+
+# Optional endpoints
+if [[ -n "${LLM_CODER_FAST_URL:-}" ]]; then
+  _probe "coder-fast (LLM_CODER_FAST_URL)" "$LLM_CODER_FAST_URL" false
+fi
+
+if [[ -n "${LLM_EMBEDDING_URL:-}" ]]; then
+  _probe "embedding (LLM_EMBEDDING_URL)" "$LLM_EMBEDDING_URL" false
+fi
+
+echo ""
+echo "=== Summary: ${PASS} ok, ${FAIL} failed, ${WARN} warned ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "RESULT: UNHEALTHY — ${FAIL} required endpoint(s) unreachable"
+  exit 1
+fi
+
+echo "RESULT: HEALTHY"
+exit 0

--- a/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
@@ -5,7 +5,7 @@
 """Documentation generation adapter using DeepSeek-R1-Distill-Qwen-32B.
 
 Generates docstrings, README sections, and API documentation using
-DeepSeek-R1-Distill-Qwen-32B (endpoint :8101 on .200). Returns
+DeepSeek-R1-Distill-Qwen-32B (endpoint :8001 on .201). Returns
 ``ContractDelegatedResponse`` with visible attribution and a tracked prompt
 version.
 
@@ -13,7 +13,7 @@ Architecture:
     - Receives a ``task_type`` (docstring, readme, api_doc) and ``source``
       text to document
     - Delegates LLM inference to HandlerLlmOpenaiCompatible via
-      TransportHolderLlmHttp pointing at the DeepSeek-R1 endpoint (:8101)
+      TransportHolderLlmHttp pointing at the DeepSeek-R1 endpoint (:8001)
     - Returns ContractDelegatedResponse with attribution metadata
 
 System Prompt Derivation:
@@ -206,7 +206,7 @@ class AdapterDocumentationGeneration:
         Args:
             base_url: Base URL of the DeepSeek-R1 endpoint.  Defaults to the
                 ``LLM_DEEPSEEK_R1_URL`` environment variable, falling back to
-                ``http://localhost:8101``.
+                ``http://localhost:8001``.
             model: Model identifier string sent in inference requests.
             max_tokens: Maximum tokens for the documentation completion.
             temperature: Sampling temperature (lower = more deterministic).
@@ -247,7 +247,7 @@ class AdapterDocumentationGeneration:
                 context=context,
             )
         self._base_url: str = base_url or os.environ.get(
-            "LLM_DEEPSEEK_R1_URL", "http://localhost:8101"
+            "LLM_DEEPSEEK_R1_URL", "http://localhost:8001"
         )
         self._model: str = model
         self._max_tokens: int = max_tokens

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -128,4 +128,4 @@ models:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
     effective_date: "2026-03-19"
-    note: "Local model on M2 Ultra (port 8101) - zero API cost"
+    note: "Local model on RTX 4090 .201 (port 8001) - zero API cost"

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
@@ -53,7 +53,7 @@ config_dependencies:
     description: "Endpoint URL for DeepSeek-R1-14B (port 8001)"
     required: false
   - key: "LLM_DEEPSEEK_R1_URL"
-    description: "Endpoint URL for DeepSeek-R1-32B (port 8101)"
+    description: "Endpoint URL for DeepSeek-R1-14B AWQ (port 8001, .201)"
     required: true
 error_handling:
   retry_policy:


### PR DESCRIPTION
## Summary

- `.200:8101` (M2 Ultra, DeepSeek-R1-32B) confirmed down — routing migrated to `.201:8001` (RTX 4090, DeepSeek-R1-14B AWQ, verified healthy)
- Updated `localhost` fallback in `adapter_documentation_generation.py` from `:8101` → `:8001`
- Updated contract description, shared key registry comment, and pricing manifest note to reflect new primary endpoint
- Added `scripts/check_llm_endpoints.sh`: probes `LLM_DEEPSEEK_R1_URL` (required) and optional `LLM_CODER_URL`, `LLM_CODER_FAST_URL`, `LLM_EMBEDDING_URL` via `/health` then `/v1/models` fallback; exits non-zero if any required endpoint is unreachable

## Files Changed

- `scripts/check_llm_endpoints.sh` — new health-check script (executable)
- `src/omnibase_infra/adapters/llm/adapter_documentation_generation.py` — fallback URL `:8101` → `:8001`
- `src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml` — description updated
- `src/omnibase_infra/configs/pricing_manifest.yaml` — note updated
- `config/shared_key_registry.yaml` — comment updated

## Diagnosis

`.200:8101` (M2 Ultra) is not responding. The rebuild-verifier agent confirmed `.201:8001` (DeepSeek-R1-14B AWQ on RTX 4090) as a healthy fallback. No hardcoded LAN IP is introduced — all routing is env-var driven; the `localhost:8001` fallback is used only in local dev when `LLM_DEEPSEEK_R1_URL` is unset.

## Test Plan

- [ ] `bash scripts/check_llm_endpoints.sh` with `LLM_DEEPSEEK_R1_URL=http://192.168.86.201:8001` → exits 0
- [ ] `bash scripts/check_llm_endpoints.sh` with `LLM_DEEPSEEK_R1_URL=http://192.168.86.200:8101` → exits 1 (FAIL)
- [ ] CI passes with no hardcoded dead endpoint

Closes OMN-8488