### PR TITLE
fix(handlers): OMN-8735 auto-wiring compliance for 2 missed handlers

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
@@ -76,7 +76,7 @@ class HandlerLlmCliSubprocess:
 
     def __init__(
         self,
-        cli: str,
+        cli: str = "claude",
         cli_args: list[str] | None = None,
         timeout: int = 120,
     ) -> None:

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
@@ -216,7 +216,9 @@ class HandlerRuntimeTick:
 
         # Null-guard: handler requires projection_reader + reducer when called.
         # They default to None only so auto-wiring can instantiate without args.
-        assert self._projection_reader is not None, "HandlerRuntimeTick: projection_reader not injected"
+        assert self._projection_reader is not None, (
+            "HandlerRuntimeTick: projection_reader not injected"
+        )
         assert self._reducer is not None, "HandlerRuntimeTick: reducer not injected"
 
         # Extract from envelope

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
@@ -129,8 +129,8 @@ class HandlerRuntimeTick:
 
     def __init__(
         self,
-        projection_reader: ProjectionReaderRegistration,
-        reducer: RegistrationReducerService,
+        projection_reader: ProjectionReaderRegistration | None = None,
+        reducer: RegistrationReducerService | None = None,
         snapshot_publisher: ProtocolSnapshotPublisher | None = None,
         timeout_coordinator: TimeoutCoordinator | None = None,
     ) -> None:
@@ -213,6 +213,11 @@ class HandlerRuntimeTick:
             ProtocolConfigurationError: If envelope_timestamp is naive (no timezone info).
         """
         start_time = time.perf_counter()
+
+        # Null-guard: handler requires projection_reader + reducer when called.
+        # They default to None only so auto-wiring can instantiate without args.
+        assert self._projection_reader is not None, "HandlerRuntimeTick: projection_reader not injected"
+        assert self._reducer is not None, "HandlerRuntimeTick: reducer not injected"
 
         # Extract from envelope
         tick = envelope.payload


### PR DESCRIPTION
## Summary

Follow-up to #1323 — two handlers missed in the original sweep:

- **HandlerLlmCliSubprocess**: `cli: str` → `cli: str = "claude"` (no-arg constructible)
- **HandlerRuntimeTick**: `projection_reader`/`reducer` → `| None = None` with null-guard assertions in `handle()`

## Why this is needed

`omninode-runtime` is crash-looping with `ModelOnexError: Auto-wiring failed for 4 contract(s)` after #1323 merged. This PR fixes the 2 omnibase_infra handlers; the 2 omnimarket handlers are in OmniNode-ai/omnimarket#<followup>.

## Test plan
- [ ] `uv run pytest tests/ -m unit -x` passes
- [ ] Runtime boots without `Auto-wiring failed` for `node_llm_inference_effect` or `node_registration_orchestrator`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * LLM handler configuration now defaults to Claude, eliminating the need for explicit setup
  * Runtime handler dependencies are now optional with runtime validation added to ensure proper injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->