### PR TITLE
fix(ci): switch auto-merge workflow to squash method (OMN-9348)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -84,7 +84,7 @@ jobs:
           PR: ${{ steps.resolve.outputs.pr }}
         run: |
           set -euo pipefail
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --merge 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Switch `auto-merge.yml` method flag from merge-commit to squash.
- `main` enforces `required_linear_history`, which rejects merge-commits and leaves auto-merge-armed PRs stalled BLOCKED while the workflow retries indefinitely.
- Aligns with `CLAUDE.md` merge-queue policy (squash for non-queue repos; queue-managed repos ignore the flag anyway).

Fixes OMN-9348.

## Test plan
- [ ] This PR should auto-merge cleanly once CI passes, demonstrating the fix.
- [ ] Subsequent PRs in this repo should auto-merge correctly without manual re-arming.