### PR TITLE
feat(catalog): decompose runtime bundle into 4 sub-bundles [OMN-9332]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,15 +154,21 @@ Every deployable unit is a typed YAML manifest; the compose file is generated, n
 
 | Bundle | Contents | Purpose |
 |--------|----------|---------|
-| `core` | postgres, redpanda | Always-on infrastructure |
-| `runtime` | valkey, migration-gate, forward-migration, omninode-runtime, runtime-effects, runtime-worker, agent-actions-consumer, skill-lifecycle-consumer, context-audit-consumer, intelligence-migration, intelligence-api, omninode-contract-resolver, autoheal + core | Full ONEX runtime stack |
+| `core` | postgres, redpanda, valkey, infisical | Always-on infrastructure |
+| `runtime` | (composed) | Full ONEX runtime stack — includes `core`, `tracing`, and the four sub-bundles below |
+| `runtime-core` | omninode-runtime, runtime-effects, agent-actions-consumer, skill-lifecycle-consumer, context-audit-consumer, omninode-contract-resolver, intelligence-api | 7 services with no env requirements beyond the 0.34.0 baseline — deploy correctness fixes without needing new secrets (OMN-9332) |
+| `runtime-integrations` | ci-relay, linear-relay, waitlist-signup-notifier | External-integration services; needs `CI_CALLBACK_TOKEN`, `LINEAR_WEBHOOK_SECRET`, `WAITLIST_NOTIFIER_SLACK_*` |
+| `runtime-observability-projections` | injection-effectiveness-consumer, savings-estimation-consumer, llm-cost-aggregation-consumer, consumer-health-projection, decision-store-consumer | Postgres projection consumers; needs `OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN` |
+| `runtime-infrastructure` | forward-migration, migration-gate, intelligence-migration, runtime-worker, retry-worker, autoheal | Migrations, workers, container autoheal |
 | `memgraph` | omnibase-infra-memgraph | Graph memory — injects `OMNIMEMORY_*` env vars |
 | `observability` | phoenix | LLM observability (Phoenix traces/evals) |
 | `tracing` | (none) + observability | Injects OTEL env vars; phoenix pulled in transitively |
 | `secrets` | infisical | Secrets management — injects `INFISICAL_ADDR` |
 | `auth` | keycloak | Local OIDC/auth |
 
-**Transitive resolution**: `runtime` includes `core`; `tracing` includes `observability`. The resolver expands all `includes` before collecting services.
+**Transitive resolution**: `runtime` includes `core`, `tracing`, and the four runtime sub-bundles; `tracing` includes `observability`. The resolver expands all `includes` before collecting services.
+
+**Incremental rollout (OMN-9332)**: when new runtime services land with new secret requirements, operators can deploy `onex up runtime-core` to pick up correctness fixes without also needing those secrets. Once the secrets are seeded (Infisical or `~/.omnibase/.env`), bring up the remaining sub-bundles with `onex up runtime-integrations`, `onex up runtime-observability-projections`, or `onex up runtime-infrastructure`.
 
 **Env injection**: Each bundle may declare `inject_env` (hardcoded values injected into generated compose) and `inject_required_env` (vars that must be present in the operator environment at start time).
 

--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -17,33 +17,53 @@ core:
     - INFISICAL_PROJECT_ID
     - INFISICAL_ENCRYPTION_KEY
     - INFISICAL_AUTH_SECRET
-runtime:
-  description: "ONEX runtime platform — kernel, effects, workers, consumers"
+runtime-core:
+  description: "ONEX runtime core — 7 services with no env requirements beyond the 0.34.0 baseline (OMN-9332). Use `onex up runtime-core` to redeploy correctness fixes without also enabling integrations that need new secrets."
   services:
-    - forward-migration
-    - migration-gate
     - omninode-runtime
     - runtime-effects
-    - runtime-worker
     - agent-actions-consumer
     - skill-lifecycle-consumer
     - context-audit-consumer
-    - intelligence-migration
-    - intelligence-api
     - omninode-contract-resolver
-    - injection-effectiveness-consumer
+    - intelligence-api
+  includes: []
+runtime-integrations:
+  description: "Runtime external-integration services — Linear, CI, Slack webhooks (OMN-9332)"
+  services:
     - ci-relay
     - linear-relay
-    - decision-store-consumer
     - waitlist-signup-notifier
+  includes: []
+runtime-observability-projections:
+  description: "Runtime projection/observability consumers — postgres projections, cost aggregation, health projection, decision store (OMN-9332)"
+  services:
+    - injection-effectiveness-consumer
     - savings-estimation-consumer
     - llm-cost-aggregation-consumer
     - consumer-health-projection
+    - decision-store-consumer
+  includes: []
+runtime-infrastructure:
+  description: "Runtime infrastructure glue — migrations, workers, autoheal (OMN-9332)"
+  services:
+    - forward-migration
+    - migration-gate
+    - intelligence-migration
+    - runtime-worker
     - retry-worker
     - autoheal
+  includes: []
+runtime:
+  description: "ONEX runtime platform — composed of runtime-core, runtime-integrations, runtime-observability-projections, runtime-infrastructure (OMN-9332). Preserves the `onex up runtime` operator contract."
+  services: []
   includes:
     - core
     - tracing # OMN-8697: always wire Phoenix OTLP tracing with the runtime
+    - runtime-core
+    - runtime-integrations
+    - runtime-observability-projections
+    - runtime-infrastructure
 observability:
   description: "LLM observability — Phoenix traces and evals"
   services:

--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -28,6 +28,8 @@ runtime-core:
     - omninode-contract-resolver
     - intelligence-api
   includes: []
+  inject_env: {}
+  inject_required_env: []
 runtime-integrations:
   description: "Runtime external-integration services — Linear, CI, Slack webhooks (OMN-9332)"
   services:
@@ -35,6 +37,12 @@ runtime-integrations:
     - linear-relay
     - waitlist-signup-notifier
   includes: []
+  inject_env: {}
+  inject_required_env:
+    - CI_CALLBACK_TOKEN
+    - LINEAR_WEBHOOK_SECRET
+    - WAITLIST_NOTIFIER_SLACK_BOT_TOKEN
+    - WAITLIST_NOTIFIER_SLACK_CHANNEL_ID
 runtime-observability-projections:
   description: "Runtime projection/observability consumers — postgres projections, cost aggregation, health projection, decision store (OMN-9332)"
   services:
@@ -44,6 +52,9 @@ runtime-observability-projections:
     - consumer-health-projection
     - decision-store-consumer
   includes: []
+  inject_env: {}
+  inject_required_env:
+    - OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN
 runtime-infrastructure:
   description: "Runtime infrastructure glue — migrations, workers, autoheal (OMN-9332)"
   services:
@@ -54,6 +65,8 @@ runtime-infrastructure:
     - retry-worker
     - autoheal
   includes: []
+  inject_env: {}
+  inject_required_env: []
 runtime:
   description: "ONEX runtime platform — composed of runtime-core, runtime-integrations, runtime-observability-projections, runtime-infrastructure (OMN-9332). Preserves the `onex up runtime` operator contract."
   services: []

--- a/tests/integration/test_catalog_roundtrip.py
+++ b/tests/integration/test_catalog_roundtrip.py
@@ -119,11 +119,16 @@ def test_catalog_generates_and_starts_core_bundle() -> None:
 
 @pytest.mark.integration
 @pytest.mark.slow
-def test_catalog_validator_rejects_missing_env() -> None:
-    """Validator must fail before starting if required vars are missing."""
-    # Build env dict without POSTGRES_PASSWORD — must pass explicit env to
-    # subprocess since monkeypatch.delenv only affects the current process.
+def test_catalog_validator_rejects_missing_env(tmp_path: Path) -> None:
+    """Validator must fail before starting if required vars are missing.
+
+    The CLI auto-loads ``$HOME/.omnibase/.env`` at startup, so removing the
+    var from the subprocess env is not sufficient on operator machines that
+    have a populated .env. Redirect HOME to an empty tmpdir so the autoload
+    finds nothing.
+    """
     env = {k: v for k, v in os.environ.items() if k != "POSTGRES_PASSWORD"}
+    env["HOME"] = str(tmp_path)
     result = subprocess.run(
         [
             "uv",

--- a/tests/unit/infra/test_runtime_bundle_decomposition.py
+++ b/tests/unit/infra/test_runtime_bundle_decomposition.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the runtime bundle decomposition (OMN-9332).
+
+The `runtime` bundle grew from 7 to 21 services; env validation became
+all-or-nothing and blocked .201 redeploy because 5 new env vars land in
+new services. Decomposition splits runtime into four sub-bundles:
+  - runtime-core: 7 original services, zero new env requirements
+  - runtime-integrations: Linear/CI/Slack-dependent services
+  - runtime-observability-projections: projection/observability consumers
+  - runtime-infrastructure: migrations, workers, autoheal
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+
+CATALOG_DIR = str(Path(__file__).resolve().parents[3] / "docker" / "catalog")
+BUNDLES_FILE = (
+    Path(__file__).resolve().parents[3] / "docker" / "catalog" / "bundles.yaml"
+)
+
+_SUB_BUNDLES = (
+    "runtime-core",
+    "runtime-integrations",
+    "runtime-observability-projections",
+    "runtime-infrastructure",
+)
+
+_RUNTIME_CORE_SERVICES = frozenset(
+    {
+        "omninode-runtime",
+        "runtime-effects",
+        "agent-actions-consumer",
+        "skill-lifecycle-consumer",
+        "context-audit-consumer",
+        "omninode-contract-resolver",
+        "intelligence-api",
+    }
+)
+
+# Env vars considered "pre-growth baseline" for the runtime-core set. These
+# are the vars that the 7 runtime-core services already relied on at the last
+# good .201 deploy (0.34.0) AND are known to be present in `~/.omnibase/.env`
+# on every operator's machine. Anything outside this set indicates drift
+# that could block a redeploy.
+_PRE_GROWTH_ENV_VARS = frozenset(
+    {
+        "POSTGRES_PASSWORD",
+        "VALKEY_PASSWORD",
+        "KEYCLOAK_ADMIN_CLIENT_SECRET",
+        "ONEX_SERVICE_CLIENT_SECRET",
+        "ONEX_REGISTRATION_AUTO_ACK",
+        # LLM endpoints: present in ~/.omnibase/.env since the .201/.200
+        # endpoint map was established. Runtime-core services reference them
+        # but they are not "new" in the OMN-9332 sense.
+        "LLM_CODER_URL",
+        "LLM_CODER_FAST_URL",
+        "LLM_EMBEDDING_URL",
+        "LLM_DEEPSEEK_R1_URL",
+        # omnidash projection DSN: present in ~/.omnibase/.env alongside
+        # POSTGRES_PASSWORD; used by intelligence-api and projection consumers.
+        "OMNIDASH_ANALYTICS_DB_URL",
+        # core bundle's Infisical requirements are resolved transitively
+        "INFISICAL_CLIENT_ID",
+        "INFISICAL_CLIENT_SECRET",
+        "INFISICAL_PROJECT_ID",
+        "INFISICAL_ENCRYPTION_KEY",
+        "INFISICAL_AUTH_SECRET",
+    }
+)
+
+
+def _load_bundles() -> dict[str, dict[str, object]]:
+    with open(BUNDLES_FILE) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.unit
+def test_all_four_sub_bundles_exist() -> None:
+    bundles = _load_bundles()
+    for name in _SUB_BUNDLES:
+        assert name in bundles, f"missing sub-bundle '{name}' in bundles.yaml"
+
+
+@pytest.mark.unit
+def test_runtime_core_has_the_seven_original_services() -> None:
+    bundles = _load_bundles()
+    declared = set(bundles["runtime-core"]["services"])
+    assert declared == _RUNTIME_CORE_SERVICES, (
+        f"runtime-core drift: expected {sorted(_RUNTIME_CORE_SERVICES)}, "
+        f"got {sorted(declared)}"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_core_required_env_is_subset_of_pre_growth() -> None:
+    """runtime-core must not demand any env var that did not exist at 0.34.0.
+
+    This is the load-bearing test: if it fails, .201 redeploy is blocked again.
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime-core"])
+    drift = resolved.required_env - _PRE_GROWTH_ENV_VARS
+    assert not drift, (
+        f"runtime-core requires env vars not present at 0.34.0 baseline: {drift}"
+    )
+
+
+@pytest.mark.unit
+def test_each_runtime_service_appears_in_exactly_one_sub_bundle() -> None:
+    bundles = _load_bundles()
+    seen: dict[str, str] = {}
+    for sub in _SUB_BUNDLES:
+        for svc in bundles[sub]["services"]:
+            if svc in seen:
+                pytest.fail(
+                    f"service '{svc}' appears in both '{seen[svc]}' and '{sub}'"
+                )
+            seen[svc] = sub
+
+
+@pytest.mark.unit
+def test_union_of_sub_bundles_equals_original_runtime() -> None:
+    """No service lost, no service gained during decomposition."""
+    bundles = _load_bundles()
+    union: set[str] = set()
+    for sub in _SUB_BUNDLES:
+        union.update(bundles[sub]["services"])
+    original = set(bundles["runtime"]["services"])
+    # The top-level `runtime` bundle, post-decomposition, is expected to carry
+    # an empty `services:` list and compose via `includes`. The authoritative
+    # set comes from resolving `runtime`.
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    # Exclude core-bundle services (postgres/redpanda/valkey/infisical) from
+    # the comparison — those come from `includes: [core]`, not from runtime
+    # decomposition.
+    core_services = {"postgres", "redpanda", "valkey", "infisical", "phoenix"}
+    runtime_services_resolved = resolved.service_names - core_services
+    assert union == runtime_services_resolved, (
+        f"decomposition drift: union={sorted(union)}, "
+        f"resolved-runtime-minus-core={sorted(runtime_services_resolved)}"
+    )
+    assert not original, (
+        "`runtime` bundle must have no direct services after decomposition — "
+        "it composes via `includes` to preserve operator contract"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_bundle_composes_all_sub_bundles_via_includes() -> None:
+    """Operator contract: `onex up runtime` must still bring up every service.
+
+    We preserve this by making `runtime` a composed bundle that includes all
+    four sub-bundles plus core and tracing.
+    """
+    bundles = _load_bundles()
+    includes = set(bundles["runtime"]["includes"])
+    for sub in _SUB_BUNDLES:
+        assert sub in includes, f"runtime bundle missing include '{sub}'"
+
+
+@pytest.mark.unit
+def test_runtime_integrations_carries_linear_ci_slack_env() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime-integrations"])
+    assert "CI_CALLBACK_TOKEN" in resolved.required_env
+    assert "LINEAR_WEBHOOK_SECRET" in resolved.required_env
+    assert "WAITLIST_NOTIFIER_SLACK_BOT_TOKEN" in resolved.required_env
+    assert "WAITLIST_NOTIFIER_SLACK_CHANNEL_ID" in resolved.required_env
+
+
+@pytest.mark.unit
+def test_runtime_observability_projections_carries_injection_dsn() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime-observability-projections"])
+    assert (
+        "OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN" in resolved.required_env
+    )
+
+
+@pytest.mark.unit
+def test_runtime_equivalent_to_sum_of_sub_bundles() -> None:
+    """Resolving `runtime` must equal resolving all four sub-bundles plus
+    core and tracing (which `runtime` pulls in transitively)."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    runtime = resolver.resolve(bundles=["runtime"])
+    composed = resolver.resolve(bundles=[*_SUB_BUNDLES, "core", "tracing"])
+    assert runtime.service_names == composed.service_names, (
+        f"runtime resolution != sum of sub-bundles (+core +tracing):\n"
+        f"  runtime-only: {sorted(runtime.service_names - composed.service_names)}\n"
+        f"  sub-only:     {sorted(composed.service_names - runtime.service_names)}"
+    )


### PR DESCRIPTION
## Summary
- Splits the 21-service `runtime` bundle into 4 env-coherent sub-bundles so the .201 redeploy can pick up correctness fixes without needing 5 new secrets that have not yet landed in `~/.omnibase/.env` or Infisical.
- Preserves the `onex up runtime` operator contract: `runtime` becomes a composed bundle (empty services, `includes` the 4 sub-bundles + `core` + `tracing`).
- Adds a TDD load-bearing invariant: `runtime-core` required env vars must be a subset of the 0.34.0 baseline.

## Bundle classification

| Sub-bundle | Services | New env requirements |
|---|---|---|
| `runtime-core` | omninode-runtime, runtime-effects, agent-actions-consumer, skill-lifecycle-consumer, context-audit-consumer, omninode-contract-resolver, intelligence-api | none (POSTGRES_PASSWORD/VALKEY_PASSWORD/ONEX_* already present) |
| `runtime-integrations` | ci-relay, linear-relay, waitlist-signup-notifier | CI_CALLBACK_TOKEN, LINEAR_WEBHOOK_SECRET, WAITLIST_NOTIFIER_SLACK_{BOT_TOKEN,CHANNEL_ID} |
| `runtime-observability-projections` | injection-effectiveness-consumer, savings-estimation-consumer, llm-cost-aggregation-consumer, consumer-health-projection, decision-store-consumer | OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN |
| `runtime-infrastructure` | forward-migration, migration-gate, intelligence-migration, runtime-worker, retry-worker, autoheal | none |

Total: 7 + 3 + 5 + 6 = 21 (matches original runtime service count; no service lost, no duplicates).

## Why
Ref: docs/diagnosis-redeploy-2026-04-20.md (option A). The redeploy was blocked because running onex up runtime --build trips env validation on 5 vars the operator doesn't have. With this PR, the operator can run onex up runtime-core to deploy the 6 correctness commits (OMN-9202, 9215, 9263, 9276, 9214, 9234) in isolation, then enable the other sub-bundles once their secrets are seeded.

## What doesn't change
- onex up runtime still brings up all 21 services (preserved via includes).
- Every service's manifest is untouched.
- No shell function changes in ~/.zshrc — the catalog CLI is the source of truth; infra-up-runtime still resolves through the same runtime bundle.

## Test plan
- [x] tests/unit/infra/test_runtime_bundle_decomposition.py — 9 new tests covering: existence of 4 sub-bundles, runtime-core membership, env-drift invariant, no-duplicate membership, union-equals-original, runtime composes all 4, integration-env carriers, observability-env carrier, runtime sum(sub-bundles)+core+tracing.
- [x] Fixed test_catalog_validator_rejects_missing_env (was failing on any machine with a populated ~/.omnibase/.env because the CLI autoloads it — now redirects HOME to a tmp path).
- [x] uv run pytest tests/unit/infra/ tests/unit/docker/ tests/integration/test_catalog_roundtrip.py tests/integration/test_catalog_extra_networks.py — 117 passed, 3 skipped.
- [x] uv run pytest tests/ -m unit — 18,643 passed; 5 pre-existing failures (runtime kernel bootstrap / policy perf / session graph projector) verified to also fail on main and are unrelated to the catalog layer.
- [x] uv run ruff format + check — clean.
- [x] uv run mypy src/ --strict — clean across 2,171 files.
- [x] pre-commit run --files — all hooks pass.
- [x] Fix: added inject_env and inject_required_env to all 4 new sub-bundles (CodeRabbit thread resolved — all 9 decomposition tests pass).

## Post-merge action
redeploy-executor can now run onex up core runtime-core --build on .201 to get the 6 correctness commits live without needing the 5 new secrets.

[skip-receipt-gate: no OMN-9332 contract in onex_change_control — infrastructure decomposition PR; ticket is the Linear issue, contract backfill tracked in OMN-9332]

Closes OMN-9332. Unblocks OMN-9321.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Docker service bundle structure by splitting the runtime stack into focused sub-bundles: `runtime-core`, `runtime-integrations`, `runtime-observability-projections`, and `runtime-infrastructure`. The `runtime` bundle now composes these sub-bundles with updated environment variable requirements for integration services and observability projections.

* **Tests**
  * Added validation tests for the new runtime bundle structure to ensure correctness and functional equivalence across all sub-bundle combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->