### PR TITLE
fix(handlers): OMN-8735 follow-up — HandlerLlmCliSubprocess + HandlerRuntimeTick

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -16,7 +16,7 @@ contract_name: "node_llm_inference_effect"
 node_name: "node_llm_inference_effect"
 contract_version:
   major: 1
-  minor: 0
+  minor: 1
   patch: 0
 node_version:
   major: 0

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 # OMN-8735: handler constructor compliance refactor (2026-04-15)
+# OMN-8735 follow-up: HandlerLlmCliSubprocess null-guard compliance (2026-04-16)
 # Copyright (c) 2026 OmniNode Team
 #
 # ONEX Node Contract

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
@@ -76,7 +76,7 @@ class HandlerLlmCliSubprocess:
 
     def __init__(
         self,
-        cli: str,
+        cli: str | None = None,
         cli_args: list[str] | None = None,
         timeout: int = 120,
     ) -> None:
@@ -85,8 +85,8 @@ class HandlerLlmCliSubprocess:
         self._timeout = timeout
 
     @property
-    def cli_name(self) -> str:
-        """Return the CLI binary name."""
+    def cli_name(self) -> str | None:
+        """Return the CLI binary name, or None if not configured."""
         return self._cli
 
     @property
@@ -112,6 +112,13 @@ class HandlerLlmCliSubprocess:
         from omnibase_infra.models.llm.model_llm_inference_response import (
             ModelLlmInferenceResponse,
         )
+
+        if self._cli is None:
+            return (
+                None,
+                EnumCliBackendStatus.UNAVAILABLE,
+                "cli not configured (no CLI binary specified)",
+            )
 
         if not shutil.which(self._cli):
             return (

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 # OMN-8735: handler constructor compliance refactor (2026-04-15)
+# OMN-8735 follow-up: HandlerRuntimeTick null-guard compliance (2026-04-16)
 # Copyright (c) 2025 OmniNode Team
 # ONEX Node Contract - Registration Orchestrator Node
 #

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -33,7 +33,7 @@
 #
 contract_version:
   major: 1
-  minor: 0
+  minor: 1
   patch: 0
 node_version: "1.0.0"
 name: "node_registration_orchestrator"

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_runtime_tick.py
@@ -53,12 +53,6 @@ from omnibase_infra.models.registration.events.model_node_liveness_expired impor
 from omnibase_infra.nodes.node_registration_orchestrator.models.model_reducer_context import (
     ModelReducerContext,
 )
-from omnibase_infra.nodes.node_registration_orchestrator.services import (
-    RegistrationReducerService,
-)
-from omnibase_infra.projectors.projection_reader_registration import (
-    ProjectionReaderRegistration,
-)
 from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
 from omnibase_infra.utils import (
     sanitize_error_message,
@@ -66,8 +60,14 @@ from omnibase_infra.utils import (
 )
 
 if TYPE_CHECKING:
+    from omnibase_infra.nodes.node_registration_orchestrator.services import (
+        RegistrationReducerService,
+    )
     from omnibase_infra.nodes.node_registration_orchestrator.timeout_coordinator import (
         TimeoutCoordinator,
+    )
+    from omnibase_infra.projectors.projection_reader_registration import (
+        ProjectionReaderRegistration,
     )
     from omnibase_infra.protocols.protocol_snapshot_publisher import (
         ProtocolSnapshotPublisher,
@@ -129,8 +129,8 @@ class HandlerRuntimeTick:
 
     def __init__(
         self,
-        projection_reader: ProjectionReaderRegistration,
-        reducer: RegistrationReducerService,
+        projection_reader: ProjectionReaderRegistration | None = None,
+        reducer: RegistrationReducerService | None = None,
         snapshot_publisher: ProtocolSnapshotPublisher | None = None,
         timeout_coordinator: TimeoutCoordinator | None = None,
     ) -> None:
@@ -227,6 +227,27 @@ class HandlerRuntimeTick:
             correlation_id=correlation_id,
         )
         validate_timezone_aware_with_context(now, ctx)
+
+        # Null-guard: handler constructs without required deps for auto-wiring.
+        # Return empty output when projection_reader or reducer are not configured.
+        if self._projection_reader is None or self._reducer is None:
+            logger.warning(
+                "HandlerRuntimeTick: projection_reader or reducer not configured — skipping tick",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            processing_time_ms = (time.perf_counter() - start_time) * 1000
+            return ModelHandlerOutput(
+                input_envelope_id=envelope.envelope_id,
+                correlation_id=correlation_id,
+                handler_id=self.handler_id,
+                node_kind=self.node_kind,
+                events=(),
+                intents=(),
+                projections=(),
+                result=None,
+                processing_time_ms=processing_time_ms,
+                timestamp=now,
+            )
 
         # Coordinator path: delegate to TimeoutCoordinator when wired.
         # Single side-effecting operation (best-effort, at-least-once).

--- a/tests/integration/handlers/test_handler_autowiring_compliance.py
+++ b/tests/integration/handlers/test_handler_autowiring_compliance.py
@@ -137,3 +137,19 @@ class TestHandlerAutowiringCompliance:
 
         handler = HandlerScopeManifestWriteComplete()
         assert handler is not None
+
+    def test_handler_llm_cli_subprocess_no_args(self) -> None:
+        from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
+            HandlerLlmCliSubprocess,
+        )
+
+        handler = HandlerLlmCliSubprocess()
+        assert handler is not None
+
+    def test_handler_runtime_tick_no_args(self) -> None:
+        from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_runtime_tick import (
+            HandlerRuntimeTick,
+        )
+
+        handler = HandlerRuntimeTick()
+        assert handler is not None

--- a/tests/integration/test_handler_autowiring_compliance_followup.py
+++ b/tests/integration/test_handler_autowiring_compliance_followup.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OMN-8735 follow-up auto-wiring constructor compliance.
+
+Verifies that HandlerLlmCliSubprocess and HandlerRuntimeTick can be instantiated
+with no constructor arguments, as required by the strict auto-wiring framework.
+
+These two handlers were missed in the initial OMN-8735 pass and are fixed in
+the follow-up PR (omnibase_infra#1325).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestHandlerAutowiringComplianceFollowup:
+    """Verify OMN-8735 follow-up: missed handlers instantiate with no constructor arguments."""
+
+    def test_handler_llm_cli_subprocess_no_args(self) -> None:
+        from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
+            HandlerLlmCliSubprocess,
+        )
+
+        handler = HandlerLlmCliSubprocess()
+        assert handler is not None
+
+    def test_handler_runtime_tick_no_args(self) -> None:
+        from omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_runtime_tick import (
+            HandlerRuntimeTick,
+        )
+
+        handler = HandlerRuntimeTick()
+        assert handler is not None

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for HandlerLlmCliSubprocess.
+
+OMN-8735 follow-up: auto-wiring compliance — no-args construction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
+    EnumCliBackendStatus,
+    HandlerLlmCliSubprocess,
+)
+
+
+@pytest.mark.unit
+def test_handler_llm_cli_subprocess_constructs_with_no_args() -> None:
+    """HandlerLlmCliSubprocess must construct with no arguments for auto-wiring."""
+    handler = HandlerLlmCliSubprocess()
+    assert handler.handler_type == EnumHandlerType.INFRA_HANDLER
+    assert handler.handler_category == EnumHandlerTypeCategory.EFFECT

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess.py
@@ -11,7 +11,6 @@ import pytest
 
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
 from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
-    EnumCliBackendStatus,
     HandlerLlmCliSubprocess,
 )
 

--- a/tests/unit/nodes/node_registration_orchestrator/test_handler_runtime_tick.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_handler_runtime_tick.py
@@ -665,3 +665,28 @@ class TestHandlerRuntimeTickTimezoneValidation:
         assert isinstance(output, ModelHandlerOutput)
         assert output.handler_id == "handler-runtime-tick"
         assert output.events == ()  # No events expected (empty projections)
+
+
+# ---------------------------------------------------------------------------
+# OMN-8735 follow-up: auto-wiring compliance — no-args construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_handler_runtime_tick_constructs_with_no_args() -> None:
+    """HandlerRuntimeTick must construct with no arguments for auto-wiring."""
+    handler = HandlerRuntimeTick()
+    assert handler.handler_id == "handler-runtime-tick"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_handler_runtime_tick_returns_empty_when_unconfigured() -> None:
+    """HandlerRuntimeTick with no deps returns empty output (null-guard path)."""
+    handler = HandlerRuntimeTick()
+    tick = create_runtime_tick()
+    envelope = create_envelope(tick, now=TEST_NOW)
+    output = await handler.handle(envelope)
+    assert isinstance(output, ModelHandlerOutput)
+    assert output.events == ()
+    assert output.intents == ()


### PR DESCRIPTION
## Summary

Follow-up to #1323. These 2 handlers were missed in the original 12-handler auto-wiring compliance fix and continued to crash-loop the .201 runtime on deploy.

- **HandlerLlmCliSubprocess**: `cli` param changed from required `str` to `str | None = None`. Null-guard in `execute_cli_inference` returns `UNAVAILABLE` status before calling `shutil.which`. `cli_name` property updated to `str | None`.
- **HandlerRuntimeTick**: `projection_reader` and `reducer` params changed to `| None = None`. Both imports moved to `TYPE_CHECKING` block (safe due to `from __future__ import annotations`). Null-guard in `handle()` returns empty `ModelHandlerOutput` with warning log when deps are not configured.

Pattern matches the 12 sibling handlers from #1323 (e.g. `HandlerChainRetrieval`).

## Tests

- New: `test_handler_llm_cli_subprocess_constructs_with_no_args`
- New: `test_handler_runtime_tick_constructs_with_no_args`
- New: `test_handler_runtime_tick_returns_empty_when_unconfigured`
- All 20 existing HandlerRuntimeTick tests continue to pass

## Test plan

- [ ] CI passes (mypy strict, ruff, all unit tests)
- [ ] After merge: trigger rebuild on .201 and verify RestartCount stable for 60s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LLM inference handler now gracefully handles an unconfigured CLI, returning an unavailable status instead of failing.
  * Registration orchestrator handler now safely handles missing runtime dependencies, returning empty responses with warning logs instead of errors.

* **Tests**
  * Added unit and integration tests verifying handlers can be auto-wired (constructed with no args) and exercise null-guard behavior.

* **Chores**
  * Bumped contract metadata minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->