### PR TITLE
fix(deploy-agent): runtime scope must not recreate core infra (OMN-9455)

### DIFF
--- a/docs/runbooks/emergency-runtime-refresh.md
+++ b/docs/runbooks/emergency-runtime-refresh.md
@@ -1,0 +1,102 @@
+# Emergency runtime refresh (OMN-9455)
+
+This runbook captures the **service-targeted runtime refresh** that must be
+used any time the automated deploy-agent pipeline is unavailable or the
+runtime containers need a surgical rebuild that **must not touch core infra**
+(Postgres, Redpanda, Valkey, Infisical, Phoenix).
+
+## When to use this runbook
+
+Use this procedure when any of the following is true:
+
+- The deploy-agent on `.201` is unavailable or wedged.
+- The runtime containers must be rebuilt urgently and there is no
+  corresponding change to core infra.
+- A prior runtime rebuild took core infra offline (OMN-9455) and the
+  operator needs to bring runtime back up without re-recreating core infra.
+
+Do **not** use this runbook for full-stack rebuilds. Use `onex up core runtime`
+(or the `infra-up` + `infra-up-runtime` shell wrappers) for those.
+
+## Why it is separate from the core-infra path
+
+`docker compose up -d --force-recreate` walks the `depends_on` graph unless
+`--no-deps` is supplied. A runtime-only rebuild without `--no-deps` therefore
+collides with the live core infra containers (Postgres/Redpanda/Valkey/
+Infisical) and can leave them half-recreated.
+
+The deploy-agent executor now enforces this separation automatically for
+`Scope.RUNTIME` (see `scripts/deploy-agent/deploy_agent/executor.py`
+`_compose_up`). This runbook is the manual equivalent for the rare cases
+where the deploy-agent is not in the loop.
+
+## Procedure
+
+Run on the host owning the compose project (currently `.201`):
+
+```bash
+cd /data/omninode/omnibase_infra
+
+# 1. Rebuild the runtime image(s) only — no core-infra rebuild.
+docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
+  --profile runtime build
+
+# 2. Recreate ONLY the runtime services. --no-deps prevents compose from
+#    touching the core infra containers via depends_on.
+docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
+  up -d --no-deps --force-recreate \
+  omninode-runtime \
+  runtime-effects \
+  runtime-worker \
+  agent-actions-consumer \
+  skill-lifecycle-consumer \
+  context-audit-consumer \
+  intelligence-migration \
+  intelligence-api \
+  omninode-contract-resolver \
+  autoheal
+
+# 3. Verify the runtime services reached running state without disturbing
+#    core infra.
+docker ps --format '{{.Names}}\t{{.State}}\t{{.Status}}' | \
+  grep -E 'omninode-runtime|runtime-effects|runtime-worker|agent-actions|skill-lifecycle|context-audit|intelligence-migration|intelligence-api|contract-resolver|autoheal'
+
+# 4. Confirm core infra is still the original containers (no restart/recreate).
+docker ps --format '{{.Names}}\t{{.RunningFor}}' | \
+  grep -E 'omnibase-infra-postgres|omnibase-infra-redpanda|omnibase-infra-valkey|omnibase-infra-infisical|omnibase-infra-phoenix'
+```
+
+Core infra container `RunningFor` values in step 4 should be older than the
+start of this procedure. If any core infra container has a fresh `RunningFor`
+value, the procedure recreated core infra (bug) — check that `--no-deps` was
+actually passed and report a regression against OMN-9455.
+
+## Subset refresh
+
+To refresh a specific runtime subset (for example, just the consumer pods),
+pass the subset to step 2 instead of the full runtime list:
+
+```bash
+docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
+  up -d --no-deps --force-recreate \
+  omninode-runtime runtime-effects
+```
+
+## Recovery after an accidental full runtime rebuild
+
+If a runtime rebuild was performed without `--no-deps` and broke core infra:
+
+1. Stop the half-recreated core infra containers:
+   ```bash
+   docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
+     stop postgres redpanda valkey infisical phoenix
+   ```
+2. Bring core infra back cleanly:
+   ```bash
+   docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
+     --profile core up -d --force-recreate \
+     postgres redpanda valkey infisical
+   ```
+3. Re-run the runtime refresh procedure above.
+4. File a Linear ticket citing OMN-9455 with the compose command that was
+   actually executed.

--- a/docs/runbooks/emergency-runtime-refresh.md
+++ b/docs/runbooks/emergency-runtime-refresh.md
@@ -95,7 +95,7 @@ If a runtime rebuild was performed without `--no-deps` and broke core infra:
    ```bash
    docker compose -f docker/docker-compose.infra.yml -p omnibase-infra \
      --profile core up -d --force-recreate \
-     postgres redpanda valkey infisical
+     postgres redpanda valkey infisical phoenix
    ```
 3. Re-run the runtime refresh procedure above.
 4. File a Linear ticket citing OMN-9455 with the compose command that was

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -47,6 +47,29 @@ PHASE_TIMEOUTS = {
 PhaseCallback = Callable[[Phase, PhaseStatus], None]
 
 
+def _requested_services_for_up(scope: Scope, services: list[str]) -> list[str]:
+    """Return the explicit service list compose should recreate for this scope.
+
+    Runtime scope must always target the runtime service list directly so a
+    runtime-only rebuild cannot recreate core infra dependencies via compose's
+    dependency graph. Core and full scopes retain the historical behavior
+    (compose chooses services from the active profile) by returning an empty
+    list when no explicit service selection was provided.
+
+    OMN-9455: a runtime rebuild on 2026-04-22 invoked ``docker compose
+    --profile runtime up -d --force-recreate --pull always`` without a service
+    list or ``--no-deps``. Compose recreated dependency graph services and
+    collided with the live ``omnibase-infra-infisical`` container, breaking
+    Redpanda/Postgres/Valkey/Phoenix. Forcing an explicit runtime service list
+    combined with ``--no-deps`` in ``_compose_up`` prevents that regression.
+    """
+    if services:
+        return services
+    if scope == Scope.RUNTIME:
+        return services_for_scope(scope)
+    return []
+
+
 def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(
         cmd,
@@ -449,6 +472,7 @@ class DeployExecutor:
         timeout = PHASE_TIMEOUTS.get(phase, 300)
 
         profile = "core" if scope == Scope.CORE else "runtime"
+        requested_services = _requested_services_for_up(scope, services)
         cmd = [
             "docker",
             "compose",
@@ -464,8 +488,13 @@ class DeployExecutor:
             "--pull",
             "always",
         ]
-        if services:
-            cmd.extend(services)
+        # OMN-9455: runtime scope must pass --no-deps so compose cannot recreate
+        # the core infra services (postgres/redpanda/valkey/infisical) declared
+        # as depends_on targets of the runtime services.
+        if scope == Scope.RUNTIME:
+            cmd.append("--no-deps")
+        if requested_services:
+            cmd.extend(requested_services)
 
         result = _run(cmd, timeout=timeout)
         if result.returncode != 0:
@@ -473,7 +502,12 @@ class DeployExecutor:
 
         # Verify containers actually reached running state — docker compose up exits 0
         # even when containers land in Created state (hit twice in production, 01:33 + 04:48).
-        expected = services if services else services_for_scope(scope)
+        # For runtime scope, verification MUST be bounded by the requested runtime
+        # service list so the runtime-only rebuild never implicitly waits on core
+        # infra containers (OMN-9455).
+        expected = (
+            requested_services if requested_services else services_for_scope(scope)
+        )
         logger.info(
             "Verifying %d container(s) reached running state: %s",
             len(expected),

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime-scope compose-up must not recreate core infra (OMN-9455).
+
+Regression tests for the 2026-04-22 incident where a runtime rebuild ran
+``docker compose ... --profile runtime up -d --force-recreate --pull always``
+without ``--no-deps`` and without an explicit service list. Compose walked the
+``depends_on`` graph and collided with the live ``omnibase-infra-infisical``
+container, breaking Redpanda/Postgres/Valkey/Phoenix.
+
+These tests pin:
+
+1. ``Scope.RUNTIME`` includes ``--no-deps`` on the compose-up command.
+2. ``Scope.RUNTIME`` targets the runtime service list explicitly even when the
+   caller passed no services.
+3. Runtime verification polls only the runtime service set (never core infra).
+4. Explicit runtime service subsets are honored verbatim and verification is
+   bounded by that subset.
+5. ``Scope.CORE`` and ``Scope.FULL`` behavior is unchanged (no ``--no-deps`` and
+   no forced runtime service list).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from deploy_agent.events import Phase, PhaseStatus, Scope, services_for_scope
+from deploy_agent.executor import (
+    DeployExecutor,
+    _requested_services_for_up,
+)
+
+
+def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
+    return None
+
+
+def _ok() -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+@pytest.mark.unit
+class TestRequestedServicesForUp:
+    """The helper deciding which services compose-up should target per-scope."""
+
+    def test_runtime_scope_with_empty_services_returns_runtime_service_list(
+        self,
+    ) -> None:
+        assert _requested_services_for_up(Scope.RUNTIME, []) == services_for_scope(
+            Scope.RUNTIME
+        )
+
+    def test_runtime_scope_with_explicit_services_returns_those_services(self) -> None:
+        requested = ["omninode-runtime", "runtime-effects"]
+        assert _requested_services_for_up(Scope.RUNTIME, requested) == requested
+
+    def test_core_scope_with_empty_services_returns_empty_list(self) -> None:
+        # Core behavior unchanged: compose infers services from the active profile.
+        assert _requested_services_for_up(Scope.CORE, []) == []
+
+    def test_core_scope_with_explicit_services_returns_those_services(self) -> None:
+        requested = ["postgres"]
+        assert _requested_services_for_up(Scope.CORE, requested) == requested
+
+    def test_full_scope_with_empty_services_returns_empty_list(self) -> None:
+        # Full-scope behavior unchanged: compose brings up both profiles.
+        assert _requested_services_for_up(Scope.FULL, []) == []
+
+
+@pytest.mark.unit
+class TestRuntimeScopeComposeUp:
+    """Regression tests for the OMN-9455 runtime rebuild incident."""
+
+    def test_runtime_scope_uses_no_deps_and_explicit_runtime_service_list(
+        self,
+    ) -> None:
+        """Runtime rebuild with no explicit services must still target runtime
+        services directly and pass --no-deps so compose cannot walk depends_on
+        into core infra."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch(
+                "deploy_agent.executor.verify_containers_up",
+                return_value=(True, []),
+            ) as mock_verify,
+        ):
+            executor._compose_up(
+                Phase.RUNTIME,
+                Scope.RUNTIME,
+                [],
+                _noop_phase_update,
+            )
+
+        assert captured_cmds, "Expected a docker compose up invocation"
+        compose_cmd = captured_cmds[0]
+        runtime_services = services_for_scope(Scope.RUNTIME)
+
+        assert "--no-deps" in compose_cmd, (
+            "Runtime scope compose up must include --no-deps to prevent "
+            "recreating core infra dependencies (OMN-9455)"
+        )
+        # Core infra must never appear as a targeted service on a runtime rebuild.
+        for core_service in ("postgres", "redpanda", "valkey", "infisical"):
+            assert core_service not in compose_cmd, (
+                f"Core infra service {core_service!r} must not appear in a "
+                "runtime-scope compose up command (OMN-9455)"
+            )
+        # The tail of the command must be exactly the runtime service list.
+        assert compose_cmd[-len(runtime_services) :] == runtime_services, (
+            "Runtime scope compose up must target the explicit runtime service "
+            f"list; got {compose_cmd}"
+        )
+        # Verification must be scoped to the requested runtime services.
+        mock_verify.assert_called_once_with(runtime_services, timeout_s=120)
+
+    def test_runtime_scope_subset_preserves_requested_services_only(self) -> None:
+        """An explicit runtime subset must be targeted verbatim; verification
+        must only wait for that subset."""
+        executor = DeployExecutor()
+        requested = ["omninode-runtime", "runtime-effects"]
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch(
+                "deploy_agent.executor.verify_containers_up",
+                return_value=(True, []),
+            ) as mock_verify,
+        ):
+            executor._compose_up(
+                Phase.RUNTIME,
+                Scope.RUNTIME,
+                requested,
+                _noop_phase_update,
+            )
+
+        compose_cmd = captured_cmds[0]
+
+        assert "--no-deps" in compose_cmd
+        assert compose_cmd[-len(requested) :] == requested
+        mock_verify.assert_called_once_with(requested, timeout_s=120)
+
+
+@pytest.mark.unit
+class TestCoreAndFullScopeComposeUp:
+    """Core and full-scope compose-up behavior must remain unchanged."""
+
+    def test_core_scope_does_not_use_no_deps(self) -> None:
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch(
+                "deploy_agent.executor.verify_containers_up",
+                return_value=(True, []),
+            ) as mock_verify,
+        ):
+            executor._compose_up(
+                Phase.CORE,
+                Scope.CORE,
+                [],
+                _noop_phase_update,
+            )
+
+        compose_cmd = captured_cmds[0]
+        core_services = services_for_scope(Scope.CORE)
+
+        assert "--no-deps" not in compose_cmd, (
+            "Core scope compose up must NOT include --no-deps (OMN-9455 is "
+            "scoped to runtime only)"
+        )
+        # Core scope with empty services must leave service selection to the
+        # active profile — no explicit services should be appended.
+        assert "--profile" in compose_cmd
+        profile_idx = compose_cmd.index("--profile")
+        assert compose_cmd[profile_idx + 1] == "core"
+        # Last positional tokens must be the compose flags, not service names.
+        assert compose_cmd[-1] == "always", (
+            "Core scope with empty services must not append explicit service "
+            f"names to compose up; got {compose_cmd}"
+        )
+        # Verification uses the scope default list when no explicit services
+        # were requested.
+        mock_verify.assert_called_once_with(core_services, timeout_s=120)
+
+    def test_core_scope_honors_explicit_service_subset(self) -> None:
+        executor = DeployExecutor()
+        requested = ["postgres"]
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _ok()
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch(
+                "deploy_agent.executor.verify_containers_up",
+                return_value=(True, []),
+            ) as mock_verify,
+        ):
+            executor._compose_up(
+                Phase.CORE,
+                Scope.CORE,
+                requested,
+                _noop_phase_update,
+            )
+
+        compose_cmd = captured_cmds[0]
+
+        assert "--no-deps" not in compose_cmd
+        assert compose_cmd[-len(requested) :] == requested
+        mock_verify.assert_called_once_with(requested, timeout_s=120)


### PR DESCRIPTION
## Summary

Fixes the deploy-agent so that a `Scope.RUNTIME` rebuild cannot recreate core
infra containers via compose's `depends_on` graph. On 2026-04-22 a runtime
rebuild executed `docker compose --profile runtime up -d --force-recreate
--pull always` without `--no-deps` and without an explicit service list.
Compose recreated the core infra dependencies, collided with the live
`omnibase-infra-infisical` container, and left Redpanda/Postgres/Valkey/
Phoenix partially broken.

## Change

`scripts/deploy-agent/deploy_agent/executor.py`:

- New helper `_requested_services_for_up(scope, services)` forces the runtime
  service list to be explicit when `scope == Scope.RUNTIME` and no services
  were supplied; core/full behavior is unchanged.
- `_compose_up` now appends `--no-deps` iff `scope == Scope.RUNTIME`.
- Runtime container verification (`verify_containers_up`) is bounded by the
  requested runtime service set, so runtime-only rebuilds never implicitly
  wait on core infra.

`docs/runbooks/emergency-runtime-refresh.md` (new): documents the manual
service-targeted runtime refresh that worked during recovery, so operators
have a runbook when the deploy-agent is out of the loop.

## Tests

`scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py` (new,
9 tests, all passing) pin:

- `--no-deps` is present on runtime compose-up and **absent** on core
  compose-up.
- Runtime scope targets the explicit runtime service list even when the
  caller supplies no services.
- Runtime verification is called with exactly the requested runtime services.
- Runtime compose-up never mentions `postgres`/`redpanda`/`valkey`/
  `infisical`.
- Runtime subsets are honored verbatim (command tail matches the subset, and
  verification is scoped to the subset).
- `Scope.CORE` explicit service subsets are honored without `--no-deps`.

The 5 helper-level cases for `_requested_services_for_up` pin the per-scope
semantics directly (runtime with empty services returns full runtime list,
core/full with empty services return empty, any scope with explicit services
returns those services verbatim).

Test evidence:

```
tests/unit/test_executor_runtime_scope.py::TestRequestedServicesForUp::test_runtime_scope_with_empty_services_returns_runtime_service_list PASSED
tests/unit/test_executor_runtime_scope.py::TestRequestedServicesForUp::test_runtime_scope_with_explicit_services_returns_those_services PASSED
tests/unit/test_executor_runtime_scope.py::TestRequestedServicesForUp::test_core_scope_with_empty_services_returns_empty_list PASSED
tests/unit/test_executor_runtime_scope.py::TestRequestedServicesForUp::test_core_scope_with_explicit_services_returns_those_services PASSED
tests/unit/test_executor_runtime_scope.py::TestRequestedServicesForUp::test_full_scope_with_empty_services_returns_empty_list PASSED
tests/unit/test_executor_runtime_scope.py::TestRuntimeScopeComposeUp::test_runtime_scope_uses_no_deps_and_explicit_runtime_service_list PASSED
tests/unit/test_executor_runtime_scope.py::TestRuntimeScopeComposeUp::test_runtime_scope_subset_preserves_requested_services_only PASSED
tests/unit/test_executor_runtime_scope.py::TestCoreAndFullScopeComposeUp::test_core_scope_does_not_use_no_deps PASSED
tests/unit/test_executor_runtime_scope.py::TestCoreAndFullScopeComposeUp::test_core_scope_honors_explicit_service_subset PASSED
9 passed in 0.09s
```

Full deploy-agent suite: 65 passed.

## Definition of Done

- [x] `Scope.RUNTIME` compose-up path includes `--no-deps`
- [x] Runtime rebuild targets only the requested runtime service set
- [x] `Scope.CORE` and `Scope.FULL` behavior remain unchanged
- [x] Unit tests pin the runtime compose command shape
- [x] Unit tests prove runtime verification checks only requested runtime services
- [x] Emergency fallback runbook written down in-repo (`docs/runbooks/emergency-runtime-refresh.md`)
- [ ] Runtime-only rebuild on `.201` completes without recreating core infra containers _(verification after merge + deploy-agent self-update re-exec)_

Linear ticket: https://linear.app/omninode/issue/OMN-9455

## Test Plan

- [x] `uv run pytest tests/unit/test_executor_runtime_scope.py -v` passes (9/9)
- [x] `uv run pytest tests/` full deploy-agent suite passes (65/65)
- [x] `pre-commit run --files <changed>` passes
- [x] `ruff format` + `ruff check --fix` clean
- [ ] Post-merge: deploy-agent self-updates on `.201`; first runtime rebuild after self-update must leave core infra containers' `RunningFor` unchanged (see runbook step 4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an operational runbook for emergency runtime refresh with criteria, step-by-step commands, verification checks, subset refresh option, and recovery guidance.

* **Bug Fixes**
  * Runtime-scoped deploys now avoid touching core infrastructure, always skip dependencies, honor explicit runtime subsets, and verify only the requested services.

* **Tests**
  * Added regression tests validating runtime/core deploy isolation and explicit-service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->