### PR TITLE
feat(projectors): FileSnapshotSink + FileSnapshotSource primitives (OMN-9206)

### DIFF
--- a/src/omnibase_infra/projectors/__init__.py
+++ b/src/omnibase_infra/projectors/__init__.py
@@ -8,17 +8,22 @@ outputs to storage (PostgreSQL) and by orchestrators to query current
 entity state.
 
 Exports:
+    FileSnapshotSink: File-backed snapshot sink (publish-side adapter)
+    FileSnapshotSource: File-backed snapshot source (read-side adapter)
     ProjectionReaderContract: Contract/topic projection reader for Registry API
     ProjectionReaderRegistration: Registration projection reader implementation
     SnapshotPublisherRegistration: Registration snapshot publisher for Kafka
 
 Related Tickets:
+    - OMN-9206: FileSnapshotSink + FileSnapshotSource primitives
     - OMN-1845: Create ProjectionReaderContract for contract/topic queries
     - OMN-947 (F2): Snapshot Publishing
     - OMN-944 (F1): Implement Registration Projection Schema
     - OMN-940 (F0): Define Projector Execution Model
 """
 
+from omnibase_infra.projectors.file_snapshot_sink import FileSnapshotSink
+from omnibase_infra.projectors.file_snapshot_source import FileSnapshotSource
 from omnibase_infra.projectors.projection_reader_contract import (
     ProjectionReaderContract,
 )
@@ -30,6 +35,8 @@ from omnibase_infra.projectors.snapshot_publisher_registration import (
 )
 
 __all__ = [
+    "FileSnapshotSink",
+    "FileSnapshotSource",
     "ProjectionReaderContract",
     "ProjectionReaderRegistration",
     "SnapshotPublisherRegistration",

--- a/src/omnibase_infra/projectors/file_snapshot_sink.py
+++ b/src/omnibase_infra/projectors/file_snapshot_sink.py
@@ -23,7 +23,25 @@ class FileSnapshotSink:
         self._root = root
         self._root.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _validate_segment(name: str, value: str) -> None:
+        """Reject path-traversal / separator inputs for a single filesystem segment."""
+        if value in {"", ".", ".."} or any(sep in value for sep in ("/", "\\")):
+            raise ValueError(f"Invalid {name}: {value!r}")
+
     async def publish(self, topic: str, key: str, value: BaseModel) -> None:
-        topic_dir = self._root / topic
+        self._validate_segment("topic", topic)
+        self._validate_segment("key", key)
+        root = self._root.resolve()
+        topic_dir = (root / topic).resolve()
+        if not topic_dir.is_relative_to(root):
+            raise ValueError(
+                f"Resolved topic directory escapes snapshot root: {topic_dir}"
+            )
         topic_dir.mkdir(parents=True, exist_ok=True)
-        (topic_dir / f"{key}.json").write_text(value.model_dump_json(indent=2))
+        target = (topic_dir / f"{key}.json").resolve()
+        if not target.is_relative_to(topic_dir):
+            raise ValueError(
+                f"Resolved snapshot path escapes topic directory: {target}"
+            )
+        target.write_text(value.model_dump_json(indent=2), encoding="utf-8")

--- a/src/omnibase_infra/projectors/file_snapshot_sink.py
+++ b/src/omnibase_infra/projectors/file_snapshot_sink.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""File-backed snapshot sink.
+
+One file per (topic, key) pair; writes compact by overwriting. Used by
+the dashboard fixture generator and by local dev adapters that do not
+have a Kafka broker available.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class FileSnapshotSink:
+    """Adapter that satisfies the publish-side of a ProtocolEventBusLike
+    by writing JSON files to a filesystem root. Compaction semantics:
+    publishing with the same (topic, key) OVERWRITES the prior file."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    async def publish(self, topic: str, key: str, value: BaseModel) -> None:
+        topic_dir = self._root / topic
+        topic_dir.mkdir(parents=True, exist_ok=True)
+        (topic_dir / f"{key}.json").write_text(value.model_dump_json(indent=2))

--- a/src/omnibase_infra/projectors/file_snapshot_source.py
+++ b/src/omnibase_infra/projectors/file_snapshot_source.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""File-backed snapshot source.
+
+Reads the compacted snapshot file for every key under a topic directory
+and yields them as typed Pydantic models. Symmetric to FileSnapshotSink.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class FileSnapshotSource[S: BaseModel]:
+    def __init__(self, root: Path, model: type[S]) -> None:
+        self._root = root
+        self._model = model
+
+    async def read_all(self, topic: str) -> AsyncIterator[S]:
+        topic_dir = self._root / topic
+        if not topic_dir.is_dir():
+            return
+        for snapshot_file in topic_dir.glob("*.json"):
+            yield self._model.model_validate_json(snapshot_file.read_text())

--- a/src/omnibase_infra/projectors/file_snapshot_source.py
+++ b/src/omnibase_infra/projectors/file_snapshot_source.py
@@ -20,8 +20,19 @@ class FileSnapshotSource[S: BaseModel]:
         self._model = model
 
     async def read_all(self, topic: str) -> AsyncIterator[S]:
-        topic_dir = self._root / topic
+        # Block traversal: reject separators/parent segments and verify the
+        # resolved directory stays under the snapshot root.
+        if topic in {"", ".", ".."} or any(sep in topic for sep in ("/", "\\")):
+            raise ValueError(f"Invalid topic: {topic!r}")
+        root = self._root.resolve()
+        topic_dir = (root / topic).resolve()
+        if not topic_dir.is_relative_to(root):
+            raise ValueError(
+                f"Resolved topic directory escapes snapshot root: {topic_dir}"
+            )
         if not topic_dir.is_dir():
             return
         for snapshot_file in topic_dir.glob("*.json"):
-            yield self._model.model_validate_json(snapshot_file.read_text())
+            yield self._model.model_validate_json(
+                snapshot_file.read_text(encoding="utf-8")
+            )

--- a/tests/unit/projectors/test_file_snapshot_adapter.py
+++ b/tests/unit/projectors/test_file_snapshot_adapter.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for FileSnapshotSink + FileSnapshotSource.
+
+Verifies the file-backed snapshot adapter pair:
+- Sink writes compacted JSON per (topic, key) pair.
+- Source reads back all snapshots under a topic and yields typed models.
+- Sink OVERWRITES on republish with the same key (compaction semantics).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_infra.projectors import FileSnapshotSink, FileSnapshotSource
+
+
+class _Snap(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entity_id: str
+    current_state: str
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_file_sink_writes_compacted_json(tmp_path: Path) -> None:
+    sink = FileSnapshotSink(tmp_path)
+    snap = _Snap(entity_id="alpha", current_state="active")
+
+    await sink.publish("onex.evt.snap.v1", "alpha", snap)
+
+    written = tmp_path / "onex.evt.snap.v1" / "alpha.json"
+    assert written.exists()
+    payload = json.loads(written.read_text())
+    assert payload == {"entity_id": "alpha", "current_state": "active"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_file_source_reads_compacted_snapshots(tmp_path: Path) -> None:
+    sink = FileSnapshotSink(tmp_path)
+    await sink.publish(
+        "onex.evt.snap.v1", "alpha", _Snap(entity_id="alpha", current_state="active")
+    )
+    await sink.publish(
+        "onex.evt.snap.v1", "beta", _Snap(entity_id="beta", current_state="idle")
+    )
+
+    source = FileSnapshotSource[_Snap](tmp_path, _Snap)
+    results = [snap async for snap in source.read_all("onex.evt.snap.v1")]
+
+    assert len(results) == 2
+    by_id = {snap.entity_id: snap.current_state for snap in results}
+    assert by_id == {"alpha": "active", "beta": "idle"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_file_sink_compaction_overwrites_by_key(tmp_path: Path) -> None:
+    sink = FileSnapshotSink(tmp_path)
+
+    await sink.publish(
+        "onex.evt.snap.v1", "alpha", _Snap(entity_id="alpha", current_state="pending")
+    )
+    await sink.publish(
+        "onex.evt.snap.v1", "alpha", _Snap(entity_id="alpha", current_state="active")
+    )
+
+    source = FileSnapshotSource[_Snap](tmp_path, _Snap)
+    results = [snap async for snap in source.read_all("onex.evt.snap.v1")]
+
+    assert len(results) == 1
+    assert results[0].entity_id == "alpha"
+    assert results[0].current_state == "active"


### PR DESCRIPTION
## Summary

Ships the `omnibase_infra` portion of Part 1 of the registry-driven dashboard integration plan (`docs/plans/2026-04-17-registry-driven-dashboard-part-1.md`). Local-file adapters for the snapshot publish/read cycle so `omnidash-v2` (and any future local dev harness) can run against fixtures without Kafka.

**Companion PR:** https://github.com/OmniNode-ai/omnibase_core/pull/845 ships `ModelDashboardHint` + `EnumDashboardWidgetType` in `omnibase_core`.

## Adds

- `FileSnapshotSink` — `publish(topic, key, value: BaseModel) -> None`, writes one JSON file per `(topic, key)` pair with compaction-overwrite semantics
- `FileSnapshotSource[S: BaseModel]` — async `read_all(topic)` yielding typed models from the compacted snapshot files
- Both use PEP 695 generic type-parameter syntax (Python 3.12+)

## Tests

`tests/unit/projectors/test_file_snapshot_adapter.py` — 3 passing unit tests:
- Sink writes compacted JSON
- Source reads compacted snapshots back as typed models
- Compaction: repeat publish on same key overwrites

```
$ uv run pytest tests/unit/projectors/test_file_snapshot_adapter.py -v
3 passed in 0.38s
```

Mypy `--strict` clean. Ruff clean. Full `pre-commit run --all-files` clean.

## Out of scope (deferred to follow-ups)

- `SnapshotPublisher[P, S]` generic generalization of `SnapshotPublisherRegistration` (Part 1 Tasks 6-7)
- `ContractInferencer` dashboard-hint extension in omnimarket (Part 1 Tasks 8-9)
- Proof of Life integration test (Part 1 Task 11)

## Test plan

- [x] `uv run pytest tests/unit/projectors/test_file_snapshot_adapter.py -v` passes (3/3)
- [x] `uv run mypy src/omnibase_infra/projectors/file_snapshot_sink.py src/omnibase_infra/projectors/file_snapshot_source.py --strict` clean
- [x] `pre-commit run --all-files` clean
- [ ] CI green on `main` after push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file-based snapshot storage for persisting and retrieving snapshots on the local filesystem.
  * Organizes snapshots by topic and key, with automatic compaction (republishing a key overwrites prior snapshot).
  * Includes path validation to prevent accidental directory traversal.

* **Tests**
  * Added unit tests verifying write/read behavior, topic/key organization, typed parsing, and compaction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->