### PR TITLE
fix(scripts): repair pull-all.sh plugin cache path detection [OMN-7369]

### DIFF
--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -127,29 +127,82 @@ for repo in "${REPOS[@]}"; do
   fi
 done
 
-# === Plugin cache refresh (Layer 2) ===
+# === Plugin cache refresh (Layer 2, OMN-7369) ===
 # When omniclaude was updated, refresh the Claude Code plugin cache.
+#
+# The cache lives at a versioned path:
+#   ~/.claude/plugins/cache/omninode-tools/onex/<version>/
+# Locate it by searching for the .deployed-commit marker file (more specific
+# than matching a generic 'skills' directory — which also appears under
+# other plugins like claude-plugins-official).
 _omniclaude_dir="$OMNI_HOME/omniclaude"
 _plugin_cache="${CLAUDE_PLUGIN_ROOT:-}"
 if [[ -z "${_plugin_cache}" ]]; then
-  # Try default plugin cache path
-  _plugin_cache=$(find "${HOME}/.claude/plugins/cache" -maxdepth 3 -name "skills" -type d 2>/dev/null | head -1)
-  [[ -n "${_plugin_cache}" ]] && _plugin_cache=$(dirname "${_plugin_cache}")
+  # Search for the .deployed-commit marker inside the onex plugin cache tree.
+  # maxdepth 5 covers: cache/omninode-tools/onex/<version>/.deployed-commit.
+  # The `|| true` suffix stops `set -eo pipefail` from treating a missing
+  # cache directory (find exits non-zero when the root does not exist) as
+  # a fatal script error — a missing cache must be a clean no-op.
+  _marker=$(find "${HOME}/.claude/plugins/cache" -maxdepth 5 -path "*/omninode-tools/onex/*" -name ".deployed-commit" -type f 2>/dev/null | head -1 || true)
+  if [[ -n "${_marker}" ]]; then
+    _plugin_cache=$(dirname "${_marker}")
+  else
+    # Fallback: marker absent (first deploy). Search for a versioned onex dir.
+    _plugin_cache=$(find "${HOME}/.claude/plugins/cache" -maxdepth 4 -path "*/omninode-tools/onex/*" -type d 2>/dev/null | head -1 || true)
+  fi
 fi
 
-if [[ -n "${_plugin_cache}" && -d "${_omniclaude_dir}" && -d "${_plugin_cache}/skills" ]]; then
+# Compute a content hash of all plugin files under a directory.
+# Excludes __pycache__, .pyc, and the marker files themselves so the hash
+# is stable regardless of which directory it is computed against.
+#
+# The hash is computed against RELATIVE paths so a repo-side and cache-side
+# computation of the same plugin tree yield the same hash (shasum emits
+# `hash  path` — absolute paths would otherwise break comparability).
+_plugin_content_hash() {
+  local root="$1"
+  ( cd "${root}" && find . -type f \
+      ! -name "*.pyc" \
+      ! -path "*/__pycache__/*" \
+      ! -name ".deployed-commit" \
+      ! -name ".content-hash" \
+      -exec shasum {} \; 2>/dev/null | sort | shasum | cut -d' ' -f1 )
+}
+
+if [[ -n "${_plugin_cache}" && -d "${_omniclaude_dir}" && -d "${_plugin_cache}" ]]; then
   _current=$(git -C "${_omniclaude_dir}" rev-parse HEAD 2>/dev/null)
   _deployed=""
   [[ -f "${_plugin_cache}/.deployed-commit" ]] && _deployed=$(cat "${_plugin_cache}/.deployed-commit" 2>/dev/null)
 
-  if [[ "${_current}" != "${_deployed}" && -n "${_current}" ]]; then
+  # Compare against repo content hash as a second signal beyond commit SHA.
+  _repo_hash=""
+  if [[ -d "${_omniclaude_dir}/plugins/onex" ]]; then
+    _repo_hash=$(_plugin_content_hash "${_omniclaude_dir}/plugins/onex")
+  fi
+  _cache_hash=""
+  [[ -f "${_plugin_cache}/.content-hash" ]] && _cache_hash=$(cat "${_plugin_cache}/.content-hash" 2>/dev/null)
+
+  if [[ -n "${_current}" ]] && { [[ "${_current}" != "${_deployed}" ]] || [[ "${_repo_hash}" != "${_cache_hash}" ]]; }; then
     echo ""
     echo "Refreshing Claude Code plugin cache (${_deployed:-none} → ${_current:0:8})..."
     _tmpdir=$(mktemp -d)
-    if git -C "${_omniclaude_dir}" archive HEAD plugins/onex/skills/ 2>/dev/null | tar -x -C "${_tmpdir}" 2>/dev/null; then
-      cp -r "${_tmpdir}/plugins/onex/skills/"* "${_plugin_cache}/skills/" 2>/dev/null
-      echo "${_current}" > "${_plugin_cache}/.deployed-commit"
-      echo "Plugin cache refreshed."
+    # Refresh the entire plugins/onex/ tree (hooks, skills, lib, agents,
+    # runtime, scripts, docs, prompts, models, _bin, tests). Copying only
+    # skills/ leaves stale code in sibling directories that schema changes
+    # silently drop — the exact failure this fix prevents.
+    if git -C "${_omniclaude_dir}" archive HEAD plugins/onex/ 2>/dev/null | tar -x -C "${_tmpdir}" 2>/dev/null; then
+      if [[ -d "${_tmpdir}/plugins/onex" ]]; then
+        # rsync with --delete would remove files the cache added (e.g.
+        # __pycache__), so use cp -R of the contents to update in place.
+        cp -R "${_tmpdir}/plugins/onex/." "${_plugin_cache}/"
+        echo "${_current}" > "${_plugin_cache}/.deployed-commit"
+        # Recompute hash against the cache after refresh and persist.
+        _new_hash=$(_plugin_content_hash "${_plugin_cache}")
+        echo "${_new_hash}" > "${_plugin_cache}/.content-hash"
+        echo "Plugin cache refreshed (content hash ${_new_hash:0:8})."
+      else
+        echo "WARN: Plugin cache refresh failed (archive missing plugins/onex/)."
+      fi
     else
       echo "WARN: Plugin cache refresh failed (git archive error)."
     fi

--- a/tests/unit/scripts/test_pull_all.py
+++ b/tests/unit/scripts/test_pull_all.py
@@ -17,6 +17,109 @@ PLIST = SCRIPTS_DIR / "ai.omninode.bare-clone-sync.plist"
 INSTALL_SCRIPT = SCRIPTS_DIR / "install-bare-clone-sync.sh"
 
 
+def _make_omniclaude_source(
+    root: Path, file_contents: dict[str, str] | None = None
+) -> Path:
+    """Create a fake omniclaude repo with a minimal plugins/onex/ tree.
+
+    Returns the path to the repo root. Commits an initial state so the
+    refresh logic in pull-all.sh can `git archive HEAD`.
+    """
+    omniclaude = root / "omniclaude"
+    onex = omniclaude / "plugins" / "onex"
+    (onex / "skills").mkdir(parents=True)
+    (onex / "hooks").mkdir(parents=True)
+    (onex / "lib").mkdir(parents=True)
+    (onex / "agents").mkdir(parents=True)
+
+    defaults = {
+        "plugins/onex/skills/example.md": "# example skill\n",
+        "plugins/onex/hooks/example.sh": "#!/bin/sh\necho hooked\n",
+        "plugins/onex/lib/example.py": "VERSION = 'v1'\n",
+        "plugins/onex/agents/example.yaml": "name: example\n",
+    }
+    for rel, contents in (file_contents or defaults).items():
+        p = omniclaude / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+
+    # Initialize as a git repo so `git archive HEAD` works. Also set up a
+    # bare upstream so `git pull --ff-only` succeeds (otherwise pull-all.sh
+    # reports the repo as FAILED and exits 1, which is unrelated to the
+    # cache-refresh logic we are testing).
+    subprocess.run(
+        ["git", "init", "-q", "--initial-branch=main"], cwd=omniclaude, check=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "add", "."],
+        cwd=omniclaude,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+        ],
+        cwd=omniclaude,
+        check=True,
+    )
+
+    upstream = root / "omniclaude.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(upstream)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(upstream)], cwd=omniclaude, check=True
+    )
+    subprocess.run(
+        ["git", "push", "-q", "-u", "origin", "main"], cwd=omniclaude, check=True
+    )
+    return omniclaude
+
+
+def _make_versioned_cache(
+    home: Path, initial_files: dict[str, str] | None = None
+) -> Path:
+    """Create a versioned plugin cache mirroring the real layout.
+
+    Layout: <home>/.claude/plugins/cache/omninode-tools/onex/<version>/
+    """
+    cache = home / ".claude" / "plugins" / "cache" / "omninode-tools" / "onex" / "2.2.5"
+    (cache / "skills").mkdir(parents=True)
+    if initial_files:
+        for rel, contents in initial_files.items():
+            p = cache / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(contents)
+    # Seed the .deployed-commit marker so detection prefers this path
+    # over any fallback directory search.
+    (cache / ".deployed-commit").write_text("0" * 40)
+    return cache
+
+
+def _run_pull_all(
+    omni_home: Path, fake_home: Path, repos: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Invoke pull-all.sh with controlled OMNI_HOME and HOME."""
+    env = {
+        **os.environ,
+        "OMNI_HOME": str(omni_home),
+        "HOME": str(fake_home),
+    }
+    # Drop CLAUDE_PLUGIN_ROOT so the auto-detection path is exercised.
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
+    args = ["bash", str(PULL_ALL), *(repos or ["omniclaude"])]
+    return subprocess.run(args, capture_output=True, text=True, env=env, check=False)
+
+
 @pytest.mark.unit
 class TestPullAllScript:
     """Tests for pull-all.sh."""
@@ -79,6 +182,129 @@ class TestPullAllScript:
             # The bare repo has no main ref and no remote, so it will
             # report FAILED — that's expected. The key is no crash.
             assert result.returncode in (0, 1)
+
+
+@pytest.mark.unit
+class TestPluginCacheRefresh:
+    """Tests for the plugin cache refresh logic in pull-all.sh (OMN-7369)."""
+
+    def test_detects_versioned_cache_path(self, tmp_path: Path) -> None:
+        """Refresh triggers when cache lives under cache/omninode-tools/onex/<ver>/."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        _make_omniclaude_source(omni_home)
+        cache = _make_versioned_cache(fake_home)
+
+        result = _run_pull_all(omni_home, fake_home)
+        assert result.returncode == 0, (
+            f"pull-all.sh failed: stdout={result.stdout} stderr={result.stderr}"
+        )
+        assert "Plugin cache refreshed" in result.stdout, (
+            f"Cache refresh did not trigger; output: {result.stdout}"
+        )
+        # The real commit should replace the 0...0 placeholder.
+        deployed = (cache / ".deployed-commit").read_text().strip()
+        assert deployed != "0" * 40
+        assert len(deployed) == 40
+
+    def test_refresh_copies_all_plugin_subdirs(self, tmp_path: Path) -> None:
+        """Refresh copies hooks, lib, agents — not just skills/."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        _make_omniclaude_source(omni_home)
+        cache = _make_versioned_cache(fake_home)
+
+        result = _run_pull_all(omni_home, fake_home)
+        assert result.returncode == 0, result.stderr
+
+        # Every subdir from the source must appear in the refreshed cache.
+        assert (cache / "skills" / "example.md").exists()
+        assert (cache / "hooks" / "example.sh").exists()
+        assert (cache / "lib" / "example.py").exists()
+        assert (cache / "agents" / "example.yaml").exists()
+
+    def test_content_hash_written_after_refresh(self, tmp_path: Path) -> None:
+        """.content-hash is computed and stored after a refresh."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        _make_omniclaude_source(omni_home)
+        cache = _make_versioned_cache(fake_home)
+
+        result = _run_pull_all(omni_home, fake_home)
+        assert result.returncode == 0, result.stderr
+
+        hash_file = cache / ".content-hash"
+        assert hash_file.exists(), ".content-hash was not created"
+        content = hash_file.read_text().strip()
+        # shasum produces a 40-char hex digest.
+        assert len(content) == 40
+        assert all(c in "0123456789abcdef" for c in content)
+
+    def test_deployed_commit_preserved_alongside_hash(self, tmp_path: Path) -> None:
+        """Existing .deployed-commit behavior is preserved."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        omniclaude = _make_omniclaude_source(omni_home)
+        cache = _make_versioned_cache(fake_home)
+
+        expected_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=omniclaude, text=True
+        ).strip()
+
+        result = _run_pull_all(omni_home, fake_home)
+        assert result.returncode == 0, result.stderr
+
+        assert (cache / ".deployed-commit").read_text().strip() == expected_commit
+        assert (cache / ".content-hash").exists()
+
+    def test_no_cache_skips_cleanly(self, tmp_path: Path) -> None:
+        """Missing plugin cache is a no-op, not an error."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        # No cache created.
+
+        _make_omniclaude_source(omni_home)
+
+        result = _run_pull_all(omni_home, fake_home)
+        assert result.returncode == 0, (
+            f"pull-all.sh should succeed with no cache; "
+            f"stdout={result.stdout} stderr={result.stderr}"
+        )
+        assert "Plugin cache refreshed" not in result.stdout
+        assert "WARN: Plugin cache refresh failed" not in result.stdout
+
+    def test_refresh_is_idempotent(self, tmp_path: Path) -> None:
+        """Second run with no changes does not re-trigger a refresh."""
+        omni_home = tmp_path / "omni_home"
+        omni_home.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        _make_omniclaude_source(omni_home)
+        _make_versioned_cache(fake_home)
+
+        first = _run_pull_all(omni_home, fake_home)
+        assert first.returncode == 0
+        assert "Plugin cache refreshed" in first.stdout
+
+        second = _run_pull_all(omni_home, fake_home)
+        assert second.returncode == 0
+        # On the second run, commit + content hash both match — no refresh.
+        assert "Plugin cache refreshed" not in second.stdout
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Fixes `pull-all.sh` plugin cache refresh — the detection logic never
fired against the real versioned cache layout, and when it did, it
only copied `skills/` and missed every other plugin subdirectory.

## Problem

- `find ${HOME}/.claude/plugins/cache -maxdepth 3 -name skills -type d`
  never matched because the cache lives one level deeper, under
  `cache/omninode-tools/onex/<version>/skills/`.
- Even when detection worked, refresh copied only `skills/` — leaving
  `hooks/`, `lib/`, `agents/`, `runtime/`, `scripts/` stale. Schema
  changes in those directories (e.g. `model_used` → `delegated_to`)
  were silently dropped by Pydantic `extra="ignore"` downstream.
- Only commit-SHA comparison was used; partial deploys, manual edits,
  and version-dir drift were all invisible.

## Changes

- Locate the cache by searching for the `.deployed-commit` marker
  (`maxdepth 5`) — specific to the onex plugin and robust to
  generic `skills` dir collisions under sibling plugins. Fallback to
  a versioned-dir search when the marker is absent (first deploy).
- Refresh the entire `plugins/onex/` tree, not just `skills/`.
- Compute and store `.content-hash` over the deployed tree alongside
  the existing `.deployed-commit` SHA. The hash uses relative paths so
  repo-side and cache-side computation are directly comparable — a
  second signal beyond the commit SHA, catching partial deploys,
  manual edits, and version-directory drift.
- Trigger refresh when either the SHA or the content hash differs.
- Preserve the clean no-op behavior when no cache exists (missing
  cache directory must not fail the script).

## Acceptance Criteria (from OMN-7369)

- [x] Cache path detection finds the versioned plugin directory correctly
- [x] Refresh copies the entire `plugins/onex/` tree, not just `skills/`
- [x] Content hash (`.content-hash`) is computed and stored after refresh
- [x] Existing commit-SHA check (`.deployed-commit`) preserved alongside the hash
- [x] No regression: repos without a plugin cache skip cleanly

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_pull_all.py -v` — 21/21 passed
- [x] `shellcheck scripts/pull-all.sh` — clean
- [x] `uv run ruff format/check tests/unit/scripts/test_pull_all.py` — clean
- [x] `uv run mypy tests/unit/scripts/test_pull_all.py --strict` — clean
- [x] `uv run pre-commit run --files scripts/pull-all.sh tests/unit/scripts/test_pull_all.py` — all hooks pass

Plan reference: `docs/plans/2026-04-02-plugin-cache-freshness.md` (Fix 1).

Closes OMN-7369.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin cache detection to locate versioned directories reliably.
  * Enhanced cache invalidation with content-based hashing for more accurate refresh triggers.

* **Tests**
  * Added comprehensive test suite for plugin cache refresh behavior, including versioned cache path detection, directory copying, and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->