### PR TITLE
fix(runtime): inject DatabaseAdapter into projection handlers [OMN-8684]

### DIFF
--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -13,6 +13,7 @@ required_env:
   - LLM_CODER_FAST_URL
   - LLM_EMBEDDING_URL
   - LLM_DEEPSEEK_R1_URL
+  - OMNIDASH_ANALYTICS_DB_URL
 hardcoded_env:
   OMNIBASE_INFRA_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra'
   OMNIINTELLIGENCE_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence'

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -22,8 +22,11 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+import os
+import re
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
@@ -103,6 +106,167 @@ def _make_dispatch_callback(
     ) -> ModelDispatchResult | None:
         handle_method = handler_instance.handle
         return await handle_method(envelope)
+
+    return _callback
+
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+_DB_URL_ENV_MAP: dict[str, str] = {
+    "omnidash_analytics": "OMNIDASH_ANALYTICS_DB_URL",
+    "omnibase_infra": "OMNIBASE_INFRA_DB_URL",
+}
+
+_TOPIC_TO_EVENT_TYPE: dict[str, str] = {
+    "node-heartbeat": "heartbeat",
+    "node-introspection": "introspection",
+}
+
+
+def _read_db_io_tables(contract_path: Path) -> list[dict[str, str]]:
+    """Read db_io.db_tables from a contract YAML. Returns [] if absent."""
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        with open(contract_path) as f:
+            raw = yaml.safe_load(f)
+        if not isinstance(raw, dict):
+            return []
+        db_io = raw.get("db_io") or {}
+        return list(db_io.get("db_tables") or [])
+    except Exception as exc:  # noqa: BLE001 — I/O boundary: safe to swallow YAML parse/file errors
+        logger.warning("Failed to read db_io from %s: %s", contract_path, exc)
+        return []
+
+
+def _build_sync_db_adapter(db_url: str) -> object:
+    """Build a synchronous psycopg2-backed DatabaseAdapter from a DSN.
+
+    Separated from _make_projection_dispatch_callback to allow test patching.
+    """
+    import psycopg2  # type: ignore[import-untyped]
+    import psycopg2.extras  # type: ignore[import-untyped]
+
+    class SyncPsycopg2Adapter:
+        _conn: object
+
+        def __init__(self, dsn: str) -> None:
+            self._dsn = dsn
+            self._conn = None
+
+        def _get_conn(self) -> object:
+            if self._conn is None or getattr(self._conn, "closed", False):
+                conn = psycopg2.connect(self._dsn)
+                conn.autocommit = True
+                self._conn = conn
+            return self._conn
+
+        def upsert(self, table: str, conflict_key: str, row: dict[str, object]) -> bool:
+            if not _TABLE_NAME_RE.match(table):
+                raise ValueError(f"Invalid table name: {table!r}")
+            conn = self._get_conn()
+            cols = list(row.keys())
+            quoted_cols = ", ".join(f'"{c}"' for c in cols)
+            placeholders = ", ".join(f"%({c})s" for c in cols)
+            updates = ", ".join(
+                f'"{c}" = EXCLUDED."{c}"' for c in cols if c != conflict_key
+            )
+            # table/conflict_key/cols validated by _TABLE_NAME_RE — not raw user input
+            parts = [
+                f'INSERT INTO "{table}" ({quoted_cols})',
+                f"VALUES ({placeholders})",
+                f'ON CONFLICT ("{conflict_key}") DO UPDATE SET {updates}',
+            ]
+            insert_sql = " ".join(parts)
+            with conn.cursor() as cur:  # type: ignore[union-attr, attr-defined]
+                cur.execute(insert_sql, row)
+            return True
+
+        def query(
+            self, table: str, filters: dict[str, object] | None = None
+        ) -> list[dict[str, object]]:
+            if not _TABLE_NAME_RE.match(table):
+                raise ValueError(f"Invalid table name: {table!r}")
+            conn = self._get_conn()
+            # table validated by _TABLE_NAME_RE — not user input
+            select_sql = f'SELECT * FROM "{table}"'  # noqa: S608
+            params: list[object] = []
+            if filters:
+                clauses = [f'"{k}" = %s' for k in filters]
+                select_sql += " WHERE " + " AND ".join(clauses)
+                params = list(filters.values())
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:  # type: ignore[union-attr, attr-defined]
+                cur.execute(select_sql, params or None)
+                return [dict(r) for r in cur.fetchall()]
+
+    return SyncPsycopg2Adapter(db_url)
+
+
+def _make_projection_dispatch_callback(
+    handler_instance: object,
+    db_tables: list[dict[str, str]],
+    subscribe_topics: tuple[str, ...],
+) -> DispatcherFunc:
+    """Create a dispatch callback for projection handlers (db_io.db_tables declared).
+
+    Builds a synchronous psycopg2 DatabaseAdapter per call and injects it into
+    input_data alongside _event_type derived from the topic name.
+    """
+    database = (
+        db_tables[0].get("database", "omnidash_analytics")
+        if db_tables
+        else "omnidash_analytics"
+    )
+    db_url_env = _DB_URL_ENV_MAP.get(database, "OMNIDASH_ANALYTICS_DB_URL")
+
+    async def _callback(
+        envelope: ModelEventEnvelope[object],
+    ) -> ModelDispatchResult | None:
+        db_url = os.environ.get(db_url_env, "")
+        if not db_url:
+            logger.error(
+                "Projection handler skipped: %s not set (database=%s)",
+                db_url_env,
+                database,
+            )
+            return None
+        try:
+            adapter = _build_sync_db_adapter(db_url)
+            topic = getattr(envelope, "topic", "") or ""
+            topic_segment = topic.split(".")[-2] if "." in topic else topic
+            event_type = _TOPIC_TO_EVENT_TYPE.get(topic_segment, "introspection")
+            payload = getattr(envelope, "payload", None)
+            input_data: dict[str, object] = (
+                dict(payload) if isinstance(payload, dict) else {}
+            )
+            if hasattr(payload, "model_dump"):
+                input_data = payload.model_dump(mode="python")  # type: ignore[union-attr]  # noqa: model-dump-bare
+            input_data["_db"] = adapter
+            input_data["_event_type"] = event_type
+            result = handler_instance.handle(input_data)  # type: ignore[union-attr]
+            logger.debug(
+                "Projection handler completed: topic=%s event_type=%s result=%s",
+                topic,
+                event_type,
+                result,
+            )
+        except TypeError as exc:
+            logger.error(
+                "Projection handler TypeError (likely missing _db or _event_type): "
+                "handler=%s topic=%s error=%s",
+                type(handler_instance).__name__,
+                getattr(envelope, "topic", "unknown"),
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Projection handler error: handler=%s topic=%s error_type=%s error=%s",
+                type(handler_instance).__name__,
+                getattr(envelope, "topic", "unknown"),
+                type(exc).__name__,
+                exc,
+            )
+        return None
 
     return _callback
 
@@ -454,7 +618,26 @@ def _wire_handler_entry(
     else:
         handler_instance = handler_cls()
 
-    callback = _make_dispatch_callback(handler_instance)
+    # Use projection callback when contract declares db_io.db_tables.
+    # Projection handlers implement handle(input_data: dict) with _db injected
+    # rather than the standard async handle(envelope) protocol.
+    db_tables = _read_db_io_tables(contract.contract_path)
+    if db_tables:
+        subscribe_topics = (
+            contract.event_bus.subscribe_topics if contract.event_bus else ()
+        )
+        callback = _make_projection_dispatch_callback(
+            handler_instance,
+            db_tables,
+            subscribe_topics,
+        )
+        logger.info(
+            "Auto-wired projection handler with DB injection: handler=%s db_tables=%s",
+            handler_ref.name,
+            [t.get("name") for t in db_tables],
+        )
+    else:
+        callback = _make_dispatch_callback(handler_instance)
     dispatcher_id = _derive_dispatcher_id(contract.name, handler_ref.name)
 
     # Determine message category from subscribe topics

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -243,7 +243,7 @@ def _make_projection_dispatch_callback(
                 input_data = payload.model_dump(mode="python")  # type: ignore[union-attr]  # noqa: model-dump-bare
             input_data["_db"] = adapter
             input_data["_event_type"] = event_type
-            result = handler_instance.handle(input_data)  # type: ignore[union-attr]
+            result = handler_instance.handle(input_data)  # type: ignore[union-attr, attr-defined]
             logger.debug(
                 "Projection handler completed: topic=%s event_type=%s result=%s",
                 topic,

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -124,19 +124,23 @@ _TOPIC_TO_EVENT_TYPE: dict[str, str] = {
 
 
 def _read_db_io_tables(contract_path: Path) -> list[dict[str, str]]:
-    """Read db_io.db_tables from a contract YAML. Returns [] if absent."""
+    """Read db_io.db_tables from a contract YAML. Returns [] if db_io is absent.
+
+    Raises on YAML parse errors or unexpected file I/O failures so the caller
+    can mark the contract as broken rather than silently falling back to the
+    non-projection wiring path.
+    """
     try:
         import yaml  # type: ignore[import-untyped]
 
         with open(contract_path) as f:
             raw = yaml.safe_load(f)
-        if not isinstance(raw, dict):
-            return []
-        db_io = raw.get("db_io") or {}
-        return list(db_io.get("db_tables") or [])
-    except Exception as exc:  # noqa: BLE001 — I/O boundary: safe to swallow YAML parse/file errors
-        logger.warning("Failed to read db_io from %s: %s", contract_path, exc)
+    except FileNotFoundError:
         return []
+    if not isinstance(raw, dict):
+        return []
+    db_io = raw.get("db_io") or {}
+    return list(db_io.get("db_tables") or [])
 
 
 def _build_sync_db_adapter(db_url: str) -> object:
@@ -164,8 +168,13 @@ def _build_sync_db_adapter(db_url: str) -> object:
         def upsert(self, table: str, conflict_key: str, row: dict[str, object]) -> bool:
             if not _TABLE_NAME_RE.match(table):
                 raise ValueError(f"Invalid table name: {table!r}")
+            if not _TABLE_NAME_RE.match(conflict_key):
+                raise ValueError(f"Invalid conflict key: {conflict_key!r}")
             conn = self._get_conn()
             cols = list(row.keys())
+            bad_cols = [c for c in cols if not _TABLE_NAME_RE.match(str(c))]
+            if bad_cols:
+                raise ValueError(f"Invalid column names: {bad_cols!r}")
             quoted_cols = ", ".join(f'"{c}"' for c in cols)
             placeholders = ", ".join(f"%({c})s" for c in cols)
             updates = ", ".join(
@@ -192,6 +201,9 @@ def _build_sync_db_adapter(db_url: str) -> object:
             select_sql = f'SELECT * FROM "{table}"'  # noqa: S608
             params: list[object] = []
             if filters:
+                bad_keys = [k for k in filters if not _TABLE_NAME_RE.match(str(k))]
+                if bad_keys:
+                    raise ValueError(f"Invalid filter keys: {bad_keys!r}")
                 clauses = [f'"{k}" = %s' for k in filters]
                 select_sql += " WHERE " + " AND ".join(clauses)
                 params = list(filters.values())

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -229,7 +229,12 @@ def _make_projection_dispatch_callback(
         if db_tables
         else "omnidash_analytics"
     )
-    db_url_env = _DB_URL_ENV_MAP.get(database, "OMNIDASH_ANALYTICS_DB_URL")
+    if database not in _DB_URL_ENV_MAP:
+        raise ValueError(
+            f"Unknown database {database!r} in contract db_io — "
+            f"must be one of {sorted(_DB_URL_ENV_MAP)!r}"
+        )
+    db_url_env = _DB_URL_ENV_MAP[database]
 
     async def _callback(
         envelope: ModelEventEnvelope[object],
@@ -246,7 +251,12 @@ def _make_projection_dispatch_callback(
             adapter = _build_sync_db_adapter(db_url)
             topic = getattr(envelope, "topic", "") or ""
             topic_segment = topic.split(".")[-2] if "." in topic else topic
-            event_type = _TOPIC_TO_EVENT_TYPE.get(topic_segment, "introspection")
+            if topic_segment not in _TOPIC_TO_EVENT_TYPE:
+                raise ValueError(
+                    f"Unknown topic segment {topic_segment!r} from topic {topic!r} — "
+                    f"must be one of {sorted(_TOPIC_TO_EVENT_TYPE)!r}"
+                )
+            event_type = _TOPIC_TO_EVENT_TYPE[topic_segment]
             payload = getattr(envelope, "payload", None)
             input_data: dict[str, object] = (
                 dict(payload) if isinstance(payload, dict) else {}
@@ -265,18 +275,17 @@ def _make_projection_dispatch_callback(
         except TypeError as exc:
             logger.error(
                 "Projection handler TypeError (likely missing _db or _event_type): "
-                "handler=%s topic=%s error=%s",
-                type(handler_instance).__name__,
-                getattr(envelope, "topic", "unknown"),
-                exc,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.error(
-                "Projection handler error: handler=%s topic=%s error_type=%s error=%s",
+                "handler=%s topic=%s error_type=%s",
                 type(handler_instance).__name__,
                 getattr(envelope, "topic", "unknown"),
                 type(exc).__name__,
-                exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Projection handler error: handler=%s topic=%s error_type=%s",
+                type(handler_instance).__name__,
+                getattr(envelope, "topic", "unknown"),
+                type(exc).__name__,
             )
         return None
 

--- a/tests/integration/projectors/test_handler_wiring_projection_dispatch.py
+++ b/tests/integration/projectors/test_handler_wiring_projection_dispatch.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test for auto-wiring DB injection into projection handlers [OMN-8684].
+
+Verifies that the wiring bridge (_make_projection_dispatch_callback) correctly
+converts a ModelEventEnvelope into the dict-with-_db protocol expected by
+projection handlers, using a mock adapter to avoid requiring a live database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _make_projection_dispatch_callback,
+)
+
+_PATCH_BUILD_ADAPTER = (
+    "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter"
+)
+_PATCH_ENVIRON_GET = "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get"
+
+
+@pytest.mark.integration
+def test_projection_dispatch_bridge_injects_db_and_event_type() -> None:
+    """Projection handler receives dict with _db and _event_type from envelope.
+
+    This verifies the protocol bridge introduced for OMN-8684:
+    before: handler.handle(envelope) → TypeError (projection handlers don't accept envelopes)
+    after: handler.handle({"_db": adapter, "_event_type": "heartbeat", ...payload...})
+    """
+    received: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            received.append(dict(input_data))
+            return {"rows_upserted": 1}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeProjectionHandler()
+    callback = _make_projection_dispatch_callback(
+        handler, db_tables, ("onex.evt.platform.node-heartbeat.v1",)
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {"service_name": "test-svc", "health_status": "healthy"}
+
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://postgres:test@localhost:5436/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(received) == 1, "Handler should have been called exactly once"
+    assert received[0]["_db"] is fake_adapter, "_db must be the injected adapter"
+    assert received[0]["_event_type"] == "heartbeat", (
+        "heartbeat topic → event_type=heartbeat"
+    )
+    assert received[0].get("service_name") == "test-svc", (
+        "payload fields must be preserved"
+    )
+
+
+@pytest.mark.integration
+def test_projection_dispatch_bridge_no_call_when_db_url_missing() -> None:
+    """Projection handler is NOT called when OMNIDASH_ANALYTICS_DB_URL is unset.
+
+    Verifies no silent error occurs — handler simply skipped, no exception raised.
+    """
+    call_count = [0]
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            call_count[0] += 1
+            return {}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeProjectionHandler()
+    callback = _make_projection_dispatch_callback(handler, db_tables, ())
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {}
+
+    with patch(_PATCH_ENVIRON_GET, return_value=""):
+        result = asyncio.run(callback(envelope))
+
+    assert result is None
+    assert call_count[0] == 0, "Handler must not be called when DB URL is absent"

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test for projection handler DB injection wiring [OMN-8684].
+
+Verifies that the auto-wiring engine correctly routes events to projection
+handlers (handlers with db_io.db_tables in contract) by injecting a DB adapter
+and _event_type, rather than passing a raw ModelEventEnvelope.
+
+Uses in-memory fakes only — no real DB or Kafka required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _build_sync_db_adapter,
+    _make_projection_dispatch_callback,
+    _read_db_io_tables,
+    _wire_handler_entry,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_contract(tmp_path: Path, db_tables_yaml: str = "") -> ModelDiscoveredContract:
+    """Write a minimal contract.yaml and return a ModelDiscoveredContract."""
+    db_io_block = f"db_io:\n  db_tables:\n{db_tables_yaml}" if db_tables_yaml else ""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(
+        f"name: projection_registration\n"
+        f"node_type: reducer\n"
+        f"contract_version: {{major: 1, minor: 0, patch: 0}}\n"
+        f"{db_io_block}\n"
+        f"event_bus:\n"
+        f"  subscribe_topics:\n"
+        f"    - onex.evt.platform.node-heartbeat.v1\n"
+    )
+    return ModelDiscoveredContract(
+        name="projection_registration",
+        node_type="reducer",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=contract_path,
+        entry_point_name="projection_registration",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=("onex.evt.platform.node-heartbeat.v1",),
+            publish_topics=(),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerProjectionRegistration",
+                        module="omnimarket.nodes.node_projection_registration.handlers.handler_projection_registration",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_projection_callback_end_to_end_with_fake_db(tmp_path: Path) -> None:
+    """Full projection dispatch path: contract → db_tables read → adapter injected → handler called."""
+    upserted_rows: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            db = input_data.pop("_db")
+            event_type = input_data.pop("_event_type")
+            db.upsert(
+                "node_service_registry",
+                "service_name",
+                {**input_data, "event_type": event_type},
+            )
+            return {"rows_upserted": 1}
+
+    class FakeDb:
+        def upsert(self, table: str, key: str, row: dict) -> bool:
+            upserted_rows.append({"table": table, "key": key, "row": row})
+            return True
+
+        def query(self, table: str, filters: dict | None = None) -> list:
+            return []
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeProjectionHandler()
+    callback = _make_projection_dispatch_callback(
+        handler, db_tables, ("onex.evt.platform.node-heartbeat.v1",)
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {"service_name": "test-svc", "health_status": "healthy"}
+
+    fake_db = FakeDb()
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter",
+        return_value=fake_db,
+    ):
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            asyncio.run(callback(envelope))
+
+    assert len(upserted_rows) == 1
+    assert upserted_rows[0]["table"] == "node_service_registry"
+    assert upserted_rows[0]["row"]["service_name"] == "test-svc"
+    assert upserted_rows[0]["row"]["event_type"] == "heartbeat"
+
+
+@pytest.mark.integration
+def test_wire_handler_entry_uses_projection_path_when_db_io_declared(
+    tmp_path: Path,
+) -> None:
+    """_wire_handler_entry selects projection callback (not standard) when contract has db_io."""
+    contract = _make_contract(
+        tmp_path,
+        db_tables_yaml="    - name: node_service_registry\n      database: omnidash_analytics\n",
+    )
+
+    # _read_db_io_tables should find the declared table
+    tables = _read_db_io_tables(contract.contract_path)
+    assert len(tables) == 1
+    assert tables[0]["database"] == "omnidash_analytics"
+
+
+@pytest.mark.integration
+def test_wire_handler_entry_uses_standard_path_when_no_db_io(tmp_path: Path) -> None:
+    """_wire_handler_entry uses standard envelope path when contract has no db_io."""
+    contract = _make_contract(tmp_path, db_tables_yaml="")
+    tables = _read_db_io_tables(contract.contract_path)
+    assert tables == []
+
+
+@pytest.mark.integration
+def test_projection_callback_no_op_when_db_url_missing(tmp_path: Path) -> None:
+    """Projection callback returns None without calling handler when DB URL unset."""
+    call_count = [0]
+
+    class CountingHandler:
+        def handle(self, input_data: dict) -> dict:
+            call_count[0] += 1
+            return {}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    callback = _make_projection_dispatch_callback(CountingHandler(), db_tables, ())
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {}
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+        return_value="",
+    ):
+        result = asyncio.run(callback(envelope))
+
+    assert result is None
+    assert call_count[0] == 0

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -18,10 +18,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
-    _build_sync_db_adapter,
     _make_projection_dispatch_callback,
     _read_db_io_tables,
-    _wire_handler_entry,
 )
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelContractVersion,

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for projection handler DB injection in auto-wiring [OMN-8684]."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _make_dispatch_callback,
+    _make_projection_dispatch_callback,
+    _read_db_io_tables,
+)
+
+_PATCH_BUILD_ADAPTER = (
+    "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter"
+)
+_PATCH_ENVIRON_GET = "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _read_db_io_tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_db_io_tables_returns_tables(tmp_path: Path) -> None:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text(
+        "name: test\n"
+        "db_io:\n"
+        "  db_tables:\n"
+        "    - name: node_service_registry\n"
+        "      database: omnidash_analytics\n"
+    )
+    tables = _read_db_io_tables(contract)
+    assert len(tables) == 1
+    assert tables[0]["name"] == "node_service_registry"
+    assert tables[0]["database"] == "omnidash_analytics"
+
+
+@pytest.mark.unit
+def test_read_db_io_tables_returns_empty_when_absent(tmp_path: Path) -> None:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text("name: test\nnode_type: EFFECT_GENERIC\n")
+    assert _read_db_io_tables(contract) == []
+
+
+@pytest.mark.unit
+def test_read_db_io_tables_returns_empty_on_missing_file() -> None:
+    assert _read_db_io_tables(Path("/nonexistent/contract.yaml")) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_dispatch_callback (standard, non-projection path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_standard_callback_calls_async_handle() -> None:
+    handler = MagicMock()
+
+    async def fake_handle(envelope: object) -> None:
+        return None
+
+    handler.handle = fake_handle
+    callback = _make_dispatch_callback(handler)
+    envelope = MagicMock()
+    asyncio.run(callback(envelope))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_projection_dispatch_callback (db injection path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_projection_callback_injects_db_and_event_type() -> None:
+    """Handler receives a dict with _db and _event_type injected."""
+    received: list[dict] = []
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            received.append(dict(input_data))
+            return {"rows_upserted": 1}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    callback = _make_projection_dispatch_callback(
+        handler, db_tables, ("onex.evt.platform.node-heartbeat.v1",)
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {"service_name": "svc-a", "health_status": "healthy"}
+
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(received) == 1
+    assert received[0]["_event_type"] == "heartbeat"
+    assert received[0]["_db"] is fake_adapter
+
+
+@pytest.mark.unit
+def test_projection_callback_maps_introspection_event_type() -> None:
+    """node-introspection topic maps to _event_type='introspection'."""
+    received: list[dict] = []
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            received.append(dict(input_data))
+            return {}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    callback = _make_projection_dispatch_callback(
+        handler, db_tables, ("onex.evt.platform.node-introspection.v1",)
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-introspection.v1"
+    envelope.payload = {"service_name": "svc-b"}
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(received) == 1
+    assert received[0]["_event_type"] == "introspection"
+
+
+@pytest.mark.unit
+def test_projection_callback_skips_when_db_url_missing() -> None:
+    """When DB URL env var is absent, handler is NOT called and no exception is raised."""
+    call_count = [0]
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            call_count[0] += 1
+            return {}
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    callback = _make_projection_dispatch_callback(handler, db_tables, ())
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {}
+
+    with patch(_PATCH_ENVIRON_GET, return_value=""):
+        result = asyncio.run(callback(envelope))
+
+    assert result is None
+    assert call_count[0] == 0
+
+
+@pytest.mark.unit
+def test_projection_callback_logs_type_error_not_raises() -> None:
+    """TypeError from handler is logged, not propagated."""
+
+    class BrokenHandler:
+        def handle(self, input_data: dict) -> dict:
+            raise TypeError("missing _db")
+
+    db_tables = [{"name": "node_service_registry", "database": "omnidash_analytics"}]
+    handler = BrokenHandler()
+    callback = _make_projection_dispatch_callback(handler, db_tables, ())
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.platform.node-heartbeat.v1"
+    envelope.payload = {}
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            result = asyncio.run(callback(envelope))
+
+    assert result is None

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -62,15 +63,18 @@ def test_read_db_io_tables_returns_empty_on_missing_file() -> None:
 
 @pytest.mark.unit
 def test_standard_callback_calls_async_handle() -> None:
-    handler = MagicMock()
+    received: list[object] = []
 
-    async def fake_handle(envelope: object) -> None:
-        return None
+    class FakeHandler:
+        async def handle(self, envelope: object) -> None:
+            received.append(envelope)
 
-    handler.handle = fake_handle
+    handler = FakeHandler()
     callback = _make_dispatch_callback(handler)
     envelope = MagicMock()
     asyncio.run(callback(envelope))
+    assert len(received) == 1
+    assert received[0] is envelope
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +149,10 @@ def test_projection_callback_maps_introspection_event_type() -> None:
 
 
 @pytest.mark.unit
-def test_projection_callback_skips_when_db_url_missing() -> None:
-    """When DB URL env var is absent, handler is NOT called and no exception is raised."""
+def test_projection_callback_skips_when_db_url_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When DB URL env var is absent, handler is NOT called and error is logged."""
     call_count = [0]
 
     class FakeHandler:
@@ -162,16 +168,22 @@ def test_projection_callback_skips_when_db_url_missing() -> None:
     envelope.topic = "onex.evt.platform.node-heartbeat.v1"
     envelope.payload = {}
 
-    with patch(_PATCH_ENVIRON_GET, return_value=""):
-        result = asyncio.run(callback(envelope))
+    with caplog.at_level(
+        logging.ERROR, logger="omnibase_infra.runtime.auto_wiring.handler_wiring"
+    ):
+        with patch(_PATCH_ENVIRON_GET, return_value=""):
+            result = asyncio.run(callback(envelope))
 
     assert result is None
     assert call_count[0] == 0
+    assert any("not set" in r.message for r in caplog.records)
 
 
 @pytest.mark.unit
-def test_projection_callback_logs_type_error_not_raises() -> None:
-    """TypeError from handler is logged, not propagated."""
+def test_projection_callback_logs_type_error_not_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """TypeError from handler is logged (not propagated), and log entry is emitted."""
 
     class BrokenHandler:
         def handle(self, input_data: dict) -> dict:
@@ -186,11 +198,15 @@ def test_projection_callback_logs_type_error_not_raises() -> None:
     envelope.payload = {}
     fake_adapter = MagicMock()
 
-    with patch(
-        _PATCH_ENVIRON_GET,
-        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    with caplog.at_level(
+        logging.ERROR, logger="omnibase_infra.runtime.auto_wiring.handler_wiring"
     ):
-        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
-            result = asyncio.run(callback(envelope))
+        with patch(
+            _PATCH_ENVIRON_GET,
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+                result = asyncio.run(callback(envelope))
 
     assert result is None
+    assert any("TypeError" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **Root cause**: Auto-wiring called `handler.handle(envelope)` but projection handlers implement `handle(input_data: dict)` expecting `_db` injected — every event silently raised TypeError and was dropped
- **Fix**: `_wire_handler_entry` now reads `db_io.db_tables` from contract YAML; when present, uses `_make_projection_dispatch_callback` which builds a `SyncPsycopg2Adapter` and injects `_db` + `_event_type` into `input_data`
- **Catalog**: Added `OMNIDASH_ANALYTICS_DB_URL` to `omninode-runtime` required_env so the runtime container has the connection string available

## Files Changed

- `src/omnibase_infra/runtime/auto_wiring/handler_wiring.py` — DB injection bridge for projection handlers
- `docker/catalog/services/omninode-runtime.yaml` — add `OMNIDASH_ANALYTICS_DB_URL` to required_env
- `tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py` — 8 new tests

## Diagnosis

Full root cause analysis: `docs/diagnosis-db-projection-connection.md`

## Unblocks

Activation Tasks 10, 12, 13 (node_registrations population, omnidash_analytics writes, dashboard nodes view). Critical path to proof-of-life (Task 25).

## Test plan

- [x] `uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py` — 8 tests pass
- [x] All pre-commit hooks pass
- [x] mypy strict clean
- [ ] After deploy: verify `node_service_registry` row count increases on heartbeat events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handler runtime now supports database injection for projection handlers, providing a synchronous DB adapter and a derived event type into handler input.

* **Chores**
  * Docker service now requires the OMNIDASH_ANALYTICS_DB_URL environment variable.

* **Tests**
  * Added unit and integration tests covering DB injection, event-type derivation, wiring selection, and error/absent-DB behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->