### PR TITLE
feat(topics): register 6 Phase 2 Kafka topics [OMN-8998]

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -181,6 +181,14 @@ services:
       rpk topic create onex.evt.omniintelligence.pattern-lifecycle-transitioned.v1 --brokers redpanda:9092 -p 3 || true
       rpk topic create onex.evt.pattern.discovered.v1 --brokers redpanda:9092 -p 3 || true
 
+      # OmniMarket domain topics — Phase 2 (pr-polish pipeline) [OMN-8998]
+      rpk topic create onex.cmd.omnimarket.pr-thread-reply.v1 --brokers redpanda:9092 -p 3 || true
+      rpk topic create onex.cmd.omnimarket.pr-conflict-hunk.v1 --brokers redpanda:9092 -p 3 || true
+      rpk topic create onex.cmd.omnimarket.pr-ci-fix.v1 --brokers redpanda:9092 -p 3 || true
+      rpk topic create onex.evt.omnimarket.pr-thread-replied.v1 --brokers redpanda:9092 -p 3 || true
+      rpk topic create onex.evt.omnimarket.pr-conflict-resolved.v1 --brokers redpanda:9092 -p 3 || true
+      rpk topic create onex.evt.omnimarket.pr-ci-fix-attempted.v1 --brokers redpanda:9092 -p 3 || true
+
       echo 'Topics created successfully!'
       rpk topic list --brokers redpanda:9092
       "


### PR DESCRIPTION
## Summary

Registers 6 omnimarket Phase 2 pr-polish pipeline topics in the E2E topic-init service (`docker/docker-compose.e2e.yml`), following the same pattern as Phase 1 omniintelligence topics.

**3 cmd topics (consumed by Phase 2 effect nodes):**
- `onex.cmd.omnimarket.pr-thread-reply.v1`
- `onex.cmd.omnimarket.pr-conflict-hunk.v1`
- `onex.cmd.omnimarket.pr-ci-fix.v1`

**3 evt topics (produced by Phase 2 effect nodes):**
- `onex.evt.omnimarket.pr-thread-replied.v1`
- `onex.evt.omnimarket.pr-conflict-resolved.v1`
- `onex.evt.omnimarket.pr-ci-fix-attempted.v1`

## DoD compliance

- Topics follow `onex.{cmd|evt}.omnimarket.{event-name}.v{N}` convention — topic-naming-lint passes
- All pre-commit hooks pass (topic naming lint, topic enum drift, topic contract parity)
- Topic-init service creates topics at E2E startup → `rpk topic list` will show all six

[skip-receipt-gate: OMN-8998 is topic registration config]
[skip-deploy-gate: deploy-agent inactive per OMN-8841]

## Test plan

- [ ] CI topic-naming-lint passes (all 6 topics conform to ONEX naming convention)
- [ ] CI topic-enum-drift passes (no Python enum files affected)
- [ ] E2E topic-init service creates all 6 topics on startup (`rpk topic list` shows them)