### PR TITLE
fix(handlers): cast asyncpg UUID to str in HandlerRegistrationStoragePostgres [OMN-9041]

### DIFF
--- a/src/omnibase_infra/handlers/registration_storage/handler_registration_storage_postgres.py
+++ b/src/omnibase_infra/handlers/registration_storage/handler_registration_storage_postgres.py
@@ -578,7 +578,7 @@ class HandlerRegistrationStoragePostgres(MixinAsyncCircuitBreaker):
                 # - node_version: VARCHAR -> ModelSemVer
                 records.append(
                     ModelRegistrationRecord(
-                        node_id=UUID(row["node_id"]),
+                        node_id=UUID(str(row["node_id"])),
                         node_type=EnumNodeKind(row["node_type"]),
                         node_version=ModelSemVer.parse(row["node_version"]),
                         capabilities=capabilities,

--- a/tests/integration/handlers/test_registration_storage_postgres_uuid_cast.py
+++ b/tests/integration/handlers/test_registration_storage_postgres_uuid_cast.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration regression guard for OMN-9041.
+
+Exercises ``HandlerRegistrationStoragePostgres.query_registrations`` end-to-end
+against a real PostgreSQL instance. Ensures that whatever concrete type asyncpg
+returns for the VARCHAR ``node_id`` column (``str`` on some asyncpg versions,
+``asyncpg.pgproto.pgproto.UUID`` on others) is cast to stdlib ``uuid.UUID``
+without raising ``AttributeError``.
+
+Context:
+    OMN-9041 — production crash in ``UUID(row["node_id"])``. Fix: wrap with
+    ``str()`` to coerce to canonical hex before handing to stdlib UUID.
+
+Skip policy:
+    Skipped when PostgreSQL is not available (no ``POSTGRES_HOST`` /
+    ``OMNIBASE_INFRA_DB_URL``). Enabled in CI via test splits that run the
+    full suite with Postgres configured.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, TypedDict
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.container import ModelONEXContainer
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.handlers.registration_storage.handler_registration_storage_postgres import (
+    HandlerRegistrationStoragePostgres,
+)
+from omnibase_infra.handlers.registration_storage.models import (
+    ModelDeleteRegistrationRequest,
+)
+from omnibase_infra.nodes.node_registration_storage_effect.models import (
+    ModelRegistrationRecord,
+    ModelStorageQuery,
+)
+from tests.helpers.util_postgres import PostgresConfig
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+_postgres_config = PostgresConfig.from_env()
+POSTGRES_AVAILABLE = _postgres_config.is_configured
+
+
+class _PostgresConfigDict(TypedDict):
+    host: str
+    port: int
+    database: str
+    user: str
+    password: str
+
+
+def _resolve_postgres_config() -> _PostgresConfigDict:
+    return {
+        "host": _postgres_config.host or "localhost",
+        "port": _postgres_config.port,
+        "database": _postgres_config.database or "omnibase_infra",
+        "user": _postgres_config.user,
+        "password": _postgres_config.password or "",
+    }
+
+
+@pytest.mark.skipif(
+    not POSTGRES_AVAILABLE,
+    reason="PostgreSQL not available (set OMNIBASE_INFRA_DB_URL or POSTGRES_HOST+POSTGRES_PASSWORD)",
+)
+class TestRegistrationStoragePostgresUuidCast:
+    """Live-DB regression guard for OMN-9041 UUID cast."""
+
+    @pytest.fixture
+    async def handler(
+        self,
+    ) -> AsyncGenerator[HandlerRegistrationStoragePostgres, None]:
+        pg = _resolve_postgres_config()
+        handler = HandlerRegistrationStoragePostgres(
+            container=MagicMock(spec=ModelONEXContainer),
+            host=pg["host"],
+            port=pg["port"],
+            database=pg["database"],
+            user=pg["user"],
+            password=pg["password"],
+        )
+        yield handler
+        await handler.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_query_round_trip_produces_stdlib_uuid(
+        self,
+        handler: HandlerRegistrationStoragePostgres,
+    ) -> None:
+        """Store + query round-trip returns ``record.node_id`` as stdlib ``uuid.UUID``.
+
+        Pre-fix (OMN-9041) this round-trip crashes with
+        ``InfraConnectionError('PostgreSQL query failed: AttributeError')``
+        when asyncpg decodes the VARCHAR column as its pgproto UUID type.
+        Post-fix the cast succeeds regardless of the row value's concrete type.
+        """
+        correlation_id = uuid4()
+        original_node_id = uuid4()
+
+        record = ModelRegistrationRecord(
+            node_id=original_node_id,
+            node_type=EnumNodeKind.EFFECT,
+            node_version=ModelSemVer.parse("1.0.0"),
+            capabilities=["omn-9041.regression"],
+            endpoints={},
+            metadata={"ticket": "OMN-9041"},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            correlation_id=correlation_id,
+        )
+
+        try:
+            store_result = await handler.store_registration(
+                record=record,
+                correlation_id=correlation_id,
+            )
+            assert store_result.success, (
+                f"store_registration failed: {store_result.error}"
+            )
+
+            query_result = await handler.query_registrations(
+                query=ModelStorageQuery(node_id=original_node_id),
+                correlation_id=correlation_id,
+            )
+            assert query_result.success, (
+                f"query_registrations failed: {query_result.error}"
+            )
+            assert len(query_result.records) == 1, (
+                "Expected exactly one record for our just-stored node_id"
+            )
+
+            fetched = query_result.records[0]
+            assert isinstance(fetched.node_id, UUID), (
+                f"node_id must be stdlib uuid.UUID after cast, got {type(fetched.node_id).__name__}"
+            )
+            assert fetched.node_id == original_node_id
+        finally:
+            await handler.delete_registration(
+                ModelDeleteRegistrationRequest(
+                    node_id=original_node_id,
+                    correlation_id=correlation_id,
+                )
+            )

--- a/tests/unit/handlers/test_handler_registration_storage_postgres_uuid_cast.py
+++ b/tests/unit/handlers/test_handler_registration_storage_postgres_uuid_cast.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression guard: asyncpg UUID rows must survive cast to stdlib UUID.
+
+Context:
+    OMN-9041 — ``UUID(row["node_id"])`` crashed in production because asyncpg
+    decoded the VARCHAR ``node_id`` column as an ``asyncpg.pgproto.pgproto.UUID``
+    object (not a ``str``). stdlib ``uuid.UUID.__init__`` calls ``.replace()``
+    on its first positional arg, which the asyncpg UUID type does not
+    implement, so the cast raised ``AttributeError``.
+
+    Fix: wrap the row value with ``str()`` before passing to stdlib ``UUID``.
+
+    This test exercises ``HandlerRegistrationStoragePostgres.query_registrations``
+    end-to-end against an in-process stub pool whose rows contain an asyncpg
+    pgproto UUID. Pre-fix this test fails with ``AttributeError`` inside the
+    row conversion loop; post-fix it passes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.container import ModelONEXContainer
+from omnibase_infra.handlers.registration_storage.handler_registration_storage_postgres import (
+    HandlerRegistrationStoragePostgres,
+)
+from omnibase_infra.nodes.node_registration_storage_effect.models import (
+    ModelStorageQuery,
+)
+
+
+class _FakeAsyncpgUUID:
+    """Stand-in for ``asyncpg.pgproto.pgproto.UUID``.
+
+    Mimics the critical failure-mode invariant: has no ``.replace()``
+    attribute, so stdlib ``uuid.UUID(fake)`` raises ``AttributeError`` unless
+    the caller coerces to ``str`` first. ``__str__`` returns a canonical
+    hex UUID, matching asyncpg's real behavior.
+    """
+
+    def __init__(self, canonical: str) -> None:
+        self._canonical = canonical
+
+    def __str__(self) -> str:
+        return self._canonical
+
+
+class _StubRecord(dict[str, Any]):
+    """Minimal ``asyncpg.Record`` stand-in supporting ``row["col"]`` access."""
+
+
+class _StubConnection:
+    def __init__(self, rows: list[_StubRecord], count: int) -> None:
+        self._rows = rows
+        self._count = count
+
+    async def fetch(self, _query: str, *_params: Any) -> list[_StubRecord]:
+        return self._rows
+
+    async def fetchval(self, _query: str, *_params: Any) -> int:
+        return self._count
+
+
+class _StubAcquireCtx:
+    def __init__(self, conn: _StubConnection) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _StubConnection:
+        return self._conn
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+
+class _StubPool:
+    def __init__(self, conn: _StubConnection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> _StubAcquireCtx:
+        return _StubAcquireCtx(self._conn)
+
+
+@pytest.mark.asyncio
+async def test_query_registrations_handles_asyncpg_pgproto_uuid() -> None:
+    """query_registrations must survive asyncpg returning pgproto UUID objects.
+
+    Regression guard for OMN-9041. Without the ``str()`` coercion in the
+    ModelRegistrationRecord construction, this test raises AttributeError
+    inside the row conversion loop.
+    """
+    canonical = "01010101-0101-0101-0101-010101010101"
+    fake_node_id = _FakeAsyncpgUUID(canonical)
+
+    row = _StubRecord(
+        node_id=fake_node_id,
+        node_type="effect",
+        node_version="1.0.0",
+        capabilities="[]",
+        endpoints="{}",
+        metadata="{}",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    handler = HandlerRegistrationStoragePostgres(
+        container=MagicMock(spec=ModelONEXContainer),
+        host="unused",
+        port=5432,
+        database="unused",
+        user="unused",
+        password="unused",
+    )
+
+    stub_pool = _StubPool(_StubConnection(rows=[row], count=1))
+
+    async def _fake_ensure_pool(correlation_id: UUID | None = None) -> _StubPool:
+        return stub_pool
+
+    handler._ensure_pool = _fake_ensure_pool  # type: ignore[method-assign]
+
+    result = await handler.query_registrations(
+        query=ModelStorageQuery(),
+        correlation_id=uuid4(),
+    )
+
+    assert result.success, f"Query should succeed; got error: {result.error}"
+    assert len(result.records) == 1
+    record = result.records[0]
+    assert isinstance(record.node_id, UUID), (
+        "node_id must be stdlib uuid.UUID after cast"
+    )
+    assert str(record.node_id) == canonical


### PR DESCRIPTION
## Summary
- Production crash: `UUID(row["node_id"])` in `HandlerRegistrationStoragePostgres.query_registrations` raised `AttributeError: 'asyncpg.pgproto.pgproto.UUID' object has no attribute 'replace'`, surfaced as `InfraConnectionError('PostgreSQL query failed: AttributeError')`.
- asyncpg decodes the VARCHAR `node_id` column as its internal `asyncpg.pgproto.pgproto.UUID` type (not `str`); stdlib `uuid.UUID.__init__` calls `.replace()` on its positional arg. Wrap with `str()` to coerce to canonical hex before the cast.
- One-line fix + unit-level stub regression guard + live-DB integration regression guard. No behavior change for string rows.

## Linear
- Ticket: [OMN-9041](https://linear.app/omninode/issue/OMN-9041)
- Discovery: OMN-9034 full-suite verification on #1327 surfaced the latent crash against `POSTGRES_HOST=192.168.86.201`.

## Changes
- `src/omnibase_infra/handlers/registration_storage/handler_registration_storage_postgres.py:581` — `UUID(row["node_id"])` → `UUID(str(row["node_id"]))`.
- `tests/unit/handlers/test_handler_registration_storage_postgres_uuid_cast.py` (new) — stubs `_ensure_pool` to feed a row whose `node_id` is a `_FakeAsyncpgUUID`. TDD-verified: pre-fix fails with `AttributeError`; post-fix passes.
- `tests/integration/handlers/test_registration_storage_postgres_uuid_cast.py` (new) — live-DB store+query round-trip; asserts stdlib `uuid.UUID` type post-cast.

## Deploy gate
[skip-deploy-gate: one-line handler bugfix - no Dockerfile/image/schema change, rides the next standard runtime image rebuild and redeploy. Deploy tracking is under OMN-8841 and does not require a per-ticket DoD item for a pure .py cast coercion.]

## Test plan
- [x] `uv run pytest tests/unit/handlers/test_handler_registration_storage_postgres_uuid_cast.py -v` - 1 passed
- [x] `POSTGRES_HOST=192.168.86.201 uv run pytest tests/integration/handlers/test_registration_storage_postgres_uuid_cast.py -v` - 1 passed (live DB)
- [x] `POSTGRES_HOST=192.168.86.201 uv run pytest tests/integration/handlers/test_registration_storage_handler_swapping.py -v` - 25 passed
- [x] `uv run mypy` + `uv run ruff check` + `uv run ruff format --check` on changed files - clean
- [x] Pre-commit hooks (40+ gates) - all passed
- [x] `POSTGRES_HOST=192.168.86.201 uv run pytest tests/ -m "not kafka and not slow" -n auto` - 21186 passed, 21 pre-existing flakes (confirmed on clean main @ b1fa2f6d)