### PR TITLE
fix(tests): use rpk consumer lag check instead of log grep for dispatch evidence [OMN-7236]

### DIFF
--- a/tests/integration/test_dispatch_roundtrip.py
+++ b/tests/integration/test_dispatch_roundtrip.py
@@ -4,7 +4,7 @@
 
 Proves the event -> handler -> side-effect chain works end-to-end by:
 1. Publishing a node-introspection event to Kafka
-2. Verifying the registration orchestrator processes it (log evidence)
+2. Verifying consumer lag reaches 0 on the introspection topic (OMN-7236)
 3. Verifying the side-effect appears in PostgreSQL (registration projection)
 
 This is the single proof that Phase 1 (foundation) is solid: events flow
@@ -18,6 +18,7 @@ Related:
     - OMN-6995: Platform Subsystem Verification epic
     - OMN-6996: Runtime health integration test
     - OMN-6997: Node registration integration test
+    - OMN-7236: Replace log-grep evidence with rpk consumer lag check
 """
 
 from __future__ import annotations
@@ -32,7 +33,6 @@ import pytest
 
 # All config from env vars — no hardcoded values.
 KAFKA_BOOTSTRAP: str = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
-RUNTIME_CONTAINER: str = os.environ.get("ONEX_RUNTIME_CONTAINER", "omninode-runtime")
 POSTGRES_HOST: str = os.environ.get("POSTGRES_HOST", "localhost")
 POSTGRES_PORT: str = os.environ.get("POSTGRES_PORT", "5436")
 POSTGRES_DB: str = os.environ.get("POSTGRES_DB", "omnibase_infra")
@@ -66,16 +66,59 @@ def _publish_kafka_event(topic: str, event: dict[str, object]) -> None:
         producer.close(timeout=5)
 
 
-def _get_runtime_logs(since: str = "60s") -> str:
-    """Retrieve recent logs from the runtime container."""
+def _get_consumer_group_for_topic(topic: str) -> str | None:
+    """Find the consumer group subscribed to a given topic via rpk group list."""
     result = subprocess.run(
-        ["docker", "logs", "--since", since, RUNTIME_CONTAINER],
+        ["docker", "exec", "omnibase-infra-redpanda", "rpk", "group", "list"],
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=15,
         check=False,
     )
-    return result.stdout + result.stderr
+    if result.returncode != 0:
+        return None
+    groups = [
+        line.strip()
+        for line in result.stdout.strip().split("\n")
+        if line.strip() and "GROUP" not in line.upper()
+    ]
+    # Return first runtime-looking group; caller can refine if needed.
+    for g in groups:
+        if "runtime" in g.lower() or "local." in g.lower():
+            return g
+    return groups[0] if groups else None
+
+
+def _get_consumer_lag(group: str, topic: str) -> int | None:
+    """Return total LAG for a consumer group on a specific topic, or None on error."""
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "omnibase-infra-redpanda",
+            "rpk",
+            "group",
+            "describe",
+            group,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    total_lag = 0
+    found_topic = False
+    for line in result.stdout.splitlines():
+        # rpk output columns: TOPIC  PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG  ...
+        parts = line.split()
+        if len(parts) >= 5 and parts[0] == topic:
+            found_topic = True
+            lag_str = parts[4]
+            if lag_str.isdigit():
+                total_lag += int(lag_str)
+    return total_lag if found_topic else None
 
 
 def _query_postgres(query: str) -> str:
@@ -138,20 +181,22 @@ class TestDispatchRoundtrip:
         )
 
     def test_event_publish_produces_log_evidence(self) -> None:
-        """Publishing a test event to Kafka must produce log evidence in runtime.
+        """Publishing a test event to Kafka must be consumed (consumer lag reaches 0).
 
-        This test publishes a node-introspection event with a unique
-        correlation ID, then polls runtime logs for that correlation ID
-        to prove the dispatch engine received and routed the event.
+        Publishes a node-introspection event then polls rpk group describe until
+        the consumer group's LAG on the introspection topic returns to 0, proving
+        the dispatch engine received and processed the event (OMN-7236).
         """
-        correlation_id = f"test-dispatch-{uuid.uuid4().hex[:12]}"
+        group = _get_consumer_group_for_topic(INTROSPECTION_TOPIC)
+        if group is None:
+            pytest.skip(
+                "No runtime consumer groups found in Redpanda. "
+                "Is the runtime stack running?"
+            )
 
-        # Construct a minimal introspection-like event. The exact schema
-        # depends on the runtime's envelope format. We use a minimal payload
-        # that the dispatch engine will at least attempt to route.
         test_event: dict[str, object] = {
             "event_type": "node_introspection",
-            "correlation_id": correlation_id,
+            "correlation_id": f"test-dispatch-{uuid.uuid4().hex[:12]}",
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "payload": {
                 "source": "integration-test",
@@ -167,34 +212,22 @@ class TestDispatchRoundtrip:
         except Exception as exc:  # noqa: BLE001
             pytest.skip(f"Cannot publish to Kafka at {KAFKA_BOOTSTRAP}: {exc}")
 
-        # Poll runtime logs for the unique correlation ID.
-        # The dispatch engine logs correlation IDs for all processed events.
+        # Poll until consumer lag on the introspection topic returns to 0.
         deadline = time.time() + 30
+        last_lag: int | None = None
         while time.time() < deadline:
-            logs = _get_runtime_logs(since="60s")
-            if correlation_id in logs:
-                return  # Success — event was received and logged
+            lag = _get_consumer_lag(group, INTROSPECTION_TOPIC)
+            if lag is not None:
+                last_lag = lag
+                if lag == 0:
+                    return  # All published messages consumed — dispatch chain live
             time.sleep(2)
 
-        # If correlation ID not found, check if any dispatch activity occurred
-        # during our window (the event may have been routed but logged differently)
-        logs = _get_runtime_logs(since="60s")
-        dispatch_evidence = [
-            line
-            for line in logs.split("\n")
-            if "dispatch" in line.lower() or "introspection" in line.lower()
-        ]
-        if dispatch_evidence:
-            # Dispatch engine is alive but our specific event wasn't logged
-            # with the correlation ID. This is acceptable — the dispatch
-            # engine may use a different envelope format.
-            return
-
         pytest.fail(
-            f"Dispatch round-trip failed: event with correlation_id "
-            f"{correlation_id!r} not found in runtime logs within 30s, "
-            f"and no dispatch activity detected. "
-            f"Node dispatch layer may be dead."
+            f"Dispatch round-trip failed: consumer group {group!r} lag on "
+            f"{INTROSPECTION_TOPIC!r} did not reach 0 within 30s "
+            f"(last observed lag: {last_lag!r}). "
+            f"Node dispatch layer may be dead or not subscribed to this topic."
         )
 
     def test_kafka_consumer_groups_active(self) -> None:


### PR DESCRIPTION
## Summary

- Replaces non-deterministic log-grep assertion in `test_event_publish_produces_log_evidence` with `rpk group describe` consumer lag = 0 check
- Publishes introspection event then polls until the consumer group's LAG on the topic reaches 0 — the authoritative Kafka-side signal that the message was processed
- Removes unused `RUNTIME_CONTAINER` constant and `_get_runtime_logs` helper; adds `_get_consumer_group_for_topic` and `_get_consumer_lag` helpers

## Test plan

- [ ] `uv run pytest tests/integration/test_dispatch_roundtrip.py::TestDispatchRoundtrip::test_event_publish_produces_log_evidence -v` passes with runtime stack running
- [ ] Test skips gracefully when Redpanda is unreachable
- [ ] Test skips gracefully when no runtime consumer groups exist
- [ ] All pre-commit hooks pass (verified locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by replacing log-based validation with consumer lag monitoring for message delivery verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->