### PR TITLE
feat(adapters): add LocalStubProjectTracker file-backed stub [OMN-8815]

### DIFF
--- a/src/omnibase_infra/adapters/project_tracker/__init__.py
+++ b/src/omnibase_infra/adapters/project_tracker/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/adapters/project_tracker/local_stub_project_tracker.py
+++ b/src/omnibase_infra/adapters/project_tracker/local_stub_project_tracker.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""File-backed stub implementation of ProtocolProjectTracker.
+
+Used when LINEAR_API_KEY / LINEAR_TOKEN is not set. Satisfies the full
+protocol shape with JSON-backed persistence under state_root/project_tracker_stub.json.
+Not intended to prove full Linear behavioral equivalence — protocol-shape
+substitute for offline/local operation only.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
+from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
+from omnibase_infra.adapters.project_tracker.model_stub_project import ModelStubProject
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class StubHealthStatus:
+    """Minimal health status for local stub — satisfies ProtocolServiceHealthStatus shape."""
+
+    def __init__(self) -> None:
+        self.service_id = "local-stub-project-tracker"
+        self.status = "healthy"
+        self.diagnostics: dict[str, str] = {}
+
+
+class LocalStubProjectTracker:
+    """JSON-backed local stub satisfying ProtocolProjectTracker.
+
+    State stored in {state_root}/project_tracker_stub.json.
+    Issue identifiers are STUB-{counter} (monotonically incrementing).
+    Writes are crash-consistent via atomic rename.
+    """
+
+    def __init__(self, state_root: Path | None = None) -> None:
+        if state_root is None:
+            state_root = Path.home() / ".onex_state" / "local-tracker"
+        self._state_root = Path(state_root)
+        self._state_file = self._state_root / "project_tracker_stub.json"
+        self._lock = threading.Lock()
+        self._connected = False
+
+    # -- internal persistence --
+
+    def _load(self) -> dict[str, object]:
+        if not self._state_file.exists():
+            return {"issues": {}, "projects": {}, "comments": {}, "counter": 0}
+        return json.loads(self._state_file.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
+    def _save(self, state: dict[str, object]) -> None:
+        self._state_root.mkdir(parents=True, exist_ok=True)
+        tmp = self._state_file.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        tmp.replace(self._state_file)
+
+    def _issue_from_dict(self, d: dict[str, object]) -> ModelStubIssue:
+        return ModelStubIssue(
+            id=str(d["id"]),
+            identifier=str(d["identifier"]),
+            title=str(d["title"]),
+            description=str(d["description"])
+            if d.get("description") is not None
+            else None,
+            state=str(d.get("state", "todo")),
+            priority=str(d["priority"]) if d.get("priority") is not None else None,
+            assignee=str(d["assignee"]) if d.get("assignee") is not None else None,
+            labels=list(d.get("labels", [])),  # type: ignore[arg-type]
+            team=str(d["team"]) if d.get("team") is not None else None,
+            project_id=str(d["project_id"])
+            if d.get("project_id") is not None
+            else None,
+            url=str(d["url"]) if d.get("url") is not None else None,
+            created_at=datetime.fromisoformat(str(d["created_at"])),
+            updated_at=datetime.fromisoformat(str(d["updated_at"])),
+        )
+
+    def _comment_from_dict(self, d: dict[str, object]) -> ModelStubComment:
+        return ModelStubComment(
+            id=str(d["id"]),
+            body=str(d["body"]),
+            author=str(d.get("author", "stub")),
+            created_at=datetime.fromisoformat(str(d["created_at"])),
+        )
+
+    def _project_from_dict(self, d: dict[str, object]) -> ModelStubProject:
+        return ModelStubProject(
+            id=str(d["id"]),
+            name=str(d["name"]),
+            description=str(d["description"])
+            if d.get("description") is not None
+            else None,
+            state=str(d["state"]) if d.get("state") is not None else None,
+            progress=float(d.get("progress", 0.0)),  # type: ignore[arg-type]
+            url=str(d["url"]) if d.get("url") is not None else None,
+        )
+
+    # -- ProtocolProjectTracker lifecycle --
+
+    async def connect(self) -> bool:
+        self._state_root.mkdir(parents=True, exist_ok=True)
+        self._connected = True
+        return True
+
+    async def health_check(self) -> StubHealthStatus:
+        return StubHealthStatus()
+
+    async def get_capabilities(self) -> list[str]:
+        return ["read", "write"]
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:
+        self._connected = False
+
+    # -- Domain operations --
+
+    async def list_issues(
+        self, filters: dict[str, str] | None = None, limit: int = 50
+    ) -> list[ModelStubIssue]:
+        with self._lock:
+            state = self._load()
+        issues_map = state.get("issues", {})
+        issues = [
+            self._issue_from_dict(v)  # type: ignore[arg-type]
+            for v in (issues_map.values() if isinstance(issues_map, dict) else [])
+        ]
+        if filters:
+            for key, val in filters.items():
+                issues = [i for i in issues if getattr(i, key, None) == val]
+        return issues[:limit]
+
+    async def get_issue(self, issue_id: str) -> ModelStubIssue:
+        with self._lock:
+            state = self._load()
+        issues_map = state.get("issues", {})
+        for d in issues_map.values() if isinstance(issues_map, dict) else []:
+            row = d  # type: ignore[assignment]
+            if row.get("id") == issue_id or row.get("identifier") == issue_id:
+                return self._issue_from_dict(row)
+        raise KeyError(f"Issue not found: {issue_id}")
+
+    async def create_issue(
+        self,
+        title: str,
+        description: str,
+        labels: list[str] | None = None,
+        assignee: str | None = None,
+        priority: str | None = None,
+        team: str | None = None,
+    ) -> ModelStubIssue:
+        with self._lock:
+            state = self._load()
+            counter = int(state.get("counter", 0)) + 1
+            state["counter"] = counter
+            issue_id = str(uuid.uuid4())
+            identifier = f"STUB-{counter}"
+            now = _now_iso()
+            row: dict[str, object] = {
+                "id": issue_id,
+                "identifier": identifier,
+                "title": title,
+                "description": description,
+                "state": "todo",
+                "priority": priority,
+                "assignee": assignee,
+                "labels": labels or [],
+                "team": team,
+                "project_id": None,
+                "url": None,
+                "created_at": now,
+                "updated_at": now,
+            }
+            issues_map = state.get("issues", {})
+            if isinstance(issues_map, dict):
+                issues_map[issue_id] = row
+            state["issues"] = issues_map
+            self._save(state)
+        return self._issue_from_dict(row)
+
+    async def update_issue(
+        self, issue_id: str, updates: dict[str, str]
+    ) -> ModelStubIssue:
+        with self._lock:
+            state = self._load()
+            issues_map = state.get("issues", {})
+            target_key: str | None = None
+            for k, d in issues_map.items() if isinstance(issues_map, dict) else []:
+                row = d  # type: ignore[assignment]
+                if row.get("id") == issue_id or row.get("identifier") == issue_id:
+                    target_key = k
+                    break
+            if target_key is None:
+                raise KeyError(f"Issue not found: {issue_id}")
+            row = issues_map[target_key]  # type: ignore[assignment,index]
+            row.update(updates)  # type: ignore[union-attr]
+            row["updated_at"] = _now_iso()  # type: ignore[index]
+            self._save(state)
+        return self._issue_from_dict(row)  # type: ignore[arg-type]
+
+    async def search_issues(self, query: str, limit: int = 50) -> list[ModelStubIssue]:
+        with self._lock:
+            state = self._load()
+        q = query.lower()
+        issues_map = state.get("issues", {})
+        results = [
+            self._issue_from_dict(d)  # type: ignore[arg-type]
+            for d in (issues_map.values() if isinstance(issues_map, dict) else [])
+            if q in str(d.get("title", "")).lower()  # type: ignore[union-attr]
+            or q in str(d.get("description") or "").lower()  # type: ignore[union-attr]
+        ]
+        return results[:limit]
+
+    async def add_comment(self, issue_id: str, body: str) -> ModelStubComment:
+        with self._lock:
+            state = self._load()
+            issues_map = state.get("issues", {})
+            found = any(
+                d.get("id") == issue_id or d.get("identifier") == issue_id  # type: ignore[union-attr]
+                for d in (issues_map.values() if isinstance(issues_map, dict) else [])
+            )
+            if not found:
+                raise KeyError(f"Issue not found: {issue_id}")
+            comment_id = str(uuid.uuid4())
+            now = _now_iso()
+            cd: dict[str, object] = {
+                "id": comment_id,
+                "issue_id": issue_id,
+                "body": body,
+                "author": "stub",
+                "created_at": now,
+            }
+            comments_map = state.get("comments", {})
+            if isinstance(comments_map, dict):
+                comments_map[comment_id] = cd
+            state["comments"] = comments_map
+            self._save(state)
+        return self._comment_from_dict(cd)
+
+    async def get_project(self, project_id: str) -> ModelStubProject:
+        with self._lock:
+            state = self._load()
+        projects_map = state.get("projects", {})
+        if isinstance(projects_map, dict) and project_id in projects_map:
+            return self._project_from_dict(projects_map[project_id])  # type: ignore[arg-type]
+        raise KeyError(f"Project not found: {project_id}")
+
+    async def list_projects(self, limit: int = 50) -> list[ModelStubProject]:
+        with self._lock:
+            state = self._load()
+        projects_map = state.get("projects", {})
+        return [
+            self._project_from_dict(v)  # type: ignore[arg-type]
+            for v in list(
+                projects_map.values() if isinstance(projects_map, dict) else []
+            )[:limit]
+        ]

--- a/src/omnibase_infra/adapters/project_tracker/local_stub_project_tracker.py
+++ b/src/omnibase_infra/adapters/project_tracker/local_stub_project_tracker.py
@@ -56,7 +56,10 @@ class LocalStubProjectTracker:
     def _load(self) -> dict[str, object]:
         if not self._state_file.exists():
             return {"issues": {}, "projects": {}, "comments": {}, "counter": 0}
-        return json.loads(self._state_file.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+        data: dict[str, object] = json.loads(
+            self._state_file.read_text(encoding="utf-8")
+        )
+        return data
 
     def _save(self, state: dict[str, object]) -> None:
         self._state_root.mkdir(parents=True, exist_ok=True)
@@ -65,6 +68,10 @@ class LocalStubProjectTracker:
         tmp.replace(self._state_file)
 
     def _issue_from_dict(self, d: dict[str, object]) -> ModelStubIssue:
+        raw_labels = d.get("labels", [])
+        labels: list[str] = (
+            [str(x) for x in raw_labels] if isinstance(raw_labels, list) else []
+        )
         return ModelStubIssue(
             id=str(d["id"]),
             identifier=str(d["identifier"]),
@@ -75,7 +82,7 @@ class LocalStubProjectTracker:
             state=str(d.get("state", "todo")),
             priority=str(d["priority"]) if d.get("priority") is not None else None,
             assignee=str(d["assignee"]) if d.get("assignee") is not None else None,
-            labels=list(d.get("labels", [])),  # type: ignore[arg-type]
+            labels=labels,
             team=str(d["team"]) if d.get("team") is not None else None,
             project_id=str(d["project_id"])
             if d.get("project_id") is not None
@@ -94,6 +101,10 @@ class LocalStubProjectTracker:
         )
 
     def _project_from_dict(self, d: dict[str, object]) -> ModelStubProject:
+        raw_progress = d.get("progress", 0.0)
+        progress = (
+            float(raw_progress) if isinstance(raw_progress, (int, float)) else 0.0
+        )
         return ModelStubProject(
             id=str(d["id"]),
             name=str(d["name"]),
@@ -101,7 +112,7 @@ class LocalStubProjectTracker:
             if d.get("description") is not None
             else None,
             state=str(d["state"]) if d.get("state") is not None else None,
-            progress=float(d.get("progress", 0.0)),  # type: ignore[arg-type]
+            progress=progress,
             url=str(d["url"]) if d.get("url") is not None else None,
         )
 
@@ -130,8 +141,9 @@ class LocalStubProjectTracker:
             state = self._load()
         issues_map = state.get("issues", {})
         issues = [
-            self._issue_from_dict(v)  # type: ignore[arg-type]
+            self._issue_from_dict(v)
             for v in (issues_map.values() if isinstance(issues_map, dict) else [])
+            if isinstance(v, dict)
         ]
         if filters:
             for key, val in filters.items():
@@ -143,9 +155,10 @@ class LocalStubProjectTracker:
             state = self._load()
         issues_map = state.get("issues", {})
         for d in issues_map.values() if isinstance(issues_map, dict) else []:
-            row = d  # type: ignore[assignment]
-            if row.get("id") == issue_id or row.get("identifier") == issue_id:
-                return self._issue_from_dict(row)
+            if not isinstance(d, dict):
+                continue
+            if d.get("id") == issue_id or d.get("identifier") == issue_id:
+                return self._issue_from_dict(d)
         raise KeyError(f"Issue not found: {issue_id}")
 
     async def create_issue(
@@ -159,7 +172,10 @@ class LocalStubProjectTracker:
     ) -> ModelStubIssue:
         with self._lock:
             state = self._load()
-            counter = int(state.get("counter", 0)) + 1
+            raw_counter = state.get("counter", 0)
+            counter = (
+                int(raw_counter) if isinstance(raw_counter, (int, float, str)) else 0
+            ) + 1
             state["counter"] = counter
             issue_id = str(uuid.uuid4())
             identifier = f"STUB-{counter}"
@@ -194,17 +210,24 @@ class LocalStubProjectTracker:
             issues_map = state.get("issues", {})
             target_key: str | None = None
             for k, d in issues_map.items() if isinstance(issues_map, dict) else []:
-                row = d  # type: ignore[assignment]
-                if row.get("id") == issue_id or row.get("identifier") == issue_id:
+                if isinstance(d, dict) and (
+                    d.get("id") == issue_id or d.get("identifier") == issue_id
+                ):
                     target_key = k
                     break
             if target_key is None:
                 raise KeyError(f"Issue not found: {issue_id}")
-            row = issues_map[target_key]  # type: ignore[assignment,index]
-            row.update(updates)  # type: ignore[union-attr]
-            row["updated_at"] = _now_iso()  # type: ignore[index]
+            if not isinstance(issues_map, dict):
+                raise KeyError(f"Issue not found: {issue_id}")
+            existing = issues_map[target_key]
+            row: dict[str, object] = (
+                dict(existing) if isinstance(existing, dict) else {}
+            )
+            row.update(updates)
+            row["updated_at"] = _now_iso()
+            issues_map[target_key] = row
             self._save(state)
-        return self._issue_from_dict(row)  # type: ignore[arg-type]
+        return self._issue_from_dict(row)
 
     async def search_issues(self, query: str, limit: int = 50) -> list[ModelStubIssue]:
         with self._lock:
@@ -212,10 +235,13 @@ class LocalStubProjectTracker:
         q = query.lower()
         issues_map = state.get("issues", {})
         results = [
-            self._issue_from_dict(d)  # type: ignore[arg-type]
+            self._issue_from_dict(d)
             for d in (issues_map.values() if isinstance(issues_map, dict) else [])
-            if q in str(d.get("title", "")).lower()  # type: ignore[union-attr]
-            or q in str(d.get("description") or "").lower()  # type: ignore[union-attr]
+            if isinstance(d, dict)
+            and (
+                q in str(d.get("title", "")).lower()
+                or q in str(d.get("description") or "").lower()
+            )
         ]
         return results[:limit]
 
@@ -224,7 +250,8 @@ class LocalStubProjectTracker:
             state = self._load()
             issues_map = state.get("issues", {})
             found = any(
-                d.get("id") == issue_id or d.get("identifier") == issue_id  # type: ignore[union-attr]
+                isinstance(d, dict)
+                and (d.get("id") == issue_id or d.get("identifier") == issue_id)
                 for d in (issues_map.values() if isinstance(issues_map, dict) else [])
             )
             if not found:
@@ -250,7 +277,9 @@ class LocalStubProjectTracker:
             state = self._load()
         projects_map = state.get("projects", {})
         if isinstance(projects_map, dict) and project_id in projects_map:
-            return self._project_from_dict(projects_map[project_id])  # type: ignore[arg-type]
+            proj = projects_map[project_id]
+            if isinstance(proj, dict):
+                return self._project_from_dict(proj)
         raise KeyError(f"Project not found: {project_id}")
 
     async def list_projects(self, limit: int = 50) -> list[ModelStubProject]:
@@ -258,8 +287,9 @@ class LocalStubProjectTracker:
             state = self._load()
         projects_map = state.get("projects", {})
         return [
-            self._project_from_dict(v)  # type: ignore[arg-type]
+            self._project_from_dict(v)
             for v in list(
                 projects_map.values() if isinstance(projects_map, dict) else []
             )[:limit]
+            if isinstance(v, dict)
         ]

--- a/src/omnibase_infra/adapters/project_tracker/model_stub_comment.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_stub_comment.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wire-format comment model for the local project tracker adapter.
+
+Mirrors omnibase_spi.contracts.services.contract_project_tracker_types.ModelComment
+(omnibase_spi >= 0.21.0). Kept here because installed omnibase_spi 0.20.x
+predates the contracts/services module.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+_SCHEMA_VERSION = "1.0"
+
+
+class ModelStubComment(BaseModel):
+    model_config = {"frozen": True, "extra": "allow"}
+
+    schema_version: str = Field(default=_SCHEMA_VERSION)
+    id: str
+    body: str
+    author: str
+    created_at: datetime

--- a/src/omnibase_infra/adapters/project_tracker/model_stub_issue.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_stub_issue.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wire-format issue model for the local project tracker adapter.
+
+Mirrors omnibase_spi.contracts.services.contract_project_tracker_types.ModelIssue
+(omnibase_spi >= 0.21.0). Kept here because installed omnibase_spi 0.20.x
+predates the contracts/services module.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ModelStubIssue(BaseModel):
+    model_config = {"frozen": True, "extra": "allow"}
+
+    id: str
+    identifier: str
+    title: str
+    description: str | None = None
+    state: str
+    priority: str | None = None
+    assignee: str | None = None
+    labels: list[str] = []
+    team: str | None = None
+    project_id: str | None = None
+    url: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/src/omnibase_infra/adapters/project_tracker/model_stub_project.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_stub_project.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wire-format project model for the local project tracker adapter.
+
+Mirrors omnibase_spi.contracts.services.contract_project_tracker_types.ModelProject
+(omnibase_spi >= 0.21.0). Kept here because installed omnibase_spi 0.20.x
+predates the contracts/services module.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ModelStubProject(BaseModel):
+    model_config = {"frozen": True, "extra": "allow"}
+
+    id: str
+    name: str
+    description: str | None = None
+    state: str | None = None
+    progress: float = 0.0
+    url: str | None = None

--- a/tests/integration/adapters/test_local_stub_project_tracker_integration.py
+++ b/tests/integration/adapters/test_local_stub_project_tracker_integration.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for LocalStubProjectTracker."""
+
+import pytest
+
+from omnibase_infra.adapters.project_tracker.local_stub_project_tracker import (
+    LocalStubProjectTracker,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_issue(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    issue = await tracker.create_issue(title="Test issue", description="body")
+    assert issue.identifier.startswith("STUB-")
+    assert issue.title == "Test issue"
+
+    fetched = await tracker.get_issue(issue.id)
+    assert fetched.id == issue.id
+
+
+@pytest.mark.asyncio
+async def test_list_issues_empty(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    issues = await tracker.list_issues()
+    assert issues == []
+
+
+@pytest.mark.asyncio
+async def test_update_issue(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    issue = await tracker.create_issue(title="Original", description="desc")
+    updated = await tracker.update_issue(
+        issue.id, {"title": "Updated", "state": "in_progress"}
+    )
+    assert updated.title == "Updated"
+    assert updated.state == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_add_comment(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    issue = await tracker.create_issue(title="Issue", description="body")
+    comment = await tracker.add_comment(issue.id, "A comment")
+    assert comment.body == "A comment"
+    assert comment.author == "stub"
+
+
+@pytest.mark.asyncio
+async def test_search_issues(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    await tracker.create_issue(title="Alpha feature", description="x")
+    await tracker.create_issue(title="Beta feature", description="y")
+
+    results = await tracker.search_issues("alpha")
+    assert len(results) == 1
+    assert results[0].title == "Alpha feature"
+
+
+@pytest.mark.asyncio
+async def test_labels_roundtrip(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    issue = await tracker.create_issue(
+        title="Labeled", description="d", labels=["bug", "p1"]
+    )
+    fetched = await tracker.get_issue(issue.id)
+    assert fetched.labels == ["bug", "p1"]
+
+
+@pytest.mark.asyncio
+async def test_health_check(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    health = await tracker.health_check()
+    assert health.status == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities(tmp_path: object) -> None:
+    from pathlib import Path
+
+    tracker = LocalStubProjectTracker(state_root=Path(str(tmp_path)))
+    await tracker.connect()
+
+    caps = await tracker.get_capabilities()
+    assert "read" in caps
+    assert "write" in caps

--- a/tests/unit/adapters/test_local_stub_project_tracker.py
+++ b/tests/unit/adapters/test_local_stub_project_tracker.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for LocalStubProjectTracker.
+
+Covers all 12 ProtocolProjectTracker methods:
+    connect, health_check, get_capabilities, close,
+    list_issues, get_issue, create_issue, update_issue,
+    search_issues, add_comment, get_project, list_projects.
+
+Also verifies crash-consistent file writes via atomic rename.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.adapters.project_tracker.local_stub_project_tracker import (
+    LocalStubProjectTracker,
+)
+from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
+from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
+from omnibase_infra.adapters.project_tracker.model_stub_project import ModelStubProject
+
+
+def run(coro):  # type: ignore[return]
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestLocalStubProjectTrackerLifecycle:
+    def test_connect_returns_true(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+            assert run(tracker.connect()) is True
+
+    def test_health_check_returns_healthy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+            run(tracker.connect())
+            status = run(tracker.health_check())
+            assert status.status == "healthy"
+
+    def test_get_capabilities_returns_read_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+            caps = run(tracker.get_capabilities())
+            assert "read" in caps
+            assert "write" in caps
+
+    def test_close_does_not_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+            run(tracker.connect())
+            run(tracker.close())
+
+
+class TestLocalStubProjectTrackerIssues:
+    def test_create_and_get_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                issue = await tracker.create_issue(
+                    title="Test ticket", description="desc", labels=["bug"]
+                )
+                assert isinstance(issue, ModelStubIssue)
+                assert issue.title == "Test ticket"
+                assert issue.identifier.startswith("STUB-")
+                assert "bug" in issue.labels
+                assert issue.state == "todo"
+
+                fetched = await tracker.get_issue(issue.id)
+                assert fetched.id == issue.id
+                assert fetched.title == "Test ticket"
+
+            asyncio.run(_run())
+
+    def test_get_issue_by_identifier(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                issue = await tracker.create_issue(
+                    title="Lookup by identifier", description=""
+                )
+                fetched = await tracker.get_issue(issue.identifier)
+                assert fetched.id == issue.id
+
+            asyncio.run(_run())
+
+    def test_get_issue_raises_key_error_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                with pytest.raises(KeyError):
+                    await tracker.get_issue("nonexistent-id")
+
+            asyncio.run(_run())
+
+    def test_identifiers_are_monotonically_incrementing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                i1 = await tracker.create_issue(title="A", description="")
+                i2 = await tracker.create_issue(title="B", description="")
+                assert i1.identifier == "STUB-1"
+                assert i2.identifier == "STUB-2"
+
+            asyncio.run(_run())
+
+    def test_list_issues_returns_all(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(title="Alpha", description="")
+                await tracker.create_issue(title="Beta", description="")
+                issues = await tracker.list_issues()
+                assert len(issues) == 2
+
+            asyncio.run(_run())
+
+    def test_list_issues_filter_by_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                issue = await tracker.create_issue(title="Alpha", description="")
+                await tracker.update_issue(issue.id, {"state": "in_progress"})
+                await tracker.create_issue(title="Beta", description="")
+                results = await tracker.list_issues(filters={"state": "in_progress"})
+                assert len(results) == 1
+                assert results[0].title == "Alpha"
+
+            asyncio.run(_run())
+
+    def test_list_issues_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                for i in range(5):
+                    await tracker.create_issue(title=f"Issue {i}", description="")
+                results = await tracker.list_issues(limit=3)
+                assert len(results) == 3
+
+            asyncio.run(_run())
+
+    def test_update_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                issue = await tracker.create_issue(title="Original", description="")
+                updated = await tracker.update_issue(
+                    issue.id, {"title": "Updated", "state": "done"}
+                )
+                assert updated.title == "Updated"
+                assert updated.state == "done"
+                assert updated.id == issue.id
+
+            asyncio.run(_run())
+
+    def test_update_issue_raises_key_error_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                with pytest.raises(KeyError):
+                    await tracker.update_issue("nonexistent", {"state": "done"})
+
+            asyncio.run(_run())
+
+    def test_search_issues_title_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(title="Alpha ticket", description="")
+                await tracker.create_issue(title="Beta ticket", description="")
+                results = await tracker.search_issues("Alpha")
+                assert len(results) == 1
+                assert results[0].title == "Alpha ticket"
+
+            asyncio.run(_run())
+
+    def test_search_issues_description_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(
+                    title="Ticket A", description="contains needle"
+                )
+                await tracker.create_issue(title="Ticket B", description="no match")
+                results = await tracker.search_issues("needle")
+                assert len(results) == 1
+                assert results[0].title == "Ticket A"
+
+            asyncio.run(_run())
+
+    def test_search_issues_case_insensitive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(title="Auth Middleware", description="")
+                results = await tracker.search_issues("auth middleware")
+                assert len(results) == 1
+
+            asyncio.run(_run())
+
+    def test_search_issues_no_match_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(title="Something", description="")
+                results = await tracker.search_issues("xyz_not_found")
+                assert results == []
+
+            asyncio.run(_run())
+
+
+class TestLocalStubProjectTrackerComments:
+    def test_add_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                issue = await tracker.create_issue(title="Commentable", description="")
+                comment = await tracker.add_comment(issue.id, "This is a comment")
+                assert isinstance(comment, ModelStubComment)
+                assert comment.body == "This is a comment"
+                assert comment.author == "stub"
+
+            asyncio.run(_run())
+
+    def test_add_comment_raises_key_error_for_missing_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                with pytest.raises(KeyError):
+                    await tracker.add_comment("nonexistent", "orphan comment")
+
+            asyncio.run(_run())
+
+
+class TestLocalStubProjectTrackerProjects:
+    def test_list_projects_empty_initially(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                projects = await tracker.list_projects()
+                assert projects == []
+
+            asyncio.run(_run())
+
+    def test_get_project_raises_key_error_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tracker = LocalStubProjectTracker(state_root=Path(tmp))
+
+            async def _run() -> None:
+                await tracker.connect()
+                with pytest.raises(KeyError):
+                    await tracker.get_project("nonexistent-project")
+
+            asyncio.run(_run())
+
+
+class TestLocalStubProjectTrackerPersistence:
+    def test_state_persists_across_instances(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp)
+
+            async def _write() -> str:
+                tracker = LocalStubProjectTracker(state_root=state_root)
+                await tracker.connect()
+                issue = await tracker.create_issue(
+                    title="Persisted", description="round-trip"
+                )
+                return issue.id
+
+            async def _read(issue_id: str) -> None:
+                tracker2 = LocalStubProjectTracker(state_root=state_root)
+                await tracker2.connect()
+                fetched = await tracker2.get_issue(issue_id)
+                assert fetched.title == "Persisted"
+
+            issue_id = asyncio.run(_write())
+            asyncio.run(_read(issue_id))
+
+    def test_atomic_write_uses_tmp_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp)
+            tracker = LocalStubProjectTracker(state_root=state_root)
+
+            async def _run() -> None:
+                await tracker.connect()
+                await tracker.create_issue(title="Atomic test", description="")
+                # After save, .tmp file should be gone (renamed to final)
+                tmp_file = state_root / "project_tracker_stub.tmp"
+                assert not tmp_file.exists()
+                assert (state_root / "project_tracker_stub.json").exists()
+
+            asyncio.run(_run())
+
+    def test_counter_increments_across_sessions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp)
+
+            async def _session1() -> None:
+                t = LocalStubProjectTracker(state_root=state_root)
+                await t.connect()
+                i = await t.create_issue(title="First session", description="")
+                assert i.identifier == "STUB-1"
+
+            async def _session2() -> None:
+                t = LocalStubProjectTracker(state_root=state_root)
+                await t.connect()
+                i = await t.create_issue(title="Second session", description="")
+                assert i.identifier == "STUB-2"
+
+            asyncio.run(_session1())
+            asyncio.run(_session2())

--- a/tests/unit/adapters/test_local_stub_project_tracker.py
+++ b/tests/unit/adapters/test_local_stub_project_tracker.py
@@ -24,7 +24,6 @@ from omnibase_infra.adapters.project_tracker.local_stub_project_tracker import (
 )
 from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
 from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
-from omnibase_infra.adapters.project_tracker.model_stub_project import ModelStubProject
 
 
 def run(coro):  # type: ignore[return]


### PR DESCRIPTION
## Summary

- Implements `LocalStubProjectTracker` in `omnibase_infra/adapters/project_tracker/` — a JSON-backed concrete impl of `ProtocolProjectTracker` for offline/local operation
- Used by DI resolver when `LINEAR_API_KEY`/`LINEAR_TOKEN` is not set (Task 3 of OMN-8812 plan)
- State persisted under `{state_root}/project_tracker_stub.json` with atomic-rename writes (crash-consistent)
- Issue identifiers: `STUB-{N}` (monotonically incrementing across sessions)
- Wire models split into one-per-file per architecture gate: `ModelStubComment`, `ModelStubIssue`, `ModelStubProject`

## All 12 protocol methods implemented

connect, health_check, get_capabilities, close, list_issues, get_issue, create_issue, update_issue, search_issues, add_comment, get_project, list_projects

## Test plan

- 24 tests in `tests/unit/adapters/test_local_stub_project_tracker.py` — all pass
- Covers: all 12 methods, persistence across sessions, atomic writes, STUB-N identifier monotonicity, KeyError on missing, case-insensitive search, filter + limit, comment orphan guard

## Notes

Wire models defined locally (not from omnibase_spi) because installed omnibase_spi 0.20.4 predates `contracts/services`. Will be replaced when spi bumps past 0.21.

Resolves OMN-8815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local stub project tracker for development and testing environments with support for creating and managing issues, searching by keywords, adding comments, and managing projects with automatic state persistence.

* **Tests**
  * Added comprehensive integration and unit tests for the project tracker adapter.

* **Chores**
  * Added SPDX license headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->