### PR TITLE
feat(deploy-agent): signed trigger helper + auth tests [OMN-9411]

### DIFF
--- a/scripts/deploy-agent/deploy-agent-trigger.sh
+++ b/scripts/deploy-agent/deploy-agent-trigger.sh
@@ -174,9 +174,16 @@ if [[ "$_publish_tool" == "kcat" ]]; then
     echo "manual-${CORRELATION_ID}/${SIGNED_JSON}" | kcat "${KCAT_ARGS[@]}"
 else
     # rpk fallback — used on .201 where rpk is available inside/outside containers
-    rpk topic produce "${TOPIC}" \
-        --brokers "${KAFKA_BOOTSTRAP_SERVERS}" \
-        <<< "${SIGNED_JSON}"
+    RPK_ARGS=(--brokers "${KAFKA_BOOTSTRAP_SERVERS}" --key "manual-${CORRELATION_ID}")
+    if [[ -n "${KAFKA_SASL_USERNAME:-}" && -n "${KAFKA_SASL_PASSWORD:-}" ]]; then
+        RPK_ARGS+=(
+            --tls-enabled
+            --sasl-mechanism PLAIN
+            --sasl-username "${KAFKA_SASL_USERNAME}"
+            --sasl-password "${KAFKA_SASL_PASSWORD}"
+        )
+    fi
+    rpk topic produce "${TOPIC}" "${RPK_ARGS[@]}" <<< "${SIGNED_JSON}"
 fi
 
 echo "Published. correlation_id=${CORRELATION_ID}"

--- a/scripts/deploy-agent/deploy-agent-trigger.sh
+++ b/scripts/deploy-agent/deploy-agent-trigger.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# deploy-agent-trigger.sh — publish a signed rebuild-requested command to the
+# deploy-agent Kafka topic (onex.cmd.deploy.rebuild-requested.v1).
+#
+# USAGE:
+#   DEPLOY_AGENT_HMAC_SECRET=<secret> \
+#   KAFKA_BOOTSTRAP_SERVERS=<host:port> \
+#     ./deploy-agent-trigger.sh \
+#       --git-ref origin/main \
+#       --reason "manual trigger by operator" \
+#       [--requested-by claude] \
+#       [--correlation-id <uuid>] \
+#       [--dry-run]
+#
+# REQUIRED ENV VARS:
+#   DEPLOY_AGENT_HMAC_SECRET   HMAC-SHA256 key — from ~/.omnibase/.env on .201
+#   KAFKA_BOOTSTRAP_SERVERS    e.g. 192.168.86.201:19092 (local) or localhost:29092 (tunnel)  # onex-allow-internal-ip # cloud-bus-ok OMN-9411
+#
+# OPTIONAL ENV VARS:
+#   KAFKA_SASL_USERNAME        SASL username (omit for PLAINTEXT connections)
+#   KAFKA_SASL_PASSWORD        SASL password
+#
+# WARNING: Unsigned triggers are silently dropped by auth.py.
+# NEVER construct the command JSON manually — always use this script so the
+# HMAC-SHA256 _signature field is computed correctly.
+#
+# The signature is HMAC-SHA256 over the JSON-serialised envelope (sort_keys,
+# no spaces) with the _signature field itself excluded — matching
+# deploy_agent/auth.py::verify_command() byte-for-byte.
+
+set -euo pipefail
+
+TOPIC="onex.cmd.deploy.rebuild-requested.v1"
+
+# ── defaults ─────────────────────────────────────────────────────────────────
+GIT_REF="origin/main"
+REASON=""
+REQUESTED_BY="operator-manual"
+CORRELATION_ID=""
+DRY_RUN=0
+
+usage() {
+    grep '^# ' "$0" | sed 's/^# //'
+    exit 1
+}
+
+# ── arg parsing ──────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --git-ref)         GIT_REF="$2";         shift 2 ;;
+        --reason)          REASON="$2";           shift 2 ;;
+        --requested-by)    REQUESTED_BY="$2";     shift 2 ;;
+        --correlation-id)  CORRELATION_ID="$2";   shift 2 ;;
+        --dry-run)         DRY_RUN=1;             shift   ;;
+        -h|--help)         usage ;;
+        *) echo "Unknown arg: $1" >&2; usage ;;
+    esac
+done
+
+# ── pre-flight ───────────────────────────────────────────────────────────────
+if [[ -z "${DEPLOY_AGENT_HMAC_SECRET:-}" ]]; then
+    echo "ERROR: DEPLOY_AGENT_HMAC_SECRET is not set." >&2
+    echo "       Source it with: source ~/.omnibase/.env" >&2
+    exit 1
+fi
+
+if [[ $DRY_RUN -eq 0 && -z "${KAFKA_BOOTSTRAP_SERVERS:-}" ]]; then
+    echo "ERROR: KAFKA_BOOTSTRAP_SERVERS is not set." >&2
+    exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 is required to compute the HMAC signature." >&2
+    exit 1
+fi
+
+# kcat is used for publish; rpk is accepted as fallback on .201
+_publish_tool=""
+if command -v kcat &>/dev/null; then
+    _publish_tool="kcat"
+elif command -v rpk &>/dev/null; then
+    _publish_tool="rpk"
+elif [[ $DRY_RUN -eq 0 ]]; then
+    echo "ERROR: kcat (or rpk) not found. Install kcat: brew install kcat" >&2
+    exit 1
+fi
+
+# ── build envelope + compute signature ───────────────────────────────────────
+if [[ -z "$CORRELATION_ID" ]]; then
+    CORRELATION_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+fi
+
+REQUESTED_AT="$(python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat())')"
+
+# Python handles sort_keys + compact separators to match auth.py exactly.
+read -r SIGNED_JSON < <(python3 - <<PYEOF
+import hashlib, hmac, json, sys
+
+secret = """${DEPLOY_AGENT_HMAC_SECRET}"""
+envelope = {
+    "correlation_id": "${CORRELATION_ID}",
+    "git_ref":        "${GIT_REF}",
+    "reason":         "${REASON}",
+    "requested_at":   "${REQUESTED_AT}",
+    "requested_by":   "${REQUESTED_BY}",
+    "scope":          "runtime",
+    "services":       [],
+}
+body = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+sig  = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+signed = {**envelope, "_signature": sig}
+print(json.dumps(signed, separators=(",", ":")))
+PYEOF
+)
+
+# ── audit log (signature masked) ─────────────────────────────────────────────
+MASKED_JSON="$(python3 -c "
+import json, sys
+d = json.loads('${SIGNED_JSON//\'/\\\'}')
+d['_signature'] = d['_signature'][:8] + '...<masked>'
+print(json.dumps(d, indent=2))
+" 2>/dev/null || echo "${SIGNED_JSON//_signature\":"*"/_signature\":\"<masked>\"}")"
+
+echo "=== deploy-agent-trigger ==="
+echo "topic:          ${TOPIC}"
+echo "git_ref:        ${GIT_REF}"
+echo "correlation_id: ${CORRELATION_ID}"
+echo "requested_by:   ${REQUESTED_BY}"
+echo "payload (sig masked):"
+echo "${MASKED_JSON}"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo ""
+    echo "(dry-run: skipping Kafka publish)"
+    exit 0
+fi
+
+# ── publish ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Publishing to ${KAFKA_BOOTSTRAP_SERVERS} ..."
+
+if [[ "$_publish_tool" == "kcat" ]]; then
+    KCAT_ARGS=(-P -b "${KAFKA_BOOTSTRAP_SERVERS}" -t "${TOPIC}" -K /)
+    if [[ -n "${KAFKA_SASL_USERNAME:-}" && -n "${KAFKA_SASL_PASSWORD:-}" ]]; then
+        KCAT_ARGS+=(
+            -X security.protocol=SASL_SSL
+            -X sasl.mechanisms=PLAIN
+            -X "sasl.username=${KAFKA_SASL_USERNAME}"
+            -X "sasl.password=${KAFKA_SASL_PASSWORD}"
+        )
+    fi
+    echo "manual-${CORRELATION_ID}/${SIGNED_JSON}" | kcat "${KCAT_ARGS[@]}"
+else
+    # rpk fallback — used on .201 where rpk is available inside/outside containers
+    rpk topic produce "${TOPIC}" \
+        --brokers "${KAFKA_BOOTSTRAP_SERVERS}" \
+        <<< "${SIGNED_JSON}"
+fi
+
+echo "Published. correlation_id=${CORRELATION_ID}"

--- a/scripts/deploy-agent/deploy-agent-trigger.sh
+++ b/scripts/deploy-agent/deploy-agent-trigger.sh
@@ -93,19 +93,33 @@ if [[ -z "$CORRELATION_ID" ]]; then
     CORRELATION_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
 fi
 
-REQUESTED_AT="$(python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat())')"
+# All user-supplied values are passed via environment variables — never
+# interpolated into Python source — so special characters cannot break
+# JSON structure or inject code.
+SIGNED_JSON="$(
+    _TRIGGER_GIT_REF="$GIT_REF" \
+    _TRIGGER_REASON="$REASON" \
+    _TRIGGER_REQUESTED_BY="$REQUESTED_BY" \
+    _TRIGGER_CORRELATION_ID="$CORRELATION_ID" \
+    python3 - <<'PYEOF'
+import hashlib
+import hmac
+import json
+import os
+from datetime import UTC, datetime
 
-# Python handles sort_keys + compact separators to match auth.py exactly.
-read -r SIGNED_JSON < <(python3 - <<PYEOF
-import hashlib, hmac, json, sys
+secret         = os.environ["DEPLOY_AGENT_HMAC_SECRET"]
+correlation_id = os.environ["_TRIGGER_CORRELATION_ID"]
+git_ref        = os.environ["_TRIGGER_GIT_REF"]
+reason         = os.environ["_TRIGGER_REASON"]
+requested_by   = os.environ["_TRIGGER_REQUESTED_BY"]
 
-secret = """${DEPLOY_AGENT_HMAC_SECRET}"""
 envelope = {
-    "correlation_id": "${CORRELATION_ID}",
-    "git_ref":        "${GIT_REF}",
-    "reason":         "${REASON}",
-    "requested_at":   "${REQUESTED_AT}",
-    "requested_by":   "${REQUESTED_BY}",
+    "correlation_id": correlation_id,
+    "git_ref":        git_ref,
+    "reason":         reason,
+    "requested_at":   datetime.now(UTC).isoformat(),
+    "requested_by":   requested_by,
     "scope":          "runtime",
     "services":       [],
 }
@@ -114,15 +128,19 @@ sig  = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 signed = {**envelope, "_signature": sig}
 print(json.dumps(signed, separators=(",", ":")))
 PYEOF
-)
+)"
 
 # ── audit log (signature masked) ─────────────────────────────────────────────
-MASKED_JSON="$(python3 -c "
-import json, sys
-d = json.loads('${SIGNED_JSON//\'/\\\'}')
-d['_signature'] = d['_signature'][:8] + '...<masked>'
+# SIGNED_JSON is passed via environment variable — never interpolated into
+# Python source — so embedded quotes or special characters cannot break syntax.
+MASKED_JSON="$(
+    _TRIGGER_SIGNED_JSON="${SIGNED_JSON}" python3 - <<'PYEOF'
+import json, os
+d = json.loads(os.environ["_TRIGGER_SIGNED_JSON"])
+d["_signature"] = d["_signature"][:8] + "...<masked>"
 print(json.dumps(d, indent=2))
-" 2>/dev/null || echo "${SIGNED_JSON//_signature\":"*"/_signature\":\"<masked>\"}")"
+PYEOF
+)"
 
 echo "=== deploy-agent-trigger ==="
 echo "topic:          ${TOPIC}"
@@ -152,6 +170,7 @@ if [[ "$_publish_tool" == "kcat" ]]; then
             -X "sasl.password=${KAFKA_SASL_PASSWORD}"
         )
     fi
+    # SIGNED_JSON piped via stdin — not passed as a shell argument
     echo "manual-${CORRELATION_ID}/${SIGNED_JSON}" | kcat "${KCAT_ARGS[@]}"
 else
     # rpk fallback — used on .201 where rpk is available inside/outside containers

--- a/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
+++ b/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Verify that the trigger helper script produces signatures accepted by auth.py.
+
+This test does NOT publish to Kafka.  It exercises the signing logic that
+deploy-agent-trigger.sh delegates to its embedded Python snippet, then feeds
+the resulting envelope to auth.py::verify_command() to confirm end-to-end
+compatibility.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+import pytest
+from deploy_agent.auth import verify_command
+
+_SECRET = "test-trigger-helper-secret-abc123"
+
+
+def _sign_like_trigger_sh(envelope: dict, secret: str) -> dict:
+    """Reproduce the signing logic from deploy-agent-trigger.sh exactly."""
+    body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {**body_dict, "_signature": sig}
+
+
+_SAMPLE_ENVELOPE = {
+    "correlation_id": "aaaaaaaa-0000-0000-0000-000000000001",
+    "git_ref": "origin/main",
+    "reason": "manual trigger by operator",
+    "requested_at": "2026-04-21T12:00:00+00:00",
+    "requested_by": "operator-manual",
+    "scope": "runtime",
+    "services": [],
+}
+
+
+def test_trigger_helper_signature_accepted_by_auth() -> None:
+    """Signature produced by trigger helper is accepted by auth.py."""
+    signed = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, _SECRET)
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is True
+
+
+def test_trigger_helper_signature_field_present() -> None:
+    """Signed envelope always contains _signature field."""
+    signed = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, _SECRET)
+    assert "_signature" in signed
+    assert len(signed["_signature"]) == 64  # hex-encoded SHA-256
+
+
+def test_trigger_helper_signature_excluded_from_body() -> None:
+    """_signature is not included in the body that is signed (no circular dep)."""
+    signed = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, _SECRET)
+    body_dict = {k: v for k, v in signed.items() if k != "_signature"}
+    body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
+    expected = hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    assert signed["_signature"] == expected
+
+
+def test_tampered_envelope_rejected_by_auth() -> None:
+    """Tampering any field after signing causes auth.py to reject."""
+    signed = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, _SECRET)
+    signed["git_ref"] = "origin/evil-branch"
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is False
+
+
+def test_wrong_secret_rejected_by_auth() -> None:
+    """Envelope signed with a different secret is rejected by auth.py."""
+    signed = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, "wrong-secret")
+    with patch.dict("os.environ", {"DEPLOY_AGENT_HMAC_SECRET": _SECRET}):
+        assert verify_command(signed) is False
+
+
+def test_sort_keys_order_is_canonical() -> None:
+    """Field insertion order doesn't affect signature — sort_keys is deterministic."""
+    envelope_shuffled = {
+        "services": [],
+        "scope": "runtime",
+        "requested_by": "operator-manual",
+        "requested_at": "2026-04-21T12:00:00+00:00",
+        "reason": "manual trigger by operator",
+        "git_ref": "origin/main",
+        "correlation_id": "aaaaaaaa-0000-0000-0000-000000000001",
+    }
+    signed_normal = _sign_like_trigger_sh(_SAMPLE_ENVELOPE, _SECRET)
+    signed_shuffled = _sign_like_trigger_sh(envelope_shuffled, _SECRET)
+    assert signed_normal["_signature"] == signed_shuffled["_signature"]

--- a/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
+++ b/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
@@ -15,7 +15,6 @@ import hmac
 import json
 from unittest.mock import patch
 
-import pytest
 from deploy_agent.auth import verify_command
 
 _SECRET = "test-trigger-helper-secret-abc123"


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy-agent/deploy-agent-trigger.sh` — a bash helper that reads `DEPLOY_AGENT_HMAC_SECRET` from env, computes the required HMAC-SHA256 `_signature` field, and publishes to `onex.cmd.deploy.rebuild-requested.v1` via kcat (rpk fallback)
- Adds `tests/unit/test_trigger_helper_signature.py` (6 tests) verifying the helper's signing logic is accepted byte-for-byte by `auth.py::verify_command()` — no live Kafka publish required

## Root cause fixed

The memory reference doc (`reference_deploy_agent.md`) showed an unsigned manual trigger example. `auth.py::verify_command()` silently drops any envelope missing `_signature` — the message is consumed and its Kafka offset committed, but no rebuild runs. This is what caused the 2026-04-20 overnight trigger to be silently rejected (root of OMN-9393).

## Auth scheme (verified against auth.py)

```
body  = json.dumps(envelope_without_signature, sort_keys=True, separators=(',',':')).encode()
sig   = hmac.new(DEPLOY_AGENT_HMAC_SECRET.encode(), body, hashlib.sha256).hexdigest()
# attach as _signature field in the published envelope
```

## Test plan

- [x] `uv run pytest tests/unit/test_trigger_helper_signature.py tests/unit/test_auth_hmac.py -v` — 12 passed
- [x] `uv run pytest tests/ -v` — 48 passed
- [x] `shellcheck scripts/deploy-agent/deploy-agent-trigger.sh` — clean
- [x] `pre-commit run --all-files` — all hooks passed
- [ ] Manual smoke test on .201 after merge (verify `DEPLOY_AGENT_HMAC_SECRET` in env, run with `--dry-run` first)

## Related

- Fixes root cause of OMN-9393 (silent unsigned trigger drop)
- Ticket: OMN-9411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command-line utility to publish cryptographically signed deploy rebuild requests with audit logging, dry-run mode, and Kafka publishing (supports TLS/SASL when configured).

* **Tests**
  * Unit tests validating signature generation and verification, including tampering detection, wrong-secret rejection, signature format, and canonical ordering invariance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->