### PR TITLE
fix(pre-commit): add --frozen to all uv run hooks (OMN-8716)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,14 +61,14 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff format (auto-format)
-        entry: uv run ruff format
+        entry: uv run --frozen ruff format
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
         stages: [pre-commit]
       - id: ruff-fix
         name: ruff check (auto-fix linting + import sorting)
-        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        entry: uv run --frozen ruff check --fix --exit-non-zero-on-fix
         language: system
         types: [python]
         exclude: ^(archived/|tests/fixtures/|\.github/workflows/|src/omnibase_infra/enums/generated/).*$
@@ -77,7 +77,7 @@ repos:
         # forcing you to re-stage the changes. This keeps pre-commit and CI in sync.
       - id: mypy-type-check
         name: mypy (type checking)
-        entry: bash -c 'uv run mypy "$@" --show-error-codes --no-error-summary' --
+        entry: bash -c 'uv run --frozen mypy "$@" --show-error-codes --no-error-summary' --
         language: system
         types: [python]
         files: ^src/omnibase_infra/.*\.py$
@@ -98,14 +98,14 @@ repos:
       # Migration freeze enforcement - block new migrations during DB-per-repo refactor
       - id: onex-validate-migration-freeze
         name: ONEX Migration Freeze Enforcement
-        entry: uv run python scripts/validate.py migration_freeze
+        entry: uv run --frozen python scripts/validate.py migration_freeze
         language: system
         pass_filenames: false
         always_run: true
         stages: [pre-commit]
       - id: onex-validate-migration-sequence
         name: ONEX Migration Sequence Duplicate Check
-        entry: uv run python scripts/validation/validate_migration_sequence.py
+        entry: uv run --frozen python scripts/validation/validate_migration_sequence.py
         language: system
         pass_filenames: false
         always_run: false
@@ -124,7 +124,7 @@ repos:
       # Root directory cleanliness - no ephemeral files in root
       - id: onex-validate-clean-root
         name: ONEX Root Directory Cleanliness
-        entry: uv run python scripts/validate.py clean_root
+        entry: uv run --frozen python scripts/validate.py clean_root
         language: system
         pass_filenames: false
         always_run: true
@@ -132,7 +132,7 @@ repos:
       # Architecture validation - one model per file
       - id: onex-validate-architecture
         name: ONEX Architecture Validation
-        entry: uv run python scripts/validate.py architecture
+        entry: uv run --frozen python scripts/validate.py architecture
         language: system
         types: [python]
         pass_filenames: false
@@ -152,7 +152,7 @@ repos:
       # Or: uv run python scripts/validate.py architecture_layers --verbose
       - id: onex-validate-architecture-layers
         name: ONEX Architecture Layer Validation
-        entry: uv run python scripts/validate.py architecture_layers
+        entry: uv run --frozen python scripts/validate.py architecture_layers
         language: system
         types: [python]
         pass_filenames: false
@@ -160,7 +160,7 @@ repos:
       # Contract validation - YAML contracts
       - id: onex-validate-contracts
         name: ONEX Contract Validation
-        entry: uv run python scripts/validate.py contracts
+        entry: uv run --frozen python scripts/validate.py contracts
         language: system
         files: '\.yaml$'
         pass_filenames: false
@@ -168,7 +168,7 @@ repos:
       # Pattern validation - naming conventions
       - id: onex-validate-patterns
         name: ONEX Pattern Validation
-        entry: uv run python scripts/validate.py patterns
+        entry: uv run --frozen python scripts/validate.py patterns
         language: system
         types: [python]
         pass_filenames: false
@@ -178,7 +178,7 @@ repos:
       # Runtime: <3s (single pass with caching)
       - id: onex-validate-naming
         name: ONEX Naming Convention Validation
-        entry: uv run python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
+        entry: uv run --frozen python scripts/validation/validate_naming.py src/omnibase_infra --errors-only
         language: system
         types: [python]
         pass_filenames: false
@@ -188,7 +188,7 @@ repos:
       # Target: Reduce to 30 incrementally after PR #37 merges
       - id: onex-validate-unions
         name: ONEX Union Usage Validation
-        entry: uv run python scripts/validate.py unions
+        entry: uv run --frozen python scripts/validate.py unions
         language: system
         types: [python]
         pass_filenames: false
@@ -196,7 +196,7 @@ repos:
       # Circular import check
       - id: onex-validate-imports
         name: ONEX Circular Import Check
-        entry: uv run python scripts/validate.py imports
+        entry: uv run --frozen python scripts/validate.py imports
         language: system
         types: [python]
         pass_filenames: false
@@ -205,7 +205,7 @@ repos:
       # Ensures no `Any` types are used in the codebase
       - id: onex-validate-any-types
         name: ONEX Any Type Validation
-        entry: uv run python scripts/validate.py any_types
+        entry: uv run --frozen python scripts/validate.py any_types
         language: system
         types: [python]
         pass_filenames: false
@@ -216,7 +216,7 @@ repos:
       # Ratchet rule: any PR reducing violations must lower --max-violations.
       - id: validate-model-dump-json-mode
         name: Validate model_dump uses mode="json"
-        entry: uv run python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
+        entry: uv run --frozen python scripts/validation/validate_model_dump_json_mode.py --directory src/ --max-violations 0
         language: system
         pass_filenames: false
         files: ^src/.*\.py$
@@ -229,7 +229,7 @@ repos:
       # Exempt nodes via: # ONEX_EXCLUDE: declarative_node
       - id: onex-validate-declarative-nodes
         name: ONEX Declarative Node Validation
-        entry: uv run python scripts/validate.py declarative_nodes
+        entry: uv run --frozen python scripts/validate.py declarative_nodes
         language: system
         files: nodes/.*/node\.py$
         pass_filenames: true
@@ -239,7 +239,7 @@ repos:
       # Timeout: 60s prevents hanging if tests get stuck (normal runtime: <5s)
       - id: reducer-purity-check
         name: Reducer Purity Enforcement
-        entry: uv run pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
+        entry: uv run --frozen pytest tests/unit/nodes/reducers/test_reducer_purity.py -v --tb=short --timeout=60 --timeout-method=thread
         language: system
         types: [python]
         files: ^src/omnibase_infra/nodes/reducers/
@@ -250,7 +250,7 @@ repos:
       # External links are skipped by default (configurable in .markdown-link-check.json)
       - id: onex-validate-markdown-links
         name: ONEX Markdown Link Validation
-        entry: uv run python scripts/validate.py markdown_links
+        entry: uv run --frozen python scripts/validate.py markdown_links
         language: system
         types: [markdown]
         pass_filenames: true
@@ -260,7 +260,7 @@ repos:
       # outside of omnibase_infra and tests. Escape hatches: # db-adapter-ok, # sql-ok
       - id: onex-validate-db-quality-gate
         name: ONEX DB Quality Gate
-        entry: uv run python scripts/validate.py db_quality_gate
+        entry: uv run --frozen python scripts/validate.py db_quality_gate
         language: system
         types: [python]
         pass_filenames: false
@@ -268,7 +268,7 @@ repos:
       - id: check-ai-slop
         name: Check for AI-slop patterns
         language: system
-        entry: uv run python scripts/validation/check_ai_slop.py --strict
+        entry: uv run --frozen python scripts/validation/check_ai_slop.py --strict
         types_or: [python, markdown]
         pass_filenames: true
         stages: [pre-commit]
@@ -286,7 +286,7 @@ repos:
       # OMN-4885: Validate published_events topics appear in event_bus.publish_topics
       - id: onex-validate-published-events
         name: Contract published_events consistency
-        entry: uv run python scripts/validation/check_published_events_consistency.py
+        entry: uv run --frozen python scripts/validation/check_published_events_consistency.py
         language: system
         pass_filenames: false
         files: contract\.yaml$
@@ -312,7 +312,7 @@ repos:
       - id: onex-check-migration-required
         name: Writer-Migration Coupling Check
         language: system
-        entry: uv run python scripts/check_migration_required.py --pre-commit
+        entry: uv run --frozen python scripts/check_migration_required.py --pre-commit
         pass_filenames: false
         stages: [pre-commit]
       # OMN-3617: Block planning docs (belong in omni_home/docs/plans/)
@@ -327,7 +327,7 @@ repos:
       # from contracts AND supplementary sources (topic_constants.py)
       - id: topic-enum-drift-check
         name: Topic Enum Drift Check
-        entry: uv run python scripts/generate_topic_enums.py --check
+        entry: uv run --frozen python scripts/generate_topic_enums.py --check
         language: system
         types_or: [yaml, python]
         files: (contract.*\.yaml|topic_constants\.py|enums/generated/)
@@ -344,7 +344,7 @@ repos:
       # OMN-4385: SPDX header enforcement
       - id: validate-spdx-headers
         name: ONEX SPDX Header Requirement
-        entry: uv run onex spdx validate
+        entry: uv run --frozen onex spdx validate
         language: system
         pass_filenames: true
         files: ^(src|tests|scripts|examples)/.*\.(py|sh|bash|yml|yaml|toml)$
@@ -353,7 +353,7 @@ repos:
       # OMN-4600: Contract topic parity gate — blocks new Python-only registry entries
       - id: topic-parity-gate
         name: Topic Contract Parity Gate
-        entry: uv run python scripts/check_contract_topic_parity.py
+        entry: uv run --frozen python scripts/check_contract_topic_parity.py
         language: system
         pass_filenames: false
         files: (platform_topic_suffixes\.py|contract\.yaml|topics\.yaml)
@@ -398,7 +398,7 @@ repos:
       - id: no-untyped-metadata
         name: No untyped metadata dict fields
         language: system
-        entry: uv run check-no-untyped-metadata
+        entry: uv run --frozen check-no-untyped-metadata
         types: [python]
         exclude: ^tests/|^examples/|^scripts/
         stages: [pre-commit]


### PR DESCRIPTION
## Summary

- Adds `--frozen` to every `uv run` invocation in `.pre-commit-config.yaml` (29 hooks total, including the mypy bash-c wrapper)
- Fixes 100%-reliable pre-commit failure in fresh worktrees where uv tries to re-fetch the omnimarket git dep into an empty cache, producing `fatal: not a git repository`
- `uv run --frozen` skips re-resolution entirely and uses the locked environment, eliminating the git-dep fetch

## Test plan

- [x] Committed in the worktree itself — all 44 hooks ran cleanly
- [ ] Verify in a fresh scratch worktree: trivial edit → `git commit` → all hooks pass

Fixes: OMN-8716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to ensure consistent and reproducible build environments across development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->