### PR TITLE
fix(deploy-agent): require HMAC-signed rebuild commands [OMN-8679]

### DIFF
--- a/scripts/deploy-agent/deploy_agent/auth.py
+++ b/scripts/deploy-agent/deploy_agent/auth.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""HMAC-SHA256 envelope authentication for deploy-agent commands."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENV_KEY = "DEPLOY_AGENT_HMAC_SECRET"
+
+
+def verify_command(envelope: dict) -> bool:
+    """Verify HMAC-SHA256 signature on a rebuild command envelope.
+
+    The signature is computed over the JSON-serialised envelope (sort_keys,
+    no spaces) *after* removing the ``_signature`` field itself.  The caller
+    must include ``_signature`` in the envelope; its absence is treated as an
+    authentication failure.
+
+    Returns True only when the signature is valid.  Logs a warning and returns
+    False on any failure so callers can emit a rejection event with the reason.
+    """
+    secret = os.environ.get(_ENV_KEY)
+    if not secret:
+        logger.error(
+            "DEPLOY_AGENT_HMAC_SECRET not set — rejecting all commands. "
+            "Generate one with: openssl rand -hex 32"
+        )
+        return False
+
+    # Pop signature before computing expected value (non-destructive: work on a copy)
+    body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
+    signature = envelope.get("_signature")
+    if not signature:
+        logger.warning("Rebuild command rejected: missing _signature field")
+        return False
+
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(signature, expected):
+        logger.warning("Rebuild command rejected: invalid HMAC signature")
+        return False
+
+    return True

--- a/scripts/deploy-agent/deploy_agent/consumer.py
+++ b/scripts/deploy-agent/deploy_agent/consumer.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from kafka import KafkaConsumer
 
+from deploy_agent.auth import verify_command
 from deploy_agent.events import (
     TOPIC_REBUILD_REQUESTED,
     ModelRebuildRequested,
@@ -40,12 +41,13 @@ class DeployConsumer:
 
         Protocol:
         1. Poll message
-        2. Validate payload (schema, scope, services legality)
-        3. Check busy (has_active_job) -> reject "busy"
-        4. Check dedup (is_duplicate) -> reject "duplicate"
-        5. Persist job state (accepted)
-        6. Commit Kafka offset
-        7. Return (command, None)
+        2. Verify HMAC signature
+        3. Validate payload (schema, scope, services legality)
+        4. Check busy (has_active_job) -> reject "busy"
+        5. Check dedup (is_duplicate) -> reject "duplicate"
+        6. Persist job state (accepted)
+        7. Commit Kafka offset
+        8. Return (command, None)
         """
         records = self.consumer.poll(timeout_ms=1000)
         if not records:
@@ -64,7 +66,16 @@ class DeployConsumer:
         payload = msg.value
         correlation_id_str = payload.get("correlation_id", "unknown")
 
-        # Step 2: Validate payload
+        # Step 2: Verify HMAC signature
+        if not verify_command(payload):
+            logger.warning(
+                "Rejecting command (correlation_id=%s): invalid_signature",
+                correlation_id_str,
+            )
+            self.consumer.commit()
+            return None, "invalid_signature"
+
+        # Step 3: Validate payload
         try:
             cmd = ModelRebuildRequested.model_validate(payload)
         except Exception as e:  # noqa: BLE001
@@ -76,28 +87,28 @@ class DeployConsumer:
             self.consumer.commit()
             return None, "invalid_payload"
 
-        # Step 3: Check busy
+        # Step 4: Check busy
         if self.job_store.has_active_job():
             logger.info("Rejecting command %s: agent busy", cmd.correlation_id)
             self.consumer.commit()
             return None, "busy"
 
-        # Step 4: Check dedup
+        # Step 5: Check dedup
         if self.job_store.is_duplicate(cmd.correlation_id):
             logger.info("Rejecting command %s: duplicate", cmd.correlation_id)
             self.consumer.commit()
             return None, "duplicate"
 
-        # Step 5: Persist job state
+        # Step 6: Persist job state
         self.job_store.accept(
             correlation_id=cmd.correlation_id,
             command=payload,
         )
 
-        # Step 6: Commit offset
+        # Step 7: Commit offset
         self.consumer.commit()
 
-        # Step 7: Return accepted command
+        # Step 8: Return accepted command
         logger.info("Accepted command %s (scope=%s)", cmd.correlation_id, cmd.scope)
         return cmd, None
 

--- a/scripts/deploy-agent/tests/unit/test_auth_hmac.py
+++ b/scripts/deploy-agent/tests/unit/test_auth_hmac.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for HMAC-SHA256 command authentication."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+from deploy_agent.auth import verify_command
+
+_SECRET = "test-secret-abc123"
+
+
+def _sign(envelope: dict, secret: str = _SECRET) -> dict:
+    body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {**envelope, "_signature": sig}
+
+
+_BASE_ENVELOPE = {
+    "correlation_id": "00000000-0000-0000-0000-000000000001",
+    "requested_by": "test",
+    "scope": "full",
+    "services": [],
+    "git_ref": "origin/main",
+}
+
+
+def test_valid_signature_passes() -> None:
+    signed = _sign(_BASE_ENVELOPE)
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is True
+
+
+def test_invalid_signature_rejected() -> None:
+    signed = _sign(_BASE_ENVELOPE)
+    signed["_signature"] = "deadbeef" * 8  # wrong but same length
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is False
+
+
+def test_missing_signature_rejected() -> None:
+    envelope = dict(_BASE_ENVELOPE)  # no _signature key
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(envelope) is False
+
+
+def test_missing_secret_rejects_all() -> None:
+    signed = _sign(_BASE_ENVELOPE)
+    with patch.dict("os.environ", {}, clear=True):
+        # Ensure key is absent even if set in outer env
+        import os
+
+        os.environ.pop("DEPLOY_AGENT_HMAC_SECRET", None)
+        assert verify_command(signed) is False
+
+
+def test_tampered_body_rejected() -> None:
+    signed = _sign(_BASE_ENVELOPE)
+    # Mutate a field after signing
+    signed["scope"] = "core"
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is False
+
+
+def test_wrong_secret_rejected() -> None:
+    signed = _sign(_BASE_ENVELOPE, secret="correct-secret")  # noqa: S106
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": "wrong-secret"}):
+        assert verify_command(signed) is False

--- a/scripts/deploy-trigger.py
+++ b/scripts/deploy-trigger.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Sign and publish a rebuild command to the deploy-agent topic.
+
+Usage:
+    python scripts/deploy-trigger.py \\
+        --scope full \\
+        --requested-by claude \\
+        [--git-ref origin/main] \\
+        [--services svc1 svc2]
+
+Requires DEPLOY_AGENT_HMAC_SECRET and KAFKA_BOOTSTRAP_SERVERS in the environment
+(source ~/.omnibase/.env first).
+Generate a secret with: openssl rand -hex 32
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+
+
+def sign_envelope(envelope: dict, secret: str) -> dict:
+    body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {**envelope, "_signature": signature}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sign and send a deploy rebuild command"
+    )
+    parser.add_argument("--scope", choices=["full", "runtime", "core"], default="full")
+    parser.add_argument("--requested-by", default="deploy-trigger-script")
+    parser.add_argument("--git-ref", default="origin/main")
+    parser.add_argument("--services", nargs="*", default=[])
+    parser.add_argument(
+        "--broker",
+        default=os.environ.get("KAFKA_BOOTSTRAP_SERVERS"),
+    )
+    parser.add_argument("--correlation-id", default=str(uuid.uuid4()))
+    args = parser.parse_args()
+
+    if not args.broker:
+        print(
+            "ERROR: KAFKA_BOOTSTRAP_SERVERS not set. Source ~/.omnibase/.env first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    secret = os.environ.get("DEPLOY_AGENT_HMAC_SECRET")
+    if not secret:
+        print(
+            "ERROR: DEPLOY_AGENT_HMAC_SECRET not set. Source ~/.omnibase/.env first.",
+            file=sys.stderr,
+        )
+        print("       Generate with: openssl rand -hex 32", file=sys.stderr)
+        sys.exit(1)
+
+    envelope = {
+        "correlation_id": args.correlation_id,
+        "requested_by": args.requested_by,
+        "scope": args.scope,
+        "services": args.services,
+        "git_ref": args.git_ref,
+        "requested_at": datetime.now(UTC).isoformat(),
+    }
+    signed = sign_envelope(envelope, secret)
+
+    payload = json.dumps(signed) + "\n"
+    print(f"Sending signed rebuild command (correlation_id={args.correlation_id})")
+    print(f"  scope={args.scope}  git_ref={args.git_ref}  broker={args.broker}")
+
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "-i",
+            "omnibase-infra-redpanda",
+            "rpk",
+            "topic",
+            "produce",
+            "onex.cmd.deploy.rebuild-requested.v1",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode == 0:
+        print(f"Published. correlation_id={args.correlation_id}")
+    else:
+        print(f"ERROR: rpk produce failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **REMOTE ROOT FIX**: Any write to `onex.cmd.deploy.rebuild-requested.v1` previously triggered git checkout + docker rebuild as `jonah` on .201 with zero authentication — effectively arbitrary code execution via the event bus
- Adds HMAC-SHA256 envelope verification in `deploy_agent/auth.py`; consumer rejects before schema validation when signature is missing, invalid, or secret is unset
- Adds `scripts/deploy-trigger.py` signing helper — callers must use this or implement equivalent signing

## Changes

| File | Change |
|------|--------|
| `scripts/deploy-agent/deploy_agent/auth.py` | New: HMAC-SHA256 `verify_command()` — fails closed when `DEPLOY_AGENT_HMAC_SECRET` unset |
| `scripts/deploy-agent/deploy_agent/consumer.py` | Adds auth check as step 2 of acceptance protocol |
| `scripts/deploy-agent/tests/unit/test_auth_hmac.py` | 6 unit tests: valid, invalid, missing sig, missing secret, tampered body, wrong secret |
| `scripts/deploy-trigger.py` | Signing helper script for producers |

## Post-merge action required (BLOCKING)

The deploy-agent will reject ALL rebuild commands until this is done on .201:

```bash
# 1. Generate a secret
openssl rand -hex 32

# 2. Add to ~/.omnibase/.env on .201:
DEPLOY_AGENT_HMAC_SECRET=<generated value>

# 3. Restart deploy-agent systemd service
sudo systemctl restart deploy-agent.service
```

**Until this is done, the agent is offline for rebuilds.** Flag this as a post-merge gate.

## Test plan

- [ ] `cd scripts/deploy-agent && python -m pytest tests/unit/test_auth_hmac.py -v` → 6 passed
- [ ] Post-merge: generate `DEPLOY_AGENT_HMAC_SECRET`, add to `.201:~/.omnibase/.env`, restart systemd service
- [ ] Post-merge: run `scripts/deploy-trigger.py --scope full --requested-by manual-test` and verify rebuild completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy commands now require HMAC-SHA256 signature verification for enhanced security and authentication
  * New deploy trigger script enables initiating signed rebuild commands with correlation tracking and metadata management

* **Tests**
  * Comprehensive unit test coverage for signature verification, tampering detection, and authentication edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->