### PR TITLE
chore: remove polymorphic-agent references from models, tests, and migrations [OMN-9504]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -889,7 +889,7 @@ The full pre-Infisical config is preserved in `docs/env-example-full.txt`.
 | Complex workflows | `agent-onex-coordinator` → `agent-workflow-coordinator` |
 | Multi-domain | `agent-ticket-manager` for planning, orchestrators for execution |
 
-**Prefer `subagent_type: "polymorphic-agent"`** for ONEX development workflows.
+**Prefer `subagent_type: "general-purpose"`** for ONEX development workflows.
 
 ### Critical Policies
 

--- a/docker/migrations/forward/022_create_agent_transformation_events_table.sql
+++ b/docker/migrations/forward/022_create_agent_transformation_events_table.sql
@@ -55,7 +55,7 @@ CREATE INDEX IF NOT EXISTS idx_agent_transformation_events_created_at
 COMMENT ON TABLE agent_transformation_events IS 'Agent transformation lifecycle events (OMN-1743). Append-only observability table.';
 COMMENT ON COLUMN agent_transformation_events.id IS 'Unique event identifier (UUID) - primary key for idempotent inserts';
 COMMENT ON COLUMN agent_transformation_events.correlation_id IS 'Request correlation ID for tracing across services';
-COMMENT ON COLUMN agent_transformation_events.source_agent IS 'Agent type before transformation (e.g., polymorphic-agent)';
+COMMENT ON COLUMN agent_transformation_events.source_agent IS 'Agent type before transformation (e.g., general-purpose)';
 COMMENT ON COLUMN agent_transformation_events.target_agent IS 'Agent type after transformation (e.g., api-architect)';
 COMMENT ON COLUMN agent_transformation_events.created_at IS 'Timestamp when event was recorded (TTL cleanup key)';
 COMMENT ON COLUMN agent_transformation_events.trigger IS 'Trigger that caused the transformation';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:17cf22c637f8195c626ba65d0b17c8b42a3f72be7cfc07b654ec04110e0ed7f1
-generated_at: 2026-04-14T05:29:47Z
+sha256:a6e5fd0ee93ddc19823dc70906849c9b14c5dca8fecca9bc3f9d1d424d33e195
+generated_at: 2026-04-23T17:48:25Z
 migration_file_count: 53

--- a/src/omnibase_infra/services/observability/agent_actions/models/__init__.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/__init__.py
@@ -48,7 +48,7 @@ Example:
     >>> action = ModelAgentAction(
     ...     id=uuid4(),
     ...     correlation_id=uuid4(),
-    ...     agent_name="polymorphic-agent",
+    ...     agent_name="general-purpose",
     ...     action_type="tool_call",
     ...     action_name="Read",
     ...     created_at=datetime.now(UTC),

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_agent_action.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_agent_action.py
@@ -30,7 +30,7 @@ Example:
     >>> from uuid import uuid4
     >>> action = ModelAgentAction(
     ...     correlation_id=uuid4(),
-    ...     agent_name="polymorphic-agent",
+    ...     agent_name="general-purpose",
     ...     action_type="tool_call",
     ...     action_name="Bash",
     ... )

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_agent_status_event.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_agent_status_event.py
@@ -29,7 +29,7 @@ Example:
     >>> event = ModelAgentStatusEvent(
     ...     id=uuid4(),
     ...     correlation_id=uuid4(),
-    ...     agent_name="polymorphic-agent",
+    ...     agent_name="general-purpose",
     ...     session_id="session-abc123",
     ...     state="working",
     ...     message="Processing code review",

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_detection_failure.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_detection_failure.py
@@ -59,7 +59,7 @@ class ModelDetectionFailure(BaseModel):
         ...     failure_reason="Confidence below threshold (0.3 < 0.5)",
         ...     created_at=datetime.now(UTC),
         ...     attempted_patterns=("code-review", "testing", "infrastructure"),
-        ...     fallback_used="polymorphic-agent",
+        ...     fallback_used="general-purpose",
         ... )
     """
 

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_performance_metric.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_performance_metric.py
@@ -62,7 +62,7 @@ class ModelPerformanceMetric(BaseModel):
         ...     metric_value=12.5,
         ...     created_at=datetime.now(UTC),
         ...     unit="ms",
-        ...     agent_name="polymorphic-agent",
+        ...     agent_name="general-purpose",
         ...     labels={"operation": "route", "status": "success"},
         ... )
     """

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_routing_decision.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_routing_decision.py
@@ -62,7 +62,7 @@ class ModelRoutingDecision(BaseModel):
         >>> decision = ModelRoutingDecision(
         ...     id=uuid4(),
         ...     correlation_id=uuid4(),
-        ...     selected_agent="polymorphic-agent",
+        ...     selected_agent="general-purpose",
         ...     confidence_score=0.87,
         ...     created_at=datetime.now(UTC),
         ...     routing_reason="Matched domain pattern for infrastructure tasks",

--- a/src/omnibase_infra/services/observability/agent_actions/models/model_transformation_event.py
+++ b/src/omnibase_infra/services/observability/agent_actions/models/model_transformation_event.py
@@ -24,7 +24,7 @@ Example:
     >>> event = ModelTransformationEvent(
     ...     id=uuid4(),
     ...     correlation_id=uuid4(),
-    ...     source_agent="polymorphic-agent",
+    ...     source_agent="general-purpose",
     ...     target_agent="api-architect",
     ...     created_at=datetime.now(UTC),
     ... )
@@ -59,7 +59,7 @@ class ModelTransformationEvent(BaseModel):
         >>> event = ModelTransformationEvent(
         ...     id=uuid4(),
         ...     correlation_id=uuid4(),
-        ...     source_agent="polymorphic-agent",
+        ...     source_agent="general-purpose",
         ...     target_agent="debug-database",
         ...     created_at=datetime.now(UTC),
         ...     trigger="User requested database debugging",

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_model_routing_decision_ingest.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_model_routing_decision_ingest.py
@@ -60,7 +60,7 @@ _PRODUCER_1_PAYLOAD: dict[str, object] = {
 _PRODUCER_2_PAYLOAD: dict[str, object] = {
     "correlation_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
     "session_id": "sess-def-456",
-    "selected_agent": "polymorphic-agent",
+    "selected_agent": "general-purpose",
     "confidence": 0.75,
     "domain": "infrastructure",
     "reasoning": "Matched infrastructure domain pattern",
@@ -99,7 +99,7 @@ class TestProducerPayloadParsing:
     def test_producer2_payload_parses_cleanly(self) -> None:
         """Full producer 2 dict parses without exception; all aliases mapped."""
         m = ModelRoutingDecisionIngest.model_validate(_PRODUCER_2_PAYLOAD)
-        assert m.selected_agent == "polymorphic-agent"
+        assert m.selected_agent == "general-purpose"
         assert m.confidence_score == pytest.approx(0.75)
         assert m.claude_session_id == "sess-def-456"
         assert m.routing_reason == "Matched infrastructure domain pattern"
@@ -442,7 +442,7 @@ class TestIngestToStrictModelCompatibility:
         ingest = ModelRoutingDecisionIngest.model_validate(
             {
                 "correlation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                "selected_agent": "polymorphic-agent",
+                "selected_agent": "general-purpose",
                 "confidence": 0.85,
                 "session_id": "sess-xyz",
                 "emitted_at": "2026-03-01T12:00:00Z",
@@ -457,7 +457,7 @@ class TestIngestToStrictModelCompatibility:
         )
         dump = ingest.model_dump()
         strict = ModelRoutingDecision.model_validate(dump)
-        assert strict.selected_agent == "polymorphic-agent"
+        assert strict.selected_agent == "general-purpose"
         assert strict.confidence_score == pytest.approx(0.85)
         assert strict.claude_session_id == "sess-xyz"
         assert strict.routing_reason == "matched pattern"

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_models.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_models.py
@@ -277,7 +277,7 @@ class TestModelTransformationEventStrict:
             ModelTransformationEvent(  # type: ignore[call-arg]
                 id=uuid4(),
                 correlation_id=uuid4(),
-                source_agent="polymorphic-agent",
+                source_agent="general-purpose",
                 target_agent="api-architect",
                 created_at=datetime.now(UTC),
                 extra_transform_data={"key": "value"},
@@ -292,7 +292,7 @@ class TestModelTransformationEventStrict:
         event = ModelTransformationEvent(
             id=uuid4(),
             correlation_id=uuid4(),
-            source_agent="polymorphic-agent",
+            source_agent="general-purpose",
             target_agent="api-architect",
             created_at=datetime.now(UTC),
         )
@@ -1037,7 +1037,7 @@ class TestModelTransformationEventProjectContext:
         event = ModelTransformationEvent(
             id=uuid4(),
             correlation_id=uuid4(),
-            source_agent="polymorphic-agent",
+            source_agent="general-purpose",
             target_agent="api-architect",
             created_at=datetime.now(UTC),
         )
@@ -1051,7 +1051,7 @@ class TestModelTransformationEventProjectContext:
         event = ModelTransformationEvent(
             id=uuid4(),
             correlation_id=uuid4(),
-            source_agent="polymorphic-agent",
+            source_agent="general-purpose",
             target_agent="api-architect",
             created_at=datetime.now(UTC),
             project_path="/home/user/projects/omnibase_infra",

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_routing_decision_schema_handshake.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_routing_decision_schema_handshake.py
@@ -93,7 +93,7 @@ def canonical_payload() -> dict[str, object]:
     return {
         "id": str(uuid4()),
         "correlation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-        "selected_agent": "polymorphic-agent",
+        "selected_agent": "general-purpose",
         "confidence_score": 0.85,
         "created_at": datetime.now(UTC).isoformat(),
     }
@@ -244,7 +244,7 @@ class TestRoutingDecisionSchemaHandshake:
         drifted from the contract.
         """
         m = ModelRoutingDecision.model_validate(canonical_payload)
-        assert m.selected_agent == "polymorphic-agent"
+        assert m.selected_agent == "general-purpose"
         assert m.confidence_score == pytest.approx(0.85)
         assert isinstance(m.id, UUID)
         assert isinstance(m.correlation_id, UUID)
@@ -452,7 +452,7 @@ class TestProducerPayloadAlignmentRegression:
         "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
         "correlation_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
         "claude_session_id": "sess-xyz-789",
-        "selected_agent": "polymorphic-agent",
+        "selected_agent": "general-purpose",
         "confidence_score": 0.87,
         "created_at": "2026-03-01T15:30:00+00:00",
         "domain": "infrastructure",
@@ -476,7 +476,7 @@ class TestProducerPayloadAlignmentRegression:
         can be retired (OMN-3424).
         """
         m = ModelRoutingDecision.model_validate(self._ROUTE_VIA_EVENTS_PAYLOAD)
-        assert m.selected_agent == "polymorphic-agent"
+        assert m.selected_agent == "general-purpose"
         assert m.confidence_score == pytest.approx(0.87)
         assert m.claude_session_id == "sess-xyz-789"
         assert m.routing_reason == "Matched infrastructure domain pattern"
@@ -547,7 +547,7 @@ class TestDriftDetection:
         drifted_payload = {
             "id": str(uuid4()),
             "correlation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            "selected_agent": "polymorphic-agent",
+            "selected_agent": "general-purpose",
             "confidence": 0.85,  # drift: old name
             "created_at": datetime.now(UTC).isoformat(),
         }
@@ -571,7 +571,7 @@ class TestDriftDetection:
         payload_missing_confidence = {
             "id": str(uuid4()),
             "correlation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            "selected_agent": "polymorphic-agent",
+            "selected_agent": "general-purpose",
             # confidence_score omitted — drift simulation
             "created_at": datetime.now(UTC).isoformat(),
         }

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_writer.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_writer.py
@@ -115,7 +115,7 @@ def sample_transformation_event() -> ModelTransformationEvent:
     return ModelTransformationEvent(
         id=uuid4(),
         correlation_id=uuid4(),
-        source_agent="polymorphic-agent",
+        source_agent="general-purpose",
         target_agent="api-architect",
         created_at=datetime.now(UTC),
         trigger="Domain pattern match",

--- a/tests/unit/services/observability/injection_effectiveness/test_context_enrichment_injection_recorded.py
+++ b/tests/unit/services/observability/injection_effectiveness/test_context_enrichment_injection_recorded.py
@@ -78,7 +78,7 @@ class TestModelContextEnrichmentEvent:
             net_tokens_saved=300,
             similarity_score=0.85,
             repo="omniclaude",
-            agent_name="polymorphic-agent",
+            agent_name="general-purpose",
         )
         assert event.model_name == "qwen3-coder-14b"
         assert event.cache_hit is True
@@ -88,7 +88,7 @@ class TestModelContextEnrichmentEvent:
         assert event.net_tokens_saved == 300
         assert event.similarity_score == 0.85
         assert event.repo == "omniclaude"
-        assert event.agent_name == "polymorphic-agent"
+        assert event.agent_name == "general-purpose"
 
     def test_frozen(self) -> None:
         event = self._minimal()
@@ -149,14 +149,14 @@ class TestModelInjectionRecordedEvent:
             patterns_injected=5,
             total_injected_tokens=1200,
             injection_latency_ms=15.3,
-            agent_name="polymorphic-agent",
+            agent_name="general-purpose",
             repo="omniclaude",
             cache_hit=True,
         )
         assert event.patterns_injected == 5
         assert event.total_injected_tokens == 1200
         assert event.injection_latency_ms == 15.3
-        assert event.agent_name == "polymorphic-agent"
+        assert event.agent_name == "general-purpose"
         assert event.repo == "omniclaude"
         assert event.cache_hit is True
 


### PR DESCRIPTION
## Summary
- Replace `polymorphic-agent` with `general-purpose` in model doctest examples, test fixtures, and SQL migration comments
- Part of the broader polymorphic-agent scrub epic (OMN-9504)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated ONEX development workflow guidance, code examples, and instructional documentation across the codebase to reflect changes in the recommended agent selection approach and configuration.

* **Tests**
  * Updated test cases, fixtures, test payloads, and assertions throughout the test suite to ensure validation and compatibility verification aligns with the new agent configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->