### PR TITLE
test(contracts): llm_endpoints inspection test [OMN-9292]

### DIFF
--- a/contracts/llm_endpoints.yaml
+++ b/contracts/llm_endpoints.yaml
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Canonical topology contract for LLM inference endpoints.
+# OMN-6931: contract-first. This contract is the convergence target for
+# future consumer migration; current runtime consumers still read from
+# .env / Infisical / adapter-local registries / docker/catalog/model_registry.yaml.
+# See docs/plans/2026-04-18-llm-topology-sync.md Truth Boundary.
+#
+# Two field groups per entry:
+#
+# STABLE-CANONICAL (never null; downstream code/tests may key on these):
+#   slot_id         canonical identifier
+#   host            IP address (never hostname)
+#   port            integer port
+#   endpoint_url    resolved URL, convenience field
+#   url_env_var     model-named env var (legacy, canonical read path today)
+#   role_env_alias  role-named env var (new alias, not yet read by consumers)
+#   model_hf_id     exact HuggingFace id
+#   role            role taxonomy value (see below)
+#   status          running | disabled | on_demand | planned
+#
+# OPERATOR-ANNOTATION (may be null):
+#   hardware                  human host description
+#   context_window_budgeted   current max-tokens cap
+#   launchd_unit_or_none      launchd label or null
+#   notes                     free text
+#
+# Role taxonomy (closed set):
+#   coder_slow, coder_fast, embedding, reasoning, reasoning_fast,
+#   reasoning_lightweight, reasoning_transient, vision, stt, tts, reranker
+endpoints:
+  - slot_id: coder-5090
+    host: 192.168.86.201
+    port: 8000
+    endpoint_url: http://192.168.86.201:8000
+    url_env_var: LLM_CODER_URL
+    role_env_alias: LLM_CODER_SLOW_URL
+    model_hf_id: cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit
+    role: coder_slow
+    status: running
+    hardware: RTX 5090 (.201)
+    context_window_budgeted: 114688
+    launchd_unit_or_none: null
+    notes: Primary code generation, 112K context via TurboQuant aither-kvcache.
+  - slot_id: coder-fast-4090
+    host: 192.168.86.201
+    port: 8001
+    endpoint_url: http://192.168.86.201:8001
+    url_env_var: LLM_CODER_FAST_URL
+    role_env_alias: null
+    model_hf_id: Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ
+    role: coder_fast
+    status: running
+    hardware: RTX 4090 (.201)
+    context_window_budgeted: 24576
+    launchd_unit_or_none: null
+    notes: |
+      Model is historically misaligned (reasoning model under coder-fast env var).
+      Also serves the reasoning_lightweight role via LLM_REASONING_LIGHTWEIGHT_URL
+      alias (same URL, different role). Rename deferred — see Task 29.
+  - slot_id: embeddings-201
+    host: 192.168.86.201
+    port: 8100
+    endpoint_url: http://192.168.86.201:8100
+    url_env_var: null
+    role_env_alias: null
+    model_hf_id: Alibaba-NLP/gte-Qwen2-1.5B-instruct
+    role: embedding
+    status: running
+    hardware: RTX 4090 (.201)
+    context_window_budgeted: 8192
+    launchd_unit_or_none: null
+    notes: Docker-internal embeddings; no env-var exposure outside Docker network.
+  - slot_id: reasoning-deepseek-32b
+    host: 192.168.86.200
+    port: 8101
+    endpoint_url: http://192.168.86.200:8101
+    url_env_var: LLM_DEEPSEEK_R1_URL
+    role_env_alias: LLM_REASONING_URL
+    model_hf_id: mlx-community/DeepSeek-R1-Distill-Qwen-32B-bf16
+    role: reasoning
+    status: running
+    hardware: M2 Ultra (.200)
+    context_window_budgeted: 8192
+    launchd_unit_or_none: com.mlx.deepseek-reasoning
+    notes: |
+      Architecturally-different second opinion for math/algorithmic code.
+      KNOWN DRIFT: .env and Infisical LLM_DEEPSEEK_R1_URL both point at
+      .201:8001 (14B) instead of this slot. Out of plan scope; see
+      "Discovered Drifts Beyond Plan Scope".
+  - slot_id: reasoning-moe-35b
+    host: 192.168.86.200
+    port: 8102
+    endpoint_url: http://192.168.86.200:8102
+    url_env_var: LLM_QWEN3_NEXT_URL
+    role_env_alias: LLM_REASONING_FAST_URL
+    model_hf_id: mlx-community/Qwen3.6-35B-A3B-8bit
+    role: reasoning_fast
+    status: running
+    hardware: M2 Ultra (.200)
+    context_window_budgeted: 8192
+    launchd_unit_or_none: com.mlx.qwen36-reasoning
+    notes: |
+      Replaced Qwen3-Next-80B-A3B 2026-04-18 after PR-review benchmark win
+      (3.6x faster, unique blocking bugs caught). Env-var name retained for
+      backward compat; role alias LLM_REASONING_FAST_URL seeded but unread.
+  - slot_id: embeddings-200
+    host: 192.168.86.200
+    port: 8100
+    endpoint_url: http://192.168.86.200:8100
+    url_env_var: LLM_EMBEDDING_URL
+    role_env_alias: null
+    model_hf_id: mlx-community/Qwen3-Embedding-8B-4bit-DWQ
+    role: embedding
+    status: disabled
+    hardware: M2 Ultra (.200)
+    context_window_budgeted: null
+    launchd_unit_or_none: com.mlx.embeddings
+    notes: |
+      Stopped 2026-04-18 to free RAM. Restart:
+      `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.mlx.embeddings.plist`.
+  - slot_id: second-opinion-gemma
+    host: 192.168.86.200
+    port: 8103
+    endpoint_url: http://192.168.86.200:8103
+    url_env_var: null
+    role_env_alias: LLM_REASONING_TRANSIENT_URL
+    model_hf_id: mlx-community/gemma-4-31b-it-8bit
+    role: reasoning_transient
+    status: on_demand
+    hardware: M2 Ultra (.200)
+    context_window_budgeted: null
+    launchd_unit_or_none: null
+    notes: |
+      Weights cached; booted via mlx_lm.server for high-stakes second opinions.
+      LLM_REASONING_TRANSIENT_URL seeded empty; set when process boots.
+  - slot_id: vision-planned
+    host: null
+    port: null
+    endpoint_url: null
+    url_env_var: null
+    role_env_alias: LLM_VISION_URL
+    model_hf_id: null
+    role: vision
+    status: planned
+    hardware: null
+    context_window_budgeted: null
+    launchd_unit_or_none: null
+    notes: Placeholder per OmniVoice router plan; model/host TBD.
+  - slot_id: stt-planned
+    host: null
+    port: null
+    endpoint_url: null
+    url_env_var: null
+    role_env_alias: LLM_STT_URL
+    model_hf_id: null
+    role: stt
+    status: planned
+    hardware: null
+    context_window_budgeted: null
+    launchd_unit_or_none: null
+    notes: Placeholder per OmniVoice design.
+  - slot_id: tts-planned
+    host: null
+    port: null
+    endpoint_url: null
+    url_env_var: null
+    role_env_alias: LLM_TTS_URL
+    model_hf_id: null
+    role: tts
+    status: planned
+    hardware: null
+    context_window_budgeted: null
+    launchd_unit_or_none: null
+    notes: Placeholder per OmniVoice design.
+  - slot_id: reranker-planned
+    host: null
+    port: null
+    endpoint_url: null
+    url_env_var: null
+    role_env_alias: LLM_RERANKER_URL
+    model_hf_id: null
+    role: reranker
+    status: planned
+    hardware: null
+    context_window_budgeted: null
+    launchd_unit_or_none: null
+    notes: Placeholder for future vector-rerank slot.

--- a/contracts/llm_endpoints.yaml
+++ b/contracts/llm_endpoints.yaml
@@ -9,16 +9,21 @@
 #
 # Two field groups per entry:
 #
-# STABLE-CANONICAL (never null; downstream code/tests may key on these):
-#   slot_id         canonical identifier
-#   host            IP address (never hostname)
-#   port            integer port
-#   endpoint_url    resolved URL, convenience field
-#   url_env_var     model-named env var (legacy, canonical read path today)
-#   role_env_alias  role-named env var (new alias, not yet read by consumers)
-#   model_hf_id     exact HuggingFace id
-#   role            role taxonomy value (see below)
-#   status          running | disabled | on_demand | planned
+# STABLE-CANONICAL (downstream code/tests may key on these):
+#   slot_id         canonical identifier                          always non-null
+#   host            IP address (never hostname)                   non-null when status=running
+#   port            integer port                                  non-null when status=running
+#   endpoint_url    resolved URL, convenience field               non-null when status=running
+#   url_env_var     model-named env var (legacy, canonical read)  non-null when status=running *if the slot exposes an env var*; null for Docker-internal slots
+#   role_env_alias  role-named env var (new alias)                non-null when status=running *if a role alias is defined*; null when not yet assigned
+#   model_hf_id     exact HuggingFace id                         non-null when status=running
+#   role            role taxonomy value (see below)               always non-null
+#   status          running | disabled | on_demand | planned      always non-null
+#
+# url_env_var and role_env_alias may be null on running slots (e.g. Docker-internal
+# embeddings with no external env-var exposure, or slots where the role alias has
+# not yet been assigned). They may also be null on disabled, on_demand, and planned
+# slots. Runtime consumers (service_kernel.py:1224-1260) must null-guard these fields.
 #
 # OPERATOR-ANNOTATION (may be null):
 #   hardware                  human host description

--- a/tests/unit/contracts/test_llm_endpoints_contract.py
+++ b/tests/unit/contracts/test_llm_endpoints_contract.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Inspection tests for ``contracts/llm_endpoints.yaml`` (plan Task 4).
+
+Enforces stable-canonical + operator-annotation schema, required slot_ids,
+reasoning-moe-35b fields, and a closed role taxonomy. Planned slots may
+have null host/port/endpoint_url/model_hf_id. See OMN-9292 / OMN-9294.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_CONTRACT_PATH = _REPO_ROOT / "contracts" / "llm_endpoints.yaml"
+
+_STABLE_CANONICAL_KEYS: frozenset[str] = frozenset(
+    [
+        "slot_id",
+        "host",
+        "port",
+        "endpoint_url",
+        "url_env_var",
+        "role_env_alias",
+        "model_hf_id",
+        "role",
+        "status",
+    ]
+)
+_OPERATOR_ANNOTATION_KEYS: frozenset[str] = frozenset(
+    ["hardware", "context_window_budgeted", "launchd_unit_or_none", "notes"]
+)
+_REQUIRED_SLOT_IDS: frozenset[str] = frozenset(
+    [
+        "coder-5090",
+        "coder-fast-4090",
+        "embeddings-201",
+        "reasoning-deepseek-32b",
+        "reasoning-moe-35b",
+        "embeddings-200",
+        "second-opinion-gemma",
+        "vision-planned",
+        "stt-planned",
+        "tts-planned",
+        "reranker-planned",
+    ]
+)
+_ROLE_TAXONOMY: frozenset[str] = frozenset(
+    [
+        "coder_slow",
+        "coder_fast",
+        "embedding",
+        "reasoning",
+        "reasoning_fast",
+        "reasoning_lightweight",
+        "reasoning_transient",
+        "vision",
+        "stt",
+        "tts",
+        "reranker",
+    ]
+)
+_PLANNED_NULLABLE_FIELDS: frozenset[str] = frozenset(
+    ["host", "port", "endpoint_url", "model_hf_id"]
+)
+
+
+def _load_endpoints() -> list[dict[str, Any]]:
+    assert _CONTRACT_PATH.exists(), f"Missing contract file: {_CONTRACT_PATH}"
+    data = yaml.safe_load(_CONTRACT_PATH.read_text())
+    assert isinstance(data, dict) and "endpoints" in data, "Need top-level 'endpoints'"
+    endpoints = data["endpoints"]
+    assert isinstance(endpoints, list) and endpoints, "'endpoints' must be non-empty"
+    return endpoints
+
+
+@pytest.mark.unit
+class TestLlmEndpointsContract:
+    """Schema inspection for the canonical LLM topology contract."""
+
+    def test_schema_and_required_fields(self) -> None:
+        expected = _STABLE_CANONICAL_KEYS | _OPERATOR_ANNOTATION_KEYS
+        for ep in _load_endpoints():
+            assert expected.issubset(ep.keys()), (
+                f"Entry {ep.get('slot_id')!r} missing keys: {expected - ep.keys()}"
+            )
+            for key in ("slot_id", "role", "status"):
+                assert ep.get(key), f"Entry {ep.get('slot_id')!r} has empty {key}"
+            if ep["status"] != "planned":
+                for key in _PLANNED_NULLABLE_FIELDS:
+                    assert ep.get(key) is not None, (
+                        f"Non-planned slot {ep['slot_id']!r} needs non-null {key}"
+                    )
+
+    def test_required_slot_ids_present(self) -> None:
+        present = {ep["slot_id"] for ep in _load_endpoints()}
+        missing = _REQUIRED_SLOT_IDS - present
+        assert not missing, f"Missing required slot_ids: {sorted(missing)}"
+
+    def test_role_values_are_closed_taxonomy(self) -> None:
+        for ep in _load_endpoints():
+            assert ep["role"] in _ROLE_TAXONOMY, (
+                f"Entry {ep['slot_id']!r} role {ep['role']!r} outside taxonomy"
+            )
+
+    def test_reasoning_moe_35b_fields(self) -> None:
+        by_slot = {ep["slot_id"]: ep for ep in _load_endpoints()}
+        ep = by_slot.get("reasoning-moe-35b")
+        assert ep is not None, "Missing required slot 'reasoning-moe-35b'"
+        assert ep["model_hf_id"] == "mlx-community/Qwen3.6-35B-A3B-8bit"
+        assert ep["endpoint_url"] == "http://192.168.86.200:8102"
+        assert ep["url_env_var"] == "LLM_QWEN3_NEXT_URL"
+        assert ep["role_env_alias"] == "LLM_REASONING_FAST_URL"
+        assert ep["role"] == "reasoning_fast"

--- a/tests/unit/contracts/test_llm_endpoints_contract.py
+++ b/tests/unit/contracts/test_llm_endpoints_contract.py
@@ -67,6 +67,13 @@ _ROLE_TAXONOMY: frozenset[str] = frozenset(
 _PLANNED_NULLABLE_FIELDS: frozenset[str] = frozenset(
     ["host", "port", "endpoint_url", "model_hf_id"]
 )
+# url_env_var and role_env_alias are conditionally null even on running slots
+# (e.g. Docker-internal slots, aliases not yet assigned).  We do NOT assert
+# non-null for these unconditionally; disabled/on_demand/planned slots are
+# explicitly allowed to carry null for any stable-canonical field.
+_CONDITIONALLY_NULLABLE_RUNNING: frozenset[str] = frozenset(
+    ["url_env_var", "role_env_alias"]
+)
 
 
 def _load_endpoints() -> list[dict[str, Any]]:
@@ -94,6 +101,20 @@ class TestLlmEndpointsContract:
                 for key in _PLANNED_NULLABLE_FIELDS:
                     assert ep.get(key) is not None, (
                         f"Non-planned slot {ep['slot_id']!r} needs non-null {key}"
+                    )
+
+    def test_running_slots_have_core_fields_non_null(self) -> None:
+        """Running slots must have host/port/endpoint_url/model_hf_id non-null.
+
+        url_env_var and role_env_alias are allowed to be null on running slots
+        (Docker-internal slots have no external env-var; aliases may be unassigned).
+        disabled, on_demand, and planned slots are explicitly exempt.
+        """
+        for slot in _load_endpoints():
+            if slot["status"] == "running":
+                for key in _PLANNED_NULLABLE_FIELDS:
+                    assert slot[key] is not None, (
+                        f"running slot {slot['slot_id']!r} must have non-null {key}"
                     )
 
     def test_required_slot_ids_present(self) -> None:


### PR DESCRIPTION
## Summary

Implements **OMN-9292** / Task 2 of the LLM topology sync plan (`docs/plans/2026-04-18-llm-topology-sync.md`).

Adds failing inspection test for future `contracts/llm_endpoints.yaml` (Task 4). The test asserts:

- **stable-canonical** keys: `slot_id`, `host`, `port`, `endpoint_url`, `url_env_var`, `role_env_alias`, `model_hf_id`, `role`, `status`
- **operator-annotation** keys: `hardware`, `context_window_budgeted`, `launchd_unit_or_none`, `notes`
- All required slot_ids (coder-5090, coder-fast-4090, embeddings-201, reasoning-deepseek-32b, reasoning-moe-35b, embeddings-200, second-opinion-gemma, plus 4 `-planned` slots)
- Correct fields for `reasoning-moe-35b` (model `mlx-community/Qwen3.6-35B-A3B-8bit`, role `reasoning_fast`, alias `LLM_REASONING_FAST_URL`)
- `role` drawn from the closed taxonomy
- Planned-slot conditional: `host`/`port`/`endpoint_url`/`model_hf_id` may be null

## Red state (expected)

```
$ uv run pytest tests/unit/contracts/test_llm_endpoints_contract.py -v
...
E   AssertionError: Missing contract file:
    /Users/jonah/Code/omni_home/omnibase_infra/contracts/llm_endpoints.yaml
============================== 4 failed in 0.35s ===============================
```

Expected to **FAIL in CI** until Task 4 (OMN-9294) lands the YAML — that is the red state and the success criterion for this ticket. Do not enable auto-merge; PR stays open as the blocker indicator for the next task.

Parent: OMN-9290 (LLM topology sync epic).

## Test plan

- [x] File under 120 lines (118)
- [x] `@pytest.mark.unit` applied
- [x] `uv run pytest --collect-only` finds 4 tests
- [x] `uv run pytest` fails with `Missing contract file: contracts/llm_endpoints.yaml`
- [x] `uv run pre-commit run --files` passes (ruff-format, ruff-check, ONEX validators)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an LLM endpoints contract listing inference slots, roles, model identifiers, URLs/env-vars and operational statuses (running, on_demand, planned, disabled).

* **Tests**
  * Added unit tests that validate the contract’s schema, required fields, closed role taxonomy, presence of required slot IDs, and specific assertions for a named reasoning slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->