### PR TITLE
fix(deploy-agent): verify containers Up before emitting rebuild-completed [OMN-8668]

### DIFF
--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -58,6 +58,54 @@ def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
     )
 
 
+def verify_containers_up(
+    expected_containers: list[str], timeout_s: int = 120
+) -> tuple[bool, list[str]]:
+    """Poll docker ps until all expected containers are running or timeout expires."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}\t{{.State}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "verify_containers_up: docker ps failed: %s", result.stderr[:200]
+            )
+            time.sleep(2)
+            continue
+        states = {
+            parts[0]: parts[1]
+            for line in result.stdout.strip().splitlines()
+            if (parts := line.split("\t", 1)) and len(parts) == 2
+        }
+        missing = [c for c in expected_containers if states.get(c) != "running"]
+        if not missing:
+            return True, []
+        logger.info(
+            "verify_containers_up: waiting for %d container(s): %s",
+            len(missing),
+            missing,
+        )
+        time.sleep(2)
+    # Final check to report exactly what is still not running
+    result = subprocess.run(
+        ["docker", "ps", "--format", "{{.Names}}\t{{.State}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    states = {
+        parts[0]: parts[1]
+        for line in result.stdout.strip().splitlines()
+        if (parts := line.split("\t", 1)) and len(parts) == 2
+    }
+    missing = [c for c in expected_containers if states.get(c) != "running"]
+    return False, missing
+
+
 class DeployExecutor:
     def self_update(self, *, skip: bool = False) -> None:
         """Pull and re-exec deploy-agent itself if behind origin/main.
@@ -422,6 +470,40 @@ class DeployExecutor:
         result = _run(cmd, timeout=timeout)
         if result.returncode != 0:
             raise RuntimeError(f"Docker compose up failed: {result.stderr}")
+
+        # Verify containers actually reached running state — docker compose up exits 0
+        # even when containers land in Created state (hit twice in production, 01:33 + 04:48).
+        expected = services if services else services_for_scope(scope)
+        logger.info(
+            "Verifying %d container(s) reached running state: %s",
+            len(expected),
+            expected,
+        )
+        ok, stuck = verify_containers_up(expected, timeout_s=120)
+        if not ok:
+            logger.warning(
+                "Containers stuck after compose up — attempting docker start recovery: %s",
+                stuck,
+            )
+            for name in stuck:
+                start_result = subprocess.run(
+                    ["docker", "start", name],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if start_result.returncode == 0:
+                    logger.info("docker start %s: ok", name)
+                else:
+                    logger.warning(
+                        "docker start %s failed: %s", name, start_result.stderr[:200]
+                    )
+            ok, stuck = verify_containers_up(expected, timeout_s=60)
+            if not ok:
+                raise RuntimeError(
+                    f"Containers still not running after docker start recovery: {stuck}"
+                )
+            logger.info("Recovery succeeded — all containers now running")
 
         on_phase_update(phase, PhaseStatus.SUCCESS)
 

--- a/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for post-recreate container start verification (OMN-8668).
+
+Covers the scenario where docker compose up exits 0 but containers land in
+Created state instead of running — the bug that caused silent infra outages
+at 01:33 and 04:48 on 2026-04-13.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import call, patch
+
+import pytest
+from deploy_agent.executor import verify_containers_up
+
+
+def _make_ps_result(
+    name_state_pairs: list[tuple[str, str]],
+) -> subprocess.CompletedProcess:
+    stdout = "\n".join(f"{name}\t{state}" for name, state in name_state_pairs)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_all_running_returns_true() -> None:
+    """Returns (True, []) immediately when all containers are running."""
+    containers = ["postgres", "redpanda", "valkey"]
+    ps_output = _make_ps_result([(c, "running") for c in containers])
+
+    with patch(
+        "deploy_agent.executor.subprocess.run", return_value=ps_output
+    ) as mock_run:
+        ok, stuck = verify_containers_up(containers, timeout_s=10)
+
+    assert ok is True
+    assert stuck == []
+    assert mock_run.call_count == 1
+
+
+def test_created_state_detected_as_missing() -> None:
+    """Containers in Created state are treated as not running (the OMN-8668 bug)."""
+    containers = ["postgres", "redpanda"]
+    # redpanda stuck in Created — the exact failure mode
+    ps_output = _make_ps_result([("postgres", "running"), ("redpanda", "created")])
+
+    call_count = 0
+
+    def fake_run(*args, **kwargs) -> subprocess.CompletedProcess:
+        nonlocal call_count
+        call_count += 1
+        return ps_output
+
+    with patch("deploy_agent.executor.subprocess.run", side_effect=fake_run):
+        with patch("deploy_agent.executor.time.sleep"):
+            with patch("deploy_agent.executor.time.monotonic", side_effect=[0, 0, 200]):
+                ok, stuck = verify_containers_up(containers, timeout_s=1)
+
+    assert ok is False
+    assert "redpanda" in stuck
+    assert "postgres" not in stuck
+
+
+def test_recovery_on_second_poll() -> None:
+    """Returns (True, []) when container transitions to running on second poll."""
+    containers = ["postgres", "redpanda"]
+    first_call = _make_ps_result([("postgres", "running"), ("redpanda", "created")])
+    second_call = _make_ps_result([("postgres", "running"), ("redpanda", "running")])
+
+    responses = [first_call, second_call]
+
+    with patch("deploy_agent.executor.subprocess.run", side_effect=responses):
+        with patch("deploy_agent.executor.time.sleep"):
+            ok, stuck = verify_containers_up(containers, timeout_s=60)
+
+    assert ok is True
+    assert stuck == []
+
+
+def test_docker_ps_failure_skips_iteration() -> None:
+    """When docker ps returns non-zero, loop retries rather than crashing."""
+    containers = ["postgres"]
+    fail_result = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="docker daemon unavailable"
+    )
+    ok_result = _make_ps_result([("postgres", "running")])
+
+    with patch(
+        "deploy_agent.executor.subprocess.run", side_effect=[fail_result, ok_result]
+    ):
+        with patch("deploy_agent.executor.time.sleep"):
+            ok, stuck = verify_containers_up(containers, timeout_s=60)
+
+    assert ok is True
+    assert stuck == []
+
+
+def test_empty_expected_list_returns_true() -> None:
+    """Empty expected list means nothing to wait for — return True immediately."""
+    ps_output = _make_ps_result([])
+
+    with patch("deploy_agent.executor.subprocess.run", return_value=ps_output):
+        ok, stuck = verify_containers_up([], timeout_s=10)
+
+    assert ok is True
+    assert stuck == []
+
+
+def test_timeout_returns_false_with_stuck_list() -> None:
+    """When timeout expires, returns (False, <stuck containers>)."""
+    containers = ["postgres", "omninode-runtime"]
+    stuck_output = _make_ps_result(
+        [("postgres", "running"), ("omninode-runtime", "created")]
+    )
+
+    monotonic_values = [0.0, 0.5, 1.5]  # deadline=1, third call is past deadline
+
+    with patch("deploy_agent.executor.subprocess.run", return_value=stuck_output):
+        with patch("deploy_agent.executor.time.sleep"):
+            with patch(
+                "deploy_agent.executor.time.monotonic", side_effect=monotonic_values
+            ):
+                ok, stuck = verify_containers_up(containers, timeout_s=1)
+
+    assert ok is False
+    assert "omninode-runtime" in stuck
+    assert "postgres" not in stuck


### PR DESCRIPTION
## Summary

- `docker compose up --force-recreate` exits 0 even when containers land in `Created` state rather than `running`. The deploy-agent was emitting `rebuild-completed` immediately on rc=0, causing two silent infra outages (01:33 and 04:48 on 2026-04-13) that required manual `infra-up` recovery.
- After `docker compose up` returns 0, the agent now polls `docker ps` for up to 120s waiting for all expected containers to reach `running` state.
- On failure it attempts automatic recovery (`docker start <name>` for each stuck container), retries verification for 60s, then raises `RuntimeError` — blocking `rebuild-completed` — if containers are still stuck.

## Changes

- `scripts/deploy-agent/deploy_agent/executor.py`: Added `verify_containers_up()` function; called from `_compose_up()` after compose returns, with docker-start recovery before raising.
- `scripts/deploy-agent/tests/unit/test_executor_start_verify.py`: 6 unit tests covering all paths (all-running, Created-state detection, recovery on second poll, docker ps failure retry, empty list, timeout).

## Test plan

- [x] `uv run pytest tests/unit/test_executor_start_verify.py` — 6/6 pass
- [x] `uv run pytest tests/` — 33/33 pass (no regressions)
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced container orchestration with active verification of container startup status and automatic detection of containers failing to reach running state.

* **Bug Fixes**
  * Implemented automatic recovery mechanism that detects stuck containers during startup and attempts to restart them with secondary verification.

* **Tests**
  * Added comprehensive unit tests covering container verification scenarios including startup success, timeout handling, and recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->