### PR TITLE
fix(deploy-agent): add single-flight lock [OMN-8678]

### DIFF
--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import signal
@@ -14,6 +15,8 @@ from aiohttp import web
 
 from deploy_agent.consumer import DeployConsumer
 from deploy_agent.events import (
+    TOPIC_REBUILD_REJECTED,
+    DeployInProgressError,
     ModelRebuildRequested,
     Phase,
     PhaseStatus,
@@ -21,6 +24,7 @@ from deploy_agent.events import (
 from deploy_agent.executor import SCOPE_BUNDLES, DeployExecutor
 from deploy_agent.health import create_health_app
 from deploy_agent.job_state import JobStore
+from deploy_agent.lock import single_flight_lock
 from deploy_agent.publisher import build_completion_payload, publish_result
 
 logger = logging.getLogger(__name__)
@@ -119,6 +123,17 @@ class DeployAgent:
         self._shutdown = True
 
     async def _execute_command(self, cmd: ModelRebuildRequested) -> None:
+        try:
+            with single_flight_lock():
+                await self._run_deploy(cmd)
+        except DeployInProgressError:
+            logger.warning(
+                "Single-flight lock held — rejecting %s (in_progress)",
+                cmd.correlation_id,
+            )
+            self._publish_rejected(cmd, reason="in_progress")
+
+    async def _run_deploy(self, cmd: ModelRebuildRequested) -> None:
         self._state = "deploying"
         cid = cmd.correlation_id
         health_checks = []
@@ -184,6 +199,26 @@ class DeployAgent:
                 logger.warning("Publish failed for %s, marked pending", cid)
 
         self._state = "idle"
+
+    def _publish_rejected(self, cmd: ModelRebuildRequested, *, reason: str) -> None:
+        from kafka import KafkaProducer
+
+        payload = json.dumps(
+            {
+                "correlation_id": str(cmd.correlation_id),
+                "reason": reason,
+                "scope": cmd.scope,
+            }
+        ).encode()
+        try:
+            producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS)
+            producer.send(TOPIC_REBUILD_REJECTED, payload)
+            producer.flush(timeout=5)
+            producer.close()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to publish rebuild-rejected for %s", cmd.correlation_id
+            )
 
     async def _retry_pending_publishes(self) -> None:
         pending = self.job_store.get_pending_publish()

--- a/scripts/deploy-agent/deploy_agent/events.py
+++ b/scripts/deploy-agent/deploy_agent/events.py
@@ -13,6 +13,11 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validat
 
 TOPIC_REBUILD_REQUESTED = "onex.cmd.deploy.rebuild-requested.v1"
 TOPIC_REBUILD_COMPLETED = "onex.evt.deploy.rebuild-completed.v1"
+TOPIC_REBUILD_REJECTED = "onex.evt.deploy.rebuild-rejected.v1"
+
+
+class DeployInProgressError(RuntimeError):
+    """Raised when a second deploy arrives while one is already running."""
 
 
 class Scope(StrEnum):

--- a/scripts/deploy-agent/deploy_agent/lock.py
+++ b/scripts/deploy-agent/deploy_agent/lock.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Single-flight advisory lock for deploy-agent rebuild operations."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+from pathlib import Path
+
+from deploy_agent.events import DeployInProgressError
+
+_LOCK_PATH = Path(os.environ.get("DEPLOY_AGENT_LOCK_PATH", "/tmp/deploy-agent.lock"))  # noqa: S108
+
+
+@contextlib.contextmanager
+def single_flight_lock():
+    """Advisory exclusive lock. Raises DeployInProgressError if already held."""
+    _LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd = _LOCK_PATH.open("w")
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        fd.close()
+        raise DeployInProgressError("Another deploy is already in flight")
+    try:
+        yield
+    finally:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        fd.close()

--- a/scripts/deploy-agent/tests/unit/test_single_flight_lock.py
+++ b/scripts/deploy-agent/tests/unit/test_single_flight_lock.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the single-flight advisory lock in deploy_agent.agent."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from deploy_agent.events import DeployInProgressError
+from deploy_agent.lock import single_flight_lock
+
+
+@pytest.mark.unit
+def test_lock_acquired_and_released(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deploy_agent.lock._LOCK_PATH", tmp_path / "deploy-agent.lock")
+    with single_flight_lock():
+        pass  # must not raise
+
+
+@pytest.mark.unit
+def test_second_attempt_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("deploy_agent.lock._LOCK_PATH", tmp_path / "deploy-agent.lock")
+
+    errors: list[Exception] = []
+    ready = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with single_flight_lock():
+            ready.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock, daemon=True)
+    holder.start()
+    ready.wait(timeout=5)
+
+    try:
+        with single_flight_lock():
+            pass
+    except DeployInProgressError as exc:
+        errors.append(exc)
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert len(errors) == 1
+    assert "in flight" in str(errors[0])
+
+
+@pytest.mark.unit
+def test_lock_released_after_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deploy_agent.lock._LOCK_PATH", tmp_path / "deploy-agent.lock")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with single_flight_lock():
+            raise RuntimeError("boom")
+
+    # Lock must be released — second acquisition must succeed.
+    with single_flight_lock():
+        pass


### PR DESCRIPTION
## Summary

- Adds `fcntl`-based advisory exclusive lock (`deploy_agent/lock.py`) around the entire rebuild execution path
- A second concurrent `rebuild-requested` command that arrives while a deploy is running raises `DeployInProgressError` and emits `onex.evt.deploy.rebuild-rejected.v1` with `reason=in_progress`
- Fixes a TOCTOU race where two commands could both pass the `has_active_job()` check before the first job's state was persisted — this race was a contributing factor to the OMN-8668 silent-fail pattern (second deploy stomped the first mid-flight)

## Changes

- `deploy_agent/lock.py` — new module with `single_flight_lock()` context manager (`LOCK_EX | LOCK_NB`)
- `deploy_agent/agent.py` — `_execute_command` now wraps `_run_deploy` with the lock; `_publish_rejected` emits the rejection event
- `deploy_agent/events.py` — adds `DeployInProgressError` and `TOPIC_REBUILD_REJECTED`
- `tests/unit/test_single_flight_lock.py` — 3 unit tests covering acquire/release, concurrent rejection, and release-after-exception

## Test plan

- [x] `test_lock_acquired_and_released` — happy path, lock acquires and releases cleanly
- [x] `test_second_attempt_raises` — concurrent attempt in a second thread raises `DeployInProgressError`
- [x] `test_lock_released_after_exception` — exception inside the lock body does not leave lock held
- [x] All 30 unit tests pass (`uv run pytest tests/unit/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added single-flight deployment protection to prevent concurrent rebuild operations from running simultaneously.

* **Bug Fixes**
  * Improved handling of concurrent deployment requests with proper rejection messages and logging when a deployment is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->