### PR TITLE
chore(ci): propagate normalization-symmetry-hook to .pre-commit-config.yaml [bot]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -428,3 +428,11 @@ ci:
   # Also skip migration freeze (checks staged files via git diff --cached, which is empty in CI;
   # CI should run: uv run python scripts/validation/validate_migration_freeze.py --check-committed)
   skip: [no-env-file, onex-validate-architecture, onex-validate-architecture-layers, onex-validate-contracts, onex-validate-patterns, onex-validate-unions, onex-validate-imports, onex-validate-any-types, onex-validate-migration-freeze]
+
+  - repo: local
+    hooks:
+      - id: normalization-symmetry
+        name: normalization-symmetry
+        entry: uv run python -m omnibase_core.validators.normalization-symmetry
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
Automated config propagation emitted by `omnibase_core/propagate-config.yml`.

- Propagation: `normalization-symmetry-hook`
- Hook ID: `normalization-symmetry`
- Release tag: `manual-24705663090`
- Source: https://github.com/OmniNode-ai/omnibase_core/releases/tag/manual-24705663090
- Tracking: OMN-9344

Idempotent — if the hook already exists in `.pre-commit-config.yaml`, the bot skips this repo.