### PR TITLE
fix(infra): purge hardcoded localhost/paths [OMN-7226]

### DIFF
--- a/src/omnibase_infra/cli/infra_test/introspect.py
+++ b/src/omnibase_infra/cli/infra_test/introspect.py
@@ -19,11 +19,11 @@ import click
 from rich.console import Console
 
 from omnibase_infra.cli.infra_test._helpers import get_broker
+from omnibase_infra.enums.generated.enum_platform_topic import EnumPlatformTopic
 
 console = Console()
 
-# Default ONEX topic for introspection events (5-segment format)
-DEFAULT_INTROSPECTION_TOPIC = "onex.evt.platform.node-introspection.v1"
+DEFAULT_INTROSPECTION_TOPIC = EnumPlatformTopic.EVT_NODE_INTROSPECTION_V1.value
 
 
 def _build_introspection_payload(

--- a/src/omnibase_infra/cli/infra_test/introspect.py
+++ b/src/omnibase_infra/cli/infra_test/introspect.py
@@ -10,6 +10,7 @@ registration orchestrator workflow.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -80,7 +81,9 @@ def _build_introspection_payload(
         "declared_capabilities": {},
         "discovered_capabilities": {},
         "contract_capabilities": None,
-        "endpoints": {"health": f"http://localhost:8080/{nid}/health"},
+        "endpoints": {
+            "health": f"{os.environ.get('ONEX_RUNTIME_URL', 'http://localhost:8080')}/{nid}/health"
+        },
         "reason": "STARTUP",
         "correlation_id": cid,
         "timestamp": now,

--- a/src/omnibase_infra/projectors/snapshot_publisher_registration.py
+++ b/src/omnibase_infra/projectors/snapshot_publisher_registration.py
@@ -48,8 +48,8 @@ Example Usage:
     from omnibase_infra.projectors import SnapshotPublisherRegistration
     from omnibase_infra.models.projection import ModelSnapshotTopicConfig
 
-    # Create producer and config
-    producer = AIOKafkaProducer(bootstrap_servers="localhost:19092")
+    # Create producer and config (use KAFKA_BOOTSTRAP_SERVERS in production)
+    producer = AIOKafkaProducer(bootstrap_servers="localhost:19092")  # local-path-ok
     config = ModelSnapshotTopicConfig.default()
 
     # Initialize publisher

--- a/tests/integration/test_introspect_cli.py
+++ b/tests/integration/test_introspect_cli.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for the introspect CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_infra.cli.infra_test.cli import cli
+from omnibase_infra.enums.generated.enum_platform_topic import EnumPlatformTopic
+
+
+@pytest.mark.integration
+class TestIntrospectCLI:
+    """Integration tests for the introspect subcommand."""
+
+    def test_introspect_emits_to_canonical_topic(self) -> None:
+        """introspect publishes to the canonical EVT_NODE_INTROSPECTION_V1 topic."""
+        runner = CliRunner()
+        captured_args: list[list[str]] = []
+
+        def fake_run(args: list[str], **kwargs: object) -> MagicMock:
+            captured_args.append(args)
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch(
+            "omnibase_infra.cli.infra_test.introspect.subprocess.run",
+            side_effect=fake_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["introspect", "--broker", "localhost:19092"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured_args) == 1
+        rpk_args = captured_args[0]
+        expected_topic = EnumPlatformTopic.EVT_NODE_INTROSPECTION_V1.value
+        assert expected_topic in rpk_args, (
+            f"Expected topic {expected_topic!r} in rpk args {rpk_args}"
+        )
+
+    def test_introspect_topic_flag_overrides_default(self) -> None:
+        """--topic flag overrides the default topic but still invokes rpk."""
+        runner = CliRunner()
+        captured_args: list[list[str]] = []
+
+        def fake_run(args: list[str], **kwargs: object) -> MagicMock:
+            captured_args.append(args)
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        custom_topic = "onex.evt.platform.node-introspection.v2"
+        with patch(
+            "omnibase_infra.cli.infra_test.introspect.subprocess.run",
+            side_effect=fake_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["introspect", "--broker", "localhost:19092", "--topic", custom_topic],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert custom_topic in captured_args[0]
+
+    def test_introspect_rpk_failure_exits_nonzero(self) -> None:
+        """When rpk returns non-zero, the CLI exits with code 1."""
+        runner = CliRunner()
+
+        def fake_run(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 1
+            result.stderr = "connection refused"
+            return result
+
+        with patch(
+            "omnibase_infra.cli.infra_test.introspect.subprocess.run",
+            side_effect=fake_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["introspect", "--broker", "localhost:19092"],
+            )
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- `cli/infra_test/introspect.py`: replace hardcoded `http://localhost:8080/{nid}/health` with `os.environ.get("ONEX_RUNTIME_URL", "http://localhost:8080")/{nid}/health` — fixes finding #5
- `projectors/snapshot_publisher_registration.py`: annotate docstring example `localhost:19092` with `# local-path-ok` marker — finding #4

## Findings triaged

- Finding #4 (snapshot_publisher docstring): docstring example, annotated `local-path-ok`
- Finding #5 (introspect.py:83): **fixed** — now reads `ONEX_RUNTIME_URL` env var
- Findings #6/#7 (batch.py, orchestrator.py): already use `os.environ["ONEX_RUNTIME_TARGET"]` — clean
- Finding #8 (capability_probe.py): already uses `os.environ.get("INTELLIGENCE_URL", "")` — clean

## Test plan

- [ ] Pre-commit passes (all hooks green)
- [ ] mypy passes on changed files
- [ ] `introspect.py` respects `ONEX_RUNTIME_URL` env var when set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Health endpoint URL is now configurable via environment variable with a localhost fallback.
  * Default introspection publish topic updated to use the canonical platform topic value.

* **Documentation**
  * Clarified example deployment notes to recommend production Kafka bootstrap server configuration.

* **Tests**
  * Added integration tests validating CLI introspection topic behavior and nonzero exit on publish failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->