### PR TITLE
feat(ci): Wave C contract-sync gate — fail PRs that drift handler/skill without contract update (OMN-8915)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,12 +614,34 @@ jobs:
           done
           echo "Contract path pre-flight: ${CHECKED} local modules checked, ${WARNINGS} warnings, ${SKIPPED} cross-repo references skipped"
 
+  contract-sync-gate:
+    name: Contract Sync Gate (Wave C) [OMN-8915]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install gh CLI
+        run: |
+          type gh || (apt-get update -qq && apt-get install -y -qq gh)
+
+      - name: Run contract-sync gate
+        run: |
+          PR="${{ github.event.pull_request.number || github.event.merge_group.head_sha }}"
+          if [[ -z "$PR" || "$PR" == "null" ]]; then
+            echo "No PR number available — skipping in merge_group context"
+            exit 0
+          fi
+          bash scripts/validate-pr-contract-sync.sh "$PR"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # Parallel test execution - 15 splits for ~618 tests each
   # Split strategy: 9265 tests / 15 = ~618 tests per split (~2-3 min each)
   # Reduced from 10 splits + -n auto after repeated xdist OOM crashes on shard 3
   test-parallel:
     name: Tests (Split ${{ matrix.split }}/15)
-    needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, plugin-env-service-completeness, compose-required-env-coverage, contract-path-preflight, contract-compliance]
+    needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, plugin-env-service-completeness, compose-required-env-coverage, contract-path-preflight, contract-compliance, contract-sync-gate]
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
@@ -898,7 +920,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, migration-integration, migration-required-check, version-pin-check, compliance]
+    needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, migration-integration, migration-required-check, version-pin-check, compliance, contract-sync-gate]
     if: always()
 
     steps:
@@ -918,6 +940,7 @@ jobs:
           migrationintegration="${{ needs.migration-integration.result }}"
           migrationrequiredcheck="${{ needs.migration-required-check.result }}"
           compliance="${{ needs.compliance.result }}"
+          contractsync="${{ needs.contract-sync-gate.result }}"
 
           if [[ "$gate" == "success" ]] && \
              [[ "$lint" == "success" ]] && \
@@ -932,7 +955,8 @@ jobs:
              [[ "$schemahandshake" == "success" ]] && \
              [[ "$migrationintegration" == "success" ]] && \
              [[ "$migrationrequiredcheck" == "success" ]] && \
-             [[ "$compliance" == "success" || "$compliance" == "skipped" ]]; then
+             [[ "$compliance" == "success" || "$compliance" == "skipped" ]] && \
+             [[ "$contractsync" == "success" || "$contractsync" == "skipped" ]]; then
             echo "All checks passed successfully"
             echo "CI Tests Gate (15 splits): Passed"
             echo "Code Quality: Passed"
@@ -948,6 +972,7 @@ jobs:
             echo "Migration Integration: Passed"
             echo "Writer-Migration Coupling Check: Passed"
             echo "Contract Compliance: $compliance"
+            echo "Contract Sync Gate (Wave C): $contractsync"
             exit 0
           else
             echo "Checks failed"
@@ -965,6 +990,7 @@ jobs:
             echo "Migration Integration: $migrationintegration"
             echo "Writer-Migration Coupling Check: $migrationrequiredcheck"
             echo "Contract Compliance: $compliance"
+            echo "Contract Sync Gate (Wave C): $contractsync"
             exit 1
           fi
 

--- a/scripts/ci_check_kafka_no_localhost_default.py
+++ b/scripts/ci_check_kafka_no_localhost_default.py
@@ -10,7 +10,7 @@ overlay is absent.
 
 This script scans src/ for:
   - os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092") patterns
-  - os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092") patterns
+  - os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092") patterns  # kafka-fallback-ok
   - DEFAULT_BOOTSTRAP_SERVERS = "localhost:19092" (in non-CLI modules)
 
 Allowlisted paths (host-only CLI tools where localhost:19092 is valid):

--- a/scripts/validate-pr-contract-sync.sh
+++ b/scripts/validate-pr-contract-sync.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# validate-pr-contract-sync.sh — Wave C CI gate [OMN-8915]
+#
+# Fails any PR that touches a node handler without also touching its
+# contract.yaml, or a skill file without touching its SKILL.md / contract.yaml.
+#
+# Usage (CI — reads from gh pr diff):
+#   validate-pr-contract-sync.sh <PR_NUMBER>
+#
+# Usage (test harness — reads from env):
+#   VALIDATE_PR_FILES="file1\nfile2" \
+#   VALIDATE_PR_COMMIT_MESSAGES="msg1\nmsg2" \
+#   validate-pr-contract-sync.sh --from-env
+#
+# Exemption:
+#   Include [skip-contract-sync] in any commit message to bypass the gate.
+#   This must be accompanied by a justification in the commit body.
+#
+# Exit codes:
+#   0: gate passes
+#   1: contract sync violation found
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Input resolution
+# ---------------------------------------------------------------------------
+
+if [[ "${1:-}" == "--from-env" ]]; then
+    changed_files="${VALIDATE_PR_FILES:-}"
+    commit_messages="${VALIDATE_PR_COMMIT_MESSAGES:-}"
+elif [[ -n "${1:-}" ]]; then
+    pr_number="$1"
+    changed_files="$(gh pr diff "$pr_number" --name-only 2>/dev/null || true)"
+    commit_messages="$(gh pr view "$pr_number" --json commits --jq '.commits[].messageHeadline' 2>/dev/null || true)"
+else
+    echo "ERROR: usage: $0 <PR_NUMBER> | --from-env" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Exemption check
+# ---------------------------------------------------------------------------
+
+if echo "$commit_messages" | grep -qF '[skip-contract-sync]'; then
+    echo "INFO: [skip-contract-sync] token found — gate bypassed."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Collect node names that have handler changes or contract changes
+# (bash 3.2-compatible — uses temp files instead of associative arrays)
+# ---------------------------------------------------------------------------
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    # Node handler pattern: .../nodes/<node>/handlers/*.py
+    if echo "$file" | grep -qE '.*/nodes/([^/]+)/handlers/[^/]+\.py$'; then
+        node="$(echo "$file" | sed -E 's|.*/nodes/([^/]+)/handlers/[^/]+\.py$|\1|')"
+        touch "$tmpdir/node_handler_${node}"
+        continue
+    fi
+
+    # Node contract pattern: .../nodes/<node>/contract.yaml
+    if echo "$file" | grep -qE '.*/nodes/([^/]+)/contract\.yaml$'; then
+        node="$(echo "$file" | sed -E 's|.*/nodes/([^/]+)/contract\.yaml$|\1|')"
+        touch "$tmpdir/node_contract_${node}"
+        continue
+    fi
+
+    # Skill manifest: plugins/onex/skills/<skill>/(SKILL.md|contract.yaml)
+    if echo "$file" | grep -qE 'plugins/onex/skills/([^/]+)/SKILL\.md$'; then
+        skill="$(echo "$file" | sed -E 's|plugins/onex/skills/([^/]+)/SKILL\.md$|\1|')"
+        touch "$tmpdir/skill_manifest_${skill}"
+        continue
+    fi
+    if echo "$file" | grep -qE 'plugins/onex/skills/([^/]+)/contract\.yaml$'; then
+        skill="$(echo "$file" | sed -E 's|plugins/onex/skills/([^/]+)/contract\.yaml$|\1|')"
+        touch "$tmpdir/skill_manifest_${skill}"
+        continue
+    fi
+
+    # Skill code/prompt: plugins/onex/skills/<skill>/<anything else>
+    if echo "$file" | grep -qE 'plugins/onex/skills/([^/]+)/[^/]+$'; then
+        skill="$(echo "$file" | sed -E 's|plugins/onex/skills/([^/]+)/[^/]+$|\1|')"
+        touch "$tmpdir/skill_code_${skill}"
+        continue
+    fi
+done <<< "$changed_files"
+
+# ---------------------------------------------------------------------------
+# Enforcement
+# ---------------------------------------------------------------------------
+
+violations=()
+
+# Nodes with handler changes but no contract change
+for marker in "$tmpdir"/node_handler_*; do
+    [[ -e "$marker" ]] || continue
+    node="${marker#"$tmpdir/node_handler_"}"
+    if [[ ! -e "$tmpdir/node_contract_${node}" ]]; then
+        violations+=("NODE  $node: handler changed but contract.yaml not updated")
+    fi
+done
+
+# Skills with code changes but no manifest change
+for marker in "$tmpdir"/skill_code_*; do
+    [[ -e "$marker" ]] || continue
+    skill="${marker#"$tmpdir/skill_code_"}"
+    if [[ ! -e "$tmpdir/skill_manifest_${skill}" ]]; then
+        violations+=("SKILL $skill: skill file changed but SKILL.md / contract.yaml not updated")
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+if [[ ${#violations[@]} -eq 0 ]]; then
+    echo "OK: contract-sync gate passed."
+    exit 0
+fi
+
+echo "FAIL: contract-sync gate — the following nodes/skills were changed without updating their contracts:"
+echo ""
+for v in "${violations[@]}"; do
+    echo "  $v"
+done
+echo ""
+echo "Fix: update the contract.yaml (node) or SKILL.md/contract.yaml (skill) to reflect your changes."
+echo "Bypass: add [skip-contract-sync] to a commit message with justification."
+exit 1

--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -44,7 +44,7 @@ def _parse_dt(value: object) -> datetime:
     return datetime.now(UTC)
 
 
-def _issue_from_mcp(d: dict[str, object]) -> ModelStubIssue:
+def _issue_from_mcp(d: dict[str, object]) -> ModelStubIssue:  # stub-ok
     """Translate a Linear MCP issue dict into ModelStubIssue wire shape."""
     state_raw = d.get("state")
     if isinstance(state_raw, dict):
@@ -152,7 +152,7 @@ def _project_from_mcp(d: dict[str, object]) -> ModelStubProject:
     )
 
 
-class LinearProjectTrackerAdapter:
+class AdapterLinearProjectTracker:
     """MCP-backed ProtocolProjectTracker implementation for Linear.
 
     Constructor accepts optional callables for each MCP operation. When a
@@ -212,7 +212,7 @@ class LinearProjectTrackerAdapter:
     ) -> Callable[..., object]:
         if callable_ is None:
             raise NotImplementedError(
-                f"LinearProjectTrackerAdapter: '{name}' callable not injected"
+                f"AdapterLinearProjectTracker: '{name}' callable not injected"
             )
         return callable_
 

--- a/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
+++ b/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
@@ -63,8 +63,10 @@ class ModelKafkaProducerConfig(BaseModel):
         # A missing env var means the overlay was not applied — fail loudly.
         bootstrap = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
         try:
-            timeout_ms = os.getenv("KAFKA_REQUEST_TIMEOUT_MS", "10000")
-            acks_raw = os.getenv("KAFKA_ACKS", "all")
+            timeout_ms = os.getenv(
+                "KAFKA_REQUEST_TIMEOUT_MS", "10000"
+            )  # kafka-fallback-ok
+            acks_raw = os.getenv("KAFKA_ACKS", "all")  # kafka-fallback-ok
             max_request_size_raw = os.getenv(
                 "KAFKA_MAX_REQUEST_SIZE", str(4 * 1024 * 1024)
             )

--- a/src/omnibase_infra/services/project_tracker/resolver.py
+++ b/src/omnibase_infra/services/project_tracker/resolver.py
@@ -5,7 +5,7 @@
 
 Single authoritative surface for selecting a `ProtocolProjectTracker`
 implementation. Token present (LINEAR_API_KEY or LINEAR_TOKEN) →
-`LinearProjectTrackerAdapter`. Absent → `LocalStubProjectTracker`.
+`AdapterLinearProjectTracker`. Absent → `LocalStubProjectTracker`.
 Fail-soft: NEVER raises; on any construction error (missing adapter
 module, constructor failure, bad token) falls back to `LocalStubProjectTracker`
 with a warning log.
@@ -47,10 +47,10 @@ def resolve_project_tracker(
     if token and not _force_construction_error:
         try:
             from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-                LinearProjectTrackerAdapter,
+                AdapterLinearProjectTracker,
             )
 
-            return LinearProjectTrackerAdapter()
+            return AdapterLinearProjectTracker()
         except Exception as exc:  # noqa: BLE001 — fail-soft is the contract
             # Log only the exception class name; never interpolate `exc` body to
             # avoid leaking upstream secrets (tokens, connection strings, PII).

--- a/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
+++ b/tests/integration/adapters/test_linear_project_tracker_adapter_integration.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Integration tests for LinearProjectTrackerAdapter.
+"""Integration tests for AdapterLinearProjectTracker.
 
 Exercises the adapter end-to-end with fake MCP callables that simulate a
 live Linear MCP server. Verifies issue creation → fetch → update →
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 import pytest
 
 from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-    LinearProjectTrackerAdapter,
+    AdapterLinearProjectTracker,
 )
 from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
 
@@ -92,7 +92,7 @@ class _FakeLinearMcp:
 @pytest.mark.asyncio
 async def test_full_issue_lifecycle() -> None:
     mcp = _FakeLinearMcp()
-    adapter = LinearProjectTrackerAdapter(
+    adapter = AdapterLinearProjectTracker(
         mcp_create_issue=mcp.create_issue,
         mcp_get_issue=mcp.get_issue,
         mcp_update_issue=mcp.update_issue,
@@ -134,7 +134,7 @@ async def test_full_issue_lifecycle() -> None:
 @pytest.mark.asyncio
 async def test_get_issue_missing_raises_key_error() -> None:
     mcp = _FakeLinearMcp()
-    adapter = LinearProjectTrackerAdapter(mcp_get_issue=mcp.get_issue)
+    adapter = AdapterLinearProjectTracker(mcp_get_issue=mcp.get_issue)
     await adapter.connect()
 
     with pytest.raises(KeyError):
@@ -145,7 +145,7 @@ async def test_get_issue_missing_raises_key_error() -> None:
 @pytest.mark.asyncio
 async def test_add_comment_on_missing_issue_raises_key_error() -> None:
     mcp = _FakeLinearMcp()
-    adapter = LinearProjectTrackerAdapter(mcp_add_comment=mcp.add_comment)
+    adapter = AdapterLinearProjectTracker(mcp_add_comment=mcp.add_comment)
     await adapter.connect()
 
     with pytest.raises(KeyError):

--- a/tests/integration/services/test_resolver_integration.py
+++ b/tests/integration/services/test_resolver_integration.py
@@ -71,12 +71,12 @@ class TestResolveProjectTrackerIntegration:
         """End-to-end token branch — activates once OMN-8816 lands."""
         pytest.importorskip(
             "omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter",
-            reason="LinearProjectTrackerAdapter ships in OMN-8816; skip until merged",
+            reason="AdapterLinearProjectTracker ships in OMN-8816; skip until merged",
         )
         from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-            LinearProjectTrackerAdapter,
+            AdapterLinearProjectTracker,
         )
 
         with patch.dict("os.environ", {"LINEAR_TOKEN": "fake"}, clear=True):
             tracker = resolve_project_tracker(state_root=tmp_path)
-        assert isinstance(tracker, LinearProjectTrackerAdapter)
+        assert isinstance(tracker, AdapterLinearProjectTracker)

--- a/tests/scripts/test_validate_pr_contract_sync.py
+++ b/tests/scripts/test_validate_pr_contract_sync.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for scripts/validate-pr-contract-sync.sh [OMN-8915].
+
+TDD-first: these tests were written before the script existed.
+Each test invokes the script with a --files argument (newline-separated list
+of changed file paths) so no live gh CLI is needed in the test suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).parent.parent.parent / "scripts" / "validate-pr-contract-sync.sh"
+)
+
+
+def run_script(
+    changed_files: list[str], commit_messages: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the gate script with a synthetic file list.
+
+    Args:
+        changed_files: Paths as they would appear in `gh pr diff --name-only`.
+        commit_messages: Commit messages to simulate [skip-contract-sync] exemption.
+    """
+    file_input = "\n".join(changed_files)
+    env_overrides = {"VALIDATE_PR_FILES": file_input}
+    if commit_messages is not None:
+        env_overrides["VALIDATE_PR_COMMIT_MESSAGES"] = "\n".join(commit_messages)
+
+    import os
+
+    env = {**os.environ, **env_overrides}
+
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--from-env"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+@pytest.mark.unit
+def test_handler_change_with_contract_change_passes():
+    """Handler change accompanied by contract.yaml change must PASS."""
+    result = run_script(
+        [
+            "src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_register.py",
+            "src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_handler_change_without_contract_change_fails():
+    """Handler change without a matching contract.yaml change must FAIL with structured message."""
+    result = run_script(
+        [
+            "src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_register.py",
+        ]
+    )
+    assert result.returncode != 0, (
+        f"Expected FAIL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert (
+        "node_registration_orchestrator" in result.stdout
+        or "node_registration_orchestrator" in result.stderr
+    )
+    assert "contract.yaml" in result.stdout or "contract.yaml" in result.stderr
+
+
+@pytest.mark.unit
+def test_skill_prompt_change_with_skill_md_passes():
+    """Skill prompt.md change accompanied by SKILL.md change must PASS."""
+    result = run_script(
+        [
+            "plugins/onex/skills/handoff/prompt.md",
+            "plugins/onex/skills/handoff/SKILL.md",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_skill_prompt_change_without_skill_md_fails():
+    """Skill prompt.md change without matching SKILL.md change must FAIL."""
+    result = run_script(
+        [
+            "plugins/onex/skills/handoff/prompt.md",
+        ]
+    )
+    assert result.returncode != 0, (
+        f"Expected FAIL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "handoff" in result.stdout or "handoff" in result.stderr
+    assert (
+        "SKILL.md" in result.stdout
+        or "contract.yaml" in result.stdout
+        or "SKILL.md" in result.stderr
+        or "contract.yaml" in result.stderr
+    )
+
+
+@pytest.mark.unit
+def test_skip_token_in_commit_passes_without_contract():
+    """[skip-contract-sync] in commit message must exempt the PR even without contract change."""
+    result = run_script(
+        changed_files=[
+            "src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_register.py",
+        ],
+        commit_messages=[
+            "fix(register): typo fix [skip-contract-sync] no contract drift"
+        ],
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS with skip token.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_skill_py_change_without_skill_md_fails():
+    """Skill .py file change without matching SKILL.md must FAIL."""
+    result = run_script(
+        [
+            "plugins/onex/skills/handoff/skill_handoff.py",
+        ]
+    )
+    assert result.returncode != 0, (
+        f"Expected FAIL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_unrelated_file_change_passes():
+    """Changes to non-handler, non-skill files must not trigger the gate."""
+    result = run_script(
+        [
+            "docs/plans/some-plan.md",
+            "pyproject.toml",
+            "README.md",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS for unrelated files.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_skill_contract_yaml_alternative_passes():
+    """Skill change accompanied by skill-level contract.yaml (not SKILL.md) must also PASS."""
+    result = run_script(
+        [
+            "plugins/onex/skills/handoff/prompt.md",
+            "plugins/onex/skills/handoff/contract.yaml",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS with contract.yaml alternative.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/services/test_resolver.py
+++ b/tests/services/test_resolver.py
@@ -5,7 +5,7 @@
 
 Three required branches (per plan Task 4.1):
     1. No token → LocalStubProjectTracker
-    2. LINEAR_TOKEN present → LinearProjectTrackerAdapter
+    2. LINEAR_TOKEN present → AdapterLinearProjectTracker
     3. Construction failure → fail-soft to LocalStubProjectTracker (never raises)
 """
 
@@ -33,15 +33,15 @@ class TestResolveProjectTracker:
     def test_returns_linear_adapter_when_token_present(self, tmp_path: Path) -> None:
         pytest.importorskip(
             "omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter",
-            reason="LinearProjectTrackerAdapter ships in OMN-8816; skip until merged",
+            reason="AdapterLinearProjectTracker ships in OMN-8816; skip until merged",
         )
         from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-            LinearProjectTrackerAdapter,
+            AdapterLinearProjectTracker,
         )
 
         with patch.dict("os.environ", {"LINEAR_TOKEN": "fake-token"}, clear=True):
             tracker = resolve_project_tracker(state_root=tmp_path)
-            assert isinstance(tracker, LinearProjectTrackerAdapter)
+            assert isinstance(tracker, AdapterLinearProjectTracker)
 
     def test_never_raises_on_construction_failure(self, tmp_path: Path) -> None:
         with patch.dict("os.environ", {"LINEAR_TOKEN": "bad-token"}, clear=True):
@@ -55,12 +55,12 @@ class TestResolveProjectTracker:
         """LINEAR_API_KEY must be honored in addition to LINEAR_TOKEN."""
         pytest.importorskip(
             "omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter",
-            reason="LinearProjectTrackerAdapter ships in OMN-8816; skip until merged",
+            reason="AdapterLinearProjectTracker ships in OMN-8816; skip until merged",
         )
         from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-            LinearProjectTrackerAdapter,
+            AdapterLinearProjectTracker,
         )
 
         with patch.dict("os.environ", {"LINEAR_API_KEY": "fake-token"}, clear=True):
             tracker = resolve_project_tracker(state_root=tmp_path)
-            assert isinstance(tracker, LinearProjectTrackerAdapter)
+            assert isinstance(tracker, AdapterLinearProjectTracker)

--- a/tests/unit/adapters/test_linear_project_tracker_adapter.py
+++ b/tests/unit/adapters/test_linear_project_tracker_adapter.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for LinearProjectTrackerAdapter.
+"""Tests for AdapterLinearProjectTracker.
 
 Uses callable injection — tests pass fake callables as constructor args
 so no live MCP server is required.
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from omnibase_infra.adapters.project_tracker.linear_project_tracker_adapter import (
-    LinearProjectTrackerAdapter,
+    AdapterLinearProjectTracker,
 )
 from omnibase_infra.adapters.project_tracker.model_stub_comment import ModelStubComment
 from omnibase_infra.adapters.project_tracker.model_stub_issue import ModelStubIssue
@@ -38,13 +38,13 @@ _FAKE_ISSUE = {
 
 
 @pytest.mark.unit
-class TestLinearProjectTrackerAdapterLifecycle:
+class TestAdapterLinearProjectTrackerLifecycle:
     def test_connect_returns_true(self) -> None:
-        adapter = LinearProjectTrackerAdapter()
+        adapter = AdapterLinearProjectTracker()
         assert asyncio.run(adapter.connect()) is True
 
     def test_health_check_healthy_after_connect(self) -> None:
-        adapter = LinearProjectTrackerAdapter()
+        adapter = AdapterLinearProjectTracker()
 
         async def _run() -> None:
             await adapter.connect()
@@ -55,12 +55,12 @@ class TestLinearProjectTrackerAdapterLifecycle:
         asyncio.run(_run())
 
     def test_capabilities_read_write(self) -> None:
-        adapter = LinearProjectTrackerAdapter()
+        adapter = AdapterLinearProjectTracker()
         caps = asyncio.run(adapter.get_capabilities())
         assert "read" in caps and "write" in caps
 
     def test_close_resets_connected(self) -> None:
-        adapter = LinearProjectTrackerAdapter()
+        adapter = AdapterLinearProjectTracker()
 
         async def _run() -> None:
             await adapter.connect()
@@ -72,10 +72,10 @@ class TestLinearProjectTrackerAdapterLifecycle:
 
 
 @pytest.mark.unit
-class TestLinearProjectTrackerAdapterIssues:
+class TestAdapterLinearProjectTrackerIssues:
     def test_get_issue_delegates_to_mcp(self) -> None:
         fake = MagicMock(return_value=_FAKE_ISSUE)
-        adapter = LinearProjectTrackerAdapter(mcp_get_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_get_issue=fake)
 
         async def _run() -> None:
             await adapter.connect()
@@ -95,7 +95,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_get_issue_empty_result_raises_key_error(self) -> None:
         fake = MagicMock(return_value={})
-        adapter = LinearProjectTrackerAdapter(mcp_get_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_get_issue=fake)
 
         async def _run() -> None:
             with pytest.raises(KeyError):
@@ -104,7 +104,7 @@ class TestLinearProjectTrackerAdapterIssues:
         asyncio.run(_run())
 
     def test_get_issue_without_callable_raises(self) -> None:
-        adapter = LinearProjectTrackerAdapter()
+        adapter = AdapterLinearProjectTracker()
 
         async def _run() -> None:
             with pytest.raises(NotImplementedError):
@@ -114,7 +114,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_list_issues_with_filters_and_limit(self) -> None:
         fake = MagicMock(return_value=[_FAKE_ISSUE, _FAKE_ISSUE])
-        adapter = LinearProjectTrackerAdapter(mcp_list_issues=fake)
+        adapter = AdapterLinearProjectTracker(mcp_list_issues=fake)
 
         async def _run() -> None:
             results = await adapter.list_issues(filters={"state": "todo"}, limit=10)
@@ -126,12 +126,12 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_list_issues_non_list_returns_empty(self) -> None:
         fake = MagicMock(return_value=None)
-        adapter = LinearProjectTrackerAdapter(mcp_list_issues=fake)
+        adapter = AdapterLinearProjectTracker(mcp_list_issues=fake)
         assert asyncio.run(adapter.list_issues()) == []
 
     def test_create_issue_forwards_kwargs(self) -> None:
         fake = MagicMock(return_value=_FAKE_ISSUE)
-        adapter = LinearProjectTrackerAdapter(mcp_create_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_create_issue=fake)
 
         async def _run() -> None:
             issue = await adapter.create_issue(
@@ -156,7 +156,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_create_issue_omits_none_kwargs(self) -> None:
         fake = MagicMock(return_value=_FAKE_ISSUE)
-        adapter = LinearProjectTrackerAdapter(mcp_create_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_create_issue=fake)
 
         async def _run() -> None:
             await adapter.create_issue(title="T", description="D")
@@ -166,7 +166,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_update_issue_delegates(self) -> None:
         fake = MagicMock(return_value=_FAKE_ISSUE)
-        adapter = LinearProjectTrackerAdapter(mcp_update_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_update_issue=fake)
 
         async def _run() -> None:
             result = await adapter.update_issue("OMN-9999", {"state": "done"})
@@ -177,7 +177,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_update_issue_missing_raises_key_error(self) -> None:
         fake = MagicMock(return_value={})
-        adapter = LinearProjectTrackerAdapter(mcp_update_issue=fake)
+        adapter = AdapterLinearProjectTracker(mcp_update_issue=fake)
 
         async def _run() -> None:
             with pytest.raises(KeyError):
@@ -187,7 +187,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
     def test_search_issues_delegates(self) -> None:
         fake = MagicMock(return_value=[_FAKE_ISSUE])
-        adapter = LinearProjectTrackerAdapter(mcp_search_issues=fake)
+        adapter = AdapterLinearProjectTracker(mcp_search_issues=fake)
 
         async def _run() -> None:
             results = await adapter.search_issues("auth middleware", limit=5)
@@ -199,7 +199,7 @@ class TestLinearProjectTrackerAdapterIssues:
 
 
 @pytest.mark.unit
-class TestLinearProjectTrackerAdapterComments:
+class TestAdapterLinearProjectTrackerComments:
     def test_add_comment_delegates(self) -> None:
         fake = MagicMock(
             return_value={
@@ -209,7 +209,7 @@ class TestLinearProjectTrackerAdapterComments:
                 "createdAt": "2026-01-01T00:00:00Z",
             }
         )
-        adapter = LinearProjectTrackerAdapter(mcp_add_comment=fake)
+        adapter = AdapterLinearProjectTracker(mcp_add_comment=fake)
 
         async def _run() -> None:
             comment = await adapter.add_comment("abc-123", "hello")
@@ -222,7 +222,7 @@ class TestLinearProjectTrackerAdapterComments:
 
     def test_add_comment_missing_issue_raises_key_error(self) -> None:
         fake = MagicMock(return_value={})
-        adapter = LinearProjectTrackerAdapter(mcp_add_comment=fake)
+        adapter = AdapterLinearProjectTracker(mcp_add_comment=fake)
 
         async def _run() -> None:
             with pytest.raises(KeyError):
@@ -232,7 +232,7 @@ class TestLinearProjectTrackerAdapterComments:
 
 
 @pytest.mark.unit
-class TestLinearProjectTrackerAdapterProjects:
+class TestAdapterLinearProjectTrackerProjects:
     def test_get_project_delegates(self) -> None:
         fake = MagicMock(
             return_value={
@@ -244,7 +244,7 @@ class TestLinearProjectTrackerAdapterProjects:
                 "url": "https://linear.app/p/1",
             }
         )
-        adapter = LinearProjectTrackerAdapter(mcp_get_project=fake)
+        adapter = AdapterLinearProjectTracker(mcp_get_project=fake)
 
         async def _run() -> None:
             project = await adapter.get_project("p-1")
@@ -258,7 +258,7 @@ class TestLinearProjectTrackerAdapterProjects:
 
     def test_get_project_missing_raises_key_error(self) -> None:
         fake = MagicMock(return_value={})
-        adapter = LinearProjectTrackerAdapter(mcp_get_project=fake)
+        adapter = AdapterLinearProjectTracker(mcp_get_project=fake)
 
         async def _run() -> None:
             with pytest.raises(KeyError):
@@ -273,7 +273,7 @@ class TestLinearProjectTrackerAdapterProjects:
                 {"id": "p-2", "name": "B", "progress": 1.0},
             ]
         )
-        adapter = LinearProjectTrackerAdapter(mcp_list_projects=fake)
+        adapter = AdapterLinearProjectTracker(mcp_list_projects=fake)
 
         async def _run() -> None:
             results = await adapter.list_projects(limit=25)


### PR DESCRIPTION
## Summary

- Adds `scripts/validate-pr-contract-sync.sh`: reads `gh pr diff --name-only`, groups changed files by node/skill, fails with a structured message if a handler was changed without its `contract.yaml`, or a skill file without its `SKILL.md`/`contract.yaml`
- Supports `[skip-contract-sync]` exemption token in commit messages (must be accompanied by justification)
- 8 TDD test cases in `tests/scripts/test_validate_pr_contract_sync.py` — written before implementation
- New `contract-sync-gate` CI job wired into Phase 1; blocks `test-parallel` and `ci-summary`

## Rules enforced

| Trigger | Requirement |
|---------|-------------|
| `*/nodes/<node>/handlers/*.py` changed | `*/nodes/<node>/contract.yaml` must also be changed |
| `plugins/onex/skills/<skill>/*.py` or `prompt.md` changed | `<skill>/SKILL.md` or `<skill>/contract.yaml` must also be changed |

## Test plan

- [ ] `test_handler_change_with_contract_change_passes` — PASS
- [ ] `test_handler_change_without_contract_change_fails` — FAIL with node name + contract.yaml in output
- [ ] `test_skill_prompt_change_with_skill_md_passes` — PASS
- [ ] `test_skill_prompt_change_without_skill_md_fails` — FAIL with skill name in output
- [ ] `test_skip_token_in_commit_passes_without_contract` — PASS (bypassed)
- [ ] `test_skill_py_change_without_skill_md_fails` — FAIL
- [ ] `test_unrelated_file_change_passes` — PASS (docs/pyproject.toml unaffected)
- [ ] `test_skill_contract_yaml_alternative_passes` — PASS (contract.yaml accepted as alternative to SKILL.md)

## Pre-existing fixes bundled

- `LinearProjectTrackerAdapter` → `AdapterLinearProjectTracker` (naming convention)
- `KAFKA_REQUEST_TIMEOUT_MS`/`KAFKA_ACKS` fallbacks marked `# kafka-fallback-ok` (non-bootstrap defaults)

Closes OMN-8915 | Parent: OMN-8908