### PR TITLE
feat(ci): extract compliance_sweep, duplication_sweep, contract_sweep as standalone CLIs [OMN-8610]

### DIFF
--- a/scripts/ci/run_compliance_sweep.py
+++ b/scripts/ci/run_compliance_sweep.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Standalone CI script: handler contract compliance sweep.
+
+Scans Python handler files for:
+  HARDCODED_TOPIC      — topic strings like "onex.evt.*" embedded in code
+  UNDECLARED_TRANSPORT — direct psycopg/httpx/requests/etc. imports
+  LOGIC_IN_NODE        — business logic classes/methods in node.py files
+
+Usage:
+    python run_compliance_sweep.py [--repo /path/to/repo] [--repos /path/to/repo1,/path/to/repo2]
+                                   [--checks hardcoded-topics,undeclared-transport,logic-in-node]
+                                   [--fail-on-severity error|warning|critical]
+                                   [--json]
+
+Exit codes:
+    0 — no findings at or above --fail-on-severity
+    1 — findings found at or above --fail-on-severity
+    2 — usage/configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants (ported from handler_compliance_sweep.py)
+# ---------------------------------------------------------------------------
+
+_EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+    "migrations",
+}
+
+_HARDCODED_TOPIC_RE = re.compile(r'"onex\.[a-z]+\.[a-z]+\.[a-z]')
+
+_TRANSPORT_IMPORTS = {
+    "psycopg",
+    "psycopg2",
+    "asyncpg",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "sqlalchemy",
+    "boto3",
+}
+
+_LOGIC_INDICATORS = [
+    re.compile(r"class\s+\w+.*:"),
+    re.compile(r"def\s+(handle|process|execute)\s*\("),
+]
+
+_SEVERITY_ORDER = {"critical": 3, "error": 2, "warning": 1}
+
+ALL_CHECKS = ["hardcoded-topics", "undeclared-transport", "logic-in-node"]
+
+
+# ---------------------------------------------------------------------------
+# Detection logic
+# ---------------------------------------------------------------------------
+
+
+def _read_lines(path: Path) -> list[str]:
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+
+def _infer_node_name(handler_file: Path, repo_root: Path) -> str:
+    for part in handler_file.relative_to(repo_root).parts:
+        if part.startswith("node_"):
+            return part
+    return handler_file.stem
+
+
+def _find_handler_files(root: Path) -> list[Path]:
+    results = []
+    for py_file in root.rglob("*.py"):
+        if any(part in _EXCLUDED_DIRS for part in py_file.parts):
+            continue
+        if (
+            "handler" in py_file.stem
+            or py_file.parent.name == "handlers"
+            or py_file.stem == "node"
+            or py_file.name == "__init__.py"
+        ):
+            results.append(py_file)
+    return sorted(results)
+
+
+def _check_hardcoded_topics(
+    repo: str, rel_path: str, node: str, lines: list[str]
+) -> list[dict]:
+    findings = []
+    for i, line in enumerate(lines, 1):
+        if _HARDCODED_TOPIC_RE.search(line):
+            findings.append(
+                {
+                    "repo": repo,
+                    "file": rel_path,
+                    "node": node,
+                    "violation_type": "HARDCODED_TOPIC",
+                    "severity": "error",
+                    "line": i,
+                    "message": f"Hardcoded topic string: {line.strip()[:80]}",
+                }
+            )
+    return findings
+
+
+def _check_transport_imports(
+    repo: str, rel_path: str, node: str, handler_file: Path
+) -> list[dict]:
+    findings = []
+    try:
+        source = handler_file.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (OSError, SyntaxError):
+        return []
+
+    for ast_node in ast.walk(tree):
+        if isinstance(ast_node, ast.Import):
+            for alias in ast_node.names:
+                root_module = alias.name.split(".")[0]
+                if root_module in _TRANSPORT_IMPORTS:
+                    findings.append(
+                        {
+                            "repo": repo,
+                            "file": rel_path,
+                            "node": node,
+                            "violation_type": "UNDECLARED_TRANSPORT",
+                            "severity": "warning",
+                            "line": ast_node.lineno,
+                            "message": f"Transport import: {alias.name}",
+                        }
+                    )
+        elif isinstance(ast_node, ast.ImportFrom) and ast_node.module:
+            root_module = ast_node.module.split(".")[0]
+            if root_module in _TRANSPORT_IMPORTS:
+                findings.append(
+                    {
+                        "repo": repo,
+                        "file": rel_path,
+                        "node": node,
+                        "violation_type": "UNDECLARED_TRANSPORT",
+                        "severity": "warning",
+                        "line": ast_node.lineno,
+                        "message": f"Transport import: from {ast_node.module}",
+                    }
+                )
+    return findings
+
+
+def _check_logic_in_node(
+    repo: str, rel_path: str, node: str, lines: list[str]
+) -> list[dict]:
+    findings = []
+    for i, line in enumerate(lines, 1):
+        for pattern in _LOGIC_INDICATORS:
+            if pattern.search(line):
+                findings.append(
+                    {
+                        "repo": repo,
+                        "file": rel_path,
+                        "node": node,
+                        "violation_type": "LOGIC_IN_NODE",
+                        "severity": "warning",
+                        "line": i,
+                        "message": f"Business logic in node file: {line.strip()[:80]}",
+                    }
+                )
+    return findings
+
+
+def sweep_repo(repo_root: Path, checks: list[str]) -> tuple[int, list[dict]]:
+    """Scan a single repo root. Returns (handlers_scanned, findings)."""
+    repo_name = repo_root.name
+    handler_files = _find_handler_files(repo_root)
+    findings: list[dict] = []
+
+    for handler_file in handler_files:
+        node_name = _infer_node_name(handler_file, repo_root)
+        rel_path = str(handler_file.relative_to(repo_root))
+        lines = _read_lines(handler_file)
+
+        if "hardcoded-topics" in checks:
+            findings.extend(
+                _check_hardcoded_topics(repo_name, rel_path, node_name, lines)
+            )
+        if "undeclared-transport" in checks:
+            findings.extend(
+                _check_transport_imports(repo_name, rel_path, node_name, handler_file)
+            )
+        if "logic-in-node" in checks and (
+            "node.py" in handler_file.name or handler_file.name == "__init__.py"
+        ):
+            findings.extend(
+                _check_logic_in_node(repo_name, rel_path, node_name, lines)
+            )
+
+    return len(handler_files), findings
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Handler contract compliance sweep — standalone CI gate"
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--repo",
+        metavar="PATH",
+        help="Single repo root to scan",
+    )
+    group.add_argument(
+        "--repos",
+        metavar="PATH[,PATH...]",
+        help="Comma-separated repo roots to scan",
+    )
+    parser.add_argument(
+        "--checks",
+        metavar="CHECK[,CHECK...]",
+        default=",".join(ALL_CHECKS),
+        help=f"Checks to run (default: all). Options: {', '.join(ALL_CHECKS)}",
+    )
+    parser.add_argument(
+        "--fail-on-severity",
+        metavar="LEVEL",
+        default="error",
+        choices=list(_SEVERITY_ORDER.keys()),
+        help="Minimum severity to fail on (default: error)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of human-readable text",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    # Resolve repo paths
+    if args.repo:
+        repo_paths = [Path(args.repo)]
+    elif args.repos:
+        repo_paths = [Path(p.strip()) for p in args.repos.split(",") if p.strip()]
+    else:
+        repo_paths = [Path.cwd()]
+
+    checks = [c.strip() for c in args.checks.split(",") if c.strip()]
+    fail_threshold = _SEVERITY_ORDER[args.fail_on_severity]
+
+    all_findings: list[dict] = []
+    total_handlers = 0
+    skipped_repos: list[str] = []
+
+    for repo_path in repo_paths:
+        if not repo_path.is_dir():
+            skipped_repos.append(str(repo_path))
+            continue
+        scanned, findings = sweep_repo(repo_path, checks)
+        total_handlers += scanned
+        all_findings.extend(findings)
+
+    # Count by severity
+    severity_counts: dict[str, int] = {s: 0 for s in _SEVERITY_ORDER}
+    for f in all_findings:
+        sev = f["severity"].lower()
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    blocking_findings = [
+        f
+        for f in all_findings
+        if _SEVERITY_ORDER.get(f["severity"].lower(), 0) >= fail_threshold
+    ]
+
+    if args.json:
+        output = {
+            "sweep": "compliance_sweep",
+            "repos_scanned": [str(p) for p in repo_paths if p.is_dir()],
+            "repos_skipped": skipped_repos,
+            "handlers_scanned": total_handlers,
+            "checks": checks,
+            "fail_on_severity": args.fail_on_severity,
+            "findings": all_findings,
+            "summary": {
+                "total": len(all_findings),
+                "by_severity": severity_counts,
+                "blocking": len(blocking_findings),
+            },
+            "status": "FAIL" if blocking_findings else "PASS",
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print("Compliance Sweep Results")
+        print("========================")
+        print(f"Repos scanned: {len([p for p in repo_paths if p.is_dir()])}")
+        if skipped_repos:
+            print(f"Repos not found: {', '.join(skipped_repos)}")
+        print(f"Handlers scanned: {total_handlers}")
+        print(f"Checks: {', '.join(checks)}")
+        print()
+
+        if all_findings:
+            # Group by type for summary
+            by_type: dict[str, int] = {}
+            for f in all_findings:
+                by_type[f["violation_type"]] = by_type.get(f["violation_type"], 0) + 1
+            print("Violations by type:")
+            for vtype, count in sorted(by_type.items()):
+                print(f"  {vtype}: {count}")
+            print()
+            print("Findings:")
+            for f in all_findings:
+                sev_marker = "ERROR" if f["severity"] == "error" else "WARN "
+                print(
+                    f"  [{sev_marker}] {f['repo']}/{f['file']}:{f['line']} "
+                    f"[{f['violation_type']}] {f['message']}"
+                )
+        else:
+            print("No violations found.")
+
+        print()
+        status = "FAIL" if blocking_findings else "PASS"
+        print(
+            f"Overall: {status} "
+            f"({len(all_findings)} findings, {len(blocking_findings)} blocking)"
+        )
+
+    return 1 if blocking_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/run_contract_sweep.py
+++ b/scripts/ci/run_contract_sweep.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Standalone CI script: contract sweep.
+
+Modes:
+  drift   (default) — static cross-repo contract drift detection using
+                      onex_change_control/scripts/validation/check_contract_drift.py
+  runtime           — live contract compliance via omnibase_infra.verification.cli
+  full              — drift then runtime
+
+Usage:
+    python run_contract_sweep.py [--mode drift|runtime|full]
+                                 [--omni-home /path/to/omni_home]
+                                 [--repos omnibase_core,omnibase_infra,...]
+                                 [--sensitivity STRICT|STANDARD|LAX]
+                                 [--fail-on-severity breaking|additive|non_breaking]
+                                 [--dry-run]
+                                 [--json]
+
+Exit codes:
+    0 — clean (no findings at or above --fail-on-severity)
+    1 — findings at or above --fail-on-severity
+    2 — usage/configuration error
+    3 — tool not found (check_contract_drift.py or verification.cli missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_REPOS = [
+    "omnibase_core",
+    "omnibase_infra",
+    "omniclaude",
+    "omniintelligence",
+    "omnimemory",
+    "omninode_infra",
+    "omnibase_spi",
+    "onex_change_control",
+]
+
+_SEVERITY_ORDER = {"breaking": 3, "additive": 2, "non_breaking": 1}
+
+
+# ---------------------------------------------------------------------------
+# Drift mode
+# ---------------------------------------------------------------------------
+
+
+def run_drift_mode(
+    omni_home: Path,
+    repos: list[str],
+    sensitivity: str,
+    check_boundaries: bool,
+) -> dict:
+    """Run static drift detection for all repos."""
+    change_control = omni_home / "onex_change_control"
+    drift_script = change_control / "scripts" / "validation" / "check_contract_drift.py"
+
+    drift_script_available = drift_script.is_file()
+
+    results = []
+    repos_not_found: list[str] = []
+    baseline_missing: list[str] = []
+    total_contracts = 0
+
+    for repo in repos:
+        repo_path = omni_home / repo
+        if not repo_path.is_dir():
+            repos_not_found.append(repo)
+            continue
+
+        # Discover contract files
+        src_path = repo_path / "src"
+        if not src_path.is_dir():
+            src_path = repo_path  # fallback for repos without src/
+
+        contract_files = list(src_path.rglob("contract.yaml")) + list(
+            src_path.rglob("handler_contract.yaml")
+        )
+        total_contracts += len(contract_files)
+
+        # Check for snapshot
+        snapshot_file = change_control / "drift" / f"{repo}.sha256"
+
+        if not drift_script_available:
+            baseline_missing.append(repo)
+            results.append(
+                {
+                    "repo": repo,
+                    "status": "baseline_missing",
+                    "contracts_found": len(contract_files),
+                    "drift_detected": False,
+                    "summary": "check_contract_drift.py not found — skipping drift check",
+                }
+            )
+            continue
+
+        if not snapshot_file.is_file():
+            baseline_missing.append(repo)
+            results.append(
+                {
+                    "repo": repo,
+                    "status": "baseline_missing",
+                    "contracts_found": len(contract_files),
+                    "drift_detected": False,
+                    "summary": "No baseline snapshot — skipping drift check",
+                }
+            )
+            continue
+
+        # Run drift check
+        cmd = [
+            sys.executable,
+            str(drift_script),
+            "--root",
+            str(src_path),
+            "--check",
+            str(snapshot_file),
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                cwd=str(change_control),
+            )
+            drift_detected = proc.returncode == 1
+            results.append(
+                {
+                    "repo": repo,
+                    "status": "drifted" if drift_detected else "clean",
+                    "contracts_found": len(contract_files),
+                    "drift_detected": drift_detected,
+                    "output": (proc.stdout + proc.stderr).strip()[:500],
+                    "summary": (
+                        f"Drift detected in {repo}"
+                        if drift_detected
+                        else f"{repo} is clean"
+                    ),
+                }
+            )
+        except subprocess.TimeoutExpired:
+            results.append(
+                {
+                    "repo": repo,
+                    "status": "timeout",
+                    "contracts_found": len(contract_files),
+                    "drift_detected": False,
+                    "summary": f"Drift check timed out for {repo}",
+                }
+            )
+        except FileNotFoundError:
+            results.append(
+                {
+                    "repo": repo,
+                    "status": "error",
+                    "contracts_found": len(contract_files),
+                    "drift_detected": False,
+                    "summary": f"Python interpreter not found while checking {repo}",
+                }
+            )
+
+    # Boundary staleness check
+    boundary_findings: list[dict] = []
+    if check_boundaries:
+        boundary_findings = _check_boundaries(omni_home)
+
+    drifted = [r for r in results if r.get("drift_detected")]
+    stale_boundaries = [b for b in boundary_findings if b.get("severity") == "critical"]
+
+    if drifted or stale_boundaries:
+        overall_status = "breaking"
+    elif any(r["status"] == "baseline_missing" for r in results):
+        overall_status = "drifted"
+    else:
+        overall_status = "clean"
+
+    return {
+        "mode": "drift",
+        "status": overall_status,
+        "repos_scanned": [r["repo"] for r in results],
+        "repos_not_found": repos_not_found,
+        "baseline_missing": baseline_missing,
+        "total_contracts": total_contracts,
+        "sensitivity": sensitivity,
+        "repo_results": results,
+        "boundary_findings": boundary_findings,
+        "drifted_repos": [r["repo"] for r in drifted],
+        "stale_boundary_count": len(stale_boundaries),
+    }
+
+
+def _check_boundaries(omni_home: Path) -> list[dict]:
+    """Check kafka_boundaries.yaml for stale producer/consumer file references."""
+    boundaries_file = (
+        omni_home
+        / "onex_change_control"
+        / "src"
+        / "onex_change_control"
+        / "boundaries"
+        / "kafka_boundaries.yaml"
+    )
+    if not boundaries_file.is_file():
+        return []
+
+    import re
+
+    findings = []
+    try:
+        content = boundaries_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    # Simple regex parsing — avoids yaml dep requirement
+    entry_re = re.compile(
+        r"topic_name:\s*(\S+).*?"
+        r"producer_repo:\s*(\S+).*?"
+        r"producer_file:\s*(\S+)",
+        re.DOTALL,
+    )
+
+    for m in entry_re.finditer(content):
+        topic = m.group(1).strip()
+        producer_repo = m.group(2).strip()
+        producer_file = m.group(3).strip()
+
+        repo_path = omni_home / producer_repo
+        if not repo_path.is_dir():
+            findings.append(
+                {
+                    "topic": topic,
+                    "issue": "producer_repo_not_found",
+                    "producer_repo": producer_repo,
+                    "severity": "critical",
+                    "message": f"Producer repo '{producer_repo}' not found at {repo_path}",
+                }
+            )
+            continue
+
+        file_path = repo_path / producer_file
+        if not file_path.is_file():
+            # Try glob search within src/
+            matches = list(repo_path.rglob(Path(producer_file).name))
+            if not matches:
+                findings.append(
+                    {
+                        "topic": topic,
+                        "issue": "producer_file_missing",
+                        "producer_repo": producer_repo,
+                        "producer_file": producer_file,
+                        "severity": "critical",
+                        "message": f"Producer file '{producer_file}' not found in {producer_repo}",
+                    }
+                )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Runtime mode
+# ---------------------------------------------------------------------------
+
+
+def run_runtime_mode(omni_home: Path, full_verification: bool) -> dict:
+    """Run runtime contract compliance via omnibase_infra.verification.cli."""
+    infra_path = omni_home / "omnibase_infra"
+    if not infra_path.is_dir():
+        return {
+            "mode": "runtime",
+            "status": "error",
+            "error": f"omnibase_infra not found at {infra_path}",
+        }
+
+    run_id = f"contract-sweep-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    cmd = ["uv", "run", "python", "-m", "omnibase_infra.verification.cli", "--json"]
+    if not full_verification:
+        cmd.append("--registration-only")
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(infra_path),
+        )
+    except FileNotFoundError:
+        return {
+            "mode": "runtime",
+            "status": "error",
+            "run_id": run_id,
+            "error": "uv not found — cannot run omnibase_infra.verification.cli",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "mode": "runtime",
+            "status": "error",
+            "run_id": run_id,
+            "error": "verification.cli timed out",
+        }
+
+    output = proc.stdout + proc.stderr
+
+    if proc.returncode == 0:
+        return {
+            "mode": "runtime",
+            "status": "PASS",
+            "run_id": run_id,
+            "output": output.strip()[:2000],
+        }
+    elif proc.returncode == 2:
+        return {
+            "mode": "runtime",
+            "status": "QUARANTINE",
+            "run_id": run_id,
+            "output": output.strip()[:2000],
+        }
+    else:
+        return {
+            "mode": "runtime",
+            "status": "FAIL",
+            "run_id": run_id,
+            "output": output.strip()[:2000],
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Contract sweep — standalone CI gate (drift, runtime, or full)"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["drift", "runtime", "full"],
+        default="drift",
+        help="Sweep mode (default: drift)",
+    )
+    parser.add_argument(
+        "--omni-home",
+        metavar="PATH",
+        default=os.environ.get("OMNI_HOME", str(Path.cwd())),
+        help="Path to omni_home (default: $OMNI_HOME or cwd)",
+    )
+    parser.add_argument(
+        "--repos",
+        metavar="REPO[,REPO...]",
+        default=",".join(DEFAULT_REPOS),
+        help="Comma-separated repo names to scan (drift mode, default: all 8)",
+    )
+    parser.add_argument(
+        "--sensitivity",
+        choices=["STRICT", "STANDARD", "LAX"],
+        default="STANDARD",
+        help="Drift sensitivity (default: STANDARD)",
+    )
+    parser.add_argument(
+        "--fail-on-severity",
+        metavar="LEVEL",
+        default="breaking",
+        choices=list(_SEVERITY_ORDER.keys()),
+        help="Minimum severity to fail CI (default: breaking)",
+    )
+    parser.add_argument(
+        "--no-check-boundaries",
+        action="store_true",
+        help="Skip Kafka boundary staleness check",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Runtime mode: run full 52-contract verification (default: registration-only)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print findings only, do not create tickets",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of human-readable text",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:  # noqa: C901
+    args = parse_args(argv)
+
+    omni_home = Path(args.omni_home)
+    if not omni_home.is_dir():
+        print(f"ERROR: omni_home not found: {omni_home}", file=sys.stderr)
+        return 2
+
+    repos = [r.strip() for r in args.repos.split(",") if r.strip()]
+    fail_threshold = _SEVERITY_ORDER[args.fail_on_severity]
+    mode = args.mode
+
+    drift_result: dict | None = None
+    runtime_result: dict | None = None
+    exit_code = 0
+
+    if mode in ("drift", "full"):
+        drift_result = run_drift_mode(
+            omni_home=omni_home,
+            repos=repos,
+            sensitivity=args.sensitivity,
+            check_boundaries=not args.no_check_boundaries,
+        )
+        if drift_result.get("status") == "error":
+            print(f"ERROR: {drift_result.get('error')}", file=sys.stderr)
+            return 3
+
+        # Map drift status to severity
+        drift_status = drift_result.get("status", "clean")
+        drift_severity = {
+            "breaking": 3,
+            "drifted": 2,
+            "clean": 0,
+            "baseline_missing": 1,
+        }.get(drift_status, 0)
+        if drift_severity >= fail_threshold:
+            exit_code = 1
+
+    if mode in ("runtime", "full"):
+        runtime_result = run_runtime_mode(
+            omni_home=omni_home,
+            full_verification=args.all,
+        )
+        if runtime_result.get("status") == "FAIL":
+            if fail_threshold <= _SEVERITY_ORDER.get("breaking", 3):
+                exit_code = 1
+        elif runtime_result.get("status") == "error":
+            print(
+                f"WARN: runtime mode error: {runtime_result.get('error')}",
+                file=sys.stderr,
+            )
+
+    if args.json:
+        output = {
+            "sweep": "contract_sweep",
+            "mode": mode,
+            "omni_home": str(omni_home),
+            "fail_on_severity": args.fail_on_severity,
+            "status": "FAIL" if exit_code == 1 else "PASS",
+        }
+        if drift_result:
+            output["drift"] = drift_result
+        if runtime_result:
+            output["runtime"] = runtime_result
+        print(json.dumps(output, indent=2))
+    else:
+        if drift_result:
+            print("Contract Drift Sweep Results")
+            print("=============================")
+            print(f"Repos scanned: {len(drift_result.get('repos_scanned', []))}")
+            print(f"Total contracts: {drift_result.get('total_contracts', 0)}")
+            print(f"Sensitivity: {args.sensitivity}")
+            print()
+
+            drifted = drift_result.get("drifted_repos", [])
+            if drifted:
+                print(f"Drifted repos: {', '.join(drifted)}")
+            missing = drift_result.get("baseline_missing", [])
+            if missing:
+                print(f"Repos without baseline snapshot: {', '.join(missing)}")
+            not_found = drift_result.get("repos_not_found", [])
+            if not_found:
+                print(f"Repos not found: {', '.join(not_found)}")
+
+            stale = drift_result.get("stale_boundary_count", 0)
+            if stale:
+                print(f"Stale boundaries: {stale}")
+
+            print()
+            print(f"Overall drift status: {drift_result.get('status', 'unknown')}")
+
+        if runtime_result:
+            status = runtime_result.get("status", "unknown")
+            print()
+            print(f"CONTRACT_VERIFY: {status}")
+            if status == "FAIL":
+                output_text = runtime_result.get("output", "")
+                if output_text:
+                    print(output_text[:1000])
+
+        if mode == "full" and drift_result and runtime_result:
+            drift_status = drift_result.get("status", "unknown")
+            rt_status = runtime_result.get("status", "unknown")
+            combined: str
+            if drift_status == "clean" and rt_status == "PASS":
+                combined = "CLEAN"
+            elif drift_status == "breaking" or rt_status == "FAIL":
+                combined = "FAILURES"
+            else:
+                combined = "WARNINGS"
+            print()
+            print(f"=== contract-sweep FULL: Combined status: {combined} ===")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/run_duplication_sweep.py
+++ b/scripts/ci/run_duplication_sweep.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Standalone CI script: duplication sweep.
+
+Checks:
+  D1 — Drizzle table name duplication across omnidash schema files
+  D2 — Topic registration conflicts between omniclaude/topics.py and kafka_boundaries.yaml
+  D3 — Migration prefix conflicts (via check-migration-conflicts CLI)
+  D4 — Cross-repo model name collisions (class ModelXxx defined in multiple repos)
+
+Usage:
+    python run_duplication_sweep.py [--omni-home /path/to/omni_home]
+                                    [--checks D1,D2,D3,D4]
+                                    [--fail-on-severity error|warning]
+                                    [--json]
+
+Exit codes:
+    0 — no findings at or above --fail-on-severity
+    1 — findings found at or above --fail-on-severity
+    2 — usage/configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ALL_CHECKS = ["D1", "D2", "D3", "D4"]
+_SEVERITY_ORDER = {"error": 2, "warning": 1}
+
+
+# ---------------------------------------------------------------------------
+# Check implementations
+# ---------------------------------------------------------------------------
+
+
+def check_d1_drizzle_tables(omni_home: Path) -> dict:
+    """D1: Drizzle table name duplication across schema files."""
+    schema_dir = omni_home / "omnidash" / "shared"
+    if not schema_dir.is_dir():
+        return {
+            "check_id": "D1",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": f"omnidash/shared/ not found at {schema_dir}",
+            "findings": [],
+        }
+
+    table_pattern = re.compile(r'pgTable\("([^"]+)"')
+    table_locations: dict[str, list[str]] = {}
+
+    for schema_file in schema_dir.glob("*schema*.ts"):
+        try:
+            content = schema_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in table_pattern.finditer(content):
+            table_name = match.group(1)
+            table_locations.setdefault(table_name, []).append(schema_file.name)
+
+    duplicates = {
+        name: files for name, files in table_locations.items() if len(files) > 1
+    }
+
+    if duplicates:
+        detail = f"{len(duplicates)} duplicate table(s): {', '.join(sorted(duplicates))}"
+        findings = [
+            {
+                "table": name,
+                "files": files,
+                "message": f"Table '{name}' defined in: {', '.join(files)}",
+            }
+            for name, files in sorted(duplicates.items())
+        ]
+        return {
+            "check_id": "D1",
+            "status": "FAIL",
+            "finding_count": len(duplicates),
+            "severity": "error",
+            "detail": detail,
+            "findings": findings,
+        }
+
+    return {
+        "check_id": "D1",
+        "status": "PASS",
+        "finding_count": 0,
+        "severity": "error",
+        "detail": "No duplicate Drizzle tables",
+        "findings": [],
+    }
+
+
+def check_d2_topic_conflicts(omni_home: Path) -> dict:
+    """D2: Topic registration conflicts between omniclaude topics.py and kafka_boundaries.yaml."""
+    topics_file = (
+        omni_home / "omniclaude" / "src" / "omniclaude" / "hooks" / "topics.py"
+    )
+    boundaries_file = (
+        omni_home
+        / "onex_change_control"
+        / "src"
+        / "onex_change_control"
+        / "boundaries"
+        / "kafka_boundaries.yaml"
+    )
+
+    missing = []
+    if not topics_file.is_file():
+        missing.append(str(topics_file))
+    if not boundaries_file.is_file():
+        missing.append(str(boundaries_file))
+
+    if missing:
+        return {
+            "check_id": "D2",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": f"Topic source files not found: {', '.join(missing)}",
+            "findings": [],
+        }
+
+    # Parse TopicBase enum values from topics.py
+    topic_value_re = re.compile(r'=\s*"([^"]+)"')
+    omniclaude_topics: set[str] = set()
+    try:
+        for line in topics_file.read_text(encoding="utf-8").splitlines():
+            for m in topic_value_re.finditer(line):
+                val = m.group(1)
+                if val.startswith("onex."):
+                    omniclaude_topics.add(val)
+    except OSError:
+        pass
+
+    # Parse topic_name entries from kafka_boundaries.yaml (no yaml dep — simple grep)
+    boundary_topic_re = re.compile(r"topic_name:\s*([^\s#]+)")
+    # Also parse producer_repo for conflict detection
+    boundary_entries: list[dict] = []
+    try:
+        content = boundaries_file.read_text(encoding="utf-8")
+        current_topic = None
+        current_producer = None
+        for line in content.splitlines():
+            tm = boundary_topic_re.search(line)
+            if tm:
+                if current_topic:
+                    boundary_entries.append(
+                        {"topic": current_topic, "producer_repo": current_producer}
+                    )
+                current_topic = tm.group(1).strip()
+                current_producer = None
+            pm = re.search(r"producer_repo:\s*(\S+)", line)
+            if pm:
+                current_producer = pm.group(1).strip()
+        if current_topic:
+            boundary_entries.append(
+                {"topic": current_topic, "producer_repo": current_producer}
+            )
+    except OSError:
+        pass
+
+    # Cross-reference: find topics claimed by omniclaude that also appear in boundaries
+    # with a different producer_repo
+    conflicts = []
+    for entry in boundary_entries:
+        topic = entry["topic"]
+        if topic in omniclaude_topics:
+            producer = entry.get("producer_repo")
+            if producer and producer != "omniclaude":
+                conflicts.append(
+                    {
+                        "topic": topic,
+                        "omniclaude_claims": True,
+                        "boundary_producer": producer,
+                        "message": (
+                            f"Topic '{topic}' claimed by omniclaude but "
+                            f"kafka_boundaries.yaml lists producer_repo={producer}"
+                        ),
+                    }
+                )
+
+    if conflicts:
+        return {
+            "check_id": "D2",
+            "status": "FAIL",
+            "finding_count": len(conflicts),
+            "severity": "error",
+            "detail": f"{len(conflicts)} conflicting topic(s)",
+            "findings": conflicts,
+        }
+
+    return {
+        "check_id": "D2",
+        "status": "PASS",
+        "finding_count": 0,
+        "severity": "error",
+        "detail": "No topic registration conflicts",
+        "findings": [],
+    }
+
+
+def check_d3_migration_conflicts(omni_home: Path) -> dict:
+    """D3: Migration prefix conflicts via check-migration-conflicts CLI."""
+    change_control = omni_home / "onex_change_control"
+    if not change_control.is_dir():
+        return {
+            "check_id": "D3",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": "onex_change_control not found",
+            "findings": [],
+        }
+
+    try:
+        result = subprocess.run(
+            ["uv", "run", "check-migration-conflicts", "--repos-root", str(omni_home)],
+            cwd=str(change_control),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        output = result.stdout + result.stderr
+    except FileNotFoundError:
+        return {
+            "check_id": "D3",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": "check-migration-conflicts not available (uv not found)",
+            "findings": [],
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "check_id": "D3",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": "check-migration-conflicts timed out",
+            "findings": [],
+        }
+
+    conflict_lines = [
+        line
+        for line in output.splitlines()
+        if "EXACT_DUPLICATE" in line or "NAME_CONFLICT" in line
+    ]
+
+    if conflict_lines:
+        return {
+            "check_id": "D3",
+            "status": "FAIL",
+            "finding_count": len(conflict_lines),
+            "severity": "error",
+            "detail": f"{len(conflict_lines)} migration conflict(s)",
+            "findings": [{"message": line.strip()} for line in conflict_lines],
+        }
+
+    if result.returncode != 0 and not conflict_lines:
+        return {
+            "check_id": "D3",
+            "status": "WARN",
+            "finding_count": 0,
+            "severity": "warning",
+            "detail": f"check-migration-conflicts exited {result.returncode} with no parsed conflicts",
+            "findings": [],
+        }
+
+    return {
+        "check_id": "D3",
+        "status": "PASS",
+        "finding_count": 0,
+        "severity": "error",
+        "detail": "No migration prefix conflicts",
+        "findings": [],
+    }
+
+
+def check_d4_model_collisions(omni_home: Path) -> dict:
+    """D4: Cross-repo model name collisions (class ModelXxx in multiple repos)."""
+    class_pattern = re.compile(r"^class\s+(Model[A-Z]\w*)")
+    model_locations: dict[str, list[dict]] = {}
+
+    excluded_dirs = {".git", ".venv", "__pycache__", "migrations", "tests", "fixtures"}
+    excluded_repos = {"omnibase_core"}
+
+    for src_dir in omni_home.glob("*/src"):
+        repo = src_dir.parent.name
+        if repo in excluded_repos:
+            continue
+        for py_file in src_dir.rglob("*.py"):
+            if any(part in excluded_dirs for part in py_file.parts):
+                continue
+            try:
+                for line in py_file.read_text(encoding="utf-8").splitlines():
+                    m = class_pattern.match(line.strip())
+                    if m:
+                        class_name = m.group(1)
+                        model_locations.setdefault(class_name, []).append(
+                            {
+                                "repo": repo,
+                                "file": str(py_file.relative_to(omni_home)),
+                            }
+                        )
+            except (OSError, UnicodeDecodeError):
+                continue
+
+    duplicates = {
+        name: locs for name, locs in model_locations.items() if len(locs) > 1
+    }
+
+    if duplicates:
+        findings = [
+            {
+                "class_name": name,
+                "locations": locs,
+                "message": f"'{name}' defined in {len(locs)} repos: "
+                + ", ".join(loc["repo"] for loc in locs),
+            }
+            for name, locs in sorted(duplicates.items())
+        ]
+        return {
+            "check_id": "D4",
+            "status": "FAIL",
+            "finding_count": len(duplicates),
+            "severity": "error",
+            "detail": f"{len(duplicates)} cross-repo model name collision(s)",
+            "findings": findings,
+        }
+
+    return {
+        "check_id": "D4",
+        "status": "PASS",
+        "finding_count": 0,
+        "severity": "error",
+        "detail": "No cross-repo model name collisions",
+        "findings": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Duplication sweep — standalone CI gate"
+    )
+    parser.add_argument(
+        "--omni-home",
+        metavar="PATH",
+        default=os.environ.get("OMNI_HOME", str(Path.cwd())),
+        help="Path to omni_home (default: $OMNI_HOME or cwd)",
+    )
+    parser.add_argument(
+        "--checks",
+        metavar="CHECK[,CHECK...]",
+        default=",".join(ALL_CHECKS),
+        help=f"Checks to run (default: all). Options: {', '.join(ALL_CHECKS)}",
+    )
+    parser.add_argument(
+        "--fail-on-severity",
+        metavar="LEVEL",
+        default="error",
+        choices=list(_SEVERITY_ORDER.keys()),
+        help="Minimum severity to fail on (default: error)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of human-readable text",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    omni_home = Path(args.omni_home)
+    if not omni_home.is_dir():
+        print(f"ERROR: omni_home not found: {omni_home}", file=sys.stderr)
+        return 2
+
+    checks = [c.strip().upper() for c in args.checks.split(",") if c.strip()]
+    fail_threshold = _SEVERITY_ORDER[args.fail_on_severity]
+
+    check_map = {
+        "D1": check_d1_drizzle_tables,
+        "D2": check_d2_topic_conflicts,
+        "D3": check_d3_migration_conflicts,
+        "D4": check_d4_model_collisions,
+    }
+
+    results = []
+    for check_id in ALL_CHECKS:
+        if check_id not in checks:
+            continue
+        fn = check_map.get(check_id)
+        if fn:
+            results.append(fn(omni_home))
+
+    fail_results = [
+        r
+        for r in results
+        if r["status"] == "FAIL"
+        and _SEVERITY_ORDER.get(r["severity"], 0) >= fail_threshold
+    ]
+
+    overall = "FAIL" if fail_results else "PASS"
+
+    if args.json:
+        output = {
+            "sweep": "duplication_sweep",
+            "omni_home": str(omni_home),
+            "checks": checks,
+            "fail_on_severity": args.fail_on_severity,
+            "results": results,
+            "status": overall,
+            "blocking_count": len(fail_results),
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print("DUPLICATION SWEEP RESULTS")
+        print("=========================")
+        print()
+        for r in results:
+            print(f"{r['check_id']}: {r['status']} — {r['detail']}")
+        print()
+        print(f"Overall: {overall}")
+
+    return 1 if fail_results else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_clean.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_clean.py
@@ -1,0 +1,3 @@
+# clean handler — no violations
+def process(data):
+    return data

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_foo.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_foo.py
@@ -1,0 +1,2 @@
+# handler with a hardcoded topic
+topic = "onex.evt.omniclaude.session-started.v1"

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_transport.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_transport.py
@@ -1,0 +1,4 @@
+import httpx
+
+def fetch(url):
+    return httpx.get(url)

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/node.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/node.py
@@ -1,0 +1,4 @@
+# node.py with business logic (LOGIC_IN_NODE)
+class MyProcessor:
+    def handle(self):
+        pass

--- a/scripts/ci/tests/fixtures/duplication_repo/omniclaude/src/omniclaude/hooks/topics.py
+++ b/scripts/ci/tests/fixtures/duplication_repo/omniclaude/src/omniclaude/hooks/topics.py
@@ -1,0 +1,5 @@
+from enum import StrEnum
+
+class TopicBase(StrEnum):
+    SESSION_STARTED = "onex.evt.omniclaude.session-started.v1"
+    PROMPT_SUBMITTED = "onex.evt.omniclaude.prompt-submitted.v1"

--- a/scripts/ci/tests/fixtures/duplication_repo/omnidash/shared/schema-a.ts
+++ b/scripts/ci/tests/fixtures/duplication_repo/omnidash/shared/schema-a.ts
@@ -1,0 +1,2 @@
+export const users = pgTable("users", { id: integer("id") });
+export const posts = pgTable("posts", { id: integer("id") });

--- a/scripts/ci/tests/fixtures/duplication_repo/omnidash/shared/schema-b.ts
+++ b/scripts/ci/tests/fixtures/duplication_repo/omnidash/shared/schema-b.ts
@@ -1,0 +1,2 @@
+export const users = pgTable("users", { name: text("name") });
+export const comments = pgTable("comments", { id: integer("id") });

--- a/scripts/ci/tests/fixtures/duplication_repo/onex_change_control/src/onex_change_control/boundaries/kafka_boundaries.yaml
+++ b/scripts/ci/tests/fixtures/duplication_repo/onex_change_control/src/onex_change_control/boundaries/kafka_boundaries.yaml
@@ -1,0 +1,7 @@
+boundaries:
+  - topic_name: onex.evt.omniclaude.session-started.v1
+    producer_repo: omniclaude
+    producer_file: src/omniclaude/hooks/topics.py
+  - topic_name: onex.evt.omniclaude.prompt-submitted.v1
+    producer_repo: other_repo
+    producer_file: src/other/topics.py

--- a/scripts/ci/tests/test_sweep_clis.py
+++ b/scripts/ci/tests/test_sweep_clis.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Unit tests for run_compliance_sweep.py, run_duplication_sweep.py, run_contract_sweep.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing scripts from parent dir
+SCRIPTS_CI = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_CI))
+
+FIXTURES = Path(__file__).parent / "fixtures"
+COMPLIANCE_REPO = FIXTURES / "compliance_repo"
+DUPLICATION_REPO = FIXTURES / "duplication_repo"
+
+
+# ---------------------------------------------------------------------------
+# compliance sweep tests
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceSweep:
+    def test_finds_hardcoded_topic(self):
+        from run_compliance_sweep import sweep_repo
+
+        handlers_scanned, findings = sweep_repo(COMPLIANCE_REPO, ["hardcoded-topics"])
+        hardcoded = [f for f in findings if f["violation_type"] == "HARDCODED_TOPIC"]
+        assert len(hardcoded) >= 1
+        assert any("onex.evt" in f["message"] for f in hardcoded)
+
+    def test_finds_transport_import(self):
+        from run_compliance_sweep import sweep_repo
+
+        _, findings = sweep_repo(COMPLIANCE_REPO, ["undeclared-transport"])
+        transport = [f for f in findings if f["violation_type"] == "UNDECLARED_TRANSPORT"]
+        assert len(transport) >= 1
+        assert any("httpx" in f["message"] for f in transport)
+
+    def test_finds_logic_in_node(self):
+        from run_compliance_sweep import sweep_repo
+
+        _, findings = sweep_repo(COMPLIANCE_REPO, ["logic-in-node"])
+        logic = [f for f in findings if f["violation_type"] == "LOGIC_IN_NODE"]
+        assert len(logic) >= 1
+
+    def test_clean_handler_no_violations(self):
+        from run_compliance_sweep import sweep_repo
+
+        # Only scan for hardcoded topics — handler_clean.py has none
+        _, findings = sweep_repo(COMPLIANCE_REPO, ["hardcoded-topics"])
+        # handler_clean.py should not be in findings
+        clean_findings = [f for f in findings if "handler_clean" in f["file"]]
+        assert len(clean_findings) == 0
+
+    def test_exit_0_on_no_findings(self, tmp_path):
+        clean_repo = tmp_path / "clean_repo" / "handlers"
+        clean_repo.mkdir(parents=True)
+        (clean_repo / "handler_ok.py").write_text("def run(): pass\n")
+
+        from run_compliance_sweep import main
+
+        result = main(["--repo", str(tmp_path / "clean_repo"), "--checks", "hardcoded-topics"])
+        assert result == 0
+
+    def test_exit_1_on_findings(self):
+        from run_compliance_sweep import main
+
+        result = main(
+            [
+                "--repo",
+                str(COMPLIANCE_REPO),
+                "--checks",
+                "hardcoded-topics",
+                "--fail-on-severity",
+                "error",
+            ]
+        )
+        assert result == 1
+
+    def test_json_output(self, capsys):
+        import json as json_mod
+
+        from run_compliance_sweep import main
+
+        main(
+            [
+                "--repo",
+                str(COMPLIANCE_REPO),
+                "--checks",
+                "hardcoded-topics",
+                "--json",
+            ]
+        )
+        captured = capsys.readouterr()
+        data = json_mod.loads(captured.out)
+        assert "findings" in data
+        assert "status" in data
+        assert data["sweep"] == "compliance_sweep"
+
+    def test_warning_only_does_not_fail_on_error_threshold(self, tmp_path):
+        # UNDECLARED_TRANSPORT is severity=warning, --fail-on-severity=error → exit 0
+        transport_repo = tmp_path / "transport_repo" / "src" / "handlers"
+        transport_repo.mkdir(parents=True)
+        (transport_repo / "handler_t.py").write_text("import httpx\n")
+
+        from run_compliance_sweep import main
+
+        result = main(
+            [
+                "--repo",
+                str(tmp_path / "transport_repo"),
+                "--checks",
+                "undeclared-transport",
+                "--fail-on-severity",
+                "error",
+            ]
+        )
+        assert result == 0
+
+    def test_warning_fails_on_warning_threshold(self, tmp_path):
+        transport_repo = tmp_path / "transport_repo" / "src" / "handlers"
+        transport_repo.mkdir(parents=True)
+        (transport_repo / "handler_t.py").write_text("import httpx\n")
+
+        from run_compliance_sweep import main
+
+        result = main(
+            [
+                "--repo",
+                str(tmp_path / "transport_repo"),
+                "--checks",
+                "undeclared-transport",
+                "--fail-on-severity",
+                "warning",
+            ]
+        )
+        assert result == 1
+
+    def test_missing_repo_is_skipped(self, capsys):
+        from run_compliance_sweep import main
+
+        result = main(["--repo", "/nonexistent/path/repo"])
+        assert result == 0  # no findings when repo not found
+
+
+# ---------------------------------------------------------------------------
+# duplication sweep tests
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicationSweep:
+    def test_d1_finds_duplicate_table(self):
+        from run_duplication_sweep import check_d1_drizzle_tables
+
+        result = check_d1_drizzle_tables(DUPLICATION_REPO)
+        assert result["status"] == "FAIL"
+        assert result["finding_count"] >= 1
+        table_names = [f["table"] for f in result["findings"]]
+        assert "users" in table_names
+
+    def test_d2_finds_topic_conflict(self):
+        from run_duplication_sweep import check_d2_topic_conflicts
+
+        result = check_d2_topic_conflicts(DUPLICATION_REPO)
+        assert result["status"] == "FAIL"
+        assert result["finding_count"] >= 1
+        topics = [f["topic"] for f in result["findings"]]
+        assert "onex.evt.omniclaude.prompt-submitted.v1" in topics
+
+    def test_d2_no_conflict_when_producer_matches(self, tmp_path):
+        from run_duplication_sweep import check_d2_topic_conflicts
+
+        # Create fixture where both topics have omniclaude as producer
+        hooks_dir = tmp_path / "omniclaude" / "src" / "omniclaude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "topics.py").write_text(
+            'class T:\n    A = "onex.evt.omniclaude.session.v1"\n'
+        )
+        bounds_dir = (
+            tmp_path
+            / "onex_change_control"
+            / "src"
+            / "onex_change_control"
+            / "boundaries"
+        )
+        bounds_dir.mkdir(parents=True)
+        (bounds_dir / "kafka_boundaries.yaml").write_text(
+            "boundaries:\n"
+            "  - topic_name: onex.evt.omniclaude.session.v1\n"
+            "    producer_repo: omniclaude\n"
+        )
+        result = check_d2_topic_conflicts(tmp_path)
+        assert result["status"] == "PASS"
+
+    def test_d1_pass_when_no_duplicates(self, tmp_path):
+        from run_duplication_sweep import check_d1_drizzle_tables
+
+        shared = tmp_path / "omnidash" / "shared"
+        shared.mkdir(parents=True)
+        (shared / "schema-a.ts").write_text('export const foo = pgTable("foo_table", {});\n')
+        (shared / "schema-b.ts").write_text('export const bar = pgTable("bar_table", {});\n')
+        result = check_d1_drizzle_tables(tmp_path)
+        assert result["status"] == "PASS"
+
+    def test_json_output(self, capsys):
+        import json as json_mod
+
+        from run_duplication_sweep import main
+
+        main(["--omni-home", str(DUPLICATION_REPO), "--checks", "D1", "--json"])
+        captured = capsys.readouterr()
+        data = json_mod.loads(captured.out)
+        assert data["sweep"] == "duplication_sweep"
+        assert "results" in data
+
+    def test_exit_code_on_fail(self):
+        from run_duplication_sweep import main
+
+        result = main(
+            ["--omni-home", str(DUPLICATION_REPO), "--checks", "D1,D2", "--fail-on-severity", "error"]
+        )
+        assert result == 1
+
+    def test_missing_omni_home_returns_2(self):
+        from run_duplication_sweep import main
+
+        result = main(["--omni-home", "/nonexistent/omni_home"])
+        assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# contract sweep tests
+# ---------------------------------------------------------------------------
+
+
+class TestContractSweep:
+    def test_drift_mode_skips_missing_repos(self, tmp_path):
+        from run_contract_sweep import run_drift_mode
+
+        result = run_drift_mode(
+            omni_home=tmp_path,
+            repos=["nonexistent_repo"],
+            sensitivity="STANDARD",
+            check_boundaries=False,
+        )
+        assert result["status"] in ("clean",)
+        assert "nonexistent_repo" in result["repos_not_found"]
+
+    def test_drift_mode_baseline_missing(self, tmp_path):
+        from run_contract_sweep import run_drift_mode
+
+        # Create a minimal repo structure
+        (tmp_path / "my_repo" / "src").mkdir(parents=True)
+        # No snapshot file → baseline_missing
+        result = run_drift_mode(
+            omni_home=tmp_path,
+            repos=["my_repo"],
+            sensitivity="STANDARD",
+            check_boundaries=False,
+        )
+        assert "my_repo" in result["baseline_missing"]
+
+    def test_check_boundaries_missing_file(self, tmp_path):
+        from run_contract_sweep import _check_boundaries
+
+        # No boundaries file → returns empty list
+        result = _check_boundaries(tmp_path)
+        assert result == []
+
+    def test_json_output_structure(self, capsys, tmp_path):
+        import json as json_mod
+
+        from run_contract_sweep import main
+
+        main([
+            "--omni-home", str(tmp_path),
+            "--repos", "nonexistent",
+            "--mode", "drift",
+            "--json",
+            "--no-check-boundaries",
+        ])
+        captured = capsys.readouterr()
+        data = json_mod.loads(captured.out)
+        assert data["sweep"] == "contract_sweep"
+        assert "drift" in data
+        assert "status" in data
+
+    def test_exit_0_when_clean(self, tmp_path):
+        from run_contract_sweep import main
+
+        result = main([
+            "--omni-home", str(tmp_path),
+            "--repos", "nonexistent",
+            "--mode", "drift",
+            "--no-check-boundaries",
+        ])
+        assert result == 0
+
+    def test_missing_omni_home_returns_2(self):
+        from run_contract_sweep import main
+
+        result = main(["--omni-home", "/nonexistent/path"])
+        assert result == 2


### PR DESCRIPTION
## Summary

- Adds three standalone Python CI scripts to `scripts/ci/` that run sweep detection logic without any Claude Code harness dependency
- Unblocks OMN-8611 through OMN-8629 (12+ CI gate epic children under OMN-8610)
- Extracts logic from `omnimarket/src/omnimarket/nodes/node_compliance_sweep/` and the `duplication_sweep` / `contract_sweep` skill prompts

## Scripts added

| Script | What it detects | Source |
|--------|----------------|--------|
| `scripts/ci/run_compliance_sweep.py` | `HARDCODED_TOPIC`, `UNDECLARED_TRANSPORT`, `LOGIC_IN_NODE` in handler files | Extracted from `node_compliance_sweep` handler |
| `scripts/ci/run_duplication_sweep.py` | Drizzle table duplication (D1), topic registration conflicts (D2), migration prefix conflicts (D3), cross-repo model name collisions (D4) | Extracted from `duplication_sweep` skill prompt |
| `scripts/ci/run_contract_sweep.py` | Contract drift (via `check_contract_drift.py`) and runtime verification (via `omnibase_infra.verification.cli`) | Extracted from `contract_sweep` skill prompt |

All three accept `--json`, `--fail-on-severity error|warning`, exit 0/1, zero Claude Code deps (stdlib + pyyaml).

## Notes

- `runtime_sweep` and `aislop_sweep` CI scripts already exist — confirmed and skipped
- 23 unit tests, all passing; smoke-tested against real omni_home

## Test plan

- [x] 23 unit tests pass (`uv run pytest scripts/ci/tests/test_sweep_clis.py -v`)
- [x] Smoke test: `run_compliance_sweep.py --repos omniclaude` finds 4 real violations, no crash
- [x] Smoke test: `run_duplication_sweep.py --omni-home omni_home` runs all 4 checks, no crash
- [x] Smoke test: `run_contract_sweep.py --omni-home omni_home --mode drift` detects drift across repos