### PR TITLE
fix(runtime): revert ProtocolDomainPlugin to inline — omnibase_spi.protocols.runtime not published [OMN-8550]

### DIFF
--- a/src/omnibase_infra/runtime/protocol_domain_plugin.py
+++ b/src/omnibase_infra/runtime/protocol_domain_plugin.py
@@ -1,29 +1,153 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Domain plugin protocol and registry for kernel-level initialization hooks.
+"""Domain plugin protocol for kernel-level initialization hooks.
 
-ProtocolDomainPlugin, ModelDomainPluginConfig, and ModelDomainPluginResult
-are defined in omnibase_spi and re-exported here for backwards compatibility.
+This module defines the ProtocolDomainPlugin protocol, enabling domain-specific
+initialization to be decoupled from the generic runtime kernel. Domains (such as
+Registration, Intelligence, etc.) can implement this protocol to hook into the
+kernel bootstrap sequence.
 
-RegistryDomainPlugin lives here (it has runtime dependencies on infra models).
+Design Pattern:
+    The plugin pattern follows dependency inversion - the kernel depends on the
+    abstract ProtocolDomainPlugin protocol, not concrete implementations. Each
+    domain provides its own plugin that implements the protocol.
+
+    ```
+    +-------------------------------------------------------------+
+    |                        Kernel Layer                         |
+    |  +--------------------------------------------------------+ |
+    |  |  kernel.py                                             | |
+    |  |    - Discovers plugins via registry                    | |
+    |  |    - Calls plugin hooks during bootstrap               | |
+    |  |    - NO domain-specific code                           | |
+    |  +--------------------------------------------------------+ |
+    |                            |                                 |
+    |                            v                                 |
+    |  +--------------------------------------------------------+ |
+    |  |  ProtocolDomainPlugin (this file)                      | |
+    |  |    - Defines initialization hooks                      | |
+    |  |    - Plugin identification (plugin_id)                 | |
+    |  |    - Lifecycle hooks (initialize, wire_handlers, etc.) | |
+    |  +--------------------------------------------------------+ |
+    +-------------------------------------------------------------+
+                                 |
+              +------------------+------------------+
+              v                  v                  v
+    +-----------------+ +-----------------+ +-----------------+
+    |  Registration   | |  Intelligence   | |  Future Domain  |
+    |  Plugin         | |  Plugin         | |  Plugin         |
+    +-----------------+ +-----------------+ +-----------------+
+    ```
+
+Lifecycle Hooks:
+    Plugins are initialized in a specific order during kernel bootstrap:
+
+    1. `should_activate()` - Check if plugin should activate based on environment
+    2. `initialize()` - Create domain-specific resources (pools, connections)
+    3. `validate_handshake()` - Run prerequisite checks (B1-B3) before wiring
+    4. `wire_handlers()` - Register handlers in the container
+    5. `wire_dispatchers()` - Register dispatchers with MessageDispatchEngine
+    6. `start_consumers()` - Start event consumers
+    7. `shutdown()` - Clean up resources during kernel shutdown
 
 Plugin Discovery:
-    1. Explicit registration via RegistryDomainPlugin.register()
-    2. Entry-point discovery via RegistryDomainPlugin.discover_from_entry_points()
+    Plugins can be registered in two ways:
+
+    1. **Explicit registration** via ``RegistryDomainPlugin.register()``
+       - Clear, auditable plugin loading
+       - Easy testing with mock plugins
+       - Explicit registrations take precedence over discovered plugins
+
+    2. **Entry-point discovery** via ``RegistryDomainPlugin.discover_from_entry_points()``
+       - Uses ``importlib.metadata.entry_points()`` for PEP 621 discovery
+       - Namespace-based security: only trusted namespaces are loaded
+       - Deterministic ordering by entry-point name then value
+       - Duplicate plugin IDs are silently skipped (explicit wins)
+
+    Explicit registration always takes precedence on duplicate ``plugin_id``.
+    Entry-point discovery is security-gated by namespace allowlisting
+    (pre-import) and protocol validation (post-import).
+
+Example Implementation:
+    ```python
+    from omnibase_infra.runtime.protocol_domain_plugin import ProtocolDomainPlugin
+    from omnibase_infra.runtime.models import (
+        ModelDomainPluginConfig,
+        ModelDomainPluginResult,
+    )
+    from omnibase_infra.runtime.models.model_handshake_result import (
+        ModelHandshakeResult,
+    )
+
+    class PluginMyDomain:
+        '''Domain plugin for MyDomain.'''
+
+        @property
+        def plugin_id(self) -> str:
+            return "my-domain"
+
+        @property
+        def display_name(self) -> str:
+            return "My Domain"
+
+        def should_activate(self, config: ModelDomainPluginConfig) -> bool:
+            return bool(os.getenv("MY_DOMAIN_HOST"))
+
+        async def initialize(
+            self,
+            config: ModelDomainPluginConfig,
+        ) -> ModelDomainPluginResult:
+            # Create pools, connections, etc.
+            self._pool = await create_pool()
+            return ModelDomainPluginResult(
+                plugin_id=self.plugin_id,
+                success=True,
+                resources_created=["pool"],
+            )
+
+        async def validate_handshake(
+            self,
+            config: ModelDomainPluginConfig,
+        ) -> ModelHandshakeResult:
+            # Optional: run prerequisite checks before wiring
+            return ModelHandshakeResult.default_pass(self.plugin_id)
+
+        async def wire_handlers(
+            self,
+            config: ModelDomainPluginConfig,
+        ) -> ModelDomainPluginResult:
+            # Register handlers with container
+            await wire_my_domain_handlers(config.container, self._pool)
+            return ModelDomainPluginResult.succeeded(
+                plugin_id=self.plugin_id,
+                services_registered=["MyHandler"],
+            )
+
+        async def shutdown(
+            self,
+            config: ModelDomainPluginConfig,
+        ) -> ModelDomainPluginResult:
+            await self._pool.close()
+            return ModelDomainPluginResult.succeeded(plugin_id=self.plugin_id)
+    ```
 
 Related:
     - OMN-1346: Registration Code Extraction
     - OMN-888: Registration Orchestrator
-    - OMN-8550: Moved ProtocolDomainPlugin to omnibase_spi
 """
 
 from __future__ import annotations
 
 import logging
 from importlib.metadata import entry_points
+from typing import Protocol, runtime_checkable
 
 from omnibase_infra.runtime.constants_security import (
     DOMAIN_PLUGIN_ENTRY_POINT_GROUP,
+)
+from omnibase_infra.runtime.models import (
+    ModelDomainPluginConfig,
+    ModelDomainPluginResult,
 )
 from omnibase_infra.runtime.models.model_handshake_result import (
     ModelHandshakeResult,
@@ -37,14 +161,278 @@ from omnibase_infra.runtime.models.model_plugin_discovery_report import (
 from omnibase_infra.runtime.models.model_security_config import ModelSecurityConfig
 from omnibase_infra.utils.util_error_sanitization import sanitize_error_message
 
-# Re-exported from omnibase_spi for backwards compatibility (OMN-8550)
-from omnibase_spi.protocols.runtime.protocol_domain_plugin import (
-    ModelDomainPluginConfig,
-    ModelDomainPluginResult,
-    ProtocolDomainPlugin,
-)
-
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ProtocolDomainPlugin(Protocol):
+    """Protocol for domain-specific initialization plugins.
+
+    Domain plugins implement this protocol to hook into the kernel bootstrap
+    sequence. Each plugin is responsible for initializing its domain-specific
+    resources, wiring handlers, and cleaning up during shutdown.
+
+    The protocol uses duck typing - any class that implements these methods
+    can be used as a domain plugin without explicit inheritance.
+
+    Thread Safety:
+        Plugin implementations should be thread-safe if they maintain state.
+        The kernel calls plugin methods sequentially during bootstrap, but
+        plugins may be accessed concurrently during runtime.
+
+    Lifecycle Order:
+        1. should_activate() - Check environment/config
+        2. initialize() - Create pools, connections
+        3. validate_handshake() - Run prerequisite checks (optional, default pass)
+        4. wire_handlers() - Register handlers in container
+        5. wire_dispatchers() - Register with dispatch engine (optional)
+        6. start_consumers() - Start event consumers (optional)
+        7. shutdown() - Clean up during kernel shutdown
+
+    Optional Methods:
+        ``validate_handshake()`` is **not** part of this Protocol definition
+        because it is optional. Plugins that implement it will be detected at
+        runtime via ``hasattr()`` in the kernel. Plugins that omit it pass
+        the handshake gate by default.
+
+        This design avoids a ``@runtime_checkable`` pitfall: if an optional
+        method were declared in the Protocol, ``isinstance()`` checks in
+        entry-point discovery would reject plugins that omit it.
+
+    Example:
+        ```python
+        class PluginMyDomain:
+            @property
+            def plugin_id(self) -> str:
+                return "my-domain"
+
+            def should_activate(self, config: ModelDomainPluginConfig) -> bool:
+                return bool(os.getenv("MY_DOMAIN_ENABLED"))  # ONEX_FLAG_EXEMPT: docstring example
+
+            async def initialize(
+                self, config: ModelDomainPluginConfig
+            ) -> ModelDomainPluginResult:
+                # Initialize domain resources
+                return ModelDomainPluginResult.succeeded("my-domain")
+
+            async def validate_handshake(
+                self, config: ModelDomainPluginConfig
+            ) -> ModelHandshakeResult:
+                # Optional: run prerequisite checks
+                return ModelHandshakeResult.default_pass("my-domain")
+
+            # ... other methods
+        ```
+    """
+
+    @property
+    def plugin_id(self) -> str:
+        """Return unique identifier for this plugin.
+
+        The plugin_id is used for:
+        - Logging and diagnostics
+        - Plugin registry lookups
+        - Status reporting in kernel banner
+
+        Returns:
+            Unique string identifier (e.g., "registration", "intelligence").
+        """
+        ...
+
+    @property
+    def display_name(self) -> str:
+        """Return human-readable name for this plugin.
+
+        Used in logs and user-facing output.
+
+        Returns:
+            Display name (e.g., "Registration", "Intelligence").
+        """
+        ...
+
+    def should_activate(self, config: ModelDomainPluginConfig) -> bool:
+        """Check if this plugin should activate based on configuration.
+
+        Called during bootstrap to determine if the plugin should run.
+        Plugins can check environment variables, config values, or other
+        conditions to decide whether to activate.
+
+        Args:
+            config: Plugin configuration with container and event bus.
+
+        Returns:
+            True if the plugin should activate, False to skip.
+
+        Example:
+            ```python
+            def should_activate(self, config: ModelDomainPluginConfig) -> bool:
+                # Only activate if PostgreSQL is configured
+                return bool(os.getenv("OMNIBASE_INFRA_DB_URL"))
+            ```
+        """
+        ...
+
+    async def initialize(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Initialize domain-specific resources.
+
+        Called after should_activate() returns True. This method should
+        create any resources the domain needs (database pools, connections,
+        etc.).
+
+        Args:
+            config: Plugin configuration with container and event bus.
+
+        Returns:
+            Result indicating success/failure and resources created.
+
+        Example:
+            ```python
+            async def initialize(
+                self, config: ModelDomainPluginConfig
+            ) -> ModelDomainPluginResult:
+                self._pool = await asyncpg.create_pool(dsn)
+                return ModelDomainPluginResult.succeeded(
+                    "my-domain",
+                    resources_created=["postgres_pool"],
+                )
+            ```
+        """
+        ...
+
+    async def wire_handlers(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Register handlers with the container.
+
+        Called after initialize(). This method should register any
+        handlers the domain provides in the container's service registry.
+
+        Args:
+            config: Plugin configuration with container and event bus.
+
+        Returns:
+            Result indicating success/failure and services registered.
+
+        Example:
+            ```python
+            async def wire_handlers(
+                self, config: ModelDomainPluginConfig
+            ) -> ModelDomainPluginResult:
+                summary = await wire_my_handlers(config.container, self._pool)
+                return ModelDomainPluginResult.succeeded(
+                    "my-domain",
+                    services_registered=summary["services"],
+                )
+            ```
+        """
+        ...
+
+    async def wire_dispatchers(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Register dispatchers with MessageDispatchEngine (optional).
+
+        Called after wire_handlers(). This method should register any
+        dispatchers the domain provides with the dispatch engine.
+
+        Note: config.dispatch_engine may be None if no engine is configured.
+        Implementations should handle this gracefully.
+
+        Args:
+            config: Plugin configuration with dispatch_engine set.
+
+        Returns:
+            Result indicating success/failure and dispatchers registered.
+        """
+        ...
+
+    async def start_consumers(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Start event consumers (optional).
+
+        Called after wire_dispatchers(). This method should start any
+        event consumers the domain needs to process events from the bus.
+
+        Args:
+            config: Plugin configuration with container and event bus.
+
+        Returns:
+            Result with unsubscribe_callbacks for cleanup during shutdown.
+        """
+        ...
+
+    async def shutdown(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Clean up domain resources during kernel shutdown.
+
+        Called during kernel shutdown. This method should close pools,
+        connections, and any other resources created during initialize().
+
+        Shutdown Order (LIFO):
+            Plugins are shut down in **reverse activation order** (Last In, First Out).
+            This ensures plugins activated later are shut down before plugins they may
+            depend on. For example, if plugins A, B, C are activated in order, shutdown
+            order is C, B, A.
+
+        Self-Contained Constraint:
+            **CRITICAL**: Plugins MUST be self-contained during shutdown.
+
+            - Plugins MUST NOT depend on resources from other plugins during shutdown
+            - Each plugin should only clean up its own resources (pools, connections)
+            - If a plugin accesses shared resources, it must handle graceful degradation
+              in case those resources are already released by another plugin
+            - Shutdown errors in one plugin do not block other plugins from shutting down
+
+            This constraint exists because:
+            1. Shutdown order may change as plugins are added/removed
+            2. Other plugins may fail to initialize, leaving resources unavailable
+            3. Exception handling during shutdown should not cascade failures
+
+        Error Handling:
+            Implementations should catch and log errors rather than raising them.
+            The kernel will continue shutting down other plugins even if one fails.
+            Return a failed ModelDomainPluginResult to report errors without blocking.
+
+        Args:
+            config: Plugin configuration. Note that during cleanup after errors,
+                a minimal config may be passed instead of the original config.
+
+        Returns:
+            Result indicating success/failure of cleanup.
+
+        Example:
+            ```python
+            async def shutdown(
+                self, config: ModelDomainPluginConfig
+            ) -> ModelDomainPluginResult:
+                errors: list[str] = []
+
+                # Close pool - handle graceful degradation
+                if self._pool is not None:
+                    try:
+                        await self._pool.close()
+                    except Exception as e:
+                        errors.append(f"pool: {e}")
+                    self._pool = None  # Always clear reference
+
+                if errors:
+                    return ModelDomainPluginResult.failed(
+                        plugin_id=self.plugin_id,
+                        error_message="; ".join(errors),
+                    )
+                return ModelDomainPluginResult.succeeded(plugin_id=self.plugin_id)
+            ```
+        """
+        ...
 
 
 class RegistryDomainPlugin:
@@ -68,6 +456,31 @@ class RegistryDomainPlugin:
     Thread Safety:
         The registry is NOT thread-safe. Plugin registration should happen
         during startup before concurrent access.
+
+    Example:
+        ```python
+        from omnibase_infra.runtime.protocol_domain_plugin import (
+            RegistryDomainPlugin,
+        )
+        from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
+            ServiceRegistration,
+        )
+
+        # 1. Register first-party plugins explicitly
+        registry = RegistryDomainPlugin()
+        registry.register(ServiceRegistration())
+
+        # 2. Discover third-party plugins from entry_points
+        report = registry.discover_from_entry_points()
+        if report.has_errors:
+            logger.warning("Plugin discovery had errors: %s", report.rejected)
+
+        # 3. Activate all registered plugins
+        plugins = registry.get_all()
+        for plugin in plugins:
+            if plugin.should_activate(config):
+                await plugin.initialize(config)
+        ```
     """
 
     def __init__(self) -> None:
@@ -99,11 +512,22 @@ class RegistryDomainPlugin:
         )
 
     def get(self, plugin_id: str) -> ProtocolDomainPlugin | None:
-        """Get a plugin by ID."""
+        """Get a plugin by ID.
+
+        Args:
+            plugin_id: The plugin identifier.
+
+        Returns:
+            The plugin instance, or None if not found.
+        """
         return self._plugins.get(plugin_id)
 
     def get_all(self) -> list[ProtocolDomainPlugin]:
-        """Get all registered plugins."""
+        """Get all registered plugins.
+
+        Returns:
+            List of all registered plugin instances.
+        """
         return list(self._plugins.values())
 
     def clear(self) -> None:
@@ -123,27 +547,72 @@ class RegistryDomainPlugin:
     ) -> ModelPluginDiscoveryReport:
         """Discover and register plugins from PEP 621 entry points.
 
+        Scans the specified entry-point group for plugin classes, validates
+        them against the security namespace allowlist, instantiates them, and
+        registers any that satisfy the ``ProtocolDomainPlugin`` protocol.
+
+        Security is enforced **inside** this method. If ``security_config`` is
+        ``None``, a default ``ModelSecurityConfig()`` is used which blocks all
+        third-party namespaces. A bare call with no arguments is always secure.
+
+        Already-registered plugins (from explicit ``register()`` calls) take
+        precedence: if a discovered plugin has a ``plugin_id`` that already
+        exists in the registry, the discovered plugin is silently skipped and
+        recorded as ``"duplicate_skipped"`` in the report.
+
         Args:
             security_config: Security configuration controlling which
-                namespaces are trusted for plugin loading.
-            group: Entry-point group name to scan.
-            strict: When True, raise on the first import or instantiation error.
+                namespaces are trusted for plugin loading. Defaults to
+                ``ModelSecurityConfig()`` (only ``omnibase_core.`` and
+                ``omnibase_infra.`` are trusted).
+            group: Entry-point group name to scan. Defaults to
+                ``DOMAIN_PLUGIN_ENTRY_POINT_GROUP``
+                (``"onex.domain_plugins"``).
+            strict: When ``True``, raise on the first import or
+                instantiation error instead of recording it in the report.
+                When ``False`` (default), errors are logged and recorded
+                but processing continues.
 
         Returns:
-            A ModelPluginDiscoveryReport containing all discovery outcomes.
+            A ``ModelPluginDiscoveryReport`` containing all discovery
+            outcomes, including accepted, rejected, and errored entries.
 
         Raises:
-            ImportError: Only when strict=True and an entry point fails to load.
-            TypeError: Only when strict=True and a loaded class fails to instantiate.
-            RuntimeError: Only when strict=True and a loaded class does not satisfy
-                ProtocolDomainPlugin.
+            ImportError: Only when ``strict=True`` and an entry point
+                fails to load.
+            TypeError: Only when ``strict=True`` and a loaded class
+                fails to instantiate.
+            RuntimeError: Only when ``strict=True`` and a loaded class
+                does not satisfy ``ProtocolDomainPlugin``.
+
+        Example:
+            >>> registry = RegistryDomainPlugin()
+            >>> report = registry.discover_from_entry_points()
+            >>> for plugin_id in report.accepted:
+            ...     print(f"Registered: {plugin_id}")
+
+            >>> # With third-party plugins enabled
+            >>> config = ModelSecurityConfig(
+            ...     allow_third_party_plugins=True,
+            ...     allowed_plugin_namespaces=(
+            ...         "omnibase_core.",
+            ...         "omnibase_infra.",
+            ...         "mycompany.plugins.",
+            ...     ),
+            ... )
+            >>> report = registry.discover_from_entry_points(
+            ...     security_config=config,
+            ... )
         """
         if security_config is None:
             security_config = ModelSecurityConfig()
 
         allowed_namespaces = security_config.get_effective_plugin_namespaces()
 
+        # Retrieve entry points for the group
         eps = entry_points(group=group)
+
+        # Sort deterministically by name then value for reproducible ordering
         sorted_eps = sorted(eps, key=lambda ep: (ep.name, ep.value))
 
         entries: list[ModelPluginDiscoveryEntry] = []
@@ -152,6 +621,7 @@ class RegistryDomainPlugin:
         for ep in sorted_eps:
             module_path = self._parse_module_path(ep.value)
 
+            # Validate namespace BEFORE importing -- pre-import security
             if not self._validate_plugin_namespace(module_path, allowed_namespaces):
                 logger.info(
                     "Plugin entry point namespace rejected: %s (module: %s)",
@@ -171,6 +641,7 @@ class RegistryDomainPlugin:
                 )
                 continue
 
+            # Load the entry point (import and resolve attribute)
             try:
                 loaded_class = ep.load()
             except Exception as exc:
@@ -194,6 +665,7 @@ class RegistryDomainPlugin:
                     ) from exc
                 continue
 
+            # Instantiate the plugin (no-arg constructor)
             try:
                 plugin = loaded_class()
             except Exception as exc:
@@ -218,6 +690,7 @@ class RegistryDomainPlugin:
                     ) from exc
                 continue
 
+            # Protocol validation
             if not isinstance(plugin, ProtocolDomainPlugin):
                 class_name = getattr(loaded_class, "__name__", repr(loaded_class))
                 reason = f"Class '{class_name}' does not satisfy ProtocolDomainPlugin"
@@ -238,6 +711,7 @@ class RegistryDomainPlugin:
                     raise RuntimeError(f"Plugin from entry point '{ep.name}': {reason}")
                 continue
 
+            # Duplicate check -- explicit registrations win
             plugin_id = plugin.plugin_id
             if plugin_id in self._plugins:
                 logger.debug(
@@ -260,6 +734,7 @@ class RegistryDomainPlugin:
                 )
                 continue
 
+            # Register the plugin
             self._plugins[plugin_id] = plugin
             accepted.append(plugin_id)
             logger.debug(
@@ -303,19 +778,68 @@ class RegistryDomainPlugin:
         module_path: str,
         allowed_namespaces: tuple[str, ...],
     ) -> bool:
-        """Validate a module path against the allowed namespace prefixes."""
+        """Validate a module path against the allowed namespace prefixes.
+
+        Uses boundary-aware matching consistent with
+        ``HandlerPluginLoader._validate_namespace()``: a namespace prefix
+        ending with ``"."`` matches any submodule, while a prefix without a
+        trailing dot requires the next character to be ``"."`` or end-of-string
+        to prevent ``"foo"`` from matching ``"foobar.module"``.
+
+        Args:
+            module_path: Dotted module path to validate
+                (e.g. ``"omnibase_infra.plugins.my_plugin"``).
+            allowed_namespaces: Tuple of allowed namespace prefixes
+                (e.g. ``("omnibase_core.", "omnibase_infra.")``).
+
+        Returns:
+            ``True`` if the module path matches at least one allowed
+            namespace, ``False`` otherwise.
+
+        Example:
+            >>> RegistryDomainPlugin._validate_plugin_namespace(
+            ...     "omnibase_infra.plugins.foo",
+            ...     ("omnibase_core.", "omnibase_infra."),
+            ... )
+            True
+            >>> RegistryDomainPlugin._validate_plugin_namespace(
+            ...     "malicious.module",
+            ...     ("omnibase_core.", "omnibase_infra."),
+            ... )
+            False
+        """
         for namespace in allowed_namespaces:
             if module_path.startswith(namespace):
+                # Namespace ends with "." -- already at package boundary
                 if namespace.endswith("."):
                     return True
-                remaining = module_path[len(namespace):]
+                # Otherwise ensure we are at a package boundary
+                remaining = module_path[len(namespace) :]
                 if remaining == "" or remaining.startswith("."):
                     return True
         return False
 
     @staticmethod
     def _parse_module_path(entry_point_value: str) -> str:
-        """Extract the module path from an entry-point value string."""
+        """Extract the module path from an entry-point value string.
+
+        Entry-point values follow the format ``"module.path:ClassName"``.
+        This method returns the part before the colon.
+
+        Args:
+            entry_point_value: Entry-point value string
+                (e.g. ``"omnibase_infra.plugins.foo:PluginFoo"``).
+
+        Returns:
+            The dotted module path
+            (e.g. ``"omnibase_infra.plugins.foo"``).
+
+        Example:
+            >>> RegistryDomainPlugin._parse_module_path(
+            ...     "omnibase_infra.plugins.foo:PluginFoo"
+            ... )
+            'omnibase_infra.plugins.foo'
+        """
         if ":" in entry_point_value:
             return entry_point_value.split(":", 1)[0]
         return entry_point_value

--- a/tests/integration/nodes/test_node_baseline_capture_effect.py
+++ b/tests/integration/nodes/test_node_baseline_capture_effect.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Integration tests for HandlerBaselineCapture (OMN-7484).
+
+Validates the baseline capture handler contract:
+  - Returns ModelBaselineCaptureOutput with correct fields
+  - D3: no snapshot emitted when measurements_captured == 0
+  - D3: snapshot emitted when measurements_captured > 0
+  - D2: lookback_hours capped at 168
+
+Tests use a mock asyncpg pool (no live DB required in CI). Tests that require
+a live PostgreSQL instance are gated on POSTGRES_INTEGRATION_TESTS=1.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.nodes.node_baseline_capture.handlers.handler_baseline_capture import (
+    HandlerBaselineCapture,
+)
+from omnibase_infra.nodes.node_baseline_capture.models.model_baseline_capture_command import (
+    ModelBaselineCaptureCommand,
+)
+from omnibase_infra.nodes.node_baseline_capture.models.model_baseline_capture_output import (
+    ModelBaselineCaptureOutput,
+)
+
+POSTGRES_AVAILABLE = os.getenv("POSTGRES_INTEGRATION_TESTS") == "1"
+
+
+def _make_mock_pool(
+    total_count: int = 0,
+    agent_rows: list[dict] | None = None,
+) -> MagicMock:
+    """Build a mock asyncpg pool that returns configurable query results."""
+    rows = agent_rows or []
+
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[_make_agent_row(r) for r in rows])
+    mock_conn.fetchrow = AsyncMock(return_value={"total": total_count})
+
+    mock_pool = MagicMock()
+    mock_pool.acquire = MagicMock()
+    mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+    return mock_pool
+
+
+def _make_agent_row(data: dict) -> MagicMock:
+    row = MagicMock()
+    row.__getitem__ = lambda self, key: data[key]
+    return row
+
+
+class TestHandlerBaselineCaptureContract:
+    """Verify the handler satisfies its DoD contract (mock pool — CI safe)."""
+
+    @pytest.mark.anyio
+    async def test_returns_model_baseline_capture_output(self) -> None:
+        pool = _make_mock_pool(total_count=0)
+        handler = HandlerBaselineCapture(pool=pool)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4())
+
+        result = await handler.handle(cmd)
+
+        assert isinstance(result, ModelBaselineCaptureOutput)
+
+    @pytest.mark.anyio
+    async def test_d3_no_snapshot_when_no_measurements(self) -> None:
+        """D3: snapshot_emitted must be False when measurements_captured == 0."""
+        publisher = AsyncMock(return_value=True)
+        pool = _make_mock_pool(total_count=0)
+        handler = HandlerBaselineCapture(pool=pool, publisher=publisher)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4())
+
+        result = await handler.handle(cmd)
+
+        assert result.measurements_captured == 0
+        assert result.snapshot_emitted is False
+        publisher.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_d3_snapshot_emitted_when_measurements_present(self) -> None:
+        """D3: snapshot_emitted must be True when measurements_captured > 0."""
+        now = datetime.now(UTC)
+        agent_rows = [
+            {
+                "pattern_id": uuid4(),
+                "pattern_label": "test-agent",
+                "sample_count": 5,
+                "avg_latency_ms": 120.0,
+                "total_tokens": 1000,
+                "avg_tokens": 200.0,
+                "success_count": 5,
+                "treatment_count": 5,
+                "control_count": 0,
+                "computed_at": now,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ]
+        publisher = AsyncMock(return_value=True)
+        pool = _make_mock_pool(total_count=5, agent_rows=agent_rows)
+        handler = HandlerBaselineCapture(pool=pool, publisher=publisher)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4())
+
+        result = await handler.handle(cmd)
+
+        assert result.measurements_captured == 5
+        assert result.snapshot_emitted is True
+        publisher.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_d2_lookback_capped_at_168_hours(self) -> None:
+        """D2: lookback_hours values above 168 must be clamped to 168."""
+        pool = _make_mock_pool(total_count=0)
+        handler = HandlerBaselineCapture(pool=pool)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4(), lookback_hours=999)
+
+        # Patch datetime.now to capture the `since` value passed to the query
+        captured_since: list[datetime] = []
+        original_fetchrow = pool.acquire.return_value.__aenter__.return_value.fetchrow
+
+        async def capture_fetchrow(sql: str, since: datetime) -> dict:
+            captured_since.append(since)
+            return {"total": 0}
+
+        pool.acquire.return_value.__aenter__.return_value.fetchrow = capture_fetchrow
+
+        await handler.handle(cmd)
+
+        assert captured_since, "fetchrow should have been called"
+        from datetime import timedelta
+
+        expected_max_window = timedelta(hours=168)
+        actual_window = datetime.now(UTC) - captured_since[0]
+        assert actual_window <= expected_max_window + timedelta(seconds=5)
+
+    @pytest.mark.anyio
+    async def test_no_publisher_no_emit(self) -> None:
+        """When no publisher is provided, snapshot_emitted is always False."""
+        pool = _make_mock_pool(total_count=10)
+        handler = HandlerBaselineCapture(pool=pool, publisher=None)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4())
+
+        result = await handler.handle(cmd)
+
+        assert result.snapshot_emitted is False
+
+    @pytest.mark.anyio
+    async def test_db_error_captured_in_errors_tuple(self) -> None:
+        """DB errors must be captured in result.errors, not raised."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(side_effect=RuntimeError("db connection lost"))
+        mock_conn.fetchrow = AsyncMock(side_effect=RuntimeError("db connection lost"))
+
+        mock_pool = MagicMock()
+        mock_pool.acquire = MagicMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        handler = HandlerBaselineCapture(pool=mock_pool)
+        cmd = ModelBaselineCaptureCommand(correlation_id=uuid4())
+
+        result = await handler.handle(cmd)
+
+        assert result.measurements_captured == 0
+        assert result.snapshot_emitted is False
+        assert len(result.errors) > 0
+
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary

- Reverts OMN-8550 re-export of ProtocolDomainPlugin from omnibase_spi — the `omnibase_spi.protocols.runtime` subpackage does not exist in the published PyPI package (0.20.4)
- This ModuleNotFoundError broke main CI (Lint, Topic Enum Drift, Fingerprint Check, Topic Drift, ONEX Validators all failing)
- Restores inline ProtocolDomainPlugin definition until omnibase_spi ships the runtime subpackage

## Root Cause

PR#1249 (OMN-8550) added `from omnibase_spi.protocols.runtime.protocol_domain_plugin import ...` but the corresponding code was never added to the omnibase_spi source repo and never published. Every import of `omnibase_infra` cascades to this missing module, breaking CI-wide.

## Correct Migration Path

1. Add `src/omnibase_spi/protocols/runtime/protocol_domain_plugin.py` to omnibase_spi
2. Publish omnibase_spi >= 0.21.0 to PyPI
3. Re-apply the omnibase_infra re-export from OMN-8550

## Test Plan

- [ ] Lint passes (ruff format + ruff check)
- [ ] Circular import check passes locally
- [ ] Topic Enum Drift Check passes in CI
- [ ] Fingerprint Check passes in CI
- [ ] All CI gates green