### PR TITLE
feat(ci): Wave G-companion — auto-trigger rebuild on runtime_change PR merge [OMN-8917]

### DIFF
--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# runtime-rebuild-trigger.yml
+#
+# Triggers a deploy-agent rebuild when a PR that touches runtime code merges
+# to main. Closes the 6-day deploy gap (OMN-7963 / pr_review_bot failure class).
+#
+# Trigger conditions (evaluated by scripts/trigger_rebuild_on_merge.py):
+#   - PR had the "runtime_change" label, OR
+#   - Any changed file matches src/omnimarket/** or src/omnibase_infra/nodes/**
+#
+# Ticket: OMN-8917
+#
+# Required GitHub Secrets:
+#   KAFKA_BOOTSTRAP_SERVERS    -- e.g. pkc-xxx.us-east-1.aws.confluent.cloud:9092
+#   KAFKA_SASL_USERNAME        -- Confluent Cloud API key (or SASL username)
+#   KAFKA_SASL_PASSWORD        -- Confluent Cloud API secret (or SASL password)
+#   DEPLOY_AGENT_HMAC_SECRET   -- HMAC secret for signing rebuild commands
+
+name: Runtime Rebuild Trigger
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  trigger-rebuild:
+    name: Trigger Deploy Agent Rebuild
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: ","
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install --quiet confluent-kafka click
+
+      - name: Trigger rebuild if runtime change detected
+        # All potentially attacker-controlled inputs (labels, head_ref) are
+        # passed through environment variables to prevent shell injection.
+        env:
+          KAFKA_BOOTSTRAP_SERVERS: ${{ secrets.KAFKA_BOOTSTRAP_SERVERS }}
+          KAFKA_SASL_USERNAME: ${{ secrets.KAFKA_SASL_USERNAME }}
+          KAFKA_SASL_PASSWORD: ${{ secrets.KAFKA_SASL_PASSWORD }}
+          DEPLOY_AGENT_HMAC_SECRET: ${{ secrets.DEPLOY_AGENT_HMAC_SECRET }}
+          PR_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python scripts/trigger_rebuild_on_merge.py \
+            --changed-files "$PR_CHANGED_FILES" \
+            --labels "$PR_LABELS" \
+            --git-ref "origin/main" \
+            --requested-by "gha/omnibase_infra/pr-$PR_NUMBER"

--- a/scripts/trigger_rebuild_on_merge.py
+++ b/scripts/trigger_rebuild_on_merge.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# trigger_rebuild_on_merge.py
+#
+# Publishes onex.cmd.deploy.rebuild-requested.v1 when a merged PR contains
+# runtime changes. Called from the runtime-rebuild-trigger GHA workflow on
+# push to main.
+#
+# Triggers when:
+#   - PR had the "runtime_change" label, OR
+#   - Any changed file matches src/omnimarket/** or src/omnibase_infra/nodes/**
+#
+# Ticket: OMN-8917
+#
+# Required environment variables (when not --dry-run):
+#   KAFKA_BOOTSTRAP_SERVERS   -- broker address(es), e.g. host:9092
+#   KAFKA_SASL_USERNAME       -- SASL username / API key
+#   KAFKA_SASL_PASSWORD       -- SASL password / API secret
+#   DEPLOY_AGENT_HMAC_SECRET  -- HMAC secret for payload signing
+#
+# Usage:
+#   python scripts/trigger_rebuild_on_merge.py \
+#     --changed-files "src/omnimarket/nodes/foo/handler.py,README.md" \
+#     --labels "runtime_change,bug" \
+#     --git-ref "origin/main" \
+#     [--dry-run]
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import hmac
+import json
+import os
+import sys
+import uuid
+from datetime import UTC, datetime
+
+import click
+
+TOPIC = "onex.cmd.deploy.rebuild-requested.v1"
+
+_RUNTIME_PATH_PATTERNS = [
+    "src/omnimarket/*",
+    "src/omnibase_infra/nodes/*",
+]
+
+_RUNTIME_LABEL = "runtime_change"
+
+
+def should_trigger(changed_files: list[str], labels: list[str]) -> bool:
+    """Return True if a rebuild should be triggered."""
+    if _RUNTIME_LABEL in labels:
+        return True
+    for f in changed_files:
+        for pattern in _RUNTIME_PATH_PATTERNS:
+            if fnmatch.fnmatch(f, pattern) or f.startswith(pattern.rstrip("*")):
+                return True
+    return False
+
+
+def _sign_envelope(envelope: dict, secret: str) -> dict:
+    body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {**envelope, "_signature": signature}
+
+
+def publish_rebuild_event(
+    bootstrap_servers: str,
+    username: str,
+    password: str,
+    hmac_secret: str,
+    git_ref: str,
+    correlation_id: str,
+    requested_by: str,
+) -> None:
+    """Publish a signed rebuild-requested event to Kafka via SASL_SSL."""
+    from confluent_kafka import Producer  # type: ignore[import-untyped]
+
+    envelope = {
+        "correlation_id": correlation_id,
+        "requested_by": requested_by,
+        "scope": "runtime",
+        "services": [],
+        "git_ref": git_ref,
+        "requested_at": datetime.now(UTC).isoformat(),
+    }
+    signed = _sign_envelope(envelope, hmac_secret)
+
+    producer_config: dict[str, str | int | float | bool] = {
+        "bootstrap.servers": bootstrap_servers,
+        "security.protocol": "SASL_SSL",
+        "sasl.mechanisms": "PLAIN",
+        "sasl.username": username,
+        "sasl.password": password,
+    }
+    producer = Producer(producer_config)
+
+    delivery_error: BaseException | None = None
+
+    def _on_delivery(err: object, _msg: object) -> None:  # type: ignore[misc]
+        nonlocal delivery_error
+        if err is not None:
+            delivery_error = RuntimeError(str(err))
+
+    message = json.dumps(signed, default=str).encode("utf-8")
+    key = f"gha-rebuild/{correlation_id}".encode()
+
+    producer.produce(
+        topic=TOPIC,
+        key=key,
+        value=message,
+        on_delivery=_on_delivery,
+    )
+    producer.flush(timeout=30)
+
+    if delivery_error is not None:
+        raise RuntimeError(f"Kafka delivery failed: {delivery_error}") from None
+
+
+@click.command()
+@click.option(
+    "--changed-files",
+    default="",
+    help="Comma-separated list of changed file paths",
+)
+@click.option(
+    "--labels",
+    default="",
+    help="Comma-separated list of PR label names",
+)
+@click.option(
+    "--git-ref",
+    default="origin/main",
+    help="Git ref to rebuild (default: origin/main)",
+)
+@click.option(
+    "--requested-by",
+    default="gha-runtime-rebuild-trigger",
+    help="Identifier for who is requesting the rebuild",
+)
+@click.option(
+    "--correlation-id",
+    default="",
+    help="Correlation ID (auto-generated if not provided)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Check trigger conditions and print decision without publishing",
+)
+def main(
+    changed_files: str,
+    labels: str,
+    git_ref: str,
+    requested_by: str,
+    correlation_id: str,
+    dry_run: bool,
+) -> None:
+    """Publish rebuild-requested event if PR contains runtime changes.
+
+    Triggers when PR had runtime_change label OR changed files match
+    src/omnimarket/** or src/omnibase_infra/nodes/**.
+    """
+    files: list[str] = (
+        [f.strip() for f in changed_files.split(",") if f.strip()]
+        if changed_files
+        else []
+    )
+    label_list: list[str] = (
+        [lb.strip() for lb in labels.split(",") if lb.strip()] if labels else []
+    )
+
+    corr_id = correlation_id or str(uuid.uuid4())
+
+    if not should_trigger(files, label_list):
+        click.echo(
+            "No rebuild trigger: no runtime_change label or runtime path changes detected."
+        )
+        sys.exit(0)
+
+    click.echo(
+        f"Rebuild triggered: git_ref={git_ref} correlation_id={corr_id} "
+        f"labels={label_list} files_matched={[f for f in files if any(f.startswith(p.rstrip('*')) for p in _RUNTIME_PATH_PATTERNS)]}"
+    )
+
+    if dry_run:
+        click.echo("(dry-run: skipping Kafka publish)")
+        sys.exit(0)
+
+    bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
+    username = os.environ.get("KAFKA_SASL_USERNAME", "")
+    password = os.environ.get("KAFKA_SASL_PASSWORD", "")
+    hmac_secret = os.environ.get("DEPLOY_AGENT_HMAC_SECRET", "")
+
+    if not bootstrap_servers:
+        click.echo("KAFKA_BOOTSTRAP_SERVERS is not set -- skipping publish")
+        sys.exit(0)
+    if not username or not password:
+        click.echo("KAFKA_SASL_USERNAME and KAFKA_SASL_PASSWORD must be set", err=True)
+        sys.exit(1)
+    if not hmac_secret:
+        click.echo("DEPLOY_AGENT_HMAC_SECRET must be set", err=True)
+        sys.exit(1)
+
+    try:
+        publish_rebuild_event(
+            bootstrap_servers=bootstrap_servers,
+            username=username,
+            password=password,
+            hmac_secret=hmac_secret,
+            git_ref=git_ref,
+            correlation_id=corr_id,
+            requested_by=requested_by,
+        )
+    except Exception as exc:  # noqa: BLE001
+        click.echo(f"Delivery error: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(f"Published rebuild-requested to {TOPIC} (correlation_id={corr_id})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_pr_merged_rebuild_trigger.py
+++ b/tests/unit/scripts/test_pr_merged_rebuild_trigger.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/trigger_rebuild_on_merge.py [OMN-8917].
+
+Tests assert path-based and label-based trigger logic with mocked Kafka publish.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "trigger_rebuild_on_merge.py"
+)
+
+
+def _import_trigger_module():
+    """Import the trigger module for unit-testing logic functions directly."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "trigger_rebuild_on_merge", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.mark.unit
+class TestRebuildTriggerLogic:
+    """Unit tests for should_trigger() path/label detection logic."""
+
+    def setup_method(self) -> None:
+        self.mod = _import_trigger_module()
+
+    def test_runtime_change_label_triggers(self) -> None:
+        """runtime_change label alone should trigger rebuild."""
+        assert self.mod.should_trigger(
+            changed_files=[],
+            labels=["runtime_change"],
+        )
+
+    def test_omnimarket_src_path_triggers(self) -> None:
+        """Changed file under src/omnimarket/ should trigger rebuild."""
+        assert self.mod.should_trigger(
+            changed_files=["src/omnimarket/nodes/foo/handler.py"],
+            labels=[],
+        )
+
+    def test_omnibase_infra_nodes_path_triggers(self) -> None:
+        """Changed file under src/omnibase_infra/nodes/ should trigger rebuild."""
+        assert self.mod.should_trigger(
+            changed_files=["src/omnibase_infra/nodes/node_foo/contract.yaml"],
+            labels=[],
+        )
+
+    def test_non_runtime_path_does_not_trigger(self) -> None:
+        """Changed file outside runtime paths should not trigger rebuild."""
+        assert not self.mod.should_trigger(
+            changed_files=["docs/plans/some-plan.md", "tests/unit/test_foo.py"],
+            labels=[],
+        )
+
+    def test_mixed_paths_one_match_triggers(self) -> None:
+        """Any single matching file among many should trigger rebuild."""
+        assert self.mod.should_trigger(
+            changed_files=[
+                "README.md",
+                "src/omnimarket/nodes/bar/node.py",
+                "pyproject.toml",
+            ],
+            labels=[],
+        )
+
+    def test_empty_inputs_no_trigger(self) -> None:
+        """No files and no labels should not trigger."""
+        assert not self.mod.should_trigger(changed_files=[], labels=[])
+
+    def test_unrelated_label_does_not_trigger(self) -> None:
+        """Labels other than runtime_change should not trigger."""
+        assert not self.mod.should_trigger(
+            changed_files=[],
+            labels=["bug", "documentation"],
+        )
+
+    def test_multiple_labels_with_runtime_change_triggers(self) -> None:
+        """runtime_change among other labels should trigger."""
+        assert self.mod.should_trigger(
+            changed_files=[],
+            labels=["bug", "runtime_change", "enhancement"],
+        )
+
+
+@pytest.mark.unit
+class TestRebuildTriggerPublish:
+    """Unit tests for publish_rebuild_event() Kafka call shape."""
+
+    def setup_method(self) -> None:
+        self.mod = _import_trigger_module()
+
+    def test_publish_calls_producer_with_correct_topic(self) -> None:
+        """publish_rebuild_event should produce to onex.cmd.deploy.rebuild-requested.v1."""
+        mock_producer = MagicMock()
+        mock_producer.flush.return_value = None
+
+        with patch.dict(
+            "os.environ",
+            {
+                "KAFKA_BOOTSTRAP_SERVERS": "broker:9092",
+                "KAFKA_SASL_USERNAME": "user",
+                "KAFKA_SASL_PASSWORD": "pass",
+                "DEPLOY_AGENT_HMAC_SECRET": "testsecret",
+            },
+        ):
+            with patch("confluent_kafka.Producer", return_value=mock_producer):
+                self.mod.publish_rebuild_event(
+                    bootstrap_servers="broker:9092",
+                    username="user",
+                    password="pass",
+                    hmac_secret="testsecret",
+                    git_ref="origin/main",
+                    correlation_id="test-corr-id",
+                    requested_by="gha-trigger",
+                )
+
+        mock_producer.produce.assert_called_once()
+        call_kwargs = mock_producer.produce.call_args
+        assert call_kwargs.kwargs["topic"] == "onex.cmd.deploy.rebuild-requested.v1"
+
+    def test_publish_event_payload_shape(self) -> None:
+        """Published payload must include scope=runtime and git_ref."""
+        import json
+
+        mock_producer = MagicMock()
+        captured_value: list[bytes] = []
+
+        def fake_produce(topic, key, value, on_delivery):
+            captured_value.append(value)
+
+        mock_producer.produce.side_effect = fake_produce
+        mock_producer.flush.return_value = None
+
+        with patch("confluent_kafka.Producer", return_value=mock_producer):
+            self.mod.publish_rebuild_event(
+                bootstrap_servers="broker:9092",
+                username="user",
+                password="pass",
+                hmac_secret="testsecret",
+                git_ref="origin/main",
+                correlation_id="test-corr-id",
+                requested_by="gha-trigger",
+            )
+
+        assert captured_value, "produce was not called"
+        payload = json.loads(captured_value[0])
+        assert payload["scope"] == "runtime"
+        assert payload["git_ref"] == "origin/main"
+        assert "correlation_id" in payload
+        assert "_signature" in payload
+
+
+@pytest.mark.unit
+class TestRebuildTriggerCLI:
+    """CLI integration tests using --dry-run flag."""
+
+    def test_dry_run_no_trigger_exits_zero(self) -> None:
+        """--dry-run with no matching files or labels should exit 0 without publishing."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-files",
+                "README.md,docs/plans/foo.md",
+                "--labels",
+                "",
+                "--git-ref",
+                "origin/main",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "no rebuild trigger" in result.stdout.lower()
+
+    def test_dry_run_with_runtime_change_label(self) -> None:
+        """--dry-run with runtime_change label should report trigger without publishing."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-files",
+                "",
+                "--labels",
+                "runtime_change",
+                "--git-ref",
+                "origin/main",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert (
+            "rebuild triggered" in result.stdout.lower()
+            or "dry-run" in result.stdout.lower()
+        )
+
+    def test_dry_run_with_omnimarket_path(self) -> None:
+        """--dry-run with omnimarket src path should report trigger."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-files",
+                "src/omnimarket/nodes/foo/handler.py",
+                "--labels",
+                "",
+                "--git-ref",
+                "origin/main",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert (
+            "rebuild triggered" in result.stdout.lower()
+            or "dry-run" in result.stdout.lower()
+        )


### PR DESCRIPTION
## Summary

- Adds `scripts/trigger_rebuild_on_merge.py` — detects `runtime_change` label or changed files under `src/omnimarket/**` / `src/omnibase_infra/nodes/**` and emits `onex.cmd.deploy.rebuild-requested.v1` with HMAC-signed payload via SASL_SSL Kafka
- Adds `.github/workflows/runtime-rebuild-trigger.yml` — fires on `pull_request: [closed]` + `merged == true` on main
- Adds `tests/unit/scripts/test_pr_merged_rebuild_trigger.py` — 13 unit tests covering path/label logic, Kafka publish shape, and CLI --dry-run behavior
- Closes the 6-day deploy gap described in OMN-7963 / pr_review_bot failure class

## Ticket

OMN-8917 (child of OMN-8908)

## DoD Evidence

- `scripts/trigger_rebuild_on_merge.py` invoked from GHA workflow on push to main
- Only triggers when PR had `runtime_change` label OR changed file matches `src/omnimarket/**` or `src/omnibase_infra/nodes/**`
- Event: `onex.cmd.deploy.rebuild-requested.v1` with `scope: runtime, git_ref: origin/main`
- 13 unit tests passing (path trigger, label trigger, Kafka publish shape with mocked Producer)
- HMAC signing reuses pattern from existing `scripts/deploy-trigger.py`

## Test plan

- [ ] CI passes (unit tests green)
- [ ] Merge a PR with `runtime_change` label to main and observe deploy agent on .201 rebuilds within 5 min (end-to-end verification — see companion omnimarket PR)
- [ ] Merge a PR touching `src/omnibase_infra/nodes/**` and observe same