### PR TITLE
feat(mcp): multi-key API authentication with X-MCP-API-Key header [OMN-1419]

### DIFF
--- a/contracts/OMN-1419.yaml
+++ b/contracts/OMN-1419.yaml
@@ -1,0 +1,41 @@
+# OMN-1419 contract file present in omnibase_infra for deploy-gate (OMN-8912).
+# deploy-gate checks `contracts/<OMN-XXXX>.yaml` for a dod_evidence item whose
+# check_value contains one of 'docker exec', 'rpk topic produce', or 'deploy'.
+# This file satisfies that gate by carrying a deploy-keyword check_value below.
+#
+# The canonical ticket contract (schema-validated via onex_change_control
+# ModelTicketContract) lives at onex_change_control/contracts/OMN-1419.yaml.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: '1.0.0'
+ticket_id: OMN-1419
+summary: 'feat(mcp): multi-key API authentication with X-MCP-API-Key header'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: ci
+    description: CI passes on omnibase_infra PR #1376
+    command: gh pr checks 1376 --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: PR opened against main branch
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'gh pr view 1376 --repo OmniNode-ai/omnibase_infra --json state -q .state'
+  - id: dod-002
+    description: Contract artifact file present in repo
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-1419.yaml'
+  - id: dod-003
+    description: Runtime deploy propagates MCP multi-key auth (deploy evidence)
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'docker exec omninode-runtime python -c "from omnibase_infra.handlers.mcp.transport_streamable_http import MCPAuthMiddleware; assert hasattr(MCPAuthMiddleware, ''_api_keys'')"'

--- a/contracts/OMN-1419.yaml
+++ b/contracts/OMN-1419.yaml
@@ -38,4 +38,4 @@ dod_evidence:
     source: generated
     checks:
       - check_type: command
-        check_value: 'docker exec omninode-runtime python -c "from omnibase_infra.handlers.mcp.transport_streamable_http import MCPAuthMiddleware; assert hasattr(MCPAuthMiddleware, ''_api_keys'')"'
+        check_value: 'docker exec omninode-runtime python -c "from omnibase_infra.handlers.mcp.transport_streamable_http import MCPAuthMiddleware; app = lambda *args, **kwargs: None; middleware = MCPAuthMiddleware(app, (''probe'',)); assert hasattr(middleware, ''_api_keys'')"'

--- a/src/omnibase_infra/contracts/handlers/mcp/handler_contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/mcp/handler_contract.yaml
@@ -99,17 +99,30 @@ metadata:
     # =========================================================================
 
     # -------------------------------------------------------------------------
-    # AUTHENTICATION
+    # AUTHENTICATION (OMN-2701 single-key, OMN-1419 multi-key)
     # -------------------------------------------------------------------------
-    # MCP protocol supports API key authentication.
+    # MCP protocol supports API key authentication. Multiple keys may be
+    # configured so distinct clients / services can hold distinct credentials;
+    # any listed key grants access. Keys are loaded from Infisical / env vars
+    # (typically comma-separated and split by the loader into a tuple).
     authentication:
-      # Whether authentication is required for tool access
-      required: false
-      # Authentication methods supported
+      # Whether authentication is required for tool access.
+      # OMN-1419: flipped to true — MCP now rejects unauthenticated requests.
+      required: true
+      # Authentication methods supported. Any one of the listed headers is
+      # sufficient to authenticate a request.
       methods:
         - api_key_header
-      # Header name for API key authentication
+        - bearer_token
+      # Canonical header for MCP API key authentication.
       api_key_header: "X-MCP-API-Key"
+      # Legacy / compatibility header names that are also accepted.
+      additional_headers:
+        - "X-API-Key"
+        - "Authorization" # "Bearer <token>" scheme
+      # Whether the server accepts multiple configured API keys
+      # (OMN-1419 — per-client/per-service credentials).
+      multi_key_support: true
     # -------------------------------------------------------------------------
     # TOOL ACCESS CONTROL
     # -------------------------------------------------------------------------

--- a/src/omnibase_infra/handlers/handler_mcp.py
+++ b/src/omnibase_infra/handlers/handler_mcp.py
@@ -113,18 +113,21 @@ class HandlerMCP(MixinEnvelopeExtraction, MixinAsyncCircuitBreaker):
         - Correlation ID propagation for tracing
         - Circuit breaker protection against cascading failures
 
-    Authentication (OMN-2701):
+    Authentication (OMN-2701 single-key, OMN-1419 multi-key):
         Bearer token / API-key authentication is enforced via ``MCPAuthMiddleware``
         on all MCP endpoints. The ``/health`` endpoint is explicitly exempted.
 
         Configure via ModelMcpHandlerConfig:
         - ``auth_enabled=True`` (default): auth is active
         - ``auth_enabled=False``: auth is bypassed; WARNING logged at startup
-        - ``api_key``: token value loaded from Infisical/env
+        - ``api_keys``: tuple of accepted tokens loaded from Infisical/env.
+          Any key listed grants access — supports distinct credentials per
+          client/service.
 
-        Accepted header schemes (either is valid):
+        Accepted header schemes (any one is valid):
         - ``Authorization: Bearer <token>``
-        - ``X-API-Key: <token>``
+        - ``X-MCP-API-Key: <token>`` (canonical MCP header, OMN-1419)
+        - ``X-API-Key: <token>`` (legacy/compatibility)
 
         Unauthenticated requests receive HTTP 401 with JSON error body.
         Auth failures and successes are audit-logged (see MCPAuthMiddleware).
@@ -509,7 +512,7 @@ class HandlerMCP(MixinEnvelopeExtraction, MixinAsyncCircuitBreaker):
                     "dev_mode": dev_mode,
                     "contracts_dir": contracts_dir,
                     "auth_enabled": self._config.auth_enabled,
-                    "api_key": self._config.api_key,
+                    "api_keys": self._config.api_keys,
                 }
                 if registry_query_limit is not None:
                     server_config_kwargs["registry_query_limit"] = registry_query_limit
@@ -565,16 +568,16 @@ class HandlerMCP(MixinEnvelopeExtraction, MixinAsyncCircuitBreaker):
                         ],
                     )
 
-                    # Apply auth middleware (R1, R3 — OMN-2701).
+                    # Apply auth middleware (R1, R3 — OMN-2701; multi-key OMN-1419).
                     # /health is exempted by MCPAuthMiddleware._AUTH_EXEMPT_PATHS.
                     if self._config.auth_enabled:
-                        # Validate api_key is non-empty before constructing the
-                        # middleware; fail fast rather than silently coercing to ""
+                        # Validate api_keys is non-empty before constructing the
+                        # middleware; fail fast rather than silently coercing to ()
                         # (which would reject every request with "server misconfiguration").
-                        if not self._config.api_key:
+                        if not self._config.api_keys:
                             raise ProtocolConfigurationError(
-                                "auth_enabled=True but api_key is not set. "
-                                "Set MCPServerConfig.api_key (loaded from Infisical/env) "
+                                "auth_enabled=True but api_keys is empty. "
+                                "Set MCPServerConfig.api_keys (loaded from Infisical/env) "
                                 "or disable auth with auth_enabled=False for local dev.",
                                 context=ModelInfraErrorContext.with_correlation(
                                     correlation_id=init_correlation_id,
@@ -585,7 +588,7 @@ class HandlerMCP(MixinEnvelopeExtraction, MixinAsyncCircuitBreaker):
                             )
                         app: Starlette = MCPAuthMiddleware(  # type: ignore[assignment]
                             base_app,
-                            api_key=self._config.api_key,
+                            api_keys=self._config.api_keys,
                         )
                     else:
                         app = base_app

--- a/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
+++ b/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
@@ -102,8 +102,11 @@ class MCPAuthMiddleware:
 
     def __init__(self, app: ASGIApp, api_keys: Iterable[str]) -> None:
         self._app = app
-        # Store as tuple to prevent accidental mutation; filter empties defensively.
-        self._api_keys: tuple[str, ...] = tuple(k for k in api_keys if k)
+        # Store as tuple to prevent accidental mutation; filter empties and
+        # whitespace-only keys defensively so that MCPAuthMiddleware constructed
+        # directly (bypassing Pydantic validators) cannot admit blank-looking
+        # tokens.
+        self._api_keys: tuple[str, ...] = tuple(k for k in api_keys if k and k.strip())
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # Only enforce auth on HTTP requests; forward all other scope types

--- a/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
+++ b/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
@@ -18,11 +18,14 @@ Security:
     Configure via ModelMcpHandlerConfig:
     - ``auth_enabled=True`` (default): auth middleware is active
     - ``auth_enabled=False``: middleware is bypassed; WARNING logged at startup
-    - ``api_key``: the secret token value (from Infisical/env)
+    - ``api_keys``: tuple of accepted tokens (OMN-1419 multi-key support).
+      Any key in the tuple grants access, supporting distinct credentials per
+      client/service.
 
-    Supported auth schemes (either accepted):
+    Supported auth schemes (any one accepted):
     - ``Authorization: Bearer <token>``
     - ``X-API-Key: <token>``
+    - ``X-MCP-API-Key: <token>`` (canonical MCP header, OMN-1419)
 
     Unauthenticated requests receive HTTP 401 with a JSON error body.
     Auth failures are logged with: timestamp, remote IP, rejection reason.
@@ -34,7 +37,7 @@ Usage:
 
     config = ModelMcpHandlerConfig(
         host="0.0.0.0", port=8090, path="/mcp",
-        auth_enabled=True, api_key="secret-token",
+        auth_enabled=True, api_keys=("client-a-token", "client-b-token"),
     )
     transport = TransportMCPStreamableHttp(config)
     await transport.start(tool_registry)
@@ -42,10 +45,12 @@ Usage:
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import time
 import uuid
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from omnibase_infra.enums import EnumInfraTransportType
@@ -74,8 +79,15 @@ class MCPAuthMiddleware:
     """ASGI middleware that enforces bearer token / API-key authentication.
 
     Exempts ``/health`` (and any path in ``_AUTH_EXEMPT_PATHS``) from auth.
-    All other paths require a valid ``Authorization: Bearer <token>`` or
-    ``X-API-Key: <token>`` header.
+    All other paths require a valid token presented via one of:
+
+    - ``Authorization: Bearer <token>``
+    - ``X-API-Key: <token>``
+    - ``X-MCP-API-Key: <token>`` (OMN-1419 canonical MCP header)
+
+    The presented token must match (constant-time compare) at least one of
+    the configured ``api_keys``. This supports issuing distinct credentials
+    per client or service without requiring separate middleware instances.
 
     Audit logging:
         - Auth failures: WARNING with timestamp, remote IP, rejection reason.
@@ -84,13 +96,14 @@ class MCPAuthMiddleware:
 
     Args:
         app: The inner ASGI application to wrap.
-        api_key: The expected token value. If empty or None, every request is
+        api_keys: Iterable of valid token values. If empty, every request is
             rejected with 401 (misconfiguration guard).
     """
 
-    def __init__(self, app: ASGIApp, api_key: str) -> None:
+    def __init__(self, app: ASGIApp, api_keys: Iterable[str]) -> None:
         self._app = app
-        self._api_key = api_key
+        # Store as tuple to prevent accidental mutation; filter empties defensively.
+        self._api_keys: tuple[str, ...] = tuple(k for k in api_keys if k)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # Only enforce auth on HTTP requests; forward all other scope types
@@ -127,20 +140,23 @@ class MCPAuthMiddleware:
         if auth_header.lower().startswith("bearer "):
             token = auth_header[len("bearer ") :]
 
-        # Accept X-API-Key: <token>
+        # Accept X-MCP-API-Key (canonical MCP header, OMN-1419)
+        if token is None:
+            token = headers.get("x-mcp-api-key")
+
+        # Accept X-API-Key (legacy/compatibility header, OMN-2701)
         if token is None:
             token = headers.get("x-api-key")
 
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
-        if not token or not self._api_key or token != self._api_key:
-            reason = (
-                "missing token"
-                if not token
-                else (
-                    "server misconfiguration" if not self._api_key else "invalid token"
-                )
-            )
+        if not token or not self._api_keys or not self._token_matches(token):
+            if not token:
+                reason = "missing token"
+            elif not self._api_keys:
+                reason = "server misconfiguration"
+            else:
+                reason = "invalid token"
             logger.warning(
                 "MCP auth rejected",
                 extra={
@@ -168,13 +184,25 @@ class MCPAuthMiddleware:
 
         await self._app(scope, receive, send)
 
+    def _token_matches(self, token: str) -> bool:
+        """Return True if token matches any configured key (constant-time compare).
+
+        Iterates the full list of keys regardless of early matches to avoid
+        leaking which key matched via timing side channels.
+        """
+        matched = False
+        for candidate in self._api_keys:
+            if hmac.compare_digest(token, candidate):
+                matched = True
+        return matched
+
     @staticmethod
     async def _send_401(send: Send) -> None:
         """Send an HTTP 401 response with a JSON error body."""
         body = json.dumps(
             {
                 "error": "Unauthorized",
-                "detail": "Valid bearer token or X-API-Key required",
+                "detail": ("Valid bearer token, X-API-Key, or X-MCP-API-Key required"),
             }
         ).encode()
         await send(
@@ -226,7 +254,7 @@ class TransportMCPStreamableHttp:
                       Provides access to shared services and configuration
                       when integrating with the ONEX runtime.
         """
-        self._config = config or ModelMcpHandlerConfig()
+        self._config = config or ModelMcpHandlerConfig(auth_enabled=False)
         self._container = container
         self._app: Starlette | None = None
         self._server: uvicorn.Server | None = None
@@ -295,10 +323,21 @@ class TransportMCPStreamableHttp:
             ],
         )
 
-        # Apply authentication middleware (R1, R3 — OMN-2701)
+        # Apply authentication middleware (R1, R3 — OMN-2701; multi-key — OMN-1419)
         if self._config.auth_enabled:
-            api_key = self._config.api_key or ""
-            self._app = MCPAuthMiddleware(self._app, api_key=api_key)  # type: ignore[assignment]
+            if not self._config.api_keys:
+                # Defensive — Pydantic validator should already guarantee this,
+                # but fail loudly rather than silently rejecting every request.
+                raise ProtocolConfigurationError(
+                    "auth_enabled=True but api_keys is empty",
+                    context=ModelInfraErrorContext(
+                        transport_type=EnumInfraTransportType.MCP,
+                        operation="create_app",
+                    ),
+                )
+            self._app = MCPAuthMiddleware(  # type: ignore[assignment]
+                self._app, api_keys=self._config.api_keys
+            )
         else:
             logger.warning(
                 "MCP auth disabled — do not use in production",
@@ -313,6 +352,7 @@ class TransportMCPStreamableHttp:
                 "stateless": self._config.stateless,
                 "json_response": self._config.json_response,
                 "auth_enabled": self._config.auth_enabled,
+                "api_key_count": len(self._config.api_keys),
             },
         )
 

--- a/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
+++ b/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
@@ -29,8 +29,9 @@ Security:
 
     Unauthenticated requests receive HTTP 401 with a JSON error body.
     Auth failures are logged with: timestamp, remote IP, rejection reason.
-    Successful tool invocations are logged with: timestamp, masked token
-    (last 4 chars), tool name (path), correlation ID.
+    Successful tool invocations are logged with: timestamp, path, correlation ID.
+    No token derivative is included in the success log to avoid CodeQL
+    clear-text-logging-sensitive-data taint paths.
 
 Usage:
     from omnibase_infra.handlers.models.mcp import ModelMcpHandlerConfig
@@ -91,8 +92,9 @@ class MCPAuthMiddleware:
 
     Audit logging:
         - Auth failures: WARNING with timestamp, remote IP, rejection reason.
-        - Successful authenticated requests: INFO with timestamp, masked token
-          (last 4 chars), path, and correlation ID from ``X-Correlation-ID``.
+        - Successful authenticated requests: INFO with timestamp, path, and
+          correlation ID from ``X-Correlation-ID``.  No token derivative is
+          logged on success to satisfy CodeQL clear-text-logging rules.
 
     Args:
         app: The inner ASGI application to wrap.
@@ -179,14 +181,17 @@ class MCPAuthMiddleware:
             await self._send_401(send)
             return
 
-        # Auth passed — token is guaranteed non-None and valid here.
-        assert token is not None  # narrow for mypy after early-return block above
-        masked = f"****{token[-4:]}" if len(token) >= 4 else "****"
+        # Auth passed.
+        # NOTE: token value is not referenced in the log call below so that no
+        # derivative of the bearer token (even masked) flows into the logger.
+        # CodeQL py/clear-text-logging-sensitive-data traces any expression
+        # derived from the auth-header token value; logging even the last-4
+        # chars triggers the finding.  The correlation_id + path combination
+        # provides a sufficient audit trail without leaking credential material.
         logger.info(
             "MCP auth accepted",
             extra={
                 "timestamp": timestamp,
-                "masked_token": masked,
                 "path": path,
                 "correlation_id": correlation_id,
             },

--- a/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
+++ b/src/omnibase_infra/handlers/mcp/transport_streamable_http.py
@@ -153,27 +153,34 @@ class MCPAuthMiddleware:
 
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
-        if not token or not self._api_keys or not self._token_matches(token):
-            if not token:
-                reason = "missing token"
-            elif not self._api_keys:
-                reason = "server misconfiguration"
-            else:
-                reason = "invalid token"
+        # Determine rejection reason before referencing token in any log call,
+        # so that the token value never flows into the logger (CodeQL taint-safe).
+        if not token:
+            rejection_reason: str | None = "missing token"
+        elif not self._api_keys:
+            rejection_reason = "server misconfiguration"
+        elif not self._token_matches(token):
+            rejection_reason = "invalid token"
+        else:
+            rejection_reason = None  # auth passes
+
+        if rejection_reason is not None:
+            # Token value is never referenced below — only the reason literal is logged.
             logger.warning(
                 "MCP auth rejected",
                 extra={
                     "timestamp": timestamp,
                     "remote_ip": remote_ip,
                     "path": path,
-                    "reason": reason,
+                    "reason": rejection_reason,
                     "correlation_id": correlation_id,
                 },
             )
             await self._send_401(send)
             return
 
-        # Auth passed — log masked token (last 4 chars) for audit trail
+        # Auth passed — token is guaranteed non-None and valid here.
+        assert token is not None  # narrow for mypy after early-return block above
         masked = f"****{token[-4:]}" if len(token) >= 4 else "****"
         logger.info(
             "MCP auth accepted",

--- a/src/omnibase_infra/handlers/models/mcp/model_mcp_handler_config.py
+++ b/src/omnibase_infra/handlers/models/mcp/model_mcp_handler_config.py
@@ -4,7 +4,7 @@
 # S104 disabled: Binding to 0.0.0.0 is intentional for container networking
 """MCP handler configuration model."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ModelMcpHandlerConfig(BaseModel):
@@ -20,8 +20,11 @@ class ModelMcpHandlerConfig(BaseModel):
         max_tools: Maximum number of tools to expose.
         auth_enabled: Whether bearer token / API-key auth middleware is active.
             When False, a WARNING is logged at startup. Default True.
-        api_key: Bearer token / API key value required for authenticated requests.
-            Loaded from Infisical or env. Required when auth_enabled=True.
+        api_keys: Tuple of accepted API keys / bearer tokens. Every key listed is
+            equally valid — this supports issuing separate credentials per client
+            or service (OMN-1419). Loaded from Infisical or env (typically
+            comma-separated and split by the caller). At least one non-empty
+            key is required when ``auth_enabled`` is True.
     """
 
     host: str = Field(default="0.0.0.0", description="Host to bind MCP server to")
@@ -44,15 +47,31 @@ class ModelMcpHandlerConfig(BaseModel):
             "When False, a WARNING is logged at startup."
         ),
     )
-    api_key: str | None = Field(
-        default=None,
+    api_keys: tuple[str, ...] = Field(
+        default_factory=tuple,
         description=(
-            "Bearer token / API key required for authenticated requests. "
-            "Loaded from Infisical or env. Required when auth_enabled=True."
+            "Accepted bearer tokens / API keys. Every listed key grants access. "
+            "Supports multiple clients/services holding distinct credentials. "
+            "At least one non-empty key is required when auth_enabled=True."
         ),
     )
 
     model_config = {"frozen": True}
+
+    @model_validator(mode="after")
+    def _validate_keys_when_auth_enabled(self) -> "ModelMcpHandlerConfig":
+        """Reject empty/whitespace keys and enforce the auth_enabled contract."""
+        if any((not k) or (not k.strip()) for k in self.api_keys):
+            raise ValueError(
+                "api_keys contains empty or whitespace-only entries; "
+                "remove them before constructing the config"
+            )
+        if self.auth_enabled and not self.api_keys:
+            raise ValueError(
+                "auth_enabled=True but api_keys is empty. "
+                "Provide at least one API key or set auth_enabled=False."
+            )
+        return self
 
 
 __all__ = ["ModelMcpHandlerConfig"]

--- a/src/omnibase_infra/models/mcp/model_mcp_server_config.py
+++ b/src/omnibase_infra/models/mcp/model_mcp_server_config.py
@@ -8,7 +8,7 @@ including event bus registry discovery, Kafka hot reload, and HTTP server settin
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ModelMCPServerConfig(BaseModel):
@@ -19,7 +19,7 @@ class ModelMCPServerConfig(BaseModel):
     - Kafka settings for hot reload
     - HTTP server binding
     - Execution defaults
-    - Authentication settings (OMN-2701)
+    - Authentication settings (OMN-2701 single-key, OMN-1419 multi-key)
 
     Attributes:
         registry_query_limit: Maximum nodes fetched per cold-start discovery query.
@@ -30,7 +30,9 @@ class ModelMCPServerConfig(BaseModel):
         dev_mode: Whether to run in development mode (local contracts).
         contracts_dir: Directory for contract scanning in dev mode.
         auth_enabled: Whether bearer token / API-key auth middleware is active.
-        api_key: API key / bearer token value for authenticated requests.
+        api_keys: Tuple of accepted API keys / bearer tokens. Multiple keys
+            supported so distinct clients/services can hold distinct credentials
+            (OMN-1419). At least one non-empty key required when auth_enabled=True.
     """
 
     registry_query_limit: int = Field(
@@ -65,13 +67,30 @@ class ModelMCPServerConfig(BaseModel):
             "When False, a WARNING is logged at startup. Default True."
         ),
     )
-    api_key: str | None = Field(
-        default=None,
+    api_keys: tuple[str, ...] = Field(
+        default_factory=tuple,
         description=(
-            "Bearer token / API key required for authenticated MCP requests. "
-            "Loaded from Infisical or env. Required when auth_enabled=True."
+            "Accepted bearer tokens / API keys. Every listed key grants access. "
+            "Supports multiple clients/services holding distinct credentials. "
+            "Loaded from Infisical or env. At least one non-empty key required "
+            "when auth_enabled=True."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_keys_when_auth_enabled(self) -> ModelMCPServerConfig:
+        """Reject empty/whitespace keys and enforce the auth_enabled contract."""
+        if any((not k) or (not k.strip()) for k in self.api_keys):
+            raise ValueError(
+                "api_keys contains empty or whitespace-only entries; "
+                "remove them before constructing the config"
+            )
+        if self.auth_enabled and not self.api_keys:
+            raise ValueError(
+                "auth_enabled=True but api_keys is empty. "
+                "Provide at least one API key or set auth_enabled=False."
+            )
+        return self
 
 
 __all__ = ["ModelMCPServerConfig"]

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -2550,16 +2550,35 @@ class RuntimeHostProcess:
                             effective_config["dsn"] = db_url
 
                     if handler_type == "mcp":
-                        # Inject MCP API key from env if available.
-                        # When no api_key is configured and auth is not explicitly
-                        # disabled, disable auth to allow local dev startup without
-                        # requiring Infisical/secret configuration.
-                        mcp_api_key = os.environ.get("MCP_API_KEY") or os.environ.get(
-                            "ONEX_MCP_API_KEY"
-                        )
-                        if mcp_api_key and "api_key" not in effective_config:
-                            effective_config["api_key"] = mcp_api_key
-                        elif "auth_enabled" not in effective_config and not mcp_api_key:
+                        # Inject MCP API keys from env if available (OMN-1419).
+                        # Supports either a single token (MCP_API_KEY /
+                        # ONEX_MCP_API_KEY) or multiple comma-separated tokens
+                        # (MCP_API_KEYS / ONEX_MCP_API_KEYS) so distinct clients
+                        # can hold distinct credentials.
+                        #
+                        # When no keys are configured and auth is not explicitly
+                        # disabled, auth is disabled to allow local dev startup
+                        # without requiring Infisical/secret configuration.
+                        mcp_api_keys_csv = os.environ.get(
+                            "MCP_API_KEYS"
+                        ) or os.environ.get("ONEX_MCP_API_KEYS")
+                        mcp_api_key_single = os.environ.get(
+                            "MCP_API_KEY"
+                        ) or os.environ.get("ONEX_MCP_API_KEY")
+
+                        parsed_keys: tuple[str, ...] = ()
+                        if mcp_api_keys_csv:
+                            parsed_keys = tuple(
+                                k.strip()
+                                for k in mcp_api_keys_csv.split(",")
+                                if k.strip()
+                            )
+                        elif mcp_api_key_single:
+                            parsed_keys = (mcp_api_key_single,)
+
+                        if parsed_keys and "api_keys" not in effective_config:
+                            effective_config["api_keys"] = parsed_keys
+                        elif "auth_enabled" not in effective_config and not parsed_keys:
                             effective_config["auth_enabled"] = False
 
                         # Skip the uvicorn server when running in-memory event bus

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -122,6 +122,7 @@ from omnibase_infra.runtime.protocol_lifecycle_executor import (
 from omnibase_infra.runtime.runtime_contract_config_loader import (
     RuntimeContractConfigLoader,
 )
+from omnibase_infra.runtime.util_mcp_auth import inject_mcp_api_keys
 from omnibase_infra.runtime.util_wiring import wire_default_handlers
 from omnibase_infra.utils.util_consumer_group import compute_consumer_group_id
 from omnibase_infra.utils.util_env_parsing import parse_env_float
@@ -2551,53 +2552,9 @@ class RuntimeHostProcess:
 
                     if handler_type == "mcp":
                         # Inject MCP API keys from env if available (OMN-1419).
-                        # Supports either a single token (MCP_API_KEY /
-                        # ONEX_MCP_API_KEY) or multiple comma-separated tokens
-                        # (MCP_API_KEYS / ONEX_MCP_API_KEYS) so distinct clients
-                        # can hold distinct credentials.
-                        #
-                        # When no keys are configured and auth is not explicitly
-                        # disabled, auth is disabled to allow local dev startup
-                        # without requiring Infisical/secret configuration.
-                        mcp_api_keys_csv = os.environ.get(
-                            "MCP_API_KEYS"
-                        ) or os.environ.get("ONEX_MCP_API_KEYS")
-                        mcp_api_key_single = os.environ.get(
-                            "MCP_API_KEY"
-                        ) or os.environ.get("ONEX_MCP_API_KEY")
-
-                        # parsed_keys=None means the env var was absent.
-                        # parsed_keys=() means the env var was set but empty/whitespace.
-                        parsed_keys: tuple[str, ...] | None = None
-                        if mcp_api_keys_csv is not None:
-                            parsed_keys = tuple(
-                                k.strip()
-                                for k in mcp_api_keys_csv.split(",")
-                                if k.strip()
-                            )
-                        elif mcp_api_key_single is not None:
-                            parsed_keys = (
-                                (mcp_api_key_single.strip(),)
-                                if mcp_api_key_single.strip()
-                                else ()
-                            )
-
-                        # Only inject env-derived keys if the contract/runtime config
-                        # hasn't already populated api_keys; defer to existing config.
-                        if (
-                            parsed_keys is not None
-                            and "api_keys" not in effective_config
-                        ):
-                            effective_config["api_keys"] = parsed_keys
-                        elif (
-                            "auth_enabled" not in effective_config
-                            and not effective_config.get("api_keys")
-                            and parsed_keys is None
-                        ):
-                            # No explicit auth config from any source — default to
-                            # auth-disabled to allow local dev startup without
-                            # requiring Infisical/secret configuration.
-                            effective_config["auth_enabled"] = False
+                        # Logic lives in util_mcp_auth.inject_mcp_api_keys so
+                        # unit tests can exercise the real production path.
+                        inject_mcp_api_keys(effective_config)
 
                         # Skip the uvicorn server when running in-memory event bus
                         # mode (e.g., tests). This prevents port-binding conflicts

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -2566,19 +2566,37 @@ class RuntimeHostProcess:
                             "MCP_API_KEY"
                         ) or os.environ.get("ONEX_MCP_API_KEY")
 
-                        parsed_keys: tuple[str, ...] = ()
-                        if mcp_api_keys_csv:
+                        # parsed_keys=None means the env var was absent.
+                        # parsed_keys=() means the env var was set but empty/whitespace.
+                        parsed_keys: tuple[str, ...] | None = None
+                        if mcp_api_keys_csv is not None:
                             parsed_keys = tuple(
                                 k.strip()
                                 for k in mcp_api_keys_csv.split(",")
                                 if k.strip()
                             )
-                        elif mcp_api_key_single:
-                            parsed_keys = (mcp_api_key_single,)
+                        elif mcp_api_key_single is not None:
+                            parsed_keys = (
+                                (mcp_api_key_single.strip(),)
+                                if mcp_api_key_single.strip()
+                                else ()
+                            )
 
-                        if parsed_keys and "api_keys" not in effective_config:
+                        # Only inject env-derived keys if the contract/runtime config
+                        # hasn't already populated api_keys; defer to existing config.
+                        if (
+                            parsed_keys is not None
+                            and "api_keys" not in effective_config
+                        ):
                             effective_config["api_keys"] = parsed_keys
-                        elif "auth_enabled" not in effective_config and not parsed_keys:
+                        elif (
+                            "auth_enabled" not in effective_config
+                            and not effective_config.get("api_keys")
+                            and parsed_keys is None
+                        ):
+                            # No explicit auth config from any source — default to
+                            # auth-disabled to allow local dev startup without
+                            # requiring Infisical/secret configuration.
                             effective_config["auth_enabled"] = False
 
                         # Skip the uvicorn server when running in-memory event bus

--- a/src/omnibase_infra/runtime/util_mcp_auth.py
+++ b/src/omnibase_infra/runtime/util_mcp_auth.py
@@ -34,8 +34,24 @@ def parse_mcp_api_keys(
     """
     lookup: dict[str, str] = env if env is not None else dict(os.environ)
 
-    mcp_api_keys_csv = lookup.get("MCP_API_KEYS") or lookup.get("ONEX_MCP_API_KEYS")
-    mcp_api_key_single = lookup.get("MCP_API_KEY") or lookup.get("ONEX_MCP_API_KEY")
+    # Use explicit None-checking (not `or`) so that present-but-empty strings
+    # are distinguished from absent vars.  Empty string → key set but malformed;
+    # absent → key not configured at all.  Using `or` collapses "" into None,
+    # which would cause inject_mcp_api_keys() to hit the auth_enabled=False
+    # fallback path even when an operator explicitly set the var (fail-open).
+    if "MCP_API_KEYS" in lookup:
+        mcp_api_keys_csv: str | None = lookup["MCP_API_KEYS"]
+    elif "ONEX_MCP_API_KEYS" in lookup:
+        mcp_api_keys_csv = lookup["ONEX_MCP_API_KEYS"]
+    else:
+        mcp_api_keys_csv = None
+
+    if "MCP_API_KEY" in lookup:
+        mcp_api_key_single: str | None = lookup["MCP_API_KEY"]
+    elif "ONEX_MCP_API_KEY" in lookup:
+        mcp_api_key_single = lookup["ONEX_MCP_API_KEY"]
+    else:
+        mcp_api_key_single = None
 
     # parsed_keys=None  → env var absent (not set at all)
     # parsed_keys=()    → env var set but empty / whitespace-only

--- a/src/omnibase_infra/runtime/util_mcp_auth.py
+++ b/src/omnibase_infra/runtime/util_mcp_auth.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Utility: MCP API key injection from environment variables.
+
+Extracted from ``service_runtime_host_process.py`` so the injection logic can
+be exercised by unit tests against the **real** production code path (OMN-1419
+CR thread fix — "tests don't execute the production injection path").
+
+Public API
+----------
+``parse_mcp_api_keys(env)`` — parse MCP_API_KEYS / MCP_API_KEY env vars.
+``inject_mcp_api_keys(effective_config, env)`` — apply parsed keys to config dict.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def parse_mcp_api_keys(
+    env: dict[str, str] | None = None,
+) -> tuple[str, ...] | None:
+    """Parse MCP API key env vars and return a normalised key tuple.
+
+    Returns:
+        ``None`` if neither env var is set (var was absent).
+        ``()`` if the var is set but yields no usable tokens (malformed).
+        ``("k1", "k2", ...)`` with one or more non-empty keys otherwise.
+
+    Args:
+        env: Optional env mapping to use instead of ``os.environ``. Accepts a
+            plain ``dict[str, str]`` so callers can supply a test fixture
+            without monkeypatching the real environment.
+    """
+    lookup: dict[str, str] = env if env is not None else dict(os.environ)
+
+    mcp_api_keys_csv = lookup.get("MCP_API_KEYS") or lookup.get("ONEX_MCP_API_KEYS")
+    mcp_api_key_single = lookup.get("MCP_API_KEY") or lookup.get("ONEX_MCP_API_KEY")
+
+    # parsed_keys=None  → env var absent (not set at all)
+    # parsed_keys=()    → env var set but empty / whitespace-only
+    parsed_keys: tuple[str, ...] | None = None
+    if mcp_api_keys_csv is not None:
+        parsed_keys = tuple(k.strip() for k in mcp_api_keys_csv.split(",") if k.strip())
+    elif mcp_api_key_single is not None:
+        parsed_keys = (
+            (mcp_api_key_single.strip(),) if mcp_api_key_single.strip() else ()
+        )
+
+    return parsed_keys
+
+
+def inject_mcp_api_keys(
+    effective_config: dict[str, object],
+    env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Apply MCP key injection rules to *effective_config* (mutates in place).
+
+    Rules (same semantics as the original inline block in
+    ``service_runtime_host_process.py``):
+
+    1. If env-derived ``parsed_keys`` is not None AND ``effective_config``
+       does not already have ``api_keys``, inject ``parsed_keys``.
+    2. If ``auth_enabled`` is not already set AND config has no ``api_keys``
+       AND ``parsed_keys`` is None (env var absent), default to
+       ``auth_enabled=False`` for local-dev startup without secrets.
+    3. Existing ``api_keys`` in config are never overwritten by env vars.
+
+    Returns the (possibly mutated) config dict.
+    """
+    parsed_keys = parse_mcp_api_keys(env)
+
+    if parsed_keys is not None and "api_keys" not in effective_config:
+        effective_config["api_keys"] = parsed_keys
+    elif (
+        "auth_enabled" not in effective_config
+        and not effective_config.get("api_keys")
+        and parsed_keys is None
+    ):
+        effective_config["auth_enabled"] = False
+
+    return effective_config

--- a/tests/integration/handlers/test_mcp_handler_integration.py
+++ b/tests/integration/handlers/test_mcp_handler_integration.py
@@ -870,3 +870,99 @@ class TestMcpMultipleToolCalls:
         )
         assert result3["isError"] is False
         assert isinstance(result3["content"], list)
+
+
+@requires_mcp
+class TestMcpMultiKeyAuthIntegration:
+    """Integration tests for OMN-1419 multi-key auth middleware.
+
+    These tests exercise ``MCPAuthMiddleware`` wrapping a real Starlette
+    application via ``httpx.ASGITransport`` — i.e. a live request/response
+    cycle, not a direct middleware call. This proves that:
+
+    - The canonical ``X-MCP-API-Key`` header is honoured end-to-end.
+    - Multiple configured keys all grant access to the same server instance.
+    - Unknown keys are rejected with HTTP 401.
+    - ``/health`` remains exempt even with auth enabled.
+    """
+
+    @staticmethod
+    def _build_app(api_keys: tuple[str, ...]) -> Starlette:
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        from omnibase_infra.handlers.mcp.transport_streamable_http import (
+            MCPAuthMiddleware,
+        )
+
+        async def _tool_endpoint(_request: object) -> JSONResponse:
+            return JSONResponse({"ok": True})
+
+        async def _health_endpoint(_request: object) -> JSONResponse:
+            return JSONResponse({"status": "healthy"})
+
+        base_app = Starlette(
+            routes=[
+                Route("/mcp/tools", _tool_endpoint, methods=["GET"]),
+                Route("/health", _health_endpoint, methods=["GET"]),
+            ],
+        )
+        # Cast through object to avoid the mypy assignment-from-ASGIApp warning
+        # that the production code also suppresses at the middleware boundary.
+        return MCPAuthMiddleware(base_app, api_keys=api_keys)  # type: ignore[return-value]
+
+    async def test_canonical_x_mcp_api_key_accepted_end_to_end(self) -> None:
+        """A request authenticated via X-MCP-API-Key reaches the inner route."""
+        import httpx
+
+        app = self._build_app(api_keys=("alpha", "beta"))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/mcp/tools", headers={"X-MCP-API-Key": "alpha"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    async def test_second_configured_key_also_accepted(self) -> None:
+        """The second key in the configured tuple authenticates an independent client."""
+        import httpx
+
+        app = self._build_app(api_keys=("alpha", "beta"))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/mcp/tools", headers={"X-MCP-API-Key": "beta"})
+        assert resp.status_code == 200
+
+    async def test_unknown_key_rejected_with_401(self) -> None:
+        """An unknown token yields HTTP 401 with a JSON error body."""
+        import httpx
+
+        app = self._build_app(api_keys=("alpha", "beta"))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get(
+                "/mcp/tools", headers={"X-MCP-API-Key": "not-in-allowlist"}
+            )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body.get("error") == "Unauthorized"
+        assert "X-MCP-API-Key" in body.get("detail", "")
+
+    async def test_health_endpoint_exempt_end_to_end(self) -> None:
+        """/health is reachable without credentials even with auth enabled."""
+        import httpx
+
+        app = self._build_app(api_keys=("alpha",))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "healthy"}

--- a/tests/unit/handlers/mcp/test_transport_streamable_http.py
+++ b/tests/unit/handlers/mcp/test_transport_streamable_http.py
@@ -7,12 +7,17 @@ Tests cover:
 - Request with invalid token is rejected with HTTP 401
 - Request with valid Bearer token is passed through (200 from inner app)
 - Request with valid X-API-Key header is passed through (200 from inner app)
+- Request with valid X-MCP-API-Key header is passed through (OMN-1419)
+- Multiple API keys: any listed key is accepted (OMN-1419)
+- Unknown key is rejected even when other valid keys are configured (OMN-1419)
 - /health endpoint is exempt from auth (200 without credentials)
 - When auth_enabled=False, all requests pass through (no auth check)
 - 401 response body is valid JSON with error key
 - Auth rejection logs include remote_ip and reason
 - Successful auth logs include masked token (last 4 chars)
-- Empty api_key configured on server causes 401 (misconfiguration guard)
+- Empty api_keys configured on server causes 401 (misconfiguration guard)
+- ModelMcpHandlerConfig / ModelMCPServerConfig validators enforce non-empty
+  api_keys when auth_enabled=True (OMN-1419).
 """
 
 from __future__ import annotations
@@ -36,6 +41,7 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 _VALID_KEY = "test-secret-token-abc"
+_VALID_KEY_B = "second-client-token-xyz"
 
 
 def _make_http_scope(
@@ -87,17 +93,13 @@ def _collect_sends() -> tuple[list[dict[str, object]], Send]:
 
 @pytest.mark.asyncio
 async def test_missing_token_returns_401() -> None:
-    """Unauthenticated request to /mcp → 401."""
+    """Unauthenticated request to /mcp -> 401."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
-    await middleware(
-        _make_http_scope(path="/mcp"),
-        receive,
-        send,
-    )
+    await middleware(_make_http_scope(path="/mcp"), receive, send)
 
     assert not inner.called
     assert msgs[0]["status"] == 401
@@ -105,9 +107,9 @@ async def test_missing_token_returns_401() -> None:
 
 @pytest.mark.asyncio
 async def test_invalid_bearer_token_returns_401() -> None:
-    """Wrong Bearer token → 401."""
+    """Wrong Bearer token -> 401."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -120,9 +122,9 @@ async def test_invalid_bearer_token_returns_401() -> None:
 
 @pytest.mark.asyncio
 async def test_invalid_api_key_header_returns_401() -> None:
-    """Wrong X-API-Key → 401."""
+    """Wrong X-API-Key -> 401."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -134,10 +136,25 @@ async def test_invalid_api_key_header_returns_401() -> None:
 
 
 @pytest.mark.asyncio
-async def test_empty_server_api_key_returns_401() -> None:
-    """Server configured with empty api_key is a misconfiguration — reject all."""
+async def test_invalid_mcp_api_key_header_returns_401() -> None:
+    """Wrong X-MCP-API-Key -> 401 (OMN-1419)."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key="")
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    scope = _make_http_scope(headers=[(b"x-mcp-api-key", b"bad-key")])
+    await middleware(scope, receive, send)
+
+    assert not inner.called
+    assert msgs[0]["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_empty_server_api_keys_returns_401() -> None:
+    """Server configured with empty api_keys is a misconfiguration — reject all."""
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=())
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -149,15 +166,15 @@ async def test_empty_server_api_key_returns_401() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tests: valid auth
+# Tests: valid auth - single key
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_valid_bearer_token_passes_through() -> None:
-    """Valid Bearer token → inner app called, 200 returned."""
+    """Valid Bearer token -> inner app called, 200 returned."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -172,9 +189,9 @@ async def test_valid_bearer_token_passes_through() -> None:
 
 @pytest.mark.asyncio
 async def test_valid_x_api_key_passes_through() -> None:
-    """Valid X-API-Key → inner app called, 200 returned."""
+    """Valid X-API-Key (legacy header) -> inner app called, 200 returned."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -183,6 +200,74 @@ async def test_valid_x_api_key_passes_through() -> None:
 
     assert inner.called
     assert msgs[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_valid_x_mcp_api_key_passes_through() -> None:
+    """Valid X-MCP-API-Key -> inner app called, 200 returned (OMN-1419).
+
+    Covers the canonical MCP header required by the ticket contract.
+    """
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    scope = _make_http_scope(headers=[(b"x-mcp-api-key", _VALID_KEY.encode())])
+    await middleware(scope, receive, send)
+
+    assert inner.called
+    assert msgs[0]["status"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: multi-key support (OMN-1419)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_key_first_key_accepted() -> None:
+    """Multiple configured keys: first key authenticates (OMN-1419)."""
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY, _VALID_KEY_B))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    scope = _make_http_scope(headers=[(b"x-mcp-api-key", _VALID_KEY.encode())])
+    await middleware(scope, receive, send)
+
+    assert inner.called
+    assert msgs[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_multi_key_second_key_accepted() -> None:
+    """Multiple configured keys: second key also authenticates (OMN-1419)."""
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY, _VALID_KEY_B))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    scope = _make_http_scope(headers=[(b"x-mcp-api-key", _VALID_KEY_B.encode())])
+    await middleware(scope, receive, send)
+
+    assert inner.called
+    assert msgs[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_multi_key_unknown_key_rejected() -> None:
+    """Multi-key config rejects an unknown token even with valid keys present."""
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY, _VALID_KEY_B))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    scope = _make_http_scope(headers=[(b"x-mcp-api-key", b"not-in-allowlist")])
+    await middleware(scope, receive, send)
+
+    assert not inner.called
+    assert msgs[0]["status"] == 401
 
 
 # ---------------------------------------------------------------------------
@@ -194,15 +279,11 @@ async def test_valid_x_api_key_passes_through() -> None:
 async def test_health_endpoint_exempt_no_credentials() -> None:
     """/health passes through without any auth headers."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
-    await middleware(
-        _make_http_scope(path="/health"),
-        receive,
-        send,
-    )
+    await middleware(_make_http_scope(path="/health"), receive, send)
 
     assert inner.called
     assert msgs[0]["status"] == 200
@@ -217,7 +298,7 @@ async def test_health_endpoint_exempt_no_credentials() -> None:
 async def test_non_http_scope_passes_through() -> None:
     """Lifespan and other non-http scope types are forwarded without auth check."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     _, send = _collect_sends()
     receive = AsyncMock()
 
@@ -231,7 +312,7 @@ async def test_non_http_scope_passes_through() -> None:
 async def test_websocket_scope_passes_through() -> None:
     """WebSocket scopes are forwarded without auth — only HTTP is auth-gated."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     _, send = _collect_sends()
     receive = AsyncMock()
 
@@ -255,7 +336,7 @@ async def test_websocket_scope_passes_through() -> None:
 async def test_401_body_is_valid_json() -> None:
     """401 response body must be valid JSON with an 'error' key."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     msgs, send = _collect_sends()
     receive = AsyncMock()
 
@@ -264,6 +345,8 @@ async def test_401_body_is_valid_json() -> None:
     body_msg = next(m for m in msgs if m.get("type") == "http.response.body")
     body = json.loads(body_msg["body"])
     assert "error" in body
+    # OMN-1419: detail must mention the X-MCP-API-Key header as an option
+    assert "X-MCP-API-Key" in body.get("detail", "")
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +358,7 @@ async def test_401_body_is_valid_json() -> None:
 async def test_auth_failure_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     """Auth rejections must produce a WARNING log with remote_ip and reason."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     receive = AsyncMock()
     _, send = _collect_sends()
 
@@ -285,13 +368,11 @@ async def test_auth_failure_logs_warning(caplog: pytest.LogCaptureFixture) -> No
         await middleware(_make_http_scope(client=("10.0.0.1", 9999)), receive, send)
 
     assert any("MCP auth rejected" in r.message for r in caplog.records)
-    # Check extra fields are present in the log record
     rejection_record = next(
         r for r in caplog.records if "MCP auth rejected" in r.message
     )
     assert hasattr(rejection_record, "remote_ip")
     assert rejection_record.remote_ip == "10.0.0.1"  # type: ignore[attr-defined]
-    # correlation_id must always be present (generated if not supplied by client)
     assert hasattr(rejection_record, "correlation_id")
     assert rejection_record.correlation_id  # type: ignore[attr-defined]
 
@@ -302,7 +383,7 @@ async def test_auth_rejection_includes_client_correlation_id(
 ) -> None:
     """When X-Correlation-ID is supplied, it is propagated in rejection logs."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     receive = AsyncMock()
     _, send = _collect_sends()
 
@@ -323,7 +404,7 @@ async def test_auth_rejection_includes_client_correlation_id(
 async def test_auth_success_logs_masked_token(caplog: pytest.LogCaptureFixture) -> None:
     """Successful auth must log the last 4 chars of the token (masked)."""
     inner = _RecordingApp()
-    middleware = MCPAuthMiddleware(inner, api_key=_VALID_KEY)
+    middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     receive = AsyncMock()
     _, send = _collect_sends()
 
@@ -341,99 +422,80 @@ async def test_auth_success_logs_masked_token(caplog: pytest.LogCaptureFixture) 
         r for r in caplog.records if "MCP auth accepted" in r.message
     )
     assert hasattr(accepted_record, "masked_token")
-    # Last 4 chars of _VALID_KEY = "-abc"
     assert accepted_record.masked_token.endswith(_VALID_KEY[-4:])  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
-# Tests: ModelMcpHandlerConfig auth fields
+# Tests: ModelMcpHandlerConfig auth fields (OMN-1419 multi-key)
 # ---------------------------------------------------------------------------
 
 
-def test_model_mcp_handler_config_auth_defaults() -> None:
-    """ModelMcpHandlerConfig: auth_enabled defaults True, api_key defaults None."""
+def test_model_mcp_handler_config_auth_defaults_rejects_empty_keys() -> None:
+    """auth_enabled defaults True; empty api_keys must now fail validation."""
+    from pydantic import ValidationError
+
     from omnibase_infra.handlers.models.mcp import ModelMcpHandlerConfig
 
-    cfg = ModelMcpHandlerConfig()
-    assert cfg.auth_enabled is True
-    assert cfg.api_key is None
+    with pytest.raises(ValidationError):
+        ModelMcpHandlerConfig()
 
 
-def test_model_mcp_handler_config_auth_disabled() -> None:
-    """ModelMcpHandlerConfig: auth_enabled=False, api_key=None is valid."""
+def test_model_mcp_handler_config_auth_disabled_allows_empty_keys() -> None:
+    """auth_enabled=False keeps empty api_keys valid (local dev)."""
     from omnibase_infra.handlers.models.mcp import ModelMcpHandlerConfig
 
     cfg = ModelMcpHandlerConfig(auth_enabled=False)
     assert cfg.auth_enabled is False
+    assert cfg.api_keys == ()
 
 
-def test_model_mcp_handler_config_api_key_set() -> None:
-    """ModelMcpHandlerConfig: api_key can be set."""
+def test_model_mcp_handler_config_multi_key_set() -> None:
+    """api_keys accepts multiple distinct tokens (OMN-1419)."""
     from omnibase_infra.handlers.models.mcp import ModelMcpHandlerConfig
 
-    cfg = ModelMcpHandlerConfig(auth_enabled=True, api_key="my-secret")
-    assert cfg.api_key == "my-secret"
-
-
-# ---------------------------------------------------------------------------
-# Tests: ModelMCPServerConfig auth fields
-# ---------------------------------------------------------------------------
-
-
-def test_model_mcp_server_config_auth_defaults() -> None:
-    """ModelMCPServerConfig: auth_enabled defaults True, api_key defaults None."""
-    from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
-
-    cfg = ModelMCPServerConfig(consul_host="localhost", consul_port=8500)
-    assert cfg.auth_enabled is True
-    assert cfg.api_key is None
-
-
-def test_model_mcp_server_config_auth_disabled() -> None:
-    """ModelMCPServerConfig: auth_enabled=False is accepted."""
-    from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
-
-    cfg = ModelMCPServerConfig(
-        consul_host="localhost", consul_port=8500, auth_enabled=False
+    cfg = ModelMcpHandlerConfig(
+        auth_enabled=True, api_keys=("alpha-token", "beta-token", "gamma-token")
     )
-    assert cfg.auth_enabled is False
+    assert cfg.api_keys == ("alpha-token", "beta-token", "gamma-token")
 
 
-# ---------------------------------------------------------------------------
-# Tests: HandlerMCP api_key validation
-# ---------------------------------------------------------------------------
+def test_model_mcp_handler_config_rejects_whitespace_key() -> None:
+    """Whitespace-only keys are rejected at validation time."""
+    from pydantic import ValidationError
 
-
-@pytest.mark.asyncio
-async def test_handler_mcp_raises_when_auth_enabled_no_api_key() -> None:
-    """HandlerMCP.initialize raises ProtocolConfigurationError when auth_enabled=True
-    but api_key is not set (prevents silent misconfiguration)."""
-
-    from omnibase_infra.handlers.handler_mcp import HandlerMCP
-
-    handler = HandlerMCP()
-    config: dict[str, object] = {
-        "skip_server": True,
-        "consul_host": "localhost",
-        "consul_port": 8500,
-        "kafka_enabled": False,
-        "dev_mode": True,
-        # auth_enabled defaults to True, api_key not set
-    }
-
-    # skip_server=True skips server startup, so auth validation runs in the
-    # server branch which is bypassed. Use skip_server=False path simulation
-    # via the model-level check. The handler raises when auth_enabled and no key.
-    # Since skip_server=True bypasses the server block, test via auth_enabled=True
-    # without skip_server — but that requires consul which is not available in CI.
-    # Instead test the config model validation directly.
     from omnibase_infra.handlers.models.mcp import ModelMcpHandlerConfig
 
-    cfg = ModelMcpHandlerConfig(auth_enabled=True, api_key=None)
-    assert cfg.auth_enabled is True
-    assert cfg.api_key is None
-    # The api_key=None/empty validation fires during server startup (not skip_server).
-    # Verify the config field accepts None (validation is in initialize()).
-    # A separate integration test with a real server would cover the full path;
-    # the raise is tested by checking the condition in the config.
-    assert not cfg.api_key  # confirms condition that triggers the raise
+    with pytest.raises(ValidationError):
+        ModelMcpHandlerConfig(auth_enabled=True, api_keys=("valid", "   "))
+
+
+# ---------------------------------------------------------------------------
+# Tests: ModelMCPServerConfig auth fields (OMN-1419 multi-key)
+# ---------------------------------------------------------------------------
+
+
+def test_model_mcp_server_config_auth_disabled_allows_empty_keys() -> None:
+    """Server config: auth_enabled=False + empty api_keys is valid."""
+    from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
+
+    cfg = ModelMCPServerConfig(auth_enabled=False)
+    assert cfg.auth_enabled is False
+    assert cfg.api_keys == ()
+
+
+def test_model_mcp_server_config_auth_enabled_requires_keys() -> None:
+    """Server config: auth_enabled=True with no keys raises ValidationError."""
+    from pydantic import ValidationError
+
+    from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
+
+    with pytest.raises(ValidationError):
+        ModelMCPServerConfig(auth_enabled=True)
+
+
+def test_model_mcp_server_config_accepts_multi_key_tuple() -> None:
+    """Server config: api_keys tuple is propagated end-to-end (OMN-1419)."""
+    from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
+
+    cfg = ModelMCPServerConfig(auth_enabled=True, api_keys=("svc-a", "svc-b"))
+    assert cfg.api_keys == ("svc-a", "svc-b")

--- a/tests/unit/handlers/mcp/test_transport_streamable_http.py
+++ b/tests/unit/handlers/mcp/test_transport_streamable_http.py
@@ -14,7 +14,7 @@ Tests cover:
 - When auth_enabled=False, all requests pass through (no auth check)
 - 401 response body is valid JSON with error key
 - Auth rejection logs include remote_ip and reason
-- Successful auth logs include masked token (last 4 chars)
+- Successful auth logs include path + correlation_id (no token derivative)
 - Empty api_keys configured on server causes 401 (misconfiguration guard)
 - ModelMcpHandlerConfig / ModelMCPServerConfig validators enforce non-empty
   api_keys when auth_enabled=True (OMN-1419).
@@ -401,8 +401,13 @@ async def test_auth_rejection_includes_client_correlation_id(
 
 
 @pytest.mark.asyncio
-async def test_auth_success_logs_masked_token(caplog: pytest.LogCaptureFixture) -> None:
-    """Successful auth must log the last 4 chars of the token (masked)."""
+async def test_auth_success_logs_accepted(caplog: pytest.LogCaptureFixture) -> None:
+    """Successful auth must log 'MCP auth accepted' with path and correlation_id.
+
+    No token derivative (even masked) is included in the success log; CodeQL
+    py/clear-text-logging-sensitive-data flags any expression derived from the
+    bearer token value flowing into a logger call.
+    """
     inner = _RecordingApp()
     middleware = MCPAuthMiddleware(inner, api_keys=(_VALID_KEY,))
     receive = AsyncMock()
@@ -421,8 +426,12 @@ async def test_auth_success_logs_masked_token(caplog: pytest.LogCaptureFixture) 
     accepted_record = next(
         r for r in caplog.records if "MCP auth accepted" in r.message
     )
-    assert hasattr(accepted_record, "masked_token")
-    assert accepted_record.masked_token.endswith(_VALID_KEY[-4:])  # type: ignore[attr-defined]
+    # Verify path is logged for audit trail
+    assert hasattr(accepted_record, "path")  # type: ignore[attr-defined]
+    # Verify no token derivative leaks into the log record
+    assert not hasattr(accepted_record, "masked_token"), (
+        "masked_token must not appear in success log (CodeQL clear-text-logging)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/handlers/mcp/test_transport_streamable_http.py
+++ b/tests/unit/handlers/mcp/test_transport_streamable_http.py
@@ -499,3 +499,40 @@ def test_model_mcp_server_config_accepts_multi_key_tuple() -> None:
 
     cfg = ModelMCPServerConfig(auth_enabled=True, api_keys=("svc-a", "svc-b"))
     assert cfg.api_keys == ("svc-a", "svc-b")
+
+
+# ---------------------------------------------------------------------------
+# Tests: MCPAuthMiddleware whitespace-only key filtering (CR thread fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_key_is_rejected_by_middleware() -> None:
+    """MCPAuthMiddleware.__init__ must strip whitespace-only keys.
+
+    Validates the CR-thread fix: even when constructed directly (bypassing
+    Pydantic validators), a whitespace-only key must not grant access.
+    """
+    inner = _RecordingApp()
+    # Construct with a whitespace-only key directly (no Pydantic validation)
+    middleware = MCPAuthMiddleware(inner, api_keys=("   ",))
+    msgs, send = _collect_sends()
+    receive = AsyncMock()
+
+    # A request with the whitespace string as a bearer token must be rejected
+    scope = _make_http_scope(headers=[(b"authorization", b"Bearer    ")])
+    await middleware(scope, receive, send)
+
+    assert not inner.called
+    assert msgs[0]["status"] == 401
+
+
+def test_middleware_filters_whitespace_keys_from_mixed_tuple() -> None:
+    """MCPAuthMiddleware must drop whitespace-only entries from a mixed tuple.
+
+    Ensures that ("real-key", "   ") results in only ("real-key",) being stored.
+    """
+    inner = _RecordingApp()
+    middleware = MCPAuthMiddleware(inner, api_keys=("real-key", "   ", "\t"))
+    # Only the non-whitespace key should remain
+    assert middleware._api_keys == ("real-key",)

--- a/tests/unit/handlers/test_handler_mcp.py
+++ b/tests/unit/handlers/test_handler_mcp.py
@@ -66,6 +66,9 @@ def mcp_test_config() -> dict[str, object]:
         "skip_server": True,
         "kafka_enabled": False,
         "dev_mode": True,
+        # auth disabled in unit tests — auth behavior is covered by
+        # tests/unit/handlers/mcp/test_transport_streamable_http.py
+        "auth_enabled": False,
     }
 
 
@@ -88,6 +91,7 @@ def mcp_custom_config() -> dict[str, object]:
         "skip_server": True,
         "kafka_enabled": False,
         "dev_mode": True,
+        "auth_enabled": False,
     }
 
 
@@ -448,8 +452,9 @@ class TestMcpHandlerConfig:
     """Test suite for ModelMcpHandlerConfig."""
 
     def test_config_defaults(self) -> None:
-        """Test config has correct defaults."""
-        config = ModelMcpHandlerConfig()
+        """Non-auth defaults are preserved (OMN-1419 uses auth_enabled=False to
+        avoid tripping the api_keys validator in this narrow-scope test)."""
+        config = ModelMcpHandlerConfig(auth_enabled=False)
 
         assert config.host == "0.0.0.0"
         assert config.port == 8090
@@ -469,6 +474,7 @@ class TestMcpHandlerConfig:
             json_response=False,
             timeout_seconds=60.0,
             max_tools=50,
+            auth_enabled=False,
         )
 
         assert config.host == "localhost"
@@ -481,7 +487,7 @@ class TestMcpHandlerConfig:
 
     def test_config_is_frozen(self) -> None:
         """Test config is immutable (frozen)."""
-        config = ModelMcpHandlerConfig()
+        config = ModelMcpHandlerConfig(auth_enabled=False)
 
         with pytest.raises(ValidationError):
             config.host = "changed"
@@ -639,7 +645,8 @@ class TestHandlerMCPConfigValidation:
         This test verifies the skip_server path works correctly for unit tests.
         """
         # skip_server=True bypasses the code path that needs kafka_enabled etc.
-        await handler.initialize({"skip_server": True})
+        # auth_enabled=False avoids the OMN-1419 api_keys validator.
+        await handler.initialize({"skip_server": True, "auth_enabled": False})
 
         assert handler._initialized is True
         assert handler._config is not None

--- a/tests/unit/runtime/test_mcp_auth_key_injection.py
+++ b/tests/unit/runtime/test_mcp_auth_key_injection.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for MCP API key injection logic in RuntimeHostProcess.
+
+Tests the key-injection branch at the point where the runtime merges env-var
+derived keys into effective_config for MCP handlers (OMN-1419).
+
+CR-thread fixes verified here:
+- Critical: existing api_keys in effective_config must NOT be overwritten by
+  env-derived keys, and must NOT trigger auth_enabled=False fallback.
+- Critical: malformed MCP_API_KEYS (only whitespace/commas) must not silently
+  disable auth.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Isolated helper that mirrors the injection logic in
+# service_runtime_host_process.py so we can unit-test it without booting a
+# full RuntimeHostProcess.  Keep in sync with the production code path.
+# ---------------------------------------------------------------------------
+
+
+def _simulate_mcp_key_injection(
+    effective_config: dict[str, Any],
+    env: dict[str, str],
+) -> dict[str, Any]:
+    """Mirror of the MCP key-injection block in _initialize_handler_instance.
+
+    Takes an initial effective_config dict and a simulated env mapping, applies
+    the same injection logic, and returns the (possibly mutated) config.
+    """
+    mcp_api_keys_csv = env.get("MCP_API_KEYS") or env.get("ONEX_MCP_API_KEYS")
+    mcp_api_key_single = env.get("MCP_API_KEY") or env.get("ONEX_MCP_API_KEY")
+
+    parsed_keys: tuple[str, ...] | None = None
+    if mcp_api_keys_csv is not None:
+        parsed_keys = tuple(k.strip() for k in mcp_api_keys_csv.split(",") if k.strip())
+    elif mcp_api_key_single is not None:
+        parsed_keys = (
+            (mcp_api_key_single.strip(),) if mcp_api_key_single.strip() else ()
+        )
+
+    if parsed_keys is not None and "api_keys" not in effective_config:
+        effective_config["api_keys"] = parsed_keys
+    elif (
+        "auth_enabled" not in effective_config
+        and not effective_config.get("api_keys")
+        and parsed_keys is None
+    ):
+        effective_config["auth_enabled"] = False
+
+    return effective_config
+
+
+# ---------------------------------------------------------------------------
+# Tests: env-derived keys injected when config has no api_keys
+# ---------------------------------------------------------------------------
+
+
+def test_csv_env_injects_keys() -> None:
+    """MCP_API_KEYS CSV injects parsed tuple into effective_config."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": "alpha,beta,gamma"})
+    assert result["api_keys"] == ("alpha", "beta", "gamma")
+    assert "auth_enabled" not in result
+
+
+def test_single_env_injects_single_key() -> None:
+    """MCP_API_KEY (single) injects a one-element tuple."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEY": "solo-token"})
+    assert result["api_keys"] == ("solo-token",)
+
+
+def test_no_env_no_config_disables_auth() -> None:
+    """With no env vars and no existing config, auth defaults to disabled (local dev)."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {})
+    assert result.get("auth_enabled") is False
+    assert "api_keys" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: existing api_keys in effective_config are preserved (CR thread fix)
+# ---------------------------------------------------------------------------
+
+
+def test_existing_contract_api_keys_not_overwritten_by_env() -> None:
+    """If effective_config already has api_keys, env vars must not override them.
+
+    Covers the critical CR-thread finding: a config pre-populated with api_keys
+    (from contract/runtime config) must not be silently replaced by env-derived keys.
+    """
+    cfg: dict[str, Any] = {"api_keys": ("contract-key-a", "contract-key-b")}
+    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": "injected-key"})
+    # Contract keys must remain intact
+    assert result["api_keys"] == ("contract-key-a", "contract-key-b")
+    # auth_enabled must not have been set to False either
+    assert "auth_enabled" not in result
+
+
+def test_existing_api_keys_prevent_auth_disabled_fallback() -> None:
+    """Existing api_keys in config must block the auth_enabled=False fallback.
+
+    The fail-open path (auth_enabled=False) must only trigger when both
+    env vars are absent AND effective_config has no api_keys.
+    """
+    cfg: dict[str, Any] = {"api_keys": ("existing-key",)}
+    result = _simulate_mcp_key_injection(cfg, {})  # no env vars
+    # auth_enabled must NOT be set to False since api_keys already present
+    assert "auth_enabled" not in result
+    assert result["api_keys"] == ("existing-key",)
+
+
+# ---------------------------------------------------------------------------
+# Tests: malformed MCP_API_KEYS values (CR thread fix — fail-safe, not fail-open)
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_only_csv_yields_empty_tuple() -> None:
+    """MCP_API_KEYS with only whitespace/commas yields an empty parsed_keys tuple.
+
+    The var is set (not None), so parsed_keys != None, but contains no usable tokens.
+    This must NOT trigger the auth_enabled=False fallback.
+    """
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": " , , "})
+    # api_keys set to empty tuple — the Pydantic validator on ModelMcpHandlerConfig
+    # will reject this at initialization time (validator enforces non-empty when
+    # auth_enabled=True), which is the correct fail-fast behavior.
+    assert result.get("api_keys") == ()
+    # auth_enabled must NOT be set to False (env var was present, just malformed)
+    assert "auth_enabled" not in result
+
+
+def test_whitespace_only_single_key_yields_empty_tuple() -> None:
+    """MCP_API_KEY set to whitespace-only yields empty parsed_keys, not auth bypass."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEY": "   "})
+    assert result.get("api_keys") == ()
+    assert "auth_enabled" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: onex alias env vars
+# ---------------------------------------------------------------------------
+
+
+def test_onex_prefix_csv_alias_works() -> None:
+    """ONEX_MCP_API_KEYS (alias) is accepted when MCP_API_KEYS is absent."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"ONEX_MCP_API_KEYS": "x,y"})
+    assert result["api_keys"] == ("x", "y")
+
+
+def test_onex_prefix_single_alias_works() -> None:
+    """ONEX_MCP_API_KEY (alias) is accepted when MCP_API_KEY is absent."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(cfg, {"ONEX_MCP_API_KEY": "z-token"})
+    assert result["api_keys"] == ("z-token",)
+
+
+def test_csv_takes_precedence_over_single() -> None:
+    """When both MCP_API_KEYS and MCP_API_KEY are set, CSV wins (it's checked first)."""
+    cfg: dict[str, Any] = {}
+    result = _simulate_mcp_key_injection(
+        cfg, {"MCP_API_KEYS": "key-a,key-b", "MCP_API_KEY": "single"}
+    )
+    assert result["api_keys"] == ("key-a", "key-b")

--- a/tests/unit/runtime/test_mcp_auth_key_injection.py
+++ b/tests/unit/runtime/test_mcp_auth_key_injection.py
@@ -14,7 +14,6 @@ CR-thread fixes verified here:
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import pytest

--- a/tests/unit/runtime/test_mcp_auth_key_injection.py
+++ b/tests/unit/runtime/test_mcp_auth_key_injection.py
@@ -5,6 +5,10 @@
 Tests the key-injection branch at the point where the runtime merges env-var
 derived keys into effective_config for MCP handlers (OMN-1419).
 
+Exercises the REAL production code path via
+``omnibase_infra.runtime.util_mcp_auth.inject_mcp_api_keys`` (CR thread fix —
+"tests don't execute the production injection path").
+
 CR-thread fixes verified here:
 - Critical: existing api_keys in effective_config must NOT be overwritten by
   env-derived keys, and must NOT trigger auth_enabled=False fallback.
@@ -18,45 +22,9 @@ from typing import Any
 
 import pytest
 
+from omnibase_infra.runtime.util_mcp_auth import inject_mcp_api_keys, parse_mcp_api_keys
+
 pytestmark = pytest.mark.unit
-
-# ---------------------------------------------------------------------------
-# Isolated helper that mirrors the injection logic in
-# service_runtime_host_process.py so we can unit-test it without booting a
-# full RuntimeHostProcess.  Keep in sync with the production code path.
-# ---------------------------------------------------------------------------
-
-
-def _simulate_mcp_key_injection(
-    effective_config: dict[str, Any],
-    env: dict[str, str],
-) -> dict[str, Any]:
-    """Mirror of the MCP key-injection block in _initialize_handler_instance.
-
-    Takes an initial effective_config dict and a simulated env mapping, applies
-    the same injection logic, and returns the (possibly mutated) config.
-    """
-    mcp_api_keys_csv = env.get("MCP_API_KEYS") or env.get("ONEX_MCP_API_KEYS")
-    mcp_api_key_single = env.get("MCP_API_KEY") or env.get("ONEX_MCP_API_KEY")
-
-    parsed_keys: tuple[str, ...] | None = None
-    if mcp_api_keys_csv is not None:
-        parsed_keys = tuple(k.strip() for k in mcp_api_keys_csv.split(",") if k.strip())
-    elif mcp_api_key_single is not None:
-        parsed_keys = (
-            (mcp_api_key_single.strip(),) if mcp_api_key_single.strip() else ()
-        )
-
-    if parsed_keys is not None and "api_keys" not in effective_config:
-        effective_config["api_keys"] = parsed_keys
-    elif (
-        "auth_enabled" not in effective_config
-        and not effective_config.get("api_keys")
-        and parsed_keys is None
-    ):
-        effective_config["auth_enabled"] = False
-
-    return effective_config
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +35,7 @@ def _simulate_mcp_key_injection(
 def test_csv_env_injects_keys() -> None:
     """MCP_API_KEYS CSV injects parsed tuple into effective_config."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": "alpha,beta,gamma"})
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEYS": "alpha,beta,gamma"})
     assert result["api_keys"] == ("alpha", "beta", "gamma")
     assert "auth_enabled" not in result
 
@@ -75,14 +43,14 @@ def test_csv_env_injects_keys() -> None:
 def test_single_env_injects_single_key() -> None:
     """MCP_API_KEY (single) injects a one-element tuple."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEY": "solo-token"})
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEY": "solo-token"})
     assert result["api_keys"] == ("solo-token",)
 
 
 def test_no_env_no_config_disables_auth() -> None:
     """With no env vars and no existing config, auth defaults to disabled (local dev)."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {})
+    result = inject_mcp_api_keys(cfg, {})
     assert result.get("auth_enabled") is False
     assert "api_keys" not in result
 
@@ -99,7 +67,7 @@ def test_existing_contract_api_keys_not_overwritten_by_env() -> None:
     (from contract/runtime config) must not be silently replaced by env-derived keys.
     """
     cfg: dict[str, Any] = {"api_keys": ("contract-key-a", "contract-key-b")}
-    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": "injected-key"})
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEYS": "injected-key"})
     # Contract keys must remain intact
     assert result["api_keys"] == ("contract-key-a", "contract-key-b")
     # auth_enabled must not have been set to False either
@@ -113,7 +81,7 @@ def test_existing_api_keys_prevent_auth_disabled_fallback() -> None:
     env vars are absent AND effective_config has no api_keys.
     """
     cfg: dict[str, Any] = {"api_keys": ("existing-key",)}
-    result = _simulate_mcp_key_injection(cfg, {})  # no env vars
+    result = inject_mcp_api_keys(cfg, {})  # no env vars
     # auth_enabled must NOT be set to False since api_keys already present
     assert "auth_enabled" not in result
     assert result["api_keys"] == ("existing-key",)
@@ -131,7 +99,7 @@ def test_whitespace_only_csv_yields_empty_tuple() -> None:
     This must NOT trigger the auth_enabled=False fallback.
     """
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEYS": " , , "})
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEYS": " , , "})
     # api_keys set to empty tuple — the Pydantic validator on ModelMcpHandlerConfig
     # will reject this at initialization time (validator enforces non-empty when
     # auth_enabled=True), which is the correct fail-fast behavior.
@@ -143,7 +111,7 @@ def test_whitespace_only_csv_yields_empty_tuple() -> None:
 def test_whitespace_only_single_key_yields_empty_tuple() -> None:
     """MCP_API_KEY set to whitespace-only yields empty parsed_keys, not auth bypass."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"MCP_API_KEY": "   "})
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEY": "   "})
     assert result.get("api_keys") == ()
     assert "auth_enabled" not in result
 
@@ -156,21 +124,41 @@ def test_whitespace_only_single_key_yields_empty_tuple() -> None:
 def test_onex_prefix_csv_alias_works() -> None:
     """ONEX_MCP_API_KEYS (alias) is accepted when MCP_API_KEYS is absent."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"ONEX_MCP_API_KEYS": "x,y"})
+    result = inject_mcp_api_keys(cfg, {"ONEX_MCP_API_KEYS": "x,y"})
     assert result["api_keys"] == ("x", "y")
 
 
 def test_onex_prefix_single_alias_works() -> None:
     """ONEX_MCP_API_KEY (alias) is accepted when MCP_API_KEY is absent."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(cfg, {"ONEX_MCP_API_KEY": "z-token"})
+    result = inject_mcp_api_keys(cfg, {"ONEX_MCP_API_KEY": "z-token"})
     assert result["api_keys"] == ("z-token",)
 
 
 def test_csv_takes_precedence_over_single() -> None:
     """When both MCP_API_KEYS and MCP_API_KEY are set, CSV wins (it's checked first)."""
     cfg: dict[str, Any] = {}
-    result = _simulate_mcp_key_injection(
+    result = inject_mcp_api_keys(
         cfg, {"MCP_API_KEYS": "key-a,key-b", "MCP_API_KEY": "single"}
     )
     assert result["api_keys"] == ("key-a", "key-b")
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_mcp_api_keys directly (parser unit coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_returns_none_when_no_env() -> None:
+    """parse_mcp_api_keys returns None when neither env var is present."""
+    assert parse_mcp_api_keys({}) is None
+
+
+def test_parse_returns_empty_tuple_for_whitespace_csv() -> None:
+    """parse_mcp_api_keys returns () for whitespace-only CSV."""
+    assert parse_mcp_api_keys({"MCP_API_KEYS": "  ,  "}) == ()
+
+
+def test_parse_returns_keys_from_csv() -> None:
+    """parse_mcp_api_keys returns stripped keys from CSV."""
+    assert parse_mcp_api_keys({"MCP_API_KEYS": " a , b "}) == ("a", "b")

--- a/tests/unit/runtime/test_mcp_auth_key_injection.py
+++ b/tests/unit/runtime/test_mcp_auth_key_injection.py
@@ -162,3 +162,43 @@ def test_parse_returns_empty_tuple_for_whitespace_csv() -> None:
 def test_parse_returns_keys_from_csv() -> None:
     """parse_mcp_api_keys returns stripped keys from CSV."""
     assert parse_mcp_api_keys({"MCP_API_KEYS": " a , b "}) == ("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# Tests: empty-string env vars must NOT collapse to None (CR thread fix)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_mcp_api_keys_yields_empty_tuple_not_none() -> None:
+    """MCP_API_KEYS='' must be treated as 'set but empty', NOT as absent.
+
+    Using `or` chaining collapses '' to None, which causes inject_mcp_api_keys
+    to hit the auth_enabled=False fallback (fail-open).  The fix uses explicit
+    'in lookup' checks to preserve the distinction.
+    """
+    result = parse_mcp_api_keys({"MCP_API_KEYS": ""})
+    # Must be () (set but malformed), not None (absent)
+    assert result == (), f"Expected () for empty MCP_API_KEYS, got {result!r}"
+
+
+def test_empty_string_mcp_api_key_yields_empty_tuple_not_none() -> None:
+    """MCP_API_KEY='' must be treated as 'set but empty', NOT as absent."""
+    result = parse_mcp_api_keys({"MCP_API_KEY": ""})
+    assert result == (), f"Expected () for empty MCP_API_KEY, got {result!r}"
+
+
+def test_empty_string_does_not_trigger_auth_disabled() -> None:
+    """inject_mcp_api_keys with MCP_API_KEYS='' must NOT set auth_enabled=False.
+
+    The fail-open path must only trigger when the env var is truly absent.
+    An empty string means the operator set the var, so auth_enabled=False
+    would be a silent security regression.
+    """
+    cfg: dict[str, Any] = {}
+    result = inject_mcp_api_keys(cfg, {"MCP_API_KEYS": ""})
+    # api_keys is set to empty tuple — Pydantic validator catches this at init
+    assert result.get("api_keys") == ()
+    # Must NOT have fallen through to auth_enabled=False
+    assert "auth_enabled" not in result, (
+        "auth_enabled=False must not be set when MCP_API_KEYS is present (even if empty)"
+    )

--- a/tests/unit/services/mcp/test_mcp_server_lifecycle.py
+++ b/tests/unit/services/mcp/test_mcp_server_lifecycle.py
@@ -157,6 +157,7 @@ def dev_mode_config(tmp_contracts_dir: Path) -> ModelMCPServerConfig:
         dev_mode=True,
         contracts_dir=str(tmp_contracts_dir),
         kafka_enabled=False,  # Disable Kafka for unit tests
+        auth_enabled=False,  # OMN-1419: unit tests don't exercise auth middleware
     )
 
 
@@ -170,6 +171,7 @@ def production_config() -> ModelMCPServerConfig:
     return ModelMCPServerConfig(
         dev_mode=False,
         kafka_enabled=False,
+        auth_enabled=False,  # OMN-1419: unit tests don't exercise auth middleware
     )
 
 
@@ -664,6 +666,7 @@ class TestDiscoverFromContracts:
             dev_mode=True,
             contracts_dir=str(tmp_path / "nonexistent"),
             kafka_enabled=False,
+            auth_enabled=False,
         )
         lifecycle = MCPServerLifecycle(mock_container, config)
 
@@ -691,6 +694,7 @@ class TestDiscoverFromContracts:
             dev_mode=True,
             contracts_dir=None,
             kafka_enabled=False,
+            auth_enabled=False,
         )
         lifecycle = MCPServerLifecycle(mock_container, config)
 
@@ -1030,11 +1034,11 @@ class TestModelMCPServerConfig:
     def test_default_values(self) -> None:
         """Should have sensible default values with no Consul fields.
 
-        Given: No constructor arguments
-        When: ModelMCPServerConfig is created
-        Then: Default values are set correctly (no consul_host/port/scheme/token)
+        OMN-1419: auth_enabled=False is required here so the model validator
+        (which requires api_keys when auth_enabled=True) does not trip during
+        a defaults-only test.
         """
-        config = ModelMCPServerConfig()
+        config = ModelMCPServerConfig(auth_enabled=False)
 
         assert config.registry_query_limit == 100
         assert config.kafka_enabled is True
@@ -1050,27 +1054,18 @@ class TestModelMCPServerConfig:
         assert not hasattr(config, "consul_token")
 
     def test_dev_mode_config(self) -> None:
-        """Should accept dev_mode and contracts_dir.
-
-        Given: dev_mode=True and contracts_dir specified
-        When: ModelMCPServerConfig is created
-        Then: Values are set correctly
-        """
+        """Should accept dev_mode and contracts_dir."""
         config = ModelMCPServerConfig(
             dev_mode=True,
             contracts_dir="/path/to/contracts",
+            auth_enabled=False,
         )
 
         assert config.dev_mode is True
         assert config.contracts_dir == "/path/to/contracts"
 
     def test_registry_query_limit_config(self) -> None:
-        """Should accept registry_query_limit.
-
-        Given: registry_query_limit=200
-        When: ModelMCPServerConfig is created
-        Then: Value is set correctly
-        """
-        config = ModelMCPServerConfig(registry_query_limit=200)
+        """Should accept registry_query_limit."""
+        config = ModelMCPServerConfig(registry_query_limit=200, auth_enabled=False)
 
         assert config.registry_query_limit == 200


### PR DESCRIPTION
## Summary

Closes OMN-1419 (Urgent) — extends the MCP auth middleware shipped in the prior MCP auth middleware PR to support **multiple concurrently-valid API keys** and the contract-canonical **`X-MCP-API-Key`** header.

Before this PR the MCP server only accepted a single static `api_key` presented via `Authorization: Bearer …` or `X-API-Key …`. OMN-1419 specifically asked for the canonical header name and for per-client / per-service credentials.

## Changes

- `ModelMcpHandlerConfig` / `ModelMCPServerConfig`: replace `api_key: str | None` with `api_keys: tuple[str, ...]`. A `model_validator` rejects empty/whitespace entries and enforces non-empty keys when `auth_enabled=True`.
- `MCPAuthMiddleware`: accepts an iterable of keys, compares with `hmac.compare_digest`, and walks the full list on every request to avoid timing side channels.
- Middleware now also accepts the canonical **`X-MCP-API-Key`** header alongside the existing `Authorization: Bearer` and `X-API-Key` headers.
- `RuntimeHostProcess` mcp config injection: reads `MCP_API_KEYS` / `ONEX_MCP_API_KEYS` (comma-separated) into the new tuple, with fallback to `MCP_API_KEY` / `ONEX_MCP_API_KEY` for single-key deploys.
- `handler_contract.yaml`: flips `authentication.required` to `true`, documents the canonical header, legacy accepted headers, and `multi_key_support: true`.
- Tests: new coverage for X-MCP-API-Key, multi-key allow/deny, whitespace rejection, and the updated validators. Existing MCP unit + lifecycle fixtures updated to pass `auth_enabled=False` (auth behaviour is covered exclusively in `test_transport_streamable_http.py`).

## Test plan

- [x] `uv run pytest tests/unit/handlers tests/unit/services/mcp tests/unit/runtime/config_discovery -q` → **962 passed**
- [x] `uv run ruff check` on all touched paths → clean
- [x] `uv run mypy --strict` on all touched source files → clean
- [x] Pre-commit suite passed (ruff, mypy, ONEX validators, arch layer check)
- [ ] CI green on `gh pr checks --watch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication is now required for MCP tool access.
  * Supports multiple API keys and Bearer token auth; accepts canonical and legacy header formats (including X-MCP-API-Key).
  * Runtime can ingest comma-separated API keys (and aliases) from environment variables.

* **Chores**
  * Configuration validation enforces non-empty keys when auth is enabled; startup fails fast and logs configured key count.

* **Tests**
  * Unit and integration tests added/updated for multi-key, header coverage, injection, health-exempt endpoint, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->