### PR TITLE
fix(OMN-9456): single-authority wiring for node_registration_orchestrator dispatchers

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -987,85 +987,44 @@ class ServiceRegistration:
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:
-        """Wire registration dispatchers into the MessageDispatchEngine.
+        """Defer registration dispatcher wiring to generic contract auto-wiring.
 
-        Calls wire_registration_dispatchers() to register 4 dispatchers + 4 routes
-        with the dispatch engine. The engine is frozen by the kernel after all
-        plugins have completed wire_dispatchers().
+        OMN-9456: Establish a single authority for registration dispatcher and
+        route wiring. The generic contract-driven auto-wiring pipeline
+        (``wire_from_manifest``) owns dispatcher and route registration because
+        ``node_registration_orchestrator/contract.yaml`` fully declares the
+        subscribed topics and handler routing.
+
+        Invoking the legacy explicit wiring helper here alongside the generic
+        path caused duplicate dispatcher registrations
+        (``ONEX_CORE_064_DUPLICATE_REGISTRATION`` for
+        ``dispatcher.registration.node-introspected``) on fresh runtime-effects
+        boots. Returning a skipped result keeps the plugin responsible for
+        domain initialization (pools, projectors, schemas, handlers, consumers)
+        while leaving dispatcher and route wiring to the single authoritative
+        contract-driven path.
 
         Args:
-            config: Plugin configuration with container and dispatch_engine.
+            config: Plugin configuration (unused apart from correlation_id).
 
         Returns:
-            Result indicating success/failure.
+            ``ModelDomainPluginResult.skipped`` indicating that generic
+            contract auto-wiring owns dispatcher and route registration.
         """
-        start_time = time.time()
         correlation_id = config.correlation_id
 
-        # Check if service_registry is available
-        if config.container.service_registry is None:
-            logger.warning(
-                "DEGRADED_MODE: ServiceRegistry not available, skipping "
-                "dispatcher wiring (correlation_id=%s)",
-                correlation_id,
-            )
-            return ModelDomainPluginResult.skipped(
-                plugin_id=self.plugin_id,
-                reason="ServiceRegistry not available",
-            )
-
-        if config.dispatch_engine is None:
-            logger.warning(
-                "DEGRADED_MODE: dispatch_engine not available, skipping "
-                "dispatcher wiring (correlation_id=%s)",
-                correlation_id,
-            )
-            return ModelDomainPluginResult.skipped(
-                plugin_id=self.plugin_id,
-                reason="dispatch_engine not available",
-            )
-
-        try:
-            from omnibase_infra.nodes.node_registration_orchestrator.wiring import (
-                wire_registration_dispatchers,
-            )
-
-            dispatch_summary = await wire_registration_dispatchers(
-                container=config.container,
-                engine=config.dispatch_engine,
-                correlation_id=correlation_id,
-                event_bus=config.event_bus,
-            )
-
-            duration = time.time() - start_time
-            logger.info(
-                "Registration dispatchers wired into engine (correlation_id=%s)",
-                correlation_id,
-                extra={
-                    "dispatchers": dispatch_summary.get("dispatchers", []),
-                    "routes": dispatch_summary.get("routes", []),
-                },
-            )
-
-            return ModelDomainPluginResult(
-                plugin_id=self.plugin_id,
-                success=True,
-                message="Registration dispatchers wired into engine",
-                resources_created=list(dispatch_summary.get("dispatchers", [])),
-                duration_seconds=duration,
-            )
-
-        except Exception as e:
-            duration = time.time() - start_time
-            logger.exception(
-                "Failed to wire registration dispatchers (correlation_id=%s)",
-                correlation_id,
-            )
-            return ModelDomainPluginResult.failed(
-                plugin_id=self.plugin_id,
-                error_message=sanitize_error_message(e),
-                duration_seconds=duration,
-            )
+        logger.info(
+            "Registration dispatcher wiring deferred to generic contract "
+            "auto-wiring (OMN-9456) (correlation_id=%s)",
+            correlation_id,
+        )
+        return ModelDomainPluginResult.skipped(
+            plugin_id=self.plugin_id,
+            reason=(
+                "generic contract auto-wiring owns registration dispatchers "
+                "and routes (OMN-9456)"
+            ),
+        )
 
     async def start_consumers(
         self,

--- a/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
+++ b/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for single-authority dispatcher wiring in registration plugin (OMN-9456).
+
+Verifies that the ServiceRegistration plugin's wire_dispatchers() correctly
+defers to generic contract-driven auto-wiring, and that the registration
+contract.yaml declares the subscribe_topics and handler_routing needed for
+auto-wiring to own the dispatcher and route registration.
+
+The duplicate-registration error (ONEX_CORE_064_DUPLICATE_REGISTRATION)
+arose because both the legacy explicit path and the generic contract-driven
+path registered dispatchers for the same contract.  This integration suite
+confirms that:
+
+1. The contract.yaml has the fields that justify auto-wiring ownership.
+2. The plugin can be imported and instantiated without side effects.
+3. No dispatcher registrations happen via the plugin path.
+
+Fixtures from conftest.py:
+    contract_data: parsed YAML content of node_registration_orchestrator/contract.yaml
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestContractDeclaresSubscribeTopics:
+    """The contract must declare event_bus.subscribe_topics — required for auto-wiring ownership.
+
+    The runtime reads event_bus.subscribe_topics to wire consumer subscriptions.
+    Generic auto-wiring owns dispatcher registration for this node because the
+    contract fully declares this field.
+    """
+
+    def test_event_bus_field_exists(self, contract_data: dict) -> None:
+        """contract.yaml must have an event_bus section."""
+        assert "event_bus" in contract_data, (
+            "event_bus section is missing from contract.yaml — "
+            "generic auto-wiring cannot own dispatcher registration without it"
+        )
+
+    def test_subscribe_topics_field_exists(self, contract_data: dict) -> None:
+        """contract.yaml event_bus must have a subscribe_topics list."""
+        event_bus = contract_data.get("event_bus", {})
+        assert "subscribe_topics" in event_bus, (
+            "event_bus.subscribe_topics is missing from contract.yaml — "
+            "generic auto-wiring cannot own dispatcher registration without it"
+        )
+
+    def test_subscribe_topics_is_non_empty(self, contract_data: dict) -> None:
+        """event_bus.subscribe_topics must contain at least one topic string."""
+        topics = contract_data.get("event_bus", {}).get("subscribe_topics", [])
+        assert isinstance(topics, list) and len(topics) > 0, (
+            "event_bus.subscribe_topics must be a non-empty list — "
+            "auto-wiring defers when no subscribe topics are declared"
+        )
+
+    def test_subscribe_topics_follow_naming_convention(
+        self, contract_data: dict
+    ) -> None:
+        """Each subscribe topic must follow the onex.{cmd|evt}.{service}.{event}.v{N} pattern."""
+        topics = contract_data.get("event_bus", {}).get("subscribe_topics", [])
+        for topic in topics:
+            assert topic.startswith("onex."), (
+                f"Topic '{topic}' does not follow the onex.{{cmd|evt}}.*.v{{N}} convention"
+            )
+
+
+class TestContractDeclaresHandlerRouting:
+    """The contract must declare handler_routing — auto-wiring reads this to build routes."""
+
+    def test_handler_routing_field_exists(self, contract_data: dict) -> None:
+        """contract.yaml must have a handler_routing section."""
+        assert "handler_routing" in contract_data, (
+            "handler_routing is missing from contract.yaml — "
+            "auto-wiring cannot build routes without this section"
+        )
+
+    def test_handler_routing_has_handlers(self, contract_data: dict) -> None:
+        """handler_routing.handlers must be a non-empty list."""
+        routing = contract_data.get("handler_routing", {})
+        handlers = routing.get("handlers", [])
+        assert isinstance(handlers, list) and len(handlers) > 0, (
+            "handler_routing.handlers must be a non-empty list"
+        )
+
+
+class TestPluginWireDispatchersNoDuplicateRegistration:
+    """The plugin.wire_dispatchers() must not register any dispatchers or routes directly."""
+
+    def test_plugin_importable(self) -> None:
+        """ServiceRegistration can be imported without side effects."""
+        from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
+            ServiceRegistration,
+        )
+
+        assert ServiceRegistration is not None
+
+    def test_plugin_instantiable(self) -> None:
+        """ServiceRegistration() can be created without arguments or side effects."""
+        from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
+            ServiceRegistration,
+        )
+
+        plugin = ServiceRegistration()
+        assert plugin is not None
+        assert plugin.plugin_id == "registration"
+
+    @pytest.mark.asyncio
+    async def test_wire_dispatchers_skips_without_touching_engine(self) -> None:
+        """wire_dispatchers() returns skipped and does not register against dispatch engine.
+
+        This is the integration-level guard for OMN-9456: the plugin must never
+        directly call register_dispatcher or register_route because doing so
+        alongside the generic auto-wiring path produces duplicate dispatcher IDs.
+        """
+        from dataclasses import dataclass
+        from uuid import uuid4
+
+        from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
+            ServiceRegistration,
+        )
+        from omnibase_infra.runtime.models.model_domain_plugin_config import (
+            ModelDomainPluginConfig,
+        )
+
+        @dataclass
+        class _NodeIdentity:
+            env: str = "test"
+            service: str = "test-service"
+            node_name: str = "test-service"
+            version: str = "v1"
+
+        engine = MagicMock()
+        engine.register_dispatcher = MagicMock()
+        engine.register_route = MagicMock()
+
+        config = ModelDomainPluginConfig(
+            container=MagicMock(),
+            event_bus=MagicMock(),
+            correlation_id=uuid4(),
+            input_topic="onex.evt.platform.node-introspection.v1",
+            output_topic="onex.evt.platform.node-registration-accepted.v1",
+            consumer_group="onex-runtime-integration-test",
+            dispatch_engine=engine,
+            node_identity=_NodeIdentity(),  # type: ignore[arg-type]
+        )
+
+        plugin = ServiceRegistration()
+        result = await plugin.wire_dispatchers(config)
+
+        # Skipped result is a success (kernel treats it as "nothing to do here")
+        assert result.success is True, (
+            "wire_dispatchers() returned a failure result — "
+            "the plugin must return a skipped success to avoid alarming the kernel"
+        )
+
+        # No dispatcher or route was registered via the plugin path
+        engine.register_dispatcher.assert_not_called()
+        engine.register_route.assert_not_called()

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
@@ -21,7 +21,6 @@ invoke the explicit wiring helper.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -34,7 +33,6 @@ from omnibase_infra.runtime.models.model_domain_plugin_config import (
     ModelDomainPluginConfig,
 )
 
-_PLUGIN_MOD = "omnibase_infra.nodes.node_registration_orchestrator.plugin"
 _WIRING_MOD = "omnibase_infra.nodes.node_registration_orchestrator.wiring"
 
 

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ServiceRegistration.wire_dispatchers deferral (OMN-9456).
+
+Verifies that the registration domain plugin defers dispatcher and route
+wiring to the generic contract-driven auto-wiring pipeline, rather than
+calling the legacy explicit ``wire_registration_dispatchers`` helper.
+
+Historical context
+------------------
+Running both the legacy explicit dispatcher wiring path and the generic
+contract auto-wiring path against the same registration contract produced
+``ONEX_CORE_064_DUPLICATE_REGISTRATION`` errors for dispatcher
+``dispatcher.registration.node-introspected`` on fresh runtime-effects boots.
+
+These tests pin the single-authority invariant: the plugin's
+``wire_dispatchers`` method MUST return a skipped result and MUST NOT
+invoke the explicit wiring helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
+    ServiceRegistration,
+)
+from omnibase_infra.runtime.models.model_domain_plugin_config import (
+    ModelDomainPluginConfig,
+)
+
+_PLUGIN_MOD = "omnibase_infra.nodes.node_registration_orchestrator.plugin"
+_WIRING_MOD = "omnibase_infra.nodes.node_registration_orchestrator.wiring"
+
+
+@dataclass
+class _DummyNodeIdentity:
+    """Minimal node identity stand-in; only attribute access is exercised."""
+
+    env: str = "test"
+    service: str = "test-service"
+    node_name: str = "test-service"
+    version: str = "v1"
+
+
+def _make_plugin_config() -> ModelDomainPluginConfig:
+    """Build a plugin config with the fields required by wire_dispatchers().
+
+    The legacy implementation read ``container.service_registry``,
+    ``dispatch_engine``, ``event_bus``, and ``correlation_id`` before
+    delegating to the explicit wiring helper. The deferred implementation
+    only needs ``correlation_id`` for logging; the remaining fields are
+    populated with plausible doubles so the invariant holds regardless of
+    whether the plugin inspects them defensively in the future.
+    """
+    container = MagicMock()
+    container.service_registry = MagicMock()
+    event_bus = MagicMock()
+    dispatch_engine = MagicMock()
+    dispatch_engine.register_dispatcher = MagicMock()
+    dispatch_engine.register_route = MagicMock()
+
+    return ModelDomainPluginConfig(
+        container=container,
+        event_bus=event_bus,
+        correlation_id=uuid4(),
+        input_topic="onex.evt.platform.node-introspection.v1",
+        output_topic="onex.evt.platform.node-registration-accepted.v1",
+        consumer_group="onex-runtime-test",
+        dispatch_engine=dispatch_engine,
+        node_identity=_DummyNodeIdentity(),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_dispatchers_returns_skipped_result() -> None:
+    """wire_dispatchers() must return a skipped success result.
+
+    Generic contract auto-wiring is the single authority for registration
+    dispatchers and routes after OMN-9456; the plugin's wire_dispatchers()
+    is a pass-through.
+    """
+    plugin = ServiceRegistration()
+    config = _make_plugin_config()
+
+    result = await plugin.wire_dispatchers(config)
+
+    # Skipped results carry success=True so the kernel does not treat them
+    # as failure (see ModelDomainPluginResult.skipped semantics).
+    assert result.success is True
+    assert result.plugin_id == "registration"
+    assert result.message.lower().startswith("plugin registration skipped")
+    # The reason must make the single-authority intent explicit for
+    # operators reading kernel logs.
+    reason_lower = result.message.lower()
+    assert "auto-wiring" in reason_lower or "auto wiring" in reason_lower
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_dispatchers_does_not_invoke_legacy_helper() -> None:
+    """wire_dispatchers() must NOT call wire_registration_dispatchers().
+
+    The legacy helper is what registered the colliding
+    ``dispatcher.registration.node-introspected`` dispatcher ID alongside
+    the generic auto-wiring path. Deferring means the helper is not
+    invoked on the kernel-native activation path at all.
+    """
+    plugin = ServiceRegistration()
+    config = _make_plugin_config()
+
+    with patch(
+        f"{_WIRING_MOD}.wire_registration_dispatchers",
+        new=AsyncMock(),
+    ) as mock_legacy_wire:
+        await plugin.wire_dispatchers(config)
+
+    mock_legacy_wire.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_dispatchers_does_not_touch_dispatch_engine() -> None:
+    """wire_dispatchers() must register zero dispatchers and zero routes.
+
+    This guards against regressions where the plugin accidentally
+    reintroduces direct ``dispatch_engine.register_dispatcher`` /
+    ``register_route`` calls — the exact class of bug that produced the
+    duplicate-registration error in OMN-9456.
+    """
+    plugin = ServiceRegistration()
+    config = _make_plugin_config()
+    engine = config.dispatch_engine
+    assert engine is not None  # mypy/runtime guard — see _make_plugin_config
+
+    await plugin.wire_dispatchers(config)
+
+    engine.register_dispatcher.assert_not_called()  # type: ignore[attr-defined]
+    engine.register_route.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_dispatchers_is_idempotent_across_repeat_calls() -> None:
+    """Calling wire_dispatchers() twice is safe — no duplicate registrations.
+
+    The kernel-native activation path invokes registration_service
+    .wire_dispatchers() explicitly; a defensive second call (e.g. from a
+    retry or a test harness) must not cause the duplicate-registration
+    error recorded in the ticket. Because the method is a pure skip, this
+    is trivially true — this test pins the invariant.
+    """
+    plugin = ServiceRegistration()
+    config = _make_plugin_config()
+
+    first = await plugin.wire_dispatchers(config)
+    second = await plugin.wire_dispatchers(config)
+
+    assert first.success is True
+    assert second.success is True
+    engine = config.dispatch_engine
+    assert engine is not None
+    engine.register_dispatcher.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fresh `runtime-effects` boots on 2026-04-22 failed with
`ONEX_CORE_064_DUPLICATE_REGISTRATION: Dispatcher with ID 'dispatcher.registration.node-introspected' is already registered.`
The registration plugin's `wire_dispatchers()` still called the legacy explicit
`wire_registration_dispatchers()` helper alongside the generic contract-driven
auto-wiring path (`wire_from_manifest`). Both paths registered dispatchers and
routes against the same `node_registration_orchestrator/contract.yaml`, producing
duplicate dispatcher IDs and aborting kernel startup.

This change establishes a single authority for registration dispatcher and route
wiring per OMN-9456:

- **Generic contract-driven auto-wiring** owns dispatcher and route registration
  because `contract.yaml` fully declares `subscribe_topics` and `handler_routing`.
- **The registration plugin** continues to own domain initialization (PostgreSQL
  pool, projector discovery, schema init, handler registration, consumer startup).
- `plugin.wire_dispatchers()` is now a pass-through that returns
  `ModelDomainPluginResult.skipped(reason="generic contract auto-wiring owns
  registration dispatchers and routes (OMN-9456)")`. The legacy helper is never
  invoked on the kernel-native activation path.

Scope is deliberately minimal: no handlers, consumers, or domain startup paths
are touched.

## Test plan

- [x] New unit tests in `tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py` pin four invariants:
  - `wire_dispatchers()` returns a skipped success result whose message mentions auto-wiring
  - `wire_registration_dispatchers()` is not called from the plugin path
  - `dispatch_engine.register_dispatcher` / `register_route` are never invoked from the plugin path
  - repeat `wire_dispatchers()` calls remain idempotent so retries cannot resurrect the duplicate-registration error
- [x] `uv run pytest tests/unit/nodes/node_registration_orchestrator/ tests/unit/runtime/test_handshake_validation.py tests/unit/runtime/test_domain_plugin_shutdown.py tests/unit/runtime/test_domain_plugin_discovery_seam.py tests/unit/runtime/test_container_wiring_registration.py` — 427 passed
- [x] `uv run ruff format && uv run ruff check --fix` — clean
- [x] `pre-commit run --files <changed>` — all hooks pass (including mypy, SPDX, arch validation, AI-slop patterns)
- [ ] CI: `reusable-runtime-boot` gate exercises the real omninode-runtime boot in compose sandbox — will confirm `RestartCount == 0` and absence of duplicate-dispatcher logs.

## Related

- Ticket: OMN-9456
- Background: OMN-1346 (Registration Code Extraction), OMN-7115 (kernel-native ServiceRegistration), OMN-9126 (runtime startup as a first-class CI gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dispatcher and route wiring is deferred to a single unified auto-wiring authority; explicit manual wiring paths removed.

* **Tests**
  * Added unit tests verifying deferred/skipped wiring behavior, idempotence, and that legacy wiring is not invoked.
  * Added integration tests asserting contract includes required routing/event_bus sections and that no direct dispatcher/route registration occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[skip-deploy-gate: plugin.py change is dispatcher pass-through only (wire_dispatchers returns skipped result); no Docker image rebuild needed; deploy-agent inactive per OMN-8841]
[skip-receipt-gate: OMN-1346/OMN-7115/OMN-9126 are background context tickets only; primary work ticket is OMN-9456 which has full contract and PASS receipts in onex_change_control]