### PR TITLE
fix(validation): backfill schema_version violations [OMN-9025]

### DIFF
--- a/src/omnibase_infra/adapters/project_tracker/model_stub_comment.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_stub_comment.py
@@ -20,7 +20,9 @@ _SCHEMA_VERSION = "1.0"
 class ModelStubComment(BaseModel):
     model_config = {"frozen": True, "extra": "allow"}
 
-    schema_version: str = Field(default=_SCHEMA_VERSION)
+    schema_version: str = Field(
+        default=_SCHEMA_VERSION
+    )  # string-version-ok: wire-format model mirroring external project tracker API contract
     id: str
     body: str
     author: str

--- a/src/omnibase_infra/event_bus/models/model_event_headers.py
+++ b/src/omnibase_infra/event_bus/models/model_event_headers.py
@@ -82,7 +82,9 @@ class ModelEventHeaders(BaseModel):
 
     source: str
     event_type: str
-    schema_version: str = Field(default="1.0.0")
+    schema_version: str = Field(
+        default="1.0.0"
+    )  # string-version-ok: event bus wire headers; Kafka/cross-service consumers deserialize as plain string
     destination: str | None = Field(default=None)
     trace_id: str | None = Field(default=None)
     span_id: str | None = Field(default=None)

--- a/src/omnibase_infra/models/checkpoint/model_checkpoint.py
+++ b/src/omnibase_infra/models/checkpoint/model_checkpoint.py
@@ -77,7 +77,7 @@ class ModelCheckpoint(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     # ── Common header ────────────────────────────────────────────────
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: checkpoint persisted to disk/DB; plain string preserves serialization compatibility for append-only checkpoint records
         default=CHECKPOINT_SCHEMA_VERSION,
         description="Forward-compatibility version string.",
     )

--- a/src/omnibase_infra/models/pricing/model_pricing_table.py
+++ b/src/omnibase_infra/models/pricing/model_pricing_table.py
@@ -72,7 +72,7 @@ class ModelPricingTable(BaseModel):
         from_attributes=True,
     )
 
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: YAML manifest format discriminator; external YAML files serialize version as plain string
         ...,
         min_length=1,
         description="Version of the pricing manifest schema.",

--- a/src/omnibase_infra/models/projection/model_registration_snapshot.py
+++ b/src/omnibase_infra/models/projection/model_registration_snapshot.py
@@ -162,7 +162,7 @@ class ModelRegistrationSnapshot(BaseModel):
     )
 
     # Schema Versioning (wire-format compatibility marker)
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: cross-language wire format; consumers in non-Python runtimes deserialize as plain string
         default="1.0.0",
         description=(
             "Schema format version for consumer compatibility. "

--- a/src/omnibase_infra/models/projectors/model_projector_schema.py
+++ b/src/omnibase_infra/models/projectors/model_projector_schema.py
@@ -114,7 +114,7 @@ class ModelProjectorSchema(BaseModel):
         description="List of index definitions",
     )
 
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: validated internally via field_validator; used as plain string in SQL comment generation
         default="1.0.0",
         description="Schema version string (semver format)",
     )

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py
@@ -74,7 +74,9 @@ class ModelSavingsEstimate(BaseModel):
         default_factory=uuid4,
         description="Correlation ID for tracing",
     )
-    schema_version: str = Field(default="1.0", description="Schema version")
+    schema_version: str = Field(
+        default="1.0", description="Schema version"
+    )  # string-version-ok: Kafka wire envelope; cross-service consumers deserialize as plain string
     actual_total_tokens: int = Field(
         default=0, ge=0, description="Total tokens consumed"
     )

--- a/src/omnibase_infra/runtime/emit_daemon/event_registry.py
+++ b/src/omnibase_infra/runtime/emit_daemon/event_registry.py
@@ -134,7 +134,7 @@ class ModelEventRegistration(BaseModel):
         default_factory=tuple,
         description="Tuple of field names that must be present in payload",
     )
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: injected into Kafka event metadata for cross-service schema evolution tracking
         default="1.0.0",
         description="Semantic version of the event schema",
     )

--- a/src/omnibase_infra/runtime/emit_daemon/model_event_registry_fingerprint_element.py
+++ b/src/omnibase_infra/runtime/emit_daemon/model_event_registry_fingerprint_element.py
@@ -36,7 +36,9 @@ class ModelEventRegistryFingerprintElement(BaseModel):
     topic_template: str = Field(
         ..., description="Canonical ONEX topic suffix (no env prefix)"
     )
-    schema_version: str = Field(..., description="Semantic version of the event schema")
+    schema_version: str = Field(
+        ..., description="Semantic version of the event schema"
+    )  # string-version-ok: fingerprint element serialized as plain string for SHA-256 canonical tuple hashing
     partition_key_field: str = Field(
         ..., description="Partition key field name, or empty string if None"
     )

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_envelope.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_envelope.py
@@ -72,7 +72,7 @@ class ModelObservabilityEnvelope(BaseModel):
     producer_id: str = Field(  # ONEX_EXCLUDE: string_id - external service identifier
         ..., description="Identifier of the service/component that produced the event."
     )
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: observability event envelope; cross-service consumers deserialize schema version as plain string
         ...,
         description="Version of the event schema for evolution tracking.",
     )

--- a/src/omnibase_infra/services/observability/savings_estimation/config.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/config.py
@@ -115,7 +115,7 @@ class ConfigSavingsEstimation(BaseSettings):
         description="Size of in-memory finalized session set for dedup optimization.",
     )
 
-    schema_version: str = Field(
+    schema_version: str = Field(  # string-version-ok: configures version injected into Kafka savings event wire format; consumers deserialize as plain string
         default="1.0",
         description="Schema version for produced savings events.",
     )

--- a/tests/integration/validation/test_schema_version_annotation_integration.py
+++ b/tests/integration/validation/test_schema_version_annotation_integration.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for schema_version field annotation backfill [OMN-9025].
+
+Verifies that models with string-version-ok annotations instantiate correctly
+and that schema_version fields accept plain string values as required by their
+wire format contracts (Kafka envelopes, cross-service consumers, YAML manifests).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+class TestSchemaVersionAnnotationBackfill:
+    """Verify annotated schema_version: str fields work correctly at runtime."""
+
+    def test_model_event_headers_schema_version_is_str(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.event_bus.models.model_event_headers import (
+            ModelEventHeaders,
+        )
+
+        headers = ModelEventHeaders(
+            source="test",
+            event_type="test.event",
+            timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        assert isinstance(headers.schema_version, str)
+        assert headers.schema_version == "1.0.0"
+
+    def test_model_event_headers_accepts_custom_version(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.event_bus.models.model_event_headers import (
+            ModelEventHeaders,
+        )
+
+        headers = ModelEventHeaders(
+            source="test",
+            event_type="test.event",
+            timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+            schema_version="2.1.0",
+        )
+        assert headers.schema_version == "2.1.0"
+
+    def test_model_stub_comment_schema_version_is_str(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.adapters.project_tracker.model_stub_comment import (
+            ModelStubComment,
+        )
+
+        comment = ModelStubComment(
+            id="c-1",
+            body="stub body",
+            author="agent",
+            created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        assert isinstance(comment.schema_version, str)
+        assert comment.schema_version == "1.0"
+
+    def test_model_event_registry_fingerprint_element_schema_version_is_str(
+        self,
+    ) -> None:
+        from omnibase_infra.runtime.emit_daemon.model_event_registry_fingerprint_element import (
+            ModelEventRegistryFingerprintElement,
+        )
+
+        element = ModelEventRegistryFingerprintElement(
+            event_type="test.event.created",
+            topic_template="onex.evt.test.event-created.v1",
+            schema_version="1.0.0",
+            partition_key_field="correlation_id",
+            required_fields=("correlation_id", "payload"),
+            element_sha256="a" * 64,
+        )
+        assert isinstance(element.schema_version, str)
+        assert element.schema_version == "1.0.0"


### PR DESCRIPTION
[skip-deploy-gate: OMN-9025 is schema_version backfill; no runtime paths affected]

## Summary

- Annotate 11 Pydantic model `schema_version: str` fields with `# string-version-ok:` comments explaining why plain `str` is correct (Kafka wire envelopes, cross-service consumers, YAML format discriminators, SHA-256 canonical tuple hashing, external API contracts)
- Excludes 2 function-parameter hits (`demo_loop_gate.py:131`, `store.py:199`) per triage — function parameters are not Pydantic field declarations
- All hooks pass: mypy --strict, ruff, pre-commit all-files

[skip-receipt-gate: OMN-9025 is schema_version backfill; no new runtime surface]

## Files changed
- `adapters/project_tracker/model_stub_comment.py`
- `event_bus/models/model_event_headers.py`
- `models/checkpoint/model_checkpoint.py`
- `models/pricing/model_pricing_table.py`
- `models/projection/model_registration_snapshot.py`
- `models/projectors/model_projector_schema.py`
- `nodes/node_savings_estimation_compute/models/model_savings_estimate.py`
- `runtime/emit_daemon/event_registry.py`
- `runtime/emit_daemon/model_event_registry_fingerprint_element.py`
- `services/observability/agent_actions/models/model_envelope.py`
- `services/observability/savings_estimation/config.py`