### PR TITLE
feat(adapters): LinearProjectTrackerAdapter — MCP-backed ProtocolProjectTracker [OMN-8816]

### DIFF
--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""MCP-backed implementation of ProtocolProjectTracker for Linear.
+
+Wraps ``mcp__linear-server__*`` MCP tool calls behind ProtocolProjectTracker.
+Uses callable injection so tests can pass fake callables without requiring
+a live MCP server.
+
+Selected by ``resolve_project_tracker()`` when ``LINEAR_TOKEN`` or
+``LINEAR_API_KEY`` is present in the environment; otherwise
+``LocalStubProjectTracker`` is used.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
+from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
+from omnibase_infra.adapters.project_tracker.model_stub_project import ModelStubProject
+
+
+class LinearHealthStatus:
+    """Minimal health status for the Linear adapter.
+
+    Satisfies the structural shape of ProtocolServiceHealthStatus without
+    importing it to keep this adapter free of SPI runtime imports.
+    """
+
+    def __init__(self, status: str = "healthy") -> None:
+        self.service_id = "linear-project-tracker"
+        self.status = status
+        self.diagnostics: dict[str, str] = {}
+
+
+def _parse_dt(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        # Linear returns RFC3339 with trailing 'Z'
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return datetime.now(UTC)
+
+
+def _issue_from_mcp(d: dict[str, Any]) -> ModelStubIssue:
+    """Translate a Linear MCP issue dict into ModelStubIssue wire shape."""
+    state_raw = d.get("state")
+    if isinstance(state_raw, dict):
+        state = str(state_raw.get("name") or state_raw.get("type") or "unknown")
+    else:
+        state = str(state_raw) if state_raw is not None else "unknown"
+
+    priority_raw = d.get("priority")
+    if isinstance(priority_raw, dict):
+        priority: str | None = (
+            str(priority_raw.get("name")) if priority_raw.get("name") else None
+        )
+    elif priority_raw is None:
+        priority = None
+    else:
+        priority = str(priority_raw)
+
+    assignee_raw = d.get("assignee")
+    if isinstance(assignee_raw, dict):
+        assignee: str | None = (
+            str(assignee_raw.get("name") or assignee_raw.get("id"))
+            if assignee_raw
+            else None
+        )
+    elif assignee_raw is None:
+        assignee = None
+    else:
+        assignee = str(assignee_raw)
+
+    labels_raw = d.get("labels", [])
+    if isinstance(labels_raw, list):
+        labels = [str(x) for x in labels_raw]
+    else:
+        labels = []
+
+    team_raw = d.get("team")
+    if isinstance(team_raw, dict):
+        team: str | None = str(team_raw.get("name") or team_raw.get("id")) or None
+    elif team_raw is None:
+        team = None
+    else:
+        team = str(team_raw)
+
+    return ModelStubIssue(
+        id=str(d.get("id", "")),
+        identifier=str(d.get("identifier", "")),
+        title=str(d.get("title", "")),
+        description=(
+            str(d["description"]) if d.get("description") is not None else None
+        ),
+        state=state,
+        priority=priority,
+        assignee=assignee,
+        labels=labels,
+        team=team,
+        project_id=(str(d["project_id"]) if d.get("project_id") is not None else None),
+        url=str(d["url"]) if d.get("url") is not None else None,
+        created_at=_parse_dt(d.get("createdAt") or d.get("created_at")),
+        updated_at=_parse_dt(d.get("updatedAt") or d.get("updated_at")),
+    )
+
+
+def _comment_from_mcp(d: dict[str, Any]) -> ModelStubComment:
+    user_raw = d.get("user")
+    if isinstance(user_raw, dict):
+        author = str(user_raw.get("name") or user_raw.get("id") or "linear-user")
+    elif user_raw is None:
+        author = "linear-user"
+    else:
+        author = str(user_raw)
+    return ModelStubComment(
+        id=str(d.get("id", "")),
+        body=str(d.get("body", "")),
+        author=author,
+        created_at=_parse_dt(d.get("createdAt") or d.get("created_at")),
+    )
+
+
+def _project_from_mcp(d: dict[str, Any]) -> ModelStubProject:
+    progress_raw = d.get("progress", 0.0)
+    progress = float(progress_raw) if isinstance(progress_raw, (int, float)) else 0.0
+    state_raw = d.get("state")
+    if isinstance(state_raw, dict):
+        state: str | None = (
+            str(state_raw.get("name")) if state_raw.get("name") else None
+        )
+    elif state_raw is None:
+        state = None
+    else:
+        state = str(state_raw)
+    return ModelStubProject(
+        id=str(d.get("id", "")),
+        name=str(d.get("name", "")),
+        description=(
+            str(d["description"]) if d.get("description") is not None else None
+        ),
+        state=state,
+        progress=progress,
+        url=str(d["url"]) if d.get("url") is not None else None,
+    )
+
+
+class LinearProjectTrackerAdapter:
+    """MCP-backed ProtocolProjectTracker implementation for Linear.
+
+    Constructor accepts optional callables for each MCP operation. When a
+    callable is ``None``, the adapter raises NotImplementedError if the
+    corresponding method is invoked. This keeps the adapter pure-Python
+    (no global MCP import) and fully testable via callable injection.
+
+    The callable contract mirrors the Linear MCP tool signatures — each
+    callable accepts keyword arguments and returns a dict (for single-
+    entity operations) or a list of dicts (for list/search operations).
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_get_issue: Callable[..., dict[str, Any]] | None = None,
+        mcp_list_issues: Callable[..., list[dict[str, Any]]] | None = None,
+        mcp_create_issue: Callable[..., dict[str, Any]] | None = None,
+        mcp_update_issue: Callable[..., dict[str, Any]] | None = None,
+        mcp_search_issues: Callable[..., list[dict[str, Any]]] | None = None,
+        mcp_add_comment: Callable[..., dict[str, Any]] | None = None,
+        mcp_get_project: Callable[..., dict[str, Any]] | None = None,
+        mcp_list_projects: Callable[..., list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._mcp_get_issue = mcp_get_issue
+        self._mcp_list_issues = mcp_list_issues
+        self._mcp_create_issue = mcp_create_issue
+        self._mcp_update_issue = mcp_update_issue
+        self._mcp_search_issues = mcp_search_issues
+        self._mcp_add_comment = mcp_add_comment
+        self._mcp_get_project = mcp_get_project
+        self._mcp_list_projects = mcp_list_projects
+        self._connected = False
+
+    # -- lifecycle --
+
+    async def connect(self) -> bool:
+        self._connected = True
+        return True
+
+    async def health_check(self) -> LinearHealthStatus:
+        return LinearHealthStatus(
+            status="healthy" if self._connected else "not_connected"
+        )
+
+    async def get_capabilities(self) -> list[str]:
+        return ["read", "write"]
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:
+        self._connected = False
+
+    # -- internal helpers --
+
+    @staticmethod
+    def _require(callable_: Callable[..., Any] | None, name: str) -> Callable[..., Any]:
+        if callable_ is None:
+            raise NotImplementedError(
+                f"LinearProjectTrackerAdapter: '{name}' callable not injected"
+            )
+        return callable_
+
+    # -- domain operations --
+
+    async def get_issue(self, issue_id: str) -> ModelStubIssue:
+        fn = self._require(self._mcp_get_issue, "mcp_get_issue")
+        result = fn(id=issue_id)
+        if not isinstance(result, dict) or not result:
+            raise KeyError(f"Issue not found: {issue_id}")
+        return _issue_from_mcp(result)
+
+    async def list_issues(
+        self, filters: dict[str, str] | None = None, limit: int = 50
+    ) -> list[ModelStubIssue]:
+        fn = self._require(self._mcp_list_issues, "mcp_list_issues")
+        kwargs: dict[str, Any] = {"limit": limit}
+        if filters:
+            kwargs.update(filters)
+        result = fn(**kwargs)
+        if not isinstance(result, list):
+            return []
+        return [_issue_from_mcp(d) for d in result if isinstance(d, dict)]
+
+    async def create_issue(
+        self,
+        title: str,
+        description: str,
+        labels: list[str] | None = None,
+        assignee: str | None = None,
+        priority: str | None = None,
+        team: str | None = None,
+    ) -> ModelStubIssue:
+        fn = self._require(self._mcp_create_issue, "mcp_create_issue")
+        kwargs: dict[str, Any] = {"title": title, "description": description}
+        if labels is not None:
+            kwargs["labels"] = labels
+        if assignee is not None:
+            kwargs["assignee"] = assignee
+        if priority is not None:
+            kwargs["priority"] = priority
+        if team is not None:
+            kwargs["team"] = team
+        result = fn(**kwargs)
+        if not isinstance(result, dict):
+            raise RuntimeError("create_issue: MCP returned non-dict result")
+        return _issue_from_mcp(result)
+
+    async def update_issue(
+        self, issue_id: str, updates: dict[str, str]
+    ) -> ModelStubIssue:
+        fn = self._require(self._mcp_update_issue, "mcp_update_issue")
+        result = fn(id=issue_id, **updates)
+        if not isinstance(result, dict) or not result:
+            raise KeyError(f"Issue not found: {issue_id}")
+        return _issue_from_mcp(result)
+
+    async def search_issues(self, query: str, limit: int = 50) -> list[ModelStubIssue]:
+        fn = self._require(self._mcp_search_issues, "mcp_search_issues")
+        result = fn(query=query, limit=limit)
+        if not isinstance(result, list):
+            return []
+        return [_issue_from_mcp(d) for d in result if isinstance(d, dict)]
+
+    async def add_comment(self, issue_id: str, body: str) -> ModelStubComment:
+        fn = self._require(self._mcp_add_comment, "mcp_add_comment")
+        result = fn(issueId=issue_id, body=body)
+        if not isinstance(result, dict) or not result:
+            raise KeyError(f"Issue not found: {issue_id}")
+        return _comment_from_mcp(result)
+
+    async def get_project(self, project_id: str) -> ModelStubProject:
+        fn = self._require(self._mcp_get_project, "mcp_get_project")
+        result = fn(id=project_id)
+        if not isinstance(result, dict) or not result:
+            raise KeyError(f"Project not found: {project_id}")
+        return _project_from_mcp(result)
+
+    async def list_projects(self, limit: int = 50) -> list[ModelStubProject]:
+        fn = self._require(self._mcp_list_projects, "mcp_list_projects")
+        result = fn(limit=limit)
+        if not isinstance(result, list):
+            return []
+        return [_project_from_mcp(d) for d in result if isinstance(d, dict)]

--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -75,10 +75,15 @@ def _issue_from_mcp(d: dict[str, object]) -> ModelStubIssue:
         assignee = str(assignee_raw)
 
     labels_raw = d.get("labels", [])
+    labels: list[str] = []
     if isinstance(labels_raw, list):
-        labels = [str(x) for x in labels_raw]
-    else:
-        labels = []
+        for item in labels_raw:
+            if isinstance(item, dict):
+                label_name = item.get("name") or item.get("id")
+                if label_name is not None:
+                    labels.append(str(label_name))
+            elif item is not None:
+                labels.append(str(item))
 
     team_raw = d.get("team")
     if isinstance(team_raw, dict):

--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
 
 from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
 from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
@@ -36,7 +35,7 @@ class LinearHealthStatus:
         self.diagnostics: dict[str, str] = {}
 
 
-def _parse_dt(value: Any) -> datetime:
+def _parse_dt(value: object) -> datetime:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str):
@@ -45,7 +44,7 @@ def _parse_dt(value: Any) -> datetime:
     return datetime.now(UTC)
 
 
-def _issue_from_mcp(d: dict[str, Any]) -> ModelStubIssue:
+def _issue_from_mcp(d: dict[str, object]) -> ModelStubIssue:
     """Translate a Linear MCP issue dict into ModelStubIssue wire shape."""
     state_raw = d.get("state")
     if isinstance(state_raw, dict):
@@ -108,7 +107,7 @@ def _issue_from_mcp(d: dict[str, Any]) -> ModelStubIssue:
     )
 
 
-def _comment_from_mcp(d: dict[str, Any]) -> ModelStubComment:
+def _comment_from_mcp(d: dict[str, object]) -> ModelStubComment:
     user_raw = d.get("user")
     if isinstance(user_raw, dict):
         author = str(user_raw.get("name") or user_raw.get("id") or "linear-user")
@@ -124,7 +123,7 @@ def _comment_from_mcp(d: dict[str, Any]) -> ModelStubComment:
     )
 
 
-def _project_from_mcp(d: dict[str, Any]) -> ModelStubProject:
+def _project_from_mcp(d: dict[str, object]) -> ModelStubProject:
     progress_raw = d.get("progress", 0.0)
     progress = float(progress_raw) if isinstance(progress_raw, (int, float)) else 0.0
     state_raw = d.get("state")
@@ -164,14 +163,14 @@ class LinearProjectTrackerAdapter:
     def __init__(
         self,
         *,
-        mcp_get_issue: Callable[..., dict[str, Any]] | None = None,
-        mcp_list_issues: Callable[..., list[dict[str, Any]]] | None = None,
-        mcp_create_issue: Callable[..., dict[str, Any]] | None = None,
-        mcp_update_issue: Callable[..., dict[str, Any]] | None = None,
-        mcp_search_issues: Callable[..., list[dict[str, Any]]] | None = None,
-        mcp_add_comment: Callable[..., dict[str, Any]] | None = None,
-        mcp_get_project: Callable[..., dict[str, Any]] | None = None,
-        mcp_list_projects: Callable[..., list[dict[str, Any]]] | None = None,
+        mcp_get_issue: Callable[..., dict[str, object]] | None = None,
+        mcp_list_issues: Callable[..., list[dict[str, object]]] | None = None,
+        mcp_create_issue: Callable[..., dict[str, object]] | None = None,
+        mcp_update_issue: Callable[..., dict[str, object]] | None = None,
+        mcp_search_issues: Callable[..., list[dict[str, object]]] | None = None,
+        mcp_add_comment: Callable[..., dict[str, object]] | None = None,
+        mcp_get_project: Callable[..., dict[str, object]] | None = None,
+        mcp_list_projects: Callable[..., list[dict[str, object]]] | None = None,
     ) -> None:
         self._mcp_get_issue = mcp_get_issue
         self._mcp_list_issues = mcp_list_issues
@@ -203,7 +202,7 @@ class LinearProjectTrackerAdapter:
     # -- internal helpers --
 
     @staticmethod
-    def _require(callable_: Callable[..., Any] | None, name: str) -> Callable[..., Any]:
+    def _require(callable_: Callable[..., object] | None, name: str) -> Callable[..., object]:
         if callable_ is None:
             raise NotImplementedError(
                 f"LinearProjectTrackerAdapter: '{name}' callable not injected"
@@ -223,7 +222,7 @@ class LinearProjectTrackerAdapter:
         self, filters: dict[str, str] | None = None, limit: int = 50
     ) -> list[ModelStubIssue]:
         fn = self._require(self._mcp_list_issues, "mcp_list_issues")
-        kwargs: dict[str, Any] = {"limit": limit}
+        kwargs: dict[str, object] = {"limit": limit}
         if filters:
             kwargs.update(filters)
         result = fn(**kwargs)
@@ -241,7 +240,7 @@ class LinearProjectTrackerAdapter:
         team: str | None = None,
     ) -> ModelStubIssue:
         fn = self._require(self._mcp_create_issue, "mcp_create_issue")
-        kwargs: dict[str, Any] = {"title": title, "description": description}
+        kwargs: dict[str, object] = {"title": title, "description": description}
         if labels is not None:
             kwargs["labels"] = labels
         if assignee is not None:

--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -202,7 +202,9 @@ class LinearProjectTrackerAdapter:
     # -- internal helpers --
 
     @staticmethod
-    def _require(callable_: Callable[..., object] | None, name: str) -> Callable[..., object]:
+    def _require(
+        callable_: Callable[..., object] | None, name: str
+    ) -> Callable[..., object]:
         if callable_ is None:
             raise NotImplementedError(
                 f"LinearProjectTrackerAdapter: '{name}' callable not injected"

--- a/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
+++ b/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for LinearProjectTrackerAdapter.
+
+Exercises the adapter end-to-end with fake MCP callables that simulate a
+live Linear MCP server. Verifies issue creation → fetch → update →
+comment → search flows against a shared in-memory store, asserting dict
+→ wire-format translation at every step.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
+    LinearProjectTrackerAdapter,
+)
+from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
+
+
+class _FakeLinearMcp:
+    """In-memory simulator for the subset of Linear MCP tools we wrap."""
+
+    def __init__(self) -> None:
+        self._issues: dict[str, dict[str, object]] = {}
+        self._counter = 0
+
+    def _now(self) -> str:
+        return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    def create_issue(self, **kwargs: object) -> dict[str, object]:
+        self._counter += 1
+        issue_id = f"fake-uuid-{self._counter}"
+        identifier = f"OMN-{9000 + self._counter}"
+        now = self._now()
+        row: dict[str, object] = {
+            "id": issue_id,
+            "identifier": identifier,
+            "title": kwargs.get("title", ""),
+            "description": kwargs.get("description", ""),
+            "state": {"name": "Todo", "type": "unstarted"},
+            "priority": None,
+            "assignee": None,
+            "labels": kwargs.get("labels", []),
+            "team": {"id": "t-1", "name": "Omninode"},
+            "url": f"https://linear.app/omninode/issue/{identifier}",
+            "createdAt": now,
+            "updatedAt": now,
+        }
+        self._issues[issue_id] = row
+        return row
+
+    def get_issue(self, **kwargs: object) -> dict[str, object]:
+        issue_id = str(kwargs["id"])
+        for row in self._issues.values():
+            if row["id"] == issue_id or row["identifier"] == issue_id:
+                return row
+        return {}
+
+    def update_issue(self, **kwargs: object) -> dict[str, object]:
+        issue_id = str(kwargs.pop("id"))
+        for row in self._issues.values():
+            if row["id"] == issue_id or row["identifier"] == issue_id:
+                row.update(kwargs)
+                row["updatedAt"] = self._now()
+                return row
+        return {}
+
+    def search_issues(self, **kwargs: object) -> list[dict[str, object]]:
+        q = str(kwargs.get("query", "")).lower()
+        return [row for row in self._issues.values() if q in str(row["title"]).lower()]
+
+    def add_comment(self, **kwargs: object) -> dict[str, object]:
+        issue_id = str(kwargs["issueId"])
+        if not any(
+            row["id"] == issue_id or row["identifier"] == issue_id
+            for row in self._issues.values()
+        ):
+            return {}
+        return {
+            "id": f"c-{len(self._issues)}-{self._counter}",
+            "body": str(kwargs["body"]),
+            "user": {"id": "u-1", "name": "Jonah"},
+            "createdAt": self._now(),
+        }
+
+
+@pytest.mark.asyncio
+async def test_full_issue_lifecycle() -> None:
+    mcp = _FakeLinearMcp()
+    adapter = LinearProjectTrackerAdapter(
+        mcp_create_issue=mcp.create_issue,
+        mcp_get_issue=mcp.get_issue,
+        mcp_update_issue=mcp.update_issue,
+        mcp_search_issues=mcp.search_issues,
+        mcp_add_comment=mcp.add_comment,
+    )
+    await adapter.connect()
+
+    created = await adapter.create_issue(
+        title="Integration test ticket",
+        description="body",
+        labels=["integration"],
+    )
+    assert isinstance(created, ModelStubIssue)
+    assert created.identifier.startswith("OMN-")
+    assert created.state == "Todo"
+    assert "integration" in created.labels
+
+    fetched = await adapter.get_issue(created.id)
+    assert fetched.id == created.id
+    assert fetched.title == "Integration test ticket"
+
+    updated = await adapter.update_issue(created.id, {"title": "Renamed"})
+    assert updated.title == "Renamed"
+    assert updated.id == created.id
+
+    hits = await adapter.search_issues("renamed")
+    assert len(hits) == 1
+    assert hits[0].id == created.id
+
+    comment = await adapter.add_comment(created.id, "hello from integration")
+    assert comment.body == "hello from integration"
+    assert comment.author == "Jonah"
+
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_get_issue_missing_raises_key_error() -> None:
+    mcp = _FakeLinearMcp()
+    adapter = LinearProjectTrackerAdapter(mcp_get_issue=mcp.get_issue)
+    await adapter.connect()
+
+    with pytest.raises(KeyError):
+        await adapter.get_issue("OMN-DOES-NOT-EXIST")
+
+
+@pytest.mark.asyncio
+async def test_add_comment_on_missing_issue_raises_key_error() -> None:
+    mcp = _FakeLinearMcp()
+    adapter = LinearProjectTrackerAdapter(mcp_add_comment=mcp.add_comment)
+    await adapter.connect()
+
+    with pytest.raises(KeyError):
+        await adapter.add_comment("NOPE", "orphan")

--- a/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
+++ b/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
@@ -88,6 +88,7 @@ class _FakeLinearMcp:
         }
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_full_issue_lifecycle() -> None:
     mcp = _FakeLinearMcp()
@@ -129,6 +130,7 @@ async def test_full_issue_lifecycle() -> None:
     await adapter.close()
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_get_issue_missing_raises_key_error() -> None:
     mcp = _FakeLinearMcp()
@@ -139,6 +141,7 @@ async def test_get_issue_missing_raises_key_error() -> None:
         await adapter.get_issue("OMN-DOES-NOT-EXIST")
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_add_comment_on_missing_issue_raises_key_error() -> None:
     mcp = _FakeLinearMcp()

--- a/tests/unit/adapters/test_linear_project_tracker_adapter.py
+++ b/tests/unit/adapters/test_linear_project_tracker_adapter.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for LinearProjectTrackerAdapter.
+
+Uses callable injection — tests pass fake callables as constructor args
+so no live MCP server is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
+    LinearProjectTrackerAdapter,
+)
+from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
+from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
+from omnibase_infra.adapters.project_tracker.model_stub_project import ModelStubProject
+
+_FAKE_ISSUE = {
+    "id": "abc-123",
+    "identifier": "OMN-9999",
+    "title": "Test Issue",
+    "description": "body",
+    "state": {"name": "In Progress", "type": "started"},
+    "priority": {"name": "High"},
+    "assignee": {"id": "u-1", "name": "Jonah"},
+    "labels": ["bug", "urgent"],
+    "team": {"id": "t-1", "name": "Omninode"},
+    "url": "https://linear.app/test",
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-02T00:00:00Z",
+}
+
+
+class TestLinearProjectTrackerAdapterLifecycle:
+    def test_connect_returns_true(self) -> None:
+        adapter = LinearProjectTrackerAdapter()
+        assert asyncio.run(adapter.connect()) is True
+
+    def test_health_check_healthy_after_connect(self) -> None:
+        adapter = LinearProjectTrackerAdapter()
+
+        async def _run() -> None:
+            await adapter.connect()
+            status = await adapter.health_check()
+            assert status.status == "healthy"
+            assert status.service_id == "linear-project-tracker"
+
+        asyncio.run(_run())
+
+    def test_capabilities_read_write(self) -> None:
+        adapter = LinearProjectTrackerAdapter()
+        caps = asyncio.run(adapter.get_capabilities())
+        assert "read" in caps and "write" in caps
+
+    def test_close_resets_connected(self) -> None:
+        adapter = LinearProjectTrackerAdapter()
+
+        async def _run() -> None:
+            await adapter.connect()
+            await adapter.close()
+            status = await adapter.health_check()
+            assert status.status == "not_connected"
+
+        asyncio.run(_run())
+
+
+class TestLinearProjectTrackerAdapterIssues:
+    def test_get_issue_delegates_to_mcp(self) -> None:
+        fake = MagicMock(return_value=_FAKE_ISSUE)
+        adapter = LinearProjectTrackerAdapter(mcp_get_issue=fake)
+
+        async def _run() -> None:
+            await adapter.connect()
+            issue = await adapter.get_issue("OMN-9999")
+            assert isinstance(issue, ModelStubIssue)
+            assert issue.identifier == "OMN-9999"
+            assert issue.id == "abc-123"
+            assert issue.title == "Test Issue"
+            assert issue.state == "In Progress"
+            assert issue.priority == "High"
+            assert issue.assignee == "Jonah"
+            assert issue.team == "Omninode"
+            assert "bug" in issue.labels
+            fake.assert_called_once_with(id="OMN-9999")
+
+        asyncio.run(_run())
+
+    def test_get_issue_empty_result_raises_key_error(self) -> None:
+        fake = MagicMock(return_value={})
+        adapter = LinearProjectTrackerAdapter(mcp_get_issue=fake)
+
+        async def _run() -> None:
+            with pytest.raises(KeyError):
+                await adapter.get_issue("NOPE-1")
+
+        asyncio.run(_run())
+
+    def test_get_issue_without_callable_raises(self) -> None:
+        adapter = LinearProjectTrackerAdapter()
+
+        async def _run() -> None:
+            with pytest.raises(NotImplementedError):
+                await adapter.get_issue("OMN-1")
+
+        asyncio.run(_run())
+
+    def test_list_issues_with_filters_and_limit(self) -> None:
+        fake = MagicMock(return_value=[_FAKE_ISSUE, _FAKE_ISSUE])
+        adapter = LinearProjectTrackerAdapter(mcp_list_issues=fake)
+
+        async def _run() -> None:
+            results = await adapter.list_issues(filters={"state": "todo"}, limit=10)
+            assert len(results) == 2
+            assert all(isinstance(r, ModelStubIssue) for r in results)
+            fake.assert_called_once_with(limit=10, state="todo")
+
+        asyncio.run(_run())
+
+    def test_list_issues_non_list_returns_empty(self) -> None:
+        fake = MagicMock(return_value=None)
+        adapter = LinearProjectTrackerAdapter(mcp_list_issues=fake)
+        assert asyncio.run(adapter.list_issues()) == []
+
+    def test_create_issue_forwards_kwargs(self) -> None:
+        fake = MagicMock(return_value=_FAKE_ISSUE)
+        adapter = LinearProjectTrackerAdapter(mcp_create_issue=fake)
+
+        async def _run() -> None:
+            issue = await adapter.create_issue(
+                title="New",
+                description="body",
+                labels=["a"],
+                assignee="u-1",
+                priority="High",
+                team="t-1",
+            )
+            assert isinstance(issue, ModelStubIssue)
+            fake.assert_called_once_with(
+                title="New",
+                description="body",
+                labels=["a"],
+                assignee="u-1",
+                priority="High",
+                team="t-1",
+            )
+
+        asyncio.run(_run())
+
+    def test_create_issue_omits_none_kwargs(self) -> None:
+        fake = MagicMock(return_value=_FAKE_ISSUE)
+        adapter = LinearProjectTrackerAdapter(mcp_create_issue=fake)
+
+        async def _run() -> None:
+            await adapter.create_issue(title="T", description="D")
+            fake.assert_called_once_with(title="T", description="D")
+
+        asyncio.run(_run())
+
+    def test_update_issue_delegates(self) -> None:
+        fake = MagicMock(return_value=_FAKE_ISSUE)
+        adapter = LinearProjectTrackerAdapter(mcp_update_issue=fake)
+
+        async def _run() -> None:
+            result = await adapter.update_issue("OMN-9999", {"state": "done"})
+            assert isinstance(result, ModelStubIssue)
+            fake.assert_called_once_with(id="OMN-9999", state="done")
+
+        asyncio.run(_run())
+
+    def test_update_issue_missing_raises_key_error(self) -> None:
+        fake = MagicMock(return_value={})
+        adapter = LinearProjectTrackerAdapter(mcp_update_issue=fake)
+
+        async def _run() -> None:
+            with pytest.raises(KeyError):
+                await adapter.update_issue("NOPE", {"state": "done"})
+
+        asyncio.run(_run())
+
+    def test_search_issues_delegates(self) -> None:
+        fake = MagicMock(return_value=[_FAKE_ISSUE])
+        adapter = LinearProjectTrackerAdapter(mcp_search_issues=fake)
+
+        async def _run() -> None:
+            results = await adapter.search_issues("auth middleware", limit=5)
+            assert len(results) == 1
+            assert results[0].identifier == "OMN-9999"
+            fake.assert_called_once_with(query="auth middleware", limit=5)
+
+        asyncio.run(_run())
+
+
+class TestLinearProjectTrackerAdapterComments:
+    def test_add_comment_delegates(self) -> None:
+        fake = MagicMock(
+            return_value={
+                "id": "c-1",
+                "body": "hello",
+                "user": {"id": "u-1", "name": "Jonah"},
+                "createdAt": "2026-01-01T00:00:00Z",
+            }
+        )
+        adapter = LinearProjectTrackerAdapter(mcp_add_comment=fake)
+
+        async def _run() -> None:
+            comment = await adapter.add_comment("abc-123", "hello")
+            assert isinstance(comment, ModelStubComment)
+            assert comment.body == "hello"
+            assert comment.author == "Jonah"
+            fake.assert_called_once_with(issueId="abc-123", body="hello")
+
+        asyncio.run(_run())
+
+    def test_add_comment_missing_issue_raises_key_error(self) -> None:
+        fake = MagicMock(return_value={})
+        adapter = LinearProjectTrackerAdapter(mcp_add_comment=fake)
+
+        async def _run() -> None:
+            with pytest.raises(KeyError):
+                await adapter.add_comment("NOPE", "text")
+
+        asyncio.run(_run())
+
+
+class TestLinearProjectTrackerAdapterProjects:
+    def test_get_project_delegates(self) -> None:
+        fake = MagicMock(
+            return_value={
+                "id": "p-1",
+                "name": "Onboarding",
+                "description": "desc",
+                "state": {"name": "active"},
+                "progress": 0.42,
+                "url": "https://linear.app/p/1",
+            }
+        )
+        adapter = LinearProjectTrackerAdapter(mcp_get_project=fake)
+
+        async def _run() -> None:
+            project = await adapter.get_project("p-1")
+            assert isinstance(project, ModelStubProject)
+            assert project.name == "Onboarding"
+            assert project.state == "active"
+            assert project.progress == pytest.approx(0.42)
+            fake.assert_called_once_with(id="p-1")
+
+        asyncio.run(_run())
+
+    def test_get_project_missing_raises_key_error(self) -> None:
+        fake = MagicMock(return_value={})
+        adapter = LinearProjectTrackerAdapter(mcp_get_project=fake)
+
+        async def _run() -> None:
+            with pytest.raises(KeyError):
+                await adapter.get_project("NOPE")
+
+        asyncio.run(_run())
+
+    def test_list_projects_delegates(self) -> None:
+        fake = MagicMock(
+            return_value=[
+                {"id": "p-1", "name": "A"},
+                {"id": "p-2", "name": "B", "progress": 1.0},
+            ]
+        )
+        adapter = LinearProjectTrackerAdapter(mcp_list_projects=fake)
+
+        async def _run() -> None:
+            results = await adapter.list_projects(limit=25)
+            assert len(results) == 2
+            assert results[0].name == "A"
+            assert results[1].progress == pytest.approx(1.0)
+            fake.assert_called_once_with(limit=25)
+
+        asyncio.run(_run())

--- a/tests/unit/adapters/test_linear_project_tracker_adapter.py
+++ b/tests/unit/adapters/test_linear_project_tracker_adapter.py
@@ -29,7 +29,7 @@ _FAKE_ISSUE = {
     "state": {"name": "In Progress", "type": "started"},
     "priority": {"name": "High"},
     "assignee": {"id": "u-1", "name": "Jonah"},
-    "labels": ["bug", "urgent"],
+    "labels": [{"id": "l-1", "name": "bug"}, {"id": "l-2", "name": "urgent"}],
     "team": {"id": "t-1", "name": "Omninode"},
     "url": "https://linear.app/test",
     "createdAt": "2026-01-01T00:00:00Z",
@@ -37,6 +37,7 @@ _FAKE_ISSUE = {
 }
 
 
+@pytest.mark.unit
 class TestLinearProjectTrackerAdapterLifecycle:
     def test_connect_returns_true(self) -> None:
         adapter = LinearProjectTrackerAdapter()
@@ -70,6 +71,7 @@ class TestLinearProjectTrackerAdapterLifecycle:
         asyncio.run(_run())
 
 
+@pytest.mark.unit
 class TestLinearProjectTrackerAdapterIssues:
     def test_get_issue_delegates_to_mcp(self) -> None:
         fake = MagicMock(return_value=_FAKE_ISSUE)
@@ -196,6 +198,7 @@ class TestLinearProjectTrackerAdapterIssues:
         asyncio.run(_run())
 
 
+@pytest.mark.unit
 class TestLinearProjectTrackerAdapterComments:
     def test_add_comment_delegates(self) -> None:
         fake = MagicMock(
@@ -228,6 +231,7 @@ class TestLinearProjectTrackerAdapterComments:
         asyncio.run(_run())
 
 
+@pytest.mark.unit
 class TestLinearProjectTrackerAdapterProjects:
     def test_get_project_delegates(self) -> None:
         fake = MagicMock(

--- a/tests/unit/adapters/test_local_stub_project_tracker.py
+++ b/tests/unit/adapters/test_local_stub_project_tracker.py
@@ -27,7 +27,14 @@ from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIs
 
 
 def run(coro):  # type: ignore[return]
-    return asyncio.get_event_loop().run_until_complete(coro)
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
 
 
 class TestLocalStubProjectTrackerLifecycle:


### PR DESCRIPTION
## Summary

Task 4 of OMN-8812 (session-as-product and onboarding). Implements `LinearProjectTrackerAdapter` — an MCP-backed concrete implementation of `ProtocolProjectTracker` (defined in `omnibase_spi`).

- **Callable injection**: constructor accepts optional callables for each `mcp__linear-server__*` operation. Tests pass `MagicMock` fakes; no live MCP server required.
- **Shape translation**: converts Linear MCP dict responses (with nested `state`/`priority`/`assignee`/`team`/`user` objects and `createdAt`/`updatedAt` RFC3339 strings) into the existing `ModelStub{Issue,Comment,Project}` wire shapes used across the adapters package.
- **Selection**: chosen by `resolve_project_tracker()` (Task 4.1) when `LINEAR_TOKEN` or `LINEAR_API_KEY` is present; falls back to `LocalStubProjectTracker` otherwise.

## Changes

- `src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py` — adapter + dict→model helpers + `LinearHealthStatus`.
- `tests/unit/adapters/test_linear_project_tracker_adapter.py` — 19 unit tests covering all 12 protocol methods, callable omission, KeyError propagation, kwarg forwarding.

## Test plan

- [x] `uv run pytest tests/unit/adapters/test_linear_project_tracker_adapter.py -v` — 19/19 pass
- [x] `uv run ruff check` + `uv run ruff format` clean
- [x] `uv run mypy src/omnibase_infra/adapters/project_tracker/` — no issues
- [ ] Full CI green (awaiting)

## Ticket

Closes OMN-8816.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Linear project tracker adapter providing comprehensive issue management capabilities including creation, retrieval, updates, searching, commenting, and project tracking features.

* **Tests**
  * Added extensive unit and integration test coverage for adapter functionality and system reliability validation.

* **Chores**
  * Enhanced asyncio event loop handling in test utilities for better robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->