### PR TITLE
fix(savings): kafka config fallback + fail-loud [OMN-7837]

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1438,12 +1438,12 @@ async def bootstrap() -> int:
                     "Savings estimation consumer started (correlation_id=%s)",
                     correlation_id,
                 )
-            except Exception:  # noqa: BLE001 — best-effort, never blocks startup
-                logger.warning(
-                    "Failed to start savings estimation consumer, continuing "
-                    "without it (correlation_id=%s)",
+            except Exception:
+                logger.exception(
+                    "Failed to start savings estimation consumer — pipeline will write zero rows "
+                    "(correlation_id=%s). Check OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS "
+                    "or KAFKA_BOOTSTRAP_SERVERS env vars.",
                     correlation_id,
-                    exc_info=True,
                 )
                 savings_task = None
 

--- a/src/omnibase_infra/services/observability/savings_estimation/config.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/config.py
@@ -8,9 +8,10 @@ Related Tickets:
 
 from __future__ import annotations
 
+import os
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from omnibase_infra.topics import topic_keys
@@ -49,9 +50,20 @@ class ConfigSavingsEstimation(BaseSettings):
     )
 
     kafka_bootstrap_servers: str = Field(
-        ...,
-        description="Kafka bootstrap servers.",
+        default_factory=lambda: os.environ.get("KAFKA_BOOTSTRAP_SERVERS", ""),
+        description="Kafka bootstrap servers. Falls back to KAFKA_BOOTSTRAP_SERVERS env var.",
     )
+
+    @field_validator("kafka_bootstrap_servers")
+    @classmethod
+    def _require_bootstrap_servers(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError(
+                "kafka_bootstrap_servers is required. Set OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS "
+                "or KAFKA_BOOTSTRAP_SERVERS."
+            )
+        return v
+
     kafka_group_id: str = Field(
         default="savings-estimation",
         description="Consumer group ID for offset tracking.",

--- a/tests/unit/observability/test_savings_estimation_config.py
+++ b/tests/unit/observability/test_savings_estimation_config.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ConfigSavingsEstimation env-var fallback behavior. [OMN-7837]"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestSavingsEstimationConfig:
+    """Verify bootstrap-server env-var resolution and fail-loud behavior."""
+
+    def test_loads_from_fallback_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", raising=False
+        )
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker-fallback:9092")
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        cfg = ConfigSavingsEstimation()
+        assert cfg.kafka_bootstrap_servers == "broker-fallback:9092"
+
+    def test_prefix_wins_over_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", "broker-specific:9092"
+        )
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker-fallback:9092")
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        cfg = ConfigSavingsEstimation()
+        assert cfg.kafka_bootstrap_servers == "broker-specific:9092"
+
+    def test_loads_from_prefix_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", "broker-specific:9092"
+        )
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        cfg = ConfigSavingsEstimation()
+        assert cfg.kafka_bootstrap_servers == "broker-specific:9092"
+
+    def test_raises_when_neither_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", raising=False
+        )
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        with pytest.raises(ValidationError):
+            ConfigSavingsEstimation()
+
+    def test_raises_when_both_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", "")
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "")
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        with pytest.raises(ValidationError):
+            ConfigSavingsEstimation()


### PR DESCRIPTION
## Summary

- `ConfigSavingsEstimation.kafka_bootstrap_servers` now falls back to `KAFKA_BOOTSTRAP_SERVERS` (the standard env var every other consumer uses) when `OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS` is absent
- Added `@field_validator` that rejects empty strings — missing config now raises `ValidationError` immediately instead of silently passing an empty value downstream
- `service_kernel.py:1441` BLE001 catch upgraded from `logger.warning` → `logger.exception` so the full traceback surfaces at ERROR level; the silent fallthrough that hid this bug for weeks is gone

## Root Cause

Per probe-savings-deep chain-link analysis: the runtime container sets `KAFKA_BOOTSTRAP_SERVERS` for all other consumers but never set `OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS`. The savings consumer never initialized. The BLE001 catch at `service_kernel.py:1441` swallowed the `ValidationError` silently, resulting in zero rows written with no observable signal.

## Test Plan

- [x] 5 unit tests added: `tests/unit/observability/test_savings_estimation_config.py`
  - `KAFKA_BOOTSTRAP_SERVERS` only → loads correctly
  - `OMNIBASE_INFRA_SAVINGS_*` only → loads correctly (prefix wins)
  - Both set → prefix env var wins (pydantic default behavior)
  - Neither set → raises `ValidationError`
  - Both empty strings → raises `ValidationError`
- [x] All 5 tests pass
- [x] Pre-commit all checks pass
- [x] No hardcoded broker strings (hook `Reject hardcoded Kafka broker address fallbacks` passed)

## Ticket

OMN-7837 — do NOT merge without hostile reviewer sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error diagnostics for savings estimation startup failures with clearer guidance on configuration requirements.

* **Refactor**
  * Enhanced Kafka bootstrap server configuration with environment variable fallback support for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->