### PR TITLE
fix(ci): merge_group condition on contract-compliance [OMN-8664]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,7 +853,7 @@ jobs:
   contract-compliance:
     name: Contract Compliance Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - name: Checkout onex_change_control

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,7 +853,7 @@ jobs:
   contract-compliance:
     name: Contract Compliance Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v6
       - name: Checkout onex_change_control


### PR DESCRIPTION
## Summary

- Adds \`|| github.event_name == 'merge_group'\` to the \`contract-compliance\` job \`if:\` condition
- Fixes the cascade: skipped gate → skipped \`test\` → failed \`ci-summary\` → blocked queue

## Context

Epic: https://linear.app/omninode/issue/OMN-8664
Reference fix: OmniNode-ai/omnimemory#253 (already in review)

omnimemory#253 is the canonical reference fix for this pattern. This PR applies the identical change.

Note on omniclaude line 102: that is a step-level markdown detection condition, intentionally not changed.