### PR TITLE
ci(handshake): drop path filter + add merge_group trigger [OMN-9049]

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -3,14 +3,9 @@ name: Check Architecture Handshake
 on:
   push:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - '.github/workflows/check-handshake.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - '.github/workflows/check-handshake.yml'
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Drop the `paths:` filter on `on.push` and `on.pull_request` in `.github/workflows/check-handshake.yml` so the architecture handshake gate fires on every PR.
- Add `merge_group:` trigger so the gate also runs in the merge queue context.
- SHA pin (`ref: 4dc7a0ad...`) intentionally left alone — OMN-9050 bot owns cross-repo SHA bumps.

## Test plan

- [x] YAML parses cleanly, `merge_group` trigger present, `paths` key absent
- [ ] On PR open, `Check Architecture Handshake / check-handshake` context fires in Actions

## Ticket

- Ticket: [OMN-9049](https://linear.app/omninode/issue/OMN-9049)
- Parent epic: OMN-9048
- Companion: OMN-9050 (automated SHA bump bot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to ensure comprehensive testing runs across all pull requests and merges to main branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->