### PR TITLE
feat(registry): add health_path entries for Phase 2 LLM models [OMN-8995]

### DIFF
--- a/docker/catalog/model_registry.yaml
+++ b/docker/catalog/model_registry.yaml
@@ -11,6 +11,7 @@ models:
     provider: local
     transport: http
     base_url_env: LLM_CODER_URL
+    health_path: "/health"
     # cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit on 192.168.86.201:8000
     # Context extended to 112K via TurboQuant aither-kvcache K4/V3 compression
     capabilities:
@@ -26,6 +27,7 @@ models:
     provider: local
     transport: http
     base_url_env: LLM_CODER_FAST_URL
+    health_path: "/health"
     # Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ on 192.168.86.201:8001
     capabilities:
       - deep_reasoning
@@ -40,6 +42,7 @@ models:
     provider: local
     transport: http
     base_url_env: LLM_DEEPSEEK_R1_URL
+    health_path: "/health"
     capabilities:
       - deep_reasoning
       - code_review
@@ -105,6 +108,7 @@ models:
     transport: http
     base_url_env: LLM_GLM_URL
     api_key_env: LLM_GLM_API_KEY
+    health_path: ""
     capabilities:
       - code_generation
       - refactoring

--- a/tests/unit/docker/test_model_registry_health_paths.py
+++ b/tests/unit/docker/test_model_registry_health_paths.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests: model_registry.yaml health_path entries for Phase 2 LLM models [OMN-8995]."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+_REGISTRY_PATH = _PROJECT_ROOT / "docker" / "catalog" / "model_registry.yaml"
+
+# Phase 2 primary and fallback model keys per OMN-8995 DoD.
+# glm-4.5 is a cloud endpoint: health_path="" means always-healthy per HandlerModelRouter.
+_PHASE2_HEALTH_PATHS: dict[str, str] = {
+    "deepseek-r1-14b": "/health",
+    "deepseek-r1-32b": "/health",
+    "qwen3-coder-30b": "/health",
+    "glm-4.5": "",
+}
+
+
+@pytest.fixture(scope="module")
+def registry() -> list[dict[str, object]]:
+    data: dict[str, list[dict[str, object]]] = yaml.safe_load(
+        _REGISTRY_PATH.read_text()
+    )
+    return data["models"]
+
+
+@pytest.mark.unit
+def test_registry_file_exists() -> None:
+    assert _REGISTRY_PATH.exists(), f"model_registry.yaml not found at {_REGISTRY_PATH}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_key", "expected_path"), list(_PHASE2_HEALTH_PATHS.items())
+)
+def test_phase2_model_has_health_path(
+    registry: list[dict[str, object]],
+    model_key: str,
+    expected_path: str,
+) -> None:
+    by_key = {str(m["model_key"]): m for m in registry}
+    assert model_key in by_key, (
+        f"model_key '{model_key}' not found in model_registry.yaml"
+    )
+    entry = by_key[model_key]
+    assert "health_path" in entry, f"'{model_key}' is missing health_path field"
+    assert entry["health_path"] == expected_path, (
+        f"'{model_key}' health_path={entry['health_path']!r}, expected {expected_path!r}"
+    )


### PR DESCRIPTION
## Summary

- Add `health_path: "/health"` to `deepseek-r1-14b`, `deepseek-r1-32b`, and `qwen3-coder-30b` in `docker/catalog/model_registry.yaml`
- Add `health_path: ""` to `glm-4.5` (cloud endpoint — empty = always-healthy per `HandlerModelRouter` semantics)
- Add `tests/unit/docker/test_model_registry_health_paths.py` — parametrized assertions on all four Phase 2 model keys (5 tests, all passing)

Data change only — no handler source changes.

## Test plan

- [x] `uv run pytest tests/unit/docker/test_model_registry_health_paths.py -v` — 5 passed
- [x] `uv run ruff check` — no issues
- [x] `uv run mypy tests/unit/docker/test_model_registry_health_paths.py --strict` — no issues
- [x] `pre-commit run --all-files` — all hooks passed

[skip-receipt-gate: OMN-8995 is registry config; no new runtime surface]
[skip-deploy-gate: deploy-agent inactive per OMN-8841]