### PR TITLE
ci(runtime): add reusable-runtime-boot workflow with real/compose mode [OMN-9250]

### DIFF
--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -127,7 +127,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          docker compose -f docker/docker-compose.e2e.yml up -d postgres redpanda
+          POSTGRES_PORT="${{ inputs.compose_pg_port }}" \
+            docker compose -f docker/docker-compose.e2e.yml up -d postgres redpanda
           # Wait for redpanda admin API + postgres to become responsive.
           for i in $(seq 1 60); do
             if docker exec omnibase-infra-redpanda rpk cluster health >/dev/null 2>&1 \
@@ -218,9 +219,18 @@ jobs:
       - name: Query registration_projections for active/fresh rows
         id: pg_liveness
         env:
-          PGPASSWORD: postgres
+          REAL_PG_PASSWORD: ${{ secrets.RUNTIME_PG_PASSWORD }}
         run: |
           set -euo pipefail
+          if [[ "${{ inputs.mode }}" == "compose" ]]; then
+            export PGPASSWORD="test-password"
+          else
+            if [[ -z "${REAL_PG_PASSWORD:-}" ]]; then
+              echo "::error::Missing secret: RUNTIME_PG_PASSWORD (required in real mode)"
+              exit 1
+            fi
+            export PGPASSWORD="${REAL_PG_PASSWORD}"
+          fi
           count=$(psql -h "${RUNTIME_HOST}" -p "${PG_PORT}" -U postgres -d "${POSTGRES_DATABASE}" \
             -tAc "SELECT count(*) FROM registration_projections WHERE current_state='active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds'")
           echo "active_fresh_registrations=${count}"
@@ -249,6 +259,14 @@ jobs:
             cat rpk_groups.txt
             exit 1
           fi
+          # Assert the group has at least one member — presence alone is not enough.
+          member_count=$(echo "$raw" | awk '/onex-runtime/{print $NF}' | grep -E '^[0-9]+$' | head -1 || echo "0")
+          if [[ -z "$member_count" ]] || [[ "$member_count" -lt 1 ]]; then
+            echo "::error::onex-runtime consumer group has 0 members (got '${member_count}')"
+            cat rpk_groups.txt
+            exit 1
+          fi
+          echo "onex-runtime group member_count=${member_count}"
 
       - name: Emit smoke-result.json artifact
         if: always()

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -1,0 +1,244 @@
+# Reusable workflow for runtime smoke / regression boot validation (OMN-9250).
+#
+# Callers: Tier-1 smoke (OMN-9251), Tier-2 regression (OMN-9252). Two modes:
+#   - `compose`: spin up postgres+redpanda via docker-compose.e2e.yml + launch
+#     the runtime in-process. Used on ubuntu-latest PR runs.
+#   - `real`:    probe live services on a caller-supplied host (runtime_host,
+#     pg_port). Used on self-hosted runners targeting the .201 stack.
+#
+# Hard gates (must pass):
+#   * /health returns .data.status == "healthy" AND .is_running == true
+#   * 60s hold: compose -> RestartCount constant; real -> /health stays healthy
+#   * registration_projections row count > 0 (active + fresh heartbeat)
+#   * rpk group list contains `onex-runtime` with >= 1 member
+#
+# Warn-only observations (never fail the job):
+#   * subscriber_count < 300 (empirical .201 threshold; see
+#     docs/plans/2026-04-19-runtime-permanent-fix-and-regression-guard-part-1.md
+#     §Rewritten Inventory §E truth-boundary rework).
+---
+name: Reusable Runtime Boot
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: "Execution mode: 'real' (probe live .201 stack) or 'compose' (bring up local stack)."
+        required: true
+        type: string
+      runtime_host:
+        description: "Runtime + postgres + redpanda host. localhost in compose mode; 192.168.86.201 in real mode."
+        required: false
+        type: string
+        default: "localhost"
+      pg_port:
+        description: "External postgres port. Defaults to 5436 per CLAUDE.md infra topology."
+        required: false
+        type: string
+        default: "5436"
+
+jobs:
+  boot:
+    name: runtime-boot (mode=${{ inputs.mode }})
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 20
+    env:
+      RUNTIME_HOST: ${{ inputs.runtime_host }}
+      PG_PORT: ${{ inputs.pg_port }}
+      # Force inmemory event bus for any in-process startup during compose mode.
+      ONEX_EVENT_BUS_TYPE: "kafka"
+      POSTGRES_DATABASE: "omnibase_infra"
+      LLM_ENDPOINT_CIDR_ALLOWLIST: "10.0.0.0/8"
+
+    steps:
+      - name: Validate mode input
+        run: |
+          set -euo pipefail
+          case "${{ inputs.mode }}" in
+            real|compose) echo "mode=${{ inputs.mode }}" ;;
+            *)
+              echo "::error::mode must be 'real' or 'compose' (got '${{ inputs.mode }}')"
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.6.14"
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install CLI dependencies (jq, curl, postgres-client)
+        if: inputs.mode == 'compose'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends jq curl postgresql-client
+          # rpk is executed via `docker exec` against the compose-managed
+          # omnibase-infra-redpanda container, so a host-level rpk install is
+          # unnecessary in compose mode.
+
+      - name: Bring up compose stack (postgres + redpanda)
+        if: inputs.mode == 'compose'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          docker compose -f docker/docker-compose.e2e.yml up -d postgres redpanda
+          # Wait for redpanda admin API + postgres to become responsive.
+          for i in $(seq 1 60); do
+            if docker exec omnibase-infra-redpanda rpk cluster health >/dev/null 2>&1 \
+               && docker exec omnibase-infra-postgres pg_isready -U postgres >/dev/null 2>&1; then
+              echo "compose infra healthy after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Launch runtime (compose mode)
+        if: inputs.mode == 'compose'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          # Background the runtime so subsequent health-wait steps can probe it.
+          uv run python -m omnibase_infra.runtime.main &
+          echo "RUNTIME_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for runtime health (hard gate)
+        id: health_wait
+        run: |
+          set -euo pipefail
+          url="http://${RUNTIME_HOST}:8085/health"
+          deadline=$((SECONDS + 90))
+          while (( SECONDS < deadline )); do
+            if body=$(curl -fsS "$url" 2>/dev/null); then
+              if echo "$body" | jq -e '.data.status == "healthy" and .is_running == true' >/dev/null; then
+                echo "$body" > health_initial.json
+                echo "runtime healthy after $SECONDS seconds"
+                break
+              fi
+            fi
+            sleep 2
+          done
+          if [[ ! -f health_initial.json ]]; then
+            echo "::error::runtime /health never reported status=healthy AND is_running=true within 90s"
+            exit 1
+          fi
+          # Warn-only observation — subscriber_count<300 is a regression SIGNAL,
+          # not a contract gate. See plan §Rewritten Inventory §E.
+          sub_count=$(jq -r '.data.subscriber_count // 0' health_initial.json)
+          echo "subscriber_count=$sub_count"
+          if [[ "$sub_count" -lt 300 ]]; then
+            echo "::warning::subscriber_count=$sub_count below empirical .201 threshold of 300 — investigate possible regression"
+          fi
+
+      - name: Hold 60s — RestartCount / health stability
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.mode }}" == "compose" ]]; then
+            start_count=$(docker inspect omninode-runtime --format '{{.RestartCount}}' 2>/dev/null || echo "0")
+            sleep 60
+            end_count=$(docker inspect omninode-runtime --format '{{.RestartCount}}' 2>/dev/null || echo "0")
+            if [[ "$start_count" != "$end_count" ]]; then
+              echo "::error::omninode-runtime RestartCount changed ${start_count} -> ${end_count} during 60s hold (crash-loop)"
+              exit 1
+            fi
+            echo "RestartCount stable at ${end_count} over 60s"
+          else
+            # Real mode: we don't control the remote container. Advisory-only
+            # stability check on /health over a 60s window.
+            url="http://${RUNTIME_HOST}:8085/health"
+            deadline=$((SECONDS + 60))
+            failures=0
+            while (( SECONDS < deadline )); do
+              if ! curl -fsS "$url" | jq -e '.data.status == "healthy"' >/dev/null; then
+                failures=$((failures + 1))
+              fi
+              sleep 5
+            done
+            if (( failures > 2 )); then
+              echo "::error::runtime /health flapped ${failures} times during 60s hold"
+              exit 1
+            fi
+            echo "runtime /health stable over 60s hold (failures=${failures})"
+          fi
+
+      - name: Query registration_projections for active/fresh rows
+        id: pg_liveness
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          count=$(psql -h "${RUNTIME_HOST}" -p "${PG_PORT}" -U postgres -d "${POSTGRES_DATABASE}" \
+            -tAc "SELECT count(*) FROM registration_projections WHERE current_state='active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds'")
+          echo "active_fresh_registrations=${count}"
+          echo "active_fresh_registrations=${count}" >> "$GITHUB_OUTPUT"
+          if [[ "${count}" -le 0 ]]; then
+            echo "::error::registration_projections has 0 active+fresh rows — runtime not publishing heartbeats"
+            exit 1
+          fi
+
+      - name: Assert onex-runtime consumer group has members
+        id: rpk_groups
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.mode }}" == "compose" ]]; then
+            raw=$(docker exec omnibase-infra-redpanda rpk group list)
+          else
+            raw=$(ssh -o StrictHostKeyChecking=no "jonah@${RUNTIME_HOST}" "docker exec omnibase-infra-redpanda rpk group list")
+          fi
+          echo "$raw" > rpk_groups.txt
+          if ! grep -qE '(^|[[:space:]])onex-runtime([[:space:]]|$)' rpk_groups.txt; then
+            echo "::error::rpk group list missing onex-runtime group"
+            cat rpk_groups.txt
+            exit 1
+          fi
+
+      - name: Emit smoke-result.json artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg mode "${{ inputs.mode }}" \
+            --arg runtime_host "${RUNTIME_HOST}" \
+            --arg pg_port "${PG_PORT}" \
+            --slurpfile health health_initial.json \
+            --arg active_fresh "${{ steps.pg_liveness.outputs.active_fresh_registrations }}" \
+            --rawfile rpk_groups rpk_groups.txt \
+            '{
+              mode: $mode,
+              runtime_host: $runtime_host,
+              pg_port: $pg_port,
+              health: $health[0],
+              active_fresh_registrations: ($active_fresh | tonumber),
+              rpk_groups: $rpk_groups
+            }' > smoke-result.json
+
+      - name: Upload smoke-result.json
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-result-${{ inputs.mode }}
+          path: smoke-result.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Stop background runtime (compose mode)
+        if: always() && inputs.mode == 'compose'
+        run: |
+          if [[ -n "${RUNTIME_PID:-}" ]]; then
+            kill "${RUNTIME_PID}" 2>/dev/null || true
+          fi
+          docker compose -f docker/docker-compose.e2e.yml down -v || true

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -6,9 +6,16 @@
 #   - `real`:    probe live services on a caller-supplied host (runtime_host,
 #     pg_port). Used on self-hosted runners targeting the .201 stack.
 #
+# Health response shape comes from
+# src/omnibase_infra/services/service_health.py::_handle_health:
+#     { "status": "healthy|degraded|unhealthy",
+#       "version": "x.y.z",
+#       "details": { "is_running": bool, "is_draining": bool, ... } }
+#
 # Hard gates (must pass):
-#   * /health returns .data.status == "healthy" AND .is_running == true
-#   * 60s hold: compose -> RestartCount constant; real -> /health stays healthy
+#   * /health returns .status == "healthy" AND .details.is_running == true
+#   * 60s hold: compose -> background runtime PID alive + /health stable;
+#                real    -> /health stable (no flapping beyond tolerance)
 #   * registration_projections row count > 0 (active + fresh heartbeat)
 #   * rpk group list contains `onex-runtime` with >= 1 member
 #
@@ -32,10 +39,20 @@ on:
         type: string
         default: "localhost"
       pg_port:
-        description: "External postgres port. Defaults to 5436 per CLAUDE.md infra topology."
+        description: "External postgres port for `real` mode. Defaults to 5436 per CLAUDE.md infra topology. (Compose mode ignores this and uses the port published by docker/docker-compose.e2e.yml, currently 5433.)"
         required: false
         type: string
         default: "5436"
+      compose_pg_port:
+        description: "External postgres port published by docker/docker-compose.e2e.yml. Overrides pg_port when mode='compose'. Keep in sync with POSTGRES_PORT default in that compose file."
+        required: false
+        type: string
+        default: "5433"
+      real_ssh_user:
+        description: "SSH username for `real` mode rpk-group-list probe. If blank, uses the runner's whoami."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   boot:
@@ -54,7 +71,8 @@ jobs:
     env:
       RUNTIME_HOST: ${{ inputs.runtime_host }}
       PG_PORT: ${{ inputs.pg_port }}
-      # Force inmemory event bus for any in-process startup during compose mode.
+      # Use Kafka-backed event bus so registration flow + rpk group membership
+      # assertions reflect real topic wiring. Compose mode runs redpanda.
       ONEX_EVENT_BUS_TYPE: "kafka"
       POSTGRES_DATABASE: "omnibase_infra"
       LLM_ENDPOINT_CIDR_ALLOWLIST: "10.0.0.0/8"
@@ -70,6 +88,19 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Resolve mode-specific postgres port
+        id: resolve_pg
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.mode }}" == "compose" ]]; then
+            effective="${{ inputs.compose_pg_port }}"
+          else
+            effective="${{ inputs.pg_port }}"
+          fi
+          echo "PG_PORT=${effective}" >> "$GITHUB_ENV"
+          echo "effective_pg_port=${effective}" >> "$GITHUB_OUTPUT"
+          echo "effective pg_port for mode=${{ inputs.mode }} -> ${effective}"
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -124,7 +155,7 @@ jobs:
           deadline=$((SECONDS + 90))
           while (( SECONDS < deadline )); do
             if body=$(curl -fsS "$url" 2>/dev/null); then
-              if echo "$body" | jq -e '.data.status == "healthy" and .is_running == true' >/dev/null; then
+              if echo "$body" | jq -e '.status == "healthy" and .details.is_running == true' >/dev/null; then
                 echo "$body" > health_initial.json
                 echo "runtime healthy after $SECONDS seconds"
                 break
@@ -133,37 +164,46 @@ jobs:
             sleep 2
           done
           if [[ ! -f health_initial.json ]]; then
-            echo "::error::runtime /health never reported status=healthy AND is_running=true within 90s"
+            echo "::error::runtime /health never reported status=healthy AND .details.is_running=true within 90s"
             exit 1
           fi
           # Warn-only observation — subscriber_count<300 is a regression SIGNAL,
           # not a contract gate. See plan §Rewritten Inventory §E.
-          sub_count=$(jq -r '.data.subscriber_count // 0' health_initial.json)
+          sub_count=$(jq -r '.details.subscriber_count // 0' health_initial.json)
           echo "subscriber_count=$sub_count"
           if [[ "$sub_count" -lt 300 ]]; then
             echo "::warning::subscriber_count=$sub_count below empirical .201 threshold of 300 — investigate possible regression"
           fi
 
-      - name: Hold 60s — RestartCount / health stability
+      - name: Hold 60s — runtime process + health stability
         run: |
           set -euo pipefail
+          url="http://${RUNTIME_HOST}:8085/health"
           if [[ "${{ inputs.mode }}" == "compose" ]]; then
-            start_count=$(docker inspect omninode-runtime --format '{{.RestartCount}}' 2>/dev/null || echo "0")
-            sleep 60
-            end_count=$(docker inspect omninode-runtime --format '{{.RestartCount}}' 2>/dev/null || echo "0")
-            if [[ "$start_count" != "$end_count" ]]; then
-              echo "::error::omninode-runtime RestartCount changed ${start_count} -> ${end_count} during 60s hold (crash-loop)"
+            # Runtime is a background Python process launched via uv (not a
+            # container), so `docker inspect RestartCount` is inapplicable.
+            # Assert the PID is still alive AND /health remains healthy.
+            if [[ -z "${RUNTIME_PID:-}" ]]; then
+              echo "::error::RUNTIME_PID not set — compose-mode launch step did not run"
               exit 1
             fi
-            echo "RestartCount stable at ${end_count} over 60s"
+            sleep 60
+            if ! kill -0 "${RUNTIME_PID}" 2>/dev/null; then
+              echo "::error::runtime PID ${RUNTIME_PID} died during 60s hold (crash)"
+              exit 1
+            fi
+            if ! curl -fsS "$url" | jq -e '.status == "healthy" and .details.is_running == true' >/dev/null; then
+              echo "::error::runtime /health degraded after 60s hold"
+              exit 1
+            fi
+            echo "runtime PID ${RUNTIME_PID} alive + /health healthy after 60s"
           else
             # Real mode: we don't control the remote container. Advisory-only
             # stability check on /health over a 60s window.
-            url="http://${RUNTIME_HOST}:8085/health"
             deadline=$((SECONDS + 60))
             failures=0
             while (( SECONDS < deadline )); do
-              if ! curl -fsS "$url" | jq -e '.data.status == "healthy"' >/dev/null; then
+              if ! curl -fsS "$url" | jq -e '.status == "healthy"' >/dev/null; then
                 failures=$((failures + 1))
               fi
               sleep 5
@@ -197,7 +237,11 @@ jobs:
           if [[ "${{ inputs.mode }}" == "compose" ]]; then
             raw=$(docker exec omnibase-infra-redpanda rpk group list)
           else
-            raw=$(ssh -o StrictHostKeyChecking=no "jonah@${RUNTIME_HOST}" "docker exec omnibase-infra-redpanda rpk group list")
+            user="${{ inputs.real_ssh_user }}"
+            if [[ -z "$user" ]]; then
+              user="$(whoami)"
+            fi
+            raw=$(ssh -o StrictHostKeyChecking=no "${user}@${RUNTIME_HOST}" "docker exec omnibase-infra-redpanda rpk group list")
           fi
           echo "$raw" > rpk_groups.txt
           if ! grep -qE '(^|[[:space:]])onex-runtime([[:space:]]|$)' rpk_groups.txt; then
@@ -210,12 +254,27 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
+          # Make artifact emission robust to partial failure — health_initial.json
+          # and rpk_groups.txt may be absent if an earlier step exited. Fall back
+          # to empty-JSON / empty-string placeholders so the artifact always
+          # uploads and downstream tooling can discriminate "ran but failed
+          # early" from "never uploaded".
+          if [[ ! -f health_initial.json ]]; then
+            echo '{}' > health_initial.json
+          fi
+          if [[ ! -f rpk_groups.txt ]]; then
+            : > rpk_groups.txt
+          fi
+          active_fresh_raw='${{ steps.pg_liveness.outputs.active_fresh_registrations }}'
+          if [[ -z "$active_fresh_raw" ]]; then
+            active_fresh_raw='0'
+          fi
           jq -n \
             --arg mode "${{ inputs.mode }}" \
             --arg runtime_host "${RUNTIME_HOST}" \
             --arg pg_port "${PG_PORT}" \
             --slurpfile health health_initial.json \
-            --arg active_fresh "${{ steps.pg_liveness.outputs.active_fresh_registrations }}" \
+            --arg active_fresh "${active_fresh_raw}" \
             --rawfile rpk_groups rpk_groups.txt \
             '{
               mode: $mode,

--- a/tests/ci/test_reusable_runtime_boot_schema.py
+++ b/tests/ci/test_reusable_runtime_boot_schema.py
@@ -7,13 +7,20 @@ Tier-2 regression (OMN-9252) can safely call it via `workflow_call`. Asserts:
 
 * `on.workflow_call.inputs.mode` is required + string + constrained to real|compose
 * `on.workflow_call.inputs.runtime_host` default == 'localhost'
-* `on.workflow_call.inputs.pg_port` default == '5436'
+* `on.workflow_call.inputs.pg_port` default == '5436' (real mode)
+* `on.workflow_call.inputs.compose_pg_port` default == '5433' (compose mode,
+  matches POSTGRES_PORT in docker/docker-compose.e2e.yml)
+* `on.workflow_call.inputs.real_ssh_user` present (empty default, falls back to
+  `whoami` on the runner — avoids hardcoded operator identity)
 * `jobs.boot.runs-on` uses the exact USE_SELF_HOSTED_RUNNERS conditional from
   ci-baseline.md §B (shared with ci.yml)
 * `jobs.boot.steps` contains checkout, uv setup, conditional compose bring-up,
-  health-wait with jq `.data.status == "healthy" and .is_running == true`,
-  60s hold + RestartCount check, psql registration_projections liveness query,
-  rpk group list check, and smoke-result.json artifact upload.
+  health-wait with jq `.status == "healthy" and .details.is_running == true`
+  (matches service_health.py::_handle_health response shape), 60s hold with
+  runtime PID-alive + health check (compose) / flapping tolerance (real),
+  psql registration_projections liveness query, rpk group list check, and
+  smoke-result.json artifact upload guarded against missing intermediate
+  files.
 """
 
 from __future__ import annotations
@@ -115,10 +122,34 @@ def test_runtime_host_input_defaults_localhost(workflow: Workflow) -> None:
 
 
 def test_pg_port_input_defaults_5436(workflow: Workflow) -> None:
+    """Real-mode default — matches CLAUDE.md infra topology for .201."""
     inputs = _inputs(workflow)
     assert "pg_port" in inputs
     assert inputs["pg_port"].get("type") == "string"
     assert inputs["pg_port"].get("default") == "5436"
+
+
+def test_compose_pg_port_input_defaults_5433(workflow: Workflow) -> None:
+    """Compose-mode default — matches POSTGRES_PORT in docker/docker-compose.e2e.yml."""
+    inputs = _inputs(workflow)
+    assert "compose_pg_port" in inputs, (
+        "compose_pg_port input missing — needed to avoid port collision with real mode"
+    )
+    assert inputs["compose_pg_port"].get("type") == "string"
+    assert inputs["compose_pg_port"].get("default") == "5433"
+
+
+def test_real_ssh_user_input_has_empty_default(workflow: Workflow) -> None:
+    """SSH user must be parameterized, not hardcoded to `jonah`."""
+    inputs = _inputs(workflow)
+    assert "real_ssh_user" in inputs, (
+        "real_ssh_user input missing — avoids hardcoded operator identity"
+    )
+    assert inputs["real_ssh_user"].get("type") == "string"
+    # Empty default → caller opts into a specific user or the runner falls
+    # back to its own `whoami`. Not an assertion on portability — it's the
+    # absence of a hardcoded operator name.
+    assert inputs["real_ssh_user"].get("default", "") == ""
 
 
 def test_boot_job_runs_on_uses_self_hosted_conditional(workflow: Workflow) -> None:
@@ -192,14 +223,21 @@ def test_boot_has_conditional_compose_bringup(workflow: Workflow) -> None:
 
 
 def test_boot_health_wait_uses_jq_hard_gate(workflow: Workflow) -> None:
-    """Health-wait step must assert jq `.data.status == "healthy" and .is_running == true`."""
+    """Health-wait step must assert the actual shape from service_health.py:
+    top-level `.status == "healthy"` AND `.details.is_running == true`.
+    """
     steps = _boot_steps(workflow)
     matched = [s for s in steps if "8085/health" in _step_text(s)]
     assert matched, "health-wait step missing"
     step_texts = "\n".join(_step_text(s) for s in matched)
-    assert ".data.status" in step_texts
+    # Probe the real JSON shape emitted by service_health.py::_handle_health.
+    assert ".status ==" in step_texts, (
+        "must assert top-level .status field (see service_health.py)"
+    )
     assert '"healthy"' in step_texts or "'healthy'" in step_texts
-    assert ".is_running" in step_texts
+    assert ".details.is_running" in step_texts, (
+        "is_running lives under .details, not top-level (see service_health.py)"
+    )
     assert "true" in step_texts
 
 
@@ -211,14 +249,25 @@ def test_boot_emits_subscriber_warning_not_hard_gate(workflow: Workflow) -> None
     assert "::warning::" in all_text, "subscriber_count must emit ::warning:: not fail"
 
 
-def test_boot_holds_60s_and_checks_restart_count(workflow: Workflow) -> None:
+def test_boot_holds_60s_with_stability_check(workflow: Workflow) -> None:
+    """60s hold step must assert runtime liveness.
+
+    In compose mode the runtime is a background Python process launched via
+    `uv run`, not a container — so `docker inspect RestartCount` is
+    inapplicable. The step must instead assert the PID is still alive +
+    /health still healthy. In real mode we fall back to a flapping-tolerance
+    check over /health.
+    """
     steps = _boot_steps(workflow)
     matched = [
-        s
-        for s in steps
-        if "restartcount" in _step_text(s) or "docker inspect" in _step_text(s)
+        s for s in steps if "sleep 60" in _step_text(s) or "60s hold" in _step_text(s)
     ]
-    assert matched, "60s-hold RestartCount check missing (compose hard gate)"
+    assert matched, "60s-hold stability step missing"
+    step_texts = "\n".join(_step_text(s) for s in matched)
+    assert "kill -0" in step_texts or "runtime_pid" in step_texts, (
+        "compose-mode branch must assert runtime PID is alive (kill -0) — "
+        "RestartCount on a host Python process is meaningless"
+    )
 
 
 def test_boot_has_psql_registration_projections_query(workflow: Workflow) -> None:

--- a/tests/ci/test_reusable_runtime_boot_schema.py
+++ b/tests/ci/test_reusable_runtime_boot_schema.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Schema tests for .github/workflows/reusable-runtime-boot.yml (OMN-9250).
+
+Validates the reusable workflow's YAML shape so Tier-1 smoke (OMN-9251) and
+Tier-2 regression (OMN-9252) can safely call it via `workflow_call`. Asserts:
+
+* `on.workflow_call.inputs.mode` is required + string + constrained to real|compose
+* `on.workflow_call.inputs.runtime_host` default == 'localhost'
+* `on.workflow_call.inputs.pg_port` default == '5436'
+* `jobs.boot.runs-on` uses the exact USE_SELF_HOSTED_RUNNERS conditional from
+  ci-baseline.md §B (shared with ci.yml)
+* `jobs.boot.steps` contains checkout, uv setup, conditional compose bring-up,
+  health-wait with jq `.data.status == "healthy" and .is_running == true`,
+  60s hold + RestartCount check, psql registration_projections liveness query,
+  rpk group list check, and smoke-result.json artifact upload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "reusable-runtime-boot.yml"
+)
+
+Workflow = dict[str, Any]
+Step = dict[str, Any]
+
+
+def _on_block(workflow: Workflow) -> dict[str, Any]:
+    # PyYAML parses the `on:` key as the Python bool True (YAML 1.1 "on"
+    # boolean alias). Accept either spelling so the test is agnostic to the
+    # underlying loader quirk. Cast keys to `Any` so mypy's dict overload
+    # accepts the bool fallback key.
+    typed_workflow: dict[Any, Any] = workflow
+    block = typed_workflow.get("on", typed_workflow.get(True))
+    assert isinstance(block, dict), "workflow missing `on` trigger"
+    return block
+
+
+def _inputs(workflow: Workflow) -> dict[str, Any]:
+    inputs = _on_block(workflow)["workflow_call"]["inputs"]
+    assert isinstance(inputs, dict)
+    return inputs
+
+
+def _boot_job(workflow: Workflow) -> dict[str, Any]:
+    job = workflow["jobs"]["boot"]
+    assert isinstance(job, dict)
+    return job
+
+
+def _boot_steps(workflow: Workflow) -> list[Step]:
+    steps = _boot_job(workflow)["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+@pytest.fixture(scope="module")
+def workflow() -> Workflow:
+    assert WORKFLOW_PATH.exists(), f"workflow missing: {WORKFLOW_PATH}"
+    with WORKFLOW_PATH.open() as fh:
+        loaded = yaml.safe_load(fh)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_workflow_is_workflow_call_reusable(workflow: Workflow) -> None:
+    assert "workflow_call" in _on_block(workflow), "workflow must expose workflow_call"
+
+
+def test_mode_input_required_string(workflow: Workflow) -> None:
+    inputs = _inputs(workflow)
+    assert "mode" in inputs, "mode input missing"
+    mode = inputs["mode"]
+    assert mode.get("required") is True, "mode must be required"
+    assert mode.get("type") == "string", "mode must be string"
+
+
+def test_mode_restricted_to_real_or_compose(workflow: Workflow) -> None:
+    """Restriction may be via `options` (enum) or a description-documented pattern.
+
+    GitHub's workflow_call does not support enum-typed inputs natively; the
+    plan accepts either `options` (forward-compat) or a description that
+    documents the `real | compose` contract. A runtime guard in the first
+    job step is not required to be asserted here — it's covered by the
+    step-level validation tests.
+    """
+    mode = _inputs(workflow)["mode"]
+    description = (mode.get("description") or "").lower()
+    options = mode.get("options") or []
+    documented = "real" in description and "compose" in description
+    enumerated = set(options) == {"real", "compose"}
+    assert documented or enumerated, (
+        "mode must be constrained to real|compose via `options` or description"
+    )
+
+
+def test_runtime_host_input_defaults_localhost(workflow: Workflow) -> None:
+    inputs = _inputs(workflow)
+    assert "runtime_host" in inputs
+    assert inputs["runtime_host"].get("type") == "string"
+    assert inputs["runtime_host"].get("default") == "localhost"
+
+
+def test_pg_port_input_defaults_5436(workflow: Workflow) -> None:
+    inputs = _inputs(workflow)
+    assert "pg_port" in inputs
+    assert inputs["pg_port"].get("type") == "string"
+    assert inputs["pg_port"].get("default") == "5436"
+
+
+def test_boot_job_runs_on_uses_self_hosted_conditional(workflow: Workflow) -> None:
+    """runs-on must match the shared ci-baseline §B conditional verbatim.
+
+    Pattern (whitespace-normalized):
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+    """
+    runs_on = _boot_job(workflow)["runs-on"]
+    assert isinstance(runs_on, str), "runs-on must be a string expression"
+    normalized = " ".join(runs_on.split())
+    assert "vars.USE_SELF_HOSTED_RUNNERS == 'true'" in normalized
+    assert "github.event_name == 'push'" in normalized
+    assert "github.event_name == 'workflow_dispatch'" in normalized
+    assert "github.event_name == 'schedule'" in normalized
+    assert 'fromJSON(\'["self-hosted","omnibase-ci"]\')' in normalized
+    assert "fromJSON('[\"ubuntu-latest\"]')" in normalized
+
+
+def test_boot_env_parameterizes_runtime_host_and_pg_port(workflow: Workflow) -> None:
+    env = _boot_job(workflow)["env"]
+    assert env.get("RUNTIME_HOST") == "${{ inputs.runtime_host }}"
+    assert env.get("PG_PORT") == "${{ inputs.pg_port }}"
+
+
+def _step_text(step: Step) -> str:
+    parts = [
+        str(step.get("name", "")),
+        str(step.get("uses", "")),
+        str(step.get("run", "")),
+    ]
+    return "\n".join(parts).lower()
+
+
+def _has_step(steps: list[Step], predicate: Callable[[Step], bool]) -> bool:
+    return any(predicate(step) for step in steps)
+
+
+def test_boot_has_checkout_step(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    assert _has_step(steps, lambda s: "actions/checkout" in str(s.get("uses", "")))
+
+
+def test_boot_has_uv_setup_step(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    assert _has_step(
+        steps,
+        lambda s: "astral-sh/setup-uv" in str(s.get("uses", ""))
+        or "uv" in _step_text(s),
+    )
+
+
+def test_boot_has_conditional_compose_bringup(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    matched = [
+        s
+        for s in steps
+        if "docker compose" in _step_text(s) or "docker-compose" in _step_text(s)
+    ]
+    assert matched, "compose bring-up step missing"
+    for step in matched:
+        cond = str(step.get("if", ""))
+        assert "inputs.mode" in cond and "compose" in cond, (
+            f"compose step must be gated on mode=='compose': {step}"
+        )
+
+
+def test_boot_health_wait_uses_jq_hard_gate(workflow: Workflow) -> None:
+    """Health-wait step must assert jq `.data.status == "healthy" and .is_running == true`."""
+    steps = _boot_steps(workflow)
+    matched = [s for s in steps if "8085/health" in _step_text(s)]
+    assert matched, "health-wait step missing"
+    step_texts = "\n".join(_step_text(s) for s in matched)
+    assert ".data.status" in step_texts
+    assert '"healthy"' in step_texts or "'healthy'" in step_texts
+    assert ".is_running" in step_texts
+    assert "true" in step_texts
+
+
+def test_boot_emits_subscriber_warning_not_hard_gate(workflow: Workflow) -> None:
+    """subscriber_count<300 must emit `::warning::` — NOT fail the job."""
+    steps = _boot_steps(workflow)
+    all_text = "\n".join(_step_text(s) for s in steps)
+    assert "subscriber_count" in all_text, "subscriber_count observation missing"
+    assert "::warning::" in all_text, "subscriber_count must emit ::warning:: not fail"
+
+
+def test_boot_holds_60s_and_checks_restart_count(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    matched = [
+        s
+        for s in steps
+        if "restartcount" in _step_text(s) or "docker inspect" in _step_text(s)
+    ]
+    assert matched, "60s-hold RestartCount check missing (compose hard gate)"
+
+
+def test_boot_has_psql_registration_projections_query(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    matched = [
+        s
+        for s in steps
+        if "psql" in _step_text(s) and "registration_projections" in _step_text(s)
+    ]
+    assert matched, "psql registration_projections liveness query missing"
+    # Must scope to active + recent heartbeat (60s window) per plan.
+    step_texts = "\n".join(_step_text(s) for s in matched)
+    assert "active" in step_texts
+    assert "last_heartbeat_at" in step_texts
+
+
+def test_boot_has_rpk_group_list_step(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    matched = [s for s in steps if "rpk group list" in _step_text(s)]
+    assert matched, "rpk group list check missing"
+
+
+def test_boot_uploads_smoke_result_artifact(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    matched = [
+        s
+        for s in steps
+        if "actions/upload-artifact" in str(s.get("uses", ""))
+        or "smoke-result" in _step_text(s)
+    ]
+    assert matched, "smoke-result.json artifact output missing"
+
+
+def test_boot_has_nine_steps_minimum(workflow: Workflow) -> None:
+    steps = _boot_steps(workflow)
+    # Plan enumerates 9 ordered steps; implementation may add minor helpers
+    # (e.g. a jq/kcat install step). Enforce >= 9 to catch accidental drops.
+    assert len(steps) >= 9, f"boot job must have >= 9 steps, found {len(steps)}"
+
+
+def test_no_hardcoded_user_paths(workflow: Workflow) -> None:
+    raw = WORKFLOW_PATH.read_text()
+    assert "/Users/" not in raw, "no /Users/ absolute paths in workflow YAML"
+    assert "/Volumes/" not in raw, "no /Volumes/ absolute paths in workflow YAML"


### PR DESCRIPTION
## Summary

Ships `.github/workflows/reusable-runtime-boot.yml` — a `workflow_call` reusable workflow that Tier-1 smoke (OMN-9251) and Tier-2 regression (OMN-9252) will invoke from both omnibase_core and omnibase_infra. Validates runtime boot via 4 hard gates + 1 warn-only observation.

- **Inputs (stable interface):** `mode` (`real`|`compose`, required), `runtime_host` (default `localhost`), `pg_port` (default `5436`), `compose_pg_port` (default `5433`), `real_ssh_user` (default `""`, falls through to `whoami`).
- **runs-on:** verbatim `USE_SELF_HOSTED_RUNNERS` conditional from `ci-baseline.md §B` (same anchor comment `OMNINODE_SELF_HOSTED_RUNS_ON_V1` as `ci.yml`).
- **Hard gates:** `.status == "healthy" AND .details.is_running == true`, 60s PID/health stability, `registration_projections` active+fresh rows > 0, `rpk group list` contains `onex-runtime`.
- **Warn-only:** `subscriber_count < 300` emits `::warning::` only (per plan §Rewritten Inventory §E truth-boundary rework — empirical observation, not contract gate).
- **Portability:** SSH user is parameterised via `real_ssh_user` input; no hardcoded `jonah@` username remains in the workflow (verified by `grep` on full repo `.github/workflows/`).

Bundles `tests/ci/test_reusable_runtime_boot_schema.py` (18 schema assertions) covering input shape, runs-on pattern, env parameterization, and the 9-step boot-job sequence.

## Test plan

- [x] TDD: schema test RED before YAML existed (18 errors confirming missing file).
- [x] TDD: schema test GREEN after YAML authored (18/18 pass).
- [x] `uv run ruff format src/ tests/` clean.
- [x] `uv run ruff check --fix src/ tests/` clean.
- [x] `uv run mypy src/ --strict` green (2171 files).
- [x] `uv run mypy tests/ci/test_reusable_runtime_boot_schema.py --strict` green.
- [x] `pre-commit run --all-files` green (SPDX header, YAML formatting, ONEX validators, ruff, AI-slop, topic lint, etc).
- [x] Python/uv versions match `ci.yml` (`astral-sh/setup-uv@v4` + `3.12` + `0.6.14`).
- [x] No hardcoded `/Users/` or `/Volumes/` paths in workflow YAML (assertion in schema test).
- [x] No hardcoded SSH usernames in workflow YAML (`grep -rn "jonah@" .github/workflows/` returns 0).
- [ ] `gh pr checks` green on this PR (watched post-push).

## Notes / scope

- **Test location:** plan specified `.github/workflows/tests/test_reusable_runtime_boot_schema.py`, but `pyproject.toml` sets `testpaths = ["tests"]` so pytest wouldn't discover that path. Placed the test under `tests/ci/` alongside the repo's other workflow-schema tests (e.g. `test_branch_protection_audit.py`, `test_compose_required_env_coverage.py`). Functionally identical, correctly discovered by CI.
- **Pre-existing unrelated failure flagged (not fixed here):** `tests/integration/registration/e2e/test_two_way_registration_e2e.py::TestSuite2RegistryDualRegistration::test_registry_receives_introspection_event` fails on `main` too — the handler emits `ModelNodeBecameActive` where the test expects `ModelNodeRegistrationAccepted`. This looks like a downstream effect of OMN-9202 (`revert(wiring): restore HandlerNodeRegistrationAcked — resolver now wires it`). It's an e2e test gated on `ALL_INFRA_AVAILABLE`, so it skips in PR CI and only fires with a fully-configured shell. Out of scope for a YAML-only CI workflow PR; worth a separate ticket.

## References

- Linear: [OMN-9250](https://linear.app/omninode/issue/OMN-9250)
- Parent epic: OMN-9235
- Plan: `docs/plans/2026-04-19-runtime-permanent-fix-and-regression-guard-part-1.md` §Task 15
- CI baseline: `docs/tracking/2026-04-19-ci-baseline.md` §B (`runs-on` pattern)
- Downstream consumers: OMN-9251 (Tier-1 smoke), OMN-9252 (Tier-2 regression)

---

## Gate bypasses

`[skip-receipt-gate: pre-existing infra import fail; tracked separately as OMN-9271 — Receipt Gate `verify / verify` step ImportErrors `omnibase_core.validation.receipt_gate_cli` because the install picks up a stale PyPI wheel of omnibase_core instead of the source checkout under `.receipt-gate-deps/omnibase_core`. Fails on `main` too. Not introduced by this PR.]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD pipeline infrastructure for runtime boot smoke validation with support for multiple execution environments
  * Added test suite to validate boot testing workflow configuration and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->