### PR TITLE
feat(OMN-9446): canonical GitHubHttpClient — single adapter for all GitHub API access

### DIFF
--- a/src/omnibase_infra/adapters/github/__init__.py
+++ b/src/omnibase_infra/adapters/github/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""GitHub adapter package — single HTTP client for all GitHub API access.
+
+Zero external dependencies. Uses urllib + GH_PAT token.
+"""

--- a/src/omnibase_infra/adapters/github/adapter_github_client.py
+++ b/src/omnibase_infra/adapters/github/adapter_github_client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Canonical GitHub HTTP client for all OmniNode nodes.
 
@@ -19,10 +19,8 @@ Capabilities:
   - Fetch open review thread comment IDs
   - Fetch conflict files
   - Enable auto-merge (GraphQL mutation)
-  - Rebase branches
   - Rerun CI checks
   - Post review thread replies
-  - Rate-limit awareness (x-ratelimit-remaining)
 
 OMN-MERGE-SWEEP.
 """
@@ -34,7 +32,6 @@ import logging
 import os
 import urllib.error
 import urllib.request
-from typing import Any
 
 _log = logging.getLogger(__name__)
 
@@ -43,17 +40,8 @@ _GITHUB_REST = "https://api.github.com"
 _DEFAULT_TIMEOUT = 30
 
 
-class GitHubHttpClient:
-    """Single GitHub HTTP client. Reads GH_PAT (fail-fast).
-
-    Usage::
-
-        from omnibase_infra.adapters.github.adapter_github_client import GitHubHttpClient
-
-        client = GitHubHttpClient()
-        prs = client.fetch_open_prs("OmniNode-ai/omnimarket")
-        protection = client.fetch_branch_protection("OmniNode-ai/omnimarket")
-    """
+class GitHubTransport:
+    """Low-level HTTP transport for GitHub API (private)."""
 
     def __init__(self, token: str | None = None) -> None:
         self._token = token or os.environ.get("GH_PAT", "")
@@ -63,11 +51,7 @@ class GitHubHttpClient:
                 "Export it before using GitHubHttpClient."
             )
 
-    # ------------------------------------------------------------------
-    # Low-level transport
-    # ------------------------------------------------------------------
-
-    def _graphql(self, query: str, variables: dict[str, object]) -> dict[str, Any]:
+    def _graphql(self, query: str, variables: dict[str, object]) -> dict[str, object]:
         """Execute a GraphQL query. Returns the ``data`` dict. Never raises."""
         payload = json.dumps({"query": query, "variables": variables}).encode()
         req = urllib.request.Request(  # noqa: S310
@@ -92,38 +76,28 @@ class GitHubHttpClient:
 
     def _rest_get(
         self, path: str, *, timeout: int = _DEFAULT_TIMEOUT
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, object] | None:
         """REST GET. Returns parsed JSON or None. Never raises."""
         return self._rest_request("GET", path, timeout=timeout)
 
     def _rest_post(
         self,
         path: str,
-        body: dict[str, Any] | None = None,
+        body: dict[str, object] | None = None,
         *,
         timeout: int = _DEFAULT_TIMEOUT,
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, object] | None:
         """REST POST. Returns parsed JSON or None. Never raises."""
         return self._rest_request("POST", path, json_body=body, timeout=timeout)
-
-    def _rest_put(
-        self,
-        path: str,
-        body: dict[str, Any] | None = None,
-        *,
-        timeout: int = _DEFAULT_TIMEOUT,
-    ) -> dict[str, Any] | None:
-        """REST PUT. Returns parsed JSON or None. Never raises."""
-        return self._rest_request("PUT", path, json_body=body, timeout=timeout)
 
     def _rest_request(
         self,
         method: str,
         path: str,
         *,
-        json_body: dict[str, Any] | None = None,
+        json_body: dict[str, object] | None = None,
         timeout: int = _DEFAULT_TIMEOUT,
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, object] | None:
         """Generic REST request. Returns parsed JSON or None. Never raises."""
         url = f"{_GITHUB_REST}{path}"
         data = json.dumps(json_body).encode() if json_body else None
@@ -150,9 +124,9 @@ class GitHubHttpClient:
             _log.warning("REST %s %s failed: %s", method, path, exc)
             return None
 
-    # ------------------------------------------------------------------
-    # PR fetching
-    # ------------------------------------------------------------------
+
+class GitHubPrApi(GitHubTransport):
+    """PR query and CI check methods (private). Inherits GitHubTransport."""
 
     _PR_GRAPHQL_QUERY = """
 query($owner: String!, $name: String!, $after: String) {
@@ -169,15 +143,10 @@ query($owner: String!, $name: String!, $after: String) {
 }
 """
 
-    def fetch_open_prs(self, repo: str) -> list[dict[str, Any]]:
-        """Fetch all open PRs with rich status fields via GraphQL.
-
-        Returns list of dicts with keys: number, title, isDraft, mergeable,
-        mergeStateStatus, reviewDecision, headRefName, baseRefName, headRefOid,
-        labels, statusCheckRollup.
-        """
+    def fetch_open_prs(self, repo: str) -> list[dict[str, object]]:
+        """Fetch all open PRs with rich status fields via GraphQL."""
         owner, name = _split_repo(repo)
-        all_prs: list[dict[str, Any]] = []
+        all_prs: list[dict[str, object]] = []
         cursor: str | None = None
 
         while True:
@@ -187,36 +156,43 @@ query($owner: String!, $name: String!, $after: String) {
 
             data = self._graphql(self._PR_GRAPHQL_QUERY, variables)
             repo_data = data.get("repository")
-            if not repo_data:
+            if not isinstance(repo_data, dict):
                 break
 
-            pr_conn = repo_data.get("pullRequests", {})
-            nodes = pr_conn.get("nodes", [])
+            pr_conn = repo_data.get("pullRequests") or {}
+            if not isinstance(pr_conn, dict):
+                break
+            nodes = pr_conn.get("nodes") or []
+            if not isinstance(nodes, list):
+                break
             for node in nodes:
-                # Flatten labels
-                label_nodes = (node.get("labels") or {}).get("nodes", [])
-                node["labels"] = [{"name": ln["name"]} for ln in label_nodes if ln]
-
-                # CI checks fetched separately via REST (GraphQL inline fragments
-                # on StatusCheckRollupContextConnection are not supported).
+                if not isinstance(node, dict):
+                    continue
+                labels_raw = node.get("labels")
+                label_nodes = (labels_raw if isinstance(labels_raw, dict) else {}).get(
+                    "nodes"
+                ) or []
+                node["labels"] = [
+                    {"name": ln["name"]} for ln in label_nodes if isinstance(ln, dict)
+                ]
                 node["statusCheckRollup"] = self._fetch_pr_checks_rest(
-                    repo, node["number"]
+                    repo, int(node["number"])
                 )
                 all_prs.append(node)
 
-            page_info = pr_conn.get("pageInfo", {})
-            if not page_info.get("hasNextPage"):
+            page_info = pr_conn.get("pageInfo") or {}
+            if not isinstance(page_info, dict) or not page_info.get("hasNextPage"):
                 break
-            cursor = page_info.get("endCursor")
+            cursor_val = page_info.get("endCursor")
+            cursor = str(cursor_val) if cursor_val else None
 
         return all_prs
 
-    def _fetch_pr_checks_rest(self, repo: str, pr_number: int) -> list[dict[str, Any]]:
-        """Fetch CI check conclusions for a PR via REST API (commit status + check suites)."""
-        # Combine commit statuses and check suites from REST
-        results: list[dict[str, Any]] = []
-
-        # Check suites via /commits/{ref}/check-runs
+    def _fetch_pr_checks_rest(
+        self, repo: str, pr_number: int
+    ) -> list[dict[str, object]]:
+        """Fetch CI check conclusions for a PR via REST API."""
+        results: list[dict[str, object]] = []
         detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
         if detail:
             head_oid = detail.get("headRefOid", "")
@@ -225,30 +201,26 @@ query($owner: String!, $name: String!, $after: String) {
                     f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15
                 )
                 if isinstance(data, dict):
-                    for run in data.get("check_runs", []):
-                        conclusion = (run.get("conclusion") or "").upper()
-                        results.append(
-                            {
-                                "name": run.get("name", ""),
-                                "conclusion": conclusion,
-                                "status": run.get("status", ""),
-                                "isRequired": True,
-                            }
-                        )
-
+                    check_runs = data.get("check_runs") or []
+                    if isinstance(check_runs, list):
+                        for run in check_runs:
+                            if not isinstance(run, dict):
+                                continue
+                            conclusion = str(run.get("conclusion") or "").upper()
+                            results.append(
+                                {
+                                    "name": str(run.get("name") or ""),
+                                    "conclusion": conclusion,
+                                    "status": str(run.get("status") or ""),
+                                    "isRequired": True,
+                                }
+                            )
         return results
-
-    # ------------------------------------------------------------------
-    # PR detail resolution
-    # ------------------------------------------------------------------
 
     def fetch_pr_detail(
         self, repo: str, pr_number: int, fields: str = "id,headRefName"
-    ) -> dict[str, Any] | None:
-        """Fetch specific fields for a single PR via GraphQL.
-
-        Returns dict with requested fields, or None on failure.
-        """
+    ) -> dict[str, object] | None:
+        """Fetch specific fields for a single PR via GraphQL."""
         query = (
             """
 query($owner: String!, $name: String!, $number: Int!) {
@@ -275,7 +247,11 @@ query($owner: String!, $name: String!, $number: Int!) {
         detail = self.fetch_pr_detail(repo, pr_number, "id,headRefName")
         if not detail:
             return None, None
-        return detail.get("id"), detail.get("headRefName")
+        node_id = detail.get("id")
+        head_ref = detail.get("headRefName")
+        return (str(node_id) if node_id else None), (
+            str(head_ref) if head_ref else None
+        )
 
     def resolve_pr_refs(self, repo: str, pr_number: int) -> tuple[str, str, str] | None:
         """Resolve (head_ref, base_ref, head_oid) for a PR. Returns None on failure."""
@@ -284,24 +260,22 @@ query($owner: String!, $name: String!, $number: Int!) {
         )
         if not detail:
             return None
-        head = detail.get("headRefName", "")
-        base = detail.get("baseRefName", "")
-        oid = detail.get("headRefOid", "")
+        head_raw = detail.get("headRefName")
+        base_raw = detail.get("baseRefName")
+        oid_raw = detail.get("headRefOid")
+        head = str(head_raw) if head_raw else ""
+        base = str(base_raw) if base_raw else ""
+        oid = str(oid_raw) if oid_raw else ""
         if not head or not base or not oid:
             _log.error("Missing ref fields for %s#%d: %r", repo, pr_number, detail)
             return None
         return head, base, oid
-
-    # ------------------------------------------------------------------
-    # CI checks
-    # ------------------------------------------------------------------
 
     def fetch_failing_run_id(self, repo: str, pr_number: int) -> str | None:
         """Find the most recent failing GitHub Actions run ID for a PR."""
         checks = self._fetch_pr_checks_rest(repo, pr_number)
         for ctx in checks:
             if ctx.get("conclusion") == "FAILURE":
-                # Get details URL from check-runs REST endpoint
                 detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
                 if detail:
                     head_oid = detail.get("headRefOid", "")
@@ -310,18 +284,27 @@ query($owner: String!, $name: String!, $number: Int!) {
                             f"/repos/{repo}/commits/{head_oid}/check-runs"
                         )
                         if isinstance(data, dict):
-                            for run in data.get("check_runs", []):
-                                if (run.get("conclusion") or "").upper() == "FAILURE":
-                                    url = str(
-                                        run.get("details_url")
-                                        or run.get("html_url")
-                                        or ""
-                                    )
-                                    run_id = (
-                                        url.rstrip("/").split("/")[-1] if url else None
-                                    )
-                                    if run_id:
-                                        return str(run_id)
+                            check_runs = data.get("check_runs") or []
+                            if isinstance(check_runs, list):
+                                for run in check_runs:
+                                    if not isinstance(run, dict):
+                                        continue
+                                    if (
+                                        str(run.get("conclusion") or "").upper()
+                                        == "FAILURE"
+                                    ):
+                                        url = str(
+                                            run.get("details_url")
+                                            or run.get("html_url")
+                                            or ""
+                                        )
+                                        run_id = (
+                                            url.rstrip("/").split("/")[-1]
+                                            if url
+                                            else None
+                                        )
+                                        if run_id:
+                                            return run_id
         return None
 
     def fetch_failing_job_name(self, repo: str, pr_number: int) -> str | None:
@@ -332,10 +315,6 @@ query($owner: String!, $name: String!, $number: Int!) {
                 name = ctx.get("name")
                 return str(name) if name is not None else None
         return None
-
-    # ------------------------------------------------------------------
-    # Review threads
-    # ------------------------------------------------------------------
 
     def fetch_open_thread_comment_ids(self, repo: str, pr_number: int) -> list[str]:
         """Resolve open review thread comment node IDs for a PR."""
@@ -355,25 +334,43 @@ query($owner: String!, $name: String!, $number: Int!) {
 """
         owner, name = _split_repo(repo)
         data = self._graphql(query, {"owner": owner, "name": name, "number": pr_number})
-        pr_data = (data.get("repository") or {}).get("pullRequest", {})
-        threads: list[dict[str, Any]] = (pr_data.get("reviewThreads") or {}).get(
-            "nodes", []
-        )
+        repo_data = data.get("repository")
+        pr_data = repo_data.get("pullRequest") if isinstance(repo_data, dict) else None
+        pr_dict = pr_data if isinstance(pr_data, dict) else {}
+        threads_raw = pr_dict.get("reviewThreads")
+        threads_raw = threads_raw if isinstance(threads_raw, dict) else {}
+        threads_list = threads_raw.get("nodes") or []
+        threads: list[dict[str, object]] = [
+            t for t in threads_list if isinstance(t, dict)
+        ]
         ids: list[str] = []
         for thread in threads:
             if thread.get("isResolved"):
                 continue
-            comments = (thread.get("comments") or {}).get("nodes", [])
-            for comment in comments:
+            comments_raw = thread.get("comments")
+            comments_dict = comments_raw if isinstance(comments_raw, dict) else {}
+            comments_nodes = comments_dict.get("nodes") or []
+            for comment in comments_nodes:
+                if not isinstance(comment, dict):
+                    continue
                 node_id = comment.get("id")
                 if node_id:
                     ids.append(str(node_id))
                     break
         return ids
 
-    # ------------------------------------------------------------------
-    # Conflict files
-    # ------------------------------------------------------------------
+
+class GitHubHttpClient(GitHubPrApi):
+    """Single GitHub HTTP client. Reads GH_PAT (fail-fast).
+
+    Usage::
+
+        from omnibase_infra.adapters.github.adapter_github_client import GitHubHttpClient
+
+        client = GitHubHttpClient()
+        prs = client.fetch_open_prs("OmniNode-ai/omnimarket")
+        protection = client.fetch_branch_protection("OmniNode-ai/omnimarket")
+    """
 
     def fetch_pr_files(self, repo: str, pr_number: int) -> list[str]:
         """Fetch file paths changed in a PR."""
@@ -382,10 +379,6 @@ query($owner: String!, $name: String!, $number: Int!) {
         if not isinstance(data, list):
             return []
         return [f["path"] for f in data if isinstance(f, dict) and f.get("path")]
-
-    # ------------------------------------------------------------------
-    # Branch protection
-    # ------------------------------------------------------------------
 
     def fetch_branch_protection(self, repo: str, branch: str = "main") -> int | None:
         """Fetch required_approving_review_count for a branch. None = no protection."""
@@ -398,10 +391,6 @@ query($owner: String!, $name: String!, $number: Int!) {
         raw = reviews.get("required_approving_review_count")
         return raw if isinstance(raw, int) else None
 
-    # ------------------------------------------------------------------
-    # Mutations (effect operations)
-    # ------------------------------------------------------------------
-
     def enable_auto_merge(self, pr_node_id: str, merge_method: str = "SQUASH") -> bool:
         """Enable auto-merge on a PR via GraphQL mutation. Returns True on success."""
         mutation = """
@@ -412,11 +401,7 @@ mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod) {
 }
 """
         data = self._graphql(
-            mutation,
-            {
-                "pullRequestId": pr_node_id,
-                "mergeMethod": merge_method,
-            },
+            mutation, {"pullRequestId": pr_node_id, "mergeMethod": merge_method}
         )
         return "enablePullRequestAutoMerge" in data
 
@@ -437,11 +422,7 @@ mutation($pullRequestReviewThreadId: ID!, $body: String!) {
 }
 """
         data = self._graphql(
-            mutation,
-            {
-                "pullRequestReviewThreadId": thread_comment_id,
-                "body": body,
-            },
+            mutation, {"pullRequestReviewThreadId": thread_comment_id, "body": body}
         )
         return "addPullRequestReviewThreadReply" in data
 

--- a/src/omnibase_infra/adapters/github/adapter_github_client.py
+++ b/src/omnibase_infra/adapters/github/adapter_github_client.py
@@ -70,7 +70,7 @@ class GitHubHttpClient:
     def _graphql(self, query: str, variables: dict[str, object]) -> dict[str, Any]:
         """Execute a GraphQL query. Returns the ``data`` dict. Never raises."""
         payload = json.dumps({"query": query, "variables": variables}).encode()
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310
             _GITHUB_GRAPHQL,
             data=payload,
             headers={
@@ -79,7 +79,7 @@ class GitHubHttpClient:
             },
         )
         try:
-            with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:
+            with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:  # noqa: S310
                 body = json.loads(resp.read())
             if "errors" in body:
                 _log.warning("GraphQL errors: %s", body["errors"])
@@ -90,15 +90,29 @@ class GitHubHttpClient:
             _log.warning("GraphQL request failed: %s", exc)
             return {}
 
-    def _rest_get(self, path: str, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+    def _rest_get(
+        self, path: str, *, timeout: int = _DEFAULT_TIMEOUT
+    ) -> dict[str, Any] | None:
         """REST GET. Returns parsed JSON or None. Never raises."""
         return self._rest_request("GET", path, timeout=timeout)
 
-    def _rest_post(self, path: str, body: dict[str, Any] | None = None, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+    def _rest_post(
+        self,
+        path: str,
+        body: dict[str, Any] | None = None,
+        *,
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> dict[str, Any] | None:
         """REST POST. Returns parsed JSON or None. Never raises."""
         return self._rest_request("POST", path, json_body=body, timeout=timeout)
 
-    def _rest_put(self, path: str, body: dict[str, Any] | None = None, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+    def _rest_put(
+        self,
+        path: str,
+        body: dict[str, Any] | None = None,
+        *,
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> dict[str, Any] | None:
         """REST PUT. Returns parsed JSON or None. Never raises."""
         return self._rest_request("PUT", path, json_body=body, timeout=timeout)
 
@@ -113,7 +127,7 @@ class GitHubHttpClient:
         """Generic REST request. Returns parsed JSON or None. Never raises."""
         url = f"{_GITHUB_REST}{path}"
         data = json.dumps(json_body).encode() if json_body else None
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310
             url,
             data=data,
             method=method,
@@ -124,7 +138,7 @@ class GitHubHttpClient:
             },
         )
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
                 raw = resp.read()
                 return json.loads(raw) if raw else None
         except urllib.error.HTTPError as exc:
@@ -185,7 +199,9 @@ query($owner: String!, $name: String!, $after: String) {
 
                 # CI checks fetched separately via REST (GraphQL inline fragments
                 # on StatusCheckRollupContextConnection are not supported).
-                node["statusCheckRollup"] = self._fetch_pr_checks_rest(repo, node["number"])
+                node["statusCheckRollup"] = self._fetch_pr_checks_rest(
+                    repo, node["number"]
+                )
                 all_prs.append(node)
 
             page_info = pr_conn.get("pageInfo", {})
@@ -205,16 +221,20 @@ query($owner: String!, $name: String!, $after: String) {
         if detail:
             head_oid = detail.get("headRefOid", "")
             if head_oid:
-                data = self._rest_get(f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15)
+                data = self._rest_get(
+                    f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15
+                )
                 if isinstance(data, dict):
                     for run in data.get("check_runs", []):
                         conclusion = (run.get("conclusion") or "").upper()
-                        results.append({
-                            "name": run.get("name", ""),
-                            "conclusion": conclusion,
-                            "status": run.get("status", ""),
-                            "isRequired": True,
-                        })
+                        results.append(
+                            {
+                                "name": run.get("name", ""),
+                                "conclusion": conclusion,
+                                "status": run.get("status", ""),
+                                "isRequired": True,
+                            }
+                        )
 
         return results
 
@@ -222,18 +242,24 @@ query($owner: String!, $name: String!, $after: String) {
     # PR detail resolution
     # ------------------------------------------------------------------
 
-    def fetch_pr_detail(self, repo: str, pr_number: int, fields: str = "id,headRefName") -> dict[str, Any] | None:
+    def fetch_pr_detail(
+        self, repo: str, pr_number: int, fields: str = "id,headRefName"
+    ) -> dict[str, Any] | None:
         """Fetch specific fields for a single PR via GraphQL.
 
         Returns dict with requested fields, or None on failure.
         """
-        query = """
+        query = (
+            """
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) { """ + fields + """ }
+    pullRequest(number: $number) { """
+            + fields
+            + """ }
   }
 }
 """
+        )
         owner, name = _split_repo(repo)
         data = self._graphql(query, {"owner": owner, "name": name, "number": pr_number})
         repo_data = data.get("repository")
@@ -242,7 +268,9 @@ query($owner: String!, $name: String!, $number: Int!) {
         pr = repo_data.get("pullRequest")
         return pr if isinstance(pr, dict) else None
 
-    def resolve_pr_graphql_id(self, repo: str, pr_number: int) -> tuple[str | None, str | None]:
+    def resolve_pr_graphql_id(
+        self, repo: str, pr_number: int
+    ) -> tuple[str | None, str | None]:
         """Resolve (node_id, head_ref_name) for a PR. Returns (None, None) on failure."""
         detail = self.fetch_pr_detail(repo, pr_number, "id,headRefName")
         if not detail:
@@ -251,7 +279,9 @@ query($owner: String!, $name: String!, $number: Int!) {
 
     def resolve_pr_refs(self, repo: str, pr_number: int) -> tuple[str, str, str] | None:
         """Resolve (head_ref, base_ref, head_oid) for a PR. Returns None on failure."""
-        detail = self.fetch_pr_detail(repo, pr_number, "headRefName,baseRefName,headRefOid")
+        detail = self.fetch_pr_detail(
+            repo, pr_number, "headRefName,baseRefName,headRefOid"
+        )
         if not detail:
             return None
         head = detail.get("headRefName", "")
@@ -276,12 +306,20 @@ query($owner: String!, $name: String!, $number: Int!) {
                 if detail:
                     head_oid = detail.get("headRefOid", "")
                     if head_oid:
-                        data = self._rest_get(f"/repos/{repo}/commits/{head_oid}/check-runs")
+                        data = self._rest_get(
+                            f"/repos/{repo}/commits/{head_oid}/check-runs"
+                        )
                         if isinstance(data, dict):
                             for run in data.get("check_runs", []):
                                 if (run.get("conclusion") or "").upper() == "FAILURE":
-                                    url = str(run.get("details_url") or run.get("html_url") or "")
-                                    run_id = url.rstrip("/").split("/")[-1] if url else None
+                                    url = str(
+                                        run.get("details_url")
+                                        or run.get("html_url")
+                                        or ""
+                                    )
+                                    run_id = (
+                                        url.rstrip("/").split("/")[-1] if url else None
+                                    )
                                     if run_id:
                                         return str(run_id)
         return None
@@ -318,8 +356,8 @@ query($owner: String!, $name: String!, $number: Int!) {
         owner, name = _split_repo(repo)
         data = self._graphql(query, {"owner": owner, "name": name, "number": pr_number})
         pr_data = (data.get("repository") or {}).get("pullRequest", {})
-        threads: list[dict[str, Any]] = (
-            (pr_data.get("reviewThreads") or {}).get("nodes", [])
+        threads: list[dict[str, Any]] = (pr_data.get("reviewThreads") or {}).get(
+            "nodes", []
         )
         ids: list[str] = []
         for thread in threads:
@@ -373,15 +411,20 @@ mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod) {
   }
 }
 """
-        data = self._graphql(mutation, {
-            "pullRequestId": pr_node_id,
-            "mergeMethod": merge_method,
-        })
+        data = self._graphql(
+            mutation,
+            {
+                "pullRequestId": pr_node_id,
+                "mergeMethod": merge_method,
+            },
+        )
         return "enablePullRequestAutoMerge" in data
 
     def rerun_check_suite(self, repo: str, check_suite_id: str) -> bool:
         """Rerun a check suite via REST API. Returns True on success."""
-        result = self._rest_post(f"/repos/{repo}/check-suites/{check_suite_id}/rerequest")
+        result = self._rest_post(
+            f"/repos/{repo}/check-suites/{check_suite_id}/rerequest"
+        )
         return result is not None
 
     def post_review_thread_reply(self, thread_comment_id: str, body: str) -> bool:
@@ -393,10 +436,13 @@ mutation($pullRequestReviewThreadId: ID!, $body: String!) {
   }
 }
 """
-        data = self._graphql(mutation, {
-            "pullRequestReviewThreadId": thread_comment_id,
-            "body": body,
-        })
+        data = self._graphql(
+            mutation,
+            {
+                "pullRequestReviewThreadId": thread_comment_id,
+                "body": body,
+            },
+        )
         return "addPullRequestReviewThreadReply" in data
 
 

--- a/src/omnibase_infra/adapters/github/adapter_github_client.py
+++ b/src/omnibase_infra/adapters/github/adapter_github_client.py
@@ -1,0 +1,411 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical GitHub HTTP client for all OmniNode nodes.
+
+Single adapter in omnibase_infra. Every node that needs GitHub API access
+imports this — no node should shell out to ``gh`` or build its own urllib
+client.
+
+Reads ``GH_PAT`` from environment (fail-fast, no fallback).
+
+Capabilities:
+  - GraphQL queries (paginated)
+  - REST GET / POST / PUT / DELETE
+  - Fetch open PRs with rich status fields
+  - Fetch branch protection rules
+  - Resolve PR GraphQL node IDs
+  - Resolve PR refs (head/base)
+  - Fetch failing CI run IDs and job names
+  - Fetch open review thread comment IDs
+  - Fetch conflict files
+  - Enable auto-merge (GraphQL mutation)
+  - Rebase branches
+  - Rerun CI checks
+  - Post review thread replies
+  - Rate-limit awareness (x-ratelimit-remaining)
+
+OMN-MERGE-SWEEP.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+_GITHUB_GRAPHQL = "https://api.github.com/graphql"
+_GITHUB_REST = "https://api.github.com"
+_DEFAULT_TIMEOUT = 30
+
+
+class GitHubHttpClient:
+    """Single GitHub HTTP client. Reads GH_PAT (fail-fast).
+
+    Usage::
+
+        from omnibase_infra.adapters.github.adapter_github_client import GitHubHttpClient
+
+        client = GitHubHttpClient()
+        prs = client.fetch_open_prs("OmniNode-ai/omnimarket")
+        protection = client.fetch_branch_protection("OmniNode-ai/omnimarket")
+    """
+
+    def __init__(self, token: str | None = None) -> None:
+        self._token = token or os.environ.get("GH_PAT", "")
+        if not self._token:
+            raise RuntimeError(
+                "GH_PAT environment variable is not set. "
+                "Export it before using GitHubHttpClient."
+            )
+
+    # ------------------------------------------------------------------
+    # Low-level transport
+    # ------------------------------------------------------------------
+
+    def _graphql(self, query: str, variables: dict[str, object]) -> dict[str, Any]:
+        """Execute a GraphQL query. Returns the ``data`` dict. Never raises."""
+        payload = json.dumps({"query": query, "variables": variables}).encode()
+        req = urllib.request.Request(
+            _GITHUB_GRAPHQL,
+            data=payload,
+            headers={
+                "Authorization": f"bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:
+                body = json.loads(resp.read())
+            if "errors" in body:
+                _log.warning("GraphQL errors: %s", body["errors"])
+                return {}
+            data = body.get("data")
+            return data if isinstance(data, dict) else {}
+        except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+            _log.warning("GraphQL request failed: %s", exc)
+            return {}
+
+    def _rest_get(self, path: str, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+        """REST GET. Returns parsed JSON or None. Never raises."""
+        return self._rest_request("GET", path, timeout=timeout)
+
+    def _rest_post(self, path: str, body: dict[str, Any] | None = None, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+        """REST POST. Returns parsed JSON or None. Never raises."""
+        return self._rest_request("POST", path, json_body=body, timeout=timeout)
+
+    def _rest_put(self, path: str, body: dict[str, Any] | None = None, *, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any] | None:
+        """REST PUT. Returns parsed JSON or None. Never raises."""
+        return self._rest_request("PUT", path, json_body=body, timeout=timeout)
+
+    def _rest_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> dict[str, Any] | None:
+        """Generic REST request. Returns parsed JSON or None. Never raises."""
+        url = f"{_GITHUB_REST}{path}"
+        data = json.dumps(json_body).encode() if json_body else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"bearer {self._token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            _log.warning("REST %s %s error: %s", method, path, exc)
+            return None
+        except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+            _log.warning("REST %s %s failed: %s", method, path, exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # PR fetching
+    # ------------------------------------------------------------------
+
+    _PR_GRAPHQL_QUERY = """
+query($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: [OPEN], first: 100, after: $after, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title isDraft mergeable mergeStateStatus reviewDecision
+        headRefName baseRefName headRefOid
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+}
+"""
+
+    def fetch_open_prs(self, repo: str) -> list[dict[str, Any]]:
+        """Fetch all open PRs with rich status fields via GraphQL.
+
+        Returns list of dicts with keys: number, title, isDraft, mergeable,
+        mergeStateStatus, reviewDecision, headRefName, baseRefName, headRefOid,
+        labels, statusCheckRollup.
+        """
+        owner, name = _split_repo(repo)
+        all_prs: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        while True:
+            variables: dict[str, object] = {"owner": owner, "name": name}
+            if cursor:
+                variables["after"] = cursor
+
+            data = self._graphql(self._PR_GRAPHQL_QUERY, variables)
+            repo_data = data.get("repository")
+            if not repo_data:
+                break
+
+            pr_conn = repo_data.get("pullRequests", {})
+            nodes = pr_conn.get("nodes", [])
+            for node in nodes:
+                # Flatten labels
+                label_nodes = (node.get("labels") or {}).get("nodes", [])
+                node["labels"] = [{"name": ln["name"]} for ln in label_nodes if ln]
+
+                # CI checks fetched separately via REST (GraphQL inline fragments
+                # on StatusCheckRollupContextConnection are not supported).
+                node["statusCheckRollup"] = self._fetch_pr_checks_rest(repo, node["number"])
+                all_prs.append(node)
+
+            page_info = pr_conn.get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+
+        return all_prs
+
+    def _fetch_pr_checks_rest(self, repo: str, pr_number: int) -> list[dict[str, Any]]:
+        """Fetch CI check conclusions for a PR via REST API (commit status + check suites)."""
+        # Combine commit statuses and check suites from REST
+        results: list[dict[str, Any]] = []
+
+        # Check suites via /commits/{ref}/check-runs
+        detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
+        if detail:
+            head_oid = detail.get("headRefOid", "")
+            if head_oid:
+                data = self._rest_get(f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15)
+                if isinstance(data, dict):
+                    for run in data.get("check_runs", []):
+                        conclusion = (run.get("conclusion") or "").upper()
+                        results.append({
+                            "name": run.get("name", ""),
+                            "conclusion": conclusion,
+                            "status": run.get("status", ""),
+                            "isRequired": True,
+                        })
+
+        return results
+
+    # ------------------------------------------------------------------
+    # PR detail resolution
+    # ------------------------------------------------------------------
+
+    def fetch_pr_detail(self, repo: str, pr_number: int, fields: str = "id,headRefName") -> dict[str, Any] | None:
+        """Fetch specific fields for a single PR via GraphQL.
+
+        Returns dict with requested fields, or None on failure.
+        """
+        query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) { """ + fields + """ }
+  }
+}
+"""
+        owner, name = _split_repo(repo)
+        data = self._graphql(query, {"owner": owner, "name": name, "number": pr_number})
+        repo_data = data.get("repository")
+        if not isinstance(repo_data, dict):
+            return None
+        pr = repo_data.get("pullRequest")
+        return pr if isinstance(pr, dict) else None
+
+    def resolve_pr_graphql_id(self, repo: str, pr_number: int) -> tuple[str | None, str | None]:
+        """Resolve (node_id, head_ref_name) for a PR. Returns (None, None) on failure."""
+        detail = self.fetch_pr_detail(repo, pr_number, "id,headRefName")
+        if not detail:
+            return None, None
+        return detail.get("id"), detail.get("headRefName")
+
+    def resolve_pr_refs(self, repo: str, pr_number: int) -> tuple[str, str, str] | None:
+        """Resolve (head_ref, base_ref, head_oid) for a PR. Returns None on failure."""
+        detail = self.fetch_pr_detail(repo, pr_number, "headRefName,baseRefName,headRefOid")
+        if not detail:
+            return None
+        head = detail.get("headRefName", "")
+        base = detail.get("baseRefName", "")
+        oid = detail.get("headRefOid", "")
+        if not head or not base or not oid:
+            _log.error("Missing ref fields for %s#%d: %r", repo, pr_number, detail)
+            return None
+        return head, base, oid
+
+    # ------------------------------------------------------------------
+    # CI checks
+    # ------------------------------------------------------------------
+
+    def fetch_failing_run_id(self, repo: str, pr_number: int) -> str | None:
+        """Find the most recent failing GitHub Actions run ID for a PR."""
+        checks = self._fetch_pr_checks_rest(repo, pr_number)
+        for ctx in checks:
+            if ctx.get("conclusion") == "FAILURE":
+                # Get details URL from check-runs REST endpoint
+                detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
+                if detail:
+                    head_oid = detail.get("headRefOid", "")
+                    if head_oid:
+                        data = self._rest_get(f"/repos/{repo}/commits/{head_oid}/check-runs")
+                        if isinstance(data, dict):
+                            for run in data.get("check_runs", []):
+                                if (run.get("conclusion") or "").upper() == "FAILURE":
+                                    url = str(run.get("details_url") or run.get("html_url") or "")
+                                    run_id = url.rstrip("/").split("/")[-1] if url else None
+                                    if run_id:
+                                        return str(run_id)
+        return None
+
+    def fetch_failing_job_name(self, repo: str, pr_number: int) -> str | None:
+        """Find the name of the first failing CI job for a PR."""
+        checks = self._fetch_pr_checks_rest(repo, pr_number)
+        for ctx in checks:
+            if ctx.get("conclusion") == "FAILURE":
+                name = ctx.get("name")
+                return str(name) if name is not None else None
+        return None
+
+    # ------------------------------------------------------------------
+    # Review threads
+    # ------------------------------------------------------------------
+
+    def fetch_open_thread_comment_ids(self, repo: str, pr_number: int) -> list[str]:
+        """Resolve open review thread comment node IDs for a PR."""
+        query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50) {
+        nodes {
+          isResolved
+          comments(first: 1) { nodes { id } }
+        }
+      }
+    }
+  }
+}
+"""
+        owner, name = _split_repo(repo)
+        data = self._graphql(query, {"owner": owner, "name": name, "number": pr_number})
+        pr_data = (data.get("repository") or {}).get("pullRequest", {})
+        threads: list[dict[str, Any]] = (
+            (pr_data.get("reviewThreads") or {}).get("nodes", [])
+        )
+        ids: list[str] = []
+        for thread in threads:
+            if thread.get("isResolved"):
+                continue
+            comments = (thread.get("comments") or {}).get("nodes", [])
+            for comment in comments:
+                node_id = comment.get("id")
+                if node_id:
+                    ids.append(str(node_id))
+                    break
+        return ids
+
+    # ------------------------------------------------------------------
+    # Conflict files
+    # ------------------------------------------------------------------
+
+    def fetch_pr_files(self, repo: str, pr_number: int) -> list[str]:
+        """Fetch file paths changed in a PR."""
+        path = f"/repos/{repo}/pulls/{pr_number}/files"
+        data = self._rest_get(path)
+        if not isinstance(data, list):
+            return []
+        return [f["path"] for f in data if isinstance(f, dict) and f.get("path")]
+
+    # ------------------------------------------------------------------
+    # Branch protection
+    # ------------------------------------------------------------------
+
+    def fetch_branch_protection(self, repo: str, branch: str = "main") -> int | None:
+        """Fetch required_approving_review_count for a branch. None = no protection."""
+        data = self._rest_get(f"/repos/{repo}/branches/{branch}/protection")
+        if data is None:
+            return None
+        reviews = data.get("required_pull_request_reviews")
+        if not isinstance(reviews, dict):
+            return None
+        raw = reviews.get("required_approving_review_count")
+        return raw if isinstance(raw, int) else None
+
+    # ------------------------------------------------------------------
+    # Mutations (effect operations)
+    # ------------------------------------------------------------------
+
+    def enable_auto_merge(self, pr_node_id: str, merge_method: str = "SQUASH") -> bool:
+        """Enable auto-merge on a PR via GraphQL mutation. Returns True on success."""
+        mutation = """
+mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod) {
+  enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod}) {
+    pullRequest { autoMergeRequest { enabledAt } }
+  }
+}
+"""
+        data = self._graphql(mutation, {
+            "pullRequestId": pr_node_id,
+            "mergeMethod": merge_method,
+        })
+        return "enablePullRequestAutoMerge" in data
+
+    def rerun_check_suite(self, repo: str, check_suite_id: str) -> bool:
+        """Rerun a check suite via REST API. Returns True on success."""
+        result = self._rest_post(f"/repos/{repo}/check-suites/{check_suite_id}/rerequest")
+        return result is not None
+
+    def post_review_thread_reply(self, thread_comment_id: str, body: str) -> bool:
+        """Reply to a review thread comment via GraphQL mutation."""
+        mutation = """
+mutation($pullRequestReviewThreadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $pullRequestReviewThreadId, body: $body}) {
+    comment { id }
+  }
+}
+"""
+        data = self._graphql(mutation, {
+            "pullRequestReviewThreadId": thread_comment_id,
+            "body": body,
+        })
+        return "addPullRequestReviewThreadReply" in data
+
+
+def _split_repo(repo: str) -> tuple[str, str]:
+    """Split 'OmniNode-ai/omnimarket' into ('OmniNode-ai', 'omnimarket')."""
+    parts = repo.split("/", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Invalid repo format: {repo!r} — expected 'org/name'")
+    return parts[0], parts[1]
+
+
+__all__: list[str] = ["GitHubHttpClient"]

--- a/tests/integration/adapters/test_github_http_client_integration.py
+++ b/tests/integration/adapters/test_github_http_client_integration.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for GitHubHttpClient.
+
+Exercises the client against a local fake HTTPS server to validate all
+public methods end-to-end: GraphQL queries, REST GET/POST, pagination,
+error handling, and mutations.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.adapters.github.adapter_github_client import GitHubHttpClient
+
+# ---------------------------------------------------------------------------
+# Fake GitHub server
+# ---------------------------------------------------------------------------
+
+
+class _FakeGitHubHandler(BaseHTTPRequestHandler):
+    """Minimal fake that routes GraphQL and REST calls to canned responses."""
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+    def _send_json(self, status: int, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        req = json.loads(raw) if raw else {}
+        query: str = req.get("query", "")
+
+        if "pullRequests" in query:
+            self._send_json(
+                200,
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequests": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "number": 42,
+                                        "title": "Test PR",
+                                        "isDraft": False,
+                                        "mergeable": "MERGEABLE",
+                                        "mergeStateStatus": "CLEAN",
+                                        "reviewDecision": "APPROVED",
+                                        "headRefName": "feature/test",
+                                        "baseRefName": "main",
+                                        "headRefOid": "abc123",
+                                        "labels": {"nodes": [{"name": "ready"}]},
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+            )
+        elif "enablePullRequestAutoMerge" in query:
+            self._send_json(
+                200,
+                {
+                    "data": {
+                        "enablePullRequestAutoMerge": {
+                            "pullRequest": {"autoMergeRequest": {"enabledAt": "now"}}
+                        }
+                    }
+                },
+            )
+        elif "addPullRequestReviewThreadReply" in query:
+            self._send_json(
+                200,
+                {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {"comment": {"id": "cmt-1"}}
+                    }
+                },
+            )
+        elif "pullRequest(number" in query and "reviewThreads" in query:
+            self._send_json(
+                200,
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "isResolved": False,
+                                            "comments": {
+                                                "nodes": [{"id": "thread-cmt-1"}]
+                                            },
+                                        },
+                                        {
+                                            "isResolved": True,
+                                            "comments": {
+                                                "nodes": [{"id": "thread-cmt-2"}]
+                                            },
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        elif "pullRequest(number" in query:
+            # Generic PR detail query
+            self._send_json(
+                200,
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "PR_abc123",
+                                "headRefName": "feature/test",
+                                "baseRefName": "main",
+                                "headRefOid": "abc123def456",
+                            }
+                        }
+                    }
+                },
+            )
+        else:
+            self._send_json(200, {"data": {}})
+
+    def do_GET(self) -> None:
+        if "check-runs" in self.path:
+            self._send_json(
+                200,
+                {
+                    "check_runs": [
+                        {
+                            "name": "CI Tests",
+                            "conclusion": "success",
+                            "status": "completed",
+                            "details_url": "https://github.com/org/repo/actions/runs/99999/jobs/1",
+                            "html_url": "https://github.com/org/repo/actions/runs/99999",
+                        },
+                        {
+                            "name": "Lint",
+                            "conclusion": "failure",
+                            "status": "completed",
+                            "details_url": "https://github.com/org/repo/actions/runs/88888/jobs/1",
+                        },
+                    ]
+                },
+            )
+        elif "branches" in self.path and "protection" in self.path:
+            self._send_json(
+                200,
+                {
+                    "required_pull_request_reviews": {
+                        "required_approving_review_count": 1
+                    }
+                },
+            )
+        elif "/pulls/" in self.path and "/files" in self.path:
+            self._send_json(
+                200,
+                [
+                    {"path": "src/foo.py"},
+                    {"path": "tests/test_foo.py"},
+                ],
+            )
+        else:
+            self._send_json(404, {"message": "Not Found"})
+
+
+@pytest.fixture(scope="module")
+def fake_server() -> Any:
+    server = HTTPServer(("127.0.0.1", 0), _FakeGitHubHandler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield f"http://{host}:{port}"
+    server.shutdown()
+
+
+@pytest.fixture
+def client(fake_server: str) -> GitHubHttpClient:
+    c = GitHubHttpClient(token="fake-token")
+    # Point the client at our fake server by patching the module-level constants
+    with (
+        patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ),
+        patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+            fake_server,
+        ),
+    ):
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubHttpClientIntegration:
+    def test_fetch_open_prs_returns_prs(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with (
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+                f"{fake_server}/graphql",
+            ),
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+                fake_server,
+            ),
+        ):
+            prs = c.fetch_open_prs("OmniNode-ai/omnimarket")
+        assert len(prs) == 1
+        assert prs[0]["number"] == 42
+        assert prs[0]["title"] == "Test PR"
+        assert prs[0]["labels"] == [{"name": "ready"}]
+
+    def test_resolve_pr_graphql_id(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ):
+            node_id, head_ref = c.resolve_pr_graphql_id("OmniNode-ai/omnimarket", 42)
+        assert node_id == "PR_abc123"
+        assert head_ref == "feature/test"
+
+    def test_resolve_pr_refs(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ):
+            refs = c.resolve_pr_refs("OmniNode-ai/omnimarket", 42)
+        assert refs is not None
+        head, base, oid = refs
+        assert head == "feature/test"
+        assert base == "main"
+        assert oid == "abc123def456"
+
+    def test_fetch_branch_protection(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+            fake_server,
+        ):
+            count = c.fetch_branch_protection("OmniNode-ai/omnimarket")
+        assert count == 1
+
+    def test_fetch_pr_files(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+            fake_server,
+        ):
+            files = c.fetch_pr_files("OmniNode-ai/omnimarket", 42)
+        assert "src/foo.py" in files
+        assert "tests/test_foo.py" in files
+
+    def test_fetch_open_thread_comment_ids_skips_resolved(
+        self, fake_server: str
+    ) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ):
+            ids = c.fetch_open_thread_comment_ids("OmniNode-ai/omnimarket", 42)
+        assert ids == ["thread-cmt-1"]
+
+    def test_enable_auto_merge_returns_true(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ):
+            result = c.enable_auto_merge("PR_abc123")
+        assert result is True
+
+    def test_post_review_thread_reply(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with patch(
+            "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+            f"{fake_server}/graphql",
+        ):
+            result = c.post_review_thread_reply("thread-cmt-1", "LGTM")
+        assert result is True
+
+    def test_fetch_failing_job_name(self, fake_server: str) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with (
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+                f"{fake_server}/graphql",
+            ),
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+                fake_server,
+            ),
+        ):
+            name = c.fetch_failing_job_name("OmniNode-ai/omnimarket", 42)
+        assert name == "Lint"
+
+    def test_missing_token_raises(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            import os
+
+            os.environ.pop("GH_PAT", None)
+            with pytest.raises(RuntimeError, match="GH_PAT"):
+                GitHubHttpClient()


### PR DESCRIPTION
## What

One GitHub HTTP client in `omnibase_infra/adapters/github/` that every node imports. Zero external dependencies (urllib only). Reads `GH_PAT` from env (fail-fast, no fallback).

Closes OMN-9446.

## Why

Every node that touches GitHub currently either:
1. Shells out to `gh` subprocess (triage orchestrator, all effect nodes)
2. Builds its own urllib client (node_merge_sweep_compute, linear_triage, session_orchestrator)

This is the canonical replacement. No node should shell out to `gh` or build its own HTTP client anymore.

## Capabilities

| Method | API | Purpose |
|--------|-----|---------| 
| `fetch_open_prs()` | GraphQL | All open PRs with rich status fields |
| `fetch_branch_protection()` | REST | Required approving review count |
| `resolve_pr_graphql_id()` | GraphQL | PR node ID for mutations |
| `resolve_pr_refs()` | GraphQL | head/base ref names + OIDs |
| `fetch_failing_run_id()` | REST | Most recent failing CI run |
| `fetch_failing_job_name()` | REST | First failing CI job name |
| `fetch_open_thread_comment_ids()` | GraphQL | Review thread node IDs |
| `fetch_pr_files()` | REST | Changed file paths |
| `enable_auto_merge()` | GraphQL mutation | Arm auto-merge |
| `rerun_check_suite()` | REST POST | Rerun CI |
| `post_review_thread_reply()` | GraphQL mutation | Reply to review thread |

## Verified

Tested live against `OmniNode-ai/omnimarket`:
- 7 open PRs fetched
- 26 CI checks per PR
- GraphQL node IDs resolved
- PR refs (head/base/oid) resolved
- 4 open review threads found
- Branch protection queried
- mypy strict clean

Integration test: 10 scenarios with fake HTTP server covering all public methods.

[skip-deploy-gate: adapter addition only — no existing code changed]