### PR TITLE
fix: isolate env leakage in postgres config and ECR tag check [OMN-8605]

### DIFF
--- a/src/omnibase_infra/runtime/models/model_postgres_pool_config.py
+++ b/src/omnibase_infra/runtime/models/model_postgres_pool_config.py
@@ -27,7 +27,7 @@ class ModelPostgresPoolConfig(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     host: str = Field(
-        default_factory=lambda: os.environ["POSTGRES_HOST"],
+        default_factory=lambda: os.environ.get("POSTGRES_HOST", "localhost"),
         description="PostgreSQL host",
     )
     port: int = Field(default=5432, ge=1, le=65535, description="PostgreSQL port")

--- a/tests/integration/adapters/test_postgres_pool_config_defaults.py
+++ b/tests/integration/adapters/test_postgres_pool_config_defaults.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for ModelPostgresPoolConfig env-fallback behaviour.
+
+Verifies that the model returns sensible defaults when POSTGRES_HOST is absent,
+exercising the os.environ.get fallback added in OMN-8605.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.models.model_postgres_pool_config import (
+    ModelPostgresPoolConfig,
+)
+
+
+def test_defaults_without_postgres_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ModelPostgresPoolConfig should fall back to 'localhost' when POSTGRES_HOST is unset."""
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    config = ModelPostgresPoolConfig(database="testdb")
+
+    assert config.host == "localhost"
+    assert config.port == 5432
+    assert config.user == "postgres"
+    assert config.database == "testdb"
+    assert config.min_size == 2
+    assert config.max_size == 10
+
+
+def test_host_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ModelPostgresPoolConfig should use POSTGRES_HOST when set."""
+    monkeypatch.setenv("POSTGRES_HOST", "db.internal")
+
+    config = ModelPostgresPoolConfig(database="testdb")
+
+    assert config.host == "db.internal"

--- a/tests/integration/adapters/test_postgres_pool_config_defaults.py
+++ b/tests/integration/adapters/test_postgres_pool_config_defaults.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from omnibase_infra.runtime.models.model_postgres_pool_config import (
     ModelPostgresPoolConfig,
 )

--- a/tests/unit/runtime/test_dependency_materializer.py
+++ b/tests/unit/runtime/test_dependency_materializer.py
@@ -174,7 +174,8 @@ class TestEnumInfraResourceType:
 class TestModelPostgresPoolConfig:
     """Tests for PostgreSQL pool configuration."""
 
-    def test_default_values(self) -> None:
+    def test_default_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
         config = ModelPostgresPoolConfig(database="testdb")
         assert config.host == "localhost"
         assert config.port == 5432

--- a/tests/unit/scripts/test_compare_environments.py
+++ b/tests/unit/scripts/test_compare_environments.py
@@ -127,10 +127,12 @@ def test_detects_wrong_postgres_user() -> None:
 
 @pytest.mark.unit
 def test_detects_missing_ecr_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
     import subprocess
 
     from compare_environments import check_ecr_tag_validity
 
+    monkeypatch.setattr(shutil, "which", lambda _x: "/usr/bin/aws")
     monkeypatch.setattr(
         subprocess,
         "run",


### PR DESCRIPTION
## Summary
- `ModelPostgresPoolConfig.host` used `os.environ["POSTGRES_HOST"]` which raises `KeyError` in CI and leaks the dev machine IP (`192.168.86.201`) when `POSTGRES_HOST` is set. Changed to `os.environ.get("POSTGRES_HOST", "localhost")`.
- `test_detects_missing_ecr_tag` wasn't patching `shutil.which`, so on machines without `aws` CLI the function returned early with INFO findings instead of running the check. Added `monkeypatch.setattr(shutil, "which", ...)`.
- `test_default_values` now uses `monkeypatch.delenv("POSTGRES_HOST", raising=False)` to prevent env leakage in any environment.

## Test plan
- [x] `tests/unit/runtime/test_dependency_materializer.py::TestModelPostgresPoolConfig::test_default_values` passes
- [x] `tests/unit/scripts/test_compare_environments.py::test_detects_missing_ecr_tag` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection config now falls back to localhost when the host environment variable is missing, preventing startup failures in unconfigured environments.

* **Tests**
  * Improved test coverage and isolation for configuration defaults and for detecting AWS CLI presence during environment comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->