### PR TITLE
fix(redpanda): advertise host IP instead of localhost for external clients [OMN-8686]

### DIFF
--- a/docker/catalog/services/redpanda.yaml
+++ b/docker/catalog/services/redpanda.yaml
@@ -24,9 +24,9 @@ command:
   - redpanda
   - start
   - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
-  - --advertise-kafka-addr internal://redpanda:9092,external://localhost:${REDPANDA_EXTERNAL_PORT:-19092}
+  - --advertise-kafka-addr internal://redpanda:9092,external://${REDPANDA_ADVERTISE_HOST:-192.168.86.201}:${REDPANDA_EXTERNAL_PORT:-19092}
   - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
-  - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:${REDPANDA_PANDAPROXY_PORT:-18082}
+  - --advertise-pandaproxy-addr internal://redpanda:8082,external://${REDPANDA_ADVERTISE_HOST:-192.168.86.201}:${REDPANDA_PANDAPROXY_PORT:-18082}
   - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
   - --rpc-addr redpanda:33145
   - --advertise-rpc-addr redpanda:33145


### PR DESCRIPTION
## Summary

- Redpanda was advertising `localhost:19092` as its external broker address in metadata
- Host-side clients (deploy-agent running as systemd service on .201) connect via `192.168.86.201:19092`, then receive broker metadata pointing to `localhost:19092`, triggering a reconnect — causing intermittent `NoBrokersAvailable` errors during the address switchover
- Fix: `--advertise-kafka-addr` external listener now uses `${REDPANDA_ADVERTISE_HOST:-192.168.86.201}` so metadata matches the connection address; `REDPANDA_ADVERTISE_HOST` env var allows override for other environments

## Root cause

The inside-Docker vs host-network distinction:
- Docker-internal clients use `internal://redpanda:9092` — unaffected by this change
- Host-side clients (deploy-agent systemd service) use port 19092 on the host IP
- Redpanda's advertised external address `localhost:19092` caused kafka-python to reconnect from `.201:19092` → `localhost:19092` → reconnect loop → `NoBrokersAvailable` during handshake

## Test plan

- [ ] After merge: trigger redeploy via deploy-agent to regenerate compose with new advertise addr
- [ ] Verify `docker inspect omnibase-infra-redpanda` shows `192.168.86.201:19092` in advertise flags after restart
- [ ] Verify deploy-agent logs show no `NoBrokersAvailable` or `socket disconnected` / reconnect loops
- [ ] Verify rpk topic list works from host: `rpk topic list --brokers 192.168.86.201:19092`