### PR TITLE
fix(env): remove stale ONEX_INPUT_TOPIC injections post OMN-8784 (OMN-8888)

### DIFF
--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -40,7 +40,6 @@ operational_defaults:
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
   OTEL_SERVICE_NAME: omninode-runtime-main
-  ONEX_INPUT_TOPIC: requests
   ONEX_OUTPUT_TOPIC: responses
   ONEX_GROUP_ID: onex-runtime-main
 ports:

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -39,7 +39,6 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  ONEX_INPUT_TOPIC: effect-requests
   ONEX_OUTPUT_TOPIC: effect-responses
   ONEX_GROUP_ID: onex-runtime-effects
 ports:

--- a/docker/catalog/services/runtime-worker.yaml
+++ b/docker/catalog/services/runtime-worker.yaml
@@ -34,7 +34,6 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  ONEX_INPUT_TOPIC: worker-requests
   ONEX_OUTPUT_TOPIC: worker-responses
   ONEX_GROUP_ID: onex-runtime-workers
 ports: null

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -598,7 +598,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-omninode-runtime-main}
       RUNTIME_PROFILE: main
-      ONEX_INPUT_TOPIC: ${ONEX_INPUT_TOPIC:-requests}
       ONEX_OUTPUT_TOPIC: ${ONEX_OUTPUT_TOPIC:-responses}
       ONEX_GROUP_ID: ${ONEX_GROUP_ID:-onex-runtime-main}
       # OMN-2342: Gate intelligence introspection/heartbeat publishing to this
@@ -648,7 +647,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-effects
       RUNTIME_PROFILE: effects
-      ONEX_INPUT_TOPIC: ${ONEX_EFFECTS_INPUT_TOPIC:-effect-requests}
       ONEX_OUTPUT_TOPIC: ${ONEX_EFFECTS_OUTPUT_TOPIC:-effect-responses}
       ONEX_GROUP_ID: ${ONEX_EFFECTS_GROUP_ID:-onex-runtime-effects}
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)
@@ -702,7 +700,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-worker
       RUNTIME_PROFILE: workers
-      ONEX_INPUT_TOPIC: ${ONEX_WORKER_INPUT_TOPIC:-worker-requests}
       ONEX_OUTPUT_TOPIC: ${ONEX_WORKER_OUTPUT_TOPIC:-worker-responses}
       ONEX_GROUP_ID: ${ONEX_WORKER_GROUP_ID:-onex-runtime-workers}
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)


### PR DESCRIPTION
## Summary

- Removes all `ONEX_INPUT_TOPIC` env injections from compose, Dockerfile, and catalog service manifests
- OMN-8784 made the kernel reject this var with `ProtocolConfigurationError`, but the compose and baked Dockerfile ENV still injected it, causing omninode-runtime to restart-loop (23+ restarts on .201)

## Root Cause

`docker/Dockerfile.runtime:308` had `ENV ONEX_INPUT_TOPIC=requests` baked into the image layer. `docker-compose.infra.yml` injected it again via `${ONEX_INPUT_TOPIC:-requests}` for all three runtime services (main, effects, worker).

## Changes

- `docker/docker-compose.infra.yml` — removed `ONEX_INPUT_TOPIC` from omninode-runtime, runtime-effects, runtime-worker service envs
- `docker/Dockerfile.runtime` — removed `ONEX_INPUT_TOPIC=requests` from baked `ENV` block
- `docker/catalog/services/omninode-runtime.yaml` — removed from `operational_defaults`
- `docker/catalog/services/runtime-effects.yaml` — removed from `operational_defaults`
- `docker/catalog/services/runtime-worker.yaml` — removed from `operational_defaults`

## DoD Evidence

- [ ] `docker inspect omninode-runtime` shows no ONEX_INPUT_TOPIC in env (requires image rebuild)
- [ ] `docker inspect omninode-runtime --format '{{.RestartCount}}'` stops climbing
- [ ] `docker logs omninode-runtime --tail 20` shows successful startup, no ProtocolConfigurationError

Fixes OMN-8888. Post OMN-8784.