### PR TITLE
chore(release): bump version to 0.34.1

### DIFF
--- a/contracts/runtime/runtime_protocol.lock.json
+++ b/contracts/runtime/runtime_protocol.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "package_version": "0.34.0",
+  "package_version": "0.34.1",
   "protocol_count": 22,
   "protocols": {
     "ProtocolAutoWiringManifestLike": {

--- a/deploy/systemd/onex-log-monitor.service
+++ b/deploy/systemd/onex-log-monitor.service
@@ -9,7 +9,7 @@ EnvironmentFile=/home/jonah/.omnibase/.env
 Environment="MONITOR_PROJECTS=omnibase-infra,omnibase-infra-runtime"
 Environment="MONITOR_FILE_LOGS=/home/jonah/.onex_state/logs/env-sync.log:/home/jonah/.onex_state/logs/hooks.log:/home/jonah/.onex_state/logs/pipeline-trace.log"
 Environment="MONITOR_JOURNALS=deploy-agent.service"
-ExecStart=/usr/bin/python3 /home/jonah/.omnibase/infra/deployed/0.34.0/scripts/monitor_logs.py
+ExecStart=/usr/bin/python3 /home/jonah/.omnibase/infra/deployed/0.34.1/scripts/monitor_logs.py
 Restart=always
 RestartSec=10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.34.0"
+version = "0.34.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}


### PR DESCRIPTION
## Release 0.34.1

[skip-receipt-gate: release bump — no ticket; patch release to publish uvicorn ceiling fix from #1371]

Patch release following the uvicorn upper bound fix in #1371.

## Changes since 0.34.0

- #1371: `chore(deps)`: loosen uvicorn upper bound `<0.45.0` → `<0.50.0` to unblock downstream Dependabot bumps

## Version bump

- `pyproject.toml`: `0.34.0` → `0.34.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.34.1.
  * Updated deployed log-monitor service to run from the new 0.34.1 release.
  * No other metadata, behavior, or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->