### PR TITLE
fix(infra): add omnimemory-network to runtime-effects so PluginMemory can reach Memgraph [OMN-8713]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         # forcing you to re-stage the changes. This keeps pre-commit and CI in sync.
       - id: mypy-type-check
         name: mypy (type checking)
-        entry: bash -c 'uv run mypy "$@" --show-error-codes --no-error-summary' --
+        entry: bash -c 'uv run --frozen mypy "$@" --show-error-codes --no-error-summary' --
         language: system
         types: [python]
         files: ^src/omnibase_infra/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,14 +61,14 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff format (auto-format)
-        entry: uv run ruff format
+        entry: uv run --frozen ruff format
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
         stages: [pre-commit]
       - id: ruff-fix
         name: ruff check (auto-fix linting + import sorting)
-        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        entry: uv run --frozen ruff check --fix --exit-non-zero-on-fix
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
@@ -98,14 +98,14 @@ repos:
       # Migration freeze enforcement - block new migrations during DB-per-repo refactor
       - id: onex-validate-migration-freeze
         name: ONEX Migration Freeze Enforcement
-        entry: uv run python scripts/validate.py migration_freeze
+        entry: uv run --frozen python scripts/validate.py migration_freeze
         language: system
         pass_filenames: false
         always_run: true
         stages: [pre-commit]
       - id: onex-validate-migration-sequence
         name: ONEX Migration Sequence Duplicate Check
-        entry: uv run python scripts/validation/validate_migration_sequence.py
+        entry: uv run --frozen python scripts/validation/validate_migration_sequence.py
         language: system
         pass_filenames: false
         always_run: false
@@ -124,7 +124,7 @@ repos:
       # Root directory cleanliness - no ephemeral files in root
       - id: onex-validate-clean-root
         name: ONEX Root Directory Cleanliness
-        entry: uv run python scripts/validate.py clean_root
+        entry: uv run --frozen python scripts/validate.py clean_root
         language: system
         pass_filenames: false
         always_run: true
@@ -132,7 +132,7 @@ repos:
       # Architecture validation - one model per file
       - id: onex-validate-architecture
         name: ONEX Architecture Validation
-        entry: uv run python scripts/validate.py architecture
+        entry: uv run --frozen python scripts/validate.py architecture
         language: system
         types: [python]
         pass_filenames: false
@@ -152,7 +152,7 @@ repos:
       # Or: uv run python scripts/validate.py architecture_layers --verbose
       - id: onex-validate-architecture-layers
         name: ONEX Architecture Layer Validation
-        entry: uv run python scripts/validate.py architecture_layers
+        entry: uv run --frozen python scripts/validate.py architecture_layers
         language: system
         types: [python]
         pass_filenames: false
@@ -160,7 +160,7 @@ repos:
       # Contract validation - YAML contracts
       - id: onex-validate-contracts
         name: ONEX Contract Validation
-        entry: uv run python scripts/validate.py contracts
+        entry: uv run --frozen python scripts/validate.py contracts
         language: system
         files: '\.yaml$'
         pass_filenames: false
@@ -168,7 +168,7 @@ repos:
       # Pattern validation - naming conventions
       - id: onex-validate-patterns
         name: ONEX Pattern Validation
-        entry: uv run python scripts/validate.py patterns
+        entry: uv run --frozen python scripts/validate.py patterns
         language: system
         types: [python]
         pass_filenames: false
@@ -178,7 +178,7 @@ repos:
       # Runtime: <3s (single pass with caching)
       - id: onex-validate-naming
         name: ONEX Naming Convention Validation
-        entry: uv run python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
+        entry: uv run --frozen python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
         language: system
         types: [python]
         pass_filenames: false
@@ -188,7 +188,7 @@ repos:
       # Target: Reduce to 30 incrementally after PR #37 merges
       - id: onex-validate-unions
         name: ONEX Union Usage Validation
-        entry: uv run python scripts/validate.py unions
+        entry: uv run --frozen python scripts/validate.py unions
         language: system
         types: [python]
         pass_filenames: false
@@ -196,7 +196,7 @@ repos:
       # Circular import check
       - id: onex-validate-imports
         name: ONEX Circular Import Check
-        entry: uv run python scripts/validate.py imports
+        entry: uv run --frozen python scripts/validate.py imports
         language: system
         types: [python]
         pass_filenames: false
@@ -205,7 +205,7 @@ repos:
       # Ensures no `Any` types are used in the codebase
       - id: onex-validate-any-types
         name: ONEX Any Type Validation
-        entry: uv run python scripts/validate.py any_types
+        entry: uv run --frozen python scripts/validate.py any_types
         language: system
         types: [python]
         pass_filenames: false
@@ -216,7 +216,7 @@ repos:
       # Ratchet rule: any PR reducing violations must lower --max-violations.
       - id: validate-model-dump-json-mode
         name: Validate model_dump uses mode="json"
-        entry: uv run python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
+        entry: uv run --frozen python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
         language: system
         pass_filenames: false
         files: ^src/.*\.py$
@@ -229,7 +229,7 @@ repos:
       # Exempt nodes via: # ONEX_EXCLUDE: declarative_node
       - id: onex-validate-declarative-nodes
         name: ONEX Declarative Node Validation
-        entry: uv run python scripts/validate.py declarative_nodes
+        entry: uv run --frozen python scripts/validate.py declarative_nodes
         language: system
         files: nodes/.*/node\.py$
         pass_filenames: true
@@ -239,7 +239,7 @@ repos:
       # Timeout: 60s prevents hanging if tests get stuck (normal runtime: <5s)
       - id: reducer-purity-check
         name: Reducer Purity Enforcement
-        entry: uv run pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
+        entry: uv run --frozen pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
         language: system
         types: [python]
         files: ^src/omnibase_infra/nodes/reducers/
@@ -250,7 +250,7 @@ repos:
       # External links are skipped by default (configurable in .markdown-link-check.json)
       - id: onex-validate-markdown-links
         name: ONEX Markdown Link Validation
-        entry: uv run python scripts/validate.py markdown_links
+        entry: uv run --frozen python scripts/validate.py markdown_links
         language: system
         types: [markdown]
         pass_filenames: true
@@ -260,7 +260,7 @@ repos:
       # outside of omnibase_infra and tests. Escape hatches: # db-adapter-ok, # sql-ok
       - id: onex-validate-db-quality-gate
         name: ONEX DB Quality Gate
-        entry: uv run python scripts/validate.py db_quality_gate
+        entry: uv run --frozen python scripts/validate.py db_quality_gate
         language: system
         types: [python]
         pass_filenames: false
@@ -268,7 +268,7 @@ repos:
       - id: check-ai-slop
         name: Check for AI-slop patterns
         language: system
-        entry: uv run python scripts/validation/check_ai_slop.py --strict
+        entry: uv run --frozen python scripts/validation/check_ai_slop.py --strict
         types_or: [python, markdown]
         pass_filenames: true
         stages: [pre-commit]
@@ -286,7 +286,7 @@ repos:
       # OMN-4885: Validate published_events topics appear in event_bus.publish_topics
       - id: onex-validate-published-events
         name: Contract published_events consistency
-        entry: uv run python scripts/validation/check_published_events_consistency.py
+        entry: uv run --frozen python scripts/validation/check_published_events_consistency.py
         language: system
         pass_filenames: false
         files: contract\.yaml$
@@ -312,7 +312,7 @@ repos:
       - id: onex-check-migration-required
         name: Writer-Migration Coupling Check
         language: system
-        entry: uv run python scripts/check_migration_required.py --pre-commit
+        entry: uv run --frozen python scripts/check_migration_required.py --pre-commit
         pass_filenames: false
         stages: [pre-commit]
       # OMN-3617: Block planning docs (belong in omni_home/docs/plans/)
@@ -327,7 +327,7 @@ repos:
       # from contracts AND supplementary sources (topic_constants.py)
       - id: topic-enum-drift-check
         name: Topic Enum Drift Check
-        entry: uv run python scripts/generate_topic_enums.py --check
+        entry: uv run --frozen python scripts/generate_topic_enums.py --check
         language: system
         types_or: [yaml, python]
         files: (contract.*\.yaml|topic_constants\.py|enums/generated/)
@@ -344,7 +344,7 @@ repos:
       # OMN-4385: SPDX header enforcement
       - id: validate-spdx-headers
         name: ONEX SPDX Header Requirement
-        entry: uv run onex spdx validate
+        entry: uv run --frozen onex spdx validate
         language: system
         pass_filenames: true
         files: ^(src|tests|scripts|examples)/.*\.(py|sh|bash|yml|yaml|toml)$
@@ -353,7 +353,7 @@ repos:
       # OMN-4600: Contract topic parity gate — blocks new Python-only registry entries
       - id: topic-parity-gate
         name: Topic Contract Parity Gate
-        entry: uv run python scripts/check_contract_topic_parity.py
+        entry: uv run --frozen python scripts/check_contract_topic_parity.py
         language: system
         pass_filenames: false
         files: (platform_topic_suffixes\.py|contract\.yaml|topics\.yaml)
@@ -398,7 +398,7 @@ repos:
       - id: no-untyped-metadata
         name: No untyped metadata dict fields
         language: system
-        entry: uv run check-no-untyped-metadata
+        entry: uv run --frozen check-no-untyped-metadata
         types: [python]
         exclude: ^tests/|^examples/|^scripts/
         stages: [pre-commit]

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -55,6 +55,8 @@ volumes:
   - effects_logs:/app/logs
   - effects_data:/app/data
   - ../contracts:/app/contracts:ro
+extra_networks:
+  - omnimemory-network
 depends_on:
   - service: omninode-runtime
     condition: service_healthy

--- a/scripts/validation/run_topic_lint.sh
+++ b/scripts/validation/run_topic_lint.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT="$SCRIPT_DIR/lint_topic_names.py"
 RC=0
 
-uv run python "$LINT" --scan-contracts src/omnibase_infra/nodes || RC=$?
-uv run python "$LINT" --scan-python src/omnibase_infra || RC=$?
+uv run --frozen python "$LINT" --scan-contracts src/omnibase_infra/nodes || RC=$?
+uv run --frozen python "$LINT" --scan-python src/omnibase_infra || RC=$?
 
 exit "$RC"

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -14,6 +14,7 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
     """Generate a docker-compose dict from a resolved stack."""
     services: dict[str, dict[str, object]] = {}
     all_volumes: set[str] = set()
+    all_extra_networks: set[str] = set()
 
     for name, manifest in resolved.manifests.items():
         svc: dict[str, object] = {}
@@ -60,7 +61,11 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
                     all_volumes.add(vol_name)
 
         # Networks
-        svc["networks"] = ["omnibase-infra-network"]
+        networks: list[str] = ["omnibase-infra-network"]
+        if manifest.extra_networks:
+            networks.extend(manifest.extra_networks)
+            all_extra_networks.update(manifest.extra_networks)
+        svc["networks"] = networks
 
         # Healthcheck
         if manifest.healthcheck:
@@ -111,16 +116,21 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
 
         services[name] = svc
 
+    # Build top-level networks block
+    top_networks: dict[str, object] = {
+        "omnibase-infra-network": {
+            "name": "omnibase-infra-network",
+            "driver": "bridge",
+        }
+    }
+    for net in sorted(all_extra_networks):
+        top_networks[net] = {"name": net, "external": True}
+
     # Build top-level compose dict
     compose: dict[str, object] = {
         "name": "omnibase-infra",
         "services": services,
-        "networks": {
-            "omnibase-infra-network": {
-                "name": "omnibase-infra-network",
-                "driver": "bridge",
-            }
-        },
+        "networks": top_networks,
     }
 
     # Volumes

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -124,6 +124,8 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
         }
     }
     for net in sorted(all_extra_networks):
+        if net == "omnibase-infra-network":
+            continue  # never overwrite the default bridge network as external
         top_networks[net] = {"name": net, "external": True}
 
     # Build top-level compose dict

--- a/src/omnibase_infra/docker/catalog/manifest_schema.py
+++ b/src/omnibase_infra/docker/catalog/manifest_schema.py
@@ -89,6 +89,11 @@ class CatalogManifest:
     stop_grace_period: str | None = None
     # Per-entry env overrides (e.g., per-entry OTEL name)
     catalog_env: dict[str, str] = field(default_factory=dict)
+    # Additional networks beyond the default omnibase-infra-network.
+    # Each entry is a network name; set external=True in the top-level compose
+    # networks block. Use when a service must reach containers on a separate
+    # compose-managed network (e.g. omnimemory-network for Memgraph).
+    extra_networks: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if isinstance(self.layer, str):

--- a/src/omnibase_infra/docker/catalog/resolver.py
+++ b/src/omnibase_infra/docker/catalog/resolver.py
@@ -101,6 +101,7 @@ def _load_manifest(path: Path) -> CatalogManifest:
         resources=resources,
         stop_grace_period=raw.get("stop_grace_period"),
         catalog_env=raw.get("catalog_env", {}),
+        extra_networks=raw.get("extra_networks", []),
     )
 
 

--- a/tests/integration/test_catalog_extra_networks.py
+++ b/tests/integration/test_catalog_extra_networks.py
@@ -114,3 +114,39 @@ def test_generate_compose_no_extra_networks_no_external_entry() -> None:
             f"Network '{net_name}' incorrectly marked external for a service "
             "that declares no extra_networks"
         )
+
+
+@pytest.mark.integration
+def test_generate_compose_default_network_not_overwritten_as_external() -> None:
+    """omnibase-infra-network in extra_networks must not overwrite the bridge definition."""
+    from omnibase_infra.docker.catalog.enum_infra_layer import EnumInfraLayer
+    from omnibase_infra.docker.catalog.manifest_schema import CatalogManifest
+    from omnibase_infra.docker.catalog.resolver import ResolvedStack
+
+    manifest = CatalogManifest(
+        name="test-svc",
+        description="",
+        image="test:latest",
+        layer=EnumInfraLayer.RUNTIME,
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=None,
+        healthcheck=None,
+        volumes=[],
+        depends_on=[],
+        extra_networks=["omnibase-infra-network"],  # reserved name in extra_networks
+    )
+    stack = ResolvedStack(
+        manifests={"test-svc": manifest},
+        required_env=set(),
+        injected_env={},
+    )
+    compose = generate_compose(stack)
+
+    top_networks = compose["networks"]  # type: ignore[index]
+    default_net = top_networks["omnibase-infra-network"]
+    assert default_net.get("driver") == "bridge", (
+        "Default network must remain a bridge, not be overwritten as external"
+    )
+    assert "external" not in default_net

--- a/tests/integration/test_catalog_extra_networks.py
+++ b/tests/integration/test_catalog_extra_networks.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for catalog extra_networks support (OMN-8713).
+
+Verifies that services declaring extra_networks in their manifest YAML:
+  - Join those networks in the generated compose service definition
+  - Cause the extra network to appear as external in the top-level networks block
+  - Do not pollute services that lack extra_networks
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.docker.catalog.generator import generate_compose
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CATALOG_DIR = str(REPO_ROOT / "docker" / "catalog")
+
+
+@pytest.mark.integration
+def test_runtime_effects_joins_omnimemory_network() -> None:
+    """runtime-effects manifest declares extra_networks: [omnimemory-network].
+
+    After generate_compose the service must appear in both omnibase-infra-network
+    and omnimemory-network.
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    # Resolve a bundle that includes runtime-effects; fall back to direct manifest
+    # lookup if no bundle wraps it.
+    manifest = resolver._manifests.get("runtime-effects")
+    if manifest is None:
+        pytest.skip("runtime-effects manifest not found in catalog — skipping")
+
+    assert "omnimemory-network" in manifest.extra_networks, (
+        "runtime-effects manifest must declare extra_networks: [omnimemory-network]"
+    )
+
+
+@pytest.mark.integration
+def test_generate_compose_extra_network_in_service_networks() -> None:
+    """generate_compose must include extra_networks in service's networks list."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    manifest = resolver._manifests.get("runtime-effects")
+    if manifest is None:
+        pytest.skip("runtime-effects manifest not found in catalog — skipping")
+
+    from omnibase_infra.docker.catalog.resolver import ResolvedStack
+
+    stack = ResolvedStack(
+        manifests={"runtime-effects": manifest},
+        required_env=set(manifest.required_env),
+        injected_env={},
+    )
+    compose = generate_compose(stack)
+
+    svc_networks = compose["services"]["runtime-effects"]["networks"]  # type: ignore[index]
+    assert "omnibase-infra-network" in svc_networks
+    assert "omnimemory-network" in svc_networks
+
+
+@pytest.mark.integration
+def test_generate_compose_extra_network_marked_external() -> None:
+    """Extra networks must appear in the top-level networks block as external."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    manifest = resolver._manifests.get("runtime-effects")
+    if manifest is None:
+        pytest.skip("runtime-effects manifest not found in catalog — skipping")
+
+    from omnibase_infra.docker.catalog.resolver import ResolvedStack
+
+    stack = ResolvedStack(
+        manifests={"runtime-effects": manifest},
+        required_env=set(manifest.required_env),
+        injected_env={},
+    )
+    compose = generate_compose(stack)
+
+    top_networks = compose["networks"]  # type: ignore[index]
+    assert "omnimemory-network" in top_networks
+    assert top_networks["omnimemory-network"] == {
+        "name": "omnimemory-network",
+        "external": True,
+    }
+
+
+@pytest.mark.integration
+def test_generate_compose_no_extra_networks_no_external_entry() -> None:
+    """Services without extra_networks must not produce external network entries."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    # postgres has no extra_networks
+    manifest = resolver._manifests.get("postgres")
+    if manifest is None:
+        pytest.skip("postgres manifest not found in catalog — skipping")
+
+    assert not manifest.extra_networks
+
+    from omnibase_infra.docker.catalog.resolver import ResolvedStack
+
+    stack = ResolvedStack(
+        manifests={"postgres": manifest},
+        required_env=set(manifest.required_env),
+        injected_env={},
+    )
+    compose = generate_compose(stack)
+
+    top_networks = compose["networks"]  # type: ignore[index]
+    # Only the default bridge network — no external entries
+    for net_name, net_cfg in top_networks.items():  # type: ignore[union-attr]
+        assert net_cfg.get("external") is not True, (
+            f"Network '{net_name}' incorrectly marked external for a service "
+            "that declares no extra_networks"
+        )

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -80,3 +80,36 @@ def test_generated_compose_includes_network_and_volumes() -> None:
     compose = generate_compose(resolved)
     assert "omnibase-infra-network" in compose["networks"]
     assert "postgres_data" in compose.get("volumes", {})
+
+
+@pytest.mark.unit
+def test_runtime_effects_has_omnimemory_network() -> None:
+    """runtime-effects must join omnimemory-network so PluginMemory can reach Memgraph."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+    svc_networks = compose["services"]["runtime-effects"]["networks"]
+    assert "omnimemory-network" in svc_networks
+    assert "omnibase-infra-network" in svc_networks
+
+
+@pytest.mark.unit
+def test_extra_networks_declared_external_in_top_level() -> None:
+    """Extra networks must appear as external in the top-level networks block."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+    top_networks = compose["networks"]
+    assert "omnimemory-network" in top_networks
+    assert top_networks["omnimemory-network"]["external"] is True
+
+
+@pytest.mark.unit
+def test_extra_networks_absent_for_services_without_them() -> None:
+    """Services without extra_networks must only be on omnibase-infra-network."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["core"])
+    compose = generate_compose(resolved)
+    pg_networks = compose["services"]["postgres"]["networks"]
+    assert pg_networks == ["omnibase-infra-network"]
+    assert "omnimemory-network" not in compose["networks"]


### PR DESCRIPTION
## Summary

- `omninode-runtime-effects` was unhealthy because the memory plugin handshake failed at startup — Memgraph (`omnimemory-network`) was unreachable from `omnibase-infra-network` where all catalog-generated services live
- Added `extra_networks` field to `CatalogManifest` schema, resolver, and generator — services declare additional networks and the generator renders them as `external: true` in the top-level compose block
- Set `extra_networks: [omnimemory-network]` on the `runtime-effects` manifest
- Added 4 unit tests asserting the new network wiring
- Fixed pre-commit hooks to use `uv run --frozen` to resolve OMN-8716 (uv fails in git worktrees when resolving `omnimarket` git dependency at hook time)

Closes OMN-8713

## Test plan
- [ ] `pytest tests/unit/infra/test_catalog_generator.py` — 10 tests pass including 4 new network tests
- [ ] `docker compose config` parses cleanly after `onex generate runtime memgraph`
- [ ] After deploy-agent rebuild: `omninode-runtime-effects` health endpoint returns 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services can now declare and utilize additional Docker networks alongside the default infrastructure network. External networks are automatically configured in the Compose specification.

* **Tests**
  * Enhanced test coverage for service network configuration and multi-network setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->