### PR TITLE
fix(infra): memgraph healthcheck uses mgconsole, not bash-ism /dev/tcp [OMN-9061]

### DIFF
--- a/docker/catalog/services/omnibase-infra-memgraph.yaml
+++ b/docker/catalog/services/omnibase-infra-memgraph.yaml
@@ -12,9 +12,10 @@ ports:
   external: 7687
   internal: 7687
 healthcheck:
-  # /dev/tcp is a bash-ism; the default CMD-SHELL uses /bin/sh (dash on Debian)
-  # which does not support it. Invoke bash explicitly.
-  test: bash -c 'echo > /dev/tcp/localhost/7687' || exit 1
+  # OMN-9061: previous sh `echo > /dev/tcp/...` parsed as a file redirect and
+  # failed with "Directory nonexistent". mgconsole ships in the image and proves
+  # the Bolt listener actually accepts a query, not just the port being open.
+  test: echo 'RETURN 1;' | mgconsole --host localhost --port ${MEMGRAPH_BOLT_PORT:-7687} --output-format=csv
   interval_s: 10
   timeout_s: 5
   retries: 5

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -391,9 +391,10 @@ services:
       --storage-snapshot-retention-count=2 --storage-wal-enabled=true --storage-snapshot-interval-sec=3600 --log-level=WARNING
 
     healthcheck:
-      # OMN-5176: nc (netcat) is NOT reliably in Memgraph v2.18.1 $PATH despite
-      # being installed. Use bash /dev/tcp probe which is always available.
-      test: ["CMD-SHELL", "echo > /dev/tcp/localhost/7687 || exit 1"]
+      # OMN-9061: previous `echo > /dev/tcp/...` needed bash, but CMD-SHELL uses
+      # /bin/sh which parses it as a file redirect ("Directory nonexistent").
+      # mgconsole ships in the image and proves Bolt accepts a real query.
+      test: ["CMD-SHELL", "echo 'RETURN 1;' | mgconsole --host localhost --port ${MEMGRAPH_BOLT_PORT:-7687} --output-format=csv"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

Memgraph container on `.201` was unhealthy because the healthcheck used `echo > /dev/tcp/localhost/7687 || exit 1` via `CMD-SHELL`. The `/dev/tcp/*` virtual path is a bash-ism; sh/dash parses the redirect as "create a file at that path" and fails every probe with `cannot create /dev/tcp/localhost/7687: Directory nonexistent`.

Swap the probe to `echo 'RETURN 1;' | mgconsole --host localhost --port $MEMGRAPH_BOLT_PORT`. `mgconsole` ships at `/usr/bin/mgconsole` in `memgraph/memgraph:2.18.1`, is sh-compatible, and exits 0 only after Bolt actually accepts a query — stronger liveness than a raw TCP probe.

Applied identically to both source files: `docker/catalog/services/omnibase-infra-memgraph.yaml` (typed manifest; generator turns string → `CMD-SHELL`) and `docker/docker-compose.infra.yml` (the legacy hand-edited compose actually in use on `.201`).

Port-awareness: probe reads `${MEMGRAPH_BOLT_PORT:-7687}` so test rigs overriding the port still work.

[skip-deploy-gate: live .201 deploy verification already performed in this PR — container went healthy within 30s of recreate, see verification section below]

## Live verification on .201

```
$ docker inspect omnibase-infra-memgraph --format '{{.State.Health.Status}}'
healthy

$ docker inspect omnibase-infra-memgraph --format '{{range .State.Health.Log}}EC={{.ExitCode}} OUT={{.Output}}{{end}}' | tail -1
EC=0 OUT="1"
```

Container went healthy within 30s of `docker compose up -d --force-recreate omnibase-infra-memgraph`.

## Deprecated-flag warnings — scope note

Ticket scope item 2 asked to remove `--auth-module-executable` and `--storage-parallel-index-recovery`. Investigation: these flags are **NOT** present in our compose Cmd or anywhere in this repo (grep returns nothing). The warnings come from memgraph 2.18.1's own flag-validation pass comparing against its internal deprecated-flag allowlist — emitted twice per start (CLI parse + config parse) independent of the actual command line:

```
[warning] The auth-module-executable flag is deprecated and superseded by auth-module-mappings...
[warning] storage_parallel_index_recovery flag is deprecated. Check storage_mode_parallel_schema_recovery...
```

Uncommented lines in `/etc/memgraph/memgraph.conf` inside the image do not contain either flag. Fully suppressing these warnings would require a memgraph image bump (out of scope for a healthcheck fix) — file a separate ticket if desired.

## Test plan

- [x] Ruff: clean (`uv run ruff check docker/ src/omnibase_infra/docker/`)
- [x] Mypy: clean (`uv run mypy src/omnibase_infra/docker/`)
- [x] Full pytest (`uv run pytest tests/ -n auto --timeout=60`): 21269 passed. 31 failures are all preexisting on `origin/main` and unrelated (LLM SLO, runtime DB, observability metrics, docker-build integration, one stale catalog-validator assertion). Verified by running the lone arguably-related failure (`test_catalog_validator_rejects_missing_env`) against `origin/main` with my changes stashed — still fails identically.
- [x] Live healthcheck verified healthy on `.201` against a scratch recreate of `omnibase-infra-memgraph`.

Cites: OMN-9061
