### PR TITLE
fix(infra): increase AUTOHEAL_START_PERIOD to 1500s for worker health window [OMN-7235]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -676,12 +676,10 @@ services:
   # ONEX Runtime - Workers (Runtime Profile)
   # ==========================================================================
   # Scalable worker containers for parallel compute operations.
-  # OMN-5095: Workers have an extended start_period (600s) and retries (5)
-  # because plugin initialization (intelligence DB ownership, schema fingerprint,
-  # message type registration) must complete before /health returns 200.
+  # OMN-7235: Workers have an extended start_period (1200s) and retries (5) because
+  # ~166 Kafka consumer groups are joined sequentially at startup (~15+ min total).
   # Unhealthy detection latency = start_period + (interval * retries) = 1200s + 150s = 1350s.
-  # AUTOHEAL_START_PERIOD must exceed start_period + retry window to avoid premature restarts.
-  # Workers wire ~166 Kafka consumers at startup (~15+ min), so 1200s start_period is needed.
+  # AUTOHEAL_START_PERIOD (1500s) exceeds this window to prevent premature restarts.
   # OMN-7569: Default replicas=0 — workers join the same per-topic consumer groups
   # as the main runtime on 1-partition topics, causing a constant rebalance storm.
   # Scale to 0 until the kernel supports profile-based subscription filtering.
@@ -1105,10 +1103,10 @@ services:
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: 60
-      # OMN-5095: Set to 840s (720s worker unhealthy window + 120s buffer) to avoid
-      # race condition where autoheal could trigger during a worker's initial health
-      # assessment. Workers need up to 600s start_period + 5×30s retries = 750s max.
-      AUTOHEAL_START_PERIOD: 840
+      # OMN-7235: Set to 1500s to exceed worker unhealthy detection window.
+      # Workers: start_period=1200s + retries=5×interval=30s = 1350s max.
+      # 1500s = 1350s + 150s buffer to prevent premature autoheal restarts.
+      AUTOHEAL_START_PERIOD: 1500
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     logging: *logging-defaults

--- a/scripts/ci/run_compliance_sweep.py
+++ b/scripts/ci/run_compliance_sweep.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Standalone CI script: handler contract compliance sweep.
 
 Scans Python handler files for:
@@ -205,9 +207,7 @@ def sweep_repo(repo_root: Path, checks: list[str]) -> tuple[int, list[dict]]:
         if "logic-in-node" in checks and (
             "node.py" in handler_file.name or handler_file.name == "__init__.py"
         ):
-            findings.extend(
-                _check_logic_in_node(repo_name, rel_path, node_name, lines)
-            )
+            findings.extend(_check_logic_in_node(repo_name, rel_path, node_name, lines))
 
     return len(handler_files), findings
 
@@ -280,7 +280,7 @@ def main(argv: list[str] | None = None) -> int:
         all_findings.extend(findings)
 
     # Count by severity
-    severity_counts: dict[str, int] = {s: 0 for s in _SEVERITY_ORDER}
+    severity_counts: dict[str, int] = dict.fromkeys(_SEVERITY_ORDER, 0)
     for f in all_findings:
         sev = f["severity"].lower()
         severity_counts[sev] = severity_counts.get(sev, 0) + 1

--- a/scripts/ci/run_contract_sweep.py
+++ b/scripts/ci/run_contract_sweep.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Standalone CI script: contract sweep.
 
 Modes:
@@ -31,7 +33,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 DEFAULT_REPOS = [
@@ -131,6 +133,7 @@ def run_drift_mode(
                 text=True,
                 timeout=120,
                 cwd=str(change_control),
+                check=False,
             )
             drift_detected = proc.returncode == 1
             results.append(
@@ -279,7 +282,7 @@ def run_runtime_mode(omni_home: Path, full_verification: bool) -> dict:
             "error": f"omnibase_infra not found at {infra_path}",
         }
 
-    run_id = f"contract-sweep-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    run_id = f"contract-sweep-{datetime.now(tz=UTC).strftime('%Y%m%d-%H%M%S')}"
     cmd = ["uv", "run", "python", "-m", "omnibase_infra.verification.cli", "--json"]
     if not full_verification:
         cmd.append("--registration-only")
@@ -291,6 +294,7 @@ def run_runtime_mode(omni_home: Path, full_verification: bool) -> dict:
             text=True,
             timeout=120,
             cwd=str(infra_path),
+            check=False,
         )
     except FileNotFoundError:
         return {
@@ -395,7 +399,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: C901
+def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
     omni_home = Path(args.omni_home)

--- a/scripts/ci/run_duplication_sweep.py
+++ b/scripts/ci/run_duplication_sweep.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Standalone CI script: duplication sweep.
 
 Checks:
@@ -69,7 +71,9 @@ def check_d1_drizzle_tables(omni_home: Path) -> dict:
     }
 
     if duplicates:
-        detail = f"{len(duplicates)} duplicate table(s): {', '.join(sorted(duplicates))}"
+        detail = (
+            f"{len(duplicates)} duplicate table(s): {', '.join(sorted(duplicates))}"
+        )
         findings = [
             {
                 "table": name,
@@ -226,6 +230,7 @@ def check_d3_migration_conflicts(omni_home: Path) -> dict:
             capture_output=True,
             text=True,
             timeout=60,
+            check=False,
         )
         output = result.stdout + result.stderr
     except FileNotFoundError:
@@ -284,7 +289,7 @@ def check_d3_migration_conflicts(omni_home: Path) -> dict:
 
 
 def check_d4_model_collisions(omni_home: Path) -> dict:
-    """D4: Cross-repo model name collisions (class ModelXxx in multiple repos)."""
+    """D4: Cross-repo model name collisions (same Model class name defined in multiple repos)."""
     class_pattern = re.compile(r"^class\s+(Model[A-Z]\w*)")
     model_locations: dict[str, list[dict]] = {}
 
@@ -312,9 +317,7 @@ def check_d4_model_collisions(omni_home: Path) -> dict:
             except (OSError, UnicodeDecodeError):
                 continue
 
-    duplicates = {
-        name: locs for name, locs in model_locations.items() if len(locs) > 1
-    }
+    duplicates = {name: locs for name, locs in model_locations.items() if len(locs) > 1}
 
     if duplicates:
         findings = [

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_clean.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_clean.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
 # clean handler — no violations
 def process(data):
     return data

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_foo.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_foo.py
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
 # handler with a hardcoded topic
 topic = "onex.evt.omniclaude.session-started.v1"

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_transport.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/handlers/handler_transport.py
@@ -1,4 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
 import httpx
+
 
 def fetch(url):
     return httpx.get(url)

--- a/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/node.py
+++ b/scripts/ci/tests/fixtures/compliance_repo/src/nodes/node_foo/node.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
 # node.py with business logic (LOGIC_IN_NODE)
 class MyProcessor:
     def handle(self):

--- a/scripts/ci/tests/fixtures/duplication_repo/omniclaude/src/omniclaude/hooks/topics.py
+++ b/scripts/ci/tests/fixtures/duplication_repo/omniclaude/src/omniclaude/hooks/topics.py
@@ -1,4 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
 from enum import StrEnum
+
 
 class TopicBase(StrEnum):
     SESSION_STARTED = "onex.evt.omniclaude.session-started.v1"

--- a/scripts/ci/tests/fixtures/duplication_repo/onex_change_control/src/onex_change_control/boundaries/kafka_boundaries.yaml
+++ b/scripts/ci/tests/fixtures/duplication_repo/onex_change_control/src/onex_change_control/boundaries/kafka_boundaries.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
 boundaries:
   - topic_name: onex.evt.omniclaude.session-started.v1
     producer_repo: omniclaude

--- a/scripts/ci/tests/test_sweep_clis.py
+++ b/scripts/ci/tests/test_sweep_clis.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Unit tests for run_compliance_sweep.py, run_duplication_sweep.py, run_contract_sweep.py."""
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ class TestComplianceSweep:
     def test_finds_hardcoded_topic(self):
         from run_compliance_sweep import sweep_repo
 
-        handlers_scanned, findings = sweep_repo(COMPLIANCE_REPO, ["hardcoded-topics"])
+        _, findings = sweep_repo(COMPLIANCE_REPO, ["hardcoded-topics"])
         hardcoded = [f for f in findings if f["violation_type"] == "HARDCODED_TOPIC"]
         assert len(hardcoded) >= 1
         assert any("onex.evt" in f["message"] for f in hardcoded)
@@ -36,7 +38,9 @@ class TestComplianceSweep:
         from run_compliance_sweep import sweep_repo
 
         _, findings = sweep_repo(COMPLIANCE_REPO, ["undeclared-transport"])
-        transport = [f for f in findings if f["violation_type"] == "UNDECLARED_TRANSPORT"]
+        transport = [
+            f for f in findings if f["violation_type"] == "UNDECLARED_TRANSPORT"
+        ]
         assert len(transport) >= 1
         assert any("httpx" in f["message"] for f in transport)
 
@@ -63,7 +67,9 @@ class TestComplianceSweep:
 
         from run_compliance_sweep import main
 
-        result = main(["--repo", str(tmp_path / "clean_repo"), "--checks", "hardcoded-topics"])
+        result = main(
+            ["--repo", str(tmp_path / "clean_repo"), "--checks", "hardcoded-topics"]
+        )
         assert result == 0
 
     def test_exit_1_on_findings(self):
@@ -201,8 +207,12 @@ class TestDuplicationSweep:
 
         shared = tmp_path / "omnidash" / "shared"
         shared.mkdir(parents=True)
-        (shared / "schema-a.ts").write_text('export const foo = pgTable("foo_table", {});\n')
-        (shared / "schema-b.ts").write_text('export const bar = pgTable("bar_table", {});\n')
+        (shared / "schema-a.ts").write_text(
+            'export const foo = pgTable("foo_table", {});\n'
+        )
+        (shared / "schema-b.ts").write_text(
+            'export const bar = pgTable("bar_table", {});\n'
+        )
         result = check_d1_drizzle_tables(tmp_path)
         assert result["status"] == "PASS"
 
@@ -221,7 +231,14 @@ class TestDuplicationSweep:
         from run_duplication_sweep import main
 
         result = main(
-            ["--omni-home", str(DUPLICATION_REPO), "--checks", "D1,D2", "--fail-on-severity", "error"]
+            [
+                "--omni-home",
+                str(DUPLICATION_REPO),
+                "--checks",
+                "D1,D2",
+                "--fail-on-severity",
+                "error",
+            ]
         )
         assert result == 1
 
@@ -276,13 +293,18 @@ class TestContractSweep:
 
         from run_contract_sweep import main
 
-        main([
-            "--omni-home", str(tmp_path),
-            "--repos", "nonexistent",
-            "--mode", "drift",
-            "--json",
-            "--no-check-boundaries",
-        ])
+        main(
+            [
+                "--omni-home",
+                str(tmp_path),
+                "--repos",
+                "nonexistent",
+                "--mode",
+                "drift",
+                "--json",
+                "--no-check-boundaries",
+            ]
+        )
         captured = capsys.readouterr()
         data = json_mod.loads(captured.out)
         assert data["sweep"] == "contract_sweep"
@@ -292,12 +314,17 @@ class TestContractSweep:
     def test_exit_0_when_clean(self, tmp_path):
         from run_contract_sweep import main
 
-        result = main([
-            "--omni-home", str(tmp_path),
-            "--repos", "nonexistent",
-            "--mode", "drift",
-            "--no-check-boundaries",
-        ])
+        result = main(
+            [
+                "--omni-home",
+                str(tmp_path),
+                "--repos",
+                "nonexistent",
+                "--mode",
+                "drift",
+                "--no-check-boundaries",
+            ]
+        )
         assert result == 0
 
     def test_missing_omni_home_returns_2(self):

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -125,7 +125,10 @@ class DeployExecutor:
         remote_sha = remote_result.stdout.strip()
 
         if local_sha == remote_sha:
-            logger.info("self_update: already at origin/main (%s), nothing to do", local_sha[:12])
+            logger.info(
+                "self_update: already at origin/main (%s), nothing to do",
+                local_sha[:12],
+            )
             return
 
         logger.info(
@@ -161,11 +164,13 @@ class DeployExecutor:
         mode = os.environ.get("DEPLOY_AGENT_MODE", "host")
         if mode == "container":
             # Let systemd/compose restart us from the freshly-pulled source.
-            logger.info("self_update: container mode — exiting with code 42 for supervisor respawn")
+            logger.info(
+                "self_update: container mode — exiting with code 42 for supervisor respawn"
+            )
             sys.exit(42)
         else:
             logger.info("self_update: host mode — re-execing process image")
-            os.execv(sys.executable, [sys.executable] + sys.argv)
+            os.execv(sys.executable, [sys.executable] + sys.argv)  # noqa: S606
 
     def preflight(self, on_phase_update: PhaseCallback) -> None:
         on_phase_update(Phase.PREFLIGHT, PhaseStatus.IN_PROGRESS)

--- a/scripts/deploy-agent/tests/unit/test_executor_self_update.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_self_update.py
@@ -14,7 +14,6 @@ import sys
 from unittest.mock import call, patch
 
 import pytest
-
 from deploy_agent.executor import DeployExecutor
 
 SHA_LOCAL = "aaaaaaaabbbbbbbb"
@@ -29,10 +28,14 @@ def _fail(stderr: str = "") -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
 
 
-def _make_git_responses(*, dirty: bool = False, local: str = SHA_LOCAL, remote: str = SHA_REMOTE):
+def _make_git_responses(
+    *, dirty: bool = False, local: str = SHA_LOCAL, remote: str = SHA_REMOTE
+):
     """Return a side_effect list for _run: status, fetch, rev-parse HEAD, rev-parse origin/main."""
 
-    def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+    def side_effect(
+        cmd: list[str], timeout: int, **kwargs
+    ) -> subprocess.CompletedProcess:
         if "status" in cmd and "--porcelain" in cmd:
             return _ok("M somefile.py" if dirty else "")
         if "fetch" in cmd:
@@ -69,7 +72,10 @@ class TestSelfUpdateDirtyTree:
     def test_dirty_tree_skips_update_without_execv(self) -> None:
         executor = DeployExecutor()
         with (
-            patch("deploy_agent.executor._run", side_effect=_make_git_responses(dirty=True)),
+            patch(
+                "deploy_agent.executor._run",
+                side_effect=_make_git_responses(dirty=True),
+            ),
             patch("os.execv") as mock_execv,
         ):
             executor.self_update()
@@ -80,7 +86,10 @@ class TestSelfUpdateCurrent:
     def test_already_current_does_not_execv(self) -> None:
         executor = DeployExecutor()
         with (
-            patch("deploy_agent.executor._run", side_effect=_make_git_responses(local=SHA_LOCAL, remote=SHA_LOCAL)),
+            patch(
+                "deploy_agent.executor._run",
+                side_effect=_make_git_responses(local=SHA_LOCAL, remote=SHA_LOCAL),
+            ),
             patch("os.execv") as mock_execv,
         ):
             executor.self_update()
@@ -110,7 +119,9 @@ class TestSelfUpdateBehind:
     def test_behind_fetch_failure_skips_execv(self) -> None:
         executor = DeployExecutor()
 
-        def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        def side_effect(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
             if "status" in cmd and "--porcelain" in cmd:
                 return _ok()
             if "fetch" in cmd:
@@ -127,7 +138,9 @@ class TestSelfUpdateBehind:
     def test_behind_pull_failure_skips_execv(self) -> None:
         executor = DeployExecutor()
 
-        def side_effect(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        def side_effect(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
             if "status" in cmd and "--porcelain" in cmd:
                 return _ok()
             if "fetch" in cmd:
@@ -194,6 +207,8 @@ class TestSelfUpdateWiredIntoRebuildScope:
         executor._compose_build = fake_build  # type: ignore[method-assign]
         executor._compose_up = fake_up  # type: ignore[method-assign]
 
-        executor.rebuild_scope(Scope.RUNTIME, [], lambda p, s: None, skip_self_update=True)
+        executor.rebuild_scope(
+            Scope.RUNTIME, [], lambda p, s: None, skip_self_update=True
+        )
 
         assert received_skip == [True]

--- a/scripts/generate_entry_points.py
+++ b/scripts/generate_entry_points.py
@@ -166,7 +166,9 @@ def _resolve_repo(repo_arg: str) -> tuple[Path, str]:
     if p.is_absolute() and p.is_dir():
         src = p / "src"
         if src.is_dir():
-            subdirs = [d for d in src.iterdir() if d.is_dir() and not d.name.startswith("_")]
+            subdirs = [
+                d for d in src.iterdir() if d.is_dir() and not d.name.startswith("_")
+            ]
             if subdirs:
                 return p, subdirs[0].name
         raise ValueError(

--- a/scripts/verify_error_triage_e2e.py
+++ b/scripts/verify_error_triage_e2e.py
@@ -730,7 +730,14 @@ def verify_service_kernel_wiring(report: VerificationReport) -> None:
     """Verify HandlerRuntimeErrorTriage is wired in service_kernel.py."""
     import pathlib
 
-    kernel_path = _OMNI_HOME / "omnibase_infra" / "src" / "omnibase_infra" / "runtime" / "service_kernel.py"
+    kernel_path = (
+        _OMNI_HOME
+        / "omnibase_infra"
+        / "src"
+        / "omnibase_infra"
+        / "runtime"
+        / "service_kernel.py"
+    )
     if not kernel_path.exists():
         report.add(
             VerificationResult(
@@ -865,7 +872,9 @@ def verify_migrations(report: VerificationReport) -> None:
     import pathlib
 
     # omnibase_infra migrations
-    infra_migrations = _OMNI_HOME / "omnibase_infra" / "docker" / "migrations" / "forward"
+    infra_migrations = (
+        _OMNI_HOME / "omnibase_infra" / "docker" / "migrations" / "forward"
+    )
     migration_055 = list(infra_migrations.glob("055_*"))
     report.add(
         VerificationResult(


### PR DESCRIPTION
## Summary

- **Root cause**: `AUTOHEAL_START_PERIOD` was 840s but the worker unhealthy detection window is 1350s (`start_period=1200s` + `retries=5 × interval=30s`). Autoheal was restarting workers before they finished joining ~166 Kafka consumer groups, causing perpetual "starting" state.
- **Fix**: Bumped `AUTOHEAL_START_PERIOD` from 840 to 1500s (1350s + 150s buffer), matching the correct math from the `runtime-worker` service comment.
- **Pre-existing cleanups**: Fixed `PLW1510` (missing `check=False` in `subprocess.run`), `RUF059` (unused variable), `S606` noqa, SPDX headers, and a stub detector false positive from `ModelXxx` docstring pattern.

## Test plan

- [ ] Pre-commit hooks all pass (verified locally)
- [ ] Catalog unit tests pass (`test_catalog_generator`, `test_catalog_completeness`, `test_catalog_resolver`)
- [ ] On next runtime deploy: verify `runtime-worker` containers reach "healthy" without autoheal restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SPDX copyright headers across CI scripts and test fixtures for licensing compliance.
  * Updated Docker Compose infrastructure timing configuration to adjust autoheal startup period from 840s to 1500s for improved health check coordination.

* **Refactor**
  * Simplified code formatting and structure across CI sweep tools and deployment utilities without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->