### PR TITLE
feat(env): add onex env render-settings command with machine registry [OMN-7527, OMN-7528]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,14 +61,14 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff format (auto-format)
-        entry: uv run ruff format
+        entry: uv run --frozen ruff format
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
         stages: [pre-commit]
       - id: ruff-fix
         name: ruff check (auto-fix linting + import sorting)
-        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        entry: uv run --frozen ruff check --fix --exit-non-zero-on-fix
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
@@ -77,7 +77,7 @@ repos:
         # forcing you to re-stage the changes. This keeps pre-commit and CI in sync.
       - id: mypy-type-check
         name: mypy (type checking)
-        entry: bash -c 'uv run mypy "$@" --show-error-codes --no-error-summary' --
+        entry: bash -c 'uv run --frozen mypy "$@" --show-error-codes --no-error-summary' --
         language: system
         types: [python]
         files: ^src/omnibase_infra/.*\.py$
@@ -98,14 +98,14 @@ repos:
       # Migration freeze enforcement - block new migrations during DB-per-repo refactor
       - id: onex-validate-migration-freeze
         name: ONEX Migration Freeze Enforcement
-        entry: uv run python scripts/validate.py migration_freeze
+        entry: uv run --frozen python scripts/validate.py migration_freeze
         language: system
         pass_filenames: false
         always_run: true
         stages: [pre-commit]
       - id: onex-validate-migration-sequence
         name: ONEX Migration Sequence Duplicate Check
-        entry: uv run python scripts/validation/validate_migration_sequence.py
+        entry: uv run --frozen python scripts/validation/validate_migration_sequence.py
         language: system
         pass_filenames: false
         always_run: false
@@ -124,7 +124,7 @@ repos:
       # Root directory cleanliness - no ephemeral files in root
       - id: onex-validate-clean-root
         name: ONEX Root Directory Cleanliness
-        entry: uv run python scripts/validate.py clean_root
+        entry: uv run --frozen python scripts/validate.py clean_root
         language: system
         pass_filenames: false
         always_run: true
@@ -132,7 +132,7 @@ repos:
       # Architecture validation - one model per file
       - id: onex-validate-architecture
         name: ONEX Architecture Validation
-        entry: uv run python scripts/validate.py architecture
+        entry: uv run --frozen python scripts/validate.py architecture
         language: system
         types: [python]
         pass_filenames: false
@@ -152,7 +152,7 @@ repos:
       # Or: uv run python scripts/validate.py architecture_layers --verbose
       - id: onex-validate-architecture-layers
         name: ONEX Architecture Layer Validation
-        entry: uv run python scripts/validate.py architecture_layers
+        entry: uv run --frozen python scripts/validate.py architecture_layers
         language: system
         types: [python]
         pass_filenames: false
@@ -160,7 +160,7 @@ repos:
       # Contract validation - YAML contracts
       - id: onex-validate-contracts
         name: ONEX Contract Validation
-        entry: uv run python scripts/validate.py contracts
+        entry: uv run --frozen python scripts/validate.py contracts
         language: system
         files: '\.yaml$'
         pass_filenames: false
@@ -168,7 +168,7 @@ repos:
       # Pattern validation - naming conventions
       - id: onex-validate-patterns
         name: ONEX Pattern Validation
-        entry: uv run python scripts/validate.py patterns
+        entry: uv run --frozen python scripts/validate.py patterns
         language: system
         types: [python]
         pass_filenames: false
@@ -178,7 +178,7 @@ repos:
       # Runtime: <3s (single pass with caching)
       - id: onex-validate-naming
         name: ONEX Naming Convention Validation
-        entry: uv run python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
+        entry: uv run --frozen python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
         language: system
         types: [python]
         pass_filenames: false
@@ -188,7 +188,7 @@ repos:
       # Target: Reduce to 30 incrementally after PR #37 merges
       - id: onex-validate-unions
         name: ONEX Union Usage Validation
-        entry: uv run python scripts/validate.py unions
+        entry: uv run --frozen python scripts/validate.py unions
         language: system
         types: [python]
         pass_filenames: false
@@ -196,7 +196,7 @@ repos:
       # Circular import check
       - id: onex-validate-imports
         name: ONEX Circular Import Check
-        entry: uv run python scripts/validate.py imports
+        entry: uv run --frozen python scripts/validate.py imports
         language: system
         types: [python]
         pass_filenames: false
@@ -205,7 +205,7 @@ repos:
       # Ensures no `Any` types are used in the codebase
       - id: onex-validate-any-types
         name: ONEX Any Type Validation
-        entry: uv run python scripts/validate.py any_types
+        entry: uv run --frozen python scripts/validate.py any_types
         language: system
         types: [python]
         pass_filenames: false
@@ -216,7 +216,7 @@ repos:
       # Ratchet rule: any PR reducing violations must lower --max-violations.
       - id: validate-model-dump-json-mode
         name: Validate model_dump uses mode="json"
-        entry: uv run python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
+        entry: uv run --frozen python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
         language: system
         pass_filenames: false
         files: ^src/.*\.py$
@@ -229,7 +229,7 @@ repos:
       # Exempt nodes via: # ONEX_EXCLUDE: declarative_node
       - id: onex-validate-declarative-nodes
         name: ONEX Declarative Node Validation
-        entry: uv run python scripts/validate.py declarative_nodes
+        entry: uv run --frozen python scripts/validate.py declarative_nodes
         language: system
         files: nodes/.*/node\.py$
         pass_filenames: true
@@ -239,7 +239,7 @@ repos:
       # Timeout: 60s prevents hanging if tests get stuck (normal runtime: <5s)
       - id: reducer-purity-check
         name: Reducer Purity Enforcement
-        entry: uv run pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
+        entry: uv run --frozen pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
         language: system
         types: [python]
         files: ^src/omnibase_infra/nodes/reducers/
@@ -250,7 +250,7 @@ repos:
       # External links are skipped by default (configurable in .markdown-link-check.json)
       - id: onex-validate-markdown-links
         name: ONEX Markdown Link Validation
-        entry: uv run python scripts/validate.py markdown_links
+        entry: uv run --frozen python scripts/validate.py markdown_links
         language: system
         types: [markdown]
         pass_filenames: true
@@ -260,7 +260,7 @@ repos:
       # outside of omnibase_infra and tests. Escape hatches: # db-adapter-ok, # sql-ok
       - id: onex-validate-db-quality-gate
         name: ONEX DB Quality Gate
-        entry: uv run python scripts/validate.py db_quality_gate
+        entry: uv run --frozen python scripts/validate.py db_quality_gate
         language: system
         types: [python]
         pass_filenames: false
@@ -268,7 +268,7 @@ repos:
       - id: check-ai-slop
         name: Check for AI-slop patterns
         language: system
-        entry: uv run python scripts/validation/check_ai_slop.py --strict
+        entry: uv run --frozen python scripts/validation/check_ai_slop.py --strict
         types_or: [python, markdown]
         pass_filenames: true
         stages: [pre-commit]
@@ -286,7 +286,7 @@ repos:
       # OMN-4885: Validate published_events topics appear in event_bus.publish_topics
       - id: onex-validate-published-events
         name: Contract published_events consistency
-        entry: uv run python scripts/validation/check_published_events_consistency.py
+        entry: uv run --frozen python scripts/validation/check_published_events_consistency.py
         language: system
         pass_filenames: false
         files: contract\.yaml$
@@ -312,7 +312,7 @@ repos:
       - id: onex-check-migration-required
         name: Writer-Migration Coupling Check
         language: system
-        entry: uv run python scripts/check_migration_required.py --pre-commit
+        entry: uv run --frozen python scripts/check_migration_required.py --pre-commit
         pass_filenames: false
         stages: [pre-commit]
       # OMN-3617: Block planning docs (belong in omni_home/docs/plans/)
@@ -327,7 +327,7 @@ repos:
       # from contracts AND supplementary sources (topic_constants.py)
       - id: topic-enum-drift-check
         name: Topic Enum Drift Check
-        entry: uv run python scripts/generate_topic_enums.py --check
+        entry: uv run --frozen python scripts/generate_topic_enums.py --check
         language: system
         types_or: [yaml, python]
         files: (contract.*\.yaml|topic_constants\.py|enums/generated/)
@@ -344,7 +344,7 @@ repos:
       # OMN-4385: SPDX header enforcement
       - id: validate-spdx-headers
         name: ONEX SPDX Header Requirement
-        entry: uv run onex spdx validate
+        entry: uv run --frozen onex spdx validate
         language: system
         pass_filenames: true
         files: ^(src|tests|scripts|examples)/.*\.(py|sh|bash|yml|yaml|toml)$
@@ -353,7 +353,7 @@ repos:
       # OMN-4600: Contract topic parity gate — blocks new Python-only registry entries
       - id: topic-parity-gate
         name: Topic Contract Parity Gate
-        entry: uv run python scripts/check_contract_topic_parity.py
+        entry: uv run --frozen python scripts/check_contract_topic_parity.py
         language: system
         pass_filenames: false
         files: (platform_topic_suffixes\.py|contract\.yaml|topics\.yaml)
@@ -398,7 +398,7 @@ repos:
       - id: no-untyped-metadata
         name: No untyped metadata dict fields
         language: system
-        entry: uv run check-no-untyped-metadata
+        entry: uv run --frozen check-no-untyped-metadata
         types: [python]
         exclude: ^tests/|^examples/|^scripts/
         stages: [pre-commit]

--- a/config/machines.yaml
+++ b/config/machines.yaml
@@ -1,0 +1,11 @@
+machines:
+  - machine_id: infra-server
+    hostname: infra-server
+    role: infra_server
+    omni_home: /home/jonah/Code/omni_home
+    resolved_home_dir: /home/jonah
+  - machine_id: m2-ultra
+    hostname: m2-ultra.local
+    role: dev_workstation
+    omni_home: /Users/jonah/Code/omni_home
+    resolved_home_dir: /Users/jonah

--- a/scripts/validation/run_topic_lint.sh
+++ b/scripts/validation/run_topic_lint.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT="$SCRIPT_DIR/lint_topic_names.py"
 RC=0
 
-uv run python "$LINT" --scan-contracts src/omnibase_infra/nodes || RC=$?
-uv run python "$LINT" --scan-python src/omnibase_infra || RC=$?
+uv run --frozen python "$LINT" --scan-contracts src/omnibase_infra/nodes || RC=$?
+uv run --frozen python "$LINT" --scan-python src/omnibase_infra || RC=$?
 
 exit "$RC"

--- a/src/omnibase_infra/cli/cli_env.py
+++ b/src/omnibase_infra/cli/cli_env.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""onex env CLI subcommand group.
+
+Provides:
+  onex env render-settings --machine-id <id>
+
+Outputs canonical settings.json JSON derived from the machine registry.
+No paths are hardcoded — all derived from ModelMachineEntry computed properties.
+
+Related:
+    - OMN-7528: Task 2 — onex env render-settings command
+    - OMN-7526: Environment suite epic
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+_MACHINES_YAML_DEFAULT = Path(__file__).parents[4] / "config" / "machines.yaml"
+
+# Fleet-wide constants — same across all machines
+_INFRA_HOST = "192.168.86.201"
+_KAFKA_BOOTSTRAP = f"{_INFRA_HOST}:19092"
+_POSTGRES_HOST = _INFRA_HOST
+_POSTGRES_PORT = "5436"
+_VALKEY_HOST = _INFRA_HOST
+_VALKEY_PORT = "6379"
+_MODEL = "opus[1m]"
+_OMNICLAUDE_MODE = "agent"
+
+
+@click.group("env")
+def env_group() -> None:  # stub-ok: click group
+    """Environment configuration commands."""
+
+
+@env_group.command("render-settings")
+@click.option("--machine-id", required=True, help="Machine ID from machines.yaml.")
+@click.option(
+    "--registry",
+    default=None,
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to machines.yaml (defaults to config/machines.yaml in repo root).",
+)
+def render_settings(machine_id: str, registry: Path | None) -> None:
+    """Render canonical settings.json for a registered machine."""
+    from omnibase_infra.models.environment.model_machine_registry import (
+        ModelMachineRegistry,
+    )
+
+    registry_path = registry or _MACHINES_YAML_DEFAULT
+    reg = ModelMachineRegistry.from_yaml(registry_path)
+
+    try:
+        machine = reg.get_machine(machine_id)
+    except KeyError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    settings = render_settings_json(machine)
+    click.echo(json.dumps(settings, indent=2))
+
+
+def render_settings_json(machine: object) -> dict:
+    """Build canonical settings.json dict from a ModelMachineEntry.
+
+    Machine-specific values (paths) come from registry entry computed properties.
+    Fleet-wide constants (infra host, Kafka, Postgres) are the same for every machine.
+    """
+    from omnibase_infra.models.environment.model_machine_registry import (
+        ModelMachineEntry,
+    )
+
+    assert isinstance(machine, ModelMachineEntry)
+
+    env: dict[str, str] = {
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        "OMNI_HOME": machine.omni_home,
+        "ONEX_STATE_DIR": machine.onex_state_dir,
+        "OMNICLAUDE_MODE": _OMNICLAUDE_MODE,
+        "OMNI_INFRA_HOST": _INFRA_HOST,
+        "MAX_THINKING_TOKENS": "10000",
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32000",
+        "DISABLE_TELEMETRY": "1",
+        "DISABLE_ERROR_REPORTING": "1",
+        "POSTGRES_HOST": _POSTGRES_HOST,
+        "POSTGRES_PORT": _POSTGRES_PORT,
+        "VALKEY_HOST": _VALKEY_HOST,
+        "VALKEY_PORT": _VALKEY_PORT,
+        "KAFKA_BOOTSTRAP_SERVERS": _KAFKA_BOOTSTRAP,
+    }
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude/settings.schema.json",
+        "env": env,
+        "includeCoAuthoredBy": True,
+        "model": _MODEL,
+        "statusLine": {
+            "command": machine.statusline_path,
+        },
+        "enabledPlugins": ["omninode-tools"],
+        "voiceEnabled": False,
+        "skipDangerousModePermissionPrompt": False,
+        "autoUpdates": True,
+    }

--- a/src/omnibase_infra/cli/cli_env.py
+++ b/src/omnibase_infra/cli/cli_env.py
@@ -16,21 +16,22 @@ Related:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import click
 
 _MACHINES_YAML_DEFAULT = Path(__file__).parents[4] / "config" / "machines.yaml"
 
-# Fleet-wide constants — same across all machines
-_INFRA_HOST = "192.168.86.201"
-_KAFKA_BOOTSTRAP = f"{_INFRA_HOST}:19092"
-_POSTGRES_HOST = _INFRA_HOST
-_POSTGRES_PORT = "5436"
-_VALKEY_HOST = _INFRA_HOST
-_VALKEY_PORT = "6379"
-_MODEL = "opus[1m]"
-_OMNICLAUDE_MODE = "agent"
+# Fleet-wide constants — read from environment with fleet defaults
+_INFRA_HOST = os.environ.get("OMNI_INFRA_HOST", "192.168.86.201")
+_KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", f"{_INFRA_HOST}:19092")
+_POSTGRES_HOST = os.environ.get("POSTGRES_HOST", _INFRA_HOST)
+_POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5436")
+_VALKEY_HOST = os.environ.get("VALKEY_HOST", _INFRA_HOST)
+_VALKEY_PORT = os.environ.get("VALKEY_PORT", "6379")
+_MODEL = os.environ.get("OMNI_MODEL", "opus[1m]")
+_OMNICLAUDE_MODE = os.environ.get("OMNICLAUDE_MODE", "agent")
 
 
 @click.group("env")

--- a/src/omnibase_infra/cli/cli_env.py
+++ b/src/omnibase_infra/cli/cli_env.py
@@ -64,7 +64,7 @@ def render_settings(machine_id: str, registry: Path | None) -> None:
     click.echo(json.dumps(settings, indent=2))
 
 
-def render_settings_json(machine: object) -> dict:
+def render_settings_json(machine: object) -> dict[str, object]:
     """Build canonical settings.json dict from a ModelMachineEntry.
 
     Machine-specific values (paths) come from registry entry computed properties.

--- a/src/omnibase_infra/cli/commands.py
+++ b/src/omnibase_infra/cli/commands.py
@@ -715,5 +715,14 @@ def _print_result(name: str, result: object) -> None:
 cli.add_command(artifact_reconcile_cmd)
 
 
+# =============================================================================
+# Environment Commands (OMN-7528)
+# =============================================================================
+
+from omnibase_infra.cli.cli_env import env_group
+
+cli.add_command(env_group)
+
+
 if __name__ == "__main__":
     cli()

--- a/src/omnibase_infra/models/environment/__init__.py
+++ b/src/omnibase_infra/models/environment/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/models/environment/model_machine_registry.py
+++ b/src/omnibase_infra/models/environment/model_machine_registry.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Machine registry models for ONEX environment management.
+
+Defines ModelMachineEntry, ModelMachineRegistry, and EnumMachineRole.
+All paths derive from omni_home and resolved_home_dir — no hardcoding.
+
+Related:
+    - OMN-7527: Task 1 — machine registry schema and seed file
+    - OMN-7526: Environment suite epic
+"""
+
+from __future__ import annotations
+
+import socket
+from enum import Enum
+from pathlib import Path
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+
+class EnumMachineRole(str, Enum):
+    INFRA_SERVER = "infra_server"
+    DEV_WORKSTATION = "dev_workstation"
+    CI_RUNNER = "ci_runner"
+
+
+class ModelMachineEntry(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    machine_id: str = Field(..., description="Unique machine identifier.")
+    hostname: str = Field(..., description="Fully qualified or short hostname.")
+    role: EnumMachineRole = Field(..., description="Machine role in the fleet.")
+    omni_home: str = Field(..., description="Absolute path to omni_home checkout.")
+    resolved_home_dir: str = Field(..., description="Absolute home directory path.")
+
+    @field_validator("omni_home", "resolved_home_dir", mode="after")
+    @classmethod
+    def _require_absolute(cls, v: str) -> str:
+        if not Path(v).is_absolute():
+            raise ValueError(f"omni_home must be absolute, got: {v}")
+        return v
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def onex_state_dir(self) -> str:
+        return f"{self.omni_home}/.onex_state"
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def statusline_path(self) -> str:
+        return f"{self.omni_home}/omniclaude/plugins/onex/hooks/scripts/statusline.sh"
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def plugin_path(self) -> str:
+        return f"{self.omni_home}/omniclaude/plugins/onex"
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def claude_settings_path(self) -> str:
+        return f"{self.resolved_home_dir}/.claude/settings.json"
+
+
+class ModelMachineRegistry(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    machines: list[ModelMachineEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _no_duplicate_ids(self) -> ModelMachineRegistry:
+        ids = [m.machine_id for m in self.machines]
+        for mid in ids:
+            if ids.count(mid) > 1:
+                raise ValueError(f"Duplicate machine_id: {mid}")
+        return self
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> ModelMachineRegistry:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return cls.model_validate(data)
+
+    def get_machine(self, machine_id: str) -> ModelMachineEntry:
+        for m in self.machines:
+            if m.machine_id == machine_id:
+                return m
+        raise KeyError(f"machine_id not found: {machine_id!r}")
+
+    def get_machines_by_role(self, role: EnumMachineRole) -> list[ModelMachineEntry]:
+        return [m for m in self.machines if m.role == role]
+
+    def resolve_local_machine(self) -> ModelMachineEntry | None:
+        local_hostname = socket.gethostname()
+        for m in self.machines:
+            if m.hostname == local_hostname or m.hostname.startswith(local_hostname):
+                return m
+        return None

--- a/src/omnibase_infra/models/environment/model_machine_registry.py
+++ b/src/omnibase_infra/models/environment/model_machine_registry.py
@@ -21,6 +21,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    ValidationInfo,
     computed_field,
     field_validator,
     model_validator,
@@ -44,9 +45,9 @@ class ModelMachineEntry(BaseModel):
 
     @field_validator("omni_home", "resolved_home_dir", mode="after")
     @classmethod
-    def _require_absolute(cls, v: str) -> str:
+    def _require_absolute(cls, v: str, info: ValidationInfo) -> str:
         if not Path(v).is_absolute():
-            raise ValueError(f"omni_home must be absolute, got: {v}")
+            raise ValueError(f"{info.field_name} must be absolute, got: {v}")
         return v
 
     @computed_field  # type: ignore[prop-decorator]

--- a/src/omnibase_infra/models/environment/model_machine_registry.py
+++ b/src/omnibase_infra/models/environment/model_machine_registry.py
@@ -49,22 +49,22 @@ class ModelMachineEntry(BaseModel):
             raise ValueError(f"omni_home must be absolute, got: {v}")
         return v
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def onex_state_dir(self) -> str:
         return f"{self.omni_home}/.onex_state"
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def statusline_path(self) -> str:
         return f"{self.omni_home}/omniclaude/plugins/onex/hooks/scripts/statusline.sh"
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def plugin_path(self) -> str:
         return f"{self.omni_home}/omniclaude/plugins/onex"
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def claude_settings_path(self) -> str:
         return f"{self.resolved_home_dir}/.claude/settings.json"

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3147,6 +3147,21 @@ pattern_exemptions:
     documentation:
       - CLAUDE.md (External Provider Identifiers)
     ticket: OMN-7766
+  # ==========================================================================
+  # ModelMachineEntry: machine_id Field Exemption (OMN-7527)
+  # ==========================================================================
+  # machine_id is a human-readable slug identifier (e.g., 'infra-server', 'm2-ultra'),
+  # not a UUID. It identifies machines in the fleet registry for log readability
+  # and operator configuration. Follows policy_id/dispatcher_id/scheduler_id pattern.
+  - file_pattern: 'model_machine_registry\.py'
+    violation_pattern: "Field 'machine_id' should use UUID"
+    reason: >
+      machine_id is a human-readable slug identifier (e.g., 'infra-server', 'm2-ultra'), not a UUID. Machine IDs appear in config/machines.yaml, CLI flags, and log messages where readability is required. UUID identifiers would degrade operator usability without providing entity-reference benefits. Consistent with policy_id, dispatcher_id, and scheduler_id patterns.
+
+    documentation:
+      - config/machines.yaml (Machine registry definitions)
+      - CLAUDE.md (Registry Naming Conventions)
+    ticket: OMN-7527
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:
@@ -3279,6 +3294,29 @@ architecture_exemptions:
     documentation:
       - CLAUDE.md (Protocol File Naming)
     ticket: OMN-7656
+  # ==========================================================================
+  # ModelMachineRegistry: Domain-grouped machine registry models (OMN-7527)
+  # ==========================================================================
+  # model_machine_registry.py groups EnumMachineRole, ModelMachineEntry, and
+  # ModelMachineRegistry as a cohesive unit. All three are tightly coupled:
+  # the enum defines valid roles, the entry uses it, and the registry holds entries.
+  # Splitting would create 3 trivial files with forced cross-imports.
+  - file_pattern: 'model_machine_registry\.py'
+    violation_pattern: '\d+ models in one file'
+    reason: >
+      Domain-grouped machine registry models. ModelMachineEntry and ModelMachineRegistry define the complete machine fleet registry interface. Per CLAUDE.md domain-grouping convention for cohesive models always used together.
+
+    documentation:
+      - CLAUDE.md (Protocol File Naming - domain-grouping convention)
+    ticket: OMN-7527
+  - file_pattern: 'model_machine_registry\.py'
+    violation_pattern: 'Mixed types in one file'
+    reason: >
+      EnumMachineRole is tightly coupled with ModelMachineEntry and ModelMachineRegistry. The enum defines the valid values for the role field; splitting it into a separate file would add cross-import complexity without benefit.
+
+    documentation:
+      - CLAUDE.md (Protocol File Naming - domain-grouping convention)
+    ticket: OMN-7527
 union_exemptions:
   # ==========================================================================
   # ModelNodeCapabilities Config Field Exemption

--- a/tests/integration/test_env_render_settings_cli.py
+++ b/tests/integration/test_env_render_settings_cli.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for onex env render-settings CLI command. [OMN-7528]"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from omnibase_infra.cli.commands import cli
+
+
+@pytest.mark.integration
+class TestEnvRenderSettingsCLI:
+    """Integration tests for the env render-settings subcommand."""
+
+    def _make_registry_yaml(self, tmp_path: Path) -> Path:
+        data = {
+            "machines": [
+                {
+                    "machine_id": "test-server",
+                    "hostname": "test-server.local",
+                    "role": "dev_workstation",
+                    "omni_home": str(tmp_path / "omni_home"),
+                    "resolved_home_dir": str(tmp_path),
+                }
+            ]
+        }
+        registry = tmp_path / "machines.yaml"
+        registry.write_text(yaml.dump(data))
+        return registry
+
+    def test_render_settings_outputs_valid_json(self, tmp_path: Path) -> None:
+        """render-settings command emits parseable JSON with required top-level keys."""
+        registry = self._make_registry_yaml(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "test-server",
+                "--registry",
+                str(registry),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert "env" in parsed
+        assert "OMNI_HOME" in parsed["env"]
+        assert "ONEX_STATE_DIR" in parsed["env"]
+
+    def test_render_settings_omni_home_from_registry(self, tmp_path: Path) -> None:
+        """OMNI_HOME in output matches the registry entry's omni_home field."""
+        expected_home = str(tmp_path / "omni_home")
+        registry = self._make_registry_yaml(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "test-server",
+                "--registry",
+                str(registry),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["env"]["OMNI_HOME"] == expected_home
+
+    def test_render_settings_unknown_machine_id_exits_nonzero(
+        self, tmp_path: Path
+    ) -> None:
+        """render-settings exits non-zero when machine-id is not in registry."""
+        registry = self._make_registry_yaml(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "nonexistent",
+                "--registry",
+                str(registry),
+            ],
+        )
+        assert result.exit_code != 0

--- a/tests/integration/test_env_render_settings_cli.py
+++ b/tests/integration/test_env_render_settings_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/unit/cli/test_cli_env.py
+++ b/tests/unit/cli/test_cli_env.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for onex env render-settings CLI command. [OMN-7528]"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from omnibase_infra.cli.cli_env import render_settings_json
+from omnibase_infra.cli.commands import cli
+from omnibase_infra.models.environment.model_machine_registry import (
+    EnumMachineRole,
+    ModelMachineEntry,
+    ModelMachineRegistry,
+)
+
+EXPECTED_ENV_KEYS = {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
+    "OMNI_HOME",
+    "ONEX_STATE_DIR",
+    "OMNICLAUDE_MODE",
+    "OMNI_INFRA_HOST",
+    "MAX_THINKING_TOKENS",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+    "DISABLE_TELEMETRY",
+    "DISABLE_ERROR_REPORTING",
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "VALKEY_HOST",
+    "VALKEY_PORT",
+    "KAFKA_BOOTSTRAP_SERVERS",
+}
+
+EXPECTED_TOP_KEYS = {
+    "$schema",
+    "env",
+    "includeCoAuthoredBy",
+    "model",
+    "statusLine",
+    "enabledPlugins",
+    "voiceEnabled",
+    "skipDangerousModePermissionPrompt",
+    "autoUpdates",
+}
+
+
+def _make_entry(**kwargs) -> ModelMachineEntry:
+    defaults = {
+        "machine_id": "test-dev",
+        "hostname": "test.local",
+        "role": EnumMachineRole.DEV_WORKSTATION,
+        "omni_home": "/Users/test/Code/omni_home",
+        "resolved_home_dir": "/Users/test",
+    }
+    defaults.update(kwargs)
+    return ModelMachineEntry(**defaults)
+
+
+class TestRenderSettingsJson:
+    def test_top_keys_exact(self) -> None:
+        result = render_settings_json(_make_entry())
+        assert set(result.keys()) == EXPECTED_TOP_KEYS
+
+    def test_env_keys_exact(self) -> None:
+        result = render_settings_json(_make_entry())
+        assert set(result["env"].keys()) == EXPECTED_ENV_KEYS
+
+    def test_omni_home_derived(self) -> None:
+        result = render_settings_json(
+            _make_entry(omni_home="/Users/test/Code/omni_home")
+        )
+        assert result["env"]["OMNI_HOME"] == "/Users/test/Code/omni_home"
+
+    def test_onex_state_dir_derived(self) -> None:
+        result = render_settings_json(
+            _make_entry(omni_home="/Users/test/Code/omni_home")
+        )
+        assert (
+            result["env"]["ONEX_STATE_DIR"] == "/Users/test/Code/omni_home/.onex_state"
+        )
+
+    def test_statusline_path_starts_with_omni_home(self) -> None:
+        result = render_settings_json(
+            _make_entry(omni_home="/Users/test/Code/omni_home")
+        )
+        assert result["statusLine"]["command"].startswith("/Users/test/Code/omni_home/")
+
+    def test_no_hooks_block(self) -> None:
+        result = render_settings_json(_make_entry())
+        assert "hooks" not in result
+
+    def test_fleet_constants(self) -> None:
+        result = render_settings_json(_make_entry())
+        assert result["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+        assert result["env"]["OMNI_INFRA_HOST"] == "192.168.86.201"
+        assert result["model"] == "opus[1m]"
+
+    def test_no_null_env_values(self) -> None:
+        result = render_settings_json(_make_entry())
+        for v in result["env"].values():
+            assert v is not None
+
+    def test_infra_machine_paths(self) -> None:
+        m = _make_entry(
+            machine_id="infra-server",
+            hostname="infra-server",
+            role=EnumMachineRole.INFRA_SERVER,
+            omni_home="/home/jonah/Code/omni_home",
+            resolved_home_dir="/home/jonah",
+        )
+        result = render_settings_json(m)
+        assert result["env"]["OMNI_HOME"] == "/home/jonah/Code/omni_home"
+        assert (
+            result["env"]["ONEX_STATE_DIR"] == "/home/jonah/Code/omni_home/.onex_state"
+        )
+        assert result["statusLine"]["command"].startswith("/home/jonah/Code/omni_home/")
+
+    def test_is_valid_json(self) -> None:
+        result = render_settings_json(_make_entry())
+        serialized = json.dumps(result)
+        reparsed = json.loads(serialized)
+        assert reparsed == result
+
+
+class TestRenderSettingsCli:
+    def _make_registry_yaml(
+        self, tmp_path: Path, machine_id: str, omni_home: str, role: str
+    ) -> Path:
+        data = {
+            "machines": [
+                {
+                    "machine_id": machine_id,
+                    "hostname": f"{machine_id}.local",
+                    "role": role,
+                    "omni_home": omni_home,
+                    "resolved_home_dir": str(Path(omni_home).parents[2]),
+                }
+            ]
+        }
+        p = tmp_path / "machines.yaml"
+        p.write_text(yaml.dump(data))
+        return p
+
+    def test_cli_infra_server(self, tmp_path: Path) -> None:
+        reg = self._make_registry_yaml(
+            tmp_path, "infra-server", "/home/jonah/Code/omni_home", "infra_server"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "infra-server",
+                "--registry",
+                str(reg),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["env"]["OMNI_HOME"] == "/home/jonah/Code/omni_home"
+
+    def test_cli_m2_ultra(self, tmp_path: Path) -> None:
+        reg = self._make_registry_yaml(
+            tmp_path, "m2-ultra", "/Users/jonah/Code/omni_home", "dev_workstation"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "m2-ultra",
+                "--registry",
+                str(reg),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["env"]["OMNI_HOME"] == "/Users/jonah/Code/omni_home"
+
+    def test_cli_unknown_machine_id_fails(self, tmp_path: Path) -> None:
+        reg = self._make_registry_yaml(
+            tmp_path, "infra-server", "/home/jonah/Code/omni_home", "infra_server"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "env",
+                "render-settings",
+                "--machine-id",
+                "unknown",
+                "--registry",
+                str(reg),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_cli_output_shape(self, tmp_path: Path) -> None:
+        reg = self._make_registry_yaml(
+            tmp_path, "test", "/Users/test/Code/omni_home", "dev_workstation"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["env", "render-settings", "--machine-id", "test", "--registry", str(reg)],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert set(parsed.keys()) == EXPECTED_TOP_KEYS
+        assert set(parsed["env"].keys()) == EXPECTED_ENV_KEYS

--- a/tests/unit/cli/test_cli_env.py
+++ b/tests/unit/cli/test_cli_env.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 import yaml
 from click.testing import CliRunner
 

--- a/tests/unit/cli/test_cli_env.py
+++ b/tests/unit/cli/test_cli_env.py
@@ -16,7 +16,6 @@ from omnibase_infra.cli.commands import cli
 from omnibase_infra.models.environment.model_machine_registry import (
     EnumMachineRole,
     ModelMachineEntry,
-    ModelMachineRegistry,
 )
 
 EXPECTED_ENV_KEYS = {

--- a/tests/unit/models/environment/__init__.py
+++ b/tests/unit/models/environment/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/environment/test_machine_registry.py
+++ b/tests/unit/models/environment/test_machine_registry.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelMachineRegistry and ModelMachineEntry. [OMN-7527]"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_infra.models.environment.model_machine_registry import (
+    EnumMachineRole,
+    ModelMachineEntry,
+    ModelMachineRegistry,
+)
+
+
+def _make_entry(**kwargs) -> ModelMachineEntry:
+    defaults = {
+        "machine_id": "test",
+        "hostname": "test.local",
+        "role": EnumMachineRole.DEV_WORKSTATION,
+        "omni_home": "/Users/test/Code/omni_home",
+        "resolved_home_dir": "/Users/test",
+    }
+    defaults.update(kwargs)
+    return ModelMachineEntry(**defaults)
+
+
+class TestModelMachineEntry:
+    def test_computed_onex_state_dir(self) -> None:
+        m = _make_entry(omni_home="/Users/test/Code/omni_home")
+        assert m.onex_state_dir == "/Users/test/Code/omni_home/.onex_state"
+
+    def test_computed_statusline_path(self) -> None:
+        m = _make_entry(omni_home="/Users/test/Code/omni_home")
+        assert m.statusline_path == (
+            "/Users/test/Code/omni_home/omniclaude/plugins/onex/hooks/scripts/statusline.sh"
+        )
+
+    def test_computed_plugin_path(self) -> None:
+        m = _make_entry(omni_home="/Users/test/Code/omni_home")
+        assert m.plugin_path == "/Users/test/Code/omni_home/omniclaude/plugins/onex"
+
+    def test_computed_claude_settings_path(self) -> None:
+        m = _make_entry(resolved_home_dir="/Users/test")
+        assert m.claude_settings_path == "/Users/test/.claude/settings.json"
+
+    def test_relative_omni_home_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="omni_home must be absolute"):
+            _make_entry(omni_home="relative/path")
+
+    def test_relative_resolved_home_dir_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="omni_home must be absolute"):
+            _make_entry(resolved_home_dir="relative/home")
+
+    def test_infra_machine_paths(self) -> None:
+        m = _make_entry(
+            machine_id="infra",
+            hostname="infra-server",
+            role=EnumMachineRole.INFRA_SERVER,
+            omni_home="/home/jonah/Code/omni_home",
+            resolved_home_dir="/home/jonah",
+        )
+        assert m.onex_state_dir == "/home/jonah/Code/omni_home/.onex_state"
+        assert m.statusline_path.startswith("/home/jonah/Code/omni_home/")
+        assert m.claude_settings_path == "/home/jonah/.claude/settings.json"
+
+
+class TestModelMachineRegistry:
+    def test_get_machine_found(self) -> None:
+        reg = ModelMachineRegistry(machines=[_make_entry(machine_id="x")])
+        m = reg.get_machine("x")
+        assert m.machine_id == "x"
+
+    def test_get_machine_not_found(self) -> None:
+        reg = ModelMachineRegistry(machines=[_make_entry(machine_id="x")])
+        with pytest.raises(KeyError):
+            reg.get_machine("missing")
+
+    def test_get_machines_by_role(self) -> None:
+        reg = ModelMachineRegistry(
+            machines=[
+                _make_entry(machine_id="a", role=EnumMachineRole.DEV_WORKSTATION),
+                _make_entry(machine_id="b", role=EnumMachineRole.INFRA_SERVER),
+                _make_entry(machine_id="c", role=EnumMachineRole.DEV_WORKSTATION),
+            ]
+        )
+        devs = reg.get_machines_by_role(EnumMachineRole.DEV_WORKSTATION)
+        assert len(devs) == 2
+        assert all(m.role == EnumMachineRole.DEV_WORKSTATION for m in devs)
+
+    def test_duplicate_machine_id_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate machine_id"):
+            ModelMachineRegistry(
+                machines=[
+                    _make_entry(machine_id="dup", hostname="h1"),
+                    _make_entry(machine_id="dup", hostname="h2"),
+                ]
+            )
+
+    def test_from_yaml(self, tmp_path: Path) -> None:
+        data = {
+            "machines": [
+                {
+                    "machine_id": "infra-server",
+                    "hostname": "infra-server",
+                    "role": "infra_server",
+                    "omni_home": "/home/jonah/Code/omni_home",
+                    "resolved_home_dir": "/home/jonah",
+                }
+            ]
+        }
+        yaml_path = tmp_path / "machines.yaml"
+        yaml_path.write_text(yaml.dump(data))
+        reg = ModelMachineRegistry.from_yaml(yaml_path)
+        assert reg.get_machine("infra-server").role == EnumMachineRole.INFRA_SERVER
+
+    def test_resolve_local_machine_no_match(self) -> None:
+        reg = ModelMachineRegistry(
+            machines=[_make_entry(machine_id="x", hostname="definitely-not-this-host")]
+        )
+        assert reg.resolve_local_machine() is None
+
+    def test_seed_file_loads(self) -> None:
+        # Walk up from tests/unit/models/environment/ to repo root
+        repo_root = Path(__file__).parents[4]
+        seed = repo_root / "config" / "machines.yaml"
+        reg = ModelMachineRegistry.from_yaml(seed)
+        assert len(reg.machines) >= 2
+        assert reg.get_machine("infra-server") is not None
+        assert reg.get_machine("m2-ultra") is not None

--- a/tests/unit/models/environment/test_machine_registry.py
+++ b/tests/unit/models/environment/test_machine_registry.py
@@ -53,7 +53,7 @@ class TestModelMachineEntry:
             _make_entry(omni_home="relative/path")
 
     def test_relative_resolved_home_dir_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="omni_home must be absolute"):
+        with pytest.raises(ValidationError, match="resolved_home_dir must be absolute"):
             _make_entry(resolved_home_dir="relative/home")
 
     def test_infra_machine_paths(self) -> None:


### PR DESCRIPTION
## Summary

- Implements OMN-7527 (Task 1): `ModelMachineEntry`, `ModelMachineRegistry`, `EnumMachineRole` in `models/environment/` with computed path properties and YAML seed file (`config/machines.yaml`)
- Implements OMN-7528 (Task 2): `onex env render-settings --machine-id <id>` CLI command that produces canonical `settings.json` from registry entries; wired into `omni-infra` CLI

All paths are derived from registry entry fields — no hardcoded paths. Fleet-wide constants (infra host, Kafka, Postgres, Valkey) are module-level constants in `cli_env.py`.

## Test plan

- [ ] `uv run pytest tests/unit/models/environment/test_machine_registry.py -v` — 14 tests pass
- [ ] `uv run pytest tests/unit/cli/test_cli_env.py -v` — 14 tests pass
- [ ] Output shape matches `EXPECTED_TOP_KEYS` and `EXPECTED_ENV_KEYS` exactly (asserted in tests)
- [ ] No empty `hooks` block in output (asserted in tests)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `env render-settings` CLI to emit machine-specific environment settings.
  * Introduced a machine registry with roles (infra server, dev workstation, CI runner) and derived path settings.
  * Added a sample machines configuration containing two machine entries.

* **Tests**
  * Added unit and integration tests covering registry validation, path derivation, and CLI output/behavior.

* **Chores**
  * Updated pre-commit hook invocations to use frozen runs and added validation exemptions for the new registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->