### PR TITLE
fix(ci): update cr-thread-gate to @main ref (OMN-8898)

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   gate:
     if: (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) && github.actor != 'dependabot[bot]'
-    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@b4b12ef5d0f77b9ffd39a5566c0be350222c2cd8
+    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
     with:
       pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
     secrets:
-      github-token: ${{ secrets.CROSS_REPO_PAT }}
+      CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary

- Updates `cr-thread-gate.yml` caller to pin to `@main` instead of a pre-fix commit SHA
- Renames secret key from deprecated `github-token` to `CROSS_REPO_PAT`
- Picks up the fix from omniclaude#1309 (CROSS_REPO_PAT fallback + push event handling)

## Context

The `b4b12ef` SHA pinned here was the initial broken version of cr-thread-gate. Part of OMN-8898 retroactive recovery sweep.

## Test plan
- [ ] CI passes on this PR
- [ ] CR thread gate check runs green