### PR TITLE
feat(ci): wire cr-thread-gate central workflow [OMN-8829]

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -1,0 +1,16 @@
+name: CR Thread Gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited, deleted]
+jobs:
+  gate:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+      github-token: ${{ secrets.CROSS_REPO_PAT }}
+


### PR DESCRIPTION
Wire the central cr-thread-gate reusable workflow (merged in OMN-8828 via omniclaude) as a caller workflow in this repo.

## What

Adds `.github/workflows/cr-thread-gate.yml` that calls the central workflow at `OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main` using the org-level `CROSS_REPO_PAT` secret.

## Why

Part of OMN-8829 / OMN-8801 epic: enforce that all CodeRabbit review threads are resolved before any PR can merge across all OmniNode repos.

## Required status check to add (after merge)

`cr-thread-gate / CodeRabbit Thread Check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for cross-repository code review thread management, triggering on pull request lifecycle events, reviews, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->