### PR TITLE
chore(security): verify-merge-queue-no-bypass.sh (OMN-8843)

### DIFF
--- a/scripts/verify-merge-queue-no-bypass.sh
+++ b/scripts/verify-merge-queue-no-bypass.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OMN-8843: Verify no merge queue ruleset has OrganizationAdmin bypass.
+# Fails with exit code 1 if any bypass_actors entry is found.
+set -euo pipefail
+
+REPOS=(
+  omniclaude
+  omnibase_core
+  omnibase_infra
+  omnibase_spi
+  omnibase_compat
+  omnidash
+  omniintelligence
+  omnimemory
+  omnimarket
+  onex_change_control
+)
+
+ORG="OmniNode-ai"
+FAILED=0
+
+for repo in "${REPOS[@]}"; do
+  ruleset_id=$(gh api "repos/$ORG/$repo/rulesets" 2>/dev/null \
+    | jq -r '.[] | select(.name | test("Merge Queue"; "i")) | .id' | head -1)
+
+  if [[ -z "$ruleset_id" ]]; then
+    echo "SKIP  $repo: no Merge Queue ruleset found"
+    continue
+  fi
+
+  bypass=$(gh api "repos/$ORG/$repo/rulesets/$ruleset_id" 2>/dev/null | jq -c '.bypass_actors')
+
+  if [[ "$bypass" == "[]" ]]; then
+    echo "OK    $repo (ruleset $ruleset_id): bypass_actors=[]"
+  else
+    echo "FAIL  $repo (ruleset $ruleset_id): bypass_actors=$bypass"
+    FAILED=1
+  fi
+done
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo ""
+  echo "ERROR: One or more merge queue rulesets have admin bypass. (OMN-8843)"
+  exit 1
+fi
+
+echo ""
+echo "All merge queue rulesets have no bypass actors."

--- a/scripts/verify-merge-queue-no-bypass.sh
+++ b/scripts/verify-merge-queue-no-bypass.sh
@@ -22,22 +22,26 @@ ORG="OmniNode-ai"
 FAILED=0
 
 for repo in "${REPOS[@]}"; do
-  ruleset_id=$(gh api "repos/$ORG/$repo/rulesets" 2>/dev/null \
-    | jq -r '.[] | select(.name | test("Merge Queue"; "i")) | .id' | head -1)
+  mapfile -t ruleset_ids < <(
+    gh api "repos/$ORG/$repo/rulesets" \
+      | jq -r '.[] | select(.name | test("Merge Queue"; "i")) | .id'
+  )
 
-  if [[ -z "$ruleset_id" ]]; then
-    echo "SKIP  $repo: no Merge Queue ruleset found"
+  if [[ ${#ruleset_ids[@]} -eq 0 ]]; then
+    echo "FAIL  $repo: no Merge Queue ruleset found"
+    FAILED=1
     continue
   fi
 
-  bypass=$(gh api "repos/$ORG/$repo/rulesets/$ruleset_id" 2>/dev/null | jq -c '.bypass_actors')
-
-  if [[ "$bypass" == "[]" ]]; then
-    echo "OK    $repo (ruleset $ruleset_id): bypass_actors=[]"
-  else
-    echo "FAIL  $repo (ruleset $ruleset_id): bypass_actors=$bypass"
-    FAILED=1
-  fi
+  for ruleset_id in "${ruleset_ids[@]}"; do
+    bypass=$(gh api "repos/$ORG/$repo/rulesets/$ruleset_id" | jq -c '.bypass_actors // []')
+    if [[ "$bypass" == "[]" ]]; then
+      echo "OK    $repo (ruleset $ruleset_id): bypass_actors=[]"
+    else
+      echo "FAIL  $repo (ruleset $ruleset_id): bypass_actors=$bypass"
+      FAILED=1
+    fi
+  done
 done
 
 if [[ "$FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Adds `scripts/verify-merge-queue-no-bypass.sh` — iterates all 10 OmniNode repos with Merge Queue rulesets and fails if any `bypass_actors` entry is found
- Provides a re-runnable gate to prevent silent re-introduction of admin bypass (root cause of 2-parent commits on PRs #1288/#1290)
- The actual ruleset patches (removing `OrganizationAdmin` bypass from all 10 repos) were applied directly via `gh api PUT` as part of OMN-8843

## Rulesets patched (no worktree, applied via API)
| Repo | Ruleset ID | Before | After |
|---|---|---|---|
| omniclaude | 13269701 | OrganizationAdmin/always | [] |
| omnibase_core | 13269695 | OrganizationAdmin/always | [] |
| omnibase_infra | 13269702 | OrganizationAdmin/always | [] |
| omnibase_spi | 13269703 | OrganizationAdmin/always | [] |
| omnibase_compat | 14745047 | OrganizationAdmin/always | [] |
| omnidash | 13930037 | OrganizationAdmin/always | [] |
| omniintelligence | 13269704 | OrganizationAdmin/always | [] |
| omnimemory | 13269706 | OrganizationAdmin/always | [] |
| omnimarket | 14745045 | OrganizationAdmin/always | [] |
| onex_change_control | 13930040 | OrganizationAdmin/always | [] |

## Test plan
- [ ] Run `bash scripts/verify-merge-queue-no-bypass.sh` — all repos should show `OK`
- [ ] Confirm no admin can merge directly to main on any repo (must go through merge queue)
- [ ] Monitor PRs for 2-parent merge commits — forensics tool should find none after this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated verification tool that scans multiple repositories to ensure merge-queue bypass settings are disabled, flags any violations, and fails the run when issues are detected.

---

Note: This release contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->