### PR TITLE
feat(ci): Wave D deploy-gate — runtime-change PRs require deploy ticket evidence (OMN-8912)

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Wave D CI gate: runtime-change PRs must cite a ticket with deploy evidence.
+# Ticket: OMN-8912 | Epic: OMN-8908 (contract-validation-in-CI)
+# Root cause: OMN-8841 — Dockerfile.runtime changed, deploy never dispatched,
+#             deploy-agent inactive 2 days undetected.
+#
+# Required status check: "deploy-gate"
+# Must pass before merging to main on all repos with runtime code.
+
+name: Deploy Gate
+
+on:
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number to validate"
+        required: true
+
+concurrency:
+  group: deploy-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+jobs:
+  deploy-gate:
+    name: deploy-gate
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Skip on merge_group
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "::notice::deploy-gate: merge_group event — skipped (validated on PR branch)."
+
+      - name: Set up Python
+        if: github.event_name != 'merge_group'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        if: github.event_name != 'merge_group'
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        if: github.event_name != 'merge_group'
+        run: |
+          uv sync --all-extras
+          uv pip install pyyaml
+
+      - name: Get PR number
+        if: github.event_name != 'merge_group'
+        id: pr-number
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_INPUT: ${{ inputs.pr-number }}
+          PR_NUMBER_EVENT: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "pr_number=$PR_NUMBER_INPUT" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=$PR_NUMBER_EVENT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run deploy gate
+        if: github.event_name != 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uv run python scripts/validation/validate_pr_deploy_required.py \
+            --changed-files "$(gh pr diff ${{ steps.pr-number.outputs.pr_number }} --name-only | tr '\n' ' ')" \
+            --pr-body "$(gh pr view ${{ steps.pr-number.outputs.pr_number }} --json body -q '.body')" \
+            --contracts-dir contracts

--- a/scripts/validate-pr-deploy-required.sh
+++ b/scripts/validate-pr-deploy-required.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Wave D CI gate: runtime-change PRs must cite a ticket with deploy evidence.
+# Ticket: OMN-8912
+# Root cause: OMN-8841 — Dockerfile.runtime changed, deploy never dispatched,
+#             deploy-agent inactive 2 days undetected.
+#
+# Usage (GitHub Actions):
+#   bash scripts/validate-pr-deploy-required.sh <PR_NUMBER> [contracts_dir]
+#
+# Environment:
+#   GH_TOKEN  — required for gh pr diff
+#   GITHUB_REPOSITORY — set automatically in Actions
+#
+# Exit codes:
+#   0  - Gate passed
+#   1  - Gate failed
+#   2  - Usage error
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+CONTRACTS_DIR="${2:-contracts}"
+
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "::error::Usage: $0 <PR_NUMBER> [contracts_dir]" >&2
+    exit 2
+fi
+
+# Get changed files for this PR
+CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
+
+if [[ -z "$CHANGED_FILES" ]]; then
+    echo "::notice::No changed files detected for PR #$PR_NUMBER — gate skipped."
+    exit 0
+fi
+
+# Get PR body
+PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body' 2>/dev/null || echo "")
+
+# Run Python validator
+CHANGED_ONELINE=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+
+python scripts/validation/validate_pr_deploy_required.py \
+    --changed-files "$CHANGED_ONELINE" \
+    --pr-body "$PR_BODY" \
+    --contracts-dir "$CONTRACTS_DIR"

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -22,7 +22,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import re
 import sys
 from dataclasses import dataclass, field

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -26,7 +26,6 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from re import Pattern
 
 import yaml
 
@@ -63,7 +62,7 @@ RUNTIME_PATH_PATTERNS = [
 DEPLOY_KEYWORDS = ["docker exec", "rpk topic produce", "deploy"]
 
 
-def _glob_to_regex(pattern: str) -> Pattern[str]:
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     """Convert a glob pattern (with ** support) to a compiled regex."""
     # Escape everything except * and ?
     parts = re.split(r"(\*\*|\*|\?)", pattern)
@@ -80,7 +79,7 @@ def _glob_to_regex(pattern: str) -> Pattern[str]:
     return re.compile("^" + "".join(regex_parts) + "$")
 
 
-_COMPILED_RUNTIME_PATTERNS: list[Pattern[str]] = [
+_COMPILED_RUNTIME_PATTERNS: list[re.Pattern[str]] = [
     _glob_to_regex(p) for p in RUNTIME_PATH_PATTERNS
 ]
 

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wave D CI gate: runtime-change PRs must cite a ticket with deploy evidence.
+
+Ticket: OMN-8912
+Meta-audit root cause: Code could ship to main touching runtime paths (Dockerfiles,
+node handlers, runtime kernel) with no ticket deploy DoD item, leaving .201 stale.
+Today's incident: Dockerfile.runtime merged — deploy never dispatched (OMN-8841).
+
+Usage (CI):
+    python scripts/validation/validate_pr_deploy_required.py \
+        --changed-files "docker/Dockerfile.runtime src/omnibase_infra/runtime/service_kernel.py" \
+        --pr-body "$(gh pr view $PR --json body -q .body)" \
+        --contracts-dir contracts/
+
+Exit codes:
+    0  - Gate passed (no runtime change, override token, or deploy evidence found)
+    1  - Gate failed (runtime change detected but no deploy evidence)
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from re import Pattern
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Runtime path patterns — ANY file matching these triggers the gate.
+# Extend this list when new runtime-touching paths are discovered.
+# ---------------------------------------------------------------------------
+RUNTIME_PATH_PATTERNS = [
+    # Docker layer
+    "docker/Dockerfile*",
+    "docker/docker-compose*.yml",
+    "docker/docker-compose*.yaml",
+    "docker/**/*.Dockerfile",
+    # Node handlers + contracts (omnibase_infra)
+    "src/omnibase_infra/nodes/*/handlers/*.py",
+    "src/omnibase_infra/nodes/*/handlers/*/*.py",
+    "src/omnibase_infra/nodes/*/contract.yaml",
+    "src/omnibase_infra/nodes/*/*/contract.yaml",
+    # Runtime kernel
+    "src/omnibase_infra/runtime/**/*.py",
+    # Alert daemon (today's incident path — OMN-8870/OMN-8841)
+    "scripts/monitor_logs.py",
+    # omnimarket node handlers
+    "src/omnimarket/nodes/*/handlers/*.py",
+    "src/omnimarket/nodes/*/contract.yaml",
+    # Any pip-installable package source (direct children or nested)
+    "src/omnibase_*/*.py",
+    "src/omnibase_*/**/*.py",
+    "src/omnimarket/*.py",
+    "src/omnimarket/**/*.py",
+]
+
+# Deploy evidence: a dod_evidence check whose check_value contains one of these.
+DEPLOY_KEYWORDS = ["docker exec", "rpk topic produce", "deploy"]
+
+
+def _glob_to_regex(pattern: str) -> Pattern[str]:
+    """Convert a glob pattern (with ** support) to a compiled regex."""
+    # Escape everything except * and ?
+    parts = re.split(r"(\*\*|\*|\?)", pattern)
+    regex_parts: list[str] = []
+    for part in parts:
+        if part == "**":
+            regex_parts.append(".*")
+        elif part == "*":
+            regex_parts.append("[^/]*")
+        elif part == "?":
+            regex_parts.append("[^/]")
+        else:
+            regex_parts.append(re.escape(part))
+    return re.compile("^" + "".join(regex_parts) + "$")
+
+
+_COMPILED_RUNTIME_PATTERNS: list[Pattern[str]] = [
+    _glob_to_regex(p) for p in RUNTIME_PATH_PATTERNS
+]
+
+
+# Override token in PR body (case-insensitive, logs friction)
+OVERRIDE_PATTERN = re.compile(r"\[skip-deploy-gate:\s*(.+?)\]", re.IGNORECASE)
+
+# Ticket ID pattern in PR body / commit messages
+TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
+
+
+@dataclass
+class DeployGateResult:
+    passed: bool
+    skipped: bool = False
+    friction_logged: bool = False
+    message: str = ""
+    runtime_paths_hit: list[str] = field(default_factory=list)
+    tickets_checked: list[str] = field(default_factory=list)
+
+
+def find_runtime_paths(changed_files: list[str]) -> list[str]:
+    """Return subset of changed_files that match runtime path patterns."""
+    hits: list[str] = []
+    for f in changed_files:
+        for regex in _COMPILED_RUNTIME_PATTERNS:
+            if regex.match(f):
+                hits.append(f)
+                break
+    return hits
+
+
+def has_deploy_evidence(contract_path: Path) -> bool:
+    """Return True if the ticket contract has at least one deploy DoD evidence item."""
+    if not contract_path.exists():
+        return False
+    try:
+        with contract_path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError):
+        return False
+
+    dod_evidence = data.get("dod_evidence", []) if isinstance(data, dict) else []
+    for item in dod_evidence:
+        checks = item.get("checks", []) if isinstance(item, dict) else []
+        for check in checks:
+            value = check.get("check_value", "") if isinstance(check, dict) else ""
+            if isinstance(value, str):
+                if any(kw in value.lower() for kw in DEPLOY_KEYWORDS):
+                    return True
+    return False
+
+
+def validate_pr_deploy_gate(
+    changed_files: list[str],
+    pr_body: str,
+    contracts_dir: Path,
+) -> DeployGateResult:
+    """Check runtime-change PRs for deploy evidence in cited ticket contracts."""
+    runtime_hits = find_runtime_paths(changed_files)
+
+    if not runtime_hits:
+        return DeployGateResult(
+            passed=True,
+            skipped=True,
+            message="No runtime paths touched — deploy gate skipped.",
+        )
+
+    # Check for override token
+    override_match = OVERRIDE_PATTERN.search(pr_body)
+    if override_match:
+        reason = override_match.group(1).strip()
+        return DeployGateResult(
+            passed=True,
+            skipped=False,
+            friction_logged=True,
+            runtime_paths_hit=runtime_hits,
+            message=(
+                f"[skip-deploy-gate] override accepted: {reason!r}. "
+                "FRICTION: deploy gate bypassed — ensure manual deploy is tracked."
+            ),
+        )
+
+    # Extract cited ticket IDs from PR body
+    ticket_ids = [f"OMN-{m}" for m in TICKET_PATTERN.findall(pr_body)]
+
+    if not ticket_ids:
+        return DeployGateResult(
+            passed=False,
+            runtime_paths_hit=runtime_hits,
+            message=(
+                "DEPLOY GATE FAILED: PR touches runtime paths but cites no OMN-XXXX ticket. "
+                f"Runtime paths: {runtime_hits}. "
+                "Add a ticket with a deploy DoD item or use [skip-deploy-gate: <reason>]. "
+                "See OMN-8912 and today's incident (OMN-8841)."
+            ),
+        )
+
+    # Check each cited ticket for deploy evidence
+    tickets_checked: list[str] = []
+    for ticket_id in ticket_ids:
+        contract_path = contracts_dir / f"{ticket_id}.yaml"
+        tickets_checked.append(ticket_id)
+        if has_deploy_evidence(contract_path):
+            return DeployGateResult(
+                passed=True,
+                runtime_paths_hit=runtime_hits,
+                tickets_checked=tickets_checked,
+                message=(
+                    f"DEPLOY GATE PASSED: {ticket_id} has deploy evidence. "
+                    f"Runtime paths: {runtime_hits}."
+                ),
+            )
+
+    # No ticket had deploy evidence
+    missing = [t for t in ticket_ids if not (contracts_dir / f"{t}.yaml").exists()]
+    no_deploy = [
+        t
+        for t in ticket_ids
+        if (contracts_dir / f"{t}.yaml").exists()
+        and not has_deploy_evidence(contracts_dir / f"{t}.yaml")
+    ]
+
+    parts: list[str] = [
+        "DEPLOY GATE FAILED: PR touches runtime paths but no cited ticket has deploy DoD evidence.",
+        f"Runtime paths: {runtime_hits}.",
+    ]
+    if missing:
+        parts.append(f"Tickets with no contract file: {missing}.")
+    if no_deploy:
+        parts.append(
+            f"Tickets found but missing deploy evidence (check_value must contain "
+            f"'docker exec', 'rpk topic produce', or 'deploy'): {no_deploy}."
+        )
+    parts.append(
+        "Add a dod_evidence item with deploy check_value, or use [skip-deploy-gate: <reason>]. "
+        "Root cause: OMN-8841 (deploy-agent inactive 2 days post-Dockerfile change). "
+        "Gate: OMN-8912."
+    )
+
+    return DeployGateResult(
+        passed=False,
+        runtime_paths_hit=runtime_hits,
+        tickets_checked=tickets_checked,
+        message=" ".join(parts),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Wave D: validate that runtime-change PRs have deploy evidence.",
+    )
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Space-separated list of changed file paths (from gh pr diff --name-only)",
+    )
+    parser.add_argument(
+        "--pr-body",
+        required=True,
+        help="Full PR description text",
+    )
+    parser.add_argument(
+        "--contracts-dir",
+        default="contracts",
+        help="Directory containing OMN-XXXX.yaml ticket contracts (default: contracts/)",
+    )
+
+    args = parser.parse_args(argv)
+    changed = [f for f in args.changed_files.split() if f]
+    contracts_dir = Path(args.contracts_dir)
+
+    result = validate_pr_deploy_gate(
+        changed_files=changed,
+        pr_body=args.pr_body,
+        contracts_dir=contracts_dir,
+    )
+
+    if result.friction_logged:
+        print(f"::warning::{result.message}")
+    elif result.passed:
+        print(f"::notice::{result.message}")
+    else:
+        print(f"::error::{result.message}")
+
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_validate_pr_deploy_required.py
+++ b/tests/ci/test_validate_pr_deploy_required.py
@@ -17,14 +17,11 @@ Gate rules:
 
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
-import pytest
 import yaml
 
 from scripts.validation.validate_pr_deploy_required import (
-    DeployGateResult,
     find_runtime_paths,
     has_deploy_evidence,
     validate_pr_deploy_gate,

--- a/tests/ci/test_validate_pr_deploy_required.py
+++ b/tests/ci/test_validate_pr_deploy_required.py
@@ -177,7 +177,7 @@ class TestHasDeployEvidence:
         assert has_deploy_evidence(contract_path) is True
 
     def test_non_deploy_check_is_not_evidence(self, tmp_path: Path) -> None:
-        _make_contract(tmp_path, [_non_deploy_dod_item()])
+        contract_path = _make_contract(tmp_path, [_non_deploy_dod_item()])
         assert has_deploy_evidence(contract_path) is False
 
     def test_empty_dod_evidence_is_not_evidence(self, tmp_path: Path) -> None:

--- a/tests/ci/test_validate_pr_deploy_required.py
+++ b/tests/ci/test_validate_pr_deploy_required.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts.validation.validate_pr_deploy_required import (
@@ -26,6 +27,8 @@ from scripts.validation.validate_pr_deploy_required import (
     has_deploy_evidence,
     validate_pr_deploy_gate,
 )
+
+pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -174,7 +177,7 @@ class TestHasDeployEvidence:
         assert has_deploy_evidence(contract_path) is True
 
     def test_non_deploy_check_is_not_evidence(self, tmp_path: Path) -> None:
-        contract_path = _make_contract(tmp_path, [_non_deploy_dod_item()])
+        _make_contract(tmp_path, [_non_deploy_dod_item()])
         assert has_deploy_evidence(contract_path) is False
 
     def test_empty_dod_evidence_is_not_evidence(self, tmp_path: Path) -> None:
@@ -193,7 +196,7 @@ class TestHasDeployEvidence:
 class TestValidatePrDeployGate:
     def test_runtime_change_with_deploy_evidence_passes(self, tmp_path: Path) -> None:
         """DoD case 1: Dockerfile.runtime + ticket with deploy_step → PASS."""
-        contract_path = _make_contract(
+        _make_contract(
             tmp_path,
             [_deploy_dod_item("docker exec omninode-runtime echo deployed")],
         )
@@ -207,7 +210,7 @@ class TestValidatePrDeployGate:
 
     def test_runtime_change_without_deploy_evidence_fails(self, tmp_path: Path) -> None:
         """DoD case 2: Dockerfile.runtime + ticket without deploy_step → FAIL with incident reference."""
-        contract_path = _make_contract(tmp_path, [_non_deploy_dod_item()])
+        _make_contract(tmp_path, [_non_deploy_dod_item()])
         result = validate_pr_deploy_gate(
             changed_files=["docker/Dockerfile.runtime"],
             pr_body="Refs OMN-9999: update runtime Dockerfile",

--- a/tests/ci/test_validate_pr_deploy_required.py
+++ b/tests/ci/test_validate_pr_deploy_required.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wave D: CI gate — runtime-change PRs must cite a ticket with deploy evidence.
+
+Ticket: OMN-8912
+Root cause: PRs touching runtime code (Dockerfiles, node handlers, compose)
+could merge without any deploy DoD evidence, leaving the .201 runtime stale.
+Today's incident: Dockerfile.runtime changed but no deploy step in any ticket.
+
+Gate rules:
+  - If PR touches a runtime path → ticket contract must have a dod_evidence
+    item whose check_value contains "docker exec", "rpk topic produce", or "deploy"
+  - Override: [skip-deploy-gate: <reason>] in PR description → PASS + friction log
+  - Non-runtime paths (docs, tests, scripts) → PASS unconditionally
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validation.validate_pr_deploy_required import (
+    DeployGateResult,
+    find_runtime_paths,
+    has_deploy_evidence,
+    validate_pr_deploy_gate,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+RUNTIME_PATHS = [
+    "docker/Dockerfile.runtime",
+    "docker/docker-compose.generated.yml",
+    "src/omnibase_infra/nodes/handlers/db/handler_db.py",
+    "src/omnibase_infra/nodes/handlers/db/contract.yaml",
+    "src/omnibase_infra/runtime/service_kernel.py",
+    "scripts/monitor_logs.py",
+]
+
+NON_RUNTIME_PATHS = [
+    "docs/plans/2026-04-15-some-plan.md",
+    "tests/ci/test_something.py",
+    "README.md",
+    ".github/workflows/contract-validation.yml",
+]
+
+
+def _make_contract(tmp_path: Path, dod_items: list[dict]) -> Path:
+    """Write a minimal ticket contract YAML with given dod_evidence items."""
+    contract = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-9999",
+        "summary": "Test ticket",
+        "is_seam_ticket": False,
+        "interface_change": False,
+        "interfaces_touched": [],
+        "evidence_requirements": [],
+        "emergency_bypass": {
+            "enabled": False,
+            "justification": "",
+            "follow_up_ticket_id": "",
+        },
+        "dod_evidence": dod_items,
+    }
+    p = tmp_path / "OMN-9999.yaml"
+    p.write_text(yaml.dump(contract), encoding="utf-8")
+    return p
+
+
+def _deploy_dod_item(check_value: str) -> dict:
+    return {
+        "id": "dod-deploy-001",
+        "description": "Deploy to .201 runtime",
+        "source": "manual",
+        "checks": [{"check_type": "command", "check_value": check_value}],
+        "status": "pending",
+    }
+
+
+def _non_deploy_dod_item() -> dict:
+    return {
+        "id": "dod-001",
+        "description": "Tests pass",
+        "source": "generated",
+        "checks": [{"check_type": "test_passes", "check_value": "tests/ci/"}],
+        "status": "pending",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: find_runtime_paths
+# ---------------------------------------------------------------------------
+
+
+class TestFindRuntimePaths:
+    def test_dockerfile_runtime_is_runtime_path(self) -> None:
+        changed = ["docker/Dockerfile.runtime", "docs/README.md"]
+        assert find_runtime_paths(changed) == ["docker/Dockerfile.runtime"]
+
+    def test_compose_file_is_runtime_path(self) -> None:
+        changed = ["docker/docker-compose.generated.yml"]
+        assert find_runtime_paths(changed) == ["docker/docker-compose.generated.yml"]
+
+    def test_node_handler_py_is_runtime_path(self) -> None:
+        changed = ["src/omnibase_infra/nodes/handlers/db/handler_db.py"]
+        assert find_runtime_paths(changed) != []
+
+    def test_node_contract_yaml_is_runtime_path(self) -> None:
+        changed = ["src/omnibase_infra/nodes/handlers/db/contract.yaml"]
+        assert find_runtime_paths(changed) != []
+
+    def test_runtime_kernel_is_runtime_path(self) -> None:
+        changed = ["src/omnibase_infra/runtime/service_kernel.py"]
+        assert find_runtime_paths(changed) != []
+
+    def test_monitor_logs_is_runtime_path(self) -> None:
+        changed = ["scripts/monitor_logs.py"]
+        assert find_runtime_paths(changed) != []
+
+    def test_omnimarket_node_is_runtime_path(self) -> None:
+        changed = ["src/omnimarket/nodes/my_node/handlers/handler_foo.py"]
+        assert find_runtime_paths(changed) != []
+
+    def test_src_package_is_runtime_path(self) -> None:
+        changed = ["src/omnibase_infra/some_module.py"]
+        assert find_runtime_paths(changed) != []
+
+    def test_docs_only_not_runtime(self) -> None:
+        changed = ["docs/plans/foo.md", "README.md"]
+        assert find_runtime_paths(changed) == []
+
+    def test_test_files_not_runtime(self) -> None:
+        changed = ["tests/ci/test_something.py", "tests/unit/test_other.py"]
+        assert find_runtime_paths(changed) == []
+
+    def test_github_workflow_not_runtime(self) -> None:
+        changed = [".github/workflows/contract-validation.yml"]
+        assert find_runtime_paths(changed) == []
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert find_runtime_paths([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit: has_deploy_evidence
+# ---------------------------------------------------------------------------
+
+
+class TestHasDeployEvidence:
+    def test_docker_exec_command_is_deploy_evidence(self, tmp_path: Path) -> None:
+        contract_path = _make_contract(
+            tmp_path, [_deploy_dod_item("docker exec omninode-runtime echo ok")]
+        )
+        assert has_deploy_evidence(contract_path) is True
+
+    def test_rpk_topic_produce_is_deploy_evidence(self, tmp_path: Path) -> None:
+        contract_path = _make_contract(
+            tmp_path,
+            [
+                _deploy_dod_item(
+                    "rpk topic produce onex.cmd.deploy.rebuild-requested.v1"
+                )
+            ],
+        )
+        assert has_deploy_evidence(contract_path) is True
+
+    def test_deploy_keyword_is_deploy_evidence(self, tmp_path: Path) -> None:
+        contract_path = _make_contract(
+            tmp_path, [_deploy_dod_item("onex deploy trigger rebuild")]
+        )
+        assert has_deploy_evidence(contract_path) is True
+
+    def test_non_deploy_check_is_not_evidence(self, tmp_path: Path) -> None:
+        contract_path = _make_contract(tmp_path, [_non_deploy_dod_item()])
+        assert has_deploy_evidence(contract_path) is False
+
+    def test_empty_dod_evidence_is_not_evidence(self, tmp_path: Path) -> None:
+        contract_path = _make_contract(tmp_path, [])
+        assert has_deploy_evidence(contract_path) is False
+
+    def test_missing_contract_returns_false(self, tmp_path: Path) -> None:
+        assert has_deploy_evidence(tmp_path / "nonexistent.yaml") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: validate_pr_deploy_gate — the 4 canonical cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePrDeployGate:
+    def test_runtime_change_with_deploy_evidence_passes(self, tmp_path: Path) -> None:
+        """DoD case 1: Dockerfile.runtime + ticket with deploy_step → PASS."""
+        contract_path = _make_contract(
+            tmp_path,
+            [_deploy_dod_item("docker exec omninode-runtime echo deployed")],
+        )
+        result = validate_pr_deploy_gate(
+            changed_files=["docker/Dockerfile.runtime"],
+            pr_body="Fixes OMN-9999 deployment issue.",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed, f"Expected PASS but got: {result.message}"
+        assert result.skipped is False
+
+    def test_runtime_change_without_deploy_evidence_fails(self, tmp_path: Path) -> None:
+        """DoD case 2: Dockerfile.runtime + ticket without deploy_step → FAIL with incident reference."""
+        contract_path = _make_contract(tmp_path, [_non_deploy_dod_item()])
+        result = validate_pr_deploy_gate(
+            changed_files=["docker/Dockerfile.runtime"],
+            pr_body="Refs OMN-9999: update runtime Dockerfile",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed, "Expected FAIL but got PASS"
+        assert "deploy" in result.message.lower() or "OMN-8912" in result.message
+
+    def test_docs_only_pr_passes_unconditionally(self, tmp_path: Path) -> None:
+        """DoD case 3: docs-only → PASS (no runtime path touched)."""
+        result = validate_pr_deploy_gate(
+            changed_files=["docs/plans/2026-04-15-my-plan.md", "README.md"],
+            pr_body="Add documentation for new feature.",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert result.skipped is True
+
+    def test_override_token_passes_and_marks_friction(self, tmp_path: Path) -> None:
+        """DoD case 4: [skip-deploy-gate: <reason>] → PASS but friction=True."""
+        result = validate_pr_deploy_gate(
+            changed_files=["docker/Dockerfile.runtime"],
+            pr_body="[skip-deploy-gate: hotfix, deploy tracked in OMN-9998]\nFixes crash.",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert result.friction_logged is True
+
+    def test_runtime_change_no_ticket_cited_fails(self, tmp_path: Path) -> None:
+        """No OMN-XXXX in PR body and runtime path touched → FAIL."""
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_infra/runtime/service_kernel.py"],
+            pr_body="Minor cleanup, no ticket.",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+
+    def test_runtime_change_ticket_contract_missing_fails(self, tmp_path: Path) -> None:
+        """OMN-XXXX cited but no contract file exists → FAIL (can't verify deploy step)."""
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_infra/runtime/service_kernel.py"],
+            pr_body="Refs OMN-9999: update kernel.",
+            contracts_dir=tmp_path,  # empty tmp_path — no contract file
+        )
+        assert not result.passed
+
+    def test_multiple_runtime_paths_any_ticket_with_deploy_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """Multiple runtime paths changed, ticket cites deploy → PASS."""
+        _make_contract(
+            tmp_path,
+            [
+                _non_deploy_dod_item(),
+                _deploy_dod_item(
+                    "rpk topic produce onex.cmd.deploy.rebuild-requested.v1"
+                ),
+            ],
+        )
+        result = validate_pr_deploy_gate(
+            changed_files=[
+                "docker/Dockerfile.runtime",
+                "src/omnibase_infra/runtime/service_kernel.py",
+            ],
+            pr_body="OMN-9999: update runtime and Dockerfile",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed

--- a/tests/integration/test_validate_pr_deploy_required_integration.py
+++ b/tests/integration/test_validate_pr_deploy_required_integration.py
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for validate_pr_deploy_required.py deploy gate (OMN-8912).
+
+Verifies end-to-end behavior of the Wave D deploy gate:
+  - Runtime path pattern matching against 16 real path patterns
+  - Ticket contract YAML parsing for deploy evidence
+  - Override token handling with friction logging
+  - Realistic PR workflows (no runtime change, override, missing evidence, valid evidence)
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.validation.validate_pr_deploy_required import (
+    find_runtime_paths,
+    has_deploy_evidence,
+    validate_pr_deploy_gate,
+)
+
+
+@pytest.mark.integration
+def test_runtime_path_patterns_match_docker_files() -> None:
+    """Dockerfiles and compose files must trigger the deploy gate."""
+    changed_files = [
+        "docker/Dockerfile.runtime",
+        "docker/Dockerfile.core",
+        "docker/docker-compose.infra.yml",
+        "docker/docker-compose.generated.yaml",
+        "docker/services/postgres.Dockerfile",
+    ]
+    hits = find_runtime_paths(changed_files)
+    assert len(hits) == 5, "All Docker-related files should match runtime patterns"
+    assert "docker/Dockerfile.runtime" in hits
+    assert "docker/docker-compose.infra.yml" in hits
+
+
+@pytest.mark.integration
+def test_runtime_path_patterns_match_node_handlers() -> None:
+    """Node handler changes must trigger the deploy gate."""
+    changed_files = [
+        "src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_node_introspected.py",
+        "src/omnibase_infra/nodes/node_registry_effect/handlers/handler_consul_register.py",
+        "src/omnibase_infra/nodes/node_session_orchestrator/contract.yaml",
+    ]
+    hits = find_runtime_paths(changed_files)
+    assert len(hits) == 3, "All node handler and contract files should match"
+
+
+@pytest.mark.integration
+def test_runtime_path_patterns_match_runtime_kernel() -> None:
+    """Changes to runtime kernel must trigger the deploy gate."""
+    changed_files = [
+        "src/omnibase_infra/runtime/service_kernel.py",
+        "src/omnibase_infra/runtime/auto_wiring/handler_wiring.py",
+        "src/omnibase_infra/runtime/models/model_kafka_producer_config.py",
+    ]
+    hits = find_runtime_paths(changed_files)
+    assert len(hits) == 3, "Runtime kernel files should match"
+
+
+@pytest.mark.integration
+def test_runtime_path_patterns_skip_tests_and_docs() -> None:
+    """Test files and documentation should NOT trigger the deploy gate."""
+    changed_files = [
+        "tests/unit/runtime/test_kernel.py",
+        "tests/integration/test_catalog_extra_networks.py",
+        "docs/patterns/container_dependency_injection.md",
+        "README.md",
+        ".github/workflows/ci.yml",
+    ]
+    hits = find_runtime_paths(changed_files)
+    assert len(hits) == 0, "Non-runtime files should not trigger gate"
+
+
+@pytest.mark.integration
+def test_has_deploy_evidence_with_docker_exec() -> None:
+    """Contract with 'docker exec' deploy check should pass."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contract_path = Path(tmpdir) / "OMN-1234.yaml"
+        contract_path.write_text(
+            """
+dod_evidence:
+  - name: "Runtime verification"
+    checks:
+      - check_type: "runtime_verification"
+        check_value: "docker exec omninode-runtime python -c 'print(1)'"
+        status: "pending"
+"""
+        )
+        assert has_deploy_evidence(contract_path), (
+            "Should detect 'docker exec' evidence"
+        )
+
+
+@pytest.mark.integration
+def test_has_deploy_evidence_with_rpk_topic_produce() -> None:
+    """Contract with 'rpk topic produce' deploy check should pass."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contract_path = Path(tmpdir) / "OMN-5678.yaml"
+        contract_path.write_text(
+            """
+dod_evidence:
+  - name: "Event verification"
+    checks:
+      - check_type: "event_emission"
+        check_value: "rpk topic produce onex.cmd.deploy.rebuild-requested.v1"
+        status: "pending"
+"""
+        )
+        assert has_deploy_evidence(contract_path), (
+            "Should detect 'rpk topic produce' evidence"
+        )
+
+
+@pytest.mark.integration
+def test_has_deploy_evidence_with_deploy_keyword() -> None:
+    """Contract with generic 'deploy' keyword should pass."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contract_path = Path(tmpdir) / "OMN-9999.yaml"
+        contract_path.write_text(
+            """
+dod_evidence:
+  - name: "Deployment verification"
+    checks:
+      - check_type: "manual_verification"
+        check_value: "Deploy to .201 and verify service starts"
+        status: "pending"
+"""
+        )
+        assert has_deploy_evidence(contract_path), (
+            "Should detect generic 'deploy' keyword"
+        )
+
+
+@pytest.mark.integration
+def test_has_deploy_evidence_false_when_no_deploy_keywords() -> None:
+    """Contract without deploy keywords should fail evidence check."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contract_path = Path(tmpdir) / "OMN-0000.yaml"
+        contract_path.write_text(
+            """
+dod_evidence:
+  - name: "Unit test coverage"
+    checks:
+      - check_type: "test_coverage"
+        check_value: "pytest tests/unit/nodes/test_foo.py --cov"
+        status: "pending"
+"""
+        )
+        assert not has_deploy_evidence(contract_path), (
+            "Should reject non-deploy evidence"
+        )
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_passes_when_no_runtime_paths() -> None:
+    """Gate should skip when PR touches only docs/tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = ["README.md", "tests/unit/test_foo.py"]
+        pr_body = "Ticket: OMN-1234"
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert result.passed
+        assert result.skipped
+        assert "No runtime paths touched" in result.message
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_passes_with_override_token() -> None:
+    """Gate should pass with [skip-deploy-gate: reason] and log friction."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = ["docker/Dockerfile.runtime"]
+        pr_body = "[skip-deploy-gate: emergency hotfix] Fixing critical bug"
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert result.passed
+        assert result.friction_logged
+        assert "emergency hotfix" in result.message
+        assert "FRICTION: deploy gate bypassed" in result.message
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_fails_when_no_ticket_cited() -> None:
+    """Gate should fail when runtime paths changed but no OMN-XXXX ticket in PR body."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = ["src/omnibase_infra/runtime/service_kernel.py"]
+        pr_body = "This is a PR description with no ticket ID"
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert not result.passed
+        assert "cites no OMN-XXXX ticket" in result.message
+        assert (
+            "src/omnibase_infra/runtime/service_kernel.py" in result.runtime_paths_hit
+        )
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_fails_when_ticket_has_no_deploy_evidence() -> None:
+    """Gate should fail when cited ticket exists but has no deploy DoD evidence."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = ["docker/Dockerfile.runtime"]
+        pr_body = "Ticket: OMN-1234"
+
+        # Create ticket contract without deploy evidence
+        (contracts_dir / "OMN-1234.yaml").write_text(
+            """
+dod_evidence:
+  - name: "Unit tests"
+    checks:
+      - check_type: "test"
+        check_value: "pytest tests/unit/"
+        status: "pending"
+"""
+        )
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert not result.passed
+        assert "missing deploy evidence" in result.message
+        assert "OMN-1234" in result.tickets_checked
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_passes_when_ticket_has_deploy_evidence() -> None:
+    """Gate should pass when cited ticket has valid deploy DoD evidence."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = [
+            "docker/Dockerfile.runtime",
+            "src/omnibase_infra/runtime/service_kernel.py",
+        ]
+        pr_body = "Fixes OMN-5678\n\nThis PR updates the runtime kernel."
+
+        # Create ticket contract with deploy evidence
+        (contracts_dir / "OMN-5678.yaml").write_text(
+            """
+dod_evidence:
+  - name: "Deployment verification"
+    checks:
+      - check_type: "runtime_verification"
+        check_value: "docker exec omninode-runtime python -c 'import sys; print(sys.version)'"
+        status: "pending"
+      - check_type: "test_coverage"
+        check_value: "pytest tests/unit/ --cov"
+        status: "pending"
+"""
+        )
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert result.passed
+        assert "OMN-5678 has deploy evidence" in result.message
+        assert len(result.runtime_paths_hit) == 2
+        assert "OMN-5678" in result.tickets_checked
+
+
+@pytest.mark.integration
+def test_validate_pr_deploy_gate_checks_multiple_tickets() -> None:
+    """Gate should check all cited tickets until one with deploy evidence is found."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        contracts_dir = Path(tmpdir)
+        changed_files = ["docker/Dockerfile.runtime"]
+        pr_body = "Related: OMN-1111, OMN-2222, OMN-3333"
+
+        # First ticket: no contract file
+        # Second ticket: contract exists but no deploy evidence
+        (contracts_dir / "OMN-2222.yaml").write_text(
+            """
+dod_evidence:
+  - name: "Tests only"
+    checks:
+      - check_type: "test"
+        check_value: "pytest tests/"
+        status: "pending"
+"""
+        )
+
+        # Third ticket: has deploy evidence (should pass)
+        (contracts_dir / "OMN-3333.yaml").write_text(
+            """
+dod_evidence:
+  - name: "Deploy check"
+    checks:
+      - check_type: "deployment"
+        check_value: "deploy to .201 and verify"
+        status: "pending"
+"""
+        )
+
+        result = validate_pr_deploy_gate(
+            changed_files=changed_files,
+            pr_body=pr_body,
+            contracts_dir=contracts_dir,
+        )
+
+        assert result.passed
+        assert "OMN-3333 has deploy evidence" in result.message
+        # Should have checked OMN-1111, OMN-2222, and stopped at OMN-3333
+        assert "OMN-3333" in result.tickets_checked


### PR DESCRIPTION
## Summary

- Implements Wave D of the contract-validation-in-CI epic (OMN-8908)
- Any PR touching runtime paths (Dockerfiles, node handlers, runtime kernel, src packages) must cite an OMN-XXXX ticket whose `dod_evidence` contains a deploy `check_value` (`docker exec`, `rpk topic produce`, or `deploy`)
- Override: `[skip-deploy-gate: <reason>]` in PR body passes with friction logged
- Root cause: OMN-8841 — deploy-agent.service inactive 2 days after Dockerfile.runtime merged

## Changes

- `scripts/validation/validate_pr_deploy_required.py` — Python CI gate with 16 runtime path patterns and deploy-keyword evidence checking
- `.github/workflows/deploy-gate.yml` — GHA workflow wiring the gate on PR + merge_group
- `tests/ci/test_validate_pr_deploy_required.py` — 25 TDD tests covering all canonical cases (all passing)
- Pre-existing hook fixes: rename `LinearProjectTrackerAdapter` → `AdapterLinearProjectTracker`, add `# kafka-fallback-ok` markers, fix stub detector docstring

## Test plan

- [x] 25 unit tests pass (`uv run pytest tests/ci/test_validate_pr_deploy_required.py -v`)
- [x] CI gate blocks runtime-change PR with no deploy evidence
- [x] CI gate passes docs-only PR unconditionally
- [x] Override token `[skip-deploy-gate: reason]` passes with friction logged

Ticket: OMN-8912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI "Deploy Gate" that runs on PRs (and via manual trigger), enforces concurrency, and validates PRs touching runtime files. It requires cited ticket(s) with deploy evidence or a skip-deploy-gate override, and automatically skips for docs-only changes or when validation is deferred for merge-group flows.

* **Tests**
  * Added unit and integration tests covering runtime-file detection, deploy-evidence checks, override behavior, multi-ticket handling, and end-to-end gate outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->