### PR TITLE
feat(ci): validate-pr-contracts Layer 1 gate (OMN-8909)

### DIFF
--- a/scripts/validate_pr_contracts.py
+++ b/scripts/validate_pr_contracts.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validate PR ticket contracts — Layer 1 gate (OMN-8909).
+
+Enforces:
+- PRs with OMN-XXXX ticket refs touching runtime code must have a contract YAML
+- Contract dod_evidence must be non-empty for runtime-touching PRs
+
+Inputs (env vars):
+    PR_DIFF_FILES   newline-separated changed file paths
+    PR_BRANCH       branch name
+    PR_TITLE        PR title
+    PR_BODY         PR body text (optional)
+    CONTRACTS_PATH  path to contracts directory
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+TICKET_PATTERN = re.compile(r"OMN-(\d+)", re.IGNORECASE)
+
+RUNTIME_PATH_PATTERNS = [
+    re.compile(r"^src/.*/nodes/.*/handler.*\.py$"),
+    re.compile(r"^src/.*/nodes/.*\.py$"),
+    re.compile(r"^plugins/onex/skills/.*/SKILL\.md$"),
+]
+
+
+def extract_ticket_ids(branch: str, title: str, body: str) -> set[str]:
+    text = f"{branch} {title} {body}"
+    return {f"OMN-{m}" for m in TICKET_PATTERN.findall(text)}
+
+
+def is_runtime_file(path: str) -> bool:
+    return any(p.match(path) for p in RUNTIME_PATH_PATTERNS)
+
+
+def has_runtime_changes(diff_files: list[str]) -> bool:
+    return any(is_runtime_file(f) for f in diff_files)
+
+
+class Finding:
+    def __init__(self, ticket_id: str, message: str, severity: str = "error") -> None:
+        self.ticket_id = ticket_id
+        self.message = message
+        self.severity = severity
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "ticket_id": self.ticket_id,
+            "message": self.message,
+            "severity": self.severity,
+        }
+
+
+def validate(
+    diff_files: list[str],
+    branch: str,
+    title: str,
+    body: str,
+    contracts_path: Path,
+) -> list[Finding]:
+    ticket_ids = extract_ticket_ids(branch, title, body)
+
+    if not ticket_ids:
+        print("SKIP: No OMN ticket references found — skipping contract gate.")
+        return []
+
+    runtime_touched = has_runtime_changes(diff_files)
+
+    if not runtime_touched:
+        print(
+            f"SKIP: No runtime files changed — skipping contract gate. Tickets: {sorted(ticket_ids)}"
+        )
+        return []
+
+    findings: list[Finding] = []
+
+    for ticket_id in sorted(ticket_ids):
+        contract_file = contracts_path / f"{ticket_id}.yaml"
+
+        if not contract_file.exists():
+            findings.append(
+                Finding(
+                    ticket_id=ticket_id,
+                    message=f"Missing contract: {contract_file.name} not found in {contracts_path}",
+                )
+            )
+            continue
+
+        with open(contract_file, encoding="utf-8") as f:
+            contract_data = yaml.safe_load(f)
+
+        if contract_data is None:
+            findings.append(
+                Finding(
+                    ticket_id=ticket_id,
+                    message=f"Contract file {contract_file.name} is empty or invalid YAML",
+                )
+            )
+            continue
+
+        dod_evidence = contract_data.get("dod_evidence", [])
+        if not dod_evidence:
+            findings.append(
+                Finding(
+                    ticket_id=ticket_id,
+                    message=f"Contract {contract_file.name} has empty dod_evidence — runtime-touching PRs require non-empty dod_evidence",
+                )
+            )
+
+    return findings
+
+
+def main() -> int:
+    diff_files_raw = os.environ.get("PR_DIFF_FILES", "")
+    branch = os.environ.get("PR_BRANCH", "")
+    title = os.environ.get("PR_TITLE", "")
+    body = os.environ.get("PR_BODY", "")
+    contracts_path_str = os.environ.get("CONTRACTS_PATH", "contracts")
+
+    diff_files = [f.strip() for f in diff_files_raw.strip().splitlines() if f.strip()]
+    contracts_path = Path(contracts_path_str)
+
+    findings = validate(diff_files, branch, title, body, contracts_path)
+
+    if not findings:
+        print("PASS: All contract checks passed.")
+        return 0
+
+    print(f"FAIL: {len(findings)} contract violation(s) found:\n")
+    for f in findings:
+        print(f"  [{f.severity.upper()}] {f.ticket_id}: {f.message}")
+
+    print(f"\n{json.dumps([f.to_dict() for f in findings], indent=2)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_pr_contracts.py
+++ b/scripts/validate_pr_contracts.py
@@ -97,14 +97,32 @@ def validate(
             )
             continue
 
-        with open(contract_file, encoding="utf-8") as f:
-            contract_data = yaml.safe_load(f)
+        try:
+            with open(contract_file, encoding="utf-8") as f:
+                contract_data = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            findings.append(
+                Finding(
+                    ticket_id=ticket_id,
+                    message=f"Contract file {contract_file.name} is invalid YAML: {exc}",
+                )
+            )
+            continue
 
         if contract_data is None:
             findings.append(
                 Finding(
                     ticket_id=ticket_id,
                     message=f"Contract file {contract_file.name} is empty or invalid YAML",
+                )
+            )
+            continue
+
+        if not isinstance(contract_data, dict):
+            findings.append(
+                Finding(
+                    ticket_id=ticket_id,
+                    message=f"Contract file {contract_file.name} must contain a YAML object at root",
                 )
             )
             continue

--- a/scripts/validation/check_kafka_no_hardcoded_fallback.sh
+++ b/scripts/validation/check_kafka_no_hardcoded_fallback.sh
@@ -21,7 +21,9 @@ MATCHES=$(grep -rn --include="*.py" \
     -E "os\.getenv\([[:space:]]*[\"']KAFKA_[^\"']+[\"'][[:space:]]*,[[:space:]]*[\"'][^\"']+[\"']" \
     . 2>/dev/null | \
     grep -v "# kafka-fallback-ok" | \
-    grep -v "# noqa" || true)
+    grep -v "# noqa" | \
+    grep -v "check_kafka_no_hardcoded_fallback.sh" | \
+    grep -v "ci_check_kafka_no_localhost_default.py" || true)
 
 if [ -n "$MATCHES" ]; then
     echo "ERROR: Hardcoded Kafka bootstrap fallback detected:"

--- a/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
+++ b/src/omnibase_infra/adapters/project_tracker/linear_project_tracker_adapter.py
@@ -44,8 +44,10 @@ def _parse_dt(value: object) -> datetime:
     return datetime.now(UTC)
 
 
-def _issue_from_mcp(d: dict[str, object]) -> ModelStubIssue:  # stub-ok
-    """Translate a Linear MCP issue dict into ModelStubIssue wire shape."""
+def _issue_from_mcp(  # stub-ok
+    d: dict[str, object],
+) -> ModelStubIssue:
+    """Translate a Linear MCP issue dict into the wire model shape."""
     state_raw = d.get("state")
     if isinstance(state_raw, dict):
         state = str(state_raw.get("name") or state_raw.get("type") or "unknown")

--- a/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
+++ b/src/omnibase_infra/runtime/models/model_kafka_producer_config.py
@@ -67,7 +67,7 @@ class ModelKafkaProducerConfig(BaseModel):
                 "KAFKA_REQUEST_TIMEOUT_MS", "10000"
             )  # kafka-fallback-ok
             acks_raw = os.getenv("KAFKA_ACKS", "all")  # kafka-fallback-ok
-            max_request_size_raw = os.getenv(
+            max_request_size_raw = os.getenv(  # kafka-fallback-ok
                 "KAFKA_MAX_REQUEST_SIZE", str(4 * 1024 * 1024)
             )
             return cls(

--- a/tests/ci/test_validate_pr_contracts.py
+++ b/tests/ci/test_validate_pr_contracts.py
@@ -12,7 +12,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
+
+pytestmark = pytest.mark.unit
 
 SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "validate_pr_contracts.py"
 

--- a/tests/ci/test_validate_pr_contracts.py
+++ b/tests/ci/test_validate_pr_contracts.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for validate_pr_contracts.py — Layer 1 contract gate.
+
+Ticket: OMN-8909
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "validate_pr_contracts.py"
+
+RUNTIME_FILE = "src/omnibase_infra/nodes/node_foo/handler.py"
+DOCS_ONLY_FILE = "docs/README.md"
+
+
+def _run(
+    *,
+    diff_files: str = "",
+    branch: str = "jonah/omn-1234-test",
+    pr_title: str = "fix: thing (OMN-1234)",
+    pr_body: str = "",
+    contracts_path: str = "",
+    env_extra: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PR_DIFF_FILES": diff_files,
+        "PR_BRANCH": branch,
+        "PR_TITLE": pr_title,
+        "CONTRACTS_PATH": contracts_path,
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+    if pr_body:
+        env["PR_BODY"] = pr_body
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+
+def _write_contract(tmp_path: Path, ticket_id: str, *, with_dod: bool = True) -> Path:
+    contracts_dir = tmp_path / "contracts"
+    contracts_dir.mkdir(exist_ok=True)
+    contract_file = contracts_dir / f"{ticket_id}.yaml"
+
+    base = {
+        "schema_version": "1.0.0",
+        "ticket_id": ticket_id,
+        "summary": "test contract",
+        "is_seam_ticket": False,
+        "interface_change": False,
+        "interfaces_touched": [],
+        "evidence_requirements": [],
+        "emergency_bypass": {
+            "enabled": False,
+            "justification": "",
+            "follow_up_ticket_id": "",
+        },
+    }
+
+    if with_dod:
+        base["dod_evidence"] = [
+            {
+                "id": "dod-001",
+                "description": "CI passes",
+                "source": "generated",
+                "checks": [{"check_type": "command", "check_value": "echo ok"}],
+            }
+        ]
+    else:
+        base["dod_evidence"] = []
+
+    contract_file.write_text(
+        yaml.dump(base, default_flow_style=False), encoding="utf-8"
+    )
+    return contracts_dir
+
+
+class TestMissingContractFails:
+    """dod-001: PRs with OMN ticket touching runtime code but no contract file must fail."""
+
+    def test_missing_contract_fails(self, tmp_path: Path) -> None:
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/omn-1234-test",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode != 0, (
+            f"Expected non-zero exit, got stdout: {result.stdout}"
+        )
+        assert "OMN-1234" in result.stdout or "OMN-1234" in result.stderr
+
+    def test_missing_contract_with_runtime_file(self, tmp_path: Path) -> None:
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+
+        result = _run(
+            diff_files="src/omnimarket/nodes/node_bar/handler_main.py",
+            branch="jonah/omn-5678-new-node",
+            pr_title="feat: add node_bar (OMN-5678)",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode != 0
+
+
+class TestEmptyDodEvidenceFails:
+    """dod-002: Contract with empty dod_evidence on runtime-touching PR must fail."""
+
+    def test_empty_dod_evidence_fails(self, tmp_path: Path) -> None:
+        contracts_dir = _write_contract(tmp_path, "OMN-1234", with_dod=False)
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/omn-1234-test",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode != 0, (
+            f"Expected non-zero exit, got stdout: {result.stdout}"
+        )
+        assert (
+            "dod_evidence" in result.stdout.lower()
+            or "dod_evidence" in result.stderr.lower()
+        )
+
+    def test_populated_dod_evidence_passes(self, tmp_path: Path) -> None:
+        contracts_dir = _write_contract(tmp_path, "OMN-1234", with_dod=True)
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/omn-1234-test",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode == 0, f"Expected exit 0, got stderr: {result.stderr}"
+
+
+class TestNoTicketSkips:
+    """dod-003: PRs with no OMN ticket reference must skip (exit 0)."""
+
+    def test_no_ticket_skips(self, tmp_path: Path) -> None:
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="dependabot/npm_and_yarn/next-15.0.0",
+            pr_title="chore(deps): bump next from 14 to 15",
+            contracts_path=str(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_release_branch_skips(self, tmp_path: Path) -> None:
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="release/v2.0.0",
+            pr_title="release: v2.0.0",
+            contracts_path=str(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_docs_only_pr_skips(self, tmp_path: Path) -> None:
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+
+        result = _run(
+            diff_files=DOCS_ONLY_FILE,
+            branch="jonah/omn-1234-docs",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode == 0
+
+
+class TestTicketExtraction:
+    """Ticket IDs are extracted from branch, title, and body."""
+
+    def test_ticket_from_title_only(self, tmp_path: Path) -> None:
+        contracts_dir = _write_contract(tmp_path, "OMN-9999", with_dod=True)
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/fix-thing",
+            pr_title="fix: resolve crash (OMN-9999)",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode == 0
+
+    def test_ticket_from_body(self, tmp_path: Path) -> None:
+        contracts_dir = _write_contract(tmp_path, "OMN-4444", with_dod=True)
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/fix-thing",
+            pr_title="fix: resolve crash",
+            pr_body="Closes OMN-4444",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode == 0
+
+    def test_multiple_tickets_all_need_contracts(self, tmp_path: Path) -> None:
+        contracts_dir = _write_contract(tmp_path, "OMN-1111", with_dod=True)
+
+        result = _run(
+            diff_files=RUNTIME_FILE,
+            branch="jonah/omn-1111-and-omn-2222",
+            pr_title="feat: multi-ticket",
+            contracts_path=str(contracts_dir),
+        )
+        assert result.returncode != 0, (
+            "Should fail because OMN-2222 contract is missing"
+        )


### PR DESCRIPTION
## Summary
- Adds `scripts/validate_pr_contracts.py` — Layer 1 contract presence + completeness gate
- Enforces: runtime-touching PRs with OMN ticket refs must have contract YAML with non-empty `dod_evidence`
- No-ticket branches (dependabot, release) and docs-only PRs skip gracefully
- 10 tests in `tests/ci/test_validate_pr_contracts.py` covering all DoD evidence items

## Test plan
- [x] `test_missing_contract_fails` — exits non-zero when contract YAML missing (dod-001)
- [x] `test_empty_dod_evidence_fails` — exits non-zero on empty dod_evidence (dod-002)
- [x] `test_no_ticket_skips` — exits 0 for no-ticket branches (dod-003)
- [x] Ticket extraction from branch, title, body
- [x] Multiple ticket validation
- [x] Docs-only PR carve-out

Ticket: OMN-8909 | Epic: OMN-8908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CLI PR validation that enforces contract YAMLs for runtime-touching changes.
  * Reduced spurious CI validation hits by excluding self/CI-related matches.

* **Tests**
  * Added extensive tests covering PR validation behavior (passes, skips, and failure cases).

* **Refactor**
  * Renamed and updated internal project-tracker adapter references for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->