### PR TITLE
fix(compose): join runtime-effects to omnimemory-network for PluginMemory (OMN-8852)

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -657,6 +657,11 @@ services:
       POSTGRES_HOST: postgres
     ports:
       - "${RUNTIME_EFFECTS_PORT:-8086}:8085"
+    # OMN-8852: runtime-effects must also join omnimemory-network so PluginMemory
+    # can reach omnimemory-memgraph:7687. The base anchor only declares omnibase-infra-network.
+    networks:
+      - omnibase-infra-network
+      - omnimemory-network
     stop_grace_period: 90s
     volumes:
       - effects_logs:/app/logs
@@ -1122,6 +1127,11 @@ networks:
   omnibase-infra-network:
     name: omnibase-infra-network
     driver: bridge
+  # OMN-8852: omnimemory-network is owned by omnimemory/docker-compose.yml.
+  # runtime-effects must join it so PluginMemory can reach omnimemory-memgraph:7687.
+  omnimemory-network:
+    name: omnimemory-network
+    external: true
 # ==========================================================================
 # Volume Configuration
 # ==========================================================================


### PR DESCRIPTION
## Summary

- **Root cause**: `OMNIMEMORY_MEMGRAPH_HOST` was blank in `omninode-runtime-effects` because `omnimemory-memgraph` runs on `omnimemory-network` (managed by `omnimemory/docker-compose.yml`) while `runtime-effects` was only on `omnibase-infra-network`. The two networks are isolated — no DNS resolution across them.
- **Fix**: Declare `omnimemory-network` as an `external` network in `docker-compose.infra.yml`, override `networks:` on `runtime-effects` to join both networks, and set `OMNIMEMORY_MEMGRAPH_HOST=omnimemory-memgraph` in `.env` on .201.
- **Why not `omnibase-infra-memgraph`**: That service has `profiles: ["omnimemory", "full"]` and port-conflicts with `omnimemory-memgraph` (both bind :7687). Only one memgraph instance should run. `omnimemory-memgraph` is already healthy.

## Operator steps (applied on .201 before this PR merges)

1. Added `OMNIMEMORY_MEMGRAPH_HOST=omnimemory-memgraph` to `/data/omninode/omnibase_infra/.env`
2. Ran `docker network connect omnimemory-network omninode-runtime-effects` (temporary — survives until next container restart)
3. This PR makes the network join durable via compose

## Test plan

- [ ] After deploy-agent rebuild: `docker inspect omninode-runtime-effects --format '{{json .NetworkSettings.Networks}}'` shows both `omnibase-infra-network` and `omnimemory-network`
- [ ] `docker exec omninode-runtime-effects bash -c "echo > /dev/tcp/omnimemory-memgraph/7687 && echo CONNECTED"` returns `CONNECTED`
- [ ] `docker logs omninode-runtime-effects --tail 50 | grep -i 'plugin.*memory'` shows no handshake failure