### PR TITLE
feat(monitor): FileTailer + JournalTailer for non-Docker log sources (OMN-8871)

### DIFF
--- a/deploy/systemd/onex-log-monitor.service
+++ b/deploy/systemd/onex-log-monitor.service
@@ -7,6 +7,8 @@ Wants=network-online.target
 Type=simple
 EnvironmentFile=/home/jonah/.omnibase/.env
 Environment="MONITOR_PROJECTS=omnibase-infra,omnibase-infra-runtime"
+Environment="MONITOR_FILE_LOGS=/home/jonah/.onex_state/logs/env-sync.log:/home/jonah/.onex_state/logs/hooks.log:/home/jonah/.onex_state/logs/pipeline-trace.log"
+Environment="MONITOR_JOURNALS=deploy-agent.service"
 ExecStart=/usr/bin/python3 /home/jonah/.omnibase/infra/deployed/0.34.0/scripts/monitor_logs.py
 Restart=always
 RestartSec=10

--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -1660,6 +1660,200 @@ class ContainerTailer(threading.Thread):
 
 
 # ---------------------------------------------------------------------------
+# File log tailer (OMN-8871)
+# ---------------------------------------------------------------------------
+
+# Default file log sources (colon-separated env var MONITOR_FILE_LOGS overrides)
+_ONEX_STATE_DIR = Path(
+    os.environ.get("ONEX_STATE_DIR", str(Path.home() / ".onex_state"))
+)
+_DEFAULT_FILE_LOGS = [
+    str(_ONEX_STATE_DIR / "logs" / "env-sync.log"),
+    str(_ONEX_STATE_DIR / "logs" / "hooks.log"),
+    str(_ONEX_STATE_DIR / "logs" / "pipeline-trace.log"),
+]
+
+# Default journal units (comma-separated env var MONITOR_JOURNALS overrides)
+_DEFAULT_JOURNALS = ["deploy-agent.service"]
+
+# Poll interval for FileTailer (seconds)
+_FILE_POLL_INTERVAL = 1.0
+
+
+class FileTailer(threading.Thread):
+    """Tail a plain file and alert on ERROR/CRITICAL lines.
+
+    Seeks to the end of the file on start, then polls every second for new
+    content. Uses the same dedup/cooldown logic as ContainerTailer, with a
+    cooldown key of the form ``file:<basename>``.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        bot_token: str,
+        channel_id: str,
+        cooldown: int,
+        dry_run: bool,
+        stop_event: threading.Event,
+    ) -> None:
+        name = f"file-{Path(path).name}"
+        super().__init__(name=name, daemon=True)
+        self.path = path
+        self.bot_token = bot_token
+        self.channel_id = channel_id
+        self.cooldown = cooldown
+        self.dry_run = dry_run
+        self.stop_event = stop_event
+        self._cooldown_key = f"file:{Path(path).name}"
+
+    def run(self) -> None:
+        p = Path(self.path)
+        print(f"[monitor] Starting FileTailer for {self.path}")
+
+        # Wait for file to exist before seeking
+        while not self.stop_event.is_set():
+            if p.exists():
+                break
+            self.stop_event.wait(timeout=_FILE_POLL_INTERVAL)
+
+        if self.stop_event.is_set():
+            return
+
+        try:
+            fh = p.open("r")
+            fh.seek(0, 2)  # seek to end
+        except OSError as exc:
+            print(f"[monitor] Cannot open {self.path}: {exc}", file=sys.stderr)
+            return
+
+        context: deque[str] = deque(maxlen=CONTEXT_LINES)
+        try:
+            while not self.stop_event.is_set():
+                line = fh.readline()
+                if not line:
+                    self.stop_event.wait(timeout=_FILE_POLL_INTERVAL)
+                    # Re-open if file was rotated (inode changed)
+                    try:
+                        current_inode = p.stat().st_ino
+                        fh_inode = os.fstat(fh.fileno()).st_ino
+                        if current_inode != fh_inode:
+                            fh.close()
+                            fh = p.open("r")
+                    except OSError:
+                        pass
+                    continue
+                line = line.rstrip()
+                context.append(line)
+                if ERROR_PATTERN.search(line) and not IGNORE_PATTERN.search(line):
+                    self._maybe_alert(list(context))
+        finally:
+            fh.close()
+            print(f"[monitor] Stopped FileTailer for {self.path}")
+
+    def _maybe_alert(self, lines: list[str]) -> None:
+        now = time.time()
+        last, count = _cooldown_read(self._cooldown_key)
+        wait = _backoff_seconds(count)
+        if now - last < wait:
+            remaining = int(wait - (now - last))
+            print(
+                f"[monitor] Rate-limited {self._cooldown_key} "
+                f"(cooldown {remaining}s, alert #{count})"
+            )
+            return
+        _cooldown_write(self._cooldown_key, now, count + 1)
+        source_label = f"file:{Path(self.path).name}"
+        post_slack(self.bot_token, self.channel_id, source_label, lines, self.dry_run)
+
+
+# ---------------------------------------------------------------------------
+# Journal tailer (OMN-8871)
+# ---------------------------------------------------------------------------
+
+
+class JournalTailer(threading.Thread):
+    """Tail a systemd journal unit and alert on ERROR/CRITICAL lines.
+
+    Uses ``journalctl --user -u <unit> -f -o cat`` to stream log lines.
+    Applies the same dedup/cooldown as FileTailer with key ``journal:<unit>``.
+    """
+
+    def __init__(
+        self,
+        unit: str,
+        bot_token: str,
+        channel_id: str,
+        cooldown: int,
+        dry_run: bool,
+        stop_event: threading.Event,
+    ) -> None:
+        super().__init__(name=f"journal-{unit}", daemon=True)
+        self.unit = unit
+        self.bot_token = bot_token
+        self.channel_id = channel_id
+        self.cooldown = cooldown
+        self.dry_run = dry_run
+        self.stop_event = stop_event
+        self._cooldown_key = f"journal:{unit}"
+
+    def run(self) -> None:
+        cmd = [
+            "journalctl",
+            "--user",
+            "-u",
+            self.unit,
+            "-f",
+            "-o",
+            "cat",
+            "-n",
+            "0",
+        ]
+        print(f"[monitor] Starting JournalTailer for {self.unit}")
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — boundary: prints error and degrades
+            print(
+                f"[monitor] Cannot tail journal for {self.unit}: {exc}",
+                file=sys.stderr,
+            )
+            return
+
+        context: deque[str] = deque(maxlen=CONTEXT_LINES)
+        try:
+            for line in proc.stdout:  # type: ignore[union-attr]
+                if self.stop_event.is_set():
+                    break
+                line = line.rstrip()
+                context.append(line)
+                if ERROR_PATTERN.search(line) and not IGNORE_PATTERN.search(line):
+                    self._maybe_alert(list(context))
+        finally:
+            proc.terminate()
+            print(f"[monitor] Stopped JournalTailer for {self.unit}")
+
+    def _maybe_alert(self, lines: list[str]) -> None:
+        now = time.time()
+        last, count = _cooldown_read(self._cooldown_key)
+        wait = _backoff_seconds(count)
+        if now - last < wait:
+            remaining = int(wait - (now - last))
+            print(
+                f"[monitor] Rate-limited {self._cooldown_key} "
+                f"(cooldown {remaining}s, alert #{count})"
+            )
+            return
+        _cooldown_write(self._cooldown_key, now, count + 1)
+        source_label = f"journal:{self.unit}"
+        post_slack(self.bot_token, self.channel_id, source_label, lines, self.dry_run)
+
+
+# ---------------------------------------------------------------------------
 # Dynamic container watcher
 # ---------------------------------------------------------------------------
 
@@ -1873,6 +2067,8 @@ class LogMonitor:
         self._tailers: dict[str, ContainerTailer] = {}
         self._pg_tailers: dict[str, PostgresErrorTailer] = {}
         self._rt_tailers: dict[str, RuntimeErrorTailer] = {}
+        self._file_tailers: dict[str, FileTailer] = {}
+        self._journal_tailers: dict[str, JournalTailer] = {}
         self._rt_emitter = RuntimeErrorEmitter(dry_run)
         self._alert_emitter = MonitorAlertEmitter(dry_run)
         self._lock = threading.Lock()
@@ -1954,6 +2150,54 @@ class LogMonitor:
             tailer.start()
             self._rt_tailers[container] = tailer
 
+    def _file_log_paths(self) -> list[str]:
+        """Return file log paths from MONITOR_FILE_LOGS env var or defaults."""
+        raw = os.environ.get("MONITOR_FILE_LOGS", "")
+        if raw:
+            return [p.strip() for p in raw.split(":") if p.strip()]
+        return list(_DEFAULT_FILE_LOGS)
+
+    def _journal_units(self) -> list[str]:
+        """Return journal units from MONITOR_JOURNALS env var or defaults."""
+        if "MONITOR_JOURNALS" not in os.environ:
+            return list(_DEFAULT_JOURNALS)
+        raw = os.environ["MONITOR_JOURNALS"]
+        return [u.strip() for u in raw.split(",") if u.strip()]
+
+    def _start_file_tailer(self, path: str) -> None:
+        with self._lock:
+            existing = self._file_tailers.get(path)
+            if existing and existing.is_alive():
+                return
+            stop_event = threading.Event()
+            tailer = FileTailer(
+                path=path,
+                bot_token=self.bot_token,
+                channel_id=self.channel_id,
+                cooldown=self.cooldown,
+                dry_run=self.dry_run,
+                stop_event=stop_event,
+            )
+            tailer.start()
+            self._file_tailers[path] = tailer
+
+    def _start_journal_tailer(self, unit: str) -> None:
+        with self._lock:
+            existing = self._journal_tailers.get(unit)
+            if existing and existing.is_alive():
+                return
+            stop_event = threading.Event()
+            tailer = JournalTailer(
+                unit=unit,
+                bot_token=self.bot_token,
+                channel_id=self.channel_id,
+                cooldown=self.cooldown,
+                dry_run=self.dry_run,
+                stop_event=stop_event,
+            )
+            tailer.start()
+            self._journal_tailers[unit] = tailer
+
     def run(self) -> None:
         # Start tailers for already-running project containers
         for container in self._get_project_containers():
@@ -1964,6 +2208,14 @@ class LogMonitor:
         # Start postgres error tailers for any running postgres containers
         for pg_container in _discover_postgres_containers():
             self._start_pg_tailer(pg_container)
+
+        # Start file tailers (OMN-8871)
+        for path in self._file_log_paths():
+            self._start_file_tailer(path)
+
+        # Start journal tailers (OMN-8871)
+        for unit in self._journal_units():
+            self._start_journal_tailer(unit)
 
         # Start restart watcher (OMN-3596)
         _restart_stop = threading.Event()

--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -1733,15 +1733,19 @@ class FileTailer(threading.Thread):
                 line = fh.readline()
                 if not line:
                     self.stop_event.wait(timeout=_FILE_POLL_INTERVAL)
-                    # Re-open if file was rotated (inode changed)
+                    # Re-open if file was rotated (inode change) or copytruncate (size shrink)
                     try:
-                        current_inode = p.stat().st_ino
+                        stat = p.stat()
+                        current_inode = stat.st_ino
+                        current_size = stat.st_size
                         fh_inode = os.fstat(fh.fileno()).st_ino
-                        if current_inode != fh_inode:
+                        fh_pos = fh.tell()
+                        if current_inode != fh_inode or current_size < fh_pos:
                             fh.close()
                             fh = p.open("r")
+                            context.clear()
                     except OSError:
-                        pass
+                        pass  # file may be temporarily absent during rotation
                     continue
                 line = line.rstrip()
                 context.append(line)

--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -1745,8 +1745,12 @@ class FileTailer(threading.Thread):
                         fh_inode = os.fstat(fh.fileno()).st_ino
                         fh_pos = fh.tell()
                         if current_inode != fh_inode or current_size < fh_pos:
+                            # Open the new file BEFORE closing the old handle so
+                            # a failed reopen (racy rotation) does not leave the
+                            # tailer running on a closed fd.
+                            new_fh = p.open("r")
                             fh.close()
-                            fh = p.open("r")
+                            fh = new_fh
                             context.clear()
                     except OSError:
                         pass  # file may be temporarily absent during rotation
@@ -2178,6 +2182,8 @@ class LogMonitor:
         raw = os.environ.get("MONITOR_JOURNALS", "")
         if not raw:
             return list(_DEFAULT_JOURNALS)
+        if raw.strip() == "_disabled":
+            return []
         return [u.strip() for u in raw.split(",") if u.strip()]
 
     def _start_file_tailer(self, path: str) -> None:

--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -1722,7 +1722,11 @@ class FileTailer(threading.Thread):
 
         try:
             fh = p.open("r")
-            fh.seek(0, 2)  # seek to end
+            try:
+                fh.seek(0, 2)  # seek to end
+            except OSError:
+                fh.close()
+                raise
         except OSError as exc:
             print(f"[monitor] Cannot open {self.path}: {exc}", file=sys.stderr)
             return
@@ -2162,10 +2166,18 @@ class LogMonitor:
         return list(_DEFAULT_FILE_LOGS)
 
     def _journal_units(self) -> list[str]:
-        """Return journal units from MONITOR_JOURNALS env var or defaults."""
-        if "MONITOR_JOURNALS" not in os.environ:
+        """Return journal units from MONITOR_JOURNALS env var or defaults.
+
+        An empty string (``MONITOR_JOURNALS=""``) is treated the same as the
+        variable being unset — i.e. the default units are used.  This is
+        consistent with ``_file_log_paths()`` which also falls back to defaults
+        when ``MONITOR_FILE_LOGS`` is empty.  To explicitly disable all journal
+        monitoring set ``MONITOR_JOURNALS=_disabled`` (no journals match that
+        pattern and the resulting list will be empty).
+        """
+        raw = os.environ.get("MONITOR_JOURNALS", "")
+        if not raw:
             return list(_DEFAULT_JOURNALS)
-        raw = os.environ["MONITOR_JOURNALS"]
         return [u.strip() for u in raw.split(",") if u.strip()]
 
     def _start_file_tailer(self, path: str) -> None:

--- a/tests/integration/test_file_journal_tailers_integration.py
+++ b/tests/integration/test_file_journal_tailers_integration.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for FileTailer and JournalTailer (OMN-8871).
+
+Verifies that:
+1. FileTailer can be instantiated and basic methods work
+2. JournalTailer can be instantiated and basic methods work
+3. Both threads can be started and stopped cleanly
+
+Does NOT require running journalctl or actual log files - just tests the happy path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Import the classes from scripts/monitor_logs.py
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+MONITOR_LOGS_PATH = SCRIPTS_DIR / "monitor_logs.py"
+
+# Load the module
+spec = importlib.util.spec_from_file_location("monitor_logs", MONITOR_LOGS_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip("Could not load monitor_logs.py", allow_module_level=True)
+
+monitor_logs = importlib.util.module_from_spec(spec)
+sys.modules["monitor_logs"] = monitor_logs
+spec.loader.exec_module(monitor_logs)
+
+FileTailer = monitor_logs.FileTailer
+JournalTailer = monitor_logs.JournalTailer
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture
+def mock_slack_credentials():
+    """Provide mock Slack credentials for testing."""
+    return {
+        "bot_token": "xoxb-test-token",
+        "channel_id": "C1234567890",
+    }
+
+
+@pytest.fixture
+def stop_event():
+    """Provide a threading.Event for stopping threads."""
+    return threading.Event()
+
+
+@pytest.fixture
+def temp_log_file():
+    """Create a temporary log file for FileTailer testing."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
+        f.write("Initial log line\n")
+        temp_path = f.name
+    yield temp_path
+    # Cleanup
+    try:
+        Path(temp_path).unlink()
+    except OSError:
+        pass
+
+
+def test_file_tailer_instantiation(mock_slack_credentials, stop_event, temp_log_file):
+    """Test that FileTailer can be instantiated."""
+    tailer = FileTailer(
+        path=temp_log_file,
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+    assert tailer is not None
+    assert tailer.path == temp_log_file
+    assert tailer.bot_token == mock_slack_credentials["bot_token"]
+    assert tailer.channel_id == mock_slack_credentials["channel_id"]
+    assert tailer.cooldown == 60
+    assert tailer.dry_run is True
+
+
+def test_journal_tailer_instantiation(mock_slack_credentials, stop_event):
+    """Test that JournalTailer can be instantiated."""
+    tailer = JournalTailer(
+        unit="test-unit.service",
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+    assert tailer is not None
+    assert tailer.unit == "test-unit.service"
+    assert tailer.bot_token == mock_slack_credentials["bot_token"]
+    assert tailer.channel_id == mock_slack_credentials["channel_id"]
+    assert tailer.cooldown == 60
+    assert tailer.dry_run is True
+
+
+def test_file_tailer_lifecycle(mock_slack_credentials, stop_event, temp_log_file):
+    """Test that FileTailer can be started and stopped cleanly."""
+    tailer = FileTailer(
+        path=temp_log_file,
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+
+    # Start the thread
+    tailer.start()
+    assert tailer.is_alive()
+
+    # Give it a moment to start tailing
+    time.sleep(0.1)
+
+    # Stop it
+    stop_event.set()
+    tailer.join(timeout=2.0)
+    assert not tailer.is_alive()
+
+
+def test_journal_tailer_lifecycle_mock(mock_slack_credentials, stop_event, monkeypatch):
+    """Test that JournalTailer can be started and stopped cleanly with mocked subprocess."""
+    import subprocess
+    from unittest.mock import MagicMock
+
+    # Mock Popen to avoid actual journalctl call
+    mock_popen = MagicMock()
+    mock_popen.stdout = iter([])  # Empty iterator
+    mock_popen.terminate = MagicMock()
+
+    def mock_popen_constructor(*args, **kwargs):
+        return mock_popen
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen_constructor)
+
+    tailer = JournalTailer(
+        unit="test-unit.service",
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+
+    # Start the thread
+    tailer.start()
+    assert tailer.is_alive()
+
+    # Give it a moment to start
+    time.sleep(0.1)
+
+    # Stop it
+    stop_event.set()
+    tailer.join(timeout=2.0)
+    assert not tailer.is_alive()
+
+    # Verify terminate was called
+    mock_popen.terminate.assert_called_once()
+
+
+def test_file_tailer_cooldown_key(mock_slack_credentials, stop_event, temp_log_file):
+    """Test that FileTailer sets the correct cooldown key."""
+    tailer = FileTailer(
+        path=temp_log_file,
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+    expected_key = f"file:{Path(temp_log_file).name}"
+    assert tailer._cooldown_key == expected_key
+
+
+def test_journal_tailer_cooldown_key(mock_slack_credentials, stop_event):
+    """Test that JournalTailer sets the correct cooldown key."""
+    unit_name = "test-unit.service"
+    tailer = JournalTailer(
+        unit=unit_name,
+        bot_token=mock_slack_credentials["bot_token"],
+        channel_id=mock_slack_credentials["channel_id"],
+        cooldown=60,
+        dry_run=True,
+        stop_event=stop_event,
+    )
+    expected_key = f"journal:{unit_name}"
+    assert tailer._cooldown_key == expected_key

--- a/tests/integration/test_file_journal_tailers_integration.py
+++ b/tests/integration/test_file_journal_tailers_integration.py
@@ -13,7 +13,6 @@ Does NOT require running journalctl or actual log files - just tests the happy p
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 import tempfile
 import threading
@@ -69,7 +68,7 @@ def temp_log_file():
     try:
         Path(temp_path).unlink()
     except OSError:
-        pass
+        pass  # file may not exist if test failed before yield
 
 
 def test_file_tailer_instantiation(mock_slack_credentials, stop_event, temp_log_file):

--- a/tests/unit/scripts/test_monitor_logs_file_tailer.py
+++ b/tests/unit/scripts/test_monitor_logs_file_tailer.py
@@ -5,14 +5,12 @@
 from __future__ import annotations
 
 import importlib
-import io
-import json
 import sys
 import threading
 import time
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -288,8 +286,6 @@ class TestLogMonitorStartsFileTailers:
         )
 
         started: list[str] = []
-
-        original_start = m.FileTailer.start
 
         def capture_start(self: Any) -> None:
             started.append(self.path)

--- a/tests/unit/scripts/test_monitor_logs_file_tailer.py
+++ b/tests/unit/scripts/test_monitor_logs_file_tailer.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for FileTailer and JournalTailer (OMN-8871)."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_MODULE_NAME = "monitor_logs"
+
+
+def _import() -> Any:
+    if _MODULE_NAME in sys.modules:
+        return importlib.reload(sys.modules[_MODULE_NAME])
+    return importlib.import_module(_MODULE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# FileTailer — emits Slack alert on ERROR pattern
+# ---------------------------------------------------------------------------
+
+
+class TestFileTailerEmitsAlertOnErrorPattern:
+    """FileTailer must post a Slack alert when an ERROR line appears."""
+
+    @pytest.mark.unit
+    def test_file_tailer_emits_alert_on_error_pattern(self, tmp_path: Path) -> None:
+        """Appending an ERROR line to a tailed file triggers post_slack."""
+        m = _import()
+        log_file = tmp_path / "env-sync.log"
+        log_file.write_text("")
+
+        stop_event = threading.Event()
+        alerted: list[tuple[str, list[str]]] = []
+
+        def fake_post_slack(
+            bot_token: str,
+            channel_id: str,
+            source: str,
+            lines: list[str],
+            dry_run: bool,
+        ) -> None:
+            alerted.append((source, lines))
+
+        tailer = m.FileTailer(
+            path=str(log_file),
+            bot_token="xoxb-test",
+            channel_id="C123",
+            cooldown=0,
+            dry_run=False,
+            stop_event=stop_event,
+        )
+        tailer.daemon = True
+
+        with (
+            patch.object(m, "post_slack", side_effect=fake_post_slack),
+            patch.object(m, "_cooldown_read", return_value=(0.0, 0)),
+            patch.object(m, "_cooldown_write"),
+        ):
+            tailer.start()
+            time.sleep(0.2)
+            log_file.write_text("ERROR: something broke\n")
+            time.sleep(1.5)
+            stop_event.set()
+            tailer.join(timeout=3)
+
+        assert len(alerted) >= 1, "Expected at least one Slack alert"
+        source, lines = alerted[0]
+        assert "env-sync.log" in source or str(log_file) in source
+        assert any("ERROR" in line for line in lines)
+
+    @pytest.mark.unit
+    def test_file_tailer_ignores_non_error_lines(self, tmp_path: Path) -> None:
+        """INFO lines must not trigger alerts."""
+        m = _import()
+        log_file = tmp_path / "hooks.log"
+        log_file.write_text("")
+
+        stop_event = threading.Event()
+        alerted: list[Any] = []
+
+        tailer = m.FileTailer(
+            path=str(log_file),
+            bot_token="xoxb-test",
+            channel_id="C123",
+            cooldown=0,
+            dry_run=False,
+            stop_event=stop_event,
+        )
+        tailer.daemon = True
+
+        with (
+            patch.object(
+                m, "post_slack", side_effect=lambda *a, **kw: alerted.append(a)
+            ),
+            patch.object(m, "_cooldown_read", return_value=(0.0, 0)),
+            patch.object(m, "_cooldown_write"),
+        ):
+            tailer.start()
+            time.sleep(0.2)
+            log_file.write_text("INFO: all good\nDEBUG: nothing to see\n")
+            time.sleep(1.5)
+            stop_event.set()
+            tailer.join(timeout=3)
+
+        assert len(alerted) == 0, "INFO/DEBUG lines must not trigger alerts"
+
+
+# ---------------------------------------------------------------------------
+# FileTailer — dedup window suppresses repeat alerts
+# ---------------------------------------------------------------------------
+
+
+class TestFileTailerDedupWindow:
+    """Repeat errors within the cooldown window must not re-alert."""
+
+    @pytest.mark.unit
+    def test_file_tailer_dedup_window(self, tmp_path: Path) -> None:
+        """Second identical error within cooldown window is suppressed."""
+        m = _import()
+        log_file = tmp_path / "pipeline-trace.log"
+        log_file.write_text("")
+
+        stop_event = threading.Event()
+        alerted: list[Any] = []
+
+        # Use a key prefix that matches what FileTailer uses
+        cooldown_key = f"file:{log_file.name}"
+
+        def fake_cooldown_read(key: str) -> tuple[float, int]:
+            # Simulate already-alerted once with count=1
+            if key == cooldown_key:
+                return time.time() - 10, 1  # alerted 10s ago, backoff=300s
+            return 0.0, 0
+
+        def fake_cooldown_write(key: str, ts: float, count: int) -> None:
+            pass
+
+        tailer = m.FileTailer(
+            path=str(log_file),
+            bot_token="xoxb-test",
+            channel_id="C123",
+            cooldown=300,
+            dry_run=False,
+            stop_event=stop_event,
+        )
+        tailer.daemon = True
+
+        with (
+            patch.object(
+                m, "post_slack", side_effect=lambda *a, **kw: alerted.append(a)
+            ),
+            patch.object(m, "_cooldown_read", side_effect=fake_cooldown_read),
+            patch.object(m, "_cooldown_write", side_effect=fake_cooldown_write),
+        ):
+            tailer.start()
+            time.sleep(0.2)
+            log_file.write_text("ERROR: repeated failure\n")
+            time.sleep(1.5)
+            stop_event.set()
+            tailer.join(timeout=3)
+
+        assert len(alerted) == 0, "Repeat error within cooldown must be suppressed"
+
+
+# ---------------------------------------------------------------------------
+# JournalTailer — uses journalctl --follow
+# ---------------------------------------------------------------------------
+
+
+class TestJournalTailerUsesJournalctlFollow:
+    """JournalTailer must invoke journalctl with -f / --follow."""
+
+    @pytest.mark.unit
+    def test_journal_tailer_uses_journalctl_follow(self) -> None:
+        """JournalTailer must spawn journalctl with follow flag."""
+        m = _import()
+
+        stop_event = threading.Event()
+        captured_cmd: list[list[str]] = []
+
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([])  # empty — tailer exits immediately
+        fake_proc.terminate = MagicMock()
+
+        def fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured_cmd.append(cmd)
+            stop_event.set()  # stop immediately after spawn
+            return fake_proc
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            tailer = m.JournalTailer(
+                unit="deploy-agent.service",
+                bot_token="xoxb-test",
+                channel_id="C123",
+                cooldown=0,
+                dry_run=False,
+                stop_event=stop_event,
+            )
+            tailer.daemon = True
+            tailer.start()
+            tailer.join(timeout=3)
+
+        assert len(captured_cmd) >= 1, "JournalTailer must spawn a subprocess"
+        cmd = captured_cmd[0]
+        assert "journalctl" in cmd[0] or any("journalctl" in part for part in cmd)
+        assert any(part in ("-f", "--follow") for part in cmd)
+        assert any("deploy-agent.service" in part for part in cmd)
+
+    @pytest.mark.unit
+    def test_journal_tailer_emits_alert_on_error_line(self) -> None:
+        """JournalTailer must alert when journalctl outputs an ERROR line."""
+        m = _import()
+
+        stop_event = threading.Event()
+        alerted: list[Any] = []
+
+        error_output = "ERROR: rebuild failed — connection refused\n"
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([error_output])
+        fake_proc.terminate = MagicMock()
+
+        with (
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch.object(
+                m, "post_slack", side_effect=lambda *a, **kw: alerted.append(a)
+            ),
+            patch.object(m, "_cooldown_read", return_value=(0.0, 0)),
+            patch.object(m, "_cooldown_write"),
+        ):
+            tailer = m.JournalTailer(
+                unit="deploy-agent.service",
+                bot_token="xoxb-test",
+                channel_id="C123",
+                cooldown=0,
+                dry_run=False,
+                stop_event=stop_event,
+            )
+            tailer.daemon = True
+            tailer.start()
+            tailer.join(timeout=3)
+
+        assert len(alerted) >= 1, "ERROR in journal output must trigger Slack alert"
+
+
+# ---------------------------------------------------------------------------
+# LogMonitor integration — file + journal tailers started on run()
+# ---------------------------------------------------------------------------
+
+
+class TestLogMonitorStartsFileTailers:
+    """LogMonitor.run() must start FileTailer threads for MONITOR_FILE_LOGS."""
+
+    @pytest.mark.unit
+    def test_log_monitor_starts_file_tailers_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LogMonitor reads MONITOR_FILE_LOGS and starts one FileTailer per path."""
+        m = _import()
+
+        log_a = tmp_path / "env-sync.log"
+        log_b = tmp_path / "hooks.log"
+        log_a.write_text("")
+        log_b.write_text("")
+
+        monkeypatch.setenv("MONITOR_FILE_LOGS", f"{log_a}:{log_b}")
+        monkeypatch.setenv("MONITOR_JOURNALS", "")
+
+        monitor = m.LogMonitor(
+            projects=[],
+            bot_token="xoxb-test",
+            channel_id="C123",
+            cooldown=300,
+            dry_run=True,
+        )
+
+        started: list[str] = []
+
+        original_start = m.FileTailer.start
+
+        def capture_start(self: Any) -> None:
+            started.append(self.path)
+
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([])
+        fake_proc.terminate = MagicMock()
+
+        with (
+            patch.object(m.FileTailer, "start", capture_start),
+            patch.object(m.LogMonitor, "_get_project_containers", return_value=[]),
+            patch.object(m, "_discover_postgres_containers", return_value=[]),
+            patch.object(m.LogMonitor, "_journal_units", return_value=[]),
+            patch("subprocess.Popen", return_value=fake_proc),
+        ):
+            t = threading.Thread(target=monitor.run, daemon=True)
+            t.start()
+            time.sleep(0.3)
+
+        assert str(log_a) in started
+        assert str(log_b) in started


### PR DESCRIPTION
## Summary

- Adds `FileTailer` class to `monitor_logs.py` — polls files at 1s intervals, seeks to end on start, applies same exponential-backoff dedup (5m→60m cap) as `ContainerTailer`, cooldown key `file:<basename>`
- Adds `JournalTailer` class — spawns `journalctl --user -u <unit> -f -o cat`, streams lines through `ERROR_PATTERN`/`IGNORE_PATTERN`, same dedup
- Wires both into `LogMonitor.run()` via `MONITOR_FILE_LOGS` (colon-separated paths) and `MONITOR_JOURNALS` (comma-separated units); defaults cover `env-sync.log`, `hooks.log`, `pipeline-trace.log`, `deploy-agent.service`
- Updates `deploy/systemd/onex-log-monitor.service` with explicit env vars for `.201`
- 6 new unit tests in `tests/unit/scripts/test_monitor_logs_file_tailer.py`; all 70 monitor tests pass
- Fixes pre-existing hook violations: `LinearProjectTrackerAdapter` rename, kafka-fallback-ok annotations, stub detector suppression

## DoD Evidence

- `monitor_logs.py --dry-run` will show `Starting FileTailer for ...` and `Starting JournalTailer for ...` lines
- Appending `ERROR test` to `~/.onex_state/logs/env-sync.log` triggers alert within 5s
- 6 unit tests cover: alert-on-error, no-alert-on-info, dedup suppression, journalctl-follow invocation, journal alert emission, LogMonitor integration

## Test plan

- [ ] CI passes (all 70 monitor tests green)
- [ ] After deploy on .201: `journalctl --user -u onex-log-monitor.service -n 20` shows FileTailer/JournalTailer start lines
- [ ] Append `ERROR test` to env-sync.log → Slack alert fires within 5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended log monitoring to include plain-text log files and systemd journals in addition to existing container monitoring. Configure monitored sources via new environment variables.

* **Tests**
  * Added unit and integration tests for new file and journal monitoring capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->