### PR TITLE
feat(docker): pass GIT_SHA build-arg for runtime image provenance (OMN-9330)

### DIFF
--- a/src/omnibase_infra/docker/catalog/cli.py
+++ b/src/omnibase_infra/docker/catalog/cli.py
@@ -168,6 +168,21 @@ def _run_seed() -> int:
     return 0
 
 
+def _current_git_sha() -> str:
+    """Return the current git SHA for the omnibase_infra repo (OMN-9330)."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return proc.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
 def cmd_seed(_args: list[str]) -> int:
     """Seed Infisical with config keys from contracts."""
     return _run_seed()
@@ -221,8 +236,17 @@ def cmd_up(args: list[str]) -> int:
     # Build if requested (OMN-7214)
     if force_build:
         print("Rebuilding images (--build)...")
+        git_sha = _current_git_sha()
         build_proc = subprocess.run(
-            ["docker", "compose", "-f", _DEFAULT_OUTPUT, "build"],
+            [
+                "docker",
+                "compose",
+                "-f",
+                _DEFAULT_OUTPUT,
+                "build",
+                "--build-arg",
+                f"GIT_SHA={git_sha}",
+            ],
             cwd=str(_REPO_ROOT),
             check=False,
         )


### PR DESCRIPTION
## Summary
- `cmd_up --build` now derives the current git SHA and passes it via `--build-arg GIT_SHA=<sha>` so the OCI label `org.opencontainers.image.revision` reflects the actual source revision instead of `unknown`
- Adds `_current_git_sha()` helper with fallback to `"unknown"` outside a git repo

## Test plan
- `docker inspect <container> --format '{{index .Config.Labels "org.opencontainers.image.revision"}}'` should return the 40-char SHA after a `--build` run
- Pre-commit hooks pass (mypy, ruff, architecture checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker builds now automatically capture and include the current git SHA, providing improved version tracking and traceability for built images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->