### PR TITLE
fix(kafka): hard-fail on missing KAFKA_BOOTSTRAP_SERVERS, remove localhost:19092 defaults [OMN-8783]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Check shared enum ownership
         run: python scripts/check_shared_enum_ownership.py src/
 
+      - name: Check Kafka bootstrap no localhost fallback (OMN-8783)
+        run: uv run python scripts/ci_check_kafka_no_localhost_default.py
+
       - name: Check topic suffix exports (F56)
         run: python scripts/validation/check_topic_suffix_exports.py
 

--- a/scripts/ci_check_kafka_no_localhost_default.py
+++ b/scripts/ci_check_kafka_no_localhost_default.py
@@ -37,9 +37,15 @@ from pathlib import Path
 
 # Patterns that indicate a silent localhost fallback in container-facing code
 _VIOLATION_PATTERNS = [
-    re.compile(r'os\.environ\.get\s*\(\s*"KAFKA_BOOTSTRAP_SERVERS"\s*,\s*"localhost:\d+"\s*\)'),
-    re.compile(r'os\.getenv\s*\(\s*"KAFKA_BOOTSTRAP_SERVERS"\s*,\s*"localhost:\d+"\s*\)'),
-    re.compile(r'DEFAULT_BOOTSTRAP_SERVERS\s*=\s*"localhost:\d+"'),
+    re.compile(
+        r'os\.environ\.get\s*\(\s*["\']KAFKA_BOOTSTRAP_SERVERS["\']\s*,\s*["\']localhost:\d+["\']\s*\)',
+        re.DOTALL,
+    ),
+    re.compile(
+        r'os\.getenv\s*\(\s*["\']KAFKA_BOOTSTRAP_SERVERS["\']\s*,\s*["\']localhost:\d+["\']\s*\)',
+        re.DOTALL,
+    ),
+    re.compile(r'DEFAULT_BOOTSTRAP_SERVERS\s*=\s*["\']localhost:\d+["\']'),
 ]
 
 # Host-side CLI tools where localhost fallback is allowlisted (bootstrap_only bucket)
@@ -51,8 +57,9 @@ _ALLOWLIST = [
 
 
 def _is_allowlisted(path: Path, src_root: Path) -> bool:
-    rel = str(path.relative_to(src_root))
-    return any(rel.replace("\\", "/").startswith(a) for a in _ALLOWLIST)
+    rel = path.relative_to(src_root).as_posix()
+    rel_from_pkg = rel.split("omnibase_infra/", 1)[-1]
+    return any(rel.startswith(a) or rel_from_pkg.startswith(a) for a in _ALLOWLIST)
 
 
 def check(src_root: Path) -> list[str]:

--- a/scripts/ci_check_kafka_no_localhost_default.py
+++ b/scripts/ci_check_kafka_no_localhost_default.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CI gate: assert no localhost:19092 default in container-facing source (OMN-8783).
+
+Docker containers must always receive KAFKA_BOOTSTRAP_SERVERS via catalog
+hardcoded_env (redpanda:9092). Any localhost:19092 fallback in production
+handler code means the container will connect to the wrong broker when the
+overlay is absent.
+
+This script scans src/ for:
+  - os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092") patterns
+  - os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092") patterns
+  - DEFAULT_BOOTSTRAP_SERVERS = "localhost:19092" (in non-CLI modules)
+
+Allowlisted paths (host-only CLI tools where localhost:19092 is valid):
+  - src/omnibase_infra/cli/artifact_reconcile.py
+  - src/omnibase_infra/cli/infra_test/
+  - src/omnibase_infra/diagnostics/
+
+Usage::
+
+    uv run python scripts/ci_check_kafka_no_localhost_default.py
+    uv run python scripts/ci_check_kafka_no_localhost_default.py --src src/
+
+Exit codes:
+    0 -- no violations found
+    1 -- violations found (stderr has details)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Patterns that indicate a silent localhost fallback in container-facing code
+_VIOLATION_PATTERNS = [
+    re.compile(r'os\.environ\.get\s*\(\s*"KAFKA_BOOTSTRAP_SERVERS"\s*,\s*"localhost:\d+"\s*\)'),
+    re.compile(r'os\.getenv\s*\(\s*"KAFKA_BOOTSTRAP_SERVERS"\s*,\s*"localhost:\d+"\s*\)'),
+    re.compile(r'DEFAULT_BOOTSTRAP_SERVERS\s*=\s*"localhost:\d+"'),
+]
+
+# Host-side CLI tools where localhost fallback is allowlisted (bootstrap_only bucket)
+_ALLOWLIST = [
+    "cli/artifact_reconcile.py",
+    "cli/infra_test/",
+    "diagnostics/",
+]
+
+
+def _is_allowlisted(path: Path, src_root: Path) -> bool:
+    rel = str(path.relative_to(src_root))
+    return any(rel.replace("\\", "/").startswith(a) for a in _ALLOWLIST)
+
+
+def check(src_root: Path) -> list[str]:
+    violations: list[str] = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        if _is_allowlisted(py_file, src_root):
+            continue
+        text = py_file.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pattern in _VIOLATION_PATTERNS:
+                if pattern.search(line):
+                    rel = py_file.relative_to(src_root)
+                    violations.append(f"{rel}:{lineno}: {line.strip()}")
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--src",
+        default="src/omnibase_infra",
+        help="Source directory to scan (default: src/omnibase_infra)",
+    )
+    args = parser.parse_args()
+    src_root = Path(args.src).resolve()
+
+    if not src_root.is_dir():
+        print(f"ERROR: src directory not found: {src_root}", file=sys.stderr)
+        return 1
+
+    violations = check(src_root)
+    if violations:
+        print(
+            "ERROR: localhost:19092 fallback detected in container-facing source (OMN-8783).",
+            file=sys.stderr,
+        )
+        print(
+            "Containers must receive KAFKA_BOOTSTRAP_SERVERS via catalog hardcoded_env.",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+
+    print(f"OK: No localhost:19092 fallback in container-facing source ({src_root}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
+++ b/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
@@ -34,7 +34,8 @@
 # =============================================================================
 # Kafka broker connection configuration
 # Comma-separated list of Kafka broker addresses
-bootstrap_servers: "${KAFKA_BOOTSTRAP_SERVERS:-localhost:19092}"
+# OMN-8783: No localhost default — overlay must provide KAFKA_BOOTSTRAP_SERVERS.
+bootstrap_servers: "${KAFKA_BOOTSTRAP_SERVERS}"
 # Environment identifier for message routing (e.g., "local", "dev", "staging", "prod")
 environment: "${KAFKA_ENVIRONMENT:-local}"
 # =============================================================================

--- a/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
+++ b/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
@@ -9,19 +9,19 @@
 # IMPORTANT: Environment Variable Substitution Mechanism
 # -------------------------------------------------------
 # The ${VAR_NAME:-default} syntax in this file is NOT processed by yaml.safe_load().
-# YAML reads these as literal strings (e.g., "${KAFKA_BOOTSTRAP_SERVERS:-localhost:19092}").
+# YAML reads these as literal strings (e.g., "${KAFKA_BOOTSTRAP_SERVERS}").
 #
 # Environment variable substitution happens AFTER YAML parsing in
 # ModelKafkaEventBusConfig.apply_environment_overrides(), which:
 # 1. Loads this file with yaml.safe_load() (treats ${...} as literal strings)
 # 2. Checks os.environ for matching environment variables (KAFKA_BOOTSTRAP_SERVERS, etc.)
 # 3. Overrides config values if environment variables are set
-# 4. Falls back to the literal defaults from this file if environment variables are not set
+# 4. Raises KeyError if KAFKA_BOOTSTRAP_SERVERS is absent — no localhost fallback (OMN-8783)
 #
 # Example: If KAFKA_BOOTSTRAP_SERVERS="kafka:9092" is set in environment:
-#   - YAML loads: bootstrap_servers: "${KAFKA_BOOTSTRAP_SERVERS:-localhost:19092}"
+#   - YAML loads: bootstrap_servers: "${KAFKA_BOOTSTRAP_SERVERS}"
 #   - apply_environment_overrides() detects KAFKA_BOOTSTRAP_SERVERS env var
-#   - Final value: "kafka:9092" (from environment, not from ${...} syntax)
+#   - Final value: "kafka:9092" (from environment)
 #
 # The ${...} syntax is used for documentation purposes to indicate which
 # environment variables can override each configuration value.

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -35,8 +35,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Default bootstrap servers (matches event_bus_kafka.py pattern)
-DEFAULT_BOOTSTRAP_SERVERS = "localhost:19092"
+# OMN-8783: No default — KAFKA_BOOTSTRAP_SERVERS must be set via overlay.
 ENV_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS"
 
 # Default partition and replication settings for standard event topics
@@ -77,7 +76,7 @@ class TopicProvisioner:
 
         Args:
             bootstrap_servers: Kafka broker addresses. If None, reads from
-                KAFKA_BOOTSTRAP_SERVERS env var or defaults to localhost:19092.
+                KAFKA_BOOTSTRAP_SERVERS env var (raises KeyError if absent).
             request_timeout_ms: Timeout for admin operations in milliseconds.
             contracts_root: Path to contract.yaml root directory. Required.
                 Topics are discovered from contracts via
@@ -101,9 +100,8 @@ class TopicProvisioner:
             raise FileNotFoundError(
                 f"contracts_root does not exist or is not a directory: {contracts_root}"
             )
-        self._bootstrap_servers = bootstrap_servers or os.environ.get(
-            ENV_BOOTSTRAP_SERVERS, DEFAULT_BOOTSTRAP_SERVERS
-        )
+        # OMN-8783: Hard-fail if not provided and env var absent.
+        self._bootstrap_servers = bootstrap_servers or os.environ[ENV_BOOTSTRAP_SERVERS]
         self._request_timeout_ms = request_timeout_ms
         self._contracts_root = contracts_root
         self._skill_manifests_root = skill_manifests_root

--- a/src/omnibase_infra/event_bus/service_topic_startup_validator.py
+++ b/src/omnibase_infra/event_bus/service_topic_startup_validator.py
@@ -33,8 +33,7 @@ from omnibase_infra.topics import ALL_PROVISIONED_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
-# Reuse constants from TopicProvisioner
-DEFAULT_BOOTSTRAP_SERVERS = "localhost:19092"
+# OMN-8783: No default — KAFKA_BOOTSTRAP_SERVERS must be set via overlay.
 ENV_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS"
 
 
@@ -65,12 +64,11 @@ class TopicStartupValidator:
 
         Args:
             bootstrap_servers: Kafka broker addresses. If None, reads from
-                KAFKA_BOOTSTRAP_SERVERS env var or defaults to localhost:19092.
+                KAFKA_BOOTSTRAP_SERVERS env var (raises KeyError if absent).
             request_timeout_ms: Timeout for admin operations in milliseconds.
         """
-        self._bootstrap_servers = bootstrap_servers or os.environ.get(
-            ENV_BOOTSTRAP_SERVERS, DEFAULT_BOOTSTRAP_SERVERS
-        )
+        # OMN-8783: Hard-fail if not provided and env var absent.
+        self._bootstrap_servers = bootstrap_servers or os.environ[ENV_BOOTSTRAP_SERVERS]
         self._request_timeout_ms = request_timeout_ms
 
     async def validate(

--- a/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
+++ b/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
@@ -52,21 +52,22 @@ class ModelKafkaProducerConfig(BaseModel):
         """Create config from KAFKA_* environment variables.
 
         Raises:
+            KeyError: If KAFKA_BOOTSTRAP_SERVERS is not set in the environment.
+                Containers must always have this injected via compose overlay —
+                no silent localhost fallback (OMN-8783).
             ValueError: If numeric env vars contain non-numeric values
                 or KAFKA_ACKS contains an invalid acks value.
         """
+        # OMN-8783: Hard-fail if KAFKA_BOOTSTRAP_SERVERS is absent. Containers
+        # receive this via hardcoded_env in the catalog manifest (redpanda:9092).
+        # A missing env var means the overlay was not applied — fail loudly.
+        bootstrap = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
         try:
-            # kafka-fallback-ok — these model-level defaults are overridden at runtime by env vars
-            bootstrap = os.getenv(
-                "KAFKA_BOOTSTRAP_SERVERS", "localhost:19092"
-            )  # kafka-fallback-ok
-            timeout_ms = os.getenv(
-                "KAFKA_REQUEST_TIMEOUT_MS", "10000"
-            )  # kafka-fallback-ok
-            acks_raw = os.getenv("KAFKA_ACKS", "all")  # kafka-fallback-ok
+            timeout_ms = os.getenv("KAFKA_REQUEST_TIMEOUT_MS", "10000")
+            acks_raw = os.getenv("KAFKA_ACKS", "all")
             max_request_size_raw = os.getenv(
                 "KAFKA_MAX_REQUEST_SIZE", str(4 * 1024 * 1024)
-            )  # kafka-fallback-ok
+            )
             return cls(
                 bootstrap_servers=bootstrap,
                 timeout_seconds=float(timeout_ms) / 1000.0,

--- a/src/omnibase_infra/runtime/request_response_wiring.py
+++ b/src/omnibase_infra/runtime/request_response_wiring.py
@@ -247,9 +247,9 @@ class RequestResponseWiring(MixinAsyncCircuitBreaker):
         else:
             import os
 
-            self._bootstrap_servers = os.environ.get(
-                "KAFKA_BOOTSTRAP_SERVERS", "localhost:19092"
-            )
+            # OMN-8783: Hard-fail if KAFKA_BOOTSTRAP_SERVERS is absent.
+            # Containers receive this via catalog hardcoded_env (redpanda:9092).
+            self._bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
 
         # Canonical topic resolver - all topic resolution delegates here
         self._topic_resolver = TopicResolver()

--- a/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
+++ b/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
@@ -62,15 +62,8 @@ class TestKafkaBootstrapNoLocalhostFallback:
         """Constructor must not embed 'localhost' when env var is absent."""
         monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
 
-        try:
-            provisioner = TopicProvisioner(contracts_root=contracts_root)
-            # If we get here, the invariant is broken — assert no localhost fallback
-            assert "localhost" not in provisioner._bootstrap_servers, (
-                f"OMN-8783 regression: localhost fallback found in "
-                f"bootstrap_servers={provisioner._bootstrap_servers!r}"
-            )
-        except KeyError:
-            pass  # Expected — hard-fail is the correct behavior
+        with pytest.raises(KeyError, match="KAFKA_BOOTSTRAP_SERVERS"):
+            TopicProvisioner(contracts_root=contracts_root)
 
     def test_explicit_bootstrap_servers_accepted(
         self,

--- a/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
+++ b/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OMN-8783: hard-fail on missing KAFKA_BOOTSTRAP_SERVERS.
+
+Exercises the full TopicProvisioner init path through the real service stack —
+no mocks on the env-var resolution. The provisioner must raise KeyError (not
+fall back to localhost) when KAFKA_BOOTSTRAP_SERVERS is absent.
+
+Related:
+    - OMN-8783: Kafka bootstrap overlay split — remove localhost:19092 fallback
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def contracts_root(tmp_path: Path) -> Path:
+    """Minimal contracts directory with a valid contract.yaml."""
+    node_dir = tmp_path / "node_example"
+    node_dir.mkdir()
+    (node_dir / "contract.yaml").write_text(
+        "name: node_example\n"
+        "version: 1.0.0\n"
+        "namespace: onex.stamped\n"
+        "event_bus:\n"
+        "  publish_topics:\n"
+        "    - onex.evt.test-producer.example-event.v1\n"
+    )
+    return tmp_path
+
+
+class TestKafkaBootstrapNoLocalhostFallback:
+    """Verify the OMN-8783 hard-fail invariant through the full service init path."""
+
+    def test_raises_key_error_when_env_absent(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TopicProvisioner raises KeyError when KAFKA_BOOTSTRAP_SERVERS is unset.
+
+        This is the core OMN-8783 invariant: no silent fallback to localhost.
+        """
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        with pytest.raises(KeyError, match="KAFKA_BOOTSTRAP_SERVERS"):
+            TopicProvisioner(contracts_root=contracts_root)
+
+    def test_no_localhost_default_used(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Constructor must not embed 'localhost' when env var is absent."""
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        try:
+            provisioner = TopicProvisioner(contracts_root=contracts_root)
+            # If we get here, the invariant is broken — assert no localhost fallback
+            assert "localhost" not in provisioner._bootstrap_servers, (
+                f"OMN-8783 regression: localhost fallback found in "
+                f"bootstrap_servers={provisioner._bootstrap_servers!r}"
+            )
+        except KeyError:
+            pass  # Expected — hard-fail is the correct behavior
+
+    def test_explicit_bootstrap_servers_accepted(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Constructor accepts an explicit bootstrap_servers arg without env var."""
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        provisioner = TopicProvisioner(
+            bootstrap_servers="redpanda:9092",
+            contracts_root=contracts_root,
+        )
+        assert provisioner._bootstrap_servers == "redpanda:9092"
+
+    def test_env_var_overlay_respected(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Constructor reads KAFKA_BOOTSTRAP_SERVERS from env when not passed explicitly."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker.example.com:9092")
+
+        provisioner = TopicProvisioner(contracts_root=contracts_root)
+        assert provisioner._bootstrap_servers == "broker.example.com:9092"
+        assert "localhost" not in provisioner._bootstrap_servers
+
+    def test_env_var_wins_over_no_arg(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Env var overlay is the only source when bootstrap_servers arg is None."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "kafka1:9092,kafka2:9092")
+
+        provisioner = TopicProvisioner(contracts_root=contracts_root)
+        assert provisioner._bootstrap_servers == "kafka1:9092,kafka2:9092"
+
+    def test_missing_contracts_root_raises_file_not_found(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """FileNotFoundError raised for nonexistent contracts_root (service-stack check)."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")
+        bad_path = tmp_path / "does_not_exist"
+
+        with pytest.raises(FileNotFoundError, match="contracts_root"):
+            TopicProvisioner(
+                bootstrap_servers="redpanda:9092",
+                contracts_root=bad_path,
+            )
+
+    def test_bootstrap_servers_env_var_constant(self) -> None:
+        """ENV_BOOTSTRAP_SERVERS constant must be KAFKA_BOOTSTRAP_SERVERS (not hardcoded)."""
+        from omnibase_infra.event_bus.service_topic_manager import ENV_BOOTSTRAP_SERVERS
+
+        assert ENV_BOOTSTRAP_SERVERS == "KAFKA_BOOTSTRAP_SERVERS"

--- a/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
+++ b/tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py
@@ -12,7 +12,6 @@ Related:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -59,10 +59,11 @@ def _make_provisioner(
 class TestTopicProvisioner:
     """Tests for TopicProvisioner."""
 
-    def test_init_defaults(self, contracts_root: Path) -> None:
-        """Default initialization uses environment or localhost."""
+    def test_init_defaults(self, contracts_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default initialization reads KAFKA_BOOTSTRAP_SERVERS from env."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")
         manager = TopicProvisioner(contracts_root=contracts_root)
-        assert manager._bootstrap_servers is not None
+        assert manager._bootstrap_servers == "redpanda:9092"
         assert manager._request_timeout_ms == 30000
 
     def test_init_custom(self, contracts_root: Path) -> None:

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -59,7 +59,9 @@ def _make_provisioner(
 class TestTopicProvisioner:
     """Tests for TopicProvisioner."""
 
-    def test_init_defaults(self, contracts_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_defaults(
+        self, contracts_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Default initialization reads KAFKA_BOOTSTRAP_SERVERS from env."""
         monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")
         manager = TopicProvisioner(contracts_root=contracts_root)

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -60,7 +60,9 @@ class TestTopicProvisioner:
     """Tests for TopicProvisioner."""
 
     def test_init_defaults(
-        self, contracts_root: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Default initialization reads KAFKA_BOOTSTRAP_SERVERS from env."""
         monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")

--- a/tests/unit/runtime/test_dependency_materializer.py
+++ b/tests/unit/runtime/test_dependency_materializer.py
@@ -246,9 +246,10 @@ class TestModelPostgresPoolConfig:
 class TestModelKafkaProducerConfig:
     """Tests for Kafka producer configuration."""
 
-    def test_default_values(self) -> None:
+    def test_default_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker:9092")
         config = ModelKafkaProducerConfig()
-        assert config.bootstrap_servers == "localhost:19092"
+        assert config.bootstrap_servers == "broker:9092"
         assert config.timeout_seconds == 10.0
         assert config.acks == EnumKafkaAcks.ALL
 

--- a/tests/unit/runtime/test_kafka_bootstrap_no_localhost_fallback.py
+++ b/tests/unit/runtime/test_kafka_bootstrap_no_localhost_fallback.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""TDD tests for OMN-8783: Kafka bootstrap overlay split.
+
+Asserts that no code path silently falls back to localhost:19092 when
+KAFKA_BOOTSTRAP_SERVERS is unset. Images must hard-fail if the overlay
+does not provide the broker address.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.models.model_kafka_producer_config import (
+    ModelKafkaProducerConfig,
+)
+
+
+@pytest.mark.unit
+class TestKafkaBootstrapNoLocalhostFallback:
+    """Verify that from_env() raises when KAFKA_BOOTSTRAP_SERVERS is absent."""
+
+    def test_from_env_raises_when_bootstrap_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """from_env() must raise KeyError, not silently use localhost:19092."""
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        with pytest.raises(KeyError, match="KAFKA_BOOTSTRAP_SERVERS"):
+            ModelKafkaProducerConfig.from_env()
+
+    def test_from_env_uses_env_var_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """from_env() uses KAFKA_BOOTSTRAP_SERVERS when set."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")
+        config = ModelKafkaProducerConfig.from_env()
+        assert config.bootstrap_servers == "redpanda:9092"
+
+    def test_from_env_does_not_return_localhost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """from_env() must never silently return localhost:19092."""
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        try:
+            config = ModelKafkaProducerConfig.from_env()
+            assert "localhost" not in config.bootstrap_servers, (
+                "from_env() must not fall back to localhost when KAFKA_BOOTSTRAP_SERVERS is unset"
+            )
+        except (KeyError, ValueError):
+            pass  # Expected — hard-fail is correct behavior

--- a/tests/unit/runtime/test_kafka_bootstrap_no_localhost_fallback.py
+++ b/tests/unit/runtime/test_kafka_bootstrap_no_localhost_fallback.py
@@ -39,12 +39,7 @@ class TestKafkaBootstrapNoLocalhostFallback:
     def test_from_env_does_not_return_localhost(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """from_env() must never silently return localhost:19092."""
+        """from_env() must raise KeyError, never silently return localhost:19092."""
         monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
-        try:
-            config = ModelKafkaProducerConfig.from_env()
-            assert "localhost" not in config.bootstrap_servers, (
-                "from_env() must not fall back to localhost when KAFKA_BOOTSTRAP_SERVERS is unset"
-            )
-        except (KeyError, ValueError):
-            pass  # Expected — hard-fail is correct behavior
+        with pytest.raises(KeyError, match="KAFKA_BOOTSTRAP_SERVERS"):
+            ModelKafkaProducerConfig.from_env()


### PR DESCRIPTION
## Summary

- Removes `localhost:19092` silent fallback from all container-facing Kafka config paths (`ModelKafkaProducerConfig.from_env()`, `RequestResponseWiring`, `TopicProvisioner`, `TopicStartupValidator`, `kafka_event_bus_config.yaml`)
- Containers now raise `KeyError` when `KAFKA_BOOTSTRAP_SERVERS` is absent — the catalog `hardcoded_env` overlay must be applied
- Adds `scripts/ci_check_kafka_no_localhost_default.py` CI gate wired into `ci.yml` to prevent regression

## DoD Evidence

- 3 TDD tests green: `test_kafka_bootstrap_no_localhost_fallback.py`
- CI gate script passes: `uv run python scripts/ci_check_kafka_no_localhost_default.py` → OK
- 504 unit tests passing (runtime + event_bus directories)
- `ruff` + `mypy` clean on all changed files
- Host-side CLI tools (`artifact_reconcile.py`, `cli/infra_test/`, `diagnostics/`) remain allowlisted per OMN-8783 spec (bootstrap_only bucket)

## Test plan

- [ ] CI green (all checks pass)
- [ ] Verify containers start with `KAFKA_BOOTSTRAP_SERVERS=redpanda:9092` via catalog overlay
- [ ] Verify container fails fast without `KAFKA_BOOTSTRAP_SERVERS` set

Closes OMN-8783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kafka bootstrap resolution now fails fast when the KAFKA_BOOTSTRAP_SERVERS environment variable is missing instead of silently falling back to localhost, affecting event bus, producer, and wiring initialization.

* **Chores**
  * Added a CI validation step to detect inadvertent localhost bootstrap fallbacks during early checks.

* **Tests**
  * Added and updated unit and integration tests to verify the hard-fail behavior and correct handling of provided bootstrap values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->