### PR TITLE
feat(runtime): health monitor — consumer group + topic coverage alerting [OMN-8662]

### DIFF
--- a/contracts/runtime/runtime_protocol.lock.json
+++ b/contracts/runtime/runtime_protocol.lock.json
@@ -1,8 +1,18 @@
 {
   "schema_version": "1.0.0",
-  "package_version": "0.24.0",
-  "protocol_count": 20,
+  "package_version": "0.34.0",
+  "protocol_count": 22,
   "protocols": {
+    "ProtocolAutoWiringManifestLike": {
+      "runtime_checkable": false,
+      "method_count": 1,
+      "methods": {
+        "all_subscribe_topics": {
+          "parameters": [],
+          "return_annotation": "Iterable[str]"
+        }
+      }
+    },
     "ProtocolCapabilityProjection": {
       "runtime_checkable": true,
       "method_count": 6,
@@ -530,6 +540,58 @@
               "default": "None"
             }
           ],
+          "return_annotation": "None"
+        }
+      }
+    },
+    "ProtocolKafkaAdminLike": {
+      "runtime_checkable": false,
+      "method_count": 5,
+      "methods": {
+        "close": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "describe_consumer_groups": {
+          "parameters": [
+            {
+              "name": "group_ids",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "Sequence[str]",
+              "default": null
+            },
+            {
+              "name": "group_coordinator_id",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "int | None",
+              "default": "None"
+            },
+            {
+              "name": "include_authorized_operations",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "bool",
+              "default": "False"
+            }
+          ],
+          "return_annotation": "list[object]"
+        },
+        "list_consumer_groups": {
+          "parameters": [
+            {
+              "name": "broker_ids",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "annotation": "Sequence[int] | None",
+              "default": "None"
+            }
+          ],
+          "return_annotation": "Sequence[tuple[str, str | None]]"
+        },
+        "start": {
+          "parameters": [],
+          "return_annotation": "None"
+        },
+        "stop": {
+          "parameters": [],
           "return_annotation": "None"
         }
       }

--- a/src/omnibase_infra/models/health/model_runtime_health_check_event.py
+++ b/src/omnibase_infra/models/health/model_runtime_health_check_event.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime health check event model.
+
+Emitted by ServiceRuntimeHealthMonitor every check interval.
+
+Schema aligns with ``onex.evt.omnibase-infra.runtime-health-check.v1``.
+
+.. versionadded:: 0.39.0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.health.model_runtime_health_dimension import (
+    ModelRuntimeHealthDimension,
+)
+
+
+class ModelRuntimeHealthCheckEvent(BaseModel):
+    """Runtime health check snapshot emitted by ServiceRuntimeHealthMonitor.
+
+    Consumers (dashboards, alerting) can subscribe to
+    ``onex.evt.omnibase-infra.runtime-health-check.v1`` to receive these events.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(..., description="Correlation ID for tracing")
+    timestamp: datetime = Field(..., description="UTC timestamp of the check")
+    status: Literal["HEALTHY", "DEGRADED", "CRITICAL"] = Field(
+        ..., description="Aggregate health status derived from worst dimension"
+    )
+    dimensions: tuple[ModelRuntimeHealthDimension, ...] = Field(
+        default_factory=tuple,
+        description="Per-dimension health breakdown",
+    )
+    contract_count: int = Field(
+        default=0,
+        description="Number of contracts discovered by the auto-wiring engine",
+    )
+    discovery_error_count: int = Field(
+        default=0,
+        description="Number of errors encountered during contract discovery",
+    )
+    consumer_group_count: int = Field(
+        default=0,
+        description="Total consumer groups visible to the Kafka admin client",
+    )
+    empty_consumer_group_count: int = Field(
+        default=0,
+        description="Consumer groups that are Empty (no active members)",
+    )
+    subscribe_topic_count: int = Field(
+        default=0,
+        description="Topics declared as subscribe targets across all contracts",
+    )
+    uncovered_topic_count: int = Field(
+        default=0,
+        description="Subscribe topics with no matching non-empty consumer group",
+    )
+
+
+__all__: list[str] = ["ModelRuntimeHealthCheckEvent"]

--- a/src/omnibase_infra/models/health/model_runtime_health_dimension.py
+++ b/src/omnibase_infra/models/health/model_runtime_health_dimension.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime health check dimension model."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRuntimeHealthDimension(BaseModel):
+    """A single health dimension in a runtime health check event."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(
+        ..., description="Dimension identifier (e.g. 'consumer_coverage')"
+    )
+    status: Literal["HEALTHY", "DEGRADED", "CRITICAL"] = Field(
+        ..., description="Health status for this dimension"
+    )
+    detail: str = Field(default="", description="Human-readable detail or empty string")
+
+
+__all__: list[str] = ["ModelRuntimeHealthDimension"]

--- a/src/omnibase_infra/protocols/__init__.py
+++ b/src/omnibase_infra/protocols/__init__.py
@@ -62,6 +62,9 @@ See Also:
     - OMN-947 (F2) for snapshot publishing design
 """
 
+from omnibase_infra.protocols.protocol_auto_wiring_manifest_like import (
+    ProtocolAutoWiringManifestLike,
+)
 from omnibase_infra.protocols.protocol_capability_projection import (
     ProtocolCapabilityProjection,
 )
@@ -73,6 +76,7 @@ from omnibase_infra.protocols.protocol_event_projector import ProtocolEventProje
 from omnibase_infra.protocols.protocol_idempotency_store import (
     ProtocolIdempotencyStore,
 )
+from omnibase_infra.protocols.protocol_kafka_admin_like import ProtocolKafkaAdminLike
 from omnibase_infra.protocols.protocol_ledger_sink import ProtocolLedgerSink
 from omnibase_infra.protocols.protocol_message_dispatcher import (
     ProtocolMessageDispatcher,
@@ -104,6 +108,7 @@ from omnibase_infra.protocols.protocol_validation_ledger_repository import (
 )
 
 __all__: list[str] = [
+    "ProtocolAutoWiringManifestLike",
     "ProtocolCapabilityProjection",
     "ProtocolCapabilityQuery",
     "ProtocolContainerAware",
@@ -111,6 +116,7 @@ __all__: list[str] = [
     "ProtocolEventBusLike",
     "ProtocolEventProjector",
     "ProtocolIdempotencyStore",
+    "ProtocolKafkaAdminLike",
     "ProtocolLedgerSink",
     "ProtocolMessageDispatcher",
     "ProtocolMessageTypeRegistry",

--- a/src/omnibase_infra/protocols/protocol_auto_wiring_manifest_like.py
+++ b/src/omnibase_infra/protocols/protocol_auto_wiring_manifest_like.py
@@ -25,7 +25,8 @@ class ProtocolAutoWiringManifestLike(Protocol):
     total_discovered: int
     total_errors: int
 
-    def all_subscribe_topics(self) -> Iterable[str]: ...
+    def all_subscribe_topics(self) -> Iterable[str]:
+        pass
 
 
 __all__: list[str] = ["ProtocolAutoWiringManifestLike"]

--- a/src/omnibase_infra/protocols/protocol_auto_wiring_manifest_like.py
+++ b/src/omnibase_infra/protocols/protocol_auto_wiring_manifest_like.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural protocol matching the shape of ``ModelAutoWiringManifest``.
+
+Defined here rather than importing ``ModelAutoWiringManifest`` directly so that
+modules consuming this shape can avoid circular imports at parse time.
+
+.. versionadded:: 0.39.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+
+class ProtocolAutoWiringManifestLike(Protocol):
+    """Minimal protocol for auto-wiring discovery manifests.
+
+    Any object exposing ``total_discovered``, ``total_errors``, and
+    ``all_subscribe_topics()`` satisfies this protocol, including
+    ``ModelAutoWiringManifest``.
+    """
+
+    total_discovered: int
+    total_errors: int
+
+    def all_subscribe_topics(self) -> Iterable[str]: ...
+
+
+__all__: list[str] = ["ProtocolAutoWiringManifestLike"]

--- a/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
+++ b/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
@@ -29,6 +29,9 @@ class ProtocolKafkaAdminLike(Protocol):
     async def stop(self) -> None:
         pass
 
+    async def close(self) -> None:
+        pass
+
     async def list_consumer_groups(
         self, broker_ids: Sequence[int] | None = None
     ) -> Sequence[tuple[str, str | None]]:

--- a/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
+++ b/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural protocol matching the AIOKafkaAdminClient methods used by the runtime.
+
+Defined here rather than importing ``AIOKafkaAdminClient`` directly so that
+modules using only this shape avoid the hard ``aiokafka`` import at module
+parse time.
+
+.. versionadded:: 0.39.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+
+class ProtocolKafkaAdminLike(Protocol):
+    """Minimal protocol for Kafka admin clients.
+
+    Any object exposing ``start``, ``close``, ``list_consumer_groups``, and
+    ``describe_consumer_groups`` satisfies this protocol, including
+    ``AIOKafkaAdminClient``.
+    """
+
+    async def start(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def list_consumer_groups(self) -> Sequence[tuple[str, str | None]]: ...
+
+    async def describe_consumer_groups(
+        self, group_ids: Sequence[str]
+    ) -> dict[str, object]: ...
+
+
+__all__: list[str] = ["ProtocolKafkaAdminLike"]

--- a/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
+++ b/src/omnibase_infra/protocols/protocol_kafka_admin_like.py
@@ -23,15 +23,24 @@ class ProtocolKafkaAdminLike(Protocol):
     ``AIOKafkaAdminClient``.
     """
 
-    async def start(self) -> None: ...
+    async def start(self) -> None:
+        pass
 
-    async def close(self) -> None: ...
+    async def stop(self) -> None:
+        pass
 
-    async def list_consumer_groups(self) -> Sequence[tuple[str, str | None]]: ...
+    async def list_consumer_groups(
+        self, broker_ids: Sequence[int] | None = None
+    ) -> Sequence[tuple[str, str | None]]:
+        pass
 
     async def describe_consumer_groups(
-        self, group_ids: Sequence[str]
-    ) -> dict[str, object]: ...
+        self,
+        group_ids: Sequence[str],
+        group_coordinator_id: int | None = None,
+        include_authorized_operations: bool = False,
+    ) -> list[object]:
+        pass
 
 
 __all__: list[str] = ["ProtocolKafkaAdminLike"]

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -689,6 +689,7 @@ async def bootstrap() -> int:
     baselines_task: asyncio.Task[None] | None = None
     _baselines_pool = None  # asyncpg.Pool | None, assigned inside try block
     savings_task: asyncio.Task[None] | None = None
+    runtime_health_monitor = None  # ServiceRuntimeHealthMonitor | None
     correlation_id = generate_correlation_id()
     bootstrap_start_time = time.time()
 
@@ -1446,6 +1447,39 @@ async def bootstrap() -> int:
                     correlation_id,
                 )
                 savings_task = None
+
+        # 3.10. Start runtime health monitor (OMN-8623)
+        # Runs every 5 minutes and emits runtime-health-check.v1 events.
+        # Checks: contract discovery errors, empty consumer groups, topic coverage.
+        # Best-effort: failure does not block kernel startup.
+        if use_kafka:
+            try:
+                from omnibase_infra.services.service_runtime_health_monitor import (
+                    ServiceRuntimeHealthMonitor,
+                )
+
+                _health_interval = float(
+                    os.environ.get("RUNTIME_HEALTH_CHECK_INTERVAL", "300")
+                )
+                runtime_health_monitor = ServiceRuntimeHealthMonitor(
+                    event_bus=event_bus,  # type: ignore[arg-type]
+                    check_interval_seconds=_health_interval,
+                )
+                await runtime_health_monitor.start()
+                logger.info(
+                    "ServiceRuntimeHealthMonitor started "
+                    "(interval=%ds, correlation_id=%s)",
+                    int(_health_interval),
+                    correlation_id,
+                )
+            except Exception:  # noqa: BLE001 — best-effort, never blocks startup
+                logger.warning(
+                    "Failed to start ServiceRuntimeHealthMonitor, continuing without it "
+                    "(correlation_id=%s)",
+                    correlation_id,
+                    exc_info=True,
+                )
+                runtime_health_monitor = None
 
         # 4. Create and wire container for dependency injection
         container_start_time = time.time()
@@ -3077,6 +3111,22 @@ async def bootstrap() -> int:
             )
             savings_task = None
 
+        # Stop ServiceRuntimeHealthMonitor (OMN-8623)
+        if runtime_health_monitor is not None:
+            try:
+                await runtime_health_monitor.stop()
+                logger.debug(
+                    "ServiceRuntimeHealthMonitor stopped (correlation_id=%s)",
+                    correlation_id,
+                )
+            except Exception:  # noqa: BLE001 — boundary: best-effort cleanup
+                logger.warning(
+                    "Error stopping ServiceRuntimeHealthMonitor (correlation_id=%s)",
+                    correlation_id,
+                    exc_info=True,
+                )
+            runtime_health_monitor = None
+
         # Stop ServiceLlmEndpointHealth (OMN-6135)
         if llm_health_service is not None:
             try:
@@ -3312,6 +3362,17 @@ async def bootstrap() -> int:
                 await savings_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
+
+        # Cleanup ServiceRuntimeHealthMonitor (OMN-8623)
+        if runtime_health_monitor is not None:
+            try:
+                await runtime_health_monitor.stop()
+            except Exception:  # noqa: BLE001 — boundary: best-effort cleanup
+                logger.warning(
+                    "Failed to stop ServiceRuntimeHealthMonitor during cleanup "
+                    "(correlation_id=%s)",
+                    correlation_id,
+                )
 
         # Cleanup ServiceLlmEndpointHealth (OMN-6135)
         if llm_health_service is not None:

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1452,6 +1452,12 @@ async def bootstrap() -> int:
         # Runs every 5 minutes and emits runtime-health-check.v1 events.
         # Checks: contract discovery errors, empty consumer groups, topic coverage.
         # Best-effort: failure does not block kernel startup.
+        #
+        # Direct instantiation is intentional: ModelONEXContainer is not yet
+        # created at this point in the kernel startup sequence (step 4 below).
+        # The monitor only needs event_bus, which is already wired. Wiring through
+        # the container would require deferring startup or restructuring the
+        # boot order — not worth the complexity for a best-effort health service.
         if use_kafka:
             try:
                 from omnibase_infra.services.service_runtime_health_monitor import (

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2979,6 +2979,22 @@ async def bootstrap() -> int:
             correlation_id,
         )
 
+        # Stop ServiceRuntimeHealthMonitor before tearing down runtime consumers.
+        if runtime_health_monitor is not None:
+            try:
+                await runtime_health_monitor.stop()
+                logger.debug(
+                    "ServiceRuntimeHealthMonitor stopped (correlation_id=%s)",
+                    correlation_id,
+                )
+            except Exception:  # noqa: BLE001 — boundary: best-effort cleanup
+                logger.warning(
+                    "Error stopping ServiceRuntimeHealthMonitor (correlation_id=%s)",
+                    correlation_id,
+                    exc_info=True,
+                )
+            runtime_health_monitor = None
+
         # Stop runtime FIRST so introspection tasks flush their final events
         # while the event bus is still active. Moving this before consumer
         # unsubscribe fixes the ~29 introspection errors per shutdown cycle
@@ -3116,22 +3132,6 @@ async def bootstrap() -> int:
                 correlation_id,
             )
             savings_task = None
-
-        # Stop ServiceRuntimeHealthMonitor (OMN-8623)
-        if runtime_health_monitor is not None:
-            try:
-                await runtime_health_monitor.stop()
-                logger.debug(
-                    "ServiceRuntimeHealthMonitor stopped (correlation_id=%s)",
-                    correlation_id,
-                )
-            except Exception:  # noqa: BLE001 — boundary: best-effort cleanup
-                logger.warning(
-                    "Error stopping ServiceRuntimeHealthMonitor (correlation_id=%s)",
-                    correlation_id,
-                    exc_info=True,
-                )
-            runtime_health_monitor = None
 
         # Stop ServiceLlmEndpointHealth (OMN-6135)
         if llm_health_service is not None:

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -277,7 +277,12 @@ class ServiceRuntimeHealthMonitor:
                     # topic name, ensuring exact-identity matching rather than a loose
                     # suffix match that could yield false positives on version tokens
                     # like "v1" (which appear in every consumer group name).
-                    non_empty_groups = set(all_group_ids) - empty_groups
+                    if describe_failed:
+                        # Consumer group states are unknown — do not compute coverage
+                        # from unreliable data; both dimensions degrade together.
+                        non_empty_groups: set[str] = set()
+                    else:
+                        non_empty_groups = set(all_group_ids) - empty_groups
                     uncovered: list[str] = []
                     for topic in sorted(subscribe_topics):
                         covered = any(topic in grp for grp in non_empty_groups)
@@ -294,6 +299,13 @@ class ServiceRuntimeHealthMonitor:
                                     f"describe_consumer_groups failed; "
                                     f"{consumer_group_count} groups listed but states unknown"
                                 ),
+                            )
+                        )
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="topic_coverage",
+                                status="DEGRADED",
+                                detail="Consumer group states unknown — topic coverage cannot be verified",
                             )
                         )
                     elif empty_consumer_group_count > 0:
@@ -318,39 +330,43 @@ class ServiceRuntimeHealthMonitor:
                             )
                         )
 
-                    if uncovered_topic_count > 0:
-                        detail_topics = ", ".join(uncovered[:5])
-                        if len(uncovered) > 5:
-                            detail_topics += f" … +{len(uncovered) - 5} more"
-                        dimensions.append(
-                            ModelRuntimeHealthDimension(
-                                name="topic_coverage",
-                                status="CRITICAL"
-                                if uncovered_topic_count > 10
-                                else "DEGRADED",
-                                detail=(
-                                    f"{uncovered_topic_count} subscribe topic(s) have"
-                                    f" no active consumer group: {detail_topics}"
-                                ),
+                    if not describe_failed:
+                        if uncovered_topic_count > 0:
+                            detail_topics = ", ".join(uncovered[:5])
+                            if len(uncovered) > 5:
+                                detail_topics += f" … +{len(uncovered) - 5} more"
+                            dimensions.append(
+                                ModelRuntimeHealthDimension(
+                                    name="topic_coverage",
+                                    status="CRITICAL"
+                                    if uncovered_topic_count > 10
+                                    else "DEGRADED",
+                                    detail=(
+                                        f"{uncovered_topic_count} subscribe topic(s) have"
+                                        f" no active consumer group: {detail_topics}"
+                                    ),
+                                )
                             )
-                        )
-                    else:
-                        dimensions.append(
-                            ModelRuntimeHealthDimension(
-                                name="topic_coverage",
-                                status="HEALTHY",
-                                detail=(
-                                    f"All {len(subscribe_topics)} subscribe topics covered"
-                                ),
+                        else:
+                            dimensions.append(
+                                ModelRuntimeHealthDimension(
+                                    name="topic_coverage",
+                                    status="HEALTHY",
+                                    detail=(
+                                        f"All {len(subscribe_topics)} subscribe topics covered"
+                                    ),
+                                )
                             )
-                        )
 
                 finally:
                     if admin is not None:
                         try:
                             await admin.close()  # type: ignore[union-attr]
-                        except Exception:  # noqa: BLE001
-                            pass
+                        except Exception:  # noqa: BLE001 — best-effort admin close
+                            logger.debug(
+                                "Runtime health: failed to close Kafka admin client",
+                                exc_info=True,
+                            )
 
             except ImportError:
                 logger.debug(
@@ -411,7 +427,7 @@ class ServiceRuntimeHealthMonitor:
             for dim in dimensions:
                 if dim.status != "HEALTHY":
                     logger.warning(
-                        "Runtime health DEGRADED dimension=%s status=%s detail=%s",
+                        "Runtime health issue dimension=%s status=%s detail=%s",
                         dim.name,
                         dim.status,
                         dim.detail,

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -434,9 +434,16 @@ class ServiceRuntimeHealthMonitor:
 
         if aggregate_status != "HEALTHY":
             for dim in dimensions:
-                if dim.status != "HEALTHY":
+                if dim.status == "CRITICAL":
+                    logger.error(
+                        "Runtime health CRITICAL dimension=%s status=%s detail=%s",
+                        dim.name,
+                        dim.status,
+                        dim.detail,
+                    )
+                elif dim.status == "DEGRADED":
                     logger.warning(
-                        "Runtime health issue dimension=%s status=%s detail=%s",
+                        "Runtime health DEGRADED dimension=%s status=%s detail=%s",
                         dim.name,
                         dim.status,
                         dim.detail,

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import os
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.models.health.model_runtime_health_check_event import (
@@ -37,6 +37,10 @@ from omnibase_infra.models.health.model_runtime_health_dimension import (
     ModelRuntimeHealthDimension,
 )
 from omnibase_infra.protocols import ProtocolTopicRegistry
+from omnibase_infra.protocols.protocol_auto_wiring_manifest_like import (
+    ProtocolAutoWiringManifestLike,
+)
+from omnibase_infra.protocols.protocol_kafka_admin_like import ProtocolKafkaAdminLike
 from omnibase_infra.topics import topic_keys
 from omnibase_infra.utils.correlation import generate_correlation_id
 
@@ -46,28 +50,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _discover_contracts() -> Any:  # ONEX_EXCLUDE: any_type
+def _discover_contracts() -> ProtocolAutoWiringManifestLike:
     """Module-level shim — allows tests to patch without lazy-import complications.
 
-    Returns Any because ModelAutoWiringManifest is imported lazily inside the
-    function body to avoid circular imports at module parse time.
+    The return type is declared as ``ProtocolAutoWiringManifestLike`` to avoid a
+    circular import of ``ModelAutoWiringManifest`` at module parse time while
+    still providing accurate type information to callers.
     """
     from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
 
-    return discover_contracts()
+    return discover_contracts()  # type: ignore[return-value]
 
 
 def _get_kafka_admin_client(
     bootstrap_servers: str, request_timeout_ms: int
-) -> Any:  # ONEX_EXCLUDE: any_type
+) -> ProtocolKafkaAdminLike:
     """Module-level shim for AIOKafkaAdminClient — patchable in tests.
 
-    Returns Any because AIOKafkaAdminClient is imported lazily inside the
-    function body to avoid hard dependency at module import time.
+    The return type is declared as ``ProtocolKafkaAdminLike`` to avoid a hard
+    import of ``AIOKafkaAdminClient`` at module import time while still providing
+    accurate type information to callers.
     """
     from aiokafka.admin import AIOKafkaAdminClient
 
-    return AIOKafkaAdminClient(
+    return AIOKafkaAdminClient(  # type: ignore[return-value]
         bootstrap_servers=bootstrap_servers,
         request_timeout_ms=request_timeout_ms,
     )
@@ -198,9 +204,9 @@ class ServiceRuntimeHealthMonitor:
         subscribe_topics: set[str] = set()
         try:
             manifest = _discover_contracts()
-            contract_count = manifest.total_discovered  # type: ignore[attr-defined]
-            discovery_error_count = manifest.total_errors  # type: ignore[attr-defined]
-            subscribe_topics = set(manifest.all_subscribe_topics())  # type: ignore[attr-defined]
+            contract_count = manifest.total_discovered
+            discovery_error_count = manifest.total_errors
+            subscribe_topics = set(manifest.all_subscribe_topics())
 
             if discovery_error_count > 0:
                 dimensions.append(

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime health monitor service.
+
+Runs every ``check_interval_seconds`` (default: 300) inside the runtime
+container and checks:
+
+1. **Consumer group coverage** — for every topic declared as a ``subscribe``
+   target in any discovered contract, verifies that a non-empty consumer group
+   exists on the broker.
+2. **Discovery errors** — if ``discover_contracts()`` found errors, the
+   dimension is DEGRADED.
+3. **Topic coverage** — every subscribe topic should have at least one
+   non-empty consumer group.
+
+Results are emitted to ``onex.evt.omnibase-infra.runtime-health-check.v1``.
+
+The service is intentionally **best-effort**: any failure during a check
+cycle is logged and the next cycle proceeds normally.
+
+.. versionadded:: 0.39.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.models.health.model_runtime_health_check_event import (
+    ModelRuntimeHealthCheckEvent,
+)
+from omnibase_infra.models.health.model_runtime_health_dimension import (
+    ModelRuntimeHealthDimension,
+)
+from omnibase_infra.protocols import ProtocolTopicRegistry
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.utils.correlation import generate_correlation_id
+
+if TYPE_CHECKING:
+    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
+
+logger = logging.getLogger(__name__)
+
+
+def _discover_contracts():  # type: ignore[return]
+    """Module-level shim — allows tests to patch without lazy-import complications."""
+    from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
+
+    return discover_contracts()
+
+
+def _get_kafka_admin_client(bootstrap_servers: str, request_timeout_ms: int):  # type: ignore[return]
+    """Module-level shim for AIOKafkaAdminClient — patchable in tests."""
+    from aiokafka.admin import AIOKafkaAdminClient
+
+    return AIOKafkaAdminClient(
+        bootstrap_servers=bootstrap_servers,
+        request_timeout_ms=request_timeout_ms,
+    )
+
+
+_HealthStatus = Literal["HEALTHY", "DEGRADED", "CRITICAL"]
+
+_DEFAULT_CHECK_INTERVAL: float = 300.0  # 5 minutes
+_KAFKA_ADMIN_TIMEOUT_MS: int = 5_000
+
+
+def _worst(statuses: list[_HealthStatus]) -> _HealthStatus:
+    """Return the worst status from a list."""
+    if "CRITICAL" in statuses:
+        return "CRITICAL"
+    if "DEGRADED" in statuses:
+        return "DEGRADED"
+    return "HEALTHY"
+
+
+class ServiceRuntimeHealthMonitor:
+    """Periodic runtime health monitor.
+
+    Usage::
+
+        monitor = ServiceRuntimeHealthMonitor(
+            event_bus=bus,
+            bootstrap_servers="redpanda:9092",
+            check_interval_seconds=300.0,
+        )
+        await monitor.start()
+        ...
+        await monitor.stop()
+    """
+
+    def __init__(
+        self,
+        event_bus: ProtocolEventBusLike | None = None,
+        bootstrap_servers: str | None = None,
+        check_interval_seconds: float = _DEFAULT_CHECK_INTERVAL,
+        topic_registry: ProtocolTopicRegistry | None = None,
+    ) -> None:
+        """Initialize the health monitor.
+
+        Args:
+            event_bus: Optional event bus for emitting health events.
+            bootstrap_servers: Kafka bootstrap servers string. Defaults to
+                ``KAFKA_BOOTSTRAP_SERVERS`` env var.
+            check_interval_seconds: How often to run a full check.
+            topic_registry: Optional topic registry. Defaults to
+                ``ServiceTopicRegistry.from_defaults()``.
+        """
+        if topic_registry is None:
+            from omnibase_infra.topics.service_topic_registry import (
+                ServiceTopicRegistry,
+            )
+
+            topic_registry = ServiceTopicRegistry.from_defaults()
+
+        self._health_topic = topic_registry.resolve(topic_keys.RUNTIME_HEALTH_CHECK)
+        self._event_bus = event_bus
+        self._bootstrap_servers = bootstrap_servers or os.environ.get(
+            "KAFKA_BOOTSTRAP_SERVERS", ""
+        )
+        self._check_interval = check_interval_seconds
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        """Start the background health check loop. Idempotent."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop(), name="runtime-health-monitor")
+        logger.info(
+            "ServiceRuntimeHealthMonitor started (interval=%ds)",
+            int(self._check_interval),
+        )
+
+    async def stop(self) -> None:
+        """Stop the background health check loop. Idempotent."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("ServiceRuntimeHealthMonitor stopped")
+
+    async def run_once(self) -> ModelRuntimeHealthCheckEvent:
+        """Run a single health check cycle and return the event.
+
+        This is the core method used by both the background loop and direct
+        one-shot callers (e.g. tests).
+
+        Returns:
+            A ``ModelRuntimeHealthCheckEvent`` with the current health state.
+        """
+        correlation_id = generate_correlation_id()
+        dimensions: list[ModelRuntimeHealthDimension] = []
+
+        # --- Dimension 1: Contract discovery health -------------------------
+        contract_count = 0
+        discovery_error_count = 0
+        subscribe_topics: set[str] = set()
+        try:
+            manifest = _discover_contracts()
+            contract_count = manifest.total_discovered
+            discovery_error_count = manifest.total_errors
+            subscribe_topics = set(manifest.all_subscribe_topics())
+
+            if discovery_error_count > 0:
+                dimensions.append(
+                    ModelRuntimeHealthDimension(
+                        name="discovery_errors",
+                        status="DEGRADED",
+                        detail=(f"{discovery_error_count} contract(s) failed to load"),
+                    )
+                )
+            else:
+                dimensions.append(
+                    ModelRuntimeHealthDimension(
+                        name="discovery_errors",
+                        status="HEALTHY",
+                        detail=f"{contract_count} contracts loaded cleanly",
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001 — boundary: dimension degrades
+            logger.warning("Runtime health: discovery check failed — %s", exc)
+            dimensions.append(
+                ModelRuntimeHealthDimension(
+                    name="discovery_errors",
+                    status="CRITICAL",
+                    detail=f"discover_contracts() raised: {type(exc).__name__}",
+                )
+            )
+
+        # --- Dimension 2 & 3: Consumer group coverage -----------------------
+        consumer_group_count = 0
+        empty_consumer_group_count = 0
+        uncovered_topic_count = 0
+
+        if self._bootstrap_servers:
+            try:
+                admin = None
+                try:
+                    admin = _get_kafka_admin_client(
+                        self._bootstrap_servers, _KAFKA_ADMIN_TIMEOUT_MS
+                    )
+                    await admin.start()
+
+                    # list_consumer_groups() returns list of (group_id, protocol_type) tuples
+                    all_groups_raw = await admin.list_consumer_groups()
+                    all_group_ids = [g[0] for g in all_groups_raw]
+                    consumer_group_count = len(all_group_ids)
+
+                    # describe_consumer_groups to find empty ones
+                    described = {}
+                    if all_group_ids:
+                        try:
+                            described = await admin.describe_consumer_groups(
+                                all_group_ids
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug(
+                                "Runtime health: describe_consumer_groups failed — %s",
+                                exc,
+                            )
+
+                    empty_groups: set[str] = set()
+                    for group_id, group_meta in described.items():
+                        # GroupMetadata.state is a string e.g. "Empty", "Stable"
+                        state = getattr(group_meta, "state", None)
+                        if state == "Empty" or not getattr(group_meta, "members", None):
+                            empty_groups.add(group_id)
+                    empty_consumer_group_count = len(empty_groups)
+
+                    # Check which subscribe topics have a matching non-empty group
+                    # Consumer groups in ONEX typically encode the topic in the group ID
+                    # (e.g. "onex-runtime-consumer-<topic-suffix>"). We consider a
+                    # topic "covered" if at least one non-empty group ID contains any
+                    # word from the topic's suffix component.
+                    non_empty_groups = set(all_group_ids) - empty_groups
+                    uncovered: list[str] = []
+                    for topic in sorted(subscribe_topics):
+                        # Extract suffix after last '.' separator as coverage key
+                        suffix = topic.rsplit(".", 1)[-1] if "." in topic else topic
+                        covered = any(suffix in grp for grp in non_empty_groups)
+                        if not covered:
+                            uncovered.append(topic)
+                    uncovered_topic_count = len(uncovered)
+
+                    if empty_consumer_group_count > 0:
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="empty_consumer_groups",
+                                status="DEGRADED",
+                                detail=(
+                                    f"{empty_consumer_group_count}/{consumer_group_count}"
+                                    " consumer groups are Empty"
+                                ),
+                            )
+                        )
+                    else:
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="empty_consumer_groups",
+                                status="HEALTHY",
+                                detail=(
+                                    f"All {consumer_group_count} consumer groups active"
+                                ),
+                            )
+                        )
+
+                    if uncovered_topic_count > 0:
+                        detail_topics = ", ".join(uncovered[:5])
+                        if len(uncovered) > 5:
+                            detail_topics += f" … +{len(uncovered) - 5} more"
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="topic_coverage",
+                                status="CRITICAL"
+                                if uncovered_topic_count > 10
+                                else "DEGRADED",
+                                detail=(
+                                    f"{uncovered_topic_count} subscribe topic(s) have"
+                                    f" no active consumer group: {detail_topics}"
+                                ),
+                            )
+                        )
+                    else:
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="topic_coverage",
+                                status="HEALTHY",
+                                detail=(
+                                    f"All {len(subscribe_topics)} subscribe topics covered"
+                                ),
+                            )
+                        )
+
+                finally:
+                    if admin is not None:
+                        try:
+                            await admin.close()
+                        except Exception:  # noqa: BLE001
+                            pass
+
+            except ImportError:
+                logger.debug(
+                    "Runtime health: aiokafka not available — consumer checks skipped"
+                )
+                dimensions.append(
+                    ModelRuntimeHealthDimension(
+                        name="consumer_coverage",
+                        status="HEALTHY",
+                        detail="aiokafka not installed — consumer checks skipped",
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 — boundary: dimension degrades
+                logger.warning("Runtime health: consumer group check failed — %s", exc)
+                dimensions.append(
+                    ModelRuntimeHealthDimension(
+                        name="consumer_coverage",
+                        status="DEGRADED",
+                        detail=f"Admin client error: {type(exc).__name__}",
+                    )
+                )
+        else:
+            dimensions.append(
+                ModelRuntimeHealthDimension(
+                    name="consumer_coverage",
+                    status="HEALTHY",
+                    detail="No bootstrap_servers configured — consumer checks skipped",
+                )
+            )
+
+        aggregate_status: _HealthStatus = _worst([d.status for d in dimensions])
+
+        event = ModelRuntimeHealthCheckEvent(
+            correlation_id=correlation_id,
+            timestamp=datetime.now(UTC),
+            status=aggregate_status,
+            dimensions=tuple(dimensions),
+            contract_count=contract_count,
+            discovery_error_count=discovery_error_count,
+            consumer_group_count=consumer_group_count,
+            empty_consumer_group_count=empty_consumer_group_count,
+            subscribe_topic_count=len(subscribe_topics),
+            uncovered_topic_count=uncovered_topic_count,
+        )
+
+        logger.info(
+            "Runtime health check: status=%s contracts=%d errors=%d "
+            "consumer_groups=%d empty=%d uncovered_topics=%d",
+            aggregate_status,
+            contract_count,
+            discovery_error_count,
+            consumer_group_count,
+            empty_consumer_group_count,
+            uncovered_topic_count,
+        )
+
+        if aggregate_status != "HEALTHY":
+            for dim in dimensions:
+                if dim.status != "HEALTHY":
+                    logger.warning(
+                        "Runtime health DEGRADED dimension=%s status=%s detail=%s",
+                        dim.name,
+                        dim.status,
+                        dim.detail,
+                    )
+
+        await self._emit(event)
+        return event
+
+    # -- Internal -------------------------------------------------------------
+
+    async def _loop(self) -> None:
+        """Background loop that runs health checks at the configured interval."""
+        while self._running:
+            try:
+                await asyncio.sleep(self._check_interval)
+                await self.run_once()
+            except asyncio.CancelledError:
+                break
+            except Exception:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "Runtime health monitor loop iteration failed (will retry in %ds)",
+                    int(self._check_interval),
+                    exc_info=True,
+                )
+
+    async def _emit(self, event: ModelRuntimeHealthCheckEvent) -> None:
+        """Emit the health event to the event bus. Best-effort fire-and-forget."""
+        if self._event_bus is None:
+            return
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=event,
+            correlation_id=event.correlation_id,
+            event_type="runtime-health-check",
+            source_tool="ServiceRuntimeHealthMonitor",
+        )
+        try:
+            await self._event_bus.publish_envelope(
+                envelope=envelope,
+                topic=self._health_topic,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to emit runtime health check event",
+                extra={"correlation_id": str(event.correlation_id)},
+            )
+
+
+__all__: list[str] = ["ServiceRuntimeHealthMonitor"]

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -258,12 +258,15 @@ class ServiceRuntimeHealthMonitor:
                     consumer_group_count = len(all_group_ids)
 
                     # describe_consumer_groups to find empty ones
-                    described = {}
+                    described: dict[str, object] = {}
                     describe_failed = False
                     if all_group_ids:
                         try:
-                            described = await admin.describe_consumer_groups(  # type: ignore[union-attr]
+                            raw_described = await admin.describe_consumer_groups(  # type: ignore[union-attr]
                                 all_group_ids
+                            )
+                            described = dict(
+                                zip(all_group_ids, raw_described, strict=False)
                             )
                         except Exception as exc:  # noqa: BLE001
                             describe_failed = True
@@ -372,7 +375,7 @@ class ServiceRuntimeHealthMonitor:
                 finally:
                     if admin is not None:
                         try:
-                            await admin.close()  # type: ignore[union-attr]
+                            await admin.close()
                         except Exception:  # noqa: BLE001 — best-effort admin close
                             logger.debug(
                                 "Runtime health: failed to close Kafka admin client",

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -120,6 +120,11 @@ class ServiceRuntimeHealthMonitor:
             topic_registry: Optional topic registry. Defaults to
                 ``ServiceTopicRegistry.from_defaults()``.
         """
+        if check_interval_seconds <= 0:
+            raise ValueError(
+                f"check_interval_seconds must be positive, got {check_interval_seconds}"
+            )
+
         if topic_registry is None:
             from omnibase_infra.topics.service_topic_registry import (
                 ServiceTopicRegistry,
@@ -139,10 +144,21 @@ class ServiceRuntimeHealthMonitor:
         self._running = False
 
     async def start(self) -> None:
-        """Start the background health check loop. Idempotent."""
+        """Start the background health check loop. Idempotent.
+
+        Runs the first health check immediately before entering the periodic loop
+        so callers get an initial signal without waiting one full interval.
+        """
         if self._running:
             return
         self._running = True
+        # Run the first check immediately so callers get an initial health signal.
+        try:
+            await self.run_once()
+        except Exception:  # noqa: BLE001 — best-effort; don't block startup
+            logger.warning(
+                "ServiceRuntimeHealthMonitor: initial check failed", exc_info=True
+            )
         self._task = asyncio.create_task(self._loop(), name="runtime-health-monitor")
         logger.info(
             "ServiceRuntimeHealthMonitor started (interval=%ds)",
@@ -232,14 +248,17 @@ class ServiceRuntimeHealthMonitor:
 
                     # describe_consumer_groups to find empty ones
                     described = {}
+                    describe_failed = False
                     if all_group_ids:
                         try:
                             described = await admin.describe_consumer_groups(  # type: ignore[union-attr]
                                 all_group_ids
                             )
                         except Exception as exc:  # noqa: BLE001
-                            logger.debug(
-                                "Runtime health: describe_consumer_groups failed — %s",
+                            describe_failed = True
+                            logger.warning(
+                                "Runtime health: describe_consumer_groups failed — %s; "
+                                "consumer group states unknown",
                                 exc,
                             )
 
@@ -266,7 +285,18 @@ class ServiceRuntimeHealthMonitor:
                             uncovered.append(topic)
                     uncovered_topic_count = len(uncovered)
 
-                    if empty_consumer_group_count > 0:
+                    if describe_failed:
+                        dimensions.append(
+                            ModelRuntimeHealthDimension(
+                                name="empty_consumer_groups",
+                                status="DEGRADED",
+                                detail=(
+                                    f"describe_consumer_groups failed; "
+                                    f"{consumer_group_count} groups listed but states unknown"
+                                ),
+                            )
+                        )
+                    elif empty_consumer_group_count > 0:
                         dimensions.append(
                             ModelRuntimeHealthDimension(
                                 name="empty_consumer_groups",
@@ -412,7 +442,7 @@ class ServiceRuntimeHealthMonitor:
         if self._event_bus is None:
             return
 
-        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+        envelope: ModelEventEnvelope[ModelRuntimeHealthCheckEvent] = ModelEventEnvelope(
             payload=event,
             correlation_id=event.correlation_id,
             event_type="runtime-health-check",

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -253,15 +253,15 @@ class ServiceRuntimeHealthMonitor:
 
                     # Check which subscribe topics have a matching non-empty group
                     # Consumer groups in ONEX typically encode the topic in the group ID
-                    # (e.g. "onex-runtime-consumer-<topic-suffix>"). We consider a
-                    # topic "covered" if at least one non-empty group ID contains any
-                    # word from the topic's suffix component.
+                    # (e.g. "onex-runtime-consumer-<topic-slug>"). We consider a topic
+                    # "covered" if at least one non-empty group ID contains the full
+                    # topic name, ensuring exact-identity matching rather than a loose
+                    # suffix match that could yield false positives on version tokens
+                    # like "v1" (which appear in every consumer group name).
                     non_empty_groups = set(all_group_ids) - empty_groups
                     uncovered: list[str] = []
                     for topic in sorted(subscribe_topics):
-                        # Extract suffix after last '.' separator as coverage key
-                        suffix = topic.rsplit(".", 1)[-1] if "." in topic else topic
-                        covered = any(suffix in grp for grp in non_empty_groups)
+                        covered = any(topic in grp for grp in non_empty_groups)
                         if not covered:
                             uncovered.append(topic)
                     uncovered_topic_count = len(uncovered)

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import os
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.models.health.model_runtime_health_check_event import (
@@ -46,15 +46,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _discover_contracts() -> object:
-    """Module-level shim — allows tests to patch without lazy-import complications."""
+def _discover_contracts() -> Any:  # ONEX_EXCLUDE: any_type
+    """Module-level shim — allows tests to patch without lazy-import complications.
+
+    Returns Any because ModelAutoWiringManifest is imported lazily inside the
+    function body to avoid circular imports at module parse time.
+    """
     from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
 
     return discover_contracts()
 
 
-def _get_kafka_admin_client(bootstrap_servers: str, request_timeout_ms: int) -> object:
-    """Module-level shim for AIOKafkaAdminClient — patchable in tests."""
+def _get_kafka_admin_client(
+    bootstrap_servers: str, request_timeout_ms: int
+) -> Any:  # ONEX_EXCLUDE: any_type
+    """Module-level shim for AIOKafkaAdminClient — patchable in tests.
+
+    Returns Any because AIOKafkaAdminClient is imported lazily inside the
+    function body to avoid hard dependency at module import time.
+    """
     from aiokafka.admin import AIOKafkaAdminClient
 
     return AIOKafkaAdminClient(
@@ -169,9 +179,9 @@ class ServiceRuntimeHealthMonitor:
         subscribe_topics: set[str] = set()
         try:
             manifest = _discover_contracts()
-            contract_count = manifest.total_discovered
-            discovery_error_count = manifest.total_errors
-            subscribe_topics = set(manifest.all_subscribe_topics())
+            contract_count = manifest.total_discovered  # type: ignore[attr-defined]
+            discovery_error_count = manifest.total_errors  # type: ignore[attr-defined]
+            subscribe_topics = set(manifest.all_subscribe_topics())  # type: ignore[attr-defined]
 
             if discovery_error_count > 0:
                 dimensions.append(
@@ -211,10 +221,10 @@ class ServiceRuntimeHealthMonitor:
                     admin = _get_kafka_admin_client(
                         self._bootstrap_servers, _KAFKA_ADMIN_TIMEOUT_MS
                     )
-                    await admin.start()
+                    await admin.start()  # type: ignore[union-attr]
 
                     # list_consumer_groups() returns list of (group_id, protocol_type) tuples
-                    all_groups_raw = await admin.list_consumer_groups()
+                    all_groups_raw = await admin.list_consumer_groups()  # type: ignore[union-attr]
                     all_group_ids = [g[0] for g in all_groups_raw]
                     consumer_group_count = len(all_group_ids)
 
@@ -222,7 +232,7 @@ class ServiceRuntimeHealthMonitor:
                     described = {}
                     if all_group_ids:
                         try:
-                            described = await admin.describe_consumer_groups(
+                            described = await admin.describe_consumer_groups(  # type: ignore[union-attr]
                                 all_group_ids
                             )
                         except Exception as exc:  # noqa: BLE001
@@ -306,7 +316,7 @@ class ServiceRuntimeHealthMonitor:
                 finally:
                     if admin is not None:
                         try:
-                            await admin.close()
+                            await admin.close()  # type: ignore[union-attr]
                         except Exception:  # noqa: BLE001
                             pass
 

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -175,6 +175,7 @@ class ServiceRuntimeHealthMonitor:
             try:
                 await self._task
             except asyncio.CancelledError:
+                # Expected: task.cancel() raises CancelledError on the awaiter.
                 pass
             self._task = None
         logger.info("ServiceRuntimeHealthMonitor stopped")
@@ -218,7 +219,11 @@ class ServiceRuntimeHealthMonitor:
                     )
                 )
         except Exception as exc:  # noqa: BLE001 — boundary: dimension degrades
-            logger.warning("Runtime health: discovery check failed — %s", exc)
+            logger.warning(
+                "Runtime health: discovery check failed — %s (correlation_id=%s)",
+                type(exc).__name__,
+                correlation_id,
+            )
             dimensions.append(
                 ModelRuntimeHealthDimension(
                     name="discovery_errors",
@@ -380,7 +385,11 @@ class ServiceRuntimeHealthMonitor:
                     )
                 )
             except Exception as exc:  # noqa: BLE001 — boundary: dimension degrades
-                logger.warning("Runtime health: consumer group check failed — %s", exc)
+                logger.warning(
+                    "Runtime health: consumer group check failed — %s (correlation_id=%s)",
+                    type(exc).__name__,
+                    correlation_id,
+                )
                 dimensions.append(
                     ModelRuntimeHealthDimension(
                         name="consumer_coverage",

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -129,9 +129,11 @@ class ServiceRuntimeHealthMonitor:
 
         self._health_topic = topic_registry.resolve(topic_keys.RUNTIME_HEALTH_CHECK)
         self._event_bus = event_bus
-        self._bootstrap_servers = bootstrap_servers or os.environ.get(
-            "KAFKA_BOOTSTRAP_SERVERS", ""
-        )
+        # Only fall back to env var when caller passes None (not when they pass "").
+        if bootstrap_servers is None:
+            self._bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
+        else:
+            self._bootstrap_servers = bootstrap_servers
         self._check_interval = check_interval_seconds
         self._task: asyncio.Task[None] | None = None
         self._running = False

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -46,14 +46,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _discover_contracts():  # type: ignore[return]
+def _discover_contracts() -> object:
     """Module-level shim — allows tests to patch without lazy-import complications."""
     from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
 
     return discover_contracts()
 
 
-def _get_kafka_admin_client(bootstrap_servers: str, request_timeout_ms: int):  # type: ignore[return]
+def _get_kafka_admin_client(bootstrap_servers: str, request_timeout_ms: int) -> object:
     """Module-level shim for AIOKafkaAdminClient — patchable in tests."""
     from aiokafka.admin import AIOKafkaAdminClient
 

--- a/src/omnibase_infra/topics/service_topic_registry.py
+++ b/src/omnibase_infra/topics/service_topic_registry.py
@@ -140,6 +140,10 @@ class ServiceTopicRegistry:
             topic_keys.CONSUMER_RESTART_CMD: (
                 "onex.cmd.omnibase-infra.consumer-restart.v1"
             ),
+            # Runtime health check
+            topic_keys.RUNTIME_HEALTH_CHECK: (
+                "onex.evt.omnibase-infra.runtime-health-check.v1"
+            ),
             # Runtime error
             topic_keys.RUNTIME_ERROR: ("onex.evt.omnibase-infra.runtime-error.v1"),
             topic_keys.ERROR_TRIAGED: ("onex.evt.omnibase-infra.error-triaged.v1"),

--- a/src/omnibase_infra/topics/topic_keys.py
+++ b/src/omnibase_infra/topics/topic_keys.py
@@ -156,6 +156,9 @@ CONSUMER_HEALTH: Final[str] = "CONSUMER_HEALTH"
 CONSUMER_RESTART_CMD: Final[str] = "CONSUMER_RESTART_CMD"
 """Consumer restart commands issued by triage node."""
 
+RUNTIME_HEALTH_CHECK: Final[str] = "RUNTIME_HEALTH_CHECK"
+"""Runtime health check events from ServiceRuntimeHealthMonitor."""
+
 # ==============================================================================
 # Runtime Error Topics
 # ==============================================================================
@@ -278,6 +281,7 @@ __all__: list[str] = [
     "ROUTING_DECIDED",
     "REWARD_ASSIGNED",
     "RUNTIME_ERROR",
+    "RUNTIME_HEALTH_CHECK",
     "SAVINGS_ESTIMATED",
     "SESSION_OUTCOME_CANONICAL",
     "SESSION_OUTCOME_CURRENT",

--- a/tests/integration/test_runtime_health_monitor.py
+++ b/tests/integration/test_runtime_health_monitor.py
@@ -108,7 +108,9 @@ async def test_run_once_emits_to_kafka(kafka_consumer: AIOKafkaConsumer) -> None
                     record = msgs[0]
                     break
         except TimeoutError:
-            pass  # record stays None; assertion below will fail with a clear message
+            # Timeout means no message arrived within the window.
+            # record stays None and the assertion below fails with a clear message.
+            pass
 
         assert record is not None, "Expected health-check event on Kafka topic"
         payload = json.loads(record.value)

--- a/tests/integration/test_runtime_health_monitor.py
+++ b/tests/integration/test_runtime_health_monitor.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for ServiceRuntimeHealthMonitor (OMN-8623).
+
+Verifies that the monitor can:
+1. Run a single health check cycle against a live Kafka broker
+2. Emit an event to the runtime-health-check topic
+3. Produce a correctly-structured event with all required fields
+
+Requires: running Kafka/Redpanda broker on localhost:19092.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+from aiokafka import AIOKafkaConsumer
+
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config.model_kafka_event_bus_config import (
+    ModelKafkaEventBusConfig,
+)
+from omnibase_infra.models.health.model_runtime_health_check_event import (
+    ModelRuntimeHealthCheckEvent,
+)
+from omnibase_infra.services.service_runtime_health_monitor import (
+    ServiceRuntimeHealthMonitor,
+)
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.kafka,
+]
+
+BOOTSTRAP_SERVERS = "localhost:19092"
+HEALTH_TOPIC = ServiceTopicRegistry.from_defaults().resolve(
+    topic_keys.RUNTIME_HEALTH_CHECK
+)
+
+
+@pytest.fixture
+async def kafka_consumer() -> AsyncGenerator[AIOKafkaConsumer, None]:
+    """Create a transient Kafka consumer subscribed to the health topic."""
+    consumer = AIOKafkaConsumer(
+        HEALTH_TOPIC,
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        auto_offset_reset="latest",
+        group_id=f"test-runtime-health-monitor-{id(object())}",
+        enable_auto_commit=False,
+    )
+    await consumer.start()
+    # Seek to end so we only see events produced during this test
+    await consumer.seek_to_end()
+    try:
+        yield consumer
+    finally:
+        await consumer.stop()
+
+
+@pytest.mark.asyncio
+async def test_run_once_returns_event() -> None:
+    """run_once() must return a valid ModelRuntimeHealthCheckEvent."""
+    monitor = ServiceRuntimeHealthMonitor(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+    )
+    event = await monitor.run_once()
+
+    assert isinstance(event, ModelRuntimeHealthCheckEvent)
+    assert event.status in ("HEALTHY", "DEGRADED", "CRITICAL")
+    assert event.contract_count >= 0
+    assert event.consumer_group_count >= 0
+    assert event.correlation_id is not None
+    assert event.timestamp is not None
+
+
+@pytest.mark.asyncio
+async def test_run_once_emits_to_kafka(kafka_consumer: AIOKafkaConsumer) -> None:
+    """run_once() must publish a health-check event to the Kafka topic."""
+    config = ModelKafkaEventBusConfig(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        environment="integration-test",
+    )
+    bus = EventBusKafka(config=config)
+    await bus.start()
+    try:
+        monitor = ServiceRuntimeHealthMonitor(
+            event_bus=bus,
+            bootstrap_servers=BOOTSTRAP_SERVERS,
+        )
+        await monitor.run_once()
+
+        # Give broker a moment to deliver the message
+        record = None
+        try:
+            records = await asyncio.wait_for(
+                kafka_consumer.getmany(timeout_ms=5000, max_records=1),
+                timeout=10.0,
+            )
+            for _tp, msgs in records.items():
+                if msgs:
+                    record = msgs[0]
+                    break
+        except TimeoutError:
+            pass
+
+        assert record is not None, "Expected health-check event on Kafka topic"
+        payload = json.loads(record.value)
+        assert "status" in payload
+        assert payload["status"] in ("HEALTHY", "DEGRADED", "CRITICAL")
+    finally:
+        await bus.stop()

--- a/tests/integration/test_runtime_health_monitor.py
+++ b/tests/integration/test_runtime_health_monitor.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import uuid
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -37,7 +39,7 @@ pytestmark = [
     pytest.mark.kafka,
 ]
 
-BOOTSTRAP_SERVERS = "localhost:19092"
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
 HEALTH_TOPIC = ServiceTopicRegistry.from_defaults().resolve(
     topic_keys.RUNTIME_HEALTH_CHECK
 )
@@ -50,7 +52,7 @@ async def kafka_consumer() -> AsyncGenerator[AIOKafkaConsumer, None]:
         HEALTH_TOPIC,
         bootstrap_servers=BOOTSTRAP_SERVERS,
         auto_offset_reset="latest",
-        group_id=f"test-runtime-health-monitor-{id(object())}",
+        group_id=f"test-runtime-health-monitor-{uuid.uuid4().hex}",
         enable_auto_commit=False,
     )
     await consumer.start()
@@ -106,7 +108,7 @@ async def test_run_once_emits_to_kafka(kafka_consumer: AIOKafkaConsumer) -> None
                     record = msgs[0]
                     break
         except TimeoutError:
-            pass
+            pass  # record stays None; assertion below will fail with a clear message
 
         assert record is not None, "Expected health-check event on Kafka topic"
         payload = json.loads(record.value)

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -65,6 +65,8 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolRegistryMetrics": "protocols/protocol_registry_metrics.py",
     "ProtocolSnapshotPublisher": "protocols/protocol_snapshot_publisher.py",
     "ProtocolSnapshotStore": "protocols/protocol_snapshot_store.py",
+    "ProtocolAutoWiringManifestLike": "protocols/protocol_auto_wiring_manifest_like.py",  # [RUNTIME] OMN-8623 manifest shape for health monitor DI
+    "ProtocolKafkaAdminLike": "protocols/protocol_kafka_admin_like.py",  # [RUNTIME] OMN-8623 Kafka admin client boundary for health monitor DI
     "ProtocolTopicRegistry": "protocols/protocol_topic_registry.py",  # [DI] OMN-5839
     "ProtocolValidationLedgerRepository": "protocols/protocol_validation_ledger_repository.py",
     # === [DI] Dependency injection boundaries ===

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -194,14 +194,16 @@ class TestRunOnceWithKafka:
         # list_consumer_groups returns list of (group_id, protocol_type)
         admin.list_consumer_groups.return_value = [(g, "consumer") for g in groups]
 
-        # describe_consumer_groups returns {group_id: GroupMetadata}
-        described = {}
+        # describe_consumer_groups returns a list of GroupMetadata in the same
+        # order as the requested group_ids (matches AIOKafkaAdminClient behaviour
+        # and ProtocolKafkaAdminLike return type of list[object]).
+        described_list = []
         for g in groups:
             meta = MagicMock()
             meta.state = "Empty" if g in empty_groups else "Stable"
             meta.members = [] if g in empty_groups else [MagicMock()]
-            described[g] = meta
-        admin.describe_consumer_groups.return_value = described
+            described_list.append(meta)
+        admin.describe_consumer_groups.return_value = described_list
         return admin
 
     @pytest.mark.asyncio

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ServiceRuntimeHealthMonitor.
+
+Validates:
+- Model instantiation and field constraints
+- run_once() produces a correctly-shaped event
+- Discovery errors surface as DEGRADED
+- Empty consumer groups surface as DEGRADED
+- Uncovered topics surface as CRITICAL/DEGRADED
+- Event emission to Kafka via ProtocolEventBusLike
+- Start/stop lifecycle is idempotent
+
+Related Tickets:
+    - OMN-8623: Runtime health alerting
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.models.health.model_runtime_health_check_event import (
+    ModelRuntimeHealthCheckEvent,
+)
+from omnibase_infra.models.health.model_runtime_health_dimension import (
+    ModelRuntimeHealthDimension,
+)
+from omnibase_infra.services.service_runtime_health_monitor import (
+    ServiceRuntimeHealthMonitor,
+    _worst,
+)
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_manifest(contracts=5, errors=0, subscribe_topics=()):
+    """Return a minimal mock ModelAutoWiringManifest."""
+    m = MagicMock()
+    m.total_discovered = contracts
+    m.total_errors = errors
+    m.all_subscribe_topics.return_value = subscribe_topics
+    return m
+
+
+# =============================================================================
+# _worst helper
+# =============================================================================
+
+
+class TestWorstHelper:
+    def test_all_healthy(self):
+        assert _worst(["HEALTHY", "HEALTHY"]) == "HEALTHY"
+
+    def test_one_degraded(self):
+        assert _worst(["HEALTHY", "DEGRADED"]) == "DEGRADED"
+
+    def test_critical_wins(self):
+        assert _worst(["HEALTHY", "DEGRADED", "CRITICAL"]) == "CRITICAL"
+
+    def test_empty_list(self):
+        assert _worst([]) == "HEALTHY"
+
+
+# =============================================================================
+# Model validation
+# =============================================================================
+
+
+class TestModelRuntimeHealthCheckEvent:
+    def test_valid_instantiation(self):
+        ev = ModelRuntimeHealthCheckEvent(
+            correlation_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            status="HEALTHY",
+        )
+        assert ev.status == "HEALTHY"
+        assert ev.dimensions == ()
+
+    def test_dimension_validation(self):
+        dim = ModelRuntimeHealthDimension(
+            name="test_dim", status="DEGRADED", detail="something bad"
+        )
+        assert dim.status == "DEGRADED"
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(Exception):
+            ModelRuntimeHealthCheckEvent(
+                correlation_id=uuid4(),
+                timestamp=datetime.now(UTC),
+                status="UNKNOWN",  # type: ignore[arg-type]
+            )
+
+
+# =============================================================================
+# ServiceRuntimeHealthMonitor — init
+# =============================================================================
+
+
+class TestServiceRuntimeHealthMonitorInit:
+    def test_defaults(self):
+        monitor = ServiceRuntimeHealthMonitor()
+        assert monitor._check_interval == 300.0
+        assert monitor._event_bus is None
+        assert not monitor._running
+
+    def test_custom_interval(self):
+        monitor = ServiceRuntimeHealthMonitor(check_interval_seconds=60.0)
+        assert monitor._check_interval == 60.0
+
+    def test_topic_resolved(self):
+        registry = ServiceTopicRegistry.from_defaults()
+        monitor = ServiceRuntimeHealthMonitor(topic_registry=registry)
+        assert (
+            monitor._health_topic == "onex.evt.omnibase-infra.runtime-health-check.v1"
+        )
+
+
+# =============================================================================
+# ServiceRuntimeHealthMonitor — run_once (no Kafka)
+# =============================================================================
+
+
+class TestRunOnceNoKafka:
+    """Tests that run_once works when bootstrap_servers is not set."""
+
+    @pytest.mark.asyncio
+    async def test_healthy_when_no_errors(self):
+        manifest = _make_manifest(contracts=10, errors=0)
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            event = await monitor.run_once()
+
+        assert event.contract_count == 10
+        assert event.discovery_error_count == 0
+        # No bootstrap_servers → consumer checks skipped → should be HEALTHY overall
+        assert event.status == "HEALTHY"
+
+    @pytest.mark.asyncio
+    async def test_degraded_on_discovery_errors(self):
+        manifest = _make_manifest(contracts=8, errors=3)
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            event = await monitor.run_once()
+
+        assert event.discovery_error_count == 3
+        assert event.status in ("DEGRADED", "CRITICAL")
+        dim_names = {d.name for d in event.dimensions}
+        assert "discovery_errors" in dim_names
+        degraded_dims = [d for d in event.dimensions if d.status != "HEALTHY"]
+        assert any(d.name == "discovery_errors" for d in degraded_dims)
+
+    @pytest.mark.asyncio
+    async def test_critical_on_discovery_exception(self):
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            side_effect=RuntimeError("boom"),
+        ):
+            event = await monitor.run_once()
+
+        assert event.status == "CRITICAL"
+        critical_dims = [d for d in event.dimensions if d.status == "CRITICAL"]
+        assert any(d.name == "discovery_errors" for d in critical_dims)
+
+
+# =============================================================================
+# ServiceRuntimeHealthMonitor — run_once with mocked Kafka admin
+# =============================================================================
+
+
+class TestRunOnceWithKafka:
+    """Tests consumer group coverage checks with mocked AIOKafkaAdminClient."""
+
+    def _mock_admin(self, groups, empty_groups):
+        """Build a mock admin client."""
+        admin = AsyncMock()
+        # list_consumer_groups returns list of (group_id, protocol_type)
+        admin.list_consumer_groups.return_value = [(g, "consumer") for g in groups]
+
+        # describe_consumer_groups returns {group_id: GroupMetadata}
+        described = {}
+        for g in groups:
+            meta = MagicMock()
+            meta.state = "Empty" if g in empty_groups else "Stable"
+            meta.members = [] if g in empty_groups else [MagicMock()]
+            described[g] = meta
+        admin.describe_consumer_groups.return_value = described
+        return admin
+
+    @pytest.mark.asyncio
+    async def test_healthy_when_all_groups_active(self):
+        groups = ["onex-consumer-v1", "onex-consumer-v2"]
+        manifest = _make_manifest(contracts=5, errors=0, subscribe_topics=["topic.v1"])
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="localhost:9092")
+
+        admin = self._mock_admin(groups, empty_groups=set())
+
+        with (
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._get_kafka_admin_client",
+                return_value=admin,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.consumer_group_count == 2
+        assert event.empty_consumer_group_count == 0
+
+    @pytest.mark.asyncio
+    async def test_degraded_when_empty_groups(self):
+        groups = ["onex-consumer-v1", "onex-consumer-v2", "onex-consumer-v3"]
+        manifest = _make_manifest(contracts=5, errors=0)
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="localhost:9092")
+
+        admin = self._mock_admin(groups, empty_groups={"onex-consumer-v2"})
+
+        with (
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._get_kafka_admin_client",
+                return_value=admin,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.empty_consumer_group_count == 1
+        degraded_dims = [d for d in event.dimensions if d.status != "HEALTHY"]
+        assert any(d.name == "empty_consumer_groups" for d in degraded_dims)
+
+
+# =============================================================================
+# ServiceRuntimeHealthMonitor — event emission
+# =============================================================================
+
+
+class TestEventEmission:
+    @pytest.mark.asyncio
+    async def test_emits_to_event_bus(self):
+        bus = AsyncMock()
+        manifest = _make_manifest()
+        monitor = ServiceRuntimeHealthMonitor(event_bus=bus, bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            await monitor.run_once()
+
+        bus.publish_envelope.assert_awaited_once()
+        call_kwargs = bus.publish_envelope.await_args
+        assert call_kwargs is not None
+        topic_arg = call_kwargs.kwargs.get("topic") or call_kwargs.args[1]
+        assert "runtime-health-check" in topic_arg
+
+    @pytest.mark.asyncio
+    async def test_emission_failure_does_not_crash(self):
+        bus = AsyncMock()
+        bus.publish_envelope.side_effect = RuntimeError("kafka down")
+        manifest = _make_manifest()
+        monitor = ServiceRuntimeHealthMonitor(event_bus=bus, bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            # Should not raise
+            event = await monitor.run_once()
+
+        assert event is not None
+
+    @pytest.mark.asyncio
+    async def test_no_emission_when_no_bus(self):
+        manifest = _make_manifest()
+        monitor = ServiceRuntimeHealthMonitor(event_bus=None, bootstrap_servers="")
+
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            event = await monitor.run_once()
+
+        assert event is not None
+
+
+# =============================================================================
+# ServiceRuntimeHealthMonitor — lifecycle
+# =============================================================================
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self):
+        monitor = ServiceRuntimeHealthMonitor(
+            bootstrap_servers="", check_interval_seconds=9999.0
+        )
+        await monitor.start()
+        assert monitor._running
+        assert monitor._task is not None
+        await monitor.stop()
+        assert not monitor._running
+        assert monitor._task is None
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self):
+        monitor = ServiceRuntimeHealthMonitor(
+            bootstrap_servers="", check_interval_seconds=9999.0
+        )
+        await monitor.start()
+        task_before = monitor._task
+        await monitor.start()  # second call
+        assert monitor._task is task_before
+        await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_idempotent_without_start(self):
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="")
+        await monitor.stop()  # should not raise
+        assert not monitor._running
+
+
+# =============================================================================
+# Topic key registration
+# =============================================================================
+
+
+class TestTopicKey:
+    def test_topic_key_registered(self):
+        assert hasattr(topic_keys, "RUNTIME_HEALTH_CHECK")
+
+    def test_topic_resolves(self):
+        registry = ServiceTopicRegistry.from_defaults()
+        topic = registry.resolve(topic_keys.RUNTIME_HEALTH_CHECK)
+        assert topic == "onex.evt.omnibase-infra.runtime-health-check.v1"

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -17,7 +17,6 @@ Related Tickets:
 
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -315,10 +314,15 @@ class TestEventEmission:
 class TestLifecycle:
     @pytest.mark.asyncio
     async def test_start_stop(self):
+        manifest = _make_manifest(contracts=5, errors=0)
         monitor = ServiceRuntimeHealthMonitor(
             bootstrap_servers="", check_interval_seconds=9999.0
         )
-        await monitor.start()
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            await monitor.start()
         assert monitor._running
         assert monitor._task is not None
         await monitor.stop()
@@ -327,12 +331,17 @@ class TestLifecycle:
 
     @pytest.mark.asyncio
     async def test_start_idempotent(self):
+        manifest = _make_manifest(contracts=5, errors=0)
         monitor = ServiceRuntimeHealthMonitor(
             bootstrap_servers="", check_interval_seconds=9999.0
         )
-        await monitor.start()
-        task_before = monitor._task
-        await monitor.start()  # second call
+        with patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ):
+            await monitor.start()
+            task_before = monitor._task
+            await monitor.start()  # second call — should not re-run initial check
         assert monitor._task is task_before
         await monitor.stop()
 

--- a/tests/unit/topics/test_service_topic_registry.py
+++ b/tests/unit/topics/test_service_topic_registry.py
@@ -176,7 +176,7 @@ class TestServiceTopicRegistryAllKeys:
     def test_all_keys_count(self) -> None:
         registry = ServiceTopicRegistry.from_defaults()
         keys = registry.all_keys()
-        assert len(keys) == 47  # updated: +1 key from OMN-7494 (savings pipeline)
+        assert len(keys) == 48  # updated: +1 key for RUNTIME_HEALTH_CHECK (OMN-8623)
 
     def test_all_keys_match_topic_keys_module(self) -> None:
         """Every key in topic_keys.__all__ must be in the registry."""

--- a/tests/unit/topics/test_service_topic_registry.py
+++ b/tests/unit/topics/test_service_topic_registry.py
@@ -176,7 +176,7 @@ class TestServiceTopicRegistryAllKeys:
     def test_all_keys_count(self) -> None:
         registry = ServiceTopicRegistry.from_defaults()
         keys = registry.all_keys()
-        assert len(keys) == 48  # updated: +1 key for RUNTIME_HEALTH_CHECK (OMN-8623)
+        assert len(keys) == len(topic_keys.__all__)
 
     def test_all_keys_match_topic_keys_module(self) -> None:
         """Every key in topic_keys.__all__ must be in the registry."""


### PR DESCRIPTION
## Summary

- Adds `ServiceRuntimeHealthMonitor`: a 5-minute periodic health check that emits `onex.evt.omnibase-infra.runtime-health-check.v1`
- Checks contract discovery errors, empty Kafka consumer groups, and subscribe topics with no active consumers
- Integrates as step 3.10 in `service_kernel` startup (best-effort, never blocks)

## What it catches

| Dimension | Status trigger |
|---|---|
| `discovery_errors` | `discover_contracts()` returns errors or raises |
| `empty_consumer_groups` | Any consumer group reports `state=Empty` |
| `topic_coverage` | Subscribe topic with no matching non-empty group (CRITICAL if >10) |

## New files

- `src/omnibase_infra/models/health/model_runtime_health_dimension.py`
- `src/omnibase_infra/models/health/model_runtime_health_check_event.py`
- `src/omnibase_infra/services/service_runtime_health_monitor.py`
- `tests/unit/services/test_service_runtime_health_monitor.py` — 23 tests, all passing

## Integration

- `RUNTIME_HEALTH_CHECK` topic key → `onex.evt.omnibase-infra.runtime-health-check.v1`
- `RUNTIME_HEALTH_CHECK_INTERVAL` env var controls interval (default: 300s)
- Gracefully skips consumer checks if `aiokafka` is unavailable or no bootstrap servers configured

## Test plan

- [x] 23 unit tests passing (mocked discovery + mocked Kafka admin)
- [x] All pre-commit hooks pass (ruff, mypy, architecture, any-type, naming)
- [x] Pre-existing test failure `test_default_values` confirmed on main (env-specific, unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime health monitoring that periodically emits health events (HEALTHY/DEGRADED/CRITICAL) with dimensional snapshots and aggregate metrics; integrates into service startup/shutdown and can publish to Kafka.
  * Added immutable health event and dimension models to represent runtime checks.
  * Registered a runtime-health-check topic key and default topic mapping.

* **Tests**
  * Added unit and integration tests covering monitor logic, models, lifecycle, and Kafka emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->