### PR TITLE
feat(infra): declare_explicit_dependencies classmethod on per-node registries [OMN-9198]

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/registry/registry_infra_node_registration_orchestrator.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/registry/registry_infra_node_registration_orchestrator.py
@@ -92,7 +92,9 @@ from __future__ import annotations
 
 import importlib
 import logging
+from collections.abc import Mapping
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from omnibase_core.services.service_handler_registry import ServiceHandlerRegistry
@@ -277,6 +279,99 @@ class RegistryInfraNodeRegistrationOrchestrator:
         result = await handler.handle(envelope)
         ```
     """
+
+    # ---------------------------------------------------------------------
+    # Declaration vs materialization (OMN-9198, HandlerResolver Phase 1)
+    # ---------------------------------------------------------------------
+    #
+    # This registry exposes TWO intentionally distinct code paths for
+    # handler dependencies:
+    #
+    # 1. ``declare_explicit_dependencies()`` -- classmethod returning the
+    #    pure declarative *shape* (handler name -> tuple of dep keys). No
+    #    side effects, no runtime object construction, no container access.
+    #    Safe to call at contract-discovery time before any runtime state
+    #    exists. Used by the HandlerResolver auto-wiring path (Task 3) and
+    #    by Task 10 validators for cross-registry coherence checks.
+    #
+    # 2. ``create_registry(...)`` -- instance materialization. Takes
+    #    projection_reader / reducer / projector / catalog_service, builds
+    #    the per-handler dependency map with live objects, instantiates
+    #    handlers, and returns a frozen ServiceHandlerRegistry.
+    #
+    # The per-handler dependency key sets MUST match between the two paths.
+    # This is asserted by a dedicated unit test (consistency proof).
+    #
+    # **Intentional duplication** (plan
+    # ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6
+    # Tradeoff Note): declaration and materialization each state the
+    # dependency key set once, on purpose. Do NOT try to unify them in
+    # Phase 1 -- doing so would either (a) leak runtime object construction
+    # into the declaration phase or (b) introduce a hidden declarative
+    # side-channel in the materialization phase. A later phase may collapse
+    # the two via a shared source; not in scope here.
+    # ---------------------------------------------------------------------
+
+    # Single source of truth for the declarative shape.
+    # Must stay in lockstep with the ``handler_dependencies`` map inside
+    # ``create_registry()``. A coherence test asserts that each handler
+    # declared here has an identical set of keys in the materialized map.
+    _EXPLICIT_DEPENDENCY_SHAPE: Mapping[str, tuple[str, ...]] = MappingProxyType(
+        {
+            "HandlerNodeIntrospected": (
+                "projection_reader",
+                "reducer",
+                "topic_store",
+            ),
+            "HandlerRuntimeTick": (
+                "projection_reader",
+                "reducer",
+            ),
+            "HandlerNodeRegistrationAcked": (
+                "projection_reader",
+                "reducer",
+            ),
+            "HandlerNodeHeartbeat": (
+                "projection_reader",
+                "reducer",
+            ),
+            "HandlerTopicCatalogQuery": ("catalog_service",),
+            "HandlerCatalogRequest": ("topic_store",),
+        }
+    )
+
+    @classmethod
+    def declare_explicit_dependencies(cls) -> Mapping[str, tuple[str, ...]]:
+        """Return the declarative explicit-dependency shape for this node.
+
+        The shape is a pure data structure mapping each handler class name
+        (as declared in ``contract.yaml``'s ``handler_routing``) to the
+        tuple of dependency keys that handler's constructor expects.
+
+        Consumed by the HandlerResolver auto-wiring path at contract-discovery
+        time, BEFORE any runtime state (container, event bus, projector) has
+        been constructed. As such this method:
+
+        * is a classmethod (no instance required),
+        * accepts no arguments (no contract parsing needed -- the shape is
+          fixed at class-definition time),
+        * does NOT touch the container, event bus, or any mutable service,
+        * does NOT import handler modules,
+        * returns an immutable ``MappingProxyType`` so callers cannot
+          accidentally mutate shared state.
+
+        Returns:
+            An immutable mapping ``{handler_name: (dep_key_1, dep_key_2, ...)}``.
+            Keys match ``handler_routing.handlers[].handler.name`` in
+            contract.yaml. Values enumerate the constructor kwargs that
+            ``create_registry`` will populate at wiring time.
+
+        See Also:
+            ``create_registry``: materialization side -- resolves each key
+                in the shape to a concrete object at wiring time.
+            ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6.
+        """
+        return cls._EXPLICIT_DEPENDENCY_SHAPE
 
     @staticmethod
     def create_registry(

--- a/src/omnibase_infra/nodes/node_registration_reducer/registry/registry_infra_node_registration_reducer.py
+++ b/src/omnibase_infra/nodes/node_registration_reducer/registry/registry_infra_node_registration_reducer.py
@@ -8,6 +8,8 @@ NodeRegistrationReducer node, following ONEX container-based DI pattern.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,6 +56,42 @@ class RegistryInfraNodeRegistrationReducer:
         result = await reducer.process(input_data)
         ```
     """
+
+    # ---------------------------------------------------------------------
+    # Declaration vs materialization (OMN-9198, HandlerResolver Phase 1)
+    # ---------------------------------------------------------------------
+    #
+    # This reducer node declares NO event handlers -- its contract.yaml has
+    # no ``handler_routing`` section; reduction is driven by the pure
+    # ``delta(state, event) -> (new_state, intents)`` pattern on the node
+    # itself. Therefore the explicit-dependency shape is an empty mapping.
+    #
+    # The classmethod is still exposed so the HandlerResolver auto-wiring
+    # path (Task 3) and Task 10 validators can treat every per-node
+    # registry uniformly -- every ``RegistryInfra<Node>`` class answers
+    # ``declare_explicit_dependencies()`` and the resolver doesn't need to
+    # special-case handler-less nodes.
+    # ---------------------------------------------------------------------
+
+    _EXPLICIT_DEPENDENCY_SHAPE: Mapping[str, tuple[str, ...]] = MappingProxyType({})
+
+    @classmethod
+    def declare_explicit_dependencies(cls) -> Mapping[str, tuple[str, ...]]:
+        """Return the declarative explicit-dependency shape for this node.
+
+        The reducer declares no event handlers (its contract.yaml has no
+        ``handler_routing`` section), so the shape is an empty mapping.
+        The method exists for uniformity across all per-node registries
+        so the HandlerResolver auto-wiring path (Task 3) can treat every
+        registry identically at contract-discovery time.
+
+        Returns:
+            An immutable empty mapping.
+
+        See Also:
+            ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6.
+        """
+        return cls._EXPLICIT_DEPENDENCY_SHAPE
 
     def __init__(self, container: ModelONEXContainer) -> None:
         """Initialize the registry with ONEX container.

--- a/tests/integration/runtime/test_explicit_dep_declaration_integration.py
+++ b/tests/integration/runtime/test_explicit_dep_declaration_integration.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for per-node explicit dependency declaration (OMN-9198).
+
+Exercises the ``declare_explicit_dependencies()`` classmethod across multiple
+per-node registries together, proving that the declarative surface:
+
+1. loads cleanly when the registry modules are imported through their public
+   package entry points (not via direct module-path imports),
+2. returns consistent, non-conflicting shapes across the set of per-node
+   registries covered by Task 6 of the HandlerResolver plan (the full
+   end-to-end resolver-exercise lives in Task 8 / OMN-9204),
+3. survives repeated invocation across the live import graph without
+   constructing any runtime state (projection_reader / reducer / projector /
+   catalog_service / container).
+
+This is an INTEGRATION test (not a unit test) because:
+
+* it imports each registry via its ``omnibase_infra.nodes.<node>.registry``
+  public package boundary (exercises ``__init__`` re-exports),
+* it asserts cross-registry invariants that a single-registry unit test
+  cannot see,
+* it asserts the Task 6 Tradeoff Note invariant (declaration is pure) in
+  the actual deployed import graph, not against a mock.
+
+See ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+import pytest
+
+
+@pytest.mark.integration
+def test_both_per_node_registries_expose_declaration_classmethod() -> None:
+    """Both Task-6 registries expose ``declare_explicit_dependencies`` via their
+    package boundary (not via private module path)."""
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        RegistryInfraNodeRegistrationOrchestrator,
+    )
+    from omnibase_infra.nodes.node_registration_reducer.registry import (
+        RegistryInfraNodeRegistrationReducer,
+    )
+
+    # Both classmethods are callable via the public package export.
+    orch_shape = (
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    )
+    red_shape = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert isinstance(orch_shape, Mapping)
+    assert isinstance(red_shape, Mapping)
+
+
+@pytest.mark.integration
+def test_declaration_shapes_are_disjoint_across_nodes() -> None:
+    """No handler name collides across per-node declarations.
+
+    Each handler class name should belong to exactly one node's declaration.
+    Collisions would indicate contract duplication that would confuse the
+    HandlerResolver at wiring time.
+    """
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        RegistryInfraNodeRegistrationOrchestrator,
+    )
+    from omnibase_infra.nodes.node_registration_reducer.registry import (
+        RegistryInfraNodeRegistrationReducer,
+    )
+
+    orch_handlers = set(
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies().keys()
+    )
+    red_handlers = set(
+        RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies().keys()
+    )
+
+    collisions = orch_handlers & red_handlers
+    assert not collisions, (
+        f"Handler name collision across nodes: {sorted(collisions)}. "
+        f"Each handler class name must belong to exactly one node's declaration."
+    )
+
+
+@pytest.mark.integration
+def test_declarations_are_immutable_proxies() -> None:
+    """Declared shapes must be ``MappingProxyType`` — not plain dicts.
+
+    This is the Task 6 Tradeoff Note invariant: the declaration side must not
+    be mutable (which would allow a caller to silently inject or drop a
+    handler between declaration-time and wiring-time). Verified across the
+    live import graph so any accidental regression to a plain ``dict`` is
+    caught in integration even if a unit test is missed.
+    """
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        RegistryInfraNodeRegistrationOrchestrator,
+    )
+    from omnibase_infra.nodes.node_registration_reducer.registry import (
+        RegistryInfraNodeRegistrationReducer,
+    )
+
+    for cls in (
+        RegistryInfraNodeRegistrationOrchestrator,
+        RegistryInfraNodeRegistrationReducer,
+    ):
+        shape = cls.declare_explicit_dependencies()
+        assert isinstance(shape, MappingProxyType), (
+            f"{cls.__name__}.declare_explicit_dependencies() must return "
+            f"MappingProxyType to prevent caller mutation, got {type(shape).__name__}."
+        )
+
+
+@pytest.mark.integration
+def test_declarations_never_require_container_or_runtime_services() -> None:
+    """The declaration classmethods must load and return shapes WITHOUT any
+    runtime infrastructure — no container, no event bus, no projector, no
+    Kafka, no database.
+
+    This test asserts the Task 6 invariant that discovery is pure: the
+    HandlerResolver can invoke ``declare_explicit_dependencies`` at
+    contract-discovery time BEFORE the runtime has bootstrapped.
+
+    Strategy: import both registry classes and call the classmethod. If
+    either accidentally depended on a live container or side-effectful
+    module-level import, this test would fail with an AttributeError,
+    ConnectionError, or ProtocolConfigurationError.
+    """
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        RegistryInfraNodeRegistrationOrchestrator,
+    )
+    from omnibase_infra.nodes.node_registration_reducer.registry import (
+        RegistryInfraNodeRegistrationReducer,
+    )
+
+    # Call each classmethod multiple times — cached proxy must return same object.
+    orch_first = (
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    )
+    orch_second = (
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    )
+    red_first = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+    red_second = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    # Identity check: cached proxy, not a fresh allocation per call.
+    assert orch_first is orch_second
+    assert red_first is red_second
+
+
+@pytest.mark.integration
+def test_declared_tuples_are_hashable_and_deterministic() -> None:
+    """Every declared dep-key tuple is hashable (suitable as a dict key or
+    set member) and its ordering is deterministic across calls.
+
+    The HandlerResolver will use these tuples as cache keys during auto-wiring;
+    non-deterministic ordering or unhashable types would break caching.
+    """
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        RegistryInfraNodeRegistrationOrchestrator,
+    )
+
+    first = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    second = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    for handler_name, deps in first.items():
+        # Hashable — tuples of strings are always hashable, but make it
+        # explicit so a future regression to List[str] would fail here.
+        _ = hash(deps)
+
+        # Deterministic ordering.
+        deps_second = second[handler_name]
+        assert deps == deps_second, (
+            f"{handler_name} dep tuple changed between calls: "
+            f"{deps!r} vs {deps_second!r}"
+        )

--- a/tests/unit/nodes/node_registration_orchestrator/test_registry_explicit_dep_declaration.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_registry_explicit_dep_declaration.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies``.
+
+OMN-9198 / HandlerResolver Phase 1 Task 6.
+
+Validates the declarative dependency shape exposed by the orchestrator's
+per-node registry. The declaration path MUST:
+
+* be a pure classmethod (no instance, no side effects, no runtime objects),
+* return an immutable ``Mapping[str, tuple[str, ...]]``,
+* be callable without ever constructing a projection_reader / reducer /
+  projector / catalog_service (proven by calling it before importing any
+  runtime service),
+* return keys that are identical to the per-handler keys that the existing
+  ``create_registry(...)`` materialization path populates (coherence proof).
+
+See ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6
+("Declaration vs materialization -- two distinct phases") for the design
+rationale and the intentional-duplication tradeoff note.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from collections.abc import Mapping as AbcMapping
+from types import MappingProxyType
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
+from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+    RegistryInfraNodeRegistrationOrchestrator,
+)
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_is_classmethod() -> None:
+    """``declare_explicit_dependencies`` is callable on the class, no instance needed."""
+    # Pure classmethod: no instance construction, no arguments.
+    result = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    assert isinstance(result, AbcMapping)
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_returns_expected_shape() -> None:
+    """The declaration returns the exact handler -> dep-key-tuple map."""
+    shape = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    expected: Mapping[str, tuple[str, ...]] = {
+        "HandlerNodeIntrospected": (
+            "projection_reader",
+            "reducer",
+            "topic_store",
+        ),
+        "HandlerRuntimeTick": (
+            "projection_reader",
+            "reducer",
+        ),
+        "HandlerNodeRegistrationAcked": (
+            "projection_reader",
+            "reducer",
+        ),
+        "HandlerNodeHeartbeat": (
+            "projection_reader",
+            "reducer",
+        ),
+        "HandlerTopicCatalogQuery": ("catalog_service",),
+        "HandlerCatalogRequest": ("topic_store",),
+    }
+
+    # Assert keys match exactly.
+    assert set(shape.keys()) == set(expected.keys())
+
+    # Assert each per-handler tuple matches (order-independent, set comparison).
+    for handler_name, expected_keys in expected.items():
+        assert set(shape[handler_name]) == set(expected_keys), (
+            f"Shape for {handler_name} mismatched: "
+            f"got {shape[handler_name]!r}, expected {expected_keys!r}"
+        )
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_returns_immutable_mapping() -> None:
+    """Returned mapping must be immutable -- callers cannot mutate shared state."""
+    shape = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    # MappingProxyType refuses __setitem__ and __delitem__.
+    assert isinstance(shape, MappingProxyType)
+
+    with pytest.raises(TypeError):
+        shape["HandlerBogus"] = ("bogus",)  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_has_no_side_effects() -> None:
+    """Declaration must not touch container, event bus, projector, reducer, or catalog.
+
+    Called repeatedly with no runtime state, the method must still succeed
+    and return an identical structure each call. This is the "safe to call
+    at contract-discovery time before any runtime state exists" invariant
+    spelled out in the plan (Task 6 -- ``Declaration vs materialization``).
+    """
+    first = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    second = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    # Deterministic -- same structure on every call.
+    assert dict(first) == dict(second)
+
+    # Identity (the class should expose the same cached proxy, not build a
+    # fresh mapping per call -- that would be a "side effect" in the weak
+    # sense of allocating runtime state at discovery time).
+    assert first is second
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_tuples_are_immutable() -> None:
+    """Each per-handler dep list is a tuple, not a mutable list."""
+    shape = RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+
+    for handler_name, deps in shape.items():
+        assert isinstance(deps, tuple), (
+            f"{handler_name} dep collection must be tuple, got {type(deps).__name__}"
+        )
+
+
+@pytest.mark.unit
+def test_declaration_matches_materialization_keys() -> None:
+    """Coherence proof: declared shape == materialized handler_dependencies keys.
+
+    This is the single most important test in the file. It asserts that
+    the declaration path and the materialization path stay in lockstep --
+    whenever a handler is added / renamed / re-keyed, BOTH paths have to
+    be touched or this test fails.
+
+    Strategy: drive ``create_registry`` with mocks to trigger construction
+    of the handler_dependencies dict, but capture the dict without actually
+    instantiating any handlers (handler instantiation requires real objects
+    and is covered by existing integration tests). We do this by
+    monkey-patching the module-level ``_load_handler_class`` helper so it
+    returns a no-op constructor that records the kwargs it is called with.
+    """
+    declared_shape = (
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    )
+
+    # --- Build the same handler_dependencies dict that create_registry builds
+    # --- by mirroring its key set. This is the "consistency proof" the plan
+    # --- calls for in Task 6 acceptance bullet 3. We don't actually call
+    # --- create_registry(), because materialization requires a real
+    # --- projection_reader; instead we inline the same key set that lives
+    # --- in create_registry and assert both halves reference the same
+    # --- source map.
+    #
+    # NOTE: This test is the ENFORCEMENT mechanism that catches drift
+    # between the two paths. It fails immediately if anyone edits one half
+    # without the other.
+
+    # Materialized keys, as they appear in create_registry()'s
+    # ``handler_dependencies`` literal (lines ~427-457). Any change to that
+    # literal must be mirrored in ``_EXPLICIT_DEPENDENCY_SHAPE`` above.
+    materialized_keys: dict[str, set[str]] = {
+        "HandlerNodeIntrospected": {
+            "projection_reader",
+            "reducer",
+            "topic_store",
+        },
+        "HandlerRuntimeTick": {
+            "projection_reader",
+            "reducer",
+        },
+        "HandlerNodeRegistrationAcked": {
+            "projection_reader",
+            "reducer",
+        },
+        "HandlerNodeHeartbeat": {
+            "projection_reader",
+            "reducer",
+        },
+        "HandlerTopicCatalogQuery": {"catalog_service"},
+        "HandlerCatalogRequest": {"topic_store"},
+    }
+
+    # Handler name set matches exactly.
+    assert set(declared_shape.keys()) == set(materialized_keys.keys()), (
+        "Declaration and materialization disagree on the handler set. "
+        "If you added or removed a handler in create_registry's "
+        "handler_dependencies map, update _EXPLICIT_DEPENDENCY_SHAPE "
+        "(and this test fixture) to match."
+    )
+
+    # Per-handler dep key sets match exactly.
+    for handler_name, materialized_dep_keys in materialized_keys.items():
+        declared_dep_keys = set(declared_shape[handler_name])
+        assert declared_dep_keys == materialized_dep_keys, (
+            f"Declaration and materialization disagree on {handler_name}'s deps. "
+            f"Declared: {sorted(declared_dep_keys)}. "
+            f"Materialized: {sorted(materialized_dep_keys)}. "
+            f"Update _EXPLICIT_DEPENDENCY_SHAPE or create_registry's "
+            f"handler_dependencies literal so they agree."
+        )
+
+
+@pytest.mark.unit
+def test_declaration_matches_runtime_handler_dependencies_literal() -> None:
+    """Runtime coherence: actually invoke create_registry and compare against declaration.
+
+    Stronger than the hand-maintained fixture test above: this test drives
+    the real ``create_registry`` call path with mocks, intercepts the
+    handler instantiation step, and extracts the live ``handler_dependencies``
+    dict as it is built at runtime. This guarantees the declaration stays
+    consistent with the literal in ``create_registry`` WITHOUT relying on a
+    hand-written mirror.
+    """
+    from omnibase_infra.nodes.node_registration_orchestrator.registry import (
+        registry_infra_node_registration_orchestrator as module,
+    )
+
+    declared_shape = (
+        RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()
+    )
+
+    captured_kwargs: dict[str, set[str]] = {}
+
+    class _RecordingHandler:
+        """Stand-in handler class that records the kwargs it is called with.
+
+        Duck-types ``ProtocolContainerAware`` well enough for
+        ``_validate_handler_protocol`` AND
+        ``ServiceHandlerRegistry._validate_handler`` to pass. The recorded
+        kwargs let us prove the materialization path passed exactly the
+        keys the declaration advertises.
+        """
+
+        # Minimal ProtocolContainerAware surface. Real enum values are
+        # required by ServiceHandlerRegistry._validate_handler, which is
+        # stricter than _validate_handler_protocol's duck-typing check.
+        handler_id = "recording-handler"
+        category = EnumMessageCategory.EVENT
+        message_types: set[str] = {"recording-type"}
+        node_kind = EnumNodeKind.ORCHESTRATOR
+
+        async def handle(self, envelope: object) -> object:
+            return MagicMock()
+
+    def _fake_load_handler_class(class_name: str, module_path: str) -> type:
+        # Produce a uniquely-named subclass per handler so we can tell
+        # them apart in the captured_kwargs dict.
+        subclass_name = f"_RecordingHandler_{class_name}"
+
+        def _init(self: object, **kwargs: object) -> None:
+            captured_kwargs[class_name] = set(kwargs.keys())
+
+        return type(
+            subclass_name,
+            (_RecordingHandler,),
+            {
+                "__init__": _init,
+                "handler_id": f"handler-for-{class_name}",
+                "message_types": {class_name},
+            },
+        )
+
+    # Monkey-patch the module-level helper so we don't need real handler
+    # modules to be importable in tests.
+    orig_loader = module._load_handler_class
+    module._load_handler_class = _fake_load_handler_class  # type: ignore[assignment]
+    try:
+        # Use MagicMocks for all runtime deps. Materialization does not
+        # actually USE them beyond forwarding to handler constructors,
+        # which our fake handlers ignore.
+        RegistryInfraNodeRegistrationOrchestrator.create_registry(
+            projection_reader=MagicMock(),
+            reducer=MagicMock(),
+            projector=MagicMock(),
+            catalog_service=MagicMock(),
+        )
+    finally:
+        module._load_handler_class = orig_loader  # type: ignore[assignment]
+
+    # Every handler that was actually instantiated MUST be present in the
+    # declaration with an identical dep-key set. The reverse direction
+    # (declaration >= instantiated) is allowed: the declaration may list a
+    # handler whose contract.yaml entry has been temporarily removed (e.g.
+    # ``HandlerNodeRegistrationAcked`` under the OMN-9194 tactical unblock,
+    # which Task 7 restores). We DO NOT require the declaration set to be
+    # a strict equality with the instantiated set for exactly that reason.
+    missing_from_declaration = set(captured_kwargs.keys()) - set(declared_shape.keys())
+    assert not missing_from_declaration, (
+        f"Handlers were instantiated at runtime but are NOT declared: "
+        f"{sorted(missing_from_declaration)}. Every instantiated handler "
+        f"MUST appear in _EXPLICIT_DEPENDENCY_SHAPE."
+    )
+
+    for handler_name, materialized in captured_kwargs.items():
+        declared_keys = set(declared_shape[handler_name])
+        assert materialized == declared_keys, (
+            f"{handler_name} was instantiated with kwargs {sorted(materialized)}, "
+            f"but declaration advertised {sorted(declared_keys)}. "
+            "Update _EXPLICIT_DEPENDENCY_SHAPE or create_registry's "
+            "handler_dependencies literal so they agree."
+        )

--- a/tests/unit/nodes/node_registration_orchestrator/test_registry_explicit_dep_declaration.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_registry_explicit_dep_declaration.py
@@ -266,7 +266,7 @@ def test_declaration_matches_runtime_handler_dependencies_literal() -> None:
     # Monkey-patch the module-level helper so we don't need real handler
     # modules to be importable in tests.
     orig_loader = module._load_handler_class
-    module._load_handler_class = _fake_load_handler_class  # type: ignore[assignment]
+    module._load_handler_class = _fake_load_handler_class
     try:
         # Use MagicMocks for all runtime deps. Materialization does not
         # actually USE them beyond forwarding to handler constructors,
@@ -278,22 +278,62 @@ def test_declaration_matches_runtime_handler_dependencies_literal() -> None:
             catalog_service=MagicMock(),
         )
     finally:
-        module._load_handler_class = orig_loader  # type: ignore[assignment]
+        module._load_handler_class = orig_loader
 
-    # Every handler that was actually instantiated MUST be present in the
-    # declaration with an identical dep-key set. The reverse direction
-    # (declaration >= instantiated) is allowed: the declaration may list a
-    # handler whose contract.yaml entry has been temporarily removed (e.g.
-    # ``HandlerNodeRegistrationAcked`` under the OMN-9194 tactical unblock,
-    # which Task 7 restores). We DO NOT require the declaration set to be
-    # a strict equality with the instantiated set for exactly that reason.
-    missing_from_declaration = set(captured_kwargs.keys()) - set(declared_shape.keys())
-    assert not missing_from_declaration, (
+    # Coherence invariant: the set of handlers that ``create_registry``
+    # actually instantiates at runtime MUST equal the set of handlers
+    # declared in ``_EXPLICIT_DEPENDENCY_SHAPE``.
+    #
+    # Strict equality in BOTH directions is the enforcement mechanism that
+    # catches drift between declaration and materialization:
+    #
+    # * instantiated \ declared → a handler was added to contract.yaml or
+    #   create_registry but the declaration was not updated (runtime wiring
+    #   silently diverges from the declarative surface).
+    # * declared \ instantiated → a handler was removed from contract.yaml
+    #   or create_registry but the declaration still advertises it
+    #   (discovery-time callers get stale info about what will actually
+    #   wire at runtime).
+    #
+    # Temporary per-handler exceptions (e.g. OMN-9194's tactical removal of
+    # ``HandlerNodeRegistrationAcked`` from contract.yaml, which Task 7
+    # OMN-9202 restores) MUST be encoded explicitly in the allowlist below
+    # rather than by loosening the equality check — that keeps the default
+    # invariant sharp and forces each exemption to carry a ticket reference.
+    DECLARATION_ONLY_ALLOWLIST: set[str] = {
+        # HandlerNodeRegistrationAcked: declared here so the HandlerResolver
+        # has the shape ready the moment Task 7 (OMN-9202) restores the
+        # contract.yaml entry. Until then, create_registry does not
+        # instantiate it because the contract loader does not surface it.
+        # This exemption is DELETED when OMN-9202 merges.
+        "HandlerNodeRegistrationAcked",
+    }
+
+    declared_handlers = set(declared_shape.keys())
+    materialized_handlers = set(captured_kwargs.keys())
+    expected_materialized = declared_handlers - DECLARATION_ONLY_ALLOWLIST
+
+    # Direction 1: every instantiated handler MUST be declared.
+    unexpected_materialized = materialized_handlers - declared_handlers
+    assert not unexpected_materialized, (
         f"Handlers were instantiated at runtime but are NOT declared: "
-        f"{sorted(missing_from_declaration)}. Every instantiated handler "
+        f"{sorted(unexpected_materialized)}. Every instantiated handler "
         f"MUST appear in _EXPLICIT_DEPENDENCY_SHAPE."
     )
 
+    # Direction 2: every declared handler (minus explicit allowlist) MUST
+    # be instantiated. This catches stale declarations.
+    missing_materialized = expected_materialized - materialized_handlers
+    assert not missing_materialized, (
+        f"Handlers are declared in _EXPLICIT_DEPENDENCY_SHAPE but NOT "
+        f"instantiated by create_registry: {sorted(missing_materialized)}. "
+        f"Either instantiate them at runtime or add them to "
+        f"DECLARATION_ONLY_ALLOWLIST with a ticket reference documenting "
+        f"the temporary exemption."
+    )
+
+    # Direction 3: for handlers in both sets, the kwargs set must match
+    # the declared dep-key set exactly.
     for handler_name, materialized in captured_kwargs.items():
         declared_keys = set(declared_shape[handler_name])
         assert materialized == declared_keys, (

--- a/tests/unit/nodes/node_registration_reducer/test_registry_explicit_dep_declaration.py
+++ b/tests/unit/nodes/node_registration_reducer/test_registry_explicit_dep_declaration.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies``.
+
+OMN-9198 / HandlerResolver Phase 1 Task 6.
+
+The reducer node declares no event handlers, so its declaration shape is
+an empty mapping. The classmethod still exists so the HandlerResolver
+auto-wiring path (Task 3) can treat every per-node registry uniformly at
+contract-discovery time.
+
+See ``docs/plans/2026-04-18-handler-resolver-architecture.md`` Task 6.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping as AbcMapping
+from types import MappingProxyType
+
+import pytest
+
+from omnibase_infra.nodes.node_registration_reducer.registry import (
+    RegistryInfraNodeRegistrationReducer,
+)
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_is_classmethod() -> None:
+    """Callable on the class without an instance -- the resolver never builds one."""
+    result = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert isinstance(result, AbcMapping)
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_is_empty_for_handler_less_node() -> None:
+    """The reducer contract has no ``handler_routing`` -- shape must be empty."""
+    shape = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert len(shape) == 0
+    assert dict(shape) == {}
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_returns_immutable_mapping() -> None:
+    """Returned mapping must be immutable."""
+    shape = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert isinstance(shape, MappingProxyType)
+
+    with pytest.raises(TypeError):
+        shape["HandlerBogus"] = ("bogus",)  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_has_no_side_effects() -> None:
+    """Deterministic and cached -- same mapping object on every call."""
+    first = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+    second = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert dict(first) == dict(second)
+    assert first is second
+
+
+@pytest.mark.unit
+def test_declare_explicit_dependencies_does_not_require_container() -> None:
+    """Declaration is a classmethod -- it must not touch an instance container.
+
+    Ensures the resolver can discover the declarative shape before any
+    runtime state (container, event bus, projector) has been constructed.
+    """
+    # Calling the classmethod without ever instantiating the registry
+    # must succeed. If this method accidentally touched ``self._container``
+    # it would fail with AttributeError.
+    shape = RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()
+
+    assert shape is not None


### PR DESCRIPTION
<!-- OMN-9198 ticket citation -->
Ticket: OMN-9198

[skip-deploy-gate: Task 6 adds a pure declarative classmethod (`declare_explicit_dependencies`) returning a frozen `MappingProxyType` — no runtime behavior change. `create_registry(...)` materialization logic is untouched. Runtime paths are modified in the file-system sense only; the module-level runtime contract is unchanged until Task 5 (OMN-9201) consumes the declaration.]

[skip-receipt-gate: Task 6 of HandlerResolver epic OMN-9195 — adds a pure declarative classmethod. No interface/event/protocol changes requiring receipt-gate assertions (declaration-side only; materialization is untouched). Contract for OMN-9198 + cited prior-fix references (OMN-9191) will be backfilled via follow-up ticket OMN-9209 within 7 days per override-SLA.]

## Summary

Task 6 of the HandlerResolver refactor (epic **OMN-9195**, plan `docs/plans/2026-04-18-handler-resolver-architecture.md`).

Exposes a pure, side-effect-free **declaration** path for per-node handler dependencies that the upcoming HandlerResolver auto-wiring code (Tasks 1-5) can consume at contract-discovery time, BEFORE any runtime state exists.

- `RegistryInfraNodeRegistrationOrchestrator.declare_explicit_dependencies()` — classmethod returning an immutable `Mapping[str, tuple[str, ...]]` enumerating each handler and its dependency keys (6 handlers, backed by a `MappingProxyType` constant).
- `RegistryInfraNodeRegistrationReducer.declare_explicit_dependencies()` — same classmethod surface, returning an empty mapping (reducer declares no event handlers), so resolver code treats all per-node registries uniformly.

## Intentional duplication (do NOT unify in Phase 1)

Per plan line 1199 **Task 6 Tradeoff Note**, the declarative shape and the existing `create_registry(...)` materialization literal each state the dependency key set once, on purpose. Collapsing them would either leak runtime object construction into the declaration phase or introduce a hidden declarative side-channel in materialization — both break the "declaration vs materialization are two distinct phases" invariant the resolver depends on.

A coherence unit test (`test_declaration_matches_runtime_handler_dependencies_literal`) drives the real `create_registry` with mocks and asserts the declared shape matches the materialized kwargs — CI fails fast if anyone edits one half in isolation.

## Out of scope

This PR does NOT:
- modify `handler_wiring.py:800-872` (Task 5 surgery)
- construct or consume a `HandlerResolver` (Tasks 1-4)
- change `ModelAutoWiringManifest` (manifest propagation lands with Task 5 when the resolver is actually invoked at wiring time; Task 6 is scoped to the registry-side declaration surface only)

## Test plan

- [x] 12 new unit tests (7 for the orchestrator registry, 5 for the reducer registry) — all pass locally
- [x] `uv run ruff format` + `uv run ruff check` clean
- [x] `uv run mypy src/... --strict` zero issues on the two modified files
- [x] `pre-commit run --files ...` clean on all 4 changed files
- [x] Full `uv run pytest tests/ -m unit` — 18566 passed, 11 pre-existing failures verified against main (unrelated to Task 6; in `test_kernel.py::TestIntegration`, `test_policy_registry_performance`, `test_runtime_host_process`, `test_consumer`, `test_session_graph_projector` — reproduce without this PR's changes)
- [ ] CI green on the PR

## Evidence — consistency proof

```
test_declaration_matches_runtime_handler_dependencies_literal PASSED
```

Driving `create_registry` with recording-handler mocks and asserting:
- every handler instantiated at runtime has an entry in `_EXPLICIT_DEPENDENCY_SHAPE`
- per-handler kwargs set == declared dep-key set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added class-level explicit dependency declaration to registry infrastructure components, returning an immutable, cached mapping of handler→dependency keys without side effects.

* **Tests**
  * Added unit and integration tests validating immutability, determinism, identity caching, and bidirectional coherence between declared dependency shapes and runtime instantiation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->