### PR TITLE
chore(systemd): daemonize monitor_logs.py as onex-log-monitor.service (OMN-8870)

### DIFF
--- a/deploy/systemd/onex-log-monitor.service
+++ b/deploy/systemd/onex-log-monitor.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OmniNode Log Monitor — Docker containers + Slack alerts
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/home/jonah/.omnibase/.env
+Environment="MONITOR_PROJECTS=omnibase-infra,omnibase-infra-runtime"
+ExecStart=/usr/bin/python3 /home/jonah/.omnibase/infra/deployed/0.34.0/scripts/monitor_logs.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

- Adds `deploy/systemd/onex-log-monitor.service` — user-scope systemd unit that runs `monitor_logs.py` as a persistent daemon on .201
- Service tails Docker container logs (projects: `omnibase-infra`, `omnibase-infra-runtime`), filters ERROR/CRITICAL lines, and posts rate-limited Slack alerts
- `Type=simple`, no WatchdogSec (script is a log-tailer with no sd_notify calls), `Restart=always` with 10s backoff

## Deployment evidence (already live on .201)

- `systemctl --user is-active onex-log-monitor.service` → `active`
- Journal: clean startup, Kafka graceful degradation (expected — confluent-kafka not in system python), no tracebacks
- Smoke test: direct Slack POST to `C08PRL6BRQE` returned `ok=true`, ts=`1776261714.953629`

## Deploy instructions

```bash
cp deploy/systemd/onex-log-monitor.service ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now onex-log-monitor.service
```

## Test plan

- [ ] `systemctl --user is-active onex-log-monitor.service` returns `active`
- [ ] `journalctl --user -u onex-log-monitor.service -n 20` shows no tracebacks
- [ ] Slack channel C08PRL6BRQE receives alerts on container ERROR lines

Fixes OMN-8870