### PR TITLE
fix(runtime): disambiguate dispatcher IDs by operation for repeated handler refs (OMN-9461)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -22,6 +22,7 @@ CI gate: any PR touching this module MUST satisfy the runtime-startup gate defin
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import logging
 import os
@@ -572,7 +573,9 @@ def _derive_route_id(
     """
     safe_topic = re.sub(r"[.\-]", "_", topic)
     if operation:
-        safe_op = re.sub(r"[.\-/]", "_", operation)
+        normalized = re.sub(r"[^A-Za-z0-9_]+", "_", operation.strip()).strip("_")
+        digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
+        safe_op = f"{normalized}_{digest}" if normalized else digest
         return f"route.auto.{contract_name}.{handler_name}.{safe_op}.{safe_topic}"
     return f"route.auto.{contract_name}.{handler_name}.{safe_topic}"
 
@@ -593,7 +596,9 @@ def _derive_dispatcher_id(
     unaffected.
     """
     if operation:
-        safe_op = re.sub(r"[.\-/]", "_", operation)
+        normalized = re.sub(r"[^A-Za-z0-9_]+", "_", operation.strip()).strip("_")
+        digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
+        safe_op = f"{normalized}_{digest}" if normalized else digest
         return f"dispatcher.auto.{contract_name}.{handler_name}.{safe_op}"
     return f"dispatcher.auto.{contract_name}.{handler_name}"
 

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -552,18 +552,49 @@ def _make_event_bus_callback(
     return callback
 
 
-def _derive_route_id(contract_name: str, handler_name: str, topic: str) -> str:
-    """Derive a route ID from contract name, handler name, and full topic path.
+def _derive_route_id(
+    contract_name: str,
+    handler_name: str,
+    topic: str,
+    operation: str | None = None,
+) -> str:
+    """Derive a route ID from contract name, handler name, full topic path, and optional operation.
 
     Uses the full topic path (sanitized) to guarantee uniqueness across topics
     that share a common segment (OMN-8735).
+
+    When two routing entries reference the same handler class for different
+    operations (e.g. ``HandlerLlmCliSubprocess`` for both ``inference.gemini_cli``
+    and ``inference.codex_cli``) and subscribe to the same topic, the
+    ``handler_name + topic`` pair alone produces a collision.  Including the
+    sanitized ``operation`` suffix guarantees each entry gets a distinct route
+    ID (OMN-9461).
     """
     safe_topic = re.sub(r"[.\-]", "_", topic)
+    if operation:
+        safe_op = re.sub(r"[.\-/]", "_", operation)
+        return f"route.auto.{contract_name}.{handler_name}.{safe_op}.{safe_topic}"
     return f"route.auto.{contract_name}.{handler_name}.{safe_topic}"
 
 
-def _derive_dispatcher_id(contract_name: str, handler_name: str) -> str:
-    """Derive a dispatcher ID from contract and handler names."""
+def _derive_dispatcher_id(
+    contract_name: str, handler_name: str, operation: str | None = None
+) -> str:
+    """Derive a dispatcher ID from contract name, handler name, and optional operation.
+
+    When two routing entries in the same contract reference the same handler
+    class (e.g. ``HandlerLlmCliSubprocess`` wired for both ``inference.gemini_cli``
+    and ``inference.codex_cli``), the plain ``handler_name`` alone produces a
+    collision.  Including the sanitized ``operation`` suffix guarantees each
+    entry gets a distinct dispatcher ID (OMN-9461).
+
+    When ``operation`` is absent the ID degrades to the original two-segment
+    form so existing contracts without repeated handler references are
+    unaffected.
+    """
+    if operation:
+        safe_op = re.sub(r"[.\-/]", "_", operation)
+        return f"dispatcher.auto.{contract_name}.{handler_name}.{safe_op}"
     return f"dispatcher.auto.{contract_name}.{handler_name}"
 
 
@@ -1287,14 +1318,18 @@ def _prepare_handler_wiring(
         )
     else:
         callback = _make_dispatch_callback(handler_instance)
-    dispatcher_id = _derive_dispatcher_id(contract.name, handler_ref.name)
+    dispatcher_id = _derive_dispatcher_id(
+        contract.name, handler_ref.name, entry.operation
+    )
 
     # Pre-compute routes (no engine calls yet)
     route_ids: list[str] = []
     routes: list[ModelDispatchRoute] = []
     if contract.event_bus:
         for topic in contract.event_bus.subscribe_topics:
-            route_id = _derive_route_id(contract.name, handler_ref.name, topic)
+            route_id = _derive_route_id(
+                contract.name, handler_ref.name, topic, entry.operation
+            )
             topic_pattern = _derive_topic_pattern_from_topic(topic)
 
             route = ModelDispatchRoute(

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -133,7 +133,7 @@ class TestDeriveIds:
                 "onex.cmd.omnibase-infra.llm-inference-request.v1",
                 "inference.gemini_cli",
             )
-            == "route.auto.my_node.HandlerLlmCliSubprocess.inference_gemini_cli.onex_cmd_omnibase_infra_llm_inference_request_v1"
+            == "route.auto.my_node.HandlerLlmCliSubprocess.inference_gemini_cli_fb462661.onex_cmd_omnibase_infra_llm_inference_request_v1"
         )
 
     def test_route_id_without_operation_unchanged(self) -> None:
@@ -162,8 +162,14 @@ class TestDeriveIds:
                 "HandlerLlmCliSubprocess",
                 "inference.gemini_cli",
             )
-            == "dispatcher.auto.node_llm_inference_effect.HandlerLlmCliSubprocess.inference_gemini_cli"
+            == "dispatcher.auto.node_llm_inference_effect.HandlerLlmCliSubprocess.inference_gemini_cli_fb462661"
         )
+
+    def test_dispatcher_id_collision_safe(self) -> None:
+        """OMN-9461: operations that normalize identically still produce distinct IDs."""
+        id_a = _derive_dispatcher_id("n", "H", "inference.a-b")
+        id_b = _derive_dispatcher_id("n", "H", "inference.a/b")
+        assert id_a != id_b
 
     def test_dispatcher_id_without_operation_unchanged(self) -> None:
         """OMN-9461: absence of operation keeps original ID form."""

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -124,9 +124,51 @@ class TestDeriveIds:
             == "route.auto.my_node.my_handler.onex_evt_platform_my_topic_v1"
         )
 
+    def test_route_id_with_operation(self) -> None:
+        """OMN-9461: operation suffix disambiguates repeated handler references."""
+        assert (
+            _derive_route_id(
+                "my_node",
+                "HandlerLlmCliSubprocess",
+                "onex.cmd.omnibase-infra.llm-inference-request.v1",
+                "inference.gemini_cli",
+            )
+            == "route.auto.my_node.HandlerLlmCliSubprocess.inference_gemini_cli.onex_cmd_omnibase_infra_llm_inference_request_v1"
+        )
+
+    def test_route_id_without_operation_unchanged(self) -> None:
+        """OMN-9461: absence of operation keeps original ID form."""
+        assert (
+            _derive_route_id(
+                "my_node",
+                "my_handler",
+                "onex.evt.platform.my-topic.v1",
+                None,
+            )
+            == "route.auto.my_node.my_handler.onex_evt_platform_my_topic_v1"
+        )
+
     def test_dispatcher_id(self) -> None:
         assert (
             _derive_dispatcher_id("my_node", "my_handler")
+            == "dispatcher.auto.my_node.my_handler"
+        )
+
+    def test_dispatcher_id_with_operation(self) -> None:
+        """OMN-9461: operation suffix disambiguates repeated handler references."""
+        assert (
+            _derive_dispatcher_id(
+                "node_llm_inference_effect",
+                "HandlerLlmCliSubprocess",
+                "inference.gemini_cli",
+            )
+            == "dispatcher.auto.node_llm_inference_effect.HandlerLlmCliSubprocess.inference_gemini_cli"
+        )
+
+    def test_dispatcher_id_without_operation_unchanged(self) -> None:
+        """OMN-9461: absence of operation keeps original ID form."""
+        assert (
+            _derive_dispatcher_id("my_node", "my_handler", None)
             == "dispatcher.auto.my_node.my_handler"
         )
 
@@ -454,6 +496,79 @@ class TestWireFromManifest:
         report = await wire_from_manifest(manifest, engine)
         assert len(report.duplicates) == 1
         assert report.duplicates[0].level == "package"
+
+    @pytest.mark.asyncio
+    async def test_repeated_handler_same_class_different_operations(self) -> None:
+        """OMN-9461: two entries referencing the same handler class for different
+        operations must wire without duplicate dispatcher or route ID collisions.
+
+        Mirrors the real node_llm_inference_effect contract which lists
+        HandlerLlmCliSubprocess for both ``inference.gemini_cli`` and
+        ``inference.codex_cli``.
+        """
+        from omnibase_infra.runtime.service_message_dispatch_engine import (
+            MessageDispatchEngine,
+        )
+
+        # Two routing entries — same handler class, different operations.
+        handler_entries = (
+            ModelHandlerRoutingEntry(
+                handler=ModelHandlerRef(name="HandlerShared", module="fake.module"),
+                event_model=None,
+                operation="inference.gemini_cli",
+            ),
+            ModelHandlerRoutingEntry(
+                handler=ModelHandlerRef(name="HandlerShared", module="fake.module"),
+                event_model=None,
+                operation="inference.codex_cli",
+            ),
+        )
+        handler_routing = ModelHandlerRouting(
+            routing_strategy="operation_match",
+            handlers=handler_entries,
+        )
+        contract = _make_contract(
+            name="node_llm_inference_effect",
+            subscribe_topics=("onex.cmd.omnibase-infra.llm-inference-request.v1",),
+            handler_routing=handler_routing,
+        )
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        class HandlerShared:
+            async def handle(self, envelope: object) -> None:
+                return None
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerShared,
+        ):
+            # Must not raise — before OMN-9461 this would raise
+            # "Dispatcher with ID ... is already registered".
+            report = await wire_from_manifest(manifest, engine)
+
+        assert report.total_failed == 0, f"Expected no failures, got: {report}"
+        assert report.total_wired == 1
+
+        all_dispatchers: list[str] = []
+        all_routes: list[str] = []
+        for r in report.results:
+            all_dispatchers.extend(r.dispatchers_registered)
+            all_routes.extend(r.routes_registered)
+
+        # Two distinct dispatcher IDs, one per operation.
+        assert len(all_dispatchers) == 2, (
+            f"Expected 2 dispatcher IDs, got {len(all_dispatchers)}: {all_dispatchers}"
+        )
+        assert len(set(all_dispatchers)) == 2, (
+            f"Duplicate dispatcher IDs: {all_dispatchers}"
+        )
+
+        # Two distinct route IDs, one per entry × one topic.
+        assert len(all_routes) == 2, (
+            f"Expected 2 route IDs, got {len(all_routes)}: {all_routes}"
+        )
+        assert len(set(all_routes)) == 2, f"Duplicate route IDs: {all_routes}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_derive_dispatcher_id` and `_derive_route_id` now include the routing entry's `operation` field as a disambiguator, preventing duplicate dispatcher ID collisions when the same handler class is referenced multiple times in a single contract
- Fixes runtime boot failure on `.201` where `node_llm_inference_effect` wires `HandlerLlmCliSubprocess` for both `inference.gemini_cli` and `inference.codex_cli`

## Test plan
- New tests: `test_dispatcher_id_with_operation`, `test_dispatcher_id_without_operation_unchanged`, `test_repeated_handler_same_class_different_operations`
- Existing `TestDeriveIds` tests updated to cover operation variants
- All 30 auto-wiring tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated routing and dispatcher identifier generation to include operation-aware disambiguation, preventing collisions when the same handler is used for multiple operations and avoiding duplicate registrations.

* **Tests**
  * Added tests confirming operation-aware IDs, collision avoidance, and successful wiring when a handler is referenced by multiple operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->