### PR TITLE
chore(security): bump setuptools to >=78.1.1 (CVE-2025-47273) [OMN-9448]

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -339,6 +339,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
+# Security: upgrade setuptools in the runtime base image to clear CVE-2025-47273.
+# The builder venv already has the patched version, but the python:3.12-slim base
+# image's system Python retains the vulnerable version. Trivy scans both stages.
+RUN pip install --no-cache-dir "setuptools>=78.1.1"
+
 # Create non-root user for security
 # UID 1000 is typically the first non-system user, good for volume permissions
 RUN groupadd --gid 1000 omniinfra && \

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -244,6 +244,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install "protobuf>=5.29.6"
 
+# Security: upgrade setuptools to clear CVE-2025-47273 (HIGH, path traversal, fixed in >=78.1.1).
+# setuptools ships with python:3.12-slim base image at an older version flagged by Trivy.
+# Force upgrade here after all other installs to ensure the patched version is present.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install "setuptools>=78.1.1"
+
 # Verify torch is CPU-only (torch.version.cuda must be None, no nvidia packages)
 RUN /app/.venv/bin/python -c "\
 import torch, pkgutil; \

--- a/src/omnibase_infra/adapters/github/__init__.py
+++ b/src/omnibase_infra/adapters/github/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """GitHub adapter package — single HTTP client for all GitHub API access.
 

--- a/tests/integration/adapters/test_github_http_client_integration.py
+++ b/tests/integration/adapters/test_github_http_client_integration.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """Integration tests for GitHubHttpClient.


### PR DESCRIPTION
## Summary

- Adds `uv pip install "setuptools>=78.1.1"` to `Dockerfile.runtime` builder stage, following the same post-install security pin pattern as the protobuf CVE fix (line 244-245)
- setuptools ships below 78.1.1 in `python:3.12-slim` base image; Trivy HIGH gate was blocking every ECR push, preventing OMN-9420/9411/9446 substrate fixes from reaching .201 runtime
- Also fixes pre-existing SPDX year (2026→2025) in two github adapter files that were blocking pre-commit on any PR touching those paths

**CVE**: CVE-2025-47273 — path traversal in setuptools, HIGH severity, fixed in 78.1.1

**Root cause**: setuptools is not in `pyproject.toml` or `uv.lock` — it comes from the Python base image. Explicit override in Dockerfile is the correct fix.

## Test plan

- [x] `tests/unit/docker/` — 68 passed, 3 skipped
- [x] `tests/integration/adapters/test_github_http_client_integration.py` — 10 passed
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] ECR build (`build-and-push-runtime.yml`) — Trivy gate should clear with setuptools>=78.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in source and test headers.
  * Added an explicit setuptools upgrade step to the runtime image setup to ensure a minimum setuptools version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->