### PR TITLE
fix(dockerfile): remove ONEX_INPUT_TOPIC/OUTPUT_TOPIC from runtime ENV (OMN-8784)

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -29,9 +29,9 @@
 #   ONEX_CONTRACTS_DIR - Contract configuration directory (default: /app/contracts)
 #   ONEX_LOG_LEVEL    - Logging level (default: INFO)
 #   ONEX_ENVIRONMENT  - Environment name (default: local)
-#   ONEX_INPUT_TOPIC  - Input topic for event bus (default: requests)
-#   ONEX_OUTPUT_TOPIC - Output topic for event bus (default: responses)
 #   ONEX_GROUP_ID     - Consumer group ID (default: onex-runtime)
+#   Note: ONEX_INPUT_TOPIC and ONEX_OUTPUT_TOPIC were removed (OMN-8784).
+#         Topics must be declared in node contract event_bus.subscribe_topics / publish_topics.
 #
 # =============================================================================
 # PERFORMANCE OPTIMIZATION TIPS
@@ -305,8 +305,6 @@ ENV PYTHONUNBUFFERED=1 \
     ONEX_LOG_LEVEL=INFO \
     # Event bus configuration
     ONEX_ENVIRONMENT=local \
-    ONEX_INPUT_TOPIC=requests \
-    ONEX_OUTPUT_TOPIC=responses \
     ONEX_GROUP_ID=onex-runtime
 
 # Deployment identity env vars (stamped at build time from ARGs above).


### PR DESCRIPTION
## Summary

- Remove `ONEX_INPUT_TOPIC=requests` and `ONEX_OUTPUT_TOPIC=responses` from `Dockerfile.runtime` ENV block
- These env vars were removed from `service_kernel.py` in OMN-8784 (PR #1299), which now hard-fails if they are present at startup
- The Dockerfile was not updated when OMN-8784 merged, causing `omninode-runtime` to crash-loop on every deploy with `ProtocolConfigurationError: ONEX_CORE_041_INVALID_CONFIGURATION`
- Also updates the comment block at the top of the Dockerfile to reflect the removal

## Root Cause

`service_kernel.py` (OMN-8784) added a guard that raises `ProtocolConfigurationError` if `ONEX_INPUT_TOPIC` is set. `Dockerfile.runtime` still baked `ONEX_INPUT_TOPIC=requests` into the image ENV, so every container started with the forbidden var → immediate crash on startup.

## Test plan

- [ ] CI passes
- [ ] After merge and deploy-agent rebuild, `omninode-runtime` starts healthy (no crash-loop)
- [ ] `docker exec omninode-runtime python -c "import omnibase_infra"` exits 0