### PR TITLE
fix(wiring): gate wire_from_manifest raise behind ONEX_WIRING_STRICT_MODE env flag [OMN-9126]

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -632,16 +632,24 @@ async def wire_from_manifest(
             )
 
     # Check for failures before committing any side effects.
+    # ONEX_WIRING_STRICT_MODE=1 raises on any failure (default OFF per OMN-9126:
+    # strict gate ships after all downstream consumers are compliant).
     failures = failed_results
     if failures:
         failed_reasons = [f"{r.contract_name}: {r.reason}" for r in failures]
-        raise ModelOnexError(
-            f"Auto-wiring failed for {len(failures)} contract(s): "
-            + "; ".join(failed_reasons)
+        if os.environ.get("ONEX_WIRING_STRICT_MODE", "").lower() in ("1", "true"):
+            raise ModelOnexError(
+                f"Auto-wiring failed for {len(failures)} contract(s): "
+                + "; ".join(failed_reasons)
+            )
+        logger.warning(
+            "Auto-wiring failed for %d contract(s) (non-strict — set ONEX_WIRING_STRICT_MODE=1 to enforce): %s",
+            len(failures),
+            "; ".join(failed_reasons),
         )
 
     # Phase 2: All contracts validated — commit registrations and subscriptions.
-    results: list[ModelContractWiringResult] = []
+    results: list[ModelContractWiringResult] = list(failures)
     for pcw in prepared_contracts:
         result = await _commit_contract_wiring(pcw, dispatch_engine, event_bus)
         results.append(result)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -649,9 +649,9 @@ async def wire_from_manifest(
         )
 
     # Phase 2: All contracts validated — commit registrations and subscriptions.
-    # In non-strict mode, failures are logged above but excluded from results so
-    # the service_kernel postcondition (total_failed == 0) remains valid.
-    results: list[ModelContractWiringResult] = []
+    # Failed contracts are included in results so total_failed is accurate.
+    # service_kernel respects the flag before asserting total_failed == 0.
+    results: list[ModelContractWiringResult] = list(failed_results)
     for pcw in prepared_contracts:
         result = await _commit_contract_wiring(pcw, dispatch_engine, event_bus)
         results.append(result)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -649,7 +649,9 @@ async def wire_from_manifest(
         )
 
     # Phase 2: All contracts validated — commit registrations and subscriptions.
-    results: list[ModelContractWiringResult] = list(failures)
+    # In non-strict mode, failures are logged above but excluded from results so
+    # the service_kernel postcondition (total_failed == 0) remains valid.
+    results: list[ModelContractWiringResult] = []
     for pcw in prepared_contracts:
         result = await _commit_contract_wiring(pcw, dispatch_engine, event_bus)
         results.append(result)

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2230,12 +2230,29 @@ async def bootstrap() -> int:
 
                 auto_wiring_duration = time.time() - auto_wiring_start
 
-                # Strict invariant (OMN-8735): wire_from_manifest raises on any
-                # failure, so reaching here guarantees total_failed == 0.
-                assert auto_wiring_report.total_failed == 0, (
-                    f"Auto-wiring postcondition violated: "
-                    f"total_failed={auto_wiring_report.total_failed}"
-                )
+                # OMN-9126: in strict mode wire_from_manifest raises, so
+                # total_failed == 0 is guaranteed. In non-strict mode failures
+                # are logged-only; assert only when strict mode is active.
+                if os.environ.get("ONEX_WIRING_STRICT_MODE", "").lower() in (
+                    "1",
+                    "true",
+                ):
+                    assert auto_wiring_report.total_failed == 0, (
+                        f"Auto-wiring postcondition violated: "
+                        f"total_failed={auto_wiring_report.total_failed}"
+                    )
+                elif auto_wiring_report.total_failed > 0:
+                    logger.warning(
+                        "Auto-wiring completed with %d failure(s) "
+                        "(non-strict mode — set ONEX_WIRING_STRICT_MODE=1 to enforce): "
+                        "%s",
+                        auto_wiring_report.total_failed,
+                        [
+                            r.contract_name
+                            for r in auto_wiring_report.results
+                            if r.outcome.value == "failed"
+                        ],
+                    )
 
                 logger.info(
                     "Auto-wiring completed in %.3fs: wired=%d skipped=%d "

--- a/tests/integration/test_auto_wiring_strict_invariant.py
+++ b/tests/integration/test_auto_wiring_strict_invariant.py
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Integration tests for strict auto-wiring startup invariant [OMN-8735].
+"""Integration tests for strict auto-wiring startup invariant [OMN-8735, OMN-9126].
 
-Verifies that wire_from_manifest raises ModelOnexError when any contract fails
-to wire, instead of silently continuing. This is the hard startup gate added
-in OMN-8735.
+OMN-8735 introduced raise-on-failure as a hard startup gate.
+OMN-9126 gates the raise behind ONEX_WIRING_STRICT_MODE (default OFF) so that
+the runtime can start with non-compliant handlers while compliance is being
+resolved, without requiring a full pre-strict rollback.
+
+Non-strict mode (default): failures logged as WARNING, included in report.
+Strict mode (ONEX_WIRING_STRICT_MODE=1): raises ModelOnexError as before.
 """
 
 from __future__ import annotations
@@ -55,12 +59,16 @@ def _make_contract(name: str, handler_module: str) -> ModelDiscoveredContract:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_wire_from_manifest_raises_on_bad_contract() -> None:
-    """wire_from_manifest must raise ModelOnexError when a contract fails to wire.
+async def test_wire_from_manifest_raises_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In strict mode, wire_from_manifest raises ModelOnexError on bad contract.
 
-    OMN-8735 strict invariant: failures abort startup, no swallow-and-continue.
+    ONEX_WIRING_STRICT_MODE=1 restores the OMN-8735 hard startup gate.
     """
     from omnibase_core.models.errors import ModelOnexError
+
+    monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
 
     contract = _make_contract(
         name="node_bad",
@@ -81,12 +89,16 @@ async def test_wire_from_manifest_raises_on_bad_contract() -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_wire_from_manifest_collects_all_failures_before_raising() -> None:
-    """All failing contracts are reported together in the raised ModelOnexError.
+async def test_wire_from_manifest_collects_all_failures_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In strict mode, all failing contracts are reported together in the raised error.
 
     Ensures the error message lists all contract names, not just the first.
     """
     from omnibase_core.models.errors import ModelOnexError
+
+    monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
 
     contracts = [
         _make_contract(
@@ -115,3 +127,35 @@ async def test_wire_from_manifest_collects_all_failures_before_raising() -> None
         assert f"node_bad_{i}" in error_msg, (
             f"Expected contract name 'node_bad_{i}' in error message: {error_msg!r}"
         )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_wire_from_manifest_non_strict_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In non-strict mode (default), wire_from_manifest returns report without raising.
+
+    OMN-9126: failures are included in report.total_failed; runtime continues.
+    """
+    monkeypatch.delenv("ONEX_WIRING_STRICT_MODE", raising=False)
+
+    contract = _make_contract(
+        name="node_bad",
+        handler_module="nonexistent.module.that.does.not.exist",
+    )
+    manifest = ModelAutoWiringManifest(contracts=[contract])
+
+    dispatch_engine = MagicMock()
+    event_bus = AsyncMock()
+
+    report = await wire_from_manifest(
+        manifest=manifest,
+        dispatch_engine=dispatch_engine,
+        event_bus=event_bus,
+    )
+
+    assert report.total_failed == 1, (
+        f"Expected 1 failure in non-strict report, got {report.total_failed}"
+    )
+    assert report.total_wired == 0

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -304,9 +304,8 @@ class TestWireFromManifest:
         with _patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ONEX_WIRING_STRICT_MODE", None)
             report = await wire_from_manifest(manifest, engine)
-        # Failures are logged but excluded from results so the service_kernel
-        # postcondition (total_failed == 0) remains valid in non-strict mode.
-        assert report.total_failed == 0
+        # OMN-9126: failures included in report so total_failed is accurate.
+        assert report.total_failed == 1
         assert report.total_wired == 0
 
     @pytest.mark.asyncio

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -304,7 +304,9 @@ class TestWireFromManifest:
         with _patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ONEX_WIRING_STRICT_MODE", None)
             report = await wire_from_manifest(manifest, engine)
-        assert report.total_failed == 1
+        # Failures are logged but excluded from results so the service_kernel
+        # postcondition (total_failed == 0) remains valid in non-strict mode.
+        assert report.total_failed == 0
         assert report.total_wired == 0
 
     @pytest.mark.asyncio

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -268,8 +268,11 @@ class TestWireFromManifest:
         assert len(report.results[0].routes_registered) >= 1
 
     @pytest.mark.asyncio
-    async def test_wire_failure_import_error_raises(self) -> None:
-        """OMN-8735: import errors must raise, not be silently captured."""
+    async def test_wire_failure_import_error_strict_mode_raises(self) -> None:
+        """OMN-9126: import errors raise in strict mode (ONEX_WIRING_STRICT_MODE=1)."""
+        import os
+        from unittest.mock import patch as _patch
+
         from omnibase_core.models.errors import ModelOnexError
 
         handler_routing = _make_handler_routing(
@@ -280,8 +283,29 @@ class TestWireFromManifest:
         manifest = ModelAutoWiringManifest(contracts=(contract,))
 
         engine = MagicMock()
-        with pytest.raises(ModelOnexError):
-            await wire_from_manifest(manifest, engine)
+        with _patch.dict(os.environ, {"ONEX_WIRING_STRICT_MODE": "1"}):
+            with pytest.raises(ModelOnexError):
+                await wire_from_manifest(manifest, engine)
+
+    @pytest.mark.asyncio
+    async def test_wire_failure_import_error_non_strict_warns(self) -> None:
+        """OMN-9126: import errors warn (not raise) in non-strict mode (default)."""
+        import os
+        from unittest.mock import patch as _patch
+
+        handler_routing = _make_handler_routing(
+            handler_name="MissingHandler",
+            handler_module="nonexistent.module",
+        )
+        contract = _make_contract(handler_routing=handler_routing)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+
+        engine = MagicMock()
+        with _patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ONEX_WIRING_STRICT_MODE", None)
+            report = await wire_from_manifest(manifest, engine)
+        assert report.total_failed == 1
+        assert report.total_wired == 0
 
     @pytest.mark.asyncio
     async def test_unsatisfiable_di_raises_on_startup(self) -> None:


### PR DESCRIPTION
[skip-receipt-gate: OMN-9126 ticket-less runtime fix]
[skip-deploy-gate: deploy-agent inactive per OMN-8841, runtime fix not deploy-gated]

## Summary

- Gates the `wire_from_manifest` raise on wiring failures behind `ONEX_WIRING_STRICT_MODE` env var (default OFF)
- In non-strict mode (default): failures are logged as WARNING and included in report; runtime continues
- In strict mode (`ONEX_WIRING_STRICT_MODE=1`): raises `ModelOnexError` as before
- Failed contracts included in `report.results` in both modes so `total_failed` is accurate

## Why

PR #1346 introduced raise-on-failure in `wire_from_manifest`. With 98 handlers still calling `asyncio.run()` in `__init__`, this caused `omninode-runtime` to crash-loop on every boot after rebuild.

Per OMN-9126 policy: strict gates ship behind an env flag (default OFF) and are flipped only after downstream consumers are compliant. The 98-handler `asyncio.run()` fix is a separate remediation effort.

## Test plan

- [x] `test_wire_failure_import_error_strict_mode_raises` — strict mode still raises
- [x] `test_wire_failure_import_error_non_strict_warns` — non-strict returns report with `total_failed==1`, no raise
- [x] All 132 `tests/unit/runtime/auto_wiring/` tests pass
- [ ] After merge: rebuild `omninode-runtime` on .201, verify container reaches `healthy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable strict mode (ONEX_WIRING_STRICT_MODE) for contract validation: strict mode fails fast on validation errors; non-strict mode logs warnings and continues while recording failures in the wiring report.
  * Kernel behavior adjusted to warn (not assert) when non-strict mode reports failures.

* **Tests**
  * Expanded tests to cover strict and non-strict wiring behaviors and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->