### PR TITLE
fix(schema): add baselines snapshot table [OMN-8667 OMN-8675]

### DIFF
--- a/docker/migrations/forward/067_create_baselines_table.sql
+++ b/docker/migrations/forward/067_create_baselines_table.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- MIGRATION: Create baselines snapshot table
+-- =============================================================================
+-- Ticket: OMN-8667
+-- Epic: OMN-7264 (Intelligent Model Router MVP)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   Creates the baselines table for storing system state snapshots captured
+--   by /onex:baseline. This is SEPARATE from baselines_comparisons which
+--   stores check-result comparisons. This table holds raw snapshot captures.
+--
+-- IDEMPOTENCY:
+--   - CREATE TABLE IF NOT EXISTS is safe to re-run.
+--   - CREATE INDEX IF NOT EXISTS is safe to re-run.
+--
+-- ROLLBACK:
+--   docker/migrations/rollback/rollback_067_create_baselines_table.sql
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.baselines (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    node_count INTEGER,
+    topic_count INTEGER,
+    test_count INTEGER,
+    coverage_pct DOUBLE PRECISION,
+    latency_p50_ms INTEGER,
+    latency_p99_ms INTEGER,
+    snapshot_json JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_baselines_created_at ON public.baselines (created_at DESC);
+
+COMMENT ON TABLE public.baselines IS
+    'System state snapshots captured by /onex:baseline skill. '
+    'Stores raw metric captures (node_count, topic_count, test coverage, latency). '
+    'Separate from baselines_comparisons which stores delta check results. (OMN-8667)';
+
+-- Update migration sentinel
+UPDATE public.db_metadata
+SET migrations_complete = TRUE,
+    schema_version = '067',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:c77f2b1f8bbf7c1f463e91a0b09ebf627157ce056150a055b0b41c7e7d4a1ca4
-generated_at: 2026-04-14T02:40:25Z
-migration_file_count: 52
+sha256:17cf22c637f8195c626ba65d0b17c8b42a3f72be7cfc07b654ec04110e0ed7f1
+generated_at: 2026-04-14T05:29:47Z
+migration_file_count: 53


### PR DESCRIPTION
## Summary

- **OMN-8667**: Adds migration `067_create_baselines_table.sql` — new `baselines` table for system state snapshots captured by `/onex:baseline`. Stores `node_count`, `topic_count`, `test_count`, `coverage_pct`, `latency_p50_ms`, `latency_p99_ms`, `snapshot_json`. Indexed on `created_at DESC`.
- **OMN-8675**: DEDUP — `node_service_registry` already exists in `omnidash_analytics` with 68 rows and a richer production schema (includes `service_url`, `health_status`, `is_active`, `last_health_check`). No migration needed.
- Schema fingerprint re-stamped: `17cf22c637f8195c626ba65d0b17c8b42a3f72be...`

## Notes

`baselines` is intentionally separate from `baselines_comparisons` (which stores delta check results from baseline comparisons). This new table holds the raw snapshot captures.

## Test plan

- [ ] Verify `baselines` table exists post-merge: `docker exec omnibase-infra-postgres psql -U postgres -d omnibase_infra -c "\dt baselines*"` — should show 4 tables including new `baselines`
- [ ] Verify fingerprint matches: `python scripts/check_schema_fingerprint.py verify`
- [ ] Verify `node_service_registry` still has 68+ rows in `omnidash_analytics` (no regression)