### PR TITLE
fix(compose): add POSTGRES_HOST to omninode-runtime env [OMN-9060]

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -600,6 +600,11 @@ services:
       RUNTIME_PROFILE: main
       ONEX_OUTPUT_TOPIC: ${ONEX_OUTPUT_TOPIC:-responses}
       ONEX_GROUP_ID: ${ONEX_GROUP_ID:-onex-runtime-main}
+      # OMN-9060: HandlerRegistrationStoragePostgres reads POSTGRES_HOST directly
+      # from env (matches the override already present on runtime-effects and
+      # runtime-worker). Without it the handler throws KeyError during wiring and
+      # the container stays DEGRADED.
+      POSTGRES_HOST: postgres
       # OMN-2342: Gate intelligence introspection/heartbeat publishing to this
       # container only. Workers and effects containers inherit x-runtime-env but
       # do NOT set this flag, so they process intelligence events without


### PR DESCRIPTION
## Summary

- `HandlerRegistrationStoragePostgres` reads `POSTGRES_HOST` directly from env and throws `KeyError` when it is missing, which has left `omninode-runtime` on `.201` in `DEGRADED` state.
- The env var was already overridden on sibling services `runtime-effects` (line 661) and `runtime-worker` (line 715) via OMN-7569 but was missed for the main runtime stanza.
- Adds `POSTGRES_HOST: postgres` (internal Docker hostname) with a comment block matching the OMN-7569 style.

Closes [OMN-9060](https://linear.app/omninode/issue/OMN-9060).

## Ground-truth evidence (pre-fix, .201)

```
$ ssh jonah@192.168.86.201 'docker inspect omninode-runtime --format "{{.State.Health.Status}}"'
starting    # has been restart-looping; 3060 restarts per ticket audit

$ ssh jonah@192.168.86.201 'docker inspect omninode-runtime --format "{{range .Config.Env}}{{println .}}{{end}}" | grep POSTGRES'
POSTGRES_PASSWORD=...
POSTGRES_USER=postgres
# POSTGRES_HOST is absent
```

## Kafka `UnicodeDecodeError` follow-up

The second failure noted in the ticket (`describe_consumer_groups` → `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 10`) originates inside the aiokafka library decoder when parsing a response frame from Redpanda. Not a trivial in-PR fix — it likely requires an aiokafka version pin or a Redpanda protocol-version investigation. Filed as a follow-up sub-ticket under OMN-9060.

## Test plan

- [x] Pre-commit hooks pass locally (ran on commit)
- [ ] CI green on this PR
- [ ] Post-merge: rebuild + restart runtime on .201 and observe `docker inspect omninode-runtime --format "{{.State.Health.Status}}"` transition away from `starting`/`unhealthy` within 10min (container has a 600s start_period)
- [ ] `docker logs omninode-runtime --since 5m | grep -c "KeyError: 'POSTGRES_HOST'"` returns `0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime service configuration to ensure proper database connectivity and prevent container degradation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->