### PR TITLE
feat(config): register 6 missing secrets in shared_key_registry.yaml [OMN-8778]

### DIFF
--- a/config/shared_key_registry.yaml
+++ b/config/shared_key_registry.yaml
@@ -23,7 +23,7 @@
 #   - scripts/register-repo.py seed-shared  (seed /shared/* in Infisical)
 #
 # version: increment minor when adding keys, major on breaking structural changes.
-version: "1.0"
+version: "1.1"
 # Keys written to /shared/<transport>/ in Infisical.
 shared:
   "/shared/db/":
@@ -87,6 +87,9 @@ shared:
     # a dedicated platform transport rather than /shared/llm/.
     - ONEX_TREE_SERVICE_URL
     - METADATA_STAMPING_SERVICE_URL
+    # HMAC signing key for local LLM inference requests — shared across all services
+    # that call the inference server. Rotate regularly. (OMN-8778)
+    - LOCAL_LLM_SHARED_SECRET
   # NOT prefetched by ConfigPrefetcher — no EnumInfraTransportType.AUTH entry; keys resolved via shell env fallback.
   "/shared/auth/":
     - OPENAI_API_KEY
@@ -96,6 +99,11 @@ shared:
     - Z_AI_API_URL
     - SERVICE_AUTH_TOKEN
     - GH_PAT
+    # Anthropic API key — used by omniclaude and any service invoking Claude directly.
+    # Note: Claude Code itself uses OAuth (not this key), but services calling the
+    # Anthropic API programmatically (e.g. omniintelligence, omnimarket LLM nodes)
+    # require this key. (OMN-8778)
+    - ANTHROPIC_API_KEY
   # NOT prefetched by ConfigPrefetcher — the prefetch pipeline is not yet wired
   # to call prefetch_for_contracts() at runtime, so VALKEY keys resolve via shell
   # env fallback only.  (EnumInfraTransportType.VALKEY and the transport_config_map
@@ -115,6 +123,16 @@ shared:
   "/shared/env/":
     - SLACK_BOT_TOKEN
     - SLACK_CHANNEL_ID
+    # Linear API key — used by omniclaude, omnimarket, and CI scripts to query/update tickets.
+    # Previously seeded at /shared/env/ (OMN-3898); now formally registered. (OMN-8778)
+    - LINEAR_API_KEY
+    # CI callback token — used by the ci-relay service to authenticate CI status callbacks.
+    - CI_CALLBACK_TOKEN
+    # MCP API key — used by omniclaude MCP server for authenticated MCP client connections.
+    - MCP_API_KEY
+    # Logfire telemetry token — used by omnidash for LLM trace/eval ingestion.
+    # Infisical is secret storage only; injection pattern unchanged (env var at runtime).
+    - LOGFIRE_TOKEN
 # Keys that must NEVER be seeded into Infisical.
 # These live OUTSIDE repos (home dir or deployment secrets) and must never
 # appear in any repo .env file. Two distinct reasons apply — see subcategories:

--- a/tests/unit/scripts/test_shared_key_registry_omn8778.py
+++ b/tests/unit/scripts/test_shared_key_registry_omn8778.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registry completeness test for OMN-8778: 6 previously-missing secrets.
+
+Validates that shared_key_registry.yaml declares every key identified in the
+OMN-8778 audit so future removals fail loudly rather than silently regressing
+Infisical coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REGISTRY_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent / "config" / "shared_key_registry.yaml"
+)
+
+# Keys added by OMN-8778 and their expected Infisical paths.
+_REQUIRED_KEYS: dict[str, str] = {
+    "ANTHROPIC_API_KEY": "/shared/auth/",
+    "LOCAL_LLM_SHARED_SECRET": "/shared/llm/",
+    "LINEAR_API_KEY": "/shared/env/",
+    "CI_CALLBACK_TOKEN": "/shared/env/",
+    "MCP_API_KEY": "/shared/env/",
+    "LOGFIRE_TOKEN": "/shared/env/",
+}
+
+
+@pytest.fixture(scope="module")
+def registry() -> dict[str, object]:
+    return yaml.safe_load(_REGISTRY_PATH.read_text())  # type: ignore[no-any-return]
+
+
+class TestOMN8778SecretRegistration:
+    def test_registry_file_exists(self) -> None:
+        assert _REGISTRY_PATH.exists(), f"shared_key_registry.yaml not found at {_REGISTRY_PATH}"
+
+    def test_registry_version_at_least_1_1(self, registry: dict[str, object]) -> None:
+        version = str(registry.get("version", "0.0"))
+        major, minor = (int(p) for p in version.split("."))
+        assert (major, minor) >= (1, 1), (
+            f"Registry version {version} predates OMN-8778 additions; expected >= 1.1"
+        )
+
+    @pytest.mark.parametrize(("key", "expected_path"), list(_REQUIRED_KEYS.items()))
+    def test_key_registered_at_correct_path(
+        self, registry: dict[str, object], key: str, expected_path: str
+    ) -> None:
+        shared: dict[str, list[str]] = registry.get("shared", {})  # type: ignore[assignment]
+        keys_at_path: list[str] = shared.get(expected_path, [])
+        assert key in keys_at_path, (
+            f"Secret '{key}' missing from shared_key_registry.yaml under '{expected_path}'. "
+            f"OMN-8778 requires it to be registered there for Infisical seeding coverage."
+        )
+
+    def test_no_required_key_in_bootstrap_only(self, registry: dict[str, object]) -> None:
+        bootstrap: list[str] = registry.get("bootstrap_only", [])  # type: ignore[assignment]
+        for key in _REQUIRED_KEYS:
+            assert key not in bootstrap, (
+                f"Secret '{key}' must not be in bootstrap_only — it is a regular Infisical secret."
+            )

--- a/tests/unit/scripts/test_shared_key_registry_omn8778.py
+++ b/tests/unit/scripts/test_shared_key_registry_omn8778.py
@@ -15,7 +15,9 @@ import pytest
 import yaml
 
 _REGISTRY_PATH = (
-    Path(__file__).resolve().parent.parent.parent.parent / "config" / "shared_key_registry.yaml"
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "config"
+    / "shared_key_registry.yaml"
 )
 
 # Keys added by OMN-8778 and their expected Infisical paths.
@@ -36,7 +38,9 @@ def registry() -> dict[str, object]:
 
 class TestOMN8778SecretRegistration:
     def test_registry_file_exists(self) -> None:
-        assert _REGISTRY_PATH.exists(), f"shared_key_registry.yaml not found at {_REGISTRY_PATH}"
+        assert _REGISTRY_PATH.exists(), (
+            f"shared_key_registry.yaml not found at {_REGISTRY_PATH}"
+        )
 
     def test_registry_version_at_least_1_1(self, registry: dict[str, object]) -> None:
         version = str(registry.get("version", "0.0"))
@@ -56,7 +60,9 @@ class TestOMN8778SecretRegistration:
             f"OMN-8778 requires it to be registered there for Infisical seeding coverage."
         )
 
-    def test_no_required_key_in_bootstrap_only(self, registry: dict[str, object]) -> None:
+    def test_no_required_key_in_bootstrap_only(
+        self, registry: dict[str, object]
+    ) -> None:
         bootstrap: list[str] = registry.get("bootstrap_only", [])  # type: ignore[assignment]
         for key in _REQUIRED_KEYS:
             assert key not in bootstrap, (


### PR DESCRIPTION
## Summary

- Registers `ANTHROPIC_API_KEY`, `LOCAL_LLM_SHARED_SECRET`, `LINEAR_API_KEY`, `CI_CALLBACK_TOKEN`, `MCP_API_KEY`, and `LOGFIRE_TOKEN` in `config/shared_key_registry.yaml` under correct Infisical paths
- Bumps registry version to 1.1
- Adds regression test (`test_shared_key_registry_omn8778.py`) asserting all 6 keys are present at correct paths and absent from `bootstrap_only`

## Paths

| Key | Infisical Path |
|-----|---------------|
| `ANTHROPIC_API_KEY` | `/shared/auth/` |
| `LOCAL_LLM_SHARED_SECRET` | `/shared/llm/` |
| `LINEAR_API_KEY` | `/shared/env/` |
| `CI_CALLBACK_TOKEN` | `/shared/env/` |
| `MCP_API_KEY` | `/shared/env/` |
| `LOGFIRE_TOKEN` | `/shared/env/` |

## Manual follow-up (not in this PR)

Provisioning secrets in Infisical requires live credentials:
```bash
uv run python scripts/seed-infisical.py --execute --set-values
```

Tracked as part of OMN-8778 DoD — operator must run this after merge.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_shared_key_registry_omn8778.py -v` — 9/9 pass
- [x] `uv run pytest tests/unit/scripts/ -q` — 322/322 pass
- [x] `uv run ruff check tests/unit/scripts/test_shared_key_registry_omn8778.py` — clean
- [x] `uv run mypy tests/unit/scripts/test_shared_key_registry_omn8778.py` — clean

Closes OMN-8778 (YAML registration portion; Infisical provisioning is manual follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new integrations: LLM, Anthropic authentication, Linear, CI callbacks, MCP, and Logfire.

* **Chores**
  * Registry schema version bumped to 1.1 to accommodate the new shared keys.

* **Tests**
  * Added validation tests to ensure registry completeness and that required secrets are correctly registered (not marked bootstrap-only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->