### PR TITLE
fix(schema): add routing_outcomes.quality_score column [OMN-8677]

### DIFF
--- a/docker/migrations/forward/066_add_quality_score_to_routing_outcomes.sql
+++ b/docker/migrations/forward/066_add_quality_score_to_routing_outcomes.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- MIGRATION: Add quality_score column to routing_outcomes
+-- =============================================================================
+-- Ticket: OMN-new (Add routing_outcomes.quality_score column)
+-- Epic: OMN-7264 (Intelligent Model Router MVP)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   Adds quality_score DOUBLE PRECISION column to routing_outcomes table.
+--   Required by node_platform_readiness._check_quality_score_coverage()
+--   which queries WHERE quality_score IS NOT NULL to assess dimension health.
+--   Missing column causes platform_readiness dimension to FAIL on every check.
+--
+-- IDEMPOTENCY:
+--   - ALTER TABLE ... ADD COLUMN IF NOT EXISTS is safe to re-run.
+--
+-- ROLLBACK:
+--   docker/migrations/rollback/rollback_066_add_quality_score_to_routing_outcomes.sql
+-- =============================================================================
+
+ALTER TABLE public.routing_outcomes
+    ADD COLUMN IF NOT EXISTS quality_score DOUBLE PRECISION;
+
+COMMENT ON COLUMN routing_outcomes.quality_score IS
+    'Overall quality score for the routing outcome (0.0-1.0). '
+    'Populated by node_routing_score_reducer after outcome evaluation. '
+    'NULL until score is computed. (OMN-new)';
+
+-- Update migration sentinel
+UPDATE public.db_metadata
+SET migrations_complete = TRUE,
+    schema_version = '066',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/rollback/rollback_066_add_quality_score_to_routing_outcomes.sql
+++ b/docker/migrations/rollback/rollback_066_add_quality_score_to_routing_outcomes.sql
@@ -1,0 +1,13 @@
+-- =============================================================================
+-- ROLLBACK: Remove quality_score column from routing_outcomes
+-- =============================================================================
+-- Ticket: OMN-new
+
+ALTER TABLE public.routing_outcomes
+    DROP COLUMN IF EXISTS quality_score;
+
+-- Revert migration sentinel
+UPDATE public.db_metadata
+SET schema_version = '065',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:a2935ede4cca3f43703e978b36d528908a00459b86b916bc90059ba432a77dea
-generated_at: 2026-04-12T23:08:10Z
-migration_file_count: 51
+sha256:c77f2b1f8bbf7c1f463e91a0b09ebf627157ce056150a055b0b41c7e7d4a1ca4
+generated_at: 2026-04-14T02:40:25Z
+migration_file_count: 52


### PR DESCRIPTION
## Summary

- Adds `quality_score DOUBLE PRECISION` column to `routing_outcomes` table via migration 066
- Missing column caused `node_platform_readiness._check_quality_score_coverage()` to error on every check, blocking the `quality_score_coverage` dimension from passing
- Unblocks platform_readiness dimension (quality_score_coverage FAIL → PASS after deploy and data population)

## Migration

- Forward: `docker/migrations/forward/066_add_quality_score_to_routing_outcomes.sql`
- Rollback: `docker/migrations/rollback/rollback_066_add_quality_score_to_routing_outcomes.sql`
- Column is nullable — NULL until populated by `node_routing_score_reducer`

## Test plan

- [ ] Migration runs cleanly on DB (idempotent: `ADD COLUMN IF NOT EXISTS`)
- [ ] `\d routing_outcomes` on .201 shows `quality_score` column after deploy
- [ ] `node_platform_readiness` quality_score_coverage dimension no longer errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quality score for routing outcomes to enable measurement and evaluation of routing decision quality.

* **Chores**
  * Database schema migration and corresponding rollback to add/remove the quality score.
  * Updated migration metadata fingerprint to reflect the new migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->