### PR TITLE
fix(ci): CR Thread Gate caller job emits 'gate / CodeRabbit Thread Check' [OMN-9032]

### DIFF
--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -1,0 +1,26 @@
+name: CR Thread Gate (caller)
+# Caller workflow for omniclaude's own PRs.
+# Produces required status check: "gate / CodeRabbit Thread Check"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  gate:
+    if: >-
+      github.event_name == 'merge_group' ||
+      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
+      github.actor != 'dependabot[bot]')
+    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
+    with:
+      pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}
+    secrets:
+      CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -1,25 +1,79 @@
 name: CR Thread Gate
+# Reusable workflow — call via:
+#   uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
+# Required status check string: "gate / CodeRabbit Thread Check"
+# (produced by callers whose job key is named 'gate:' and uses this workflow)
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, dismissed]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
-  issue_comment:
-    types: [created, edited, deleted]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
+    secrets:
+      CROSS_REPO_PAT:
+        description: "GitHub PAT with read:discussion scope for CR thread queries"
+        required: false
+      github-token:
+        description: "Deprecated: pass CROSS_REPO_PAT instead"
+        required: false
+    inputs:
+      repo:
+        description: "Target repo name (owner/repo or bare name). Defaults to caller's github.repository."
+        required: false
+        type: string
+        default: ""
+      pr-number:
+        description: "Pull request number to check. Pass '0' or empty to skip (merge_group context)."
+        required: false
+        type: string
+        default: ""
+
 jobs:
   gate:
-    if: >-
-      github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
-      github.actor != 'dependabot[bot]')
-    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
-    with:
-      pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}
-    secrets:
-      CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
+    name: CodeRabbit Thread Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout omniclaude scripts
+        uses: actions/checkout@v4
+        with:
+          repository: OmniNode-ai/omniclaude
+          ref: main
+          sparse-checkout: scripts/check-unresolved-threads.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve repo name
+        id: resolve-repo
+        run: |
+          REPO="${{ inputs.repo }}"
+          [ -z "$REPO" ] && REPO="${{ github.repository }}"
+          # Strip owner prefix if present (owner/repo -> repo)
+          echo "repo=${REPO##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR number
+        id: resolve-pr
+        run: |
+          PR="${{ inputs.pr-number }}"
+          if [ -z "$PR" ]; then
+            PR="${{ github.event.pull_request.number }}"
+          fi
+          if [ -z "$PR" ]; then
+            PR="${{ github.event.issue.number }}"
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Check unresolved CodeRabbit threads
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || secrets.github-token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ steps.resolve-pr.outputs.pr }}"
+          if [ -z "$PR" ] || [ "$PR" = "0" ]; then
+            echo "No PR number — skipping (merge_group context)."
+            exit 0
+          fi
+          chmod +x scripts/check-unresolved-threads.sh
+          COUNT=$(bash scripts/check-unresolved-threads.sh \
+            "${{ github.repository_owner }}" \
+            "${{ steps.resolve-repo.outputs.repo }}" \
+            "$PR")
+          echo "Unresolved CodeRabbit threads: $COUNT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::$COUNT unresolved CodeRabbit thread(s). Resolve all CR threads before merging."
+            exit 1
+          fi
+          echo "All CodeRabbit threads resolved."

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -10,32 +10,16 @@ on:
     types: [resolved, unresolved]
   issue_comment:
     types: [created, edited, deleted]
+  merge_group:
+    types: [checks_requested]
 jobs:
-  resolve-pr:
-    name: Resolve PR number
-    runs-on: ubuntu-latest
-    outputs:
-      pr-number: ${{ steps.pr.outputs.number }}
-      has-pr: ${{ steps.pr.outputs.has_pr }}
-    steps:
-      - id: pr
-        run: |
-          NUMBER="${{ github.event.pull_request.number }}"
-          if [ -z "$NUMBER" ]; then
-            NUMBER="${{ github.event.issue.number }}"
-          fi
-          if [ -n "$NUMBER" ]; then
-            echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
-            echo "has_pr=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=0" >> "$GITHUB_OUTPUT"
-            echo "has_pr=false" >> "$GITHUB_OUTPUT"
-          fi
   gate:
-    needs: resolve-pr
-    if: needs.resolve-pr.outputs.has-pr == 'true' && (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) && github.actor != 'dependabot[bot]'
+    if: >-
+      github.event_name == 'merge_group' ||
+      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
+      github.actor != 'dependabot[bot]')
     uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
     with:
-      pr-number: ${{ needs.resolve-pr.outputs.pr-number }}
+      pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary

Fix CR Thread Gate workflow: replace two-job resolve-pr+gate pattern with single gate job; add merge_group trigger; use format() pr-number expression to fix 0-job failures and ensure 'gate / CodeRabbit Thread Check' is emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code review thread validation workflow that ensures all review threads are resolved before merging.

* **Chores**
  * Refactored code review automation infrastructure to support reusable workflow patterns across repositories, enabling consistent thread resolution enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->