### PR TITLE
feat(ci): block PR with test deletion without replacement [OMN-8732]

### DIFF
--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -8,6 +8,13 @@
 # 14 days (tracked via PROMOTION_DATE).
 #
 # Exemptions: docs-only, config-only, and pure refactor PRs.
+#
+# OMN-8732: Test removal gate
+#
+# Hard-blocks merge when a PR deletes a tests/integration/*.py file
+# without adding a replacement. Override: include
+# [skip-test-removal-gate: <reason>] in the PR body for legitimate
+# test consolidation.
 
 name: Integration Test Check
 
@@ -96,3 +103,49 @@ jobs:
             echo "::warning::Feature PR without integration test. This will become a hard gate after $PROMOTION_DATE. Consider adding a test in tests/integration/ or tests/e2e/."
             exit 0
           fi
+
+  check-test-removal:
+    name: Integration Test Removal Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect integration test deletions without replacements
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Allow legitimate test consolidation via override token
+          if echo "${PR_BODY:-}" | grep -qF '[skip-test-removal-gate:'; then
+            echo "skip-test-removal-gate token found — bypassing test removal check"
+            exit 0
+          fi
+
+          # Count deleted and added tests/integration/*.py files in this PR
+          DELETED=$(git diff --name-status origin/main...HEAD \
+            | awk '$1 == "D" && $2 ~ /^tests\/integration\/[^/]+\.py$/ {print $2}' \
+            | wc -l | tr -d ' ')
+          ADDED=$(git diff --name-status origin/main...HEAD \
+            | awk '($1 == "A" || $1 == "M") && $2 ~ /^tests\/integration\/[^/]+\.py$/ {print $2}' \
+            | wc -l | tr -d ' ')
+
+          echo "Integration test files deleted: $DELETED"
+          echo "Integration test files added/modified: $ADDED"
+
+          if [ "$DELETED" -eq 0 ]; then
+            echo "No integration test files deleted — gate passed"
+            exit 0
+          fi
+
+          if [ "$ADDED" -ge "$DELETED" ]; then
+            echo "Deleted tests covered by $ADDED replacement(s) — gate passed"
+            exit 0
+          fi
+
+          UNMATCHED=$((DELETED - ADDED))
+          echo "::error::PR deletes $DELETED integration test file(s) with only $ADDED replacement(s). $UNMATCHED deletion(s) are unmatched. Either add replacement tests in tests/integration/ or include [skip-test-removal-gate: <reason>] in the PR body for legitimate consolidation."
+          exit 1

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -125,27 +125,8 @@ jobs:
             exit 0
           fi
 
-          # Count deleted and added tests/integration/*.py files in this PR
-          DELETED=$(git diff --name-status origin/main...HEAD \
-            | awk '$1 == "D" && $2 ~ /^tests\/integration\/[^/]+\.py$/ {print $2}' \
-            | wc -l | tr -d ' ')
-          ADDED=$(git diff --name-status origin/main...HEAD \
-            | awk '($1 == "A" || $1 == "M") && $2 ~ /^tests\/integration\/[^/]+\.py$/ {print $2}' \
-            | wc -l | tr -d ' ')
-
-          echo "Integration test files deleted: $DELETED"
-          echo "Integration test files added/modified: $ADDED"
-
-          if [ "$DELETED" -eq 0 ]; then
-            echo "No integration test files deleted — gate passed"
-            exit 0
-          fi
-
-          if [ "$ADDED" -ge "$DELETED" ]; then
-            echo "Deleted tests covered by $ADDED replacement(s) — gate passed"
-            exit 0
-          fi
-
-          UNMATCHED=$((DELETED - ADDED))
-          echo "::error::PR deletes $DELETED integration test file(s) with only $ADDED replacement(s). $UNMATCHED deletion(s) are unmatched. Either add replacement tests in tests/integration/ or include [skip-test-removal-gate: <reason>] in the PR body for legitimate consolidation."
-          exit 1
+          # Counting logic lives in a Python script so it can be unit-tested
+          # against synthetic git diff outputs. See
+          # tests/ci/test_validate_test_removal_gate.py for the hardened
+          # rename/modify coverage (CR thread on PR #1336).
+          python scripts/validation/validate_test_removal_gate.py --base origin/main

--- a/scripts/validation/validate_test_removal_gate.py
+++ b/scripts/validation/validate_test_removal_gate.py
@@ -39,7 +39,6 @@ import argparse
 import re
 import subprocess
 import sys
-from pathlib import Path
 
 INTEGRATION_TEST_RE = re.compile(r"^tests/integration/[^/]+\.py$")
 

--- a/scripts/validation/validate_test_removal_gate.py
+++ b/scripts/validation/validate_test_removal_gate.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-8732: Test removal gate — blocks PRs that delete integration tests
+without adding replacements.
+
+Parses `git diff --name-status -M` output and counts integration test
+deletions vs genuine additions. Hardened against two counting bypasses
+flagged by CodeRabbit on PR #1336:
+
+  1. `M` (modified) was previously counted as a replacement. Modifying
+     any existing integration test could offset a deletion. Now `M` is
+     ignored — only `A` (added) and qualifying renames count as new tests.
+
+  2. Renames (`R*`) were not handled. Moving a file OUT of
+     `tests/integration/` bypassed the gate because the file did not
+     show as deleted. Now renames are decomposed:
+       - renamed OUT of tests/integration/ → counts as deletion
+       - renamed INTO tests/integration/   → counts as addition
+     Copies (`C*`) are handled symmetrically on the addition side.
+
+Usage:
+    python scripts/validation/validate_test_removal_gate.py
+    python scripts/validation/validate_test_removal_gate.py --base origin/main
+
+Reads diff from `git diff --name-status -M <base>...HEAD` by default, or
+from stdin if `--stdin` is passed (used in unit tests).
+
+Exit codes:
+    0 — no unmatched deletions
+    1 — unmatched deletion(s) present; PR body must carry
+        `[skip-test-removal-gate: <reason>]` to bypass in CI
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+INTEGRATION_TEST_RE = re.compile(r"^tests/integration/[^/]+\.py$")
+
+RENAME_STATUS_RE = re.compile(r"^R[0-9]+$")
+COPY_STATUS_RE = re.compile(r"^C[0-9]+$")
+
+
+def _is_integration_test(path: str) -> bool:
+    return bool(INTEGRATION_TEST_RE.match(path))
+
+
+def count_deletions_and_additions(diff_output: str) -> tuple[int, int]:
+    """Count integration-test deletions and additions from `git diff --name-status -M` output.
+
+    Rules:
+      - `D <path>` where path matches integration test → +1 deletion
+      - `A <path>` where path matches integration test → +1 addition
+      - `M <path>` — ignored (modification is not a replacement)
+      - `R<score> <old> <new>`:
+          * old matches and new does not → +1 deletion (moved out)
+          * new matches and old does not → +1 addition (moved in)
+          * both match — rename within tests/integration/, counted as
+            neither deletion nor addition (net zero file count)
+          * neither matches — irrelevant
+      - `C<score> <old> <new>` where new matches → +1 addition (copied in).
+        Copies never count as deletions because the source file is preserved.
+
+    Lines are tab-separated as emitted by `git diff --name-status`.
+    """
+    deleted = 0
+    added = 0
+
+    for raw_line in diff_output.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+
+        if status == "D" and len(parts) >= 2:
+            if _is_integration_test(parts[1]):
+                deleted += 1
+            continue
+
+        if status == "A" and len(parts) >= 2:
+            if _is_integration_test(parts[1]):
+                added += 1
+            continue
+
+        if status == "M":
+            continue
+
+        if RENAME_STATUS_RE.match(status) and len(parts) >= 3:
+            old_path, new_path = parts[1], parts[2]
+            old_match = _is_integration_test(old_path)
+            new_match = _is_integration_test(new_path)
+            if old_match and not new_match:
+                deleted += 1
+            elif new_match and not old_match:
+                added += 1
+            continue
+
+        if COPY_STATUS_RE.match(status) and len(parts) >= 3:
+            new_path = parts[2]
+            if _is_integration_test(new_path):
+                added += 1
+            continue
+
+    return deleted, added
+
+
+def _run_git_diff(base: str) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-M", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main)",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read `git diff --name-status` output from stdin instead of invoking git",
+    )
+    args = parser.parse_args(argv)
+
+    if args.stdin:
+        diff_output = sys.stdin.read()
+    else:
+        diff_output = _run_git_diff(args.base)
+
+    deleted, added = count_deletions_and_additions(diff_output)
+
+    print(f"Integration test files deleted: {deleted}")
+    print(f"Integration test files added: {added}")
+
+    if deleted == 0:
+        print("No integration test files deleted — gate passed")
+        return 0
+
+    if added >= deleted:
+        print(f"Deleted tests covered by {added} replacement(s) — gate passed")
+        return 0
+
+    unmatched = deleted - added
+    print(
+        f"::error::PR deletes {deleted} integration test file(s) with only "
+        f"{added} replacement(s). {unmatched} deletion(s) are unmatched. "
+        "Either add replacement tests in tests/integration/ or include "
+        "[skip-test-removal-gate: <reason>] in the PR body for legitimate "
+        "consolidation.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_validate_test_removal_gate.py
+++ b/tests/ci/test_validate_test_removal_gate.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for OMN-8732 test removal gate counting logic.
+
+Covers the two CR bypasses flagged on PR #1336:
+  1. Modified integration tests must NOT count as replacements for deletions.
+  2. Renames OUT of tests/integration/ must count as deletions; renames INTO
+     must count as additions.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from scripts.validation.validate_test_removal_gate import (
+    count_deletions_and_additions,
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# count_deletions_and_additions
+# ---------------------------------------------------------------------------
+
+
+def test_pure_deletion_counts_as_deletion() -> None:
+    diff = "D\ttests/integration/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (1, 0)
+
+
+def test_pure_addition_counts_as_addition() -> None:
+    diff = "A\ttests/integration/test_bar.py\n"
+    assert count_deletions_and_additions(diff) == (0, 1)
+
+
+def test_modified_does_not_count_as_addition() -> None:
+    """Regression: the previous counter treated M as a replacement, so
+    modifying an unrelated integration test could cancel a deletion."""
+    diff = "D\ttests/integration/test_old.py\nM\ttests/integration/test_unrelated.py\n"
+    # Deletion is unmatched — modification MUST NOT offset it.
+    assert count_deletions_and_additions(diff) == (1, 0)
+
+
+def test_modification_only_counts_nothing() -> None:
+    diff = "M\ttests/integration/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_rename_out_of_integration_counts_as_deletion() -> None:
+    """Regression: `git mv tests/integration/test_foo.py tests/unit/test_foo.py`
+    previously produced an R* record the old awk parser ignored, letting the
+    file escape the integration suite without triggering the gate."""
+    diff = "R100\ttests/integration/test_foo.py\ttests/unit/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (1, 0)
+
+
+def test_rename_into_integration_counts_as_addition() -> None:
+    diff = "R100\ttests/unit/test_foo.py\ttests/integration/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (0, 1)
+
+
+def test_rename_within_integration_counts_as_neither() -> None:
+    diff = "R090\ttests/integration/test_old.py\ttests/integration/test_new.py\n"
+    # File count inside tests/integration/ is unchanged, so the gate should
+    # neither fire nor consume a replacement slot.
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_rename_out_plus_unrelated_modification_still_blocks() -> None:
+    """End-to-end bypass attempt: rename a test out of integration/ and also
+    modify a different integration test to try to offset the deletion."""
+    diff = (
+        "R100\ttests/integration/test_old.py\ttests/unit/test_old.py\n"
+        "M\ttests/integration/test_unrelated.py\n"
+    )
+    assert count_deletions_and_additions(diff) == (1, 0)
+
+
+def test_copy_into_integration_counts_as_addition() -> None:
+    diff = "C075\ttests/unit/test_foo.py\ttests/integration/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (0, 1)
+
+
+def test_copy_out_of_integration_counts_as_nothing() -> None:
+    # Copy preserves the source, so it is not a deletion.
+    diff = "C075\ttests/integration/test_foo.py\ttests/unit/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_non_integration_paths_ignored() -> None:
+    diff = (
+        "D\ttests/unit/test_foo.py\nA\tsrc/module/new.py\nR100\tdocs/a.md\tdocs/b.md\n"
+    )
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_nested_integration_subdir_ignored() -> None:
+    # Regex anchors to a single-level file directly under tests/integration/
+    diff = "D\ttests/integration/subdir/test_foo.py\n"
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_non_python_file_ignored() -> None:
+    diff = "D\ttests/integration/conftest.yaml\n"
+    assert count_deletions_and_additions(diff) == (0, 0)
+
+
+def test_multiple_mixed_records() -> None:
+    diff = (
+        "D\ttests/integration/test_alpha.py\n"
+        "D\ttests/integration/test_beta.py\n"
+        "A\ttests/integration/test_gamma.py\n"
+        "M\ttests/integration/test_delta.py\n"
+        "R100\ttests/integration/test_epsilon.py\ttests/unit/test_epsilon.py\n"
+        "R100\ttests/unit/test_zeta.py\ttests/integration/test_zeta.py\n"
+    )
+    # Deletions: alpha, beta, epsilon (renamed out) = 3
+    # Additions: gamma, zeta (renamed in) = 2
+    # Modifications ignored.
+    assert count_deletions_and_additions(diff) == (3, 2)
+
+
+def test_blank_and_crlf_lines_tolerated() -> None:
+    diff = "D\ttests/integration/test_foo.py\r\n\nA\ttests/integration/test_bar.py\n"
+    assert count_deletions_and_additions(diff) == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes (via --stdin)
+# ---------------------------------------------------------------------------
+
+
+def _run_main_with_stdin(diff: str, monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(diff))
+    return main(["--stdin"])
+
+
+def test_main_passes_when_deletions_fully_matched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diff = "D\ttests/integration/test_old.py\nA\ttests/integration/test_new.py\n"
+    assert _run_main_with_stdin(diff, monkeypatch) == 0
+
+
+def test_main_fails_when_modification_was_the_only_offset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Key regression: the pre-fix gate would have passed this PR."""
+    diff = "D\ttests/integration/test_old.py\nM\ttests/integration/test_other.py\n"
+    assert _run_main_with_stdin(diff, monkeypatch) == 1
+
+
+def test_main_fails_when_rename_out_is_unmatched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diff = "R100\ttests/integration/test_old.py\ttests/unit/test_old.py\n"
+    assert _run_main_with_stdin(diff, monkeypatch) == 1
+
+
+def test_main_passes_on_empty_diff(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _run_main_with_stdin("", monkeypatch) == 0
+
+
+def test_main_passes_on_rename_within_integration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diff = "R090\ttests/integration/test_old.py\ttests/integration/test_new.py\n"
+    assert _run_main_with_stdin(diff, monkeypatch) == 0


### PR DESCRIPTION
## Summary

- Adds `check-test-removal` job to `integration-test-check.yml` (OMN-8732, parent OMN-8718)
- Hard-blocks merge when a PR deletes `tests/integration/*.py` files without adding the same number of replacements
- Override mechanism: include `[skip-test-removal-gate: <reason>]` in PR body for legitimate test consolidation (consistent with `[skip-receipt-gate:]` and `[skip-deploy-gate:]` patterns)

## Implementation

Uses `git diff --name-status origin/main...HEAD` + `awk` to count `D` (deleted) vs `A`/`M` (added/modified) files under `tests/integration/`. Fails if deletions exceed additions; passes immediately if deletions == 0 or additions >= deletions.

## Test plan

- [ ] PR that only deletes a `tests/integration/*.py` → `check-test-removal` fails
- [ ] PR that deletes a test and adds a replacement → passes
- [ ] PR with `[skip-test-removal-gate: consolidating tests]` in body → bypasses check
- [ ] PR with no test file changes → passes immediately

[skip-receipt-gate: OMN-8732 is CI-gate; no runtime surface]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a PR validation gate that blocks removal of integration tests unless equivalent replacements are provided; can be bypassed with a manual override token in the PR body.
* **Tests**
  * Added unit tests covering deletion/addition counting, rename/copy handling, modification rules, and diff edge cases to ensure the gate behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->