### PR TITLE
feat(deploy-agent): add compose_gen phase — regenerate compose from catalog on every deploy [OMN-8430]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -538,4 +538,3 @@ node_validation_executor = "omnibase_infra.nodes.node_validation_executor"
 node_validation_ledger_projection_compute = "omnibase_infra.nodes.node_validation_ledger_projection_compute"
 node_validation_orchestrator = "omnibase_infra.nodes.node_validation_orchestrator"
 node_vector_store_effect = "omnibase_infra.nodes.node_vector_store_effect"
-

--- a/scripts/check_llm_endpoints.sh
+++ b/scripts/check_llm_endpoints.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
 # check_llm_endpoints.sh — probe all known LLM inference endpoints.
 # Exits 0 if all required endpoints are healthy, non-zero otherwise.
 #

--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -18,7 +18,7 @@ from deploy_agent.events import (
     Phase,
     PhaseStatus,
 )
-from deploy_agent.executor import DeployExecutor
+from deploy_agent.executor import SCOPE_BUNDLES, DeployExecutor
 from deploy_agent.health import create_health_app
 from deploy_agent.job_state import JobStore
 from deploy_agent.publisher import build_completion_payload, publish_result
@@ -132,6 +132,12 @@ class DeployAgent:
             # Git pull
             self._current_git_sha = self.executor.git_pull(
                 cmd.git_ref, on_phase_update=on_phase_update
+            )
+
+            # Regenerate compose from catalog (non-fatal — logs warning on failure)
+            self.executor.compose_gen(
+                SCOPE_BUNDLES.get(cmd.scope, ["core", "runtime"]),
+                on_phase_update=on_phase_update,
             )
 
             # Seed Infisical before containers start (non-fatal)

--- a/scripts/deploy-agent/deploy_agent/events.py
+++ b/scripts/deploy-agent/deploy_agent/events.py
@@ -24,6 +24,7 @@ class Scope(StrEnum):
 class Phase(StrEnum):
     PREFLIGHT = "preflight"
     GIT = "git"
+    COMPOSE_GEN = "compose_gen"
     SEED = "seed"
     CORE = "core"
     RUNTIME = "runtime"

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -18,6 +18,14 @@ from deploy_agent.events import (
     services_for_scope,
 )
 
+# Maps deploy scope to catalog bundle names used by compose_gen.
+# Scope.FULL regenerates both core and runtime bundles.
+SCOPE_BUNDLES: dict[Scope, list[str]] = {
+    Scope.CORE: ["core"],
+    Scope.RUNTIME: ["core", "runtime"],
+    Scope.FULL: ["core", "runtime"],
+}
+
 logger = logging.getLogger(__name__)
 
 REPO_DIR = "/data/omninode/omnibase_infra"
@@ -27,6 +35,7 @@ COMPOSE_PROJECT = "omnibase-infra"
 PHASE_TIMEOUTS = {
     Phase.PREFLIGHT: 30,
     Phase.GIT: 60,
+    Phase.COMPOSE_GEN: 120,
     Phase.CORE: 300,
     Phase.RUNTIME: 300,
     Phase.VERIFICATION: 120,
@@ -102,6 +111,48 @@ class DeployExecutor:
 
         on_phase_update(Phase.GIT, PhaseStatus.SUCCESS)
         return sha
+
+    def compose_gen(self, bundles: list[str], on_phase_update: PhaseCallback) -> None:
+        """Regenerate docker-compose.infra.yml from the catalog CLI.
+
+        Runs ``uv run python -m omnibase_infra.docker.catalog.cli generate
+        <bundles> --output <COMPOSE_FILE>`` so every deploy reflects the current
+        catalog state rather than a static snapshot. This closes the drift window
+        where catalog changes (e.g. new LLM_* env vars) were merged but never
+        landed in the running containers (OMN-8430).
+
+        Non-fatal if the catalog CLI binary is unavailable — logs a warning and
+        continues so that a missing virtualenv does not block a deploy entirely.
+        """
+        on_phase_update(Phase.COMPOSE_GEN, PhaseStatus.IN_PROGRESS)
+        timeout = PHASE_TIMEOUTS[Phase.COMPOSE_GEN]
+
+        selected = bundles if bundles else ["core", "runtime"]
+        cmd = [
+            "uv",
+            "run",
+            "--project",
+            REPO_DIR,
+            "python",
+            "-m",
+            "omnibase_infra.docker.catalog.cli",
+            "generate",
+            *selected,
+            "--output",
+            COMPOSE_FILE,
+        ]
+
+        result = _run(cmd, timeout=timeout, cwd=REPO_DIR)
+        if result.returncode != 0:
+            logger.warning(
+                "compose_gen returned non-zero (exit=%d) — continuing with existing compose file. stderr: %s",
+                result.returncode,
+                result.stderr[:500],
+            )
+        else:
+            logger.info("compose_gen complete: %s", result.stdout.strip())
+
+        on_phase_update(Phase.COMPOSE_GEN, PhaseStatus.SUCCESS)
 
     def seed_infisical(self, on_phase_update: PhaseCallback) -> None:
         """Seed Infisical with required secrets before runtime containers start.

--- a/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the compose_gen phase added in OMN-8430.
+
+compose_gen must regenerate docker-compose.infra.yml from the catalog CLI on
+every deploy so that catalog changes (e.g. new LLM_* env vars) are reflected
+in the running containers immediately after the next redeploy — not silently
+skipped because the static compose file is never updated.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from deploy_agent.events import Phase, PhaseStatus, Scope
+from deploy_agent.executor import SCOPE_BUNDLES, DeployExecutor
+
+
+def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
+    pass
+
+
+def _make_result(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestComposeGen:
+    """compose_gen must invoke catalog CLI and write to COMPOSE_FILE."""
+
+    def test_compose_gen_calls_catalog_cli(self) -> None:
+        """compose_gen must invoke uv run python -m omnibase_infra.docker.catalog.cli generate."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(["core", "runtime"], _noop_phase_update)
+
+        assert captured_cmds, "Expected compose_gen to call _run at least once"
+        cmd = captured_cmds[0]
+
+        assert "python" in cmd, f"Expected 'python' in cmd, got: {cmd}"
+        assert "-m" in cmd, f"Expected '-m' in cmd, got: {cmd}"
+        assert "omnibase_infra.docker.catalog.cli" in cmd, (
+            f"Expected catalog CLI module in cmd, got: {cmd}"
+        )
+        assert "generate" in cmd, f"Expected 'generate' subcommand in cmd, got: {cmd}"
+
+    def test_compose_gen_passes_bundles(self) -> None:
+        """compose_gen must pass the provided bundle names to the catalog CLI."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(["core", "runtime"], _noop_phase_update)
+
+        cmd = captured_cmds[0]
+        assert "core" in cmd, f"Expected 'core' bundle in cmd, got: {cmd}"
+        assert "runtime" in cmd, f"Expected 'runtime' bundle in cmd, got: {cmd}"
+
+    def test_compose_gen_writes_to_compose_file(self) -> None:
+        """compose_gen must pass --output pointing to COMPOSE_FILE."""
+        from deploy_agent.executor import COMPOSE_FILE
+
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(["core", "runtime"], _noop_phase_update)
+
+        cmd = captured_cmds[0]
+        assert "--output" in cmd, f"Expected --output flag in cmd, got: {cmd}"
+        output_idx = cmd.index("--output") + 1
+        assert cmd[output_idx] == COMPOSE_FILE, (
+            f"Expected --output {COMPOSE_FILE!r}, got {cmd[output_idx]!r}"
+        )
+
+    def test_compose_gen_succeeds_on_catalog_cli_failure(self) -> None:
+        """compose_gen must not raise even when the catalog CLI exits non-zero (non-fatal)."""
+        executor = DeployExecutor()
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            return _make_result(returncode=1, stderr="catalog CLI failed")
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            # Must not raise
+            executor.compose_gen(["core", "runtime"], _noop_phase_update)
+
+    def test_compose_gen_emits_in_progress_then_success(self) -> None:
+        """compose_gen must call on_phase_update with IN_PROGRESS then SUCCESS."""
+        executor = DeployExecutor()
+        phase_updates: list[tuple[Phase, PhaseStatus]] = []
+
+        def track_updates(phase: Phase, status: PhaseStatus) -> None:
+            phase_updates.append((phase, status))
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(["core", "runtime"], track_updates)
+
+        assert (
+            Phase.COMPOSE_GEN,
+            PhaseStatus.IN_PROGRESS,
+        ) in phase_updates, "Expected IN_PROGRESS update for COMPOSE_GEN"
+        assert (
+            Phase.COMPOSE_GEN,
+            PhaseStatus.SUCCESS,
+        ) in phase_updates, "Expected SUCCESS update for COMPOSE_GEN"
+
+    def test_scope_bundles_covers_all_scopes(self) -> None:
+        """SCOPE_BUNDLES must have an entry for every Scope value."""
+        for scope in Scope:
+            assert scope in SCOPE_BUNDLES, (
+                f"SCOPE_BUNDLES is missing entry for Scope.{scope}"
+            )
+
+    @pytest.mark.parametrize(
+        ("scope", "expected_bundles"),
+        [
+            (Scope.CORE, ["core"]),
+            (Scope.RUNTIME, ["core", "runtime"]),
+            (Scope.FULL, ["core", "runtime"]),
+        ],
+    )
+    def test_scope_bundles_values(
+        self, scope: Scope, expected_bundles: list[str]
+    ) -> None:
+        """SCOPE_BUNDLES must map each scope to the correct catalog bundle list."""
+        assert SCOPE_BUNDLES[scope] == expected_bundles, (
+            f"Scope.{scope} should map to {expected_bundles}, got {SCOPE_BUNDLES[scope]}"
+        )


### PR DESCRIPTION
## Summary

Closes the deploy-agent compose drift gap identified in OMN-8430.

- **Root cause**: deploy-agent hardcoded `COMPOSE_FILE = docker/docker-compose.infra.yml` and never regenerated it from the catalog. Catalog changes (e.g. `LLM_*` env vars added in #1227) merged but were silently invisible in running containers because the static compose was never updated.
- **Fix**: Add a `COMPOSE_GEN` phase (between `GIT` and `SEED`) that runs `uv run python -m omnibase_infra.docker.catalog.cli generate <bundles> --output <COMPOSE_FILE>` on every deploy. Non-fatal on failure — logs a warning and continues with the existing file.
- **Scope mapping**: `SCOPE_BUNDLES` dict maps each deploy `Scope` to the correct catalog bundle list (`core` → `["core"]`, `runtime`/`full` → `["core", "runtime"]`).

## Changes

| File | Change |
|------|--------|
| `deploy_agent/events.py` | Add `Phase.COMPOSE_GEN` between `GIT` and `SEED` |
| `deploy_agent/executor.py` | Add `SCOPE_BUNDLES` constant and `compose_gen()` method |
| `deploy_agent/agent.py` | Wire `compose_gen()` into `_execute_command` after `git_pull` |
| `tests/unit/test_executor_compose_gen.py` | 9 new unit tests covering all contract obligations |
| `scripts/check_llm_endpoints.sh` | Fix missing SPDX header (pre-existing, caught by hook) |
| `pyproject.toml` | Fix missing trailing newline (pre-existing, caught by hook) |

## Test plan

- [ ] All 17 unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] `ruff format` + `ruff check --fix` clean
- [ ] `pre-commit run --all-files` clean (all hooks pass)
- [ ] On next redeploy to .201, verify `docker exec omninode-runtime-effects env | grep LLM_` returns populated vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compose-generation phase to the deployment pipeline for infrastructure bundle configuration regeneration.

* **Chores**
  * Added SPDX license headers to deployment scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->