### PR TITLE
fix(onboarding): fix 3 rendered_output bugs — all steps shown, pass/fail indicators, strip HTML comment [OMN-8810]

### DIFF
--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
@@ -90,9 +90,9 @@ async def handle_onboarding(
             )
             completed_steps.append(step)
 
-    # Render output
+    # Render output — pass all steps (not just completed) so failed/skipped appear
     renderer = RendererOnboardingMarkdown()
-    rendered = renderer.render(completed_steps, title="Onboarding Progress")
+    rendered = renderer.render(steps, step_results, title="Onboarding Progress")
 
     all_passed = all(r.passed for r in step_results)
     return ModelOnboardingOutput(

--- a/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
+++ b/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
@@ -38,7 +38,9 @@ class RendererOnboardingMarkdown:
         ]
 
         passed_count = sum(
-            1 for s in steps if result_by_key.get(s.step_key) and result_by_key[s.step_key].passed
+            1
+            for s in steps
+            if result_by_key.get(s.step_key) and result_by_key[s.step_key].passed
         )
         lines.append(f"{passed_count}/{len(steps)} steps passed")
         lines.append("")

--- a/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
+++ b/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
@@ -9,6 +9,7 @@ from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_step_result 
     ModelStepResult,
 )
 from omnibase_infra.onboarding.model_onboarding_step import ModelOnboardingStep
+from omnibase_infra.utils import sanitize_error_string
 
 
 class RendererOnboardingMarkdown:
@@ -55,7 +56,7 @@ class RendererOnboardingMarkdown:
                 suffix = ""
             else:
                 indicator = "[!]"
-                suffix = f" — {result.message}" if result.message else ""
+                suffix = f" — {sanitize_error_string(result.message)}" if result.message else ""
 
             lines.append(f"## {step.name}")
             lines.append("")

--- a/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
+++ b/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
@@ -56,7 +56,11 @@ class RendererOnboardingMarkdown:
                 suffix = ""
             else:
                 indicator = "[!]"
-                suffix = f" — {sanitize_error_string(result.message)}" if result.message else ""
+                suffix = (
+                    f" — {sanitize_error_string(result.message)}"
+                    if result.message
+                    else ""
+                )
 
             lines.append(f"## {step.name}")
             lines.append("")

--- a/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
+++ b/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_step_result import (
+    ModelStepResult,
+)
 from omnibase_infra.onboarding.model_onboarding_step import ModelOnboardingStep
 
 
@@ -14,32 +17,46 @@ class RendererOnboardingMarkdown:
     def render(
         self,
         steps: list[ModelOnboardingStep],
+        step_results: list[ModelStepResult],
         title: str = "Onboarding Checklist",
     ) -> str:
-        """Render steps as a markdown checklist.
+        """Render all steps with pass/fail indicators as a markdown checklist.
 
         Args:
-            steps: Resolved steps in execution order.
+            steps: All resolved steps in execution order.
+            step_results: Per-step execution results (same length and order as steps).
             title: Document title.
 
         Returns:
             Markdown string with checklist.
         """
+        result_by_key = {r.step_key: r for r in step_results}
+
         lines: list[str] = [
-            "<!-- GENERATED FROM canonical.yaml -- DO NOT EDIT MANUALLY -->",
-            "",
             f"# {title}",
             "",
         ]
 
-        for i, step in enumerate(steps, 1):
+        passed_count = sum(1 for r in step_results if r.passed)
+        lines.append(f"{passed_count}/{len(step_results)} steps passed")
+        lines.append("")
+
+        for step in steps:
+            result = result_by_key.get(step.step_key)
+            if result is None or result.passed:
+                indicator = "[x]"
+                suffix = ""
+            else:
+                indicator = "[!]"
+                suffix = f" — {result.message}" if result and result.message else ""
+
             lines.append(f"## {step.name}")
             lines.append("")
             if step.description:
                 lines.append(step.description)
                 lines.append("")
 
-            lines.append(f"- [ ] **{step.name}**")
+            lines.append(f"- {indicator} **{step.name}**{suffix}")
 
             if step.verification:
                 lines.append(

--- a/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
+++ b/src/omnibase_infra/onboarding/renderers/renderer_markdown.py
@@ -37,18 +37,23 @@ class RendererOnboardingMarkdown:
             "",
         ]
 
-        passed_count = sum(1 for r in step_results if r.passed)
-        lines.append(f"{passed_count}/{len(step_results)} steps passed")
+        passed_count = sum(
+            1 for s in steps if result_by_key.get(s.step_key) and result_by_key[s.step_key].passed
+        )
+        lines.append(f"{passed_count}/{len(steps)} steps passed")
         lines.append("")
 
         for step in steps:
             result = result_by_key.get(step.step_key)
-            if result is None or result.passed:
+            if result is None:
+                indicator = "[?]"
+                suffix = " — Missing execution result"
+            elif result.passed:
                 indicator = "[x]"
                 suffix = ""
             else:
                 indicator = "[!]"
-                suffix = f" — {result.message}" if result and result.message else ""
+                suffix = f" — {result.message}" if result.message else ""
 
             lines.append(f"## {step.name}")
             lines.append("")

--- a/tests/integration/test_onboarding_renderer_integration.py
+++ b/tests/integration/test_onboarding_renderer_integration.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for the onboarding renderer pipeline (OMN-8810).
+
+Validates the full renderer pipeline: load canonical graph -> resolve policy
+-> construct step_results -> render markdown output. Tests run against real
+canonical.yaml data without external service dependencies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_step_result import (
+    ModelStepResult,
+)
+from omnibase_infra.onboarding.loader import load_canonical_graph
+from omnibase_infra.onboarding.policy_resolver import resolve_policy
+from omnibase_infra.onboarding.renderers.renderer_markdown import (
+    RendererOnboardingMarkdown,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class TestOnboardingRendererIntegration:
+    """Integration: renderer pipeline with real canonical graph data."""
+
+    def _load_steps(self) -> list:
+        graph = load_canonical_graph()
+        return resolve_policy(graph, target_capabilities=["first_node_running"])
+
+    def _all_passing(self, steps: list) -> list[ModelStepResult]:
+        return [
+            ModelStepResult(step_key=s.step_key, passed=True, message="Passed")
+            for s in steps
+        ]
+
+    def test_all_steps_present_in_rendered_output(self) -> None:
+        steps = self._load_steps()
+        results = self._all_passing(steps)
+        output = RendererOnboardingMarkdown().render(steps, results)
+        for step in steps:
+            assert step.name in output, (
+                f"Step '{step.name}' missing from rendered output"
+            )
+
+    def test_no_html_comment_in_rendered_output(self) -> None:
+        steps = self._load_steps()
+        results = self._all_passing(steps)
+        output = RendererOnboardingMarkdown().render(steps, results)
+        assert "GENERATED FROM canonical.yaml" not in output
+        assert "<!--" not in output
+
+    def test_pass_fail_indicators_correct(self) -> None:
+        steps = self._load_steps()
+        assert len(steps) >= 2, "Need at least 2 steps to test indicators"
+        results = [
+            ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
+            ModelStepResult(
+                step_key=steps[1].step_key, passed=False, message="intentional failure"
+            ),
+        ] + [
+            ModelStepResult(step_key=s.step_key, passed=False, message="Skipped")
+            for s in steps[2:]
+        ]
+        output = RendererOnboardingMarkdown().render(steps, results)
+        assert "[x]" in output
+        assert "[!]" in output
+        assert "intentional failure" in output
+
+    def test_summary_line_reflects_pass_count(self) -> None:
+        steps = self._load_steps()
+        results = self._all_passing(steps)
+        output = RendererOnboardingMarkdown().render(steps, results)
+        expected = f"{len(steps)}/{len(steps)} steps passed"
+        assert expected in output

--- a/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding.py
+++ b/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding.py
@@ -95,7 +95,7 @@ class TestHandleOnboarding:
 
     @pytest.mark.asyncio
     async def test_partial_progress_rendering(self) -> None:
-        """Rendered output includes only completed steps."""
+        """Rendered output includes all steps with correct pass/fail indicators."""
         input_model = ModelOnboardingInput(
             target_capabilities=["first_node_running"],
         )
@@ -114,7 +114,13 @@ class TestHandleOnboarding:
         ):
             output = await handle_onboarding(input_model)
 
-        # Only first step (Check Python) should be in rendered output
+        # All 5 steps appear in rendered output (not just completed ones)
         assert "Check Python" in output.rendered_output
-        # Third step (Install omnibase_core) should NOT be rendered
-        assert "Install omnibase_core" not in output.rendered_output
+        # Passed step shows [x] indicator
+        assert "[x]" in output.rendered_output
+        # Failed step shows [!] indicator
+        assert "[!]" in output.rendered_output
+        # No leaked HTML comment
+        assert "<!-- GENERATED FROM" not in output.rendered_output
+        # Summary line present
+        assert "steps passed" in output.rendered_output

--- a/tests/unit/onboarding/test_renderers.py
+++ b/tests/unit/onboarding/test_renderers.py
@@ -94,9 +94,7 @@ class TestRendererOnboardingMarkdown:
         steps = _get_standalone_steps()
         results = [
             ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
-            ModelStepResult(
-                step_key=steps[1].step_key, passed=False, message="failed"
-            ),
+            ModelStepResult(step_key=steps[1].step_key, passed=False, message="failed"),
         ] + [
             ModelStepResult(
                 step_key=s.step_key,

--- a/tests/unit/onboarding/test_renderers.py
+++ b/tests/unit/onboarding/test_renderers.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_step_result import (
+    ModelStepResult,
+)
 from omnibase_infra.onboarding.loader import load_canonical_graph
 from omnibase_infra.onboarding.policy_resolver import resolve_policy
 from omnibase_infra.onboarding.renderers.renderer_cli import RendererOnboardingCli
@@ -18,30 +21,95 @@ def _get_standalone_steps():
     return resolve_policy(graph, target_capabilities=["first_node_running"])
 
 
+def _all_passing_results(steps):
+    return [
+        ModelStepResult(step_key=s.step_key, passed=True, message="Passed")
+        for s in steps
+    ]
+
+
 class TestRendererOnboardingMarkdown:
     """Tests for the markdown renderer."""
 
     def test_produces_valid_checklist(self) -> None:
         steps = _get_standalone_steps()
+        results = _all_passing_results(steps)
         renderer = RendererOnboardingMarkdown()
-        output = renderer.render(steps, title="Standalone Quickstart")
+        output = renderer.render(steps, results, title="Standalone Quickstart")
         assert "# Standalone Quickstart" in output
-        assert "- [ ]" in output
-        assert "GENERATED FROM canonical.yaml" in output
+        assert "[x]" in output
+
+    def test_no_html_comment_in_output(self) -> None:
+        steps = _get_standalone_steps()
+        results = _all_passing_results(steps)
+        renderer = RendererOnboardingMarkdown()
+        output = renderer.render(steps, results)
+        assert "GENERATED FROM canonical.yaml" not in output
+        assert "<!--" not in output
 
     def test_contains_step_names(self) -> None:
         steps = _get_standalone_steps()
+        results = _all_passing_results(steps)
         renderer = RendererOnboardingMarkdown()
-        output = renderer.render(steps)
+        output = renderer.render(steps, results)
         assert "Check Python Installation" in output
         assert "Install uv Package Manager" in output
 
     def test_contains_verification_commands(self) -> None:
         steps = _get_standalone_steps()
+        results = _all_passing_results(steps)
         renderer = RendererOnboardingMarkdown()
-        output = renderer.render(steps)
+        output = renderer.render(steps, results)
         assert "python3 --version" in output
         assert "uv --version" in output
+
+    def test_failed_step_shows_exclamation_indicator(self) -> None:
+        steps = _get_standalone_steps()
+        results = [
+            ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
+            ModelStepResult(
+                step_key=steps[1].step_key, passed=False, message="command not found"
+            ),
+        ] + [
+            ModelStepResult(
+                step_key=s.step_key,
+                passed=False,
+                message="Skipped due to previous failure",
+            )
+            for s in steps[2:]
+        ]
+        renderer = RendererOnboardingMarkdown()
+        output = renderer.render(steps, results)
+        assert "[!]" in output
+        assert "command not found" in output
+
+    def test_summary_line_shows_pass_count(self) -> None:
+        steps = _get_standalone_steps()
+        results = _all_passing_results(steps)
+        renderer = RendererOnboardingMarkdown()
+        output = renderer.render(steps, results)
+        assert "steps passed" in output
+
+    def test_all_steps_rendered_even_when_some_fail(self) -> None:
+        steps = _get_standalone_steps()
+        results = [
+            ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
+            ModelStepResult(
+                step_key=steps[1].step_key, passed=False, message="failed"
+            ),
+        ] + [
+            ModelStepResult(
+                step_key=s.step_key,
+                passed=False,
+                message="Skipped due to previous failure",
+            )
+            for s in steps[2:]
+        ]
+        renderer = RendererOnboardingMarkdown()
+        output = renderer.render(steps, results)
+        # All 5 step names must appear, not just the passed ones
+        for step in steps:
+            assert step.name in output
 
 
 class TestRendererOnboardingCli:

--- a/tests/unit/onboarding/test_renderers.py
+++ b/tests/unit/onboarding/test_renderers.py
@@ -90,6 +90,18 @@ class TestRendererOnboardingMarkdown:
         output = renderer.render(steps, results)
         assert "steps passed" in output
 
+    def test_missing_step_result_renders_unknown_indicator(self) -> None:
+        steps = _get_standalone_steps()
+        # Only provide results for all steps except the first
+        results = [
+            ModelStepResult(step_key=s.step_key, passed=True, message="OK")
+            for s in steps[1:]
+        ]
+        renderer = RendererOnboardingMarkdown()
+        output = renderer.render(steps, results)
+        assert "[?]" in output
+        assert "Missing execution result" in output
+
     def test_all_steps_rendered_even_when_some_fail(self) -> None:
         steps = _get_standalone_steps()
         results = [

--- a/tests/unit/onboarding/test_renderers.py
+++ b/tests/unit/onboarding/test_renderers.py
@@ -65,6 +65,7 @@ class TestRendererOnboardingMarkdown:
 
     def test_failed_step_shows_exclamation_indicator(self) -> None:
         steps = _get_standalone_steps()
+        assert len(steps) >= 2, "Need at least 2 steps to test fail indicator"
         results = [
             ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
             ModelStepResult(
@@ -104,6 +105,7 @@ class TestRendererOnboardingMarkdown:
 
     def test_all_steps_rendered_even_when_some_fail(self) -> None:
         steps = _get_standalone_steps()
+        assert len(steps) >= 2, "Need at least 2 steps to test mixed outcomes"
         results = [
             ModelStepResult(step_key=steps[0].step_key, passed=True, message="OK"),
             ModelStepResult(step_key=steps[1].step_key, passed=False, message="failed"),


### PR DESCRIPTION
## Summary

Fixes 3 bugs in `rendered_output` from `handle_onboarding` / `RendererOnboardingMarkdown` exposed by OMN-8796 dogfood run.

- **Bug 1 (missing steps)**: Handler passed `completed_steps` (only passing steps) to renderer instead of all steps. Fixed by passing the full `steps` list so every step appears in output.
- **Bug 2 (wrong pass/fail indicators)**: Renderer hardcoded `- [ ]` regardless of actual step `passed` field. Fixed by redesigning `render()` to accept `step_results: list[ModelStepResult]`, rendering `[x]` for passed and `[!] step_name — error_message` for failed. Adds summary line: `N/M steps passed`.
- **Bug 3 (leaked HTML comment)**: `<!-- GENERATED FROM canonical.yaml -- DO NOT EDIT MANUALLY -->` appeared verbatim in user-facing output. Fixed by removing it from the renderer.

## Files Changed

- `src/omnibase_infra/onboarding/renderers/renderer_markdown.py` — new `render(steps, step_results, title)` signature; removed HTML comment; [x]/[!] indicators; summary line
- `src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py` — pass `steps` + `step_results` to renderer
- `tests/unit/onboarding/test_renderers.py` — updated for new signature; added 4 new tests covering all 3 bugs
- `tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding.py` — updated to assert new correct behavior

## Test plan

- [x] `uv run pytest tests/unit/onboarding/test_renderers.py tests/unit/nodes/node_onboarding_orchestrator/ -v` — 21/21 pass
- [x] `uv run pytest tests/unit/ -q -n auto --ignore=tests/unit/runtime --ignore=tests/unit/event_bus` — 13586 passed, 1 pre-existing unrelated failure
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean on changed files

Closes OMN-8810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding progress now shows every step — including failed or skipped ones — with visual status indicators: [x] passed, [!] failed, [?] missing.
  * Failure messages are shown inline next to failed steps (sanitized).
  * Added a summary line showing overall progress as "X/Y steps passed".

* **Tests**
  * Updated unit tests and added integration tests to verify full-step rendering, pass/fail/missing indicators, inline messages, summary counts, and absence of HTML comment markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->