### PR TITLE
fix(runtime): sweep banned ONEX_{INPUT,OUTPUT}_TOPIC from compose + catalog [OMN-8840]

### DIFF
--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -40,7 +40,8 @@ operational_defaults:
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
   OTEL_SERVICE_NAME: omninode-runtime-main
-  ONEX_OUTPUT_TOPIC: responses
+  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-main
 ports:
   external: 8085

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -39,7 +39,8 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  ONEX_OUTPUT_TOPIC: effect-responses
+  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-effects
 ports:
   external: 8086

--- a/docker/catalog/services/runtime-worker.yaml
+++ b/docker/catalog/services/runtime-worker.yaml
@@ -34,7 +34,8 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  ONEX_OUTPUT_TOPIC: worker-responses
+  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-workers
 ports: null
 healthcheck:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -281,8 +281,8 @@ services:
       # Runtime configuration
       ONEX_ENVIRONMENT: test
       ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-DEBUG}
-      ONEX_INPUT_TOPIC: onex.evt.platform.node-introspection.v1
-      ONEX_OUTPUT_TOPIC: onex.evt.platform.registration-completed.v1
+      # OMN-8840/OMN-8784: ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC removed (banned env vars).
+      # e2e runtime derives topics from node contracts mounted at /app/contracts.
       ONEX_GROUP_ID: onex-runtime-e2e
       ONEX_CONTRACTS_DIR: /app/contracts
     ports:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -598,7 +598,9 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-omninode-runtime-main}
       RUNTIME_PROFILE: main
-      ONEX_OUTPUT_TOPIC: ${ONEX_OUTPUT_TOPIC:-responses}
+      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+      # Topics come from each node's contract.yaml event_bus declaration;
+      # setting this var raises ProtocolConfigurationError at kernel bootstrap.
       ONEX_GROUP_ID: ${ONEX_GROUP_ID:-onex-runtime-main}
       # OMN-2342: Gate intelligence introspection/heartbeat publishing to this
       # container only. Workers and effects containers inherit x-runtime-env but
@@ -647,7 +649,8 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-effects
       RUNTIME_PROFILE: effects
-      ONEX_OUTPUT_TOPIC: ${ONEX_EFFECTS_OUTPUT_TOPIC:-effect-responses}
+      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+      # Topics come from each node's contract.yaml event_bus declaration.
       ONEX_GROUP_ID: ${ONEX_EFFECTS_GROUP_ID:-onex-runtime-effects}
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)
       OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
@@ -700,7 +703,8 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-worker
       RUNTIME_PROFILE: workers
-      ONEX_OUTPUT_TOPIC: ${ONEX_WORKER_OUTPUT_TOPIC:-worker-responses}
+      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+      # Topics come from each node's contract.yaml event_bus declaration.
       ONEX_GROUP_ID: ${ONEX_WORKER_GROUP_ID:-onex-runtime-workers}
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)
       OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"


### PR DESCRIPTION
## Summary

Runtime-effects (and runtime-main, runtime-worker) containers crash-loop at
`[ONEX_CORE_041]` before the kernel can start, because the compose + catalog
stack continued to inject the banned env vars `ONEX_INPUT_TOPIC` and
`ONEX_OUTPUT_TOPIC`. OMN-8784 removed those vars from the kernel and wired
a fail-fast deprecation guard (`_DEPRECATED_TOPIC_ENV_VARS` in
`src/omnibase_infra/runtime/service_kernel.py`) — the guard raises
`ProtocolConfigurationError` as soon as the value is read from the env.

This PR sweeps every remaining producer of those env vars in
`omnibase_infra`:

- `docker/docker-compose.infra.yml` — runtime-main, runtime-effects, runtime-worker
- `docker/docker-compose.e2e.yml` — e2e runtime
- `docker/catalog/services/omninode-runtime.yaml` (operational_defaults)
- `docker/catalog/services/runtime-effects.yaml` (operational_defaults)
- `docker/catalog/services/runtime-worker.yaml` (operational_defaults)

Topics are now derived exclusively from each node's `contract.yaml`
`event_bus.subscribe_topics` / `publish_topics` declarations, per the
contract-first rule established by OMN-8784.

No code changes — compose + catalog manifests only. The kernel's
deprecation guard, related unit tests, and contract-driven topic resolution
already exist and require no modification.

## Context

- **Ticket:** OMN-8840 (https://linear.app/omninode/issue/OMN-8840) — re-diagnosed
  in the 2026-04-17 morning session as a banned-var sweep, NOT a
  subscription-wiring problem. The prior diagnosis ("202+ sequential Kafka
  subscriptions") was a red herring; the kernel never got far enough to
  attempt any subscription because the env-var guard fires during bootstrap.
- **Root cause:** OMN-8784 (https://linear.app/omninode/issue/OMN-8784)
  removed `ONEX_INPUT_TOPIC` and `ONEX_OUTPUT_TOPIC` from the kernel and
  introduced the deprecation guard at
  `src/omnibase_infra/runtime/service_kernel.py:196-201`, but the compose
  and catalog manifests that inject those vars into the runtime containers
  were never swept — so the very next container start after the code
  removal tripped the guard.
- **Companion PR:** `OmniNode-ai/omninode_infra` branch
  `jonah/omn-8840-banned-var-sweep` removes the same env entries from the
  `onex-dev` k8s deployments (runtime, runtime-effects, runtime-worker).

## Test plan

- [ ] CI pre-commit + lint passes (no Python code touched; yaml-only changes)
- [ ] On merge, rebuild runtime image + `docker compose up -d runtime-effects`
      on `.201` and confirm `docker logs runtime-effects` emits no
      `[ONEX_CORE_041]` within 30s of start
- [ ] Follow-up: close Linear OMN-8840 with verbatim log evidence once the
      container restart is verified green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hardcoded output topic environment variables from runtime service configurations (omninode-runtime, runtime-effects, runtime-worker, and E2E setup).
  * Output topic configuration now derives from individual node contract definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deploy gate

[skip-deploy-gate: pre-deploy-unblock] The runtime-effects container crash-loops before the kernel bootstraps because the banned env vars (ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC) are still injected by compose + catalog manifests. No runtime deploy can succeed until these injections are removed — the gate's own dod_evidence target (a successful deploy) is blocked BY the bug this PR fixes. Post-merge, OMN-8840 will be closed with verbatim `docker logs runtime-effects` evidence showing clean bootstrap with no ONEX_CORE_041 within 30s of start.