### PR TITLE
chore(deps): loosen uvicorn upper bound to <1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # Core dependencies
     "pydantic>=2.11.7,<3.0.0",
     "fastapi>=0.120.1,<0.137.0",
-    "uvicorn>=0.32.0,<1.0.0",
+    "uvicorn>=0.32.0,<0.50.0",
     "pyyaml>=6.0.2,<7.0.0",
     "aiohttp>=3.9.0,<4.0.0",
     # Database dependencies (for PostgreSQL connection manager)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # Core dependencies
     "pydantic>=2.11.7,<3.0.0",
     "fastapi>=0.120.1,<0.137.0",
-    "uvicorn>=0.32.0,<0.45.0",
+    "uvicorn>=0.32.0,<1.0.0",
     "pyyaml>=6.0.2,<7.0.0",
     "aiohttp>=3.9.0,<4.0.0",
     # Database dependencies (for PostgreSQL connection manager)

--- a/uv.lock
+++ b/uv.lock
@@ -2033,7 +2033,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=23.2.0,<26.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
     { name = "textual", specifier = ">=0.89.0,<9.0.0" },
-    { name = "uvicorn", specifier = ">=0.32.0,<0.45.0" },
+    { name = "uvicorn", specifier = ">=0.32.0,<1.0.0" },
     { name = "watchdog", specifier = ">=4.0.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2033,7 +2033,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=23.2.0,<26.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
     { name = "textual", specifier = ">=0.89.0,<9.0.0" },
-    { name = "uvicorn", specifier = ">=0.32.0,<1.0.0" },
+    { name = "uvicorn", specifier = ">=0.32.0,<0.50.0" },
     { name = "watchdog", specifier = ">=4.0.0" },
 ]
 


### PR DESCRIPTION
## Summary

[skip-receipt-gate: chore/deps — no ticket; loosens uvicorn upper bound to unblock downstream Dependabot]

- Loosens `uvicorn` constraint from `>=0.32.0,<0.45.0` to `>=0.32.0,<0.50.0`
- Removes the `<0.45.0` ceiling that blocked Dependabot bumps in downstream repos
- Context: omnimemory PR #279 was closed because `uvicorn>=0.45.0` was requested but this package pinned `<0.45.0`, causing `uv` resolution failures
- Ceiling set to `<0.50.0` (not `<1.0.0`) per hostile reviewer: pre-1.0 SemVer is unstable; bounded window is safer than opening full range

## Changes

- `pyproject.toml`: uvicorn upper bound `<0.45.0` → `<0.50.0`
- `uv.lock`: specifier updated to match; no other dependency churn

## Verification

- `uv lock` resolved cleanly with no unrelated dependency changes
- Pre-commit passed on changed files
- Test suite: 60 passed, 1 skipped, 1 pre-existing performance benchmark flake (unrelated)