### PR TITLE
ci(receipt-gate): wire omnibase_infra caller [fan-out of omnibase_core#834/#836]

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Caller workflow that invokes the omnibase_core-hosted receipt-gate on every
+# PR targeting main in omnibase_infra.
+#
+# Receipt-gate enforces "Enforcement by Receipt": every PR must cite a Linear
+# ticket whose dod_evidence items all have PASS ModelDodReceipt artifacts at
+# the canonical path under onex_change_control/drift/dod_receipts/. Missing
+# or failing receipts block merge.
+#
+# The reusable workflow is hosted centrally in omnibase_core (one source of
+# truth, per OMN-8828 cr-thread-gate precedent). Each downstream repo wires
+# its own caller that references the central workflow by remote path.
+#
+# Required-status-check name (for branch-protection): `Receipt Gate / verify`.
+
+name: Receipt Gate
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify:
+    uses: OmniNode-ai/omnibase_core/.github/workflows/receipt-gate.yml@main


### PR DESCRIPTION
## Summary

Fan-out of the receipt-gate from [omnibase_core#834](https://github.com/OmniNode-ai/omnibase_core/pull/834) (reusable workflow) + [omnibase_core#836](https://github.com/OmniNode-ai/omnibase_core/pull/836) (self-caller) to omnibase_infra.

Same pattern as OMN-8828 cr-thread-gate:
- Reusable workflow hosted centrally in omnibase_core
- Each downstream repo wires a local caller via \`uses: OmniNode-ai/omnibase_core/.github/workflows/receipt-gate.yml@main\`

## Dependency

Must merge AFTER omnibase_core#834 lands. Until then \`Receipt Gate / verify\` fails the \`uses:\` lookup.

## Follow-up (not this PR)

Branch-protection flip to make \`Receipt Gate / verify\` required status check on omnibase_infra main.

## Override

\`\`\`
[skip-receipt-gate: fan-out bootstrap — gate logic lives in omnibase_core, this PR only wires the caller]
\`\`\`