### PR TITLE
OMN-9457: contain async-incompatible handlers in auto-wiring

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/__init__.py
+++ b/src/omnibase_infra/runtime/auto_wiring/__init__.py
@@ -15,6 +15,9 @@ from omnibase_infra.runtime.auto_wiring.discovery import (
     discover_contracts,
     discover_contracts_from_paths,
 )
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     wire_from_manifest,
 )
@@ -40,9 +43,11 @@ from omnibase_infra.runtime.auto_wiring.report import (
     ModelAutoWiringReport,
     ModelContractWiringResult,
     ModelDuplicateTopicOwnership,
+    ModelQuarantinedWiring,
 )
 
 __all__ = [
+    "EnumQuarantineReason",
     "EnumWiringOutcome",
     "HandshakeFailureReason",
     "LifecycleHookExecutor",
@@ -63,6 +68,7 @@ __all__ = [
     "ModelLifecycleHookResult",
     "ModelLifecycleHooks",
     "ModelQuarantineRecord",
+    "ModelQuarantinedWiring",
     "discover_contracts",
     "discover_contracts_from_paths",
     "wire_from_manifest",

--- a/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
+++ b/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structured reasons for handler quarantine during auto-wiring (OMN-9457).
+
+Distinct from :class:`HandshakeFailureReason` (OMN-7657), which classifies
+failures of the pre-wiring handshake lifecycle hooks. These values classify
+handler construction failures that are deterministically contained by
+auto-wiring so a single async-incompatible handler cannot poison runtime-effects
+boot.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumQuarantineReason(str, Enum):
+    """Structured reasons for auto-wiring handler quarantine.
+
+    Each value maps to a distinct operational response:
+
+    - ``ASYNC_INCOMPATIBLE``: handler construction raised
+      ``RuntimeError: asyncio.run() cannot be called from a running event loop``.
+      The handler relies on ``asyncio.run()`` in its ``__init__`` or a
+      container-resolved dependency, which is incompatible with runtime-managed
+      async boot. Follow-up: convert the handler or its dependency to async-safe
+      construction.
+    """
+
+    ASYNC_INCOMPATIBLE = "async_incompatible"
+
+
+__all__ = ["EnumQuarantineReason"]

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -46,6 +46,9 @@ from omnibase_core.services.service_handler_resolver import ServiceHandlerResolv
 from omnibase_core.services.service_local_handler_ownership_query import (
     ServiceLocalHandlerOwnershipQuery,
 )
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
     ModelDiscoveredContract,
@@ -56,6 +59,7 @@ from omnibase_infra.runtime.auto_wiring.report import (
     ModelAutoWiringReport,
     ModelContractWiringResult,
     ModelDuplicateTopicOwnership,
+    ModelQuarantinedWiring,
     ModelSkippedEntry,
     ModelWiringOutcome,
 )
@@ -92,6 +96,43 @@ def _sanitize_exc(exc: BaseException) -> str:
     raw = str(exc) or type(exc).__name__
     sanitized = _SENSITIVE_PATTERN.sub("<redacted>", raw)
     return sanitized[:200]
+
+
+# Deterministic signature matching ``asyncio.run() cannot be called from a
+# running event loop`` (raised by asyncio.run when invoked from within a
+# thread that already has an active loop). OMN-9457: containment keys on the
+# exact CPython message so best-effort string heuristics are avoided.
+_ASYNC_INCOMPAT_MESSAGES: tuple[str, ...] = (
+    "asyncio.run() cannot be called from a running event loop",
+)
+
+
+def _is_async_incompat_runtime_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` is the deterministic async-incompat signature.
+
+    Matches ``RuntimeError`` raised by CPython's ``asyncio.run()`` when a
+    synchronous handler constructor (or a dependency it resolves) calls
+    ``asyncio.run()`` from within runtime-managed async boot. The signature
+    is an exact substring match against the message emitted by
+    ``asyncio.runners.run`` — the call site that triggers the poisoning
+    behavior described in OMN-9457. Wrapped ``RuntimeError``s raised via
+    ``raise X from original`` are also recognised by walking ``__cause__``
+    and ``__context__``.
+    """
+    visited: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if isinstance(current, RuntimeError):
+            message = str(current)
+            if any(needle in message for needle in _ASYNC_INCOMPAT_MESSAGES):
+                return True
+        # Walk __cause__ first (explicit `raise X from Y`), then
+        # __context__ (implicit propagation during handling). Either can
+        # carry the original asyncio.run() failure when the handler's
+        # constructor wraps it in a RuntimeError of its own.
+        current = current.__cause__ or current.__context__
+    return False
 
 
 async def _async_resolve_from_container(
@@ -143,6 +184,9 @@ class PreparedWiring:
     wiring never reaches the engine on later failure (OMN-8735).
     ``resolution_outcome`` / ``handler_name`` / ``skip_reason`` carry the
     resolver's per-handler outcome into the wiring report (OMN-9201).
+    ``quarantine_reason`` / ``quarantine_detail`` / ``handler_module`` carry
+    OMN-9457 containment state when handler construction deterministically
+    failed with an async-incompatible signature.
     """
 
     dispatcher_id: str
@@ -150,10 +194,13 @@ class PreparedWiring:
     category: EnumMessageCategory
     message_types: set[str] | None
     handler_name: str = ""
+    handler_module: str = ""
     resolution_outcome: EnumHandlerResolutionOutcome = (
         EnumHandlerResolutionOutcome.UNRESOLVABLE
     )
     skip_reason: str = ""
+    quarantine_reason: EnumQuarantineReason | None = None
+    quarantine_detail: str = ""
     route_ids: list[str] = field(default_factory=list)
     routes: list[ModelDispatchRoute] = field(default_factory=list)
 
@@ -163,6 +210,11 @@ class PreparedWiring:
             self.resolution_outcome
             is EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
         )
+
+    @property
+    def is_quarantined(self) -> bool:
+        """True when OMN-9457 containment fired for this handler."""
+        return self.quarantine_reason is not None
 
 
 @dataclass
@@ -724,16 +776,42 @@ async def wire_from_manifest(
             dup.level,
         )
 
+    # OMN-9457: flatten per-contract quarantines into a report-level list so
+    # callers can enumerate every contained handler without walking every
+    # result. Order mirrors the per-contract scan so the flat list is
+    # deterministic across runs.
+    all_quarantined: list[ModelQuarantinedWiring] = []
+    for result in results:
+        all_quarantined.extend(result.quarantined_handlers)
+
     report = ModelAutoWiringReport(
         results=tuple(results),
         duplicates=tuple(duplicates),
+        quarantined_handlers=tuple(all_quarantined),
     )
 
+    if all_quarantined:
+        # High-visibility summary: operators tailing runtime-effects logs
+        # on first boot need to see the quarantined set without digging
+        # through per-contract DEBUG lines.
+        summary = ", ".join(
+            f"{q.contract_name}:{q.handler_name}={q.reason.value}"
+            for q in all_quarantined
+        )
+        logger.warning(
+            "Auto-wiring quarantined %d handler(s) — runtime will continue "
+            "without them. Follow-up migration required: %s",
+            len(all_quarantined),
+            summary,
+        )
+
     logger.info(
-        "Auto-wiring complete: wired=%d skipped=%d failed=%d duplicates=%d",
+        "Auto-wiring complete: wired=%d skipped=%d failed=%d "
+        "quarantined=%d duplicates=%d",
         report.total_wired,
         report.total_skipped,
         report.total_failed,
+        report.total_quarantined,
         len(report.duplicates),
     )
 
@@ -850,10 +928,23 @@ async def _commit_contract_wiring(
     topics_subscribed: list[str] = []
     wirings: list[ModelWiringOutcome] = []
     skipped_handlers: list[ModelSkippedEntry] = []
+    quarantined: list[ModelQuarantinedWiring] = []
 
     for prepared in pcw.prepared_wirings:
         dispatcher_id, route_ids = _commit_handler_wiring(prepared, dispatch_engine)
-        if prepared.is_skip:
+        if prepared.is_quarantined:
+            assert prepared.quarantine_reason is not None  # narrow for mypy
+            quarantined.append(
+                ModelQuarantinedWiring(
+                    contract_name=contract.name,
+                    package_name=contract.package_name,
+                    handler_module=prepared.handler_module,
+                    handler_name=prepared.handler_name,
+                    reason=prepared.quarantine_reason,
+                    detail=prepared.quarantine_detail,
+                )
+            )
+        elif prepared.is_skip:
             skipped_handlers.append(
                 ModelSkippedEntry(
                     handler_name=prepared.handler_name,
@@ -904,6 +995,24 @@ async def _commit_contract_wiring(
                 contract.name,
             )
 
+    # OMN-9457: when every handler was quarantined, report SKIPPED — there
+    # is nothing wired on the dispatch engine. Otherwise the contract is
+    # WIRED and quarantined handlers travel alongside the success in the
+    # dedicated report field so they remain visible for follow-up migration.
+    has_live_handler = any(
+        not (p.is_quarantined or p.is_skip) for p in pcw.prepared_wirings
+    )
+    if pcw.prepared_wirings and not has_live_handler and quarantined:
+        return ModelContractWiringResult(
+            contract_name=contract.name,
+            package_name=contract.package_name,
+            outcome=EnumWiringOutcome.SKIPPED,
+            reason="all handlers quarantined",
+            wirings=tuple(wirings),
+            skipped_handlers=tuple(skipped_handlers),
+            quarantined_handlers=tuple(quarantined),
+        )
+
     return ModelContractWiringResult(
         contract_name=contract.name,
         package_name=contract.package_name,
@@ -913,6 +1022,7 @@ async def _commit_contract_wiring(
         topics_subscribed=tuple(topics_subscribed),
         wirings=tuple(wirings),
         skipped_handlers=tuple(skipped_handlers),
+        quarantined_handlers=tuple(quarantined),
     )
 
 
@@ -1004,6 +1114,50 @@ def _prepare_handler_wiring(
         pre_resolved_handlers.get(handler_ref.name) if pre_resolved_handlers else None
     )
 
+    # Determine category up-front so the quarantine sentinel below (which
+    # bypasses the regular resolve/construct path) can still carry consistent
+    # reporting metadata.
+    _category_str_early = "EVENT"
+    if contract.event_bus and contract.event_bus.subscribe_topics:
+        _category_str_early = _derive_message_category(
+            contract.event_bus.subscribe_topics[0]
+        )
+    _early_category = EnumMessageCategory(_category_str_early)
+
+    def _quarantine_prepared(exc: BaseException) -> PreparedWiring:
+        """Return a containment-only PreparedWiring for an async-incompat handler.
+
+        OMN-9457: the handler's constructor raised ``RuntimeError: asyncio.run()
+        cannot be called from a running event loop``. We deterministically
+        contain it — no dispatcher / route registration — and surface it on the
+        wiring report so follow-up migration is visible rather than
+        partially-broken runtime state.
+        """
+        detail = _sanitize_exc(exc)
+        logger.warning(
+            "Auto-wiring: quarantining async-incompatible handler %s.%s "
+            "(contract=%s, package=%s): %s. Runtime-effects boot will "
+            "continue; convert the handler to async-safe construction to "
+            "re-enable it.",
+            handler_ref.module,
+            handler_ref.name,
+            contract.name,
+            contract.package_name,
+            detail,
+        )
+        return PreparedWiring(
+            dispatcher_id="",
+            dispatcher=_skip_dispatcher,
+            category=_early_category,
+            message_types=None,
+            handler_name=handler_ref.name,
+            handler_module=handler_ref.module,
+            resolution_outcome=EnumHandlerResolutionOutcome.UNRESOLVABLE,
+            skip_reason=f"quarantined:{EnumQuarantineReason.ASYNC_INCOMPATIBLE.value}",
+            quarantine_reason=EnumQuarantineReason.ASYNC_INCOMPATIBLE,
+            quarantine_detail=detail,
+        )
+
     if pre_resolved_instance is not None:
         resolution = ModelHandlerResolution(
             outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
@@ -1029,14 +1183,19 @@ def _prepare_handler_wiring(
             container=_effective_container,
             ownership_query=ownership_query,
         )
-        resolution = resolver.resolve(ctx)
+        try:
+            resolution = resolver.resolve(ctx)
+        except RuntimeError as exc:
+            # OMN-9457: deterministic containment for handlers whose
+            # construction path calls asyncio.run() inside runtime-managed
+            # async boot. Any other RuntimeError propagates unchanged.
+            if _is_async_incompat_runtime_error(exc):
+                return _quarantine_prepared(exc)
+            raise
 
-    # Determine category + message types up-front; both skip and non-skip
-    # paths carry them on PreparedWiring for deterministic reporting.
-    category_str = "EVENT"
-    if contract.event_bus and contract.event_bus.subscribe_topics:
-        category_str = _derive_message_category(contract.event_bus.subscribe_topics[0])
-    category = EnumMessageCategory(category_str)
+    # _early_category was computed up-front so the quarantine sentinel could
+    # carry consistent reporting metadata; reuse it here for the live path.
+    category = _early_category
 
     message_types: set[str] | None = None
     if entry.event_model is not None:
@@ -1064,6 +1223,7 @@ def _prepare_handler_wiring(
             category=category,
             message_types=message_types,
             handler_name=handler_ref.name,
+            handler_module=handler_ref.module,
             resolution_outcome=resolution.outcome,
             skip_reason=resolution.skipped_reason,
         )
@@ -1118,6 +1278,7 @@ def _prepare_handler_wiring(
         category=category,
         message_types=message_types,
         handler_name=handler_ref.name,
+        handler_module=handler_ref.module,
         resolution_outcome=resolution.outcome,
         route_ids=route_ids,
         routes=routes,
@@ -1136,13 +1297,16 @@ def _commit_handler_wiring(
 
     Skip entries (``prepared.is_skip``) are no-ops — the resolver emitted
     ``RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP`` for this handler, so nothing is
-    registered on the dispatch engine (OMN-9201).
+    registered on the dispatch engine (OMN-9201). Quarantined entries
+    (``prepared.is_quarantined``) are also no-ops — OMN-9457 containment
+    keeps async-incompatible handlers off the dispatch engine so they
+    cannot poison runtime-effects boot.
 
     Returns:
         Tuple of (dispatcher_id, list of route_ids registered). Returns
-        ``("", [])`` for skip entries.
+        ``("", [])`` for skip / quarantined entries.
     """
-    if prepared.is_skip:
+    if prepared.is_skip or prepared.is_quarantined:
         return "", []
 
     from omnibase_infra.runtime.service_message_dispatch_engine import (

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -98,40 +98,68 @@ def _sanitize_exc(exc: BaseException) -> str:
     return sanitized[:200]
 
 
-# Deterministic signature matching ``asyncio.run() cannot be called from a
-# running event loop`` (raised by asyncio.run when invoked from within a
-# thread that already has an active loop). OMN-9457: containment keys on the
-# exact CPython message so best-effort string heuristics are avoided.
+# Deterministic signatures raised by CPython when ``asyncio.run`` /
+# ``asyncio.Runner`` is invoked from inside an already-running event loop.
+# OMN-9457 keys containment on the exact messages so best-effort string
+# heuristics are avoided. Messages were verified empirically against CPython
+# 3.11 / 3.12 source (the runtime target) and confirmed by inspecting
+# ``asyncio.runners`` at runtime (asyncio/runners.py).
+#
+# CPython behaviour (3.11 / 3.12, verified from source):
+#   * ``asyncio.run(coro)``
+#     -> "asyncio.run() cannot be called from a running event loop"
+#     (raised at the if-running-loop guard in asyncio/runners.py::run().)
+#   * ``asyncio.Runner.run(coro)`` when another loop is active
+#     -> "Runner.run() cannot be called from a running event loop"
+#     (raised from asyncio/runners.py::Runner.run().)
+#   * ``BaseEventLoop.run_until_complete`` nested call
+#     -> "Cannot run the event loop while another loop is running"
+#     (raised from asyncio/base_events.py::run_until_complete().)
+#
+# All three variants are matched because handlers may call any of these entry
+# points, directly or transitively (e.g. a sync client that drives an async
+# call with ``asyncio.run`` or ``asyncio.Runner``).
 _ASYNC_INCOMPAT_MESSAGES: tuple[str, ...] = (
     "asyncio.run() cannot be called from a running event loop",
+    "Runner.run() cannot be called from a running event loop",
+    "Cannot run the event loop while another loop is running",
 )
 
 
 def _is_async_incompat_runtime_error(exc: BaseException) -> bool:
     """Return True if ``exc`` is the deterministic async-incompat signature.
 
-    Matches ``RuntimeError`` raised by CPython's ``asyncio.run()`` when a
-    synchronous handler constructor (or a dependency it resolves) calls
-    ``asyncio.run()`` from within runtime-managed async boot. The signature
-    is an exact substring match against the message emitted by
-    ``asyncio.runners.run`` — the call site that triggers the poisoning
-    behavior described in OMN-9457. Wrapped ``RuntimeError``s raised via
-    ``raise X from original`` are also recognised by walking ``__cause__``
-    and ``__context__``.
+    Matches ``RuntimeError`` raised by CPython's ``asyncio.run`` /
+    ``asyncio.Runner.run`` when a synchronous handler constructor (or a
+    dependency it resolves) calls ``asyncio.run()`` from within
+    runtime-managed async boot. The detector walks the full exception
+    chain — ``__cause__`` and ``__context__`` — because wrapped
+    ``RuntimeError``s raised via ``raise X from original`` or propagated
+    implicitly during handling may carry the original asyncio failure on
+    either attribute (and per PEP 3134 both can be set simultaneously).
+    Matching uses exact substring presence against the known CPython
+    messages only, so unrelated ``RuntimeError``s are never misclassified.
     """
     visited: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in visited:
+    stack: list[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None or id(current) in visited:
+            continue
         visited.add(id(current))
         if isinstance(current, RuntimeError):
             message = str(current)
             if any(needle in message for needle in _ASYNC_INCOMPAT_MESSAGES):
                 return True
-        # Walk __cause__ first (explicit `raise X from Y`), then
-        # __context__ (implicit propagation during handling). Either can
-        # carry the original asyncio.run() failure when the handler's
-        # constructor wraps it in a RuntimeError of its own.
-        current = current.__cause__ or current.__context__
+        # Explore BOTH branches of the exception chain. Per PEP 3134 an
+        # exception may carry ``__cause__`` (explicit ``raise X from Y``)
+        # and ``__context__`` (implicit propagation during handling)
+        # simultaneously; skipping one branch can hide the original
+        # asyncio failure when the handler constructor wraps it.
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        if current.__context__ is not None:
+            stack.append(current.__context__)
     return False
 
 
@@ -995,14 +1023,20 @@ async def _commit_contract_wiring(
                 contract.name,
             )
 
-    # OMN-9457: when every handler was quarantined, report SKIPPED — there
-    # is nothing wired on the dispatch engine. Otherwise the contract is
-    # WIRED and quarantined handlers travel alongside the success in the
-    # dedicated report field so they remain visible for follow-up migration.
-    has_live_handler = any(
-        not (p.is_quarantined or p.is_skip) for p in pcw.prepared_wirings
+    # OMN-9457: when every prepared handler was quarantined, report SKIPPED
+    # with reason "all handlers quarantined" — there is nothing wired on
+    # the dispatch engine and the quarantine is the reason. A mixed
+    # contract where some handlers were resolver-skipped (not quarantined)
+    # and the rest quarantined does NOT take this path: "all handlers
+    # quarantined" must mean *every* handler quarantined, not "no live
+    # handlers and at least one quarantined". Mixed skip+quarantine
+    # contracts fall through to the normal WIRED return below so the
+    # existing resolver-skip reasoning remains authoritative for the
+    # skipped handlers.
+    all_handlers_quarantined = bool(pcw.prepared_wirings) and all(
+        p.is_quarantined for p in pcw.prepared_wirings
     )
-    if pcw.prepared_wirings and not has_live_handler and quarantined:
+    if all_handlers_quarantined:
         return ModelContractWiringResult(
             contract_name=contract.name,
             package_name=contract.package_name,

--- a/src/omnibase_infra/runtime/auto_wiring/report.py
+++ b/src/omnibase_infra/runtime/auto_wiring/report.py
@@ -21,6 +21,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from omnibase_core.enums.enum_handler_resolution_outcome import (
     EnumHandlerResolutionOutcome,
 )
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
 
 
 class EnumWiringOutcome(str, Enum):
@@ -73,6 +76,40 @@ class ModelSkippedEntry(BaseModel):
     reason: str = Field(..., description="Skip reason (human-readable)")
 
 
+class ModelQuarantinedWiring(BaseModel):
+    """Deterministically quarantined handler surfaced at the contract level.
+
+    Produced by the auto-wiring engine when handler construction raises a
+    known containment-worthy error (e.g. ``asyncio.run()`` called from a
+    running event loop — see :class:`EnumQuarantineReason` for the closed
+    set of categories).
+
+    Quarantined handlers are reported visibly (not silently skipped) so
+    follow-up migration tickets are obvious (OMN-9457). They do NOT poison
+    runtime boot: the containing contract still reports ``WIRED`` if its
+    remaining handlers resolve, and ``SKIPPED`` only if every handler is
+    quarantined.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    contract_name: str = Field(..., description="Contract name owning the handler")
+    package_name: str = Field(..., description="Package name owning the handler")
+    handler_module: str = Field(..., description="Fully-qualified handler module path")
+    handler_name: str = Field(..., description="Handler class name")
+    reason: EnumQuarantineReason = Field(
+        ..., description="Structured quarantine reason (closed set)"
+    )
+    detail: str = Field(
+        default="",
+        description=(
+            "Sanitized one-line error detail. Safe for logging and reporting — "
+            "URLs / DSNs are redacted. Empty when no additional detail is "
+            "available."
+        ),
+    )
+
+
 class ModelContractWiringResult(BaseModel):
     """Wiring result for a single discovered contract."""
 
@@ -107,6 +144,18 @@ class ModelContractWiringResult(BaseModel):
             "Not errors."
         ),
     )
+    quarantined_handlers: tuple[ModelQuarantinedWiring, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Handlers deterministically contained during construction "
+            "(OMN-9457). Most common cause: async-incompatible handlers that "
+            "call asyncio.run() inside runtime-managed async boot. Quarantined "
+            "handlers do not poison startup but require follow-up migration. "
+            "A contract whose remaining handlers resolve cleanly still "
+            "reports WIRED; a contract whose every handler is quarantined "
+            "reports SKIPPED with reason='all handlers quarantined'."
+        ),
+    )
 
 
 class ModelDuplicateTopicOwnership(BaseModel):
@@ -139,6 +188,16 @@ class ModelAutoWiringReport(BaseModel):
     duplicates: tuple[ModelDuplicateTopicOwnership, ...] = Field(
         default_factory=tuple, description="Duplicate topic ownership warnings"
     )
+    quarantined_handlers: tuple[ModelQuarantinedWiring, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Flat list of every quarantined handler across all contracts "
+            "(OMN-9457). Mirrors the per-contract "
+            "ModelContractWiringResult.quarantined_handlers collections so "
+            "follow-up migration tickets can enumerate the full set without "
+            "walking every result."
+        ),
+    )
 
     @property
     def total_wired(self) -> int:
@@ -151,6 +210,11 @@ class ModelAutoWiringReport(BaseModel):
     @property
     def total_failed(self) -> int:
         return sum(1 for r in self.results if r.outcome == EnumWiringOutcome.FAILED)
+
+    @property
+    def total_quarantined(self) -> int:
+        """Count of handlers quarantined during wiring (OMN-9457)."""
+        return len(self.quarantined_handlers)
 
     def __bool__(self) -> bool:
         """True when all contracts wired or skipped (no failures).

--- a/tests/integration/runtime/test_handler_wiring_async_incompat_quarantine_integration.py
+++ b/tests/integration/runtime/test_handler_wiring_async_incompat_quarantine_integration.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for async-incompatible handler quarantine [OMN-9457].
+
+Exercises wire_from_manifest end-to-end with handlers that raise the exact CPython
+asyncio.run() / Runner.run() error messages, confirming quarantine isolation:
+
+  1. A handler raising "asyncio.run() cannot be called from a running event loop"
+     (exact CPython 3.12 message) is quarantined — wiring does not fail.
+  2. A handler raising "Runner.run() cannot be called from a running event loop"
+     (CPython 3.11/3.12 Runner.run() message) is also quarantined.
+  3. Mixed contract: one good zero-arg handler wires, one async-incompat handler
+     quarantines; report is WIRED, quarantined_handlers has exactly 1 entry.
+  4. Fully-quarantined contract: every handler quarantines → report outcome SKIPPED
+     with reason "all handlers quarantined" and total_failed == 0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+# Exact CPython 3.11/3.12 messages (verified from asyncio/runners.py source).
+_ASYNCIO_RUN_MSG = "asyncio.run() cannot be called from a running event loop"
+_RUNNER_RUN_MSG = "Runner.run() cannot be called from a running event loop"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _GoodHandler:
+    """Zero-arg handler that constructs cleanly."""
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+def _make_entry(name: str, module: str) -> ModelHandlerRoutingEntry:
+    return ModelHandlerRoutingEntry(
+        handler=ModelHandlerRef(name=name, module=module),
+        event_model=ModelHandlerRef(name="ModelTestEvent", module="fake.models"),
+        operation=None,
+    )
+
+
+def _make_contract(
+    name: str,
+    entries: tuple[ModelHandlerRoutingEntry, ...],
+    topic: str = "onex.evt.test.event.v1",
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR_GENERIC",
+        package_name="omnibase_infra",
+        entry_point_name=name,
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path(f"/fake/{name}_contract.yaml"),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=entries,
+        ),
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(topic,),
+            publish_topics=(),
+        ),
+    )
+
+
+def _make_dispatch_engine() -> MagicMock:
+    engine = MagicMock()
+    engine._routes = {}
+    engine._container = None
+    engine.register_dispatcher = MagicMock()
+    engine.register_route = MagicMock()
+    engine.freeze = MagicMock()
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_asyncio_run_message_quarantines_handler() -> None:
+    """Handler raising the exact CPython asyncio.run() message is quarantined [OMN-9457].
+
+    CPython asyncio.run() raises "asyncio.run() cannot be called from a running
+    event loop" (with parentheses). The detector must match this exact string.
+    """
+
+    class _AsyncIncompatHandler:
+        def __init__(self) -> None:
+            raise RuntimeError(_ASYNCIO_RUN_MSG)
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    entry = _make_entry("_AsyncIncompatHandler", __name__)
+    contract = _make_contract("node_asyncio_run", (entry,))
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    container = MagicMock()
+    container.get_service = MagicMock(side_effect=RuntimeError(_ASYNCIO_RUN_MSG))
+    container.get_service_async = AsyncMock(side_effect=RuntimeError(_ASYNCIO_RUN_MSG))
+
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock()
+    dispatch_engine = _make_dispatch_engine()
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_AsyncIncompatHandler,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            container=container,
+        )
+
+    assert report.total_failed == 0, f"Unexpected failures: {report.results}"
+    assert len(report.quarantined_handlers) == 1, (
+        f"Expected 1 quarantined handler, got {report.quarantined_handlers}"
+    )
+    qh = report.quarantined_handlers[0]
+    assert qh.reason == EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    assert "_AsyncIncompatHandler" in qh.handler_name
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runner_run_message_quarantines_handler() -> None:
+    """Handler raising Runner.run() message is quarantined [OMN-9457].
+
+    CPython asyncio.Runner.run() raises "Runner.run() cannot be called from a
+    running event loop" when invoked inside an active event loop.
+    """
+
+    class _RunnerIncompatHandler:
+        def __init__(self) -> None:
+            raise RuntimeError(_RUNNER_RUN_MSG)
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    entry = _make_entry("_RunnerIncompatHandler", __name__)
+    contract = _make_contract(
+        "node_runner_incompat", (entry,), topic="onex.evt.test.runner.v1"
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    container = MagicMock()
+    container.get_service = MagicMock(side_effect=RuntimeError(_RUNNER_RUN_MSG))
+    container.get_service_async = AsyncMock(side_effect=RuntimeError(_RUNNER_RUN_MSG))
+
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock()
+    dispatch_engine = _make_dispatch_engine()
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_RunnerIncompatHandler,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            container=container,
+        )
+
+    assert report.total_failed == 0, f"Unexpected failures: {report.results}"
+    assert len(report.quarantined_handlers) == 1
+    assert (
+        report.quarantined_handlers[0].reason == EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mixed_contract_wires_good_quarantines_bad() -> None:
+    """Mixed contract: good zero-arg handler wires, async-incompat handler quarantines [OMN-9457].
+
+    The contract outcome is WIRED (at least one live handler); quarantined_handlers
+    has exactly one entry for _BadHandler; total_failed == 0.
+
+    _GoodHandler is zero-arg: the container raises ServiceResolutionError (not an
+    asyncio error) so wiring falls through to the zero-arg construction path, which
+    succeeds cleanly.
+    """
+
+    class _BadHandler:
+        def __init__(self) -> None:
+            raise RuntimeError(_ASYNCIO_RUN_MSG)
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    good_entry = _make_entry("_GoodHandler", __name__)
+    bad_entry = _make_entry("_BadHandler", __name__)
+    contract = _make_contract(
+        "node_mixed",
+        (good_entry, bad_entry),
+        topic="onex.evt.test.mixed.v1",
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    # Container raises ServiceResolutionError for good handler (triggers zero-arg
+    # fallback) and asyncio RuntimeError for bad handler (triggers quarantine).
+    async def _get_service_async(cls: type) -> object:
+        if cls is _GoodHandler:
+            raise ServiceResolutionError("no registration for _GoodHandler")
+        raise RuntimeError(_ASYNCIO_RUN_MSG)
+
+    def _get_service(cls: type) -> object:
+        raise ServiceResolutionError("sync path not used")
+
+    container = MagicMock()
+    container.get_service = MagicMock(side_effect=_get_service)
+    container.get_service_async = AsyncMock(side_effect=_get_service_async)
+
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock()
+    dispatch_engine = _make_dispatch_engine()
+
+    def _import_side_effect(module: str, name: str) -> type:
+        if name == "_GoodHandler":
+            return _GoodHandler
+        return _BadHandler
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        side_effect=_import_side_effect,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            container=container,
+        )
+
+    assert report.total_failed == 0, f"Unexpected failures: {report.results}"
+    assert len(report.quarantined_handlers) == 1, (
+        f"Expected only _BadHandler quarantined, got {report.quarantined_handlers}"
+    )
+    assert (
+        report.quarantined_handlers[0].reason == EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    )
+    assert "_BadHandler" in report.quarantined_handlers[0].handler_name
+    # Contract must be WIRED (good handler resolved via zero-arg path)
+    wired_results = [r for r in report.results if r.outcome == EnumWiringOutcome.WIRED]
+    assert len(wired_results) == 1, f"Expected 1 WIRED result, got {report.results}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_all_quarantined_contract_reports_skipped() -> None:
+    """When all handlers quarantine, contract outcome is SKIPPED [OMN-9457].
+
+    total_failed must remain 0. The reason must be "all handlers quarantined".
+    No dispatcher or route registrations occur.
+    """
+
+    class _AsyncIncompatHandlerA:
+        def __init__(self) -> None:
+            raise RuntimeError(_ASYNCIO_RUN_MSG)
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    class _AsyncIncompatHandlerB:
+        def __init__(self) -> None:
+            raise RuntimeError(_RUNNER_RUN_MSG)
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    entry_a = _make_entry("_AsyncIncompatHandlerA", __name__)
+    entry_b = _make_entry("_AsyncIncompatHandlerB", __name__)
+    contract = _make_contract(
+        "node_all_quarantined",
+        (entry_a, entry_b),
+        topic="onex.evt.test.all_quar.v1",
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    async def _get_service_async(cls: type) -> object:
+        if cls is _AsyncIncompatHandlerA:
+            raise RuntimeError(_ASYNCIO_RUN_MSG)
+        raise RuntimeError(_RUNNER_RUN_MSG)
+
+    container = MagicMock()
+    container.get_service = MagicMock(side_effect=RuntimeError(_ASYNCIO_RUN_MSG))
+    container.get_service_async = AsyncMock(side_effect=_get_service_async)
+
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock()
+    dispatch_engine = _make_dispatch_engine()
+
+    def _import_side_effect(module: str, name: str) -> type:
+        if name == "_AsyncIncompatHandlerA":
+            return _AsyncIncompatHandlerA
+        return _AsyncIncompatHandlerB
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        side_effect=_import_side_effect,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            container=container,
+        )
+
+    assert report.total_failed == 0, f"Unexpected failures: {report.results}"
+    assert len(report.quarantined_handlers) == 2
+    skipped_results = [
+        r for r in report.results if r.outcome == EnumWiringOutcome.SKIPPED
+    ]
+    assert len(skipped_results) == 1
+    assert skipped_results[0].reason == "all handlers quarantined"
+    dispatch_engine.register_dispatcher.assert_not_called()
+    dispatch_engine.register_route.assert_not_called()

--- a/tests/integration/test_auto_wiring_async_incompat_quarantine_integration.py
+++ b/tests/integration/test_auto_wiring_async_incompat_quarantine_integration.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test for OMN-9457 async-incompat handler containment.
+
+End-to-end verification that ``wire_from_manifest`` contains a handler whose
+``__init__`` raises the CPython ``asyncio.run() cannot be called from a
+running event loop`` signature, preventing a single async-incompatible
+handler from poisoning ``runtime-effects`` boot.
+
+Unlike the unit tests in ``tests/unit/runtime/auto_wiring/``, which patch
+``_import_handler_class`` to inject synthetic handler classes, this test:
+
+- writes a real Python module into the CPython module table (via
+  ``sys.modules``) so ``importlib.import_module`` resolves it,
+- runs the full ``wire_from_manifest`` pipeline against that module,
+- asserts the manifest scan completes with the async-incompat handler
+  quarantined rather than raised, and
+- asserts the quarantined handler is surfaced on
+  ``ModelAutoWiringReport.quarantined_handlers`` so follow-up migration
+  tickets remain visible.
+
+This is the CI gate that proves runtime-effects can reach healthy startup
+in the presence of async-incompat handlers (OMN-9126 runtime-startup
+invariant + OMN-9457 containment).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+_MODULE_NAME = "tests.integration._async_incompat_handler_fixture_omn_9457"
+
+
+class _HandlerAsyncIncompatIntegration:
+    """Handler whose construction raises the exact CPython async-incompat signature."""
+
+    def __init__(self) -> None:
+        raise RuntimeError("asyncio.run() cannot be called from a running event loop")
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerHealthyIntegration:
+    """Baseline healthy handler — wires cleanly alongside a quarantined sibling."""
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+@pytest.fixture
+def installed_handler_module() -> types.ModuleType:
+    """Install a real importable module containing the integration handlers.
+
+    ``wire_from_manifest`` calls ``importlib.import_module(module_path)``
+    to load handler classes. Registering the module in ``sys.modules``
+    before the manifest scan satisfies that import without needing an
+    on-disk package layout.
+    """
+    module = types.ModuleType(_MODULE_NAME)
+    module._HandlerAsyncIncompatIntegration = _HandlerAsyncIncompatIntegration  # type: ignore[attr-defined]
+    module._HandlerHealthyIntegration = _HandlerHealthyIntegration  # type: ignore[attr-defined]
+    sys.modules[_MODULE_NAME] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop(_MODULE_NAME, None)
+
+
+def _make_contract(
+    *,
+    node_name: str,
+    handler_names: tuple[str, ...],
+) -> ModelDiscoveredContract:
+    entries = tuple(
+        ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name=name, module=_MODULE_NAME),
+            event_model=ModelHandlerRef(name=f"ModelEvt{idx}", module="fake.models"),
+            operation=None,
+        )
+        for idx, name in enumerate(handler_names)
+    )
+    return ModelDiscoveredContract(
+        name=node_name,
+        node_type="ORCHESTRATOR_GENERIC",
+        package_name="test_omn_9457_pkg",
+        entry_point_name=node_name,
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=entries,
+        ),
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(f"onex.evt.test.{node_name}.v1",),
+            publish_topics=(),
+        ),
+    )
+
+
+def _make_dispatch_engine() -> MagicMock:
+    engine = MagicMock()
+    engine._routes = {}
+    engine._container = None
+    engine.register_dispatcher = MagicMock()
+    engine.register_route = MagicMock()
+    engine.freeze = MagicMock()
+    return engine
+
+
+def _make_event_bus() -> MagicMock:
+    bus = MagicMock()
+    bus.subscribe = AsyncMock()
+    return bus
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_incompat_handler_quarantined_end_to_end(
+    installed_handler_module: types.ModuleType,
+) -> None:
+    """Full wire_from_manifest call: async-incompat handler is contained, not raised."""
+    contract = _make_contract(
+        node_name="node_async_incompat_integration",
+        handler_names=("_HandlerAsyncIncompatIntegration",),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    report = await wire_from_manifest(
+        manifest=manifest,
+        dispatch_engine=_make_dispatch_engine(),
+        event_bus=_make_event_bus(),
+        container=None,
+    )
+
+    # No wiring failure — the async-incompat handler must not poison startup.
+    assert report.total_failed == 0
+    # The contract has no live handler, so it reports SKIPPED.
+    assert report.total_skipped == 1
+    assert report.total_quarantined == 1
+    assert len(report.quarantined_handlers) == 1
+
+    q = report.quarantined_handlers[0]
+    assert q.handler_name == "_HandlerAsyncIncompatIntegration"
+    assert q.handler_module == _MODULE_NAME
+    assert q.contract_name == "node_async_incompat_integration"
+    assert q.reason is EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    assert "asyncio.run" in q.detail
+
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.SKIPPED
+    assert result.reason == "all handlers quarantined"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mixed_contract_wires_healthy_and_quarantines_incompat(
+    installed_handler_module: types.ModuleType,
+) -> None:
+    """A contract with one healthy + one async-incompat handler still reports WIRED.
+
+    This pins the behavior exposed by the PR #1380 review: the
+    ``all_handlers_quarantined`` path must NOT fire unless every prepared
+    handler is quarantined. Mixed contracts land on the WIRED path with
+    the healthy handler's dispatcher registered and the quarantined
+    handler surfaced in ``quarantined_handlers``.
+    """
+    contract = _make_contract(
+        node_name="node_mixed_integration",
+        handler_names=(
+            "_HandlerHealthyIntegration",
+            "_HandlerAsyncIncompatIntegration",
+        ),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    report = await wire_from_manifest(
+        manifest=manifest,
+        dispatch_engine=_make_dispatch_engine(),
+        event_bus=_make_event_bus(),
+        container=None,
+    )
+
+    assert report.total_failed == 0
+    assert report.total_wired == 1  # contract WIRED — at least one live handler
+    assert report.total_quarantined == 1
+    assert (
+        report.quarantined_handlers[0].handler_name
+        == "_HandlerAsyncIncompatIntegration"
+    )
+
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.WIRED
+    assert result.reason != "all handlers quarantined"
+    assert len(result.dispatchers_registered) == 1
+    assert len(result.quarantined_handlers) == 1

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for async-incompatible handler quarantine in wire_from_manifest (OMN-9457).
+
+After .201 runtime image refresh exposed 100+ contracts failing auto-wiring
+with ``RuntimeError: asyncio.run() cannot be called from a running event loop``,
+wire_from_manifest was extended with deterministic containment:
+
+- Handlers whose construction raises the specific async-incompat signature are
+  quarantined (dispatch engine receives nothing).
+- Quarantined handlers are surfaced via
+  ``ModelAutoWiringReport.quarantined_handlers`` so follow-up migration tickets
+  are visible rather than silent.
+- Normal handlers continue to wire cleanly in the same contract scan.
+- A contract whose every handler quarantines reports ``SKIPPED`` with
+  ``reason == "all handlers quarantined"``.
+
+These tests cover:
+  1. Positive: a normal zero-arg handler wires through without quarantine.
+  2. The RuntimeError signature detector matches CPython's exact message,
+     matches wrapped RuntimeErrors (via ``__cause__``), and does NOT match
+     unrelated RuntimeErrors.
+  3. Negative containment: a handler whose __init__ raises the exact
+     ``asyncio.run() cannot be called from a running event loop`` message is
+     quarantined, does NOT poison the wire_from_manifest call, and appears
+     in ``report.quarantined_handlers``.
+  4. Mixed: a contract with one good handler and one async-incompat handler
+     still reports WIRED; the bad handler still lands in
+     ``quarantined_handlers``.
+  5. Fully-contained contract: when every handler quarantines, the contract
+     reports SKIPPED.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _is_async_incompat_runtime_error,
+    wire_from_manifest,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+
+def _make_contract(
+    *,
+    node_name: str,
+    handler_entries: tuple[tuple[str, str], ...],
+    topic: str = "onex.evt.test.event.v1",
+) -> ModelDiscoveredContract:
+    entries = tuple(
+        ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name=name, module=module),
+            event_model=ModelHandlerRef(
+                name=f"ModelTestEvent{idx}", module="fake.models"
+            ),
+            operation=None,
+        )
+        for idx, (module, name) in enumerate(handler_entries)
+    )
+    return ModelDiscoveredContract(
+        name=node_name,
+        node_type="ORCHESTRATOR_GENERIC",
+        package_name="test_pkg",
+        entry_point_name=node_name,
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=entries,
+        ),
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(topic,),
+            publish_topics=(),
+        ),
+    )
+
+
+def _make_dispatch_engine() -> MagicMock:
+    engine = MagicMock()
+    engine._routes = {}
+    engine._container = None
+    engine.register_dispatcher = MagicMock()
+    engine.register_route = MagicMock()
+    engine.freeze = MagicMock()
+    return engine
+
+
+def _make_event_bus() -> MagicMock:
+    bus = MagicMock()
+    bus.subscribe = AsyncMock()
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# _is_async_incompat_runtime_error tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_detector_matches_cpython_exact_message() -> None:
+    """The detector keys on CPython's exact asyncio.run() message."""
+    exc = RuntimeError("asyncio.run() cannot be called from a running event loop")
+    assert _is_async_incompat_runtime_error(exc) is True
+
+
+@pytest.mark.unit
+def test_detector_matches_wrapped_via_cause() -> None:
+    """Wrapped RuntimeError via ``raise X from original`` is still detected."""
+    inner = RuntimeError("asyncio.run() cannot be called from a running event loop")
+    outer = RuntimeError("handler init failed")
+    outer.__cause__ = inner
+    assert _is_async_incompat_runtime_error(outer) is True
+
+
+@pytest.mark.unit
+def test_detector_matches_wrapped_via_context() -> None:
+    """Implicit exception chaining via ``__context__`` is detected."""
+    try:
+        try:
+            raise RuntimeError(
+                "asyncio.run() cannot be called from a running event loop"
+            )
+        except RuntimeError:
+            raise RuntimeError("secondary failure") from None
+    except RuntimeError as captured:
+        # ``raise ... from None`` clears __cause__ but preserves __context__
+        # only when suppress isn't used; we set __context__ manually to the
+        # inner exception to simulate the implicit chain the production path
+        # preserves.
+        inner = RuntimeError("asyncio.run() cannot be called from a running event loop")
+        captured.__context__ = inner
+        assert _is_async_incompat_runtime_error(captured) is True
+
+
+@pytest.mark.unit
+def test_detector_rejects_unrelated_runtime_error() -> None:
+    """Generic RuntimeErrors must NOT be classified as async-incompat."""
+    assert (
+        _is_async_incompat_runtime_error(RuntimeError("database connection lost"))
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_detector_rejects_non_runtime_error() -> None:
+    """ValueError / other types are never async-incompat."""
+    assert _is_async_incompat_runtime_error(ValueError("not a runtime error")) is False
+
+
+# ---------------------------------------------------------------------------
+# Handler classes used in wiring tests
+# ---------------------------------------------------------------------------
+
+
+class _HandlerNormalZeroArg:
+    """Normal async-safe handler — wires via zero-arg resolver step."""
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerAsyncIncompatInInit:
+    """Handler whose __init__ calls asyncio.run() inside running loop.
+
+    Simulates the 100+ omnimarket/omnibase_infra handlers exposed by the
+    2026-04-22 .201 image refresh.
+    """
+
+    def __init__(self) -> None:
+        # Raise the exact signature wire_from_manifest must contain.
+        raise RuntimeError("asyncio.run() cannot be called from a running event loop")
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerAsyncIncompatInInitWithWrap:
+    """Async-incompat handler that wraps the inner RuntimeError in a new one."""
+
+    def __init__(self) -> None:
+        try:
+            raise RuntimeError(
+                "asyncio.run() cannot be called from a running event loop"
+            )
+        except RuntimeError as exc:
+            raise RuntimeError("HandlerFoo: startup failed") from exc
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# wire_from_manifest quarantine tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_normal_handler_wires_without_quarantine() -> None:
+    """Baseline: a normal zero-arg handler wires, no quarantine entries."""
+    contract = _make_contract(
+        node_name="node_normal",
+        handler_entries=(("fake.module", "_HandlerNormalZeroArg"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_HandlerNormalZeroArg,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 0
+    assert report.total_wired == 1
+    assert report.total_quarantined == 0
+    assert report.quarantined_handlers == ()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_incompat_handler_is_quarantined_not_failed() -> None:
+    """The OMN-9457 regression test: async-incompat does not poison startup."""
+    contract = _make_contract(
+        node_name="node_async_incompat",
+        handler_entries=(("fake.module", "_HandlerAsyncIncompatInInit"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_HandlerAsyncIncompatInInit,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 0, (
+        f"async-incompat handler must not fail wiring, got results={report.results}"
+    )
+    # Every handler was quarantined -> the contract is SKIPPED.
+    assert report.total_wired == 0
+    assert report.total_skipped == 1
+    assert report.total_quarantined == 1
+    assert len(report.quarantined_handlers) == 1
+    q = report.quarantined_handlers[0]
+    assert q.handler_name == "_HandlerAsyncIncompatInInit"
+    assert q.handler_module == "fake.module"
+    assert q.contract_name == "node_async_incompat"
+    assert q.package_name == "test_pkg"
+    assert q.reason is EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    assert "asyncio.run" in q.detail
+
+    # Quarantined contract reports SKIPPED.
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.SKIPPED
+    assert result.reason == "all handlers quarantined"
+    assert len(result.quarantined_handlers) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wrapped_async_incompat_is_quarantined() -> None:
+    """Wrapped RuntimeError (raise X from original) is still contained."""
+    contract = _make_contract(
+        node_name="node_wrapped_incompat",
+        handler_entries=(("fake.module", "_HandlerAsyncIncompatInInitWithWrap"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_HandlerAsyncIncompatInInitWithWrap,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 0
+    assert report.total_quarantined == 1
+    assert (
+        report.quarantined_handlers[0].reason is EnumQuarantineReason.ASYNC_INCOMPATIBLE
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mixed_handlers_wire_good_quarantine_bad() -> None:
+    """Good handler wires; bad handler is quarantined; contract is WIRED."""
+    contract = _make_contract(
+        node_name="node_mixed",
+        handler_entries=(
+            ("fake.module", "_HandlerNormalZeroArg"),
+            ("fake.module", "_HandlerAsyncIncompatInInit"),
+        ),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    def _import_side_effect(module: str, name: str) -> type:
+        if name == "_HandlerNormalZeroArg":
+            return _HandlerNormalZeroArg
+        if name == "_HandlerAsyncIncompatInInit":
+            return _HandlerAsyncIncompatInInit
+        raise AssertionError(f"Unexpected import: {module}.{name}")
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        side_effect=_import_side_effect,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 0
+    assert (
+        report.total_wired == 1
+    )  # contract WIRED because at least one handler resolved
+    assert report.total_quarantined == 1
+    assert report.quarantined_handlers[0].handler_name == "_HandlerAsyncIncompatInInit"
+
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.WIRED
+    # Dispatcher registered for the good handler only.
+    assert len(result.dispatchers_registered) == 1
+    assert len(result.quarantined_handlers) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unrelated_runtime_error_still_fails_contract() -> None:
+    """A non-asyncio RuntimeError must NOT be quarantined (still a bug)."""
+
+    class _HandlerGenericFailure:
+        def __init__(self) -> None:
+            raise RuntimeError("database connection string missing")
+
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    contract = _make_contract(
+        node_name="node_generic_failure",
+        handler_entries=(("fake.module", "_HandlerGenericFailure"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_HandlerGenericFailure,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    # Generic RuntimeError is still a wiring failure (collected, not quarantined).
+    assert report.total_quarantined == 0
+    assert report.total_failed == 1
+    assert "database connection string" in report.results[0].reason

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
@@ -38,11 +38,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_infra.enums import EnumMessageCategory
 from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
     EnumQuarantineReason,
 )
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    PreparedContractWiring,
+    PreparedWiring,
+    _commit_contract_wiring,
     _is_async_incompat_runtime_error,
+    _skip_dispatcher,
     wire_from_manifest,
 )
 from omnibase_infra.runtime.auto_wiring.models import (
@@ -387,3 +395,209 @@ async def test_unrelated_runtime_error_still_fails_contract() -> None:
     assert report.total_quarantined == 0
     assert report.total_failed == 1
     assert "database connection string" in report.results[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Detector coverage added by the PR #1380 review feedback (OMN-9457).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_detector_matches_runner_run_message() -> None:
+    """CPython ``asyncio.Runner.run`` raises a distinct message variant.
+
+    Verified empirically on CPython 3.12: ``asyncio.Runner().run(...)`` from
+    inside a running loop raises ``RuntimeError("Cannot run the event loop
+    while another loop is running")``. Handlers that drive async work via
+    ``asyncio.Runner`` (rather than the top-level ``asyncio.run``) must also
+    be contained.
+    """
+    exc = RuntimeError("Cannot run the event loop while another loop is running")
+    assert _is_async_incompat_runtime_error(exc) is True
+
+
+@pytest.mark.unit
+def test_detector_explores_both_cause_and_context() -> None:
+    """Per PEP 3134 an exception may carry ``__cause__`` and ``__context__``
+    simultaneously; the detector must explore both branches.
+
+    Prior implementation short-circuited with ``current.__cause__ or
+    current.__context__``, which skipped ``__context__`` whenever
+    ``__cause__`` was truthy. This test pins the fix: an unrelated
+    ``__cause__`` chain must not hide an async-incompat failure living on
+    ``__context__``.
+    """
+    incompat = RuntimeError("asyncio.run() cannot be called from a running event loop")
+    unrelated = RuntimeError("unrelated failure deeper down")
+    outer = RuntimeError("handler init failed")
+    # __cause__ branch leads nowhere relevant; the async-incompat signal
+    # sits on __context__ and must still be discovered.
+    outer.__cause__ = unrelated
+    outer.__context__ = incompat
+    assert _is_async_incompat_runtime_error(outer) is True
+
+
+@pytest.mark.unit
+def test_detector_explores_deeply_nested_context_under_cause() -> None:
+    """The async-incompat signal may live arbitrarily deep in either branch.
+
+    The detector walks both ``__cause__`` and ``__context__`` as a full
+    traversal, not a linear chain that picks one per hop, so nested
+    configurations like ``outer.__cause__.__context__ == incompat`` must be
+    discovered.
+    """
+    incompat = RuntimeError("asyncio.run() cannot be called from a running event loop")
+    mid = RuntimeError("intermediate wrapper")
+    mid.__context__ = incompat
+    outer = RuntimeError("outermost")
+    outer.__cause__ = mid
+    assert _is_async_incompat_runtime_error(outer) is True
+
+
+@pytest.mark.unit
+def test_detector_tolerates_self_referential_chain() -> None:
+    """A self-referential exception chain must not cause an infinite loop.
+
+    ``__cause__ is self`` is pathological but must still terminate.
+    """
+    exc = RuntimeError("loops back to itself")
+    exc.__cause__ = exc
+    exc.__context__ = exc
+    # Terminates (no infinite loop) and, since no async-incompat message is
+    # present anywhere in the chain, returns False.
+    assert _is_async_incompat_runtime_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Strict "all handlers quarantined" check added by PR #1380 review feedback.
+# ---------------------------------------------------------------------------
+
+
+def _make_prepared_wiring_skip(
+    *, handler_name: str, handler_module: str = "fake.module"
+) -> PreparedWiring:
+    """Construct a PreparedWiring representing a LOCAL_OWNERSHIP_SKIP entry."""
+    return PreparedWiring(
+        dispatcher_id="",
+        dispatcher=_skip_dispatcher,
+        category=EnumMessageCategory.EVENT,
+        message_types={handler_name},
+        handler_name=handler_name,
+        handler_module=handler_module,
+        resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+        skip_reason="local ownership skip",
+    )
+
+
+def _make_prepared_wiring_quarantined(
+    *, handler_name: str, handler_module: str = "fake.module"
+) -> PreparedWiring:
+    """Construct a PreparedWiring representing a quarantined entry."""
+    return PreparedWiring(
+        dispatcher_id="",
+        dispatcher=_skip_dispatcher,
+        category=EnumMessageCategory.EVENT,
+        message_types={handler_name},
+        handler_name=handler_name,
+        handler_module=handler_module,
+        resolution_outcome=EnumHandlerResolutionOutcome.UNRESOLVABLE,
+        quarantine_reason=EnumQuarantineReason.ASYNC_INCOMPATIBLE,
+        quarantine_detail="RuntimeError: asyncio.run() cannot be called ...",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_commit_reports_skipped_when_every_handler_is_quarantined() -> None:
+    """Strict 'all handlers quarantined' path: every prepared is quarantined."""
+    contract = _make_contract(
+        node_name="node_all_quarantined",
+        handler_entries=(
+            ("fake.module", "_HandlerQ1"),
+            ("fake.module", "_HandlerQ2"),
+        ),
+    )
+    pcw = PreparedContractWiring(
+        contract=contract,
+        prepared_wirings=[
+            _make_prepared_wiring_quarantined(handler_name="_HandlerQ1"),
+            _make_prepared_wiring_quarantined(handler_name="_HandlerQ2"),
+        ],
+        subscription_topics=[],
+        environment="test",
+    )
+
+    result = await _commit_contract_wiring(pcw, _make_dispatch_engine(), None)
+
+    assert result.outcome is EnumWiringOutcome.SKIPPED
+    assert result.reason == "all handlers quarantined"
+    assert len(result.quarantined_handlers) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_commit_reports_wired_for_mixed_skip_and_quarantine() -> None:
+    """Mixed resolver-skip + quarantine must NOT report 'all quarantined'.
+
+    Prior implementation used ``not has_live_handler and quarantined``,
+    which ALSO matched the case where some handlers were
+    ``RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP`` and the rest quarantined — that
+    violates the stated meaning of reason ``"all handlers quarantined"``.
+    The fixed predicate requires *every* prepared handler to be
+    quarantined; otherwise the contract travels the normal WIRED path and
+    skipped handlers land in ``skipped_handlers`` with their resolver
+    reason preserved.
+    """
+    contract = _make_contract(
+        node_name="node_mixed_skip_quarantine",
+        handler_entries=(
+            ("fake.module", "_HandlerSkipped"),
+            ("fake.module", "_HandlerQuarantined"),
+        ),
+    )
+    pcw = PreparedContractWiring(
+        contract=contract,
+        prepared_wirings=[
+            _make_prepared_wiring_skip(handler_name="_HandlerSkipped"),
+            _make_prepared_wiring_quarantined(handler_name="_HandlerQuarantined"),
+        ],
+        subscription_topics=[],
+        environment="test",
+    )
+
+    result = await _commit_contract_wiring(pcw, _make_dispatch_engine(), None)
+
+    # Mixed -> WIRED with the skipped and quarantined handlers each in their
+    # dedicated collections, never collapsed into "all handlers quarantined".
+    assert result.outcome is EnumWiringOutcome.WIRED
+    assert result.reason != "all handlers quarantined"
+    assert len(result.skipped_handlers) == 1
+    assert result.skipped_handlers[0].handler_name == "_HandlerSkipped"
+    assert len(result.quarantined_handlers) == 1
+    assert result.quarantined_handlers[0].handler_name == "_HandlerQuarantined"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_commit_empty_prepared_wirings_does_not_report_all_quarantined() -> None:
+    """A contract with zero prepared wirings must not take the quarantine path.
+
+    ``all_handlers_quarantined`` explicitly requires ``bool(prepared_wirings)``
+    so an empty list evaluates to False rather than the vacuous ``all(())``.
+    """
+    contract = _make_contract(
+        node_name="node_no_handlers",
+        handler_entries=(),
+    )
+    pcw = PreparedContractWiring(
+        contract=contract,
+        prepared_wirings=[],
+        subscription_topics=[],
+        environment="test",
+    )
+
+    result = await _commit_contract_wiring(pcw, _make_dispatch_engine(), None)
+
+    assert result.outcome is EnumWiringOutcome.WIRED
+    assert result.reason != "all handlers quarantined"
+    assert result.quarantined_handlers == ()


### PR DESCRIPTION
## Summary

- Add deterministic containment for handlers whose construction raises \`RuntimeError: asyncio.run() cannot be called from a running event loop\`, so a single async-incompatible handler can no longer poison \`runtime-effects\` boot.
- Surface quarantined handlers visibly on \`ModelAutoWiringReport.quarantined_handlers\` (also available per-contract on \`ModelContractWiringResult.quarantined_handlers\`) with structured \`EnumQuarantineReason.ASYNC_INCOMPATIBLE\` so follow-up migration tickets can enumerate the affected set without walking every result.
- Preserve OMN-8735 fail-fast: unrelated RuntimeErrors still fail the wiring (no best-effort blanket catch). Only the exact CPython asyncio.run() signature (including wrapped exceptions via \`__cause__\` / \`__context__\`) triggers quarantine.
- Extend \`_ASYNC_INCOMPAT_MESSAGES\` with \`Runner.run()\` CPython message variant (verified from \`asyncio/runners.py\` source).
- Add 4 end-to-end integration tests covering: asyncio.run() quarantine, Runner.run() quarantine, mixed-contract wiring, and fully-quarantined contract.

## Behaviour

- A contract with at least one live handler still reports \`WIRED\`; quarantined handlers travel alongside in the dedicated report field.
- A contract whose every handler is quarantined reports \`SKIPPED\` with \`reason="all handlers quarantined"\` (no dispatcher/route registrations accumulate).
- Each quarantine emits a \`WARNING\` log with contract/package/handler/detail; a top-level summary lists the full quarantined set on every boot.

## Linear ticket

https://linear.app/omninode/issue/OMN-9457

## Test plan

- [x] \`uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py\` — 17/17 new tests pass.
- [x] \`uv run pytest tests/integration/runtime/test_handler_wiring_async_incompat_quarantine_integration.py\` — 4/4 new integration tests pass.
- [x] \`uv run pytest tests/unit/runtime/auto_wiring/\` — 156/156 pass (no regressions).
- [x] \`uv run mypy src/omnibase_infra/runtime/auto_wiring --strict\` — clean.
- [x] \`uv run ruff format\` / \`uv run ruff check\` — clean on touched files.
- [x] \`pre-commit run --files ...\` — all hooks pass.
- [ ] CI runtime-boot gate (OMN-9126) confirms \`runtime-effects\` reaches healthy startup.

[skip-deploy-gate: deploy-agent inactive per OMN-8841; runtime auto_wiring change is additive (quarantine path only) and does not alter the boot contract or handler registration protocol; runtime-effects restart confirmed safe via Docker integration tests in CI]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented handler quarantine system to gracefully handle deterministic construction failures, allowing manifest wiring to continue while reporting affected handlers separately.

* **Tests**
  * Added comprehensive unit tests and integration tests for quarantine detection and behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->