### PR TITLE
docs(claude-md): runtime startup first-class CI gate rule [OMN-9126]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,15 @@
 
 <!-- How were these changes tested? -->
 
+## Runtime startup gate (OMN-9126)
+
+If this PR touches `auto_wiring/`, `service_kernel.py`, handler `__init__` signatures, or kernel-level registration:
+- [ ] Test loads the **real** contract manifest from disk (no fake/stub handlers)
+- [ ] Test calls `wire_from_manifest` with the same args the kernel uses in production
+- [ ] Test asserts zero wiring failures
+- [ ] CI boots `omninode-runtime` in a compose sandbox and asserts `RestartCount == 0` after 45s
+- [ ] N/A — this PR does not touch any of the above
+
 ## Type safety checklist
 - [ ] No new `metadata["key"]` or `metadata.get("key")` string literal access on Pydantic model fields
 - [ ] No new `metadata: dict[str, Any]` fields without TypedDict or `# ONEX_EXCLUDE:` comment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ If this PR touches `auto_wiring/`, `service_kernel.py`, handler `__init__` signa
 - [ ] Test loads the **real** contract manifest from disk (no fake/stub handlers)
 - [ ] Test calls `wire_from_manifest` with the same args the kernel uses in production
 - [ ] Test asserts zero wiring failures
-- [ ] CI boots `omninode-runtime` in a compose sandbox and asserts `RestartCount == 0` after 45s
+- [ ] CI boots `omninode-runtime` in a compose sandbox, waits for Docker `healthy` within compose `start_period`, and asserts `RestartCount == 0` at the health-ready checkpoint
 - [ ] N/A — this PR does not touch any of the above
 
 ## Type safety checklist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,7 +797,12 @@ Any PR that touches `auto_wiring/`, `service_kernel.py`, handler `__init__` sign
 2. Runs `wire_from_manifest` with the same args the kernel passes in production.
 3. Asserts zero failures for required handlers.
 
-CI must additionally boot `omninode-runtime` in a compose sandbox and assert `RestartCount == 0` after 45s.
+CI must additionally boot `omninode-runtime` in a compose sandbox and assert:
+
+- the container reaches Docker healthy state within the configured compose `start_period` (currently 600s for `omninode-runtime`, see `docker/docker-compose.infra.yml`), and
+- `RestartCount == 0` at the health-ready checkpoint — not a fixed 45s wall-clock window.
+
+Ad-hoc short timeouts are forbidden: any PR that shortens the gate below `start_period` must also update the compose healthcheck in the same PR, with justification.
 
 **Forbidden:** aspirational integration gates — "there's a test file but it uses fake handlers." The boot must actually happen against real handlers.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,6 +789,20 @@ uv run pytest tests/ -n 0 -xvs
 | `cleanup_consul_test_services` | Cleans Consul test registrations |
 | `cleanup_postgres_test_projections` | Cleans PostgreSQL test rows |
 
+### Runtime Startup is a First-Class CI Gate (OMN-9126)
+
+Any PR that touches `auto_wiring/`, `service_kernel.py`, handler `__init__` signatures, or kernel-level registration MUST include a test that:
+
+1. Loads the real contract manifest from disk.
+2. Runs `wire_from_manifest` with the same args the kernel passes in production.
+3. Asserts zero failures for required handlers.
+
+CI must additionally boot `omninode-runtime` in a compose sandbox and assert `RestartCount == 0` after 45s.
+
+**Forbidden:** aspirational integration gates — "there's a test file but it uses fake handlers." The boot must actually happen against real handlers.
+
+**Strict-mode invariants** that tighten acceptance land AFTER all downstream consumers are compliant, not before. If a strict gate must ship first, it ships behind an env flag (default OFF) and is flipped in a separate PR once compliance is merged.
+
 ---
 
 ## Contract-Driven Config Discovery

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -15,6 +15,9 @@ and wires handlers into the :class:`MessageDispatchEngine`:
 6. Return a :class:`ModelAutoWiringReport` with per-contract outcomes.
 
 This module performs I/O (module imports, Kafka subscriptions) — it is NOT pure.
+
+CI gate: any PR touching this module MUST satisfy the runtime-startup gate defined in
+``omnibase_infra/CLAUDE.md`` § "Runtime Startup is a First-Class CI Gate (OMN-9126)".
 """
 
 from __future__ import annotations

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -17,7 +17,7 @@ and wires handlers into the :class:`MessageDispatchEngine`:
 This module performs I/O (module imports, Kafka subscriptions) — it is NOT pure.
 
 CI gate: any PR touching this module MUST satisfy the runtime-startup gate defined in
-``omnibase_infra/CLAUDE.md`` § "Runtime Startup is a First-Class CI Gate (OMN-9126)".
+``CLAUDE.md`` § "Runtime Startup is a First-Class CI Gate (OMN-9126)" (repo root).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Adds **Runtime Startup is a First-Class CI Gate** standing rule to `omnibase_infra/CLAUDE.md` §Testing and CI.
- Cross-links the rule from `handler_wiring.py` module docstring.

## Rule

Any PR touching `auto_wiring/`, `service_kernel.py`, handler `__init__` signatures, or kernel-level registration must:
1. Load the real contract manifest from disk.
2. Run `wire_from_manifest` with production args.
3. Assert zero failures for required handlers.

CI must additionally boot `omninode-runtime` in a compose sandbox and assert `RestartCount == 0` after 45s. Aspirational gates using fake handlers are forbidden.

## Notes

- `~/.claude/CLAUDE.md` (user-level shared config) is not PRable — that edit must be applied manually per the DoD. The rule lives in the repo-level CLAUDE.md as primary ratification.

[skip-receipt-gate: OMN-9126 is doc-only]
[skip-deploy-gate: deploy-agent inactive per OMN-8841]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CI section and PR-template checklist enforcing a runtime-startup gate: load the real on-disk contract manifest, perform production-equivalent wiring, and assert zero required-handler failures.
  * Require a real runtime boot in a compose sandbox and verify health at the health-ready checkpoint (RestartCount == 0); forbid fake/shortened gates unless justified and updated in the same PR.
  * Clarified strict-mode rollout: only after downstream compliance or behind an OFF-by-default flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->