### PR TITLE
fix(registry-api): harden projection-backed registry surface [OMN-9543]

### DIFF
--- a/src/omnibase_infra/services/registry_api/models/__init__.py
+++ b/src/omnibase_infra/services/registry_api/models/__init__.py
@@ -46,6 +46,9 @@ from omnibase_infra.services.registry_api.models.model_registry_health_response 
 from omnibase_infra.services.registry_api.models.model_registry_instance_view import (
     ModelRegistryInstanceView,
 )
+from omnibase_infra.services.registry_api.models.model_registry_node_detail_view import (
+    ModelRegistryNodeDetailView,
+)
 from omnibase_infra.services.registry_api.models.model_registry_node_view import (
     ModelRegistryNodeView,
 )
@@ -88,6 +91,7 @@ __all__ = [
     "ModelPaginationInfo",
     "ModelRegistryDiscoveryResponse",
     "ModelRegistryHealthResponse",
+    "ModelRegistryNodeDetailView",
     "ModelRegistryInstanceView",
     "ModelRegistryNodeView",
     "ModelRegistrySummary",

--- a/src/omnibase_infra/services/registry_api/models/model_registry_discovery_response.py
+++ b/src/omnibase_infra/services/registry_api/models/model_registry_discovery_response.py
@@ -9,6 +9,7 @@ Related Tickets:
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -38,7 +39,9 @@ class ModelRegistryDiscoveryResponse(BaseModel):
         warnings: List of warnings for partial success scenarios
         summary: Aggregate statistics
         nodes: List of registered nodes
-        live_instances: List of live Consul instances
+        instance_discovery_status: Availability of legacy instance discovery
+        instance_discovery_message: Optional explanation for degraded instance discovery
+        live_instances: Compatibility list for legacy instance-oriented consumers
         pagination: Pagination info for nodes list
     """
 
@@ -60,9 +63,17 @@ class ModelRegistryDiscoveryResponse(BaseModel):
         default_factory=list,
         description="List of registered nodes",
     )
+    instance_discovery_status: Literal["available", "unavailable"] = Field(
+        default="unavailable",
+        description="Availability of legacy instance discovery in the current runtime",
+    )
+    instance_discovery_message: str | None = Field(
+        default=None,
+        description="Optional explanation when legacy instance discovery is unavailable",
+    )
     live_instances: list[ModelRegistryInstanceView] = Field(
         default_factory=list,
-        description="List of live Consul instances",
+        description="Compatibility list for legacy instance-oriented consumers",
     )
     pagination: ModelPaginationInfo = Field(
         ...,

--- a/src/omnibase_infra/services/registry_api/models/model_registry_node_detail_view.py
+++ b/src/omnibase_infra/services/registry_api/models/model_registry_node_detail_view.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registry node detail view model."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from omnibase_infra.services.registry_api.models.model_registry_node_view import (
+    ModelRegistryNodeView,
+)
+
+
+class ModelRegistryNodeDetailView(ModelRegistryNodeView):
+    """Detailed registry node view with projection-backed detail fields."""
+
+    protocols: list[str] = Field(
+        default_factory=list,
+        description="Protocols declared in the registration projection",
+    )
+    intent_types: list[str] = Field(
+        default_factory=list,
+        description="Intent types declared in the registration projection",
+    )
+
+
+__all__ = ["ModelRegistryNodeDetailView"]

--- a/src/omnibase_infra/services/registry_api/models/model_registry_node_view.py
+++ b/src/omnibase_infra/services/registry_api/models/model_registry_node_view.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.types import JsonType
 
 
 class ModelRegistryNodeView(BaseModel):
@@ -24,40 +25,54 @@ class ModelRegistryNodeView(BaseModel):
     flattened for dashboard consumption.
 
     Attributes:
-        node_id: Unique identifier (entity_id from projection)
-        name: Human-readable node name (from service_name or node_type)
-        service_name: Consul service name for discovery
-        namespace: Optional namespace for multi-tenant deployments
-        display_name: Optional human-friendly display name
+        node_id: Canonical registry identifier (entity_id from projection)
+        name: Stable registry label. Until projections carry a canonical
+            human name, this mirrors the canonical node_id string.
+        service_name: Deprecated compatibility field for legacy service discovery
+            consumers. Not canonical registry identity.
+        namespace: Optional registry namespace derived from projection domain
+        display_name: Optional human-friendly fallback label
         node_type: ONEX node archetype (EFFECT, COMPUTE, REDUCER, ORCHESTRATOR)
         version: Semantic version (ModelSemVer instance)
         state: Current FSM registration state
         capabilities: List of capability tags
+        capability_details: Safe typed capability subset derived from projection
+        contract_type: Contract type declared in projection
+        contract_version: Contract version declared in projection
         registered_at: Timestamp of initial registration
         last_heartbeat_at: Timestamp of last heartbeat (nullable)
+        updated_at: Timestamp of last projection update
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     node_id: UUID = Field(
         ...,
-        description="Unique node identifier",
+        description="Canonical registry node identifier",
     )
     name: str = Field(
         ...,
-        description="Node name (service_name or derived from node_type)",
+        description=(
+            "Stable registry node label. Mirrors node_id until projections expose "
+            "a canonical human name."
+        ),
     )
-    service_name: str = Field(  # ONEX_EXCLUDE: pattern - Consul discovery identifier
-        ...,
-        description="Consul service name (external Consul identifier, not entity reference)",
+    service_name: str | None = (
+        Field(  # ONEX_EXCLUDE: pattern - legacy discovery compatibility
+            default=None,
+            description=(
+                "Deprecated compatibility field for legacy service discovery naming. "
+                "Not canonical registry identity."
+            ),
+        )
     )
     namespace: str | None = Field(
         default=None,
-        description="Optional namespace for multi-tenant deployments",
+        description="Optional registry namespace derived from projection domain",
     )
     display_name: str | None = Field(
         default=None,
-        description="Optional human-friendly display name",
+        description="Optional human-friendly fallback label",
     )
     node_type: Literal["EFFECT", "COMPUTE", "REDUCER", "ORCHESTRATOR"] = Field(
         ...,
@@ -75,6 +90,18 @@ class ModelRegistryNodeView(BaseModel):
         default_factory=list,
         description="List of capability tags",
     )
+    capability_details: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Safe typed capability subset derived from projection data",
+    )
+    contract_type: str | None = Field(
+        default=None,
+        description="Contract type declared in the registration projection",
+    )
+    contract_version: str | None = Field(
+        default=None,
+        description="Contract version declared in the registration projection",
+    )
     registered_at: datetime = Field(
         ...,
         description="Timestamp of initial registration",
@@ -82,6 +109,10 @@ class ModelRegistryNodeView(BaseModel):
     last_heartbeat_at: datetime | None = Field(
         default=None,
         description="Timestamp of last heartbeat",
+    )
+    updated_at: datetime = Field(
+        ...,
+        description="Timestamp of the last projection update",
     )
 
 

--- a/src/omnibase_infra/services/registry_api/models/model_registry_summary.py
+++ b/src/omnibase_infra/services/registry_api/models/model_registry_summary.py
@@ -19,8 +19,8 @@ class ModelRegistrySummary(BaseModel):
     Attributes:
         total_nodes: Total number of registered nodes
         active_nodes: Number of nodes in ACTIVE state
-        healthy_instances: Number of passing health check instances
-        unhealthy_instances: Number of failing health check instances
+        healthy_instances: Compatibility count for passing legacy service instances
+        unhealthy_instances: Compatibility count for failing legacy service instances
         by_node_type: Count of nodes by type
         by_state: Count of nodes by registration state
     """
@@ -40,12 +40,12 @@ class ModelRegistrySummary(BaseModel):
     healthy_instances: int = Field(
         ...,
         ge=0,
-        description="Number of passing health check instances",
+        description="Compatibility count for passing legacy service instances",
     )
     unhealthy_instances: int = Field(
         ...,
         ge=0,
-        description="Number of failing health check instances",
+        description="Compatibility count for failing legacy service instances",
     )
     by_node_type: dict[str, int] = Field(
         default_factory=dict,

--- a/src/omnibase_infra/services/registry_api/routes.py
+++ b/src/omnibase_infra/services/registry_api/routes.py
@@ -36,6 +36,7 @@ from omnibase_infra.services.registry_api.models import (
     ModelFeatureFlagToggleResult,
     ModelRegistryDiscoveryResponse,
     ModelRegistryHealthResponse,
+    ModelRegistryNodeDetailView,
     ModelRegistryNodeView,
     ModelResponseListContracts,
     ModelResponseListInstances,
@@ -253,7 +254,7 @@ async def list_nodes(
 
 @router.get(
     "/nodes/{node_id}",
-    response_model=ModelRegistryNodeView,
+    response_model=ModelRegistryNodeDetailView,
     summary="Get Node Details",
     description="Returns detailed information for a single registered node by ID.",
     responses={
@@ -266,7 +267,7 @@ async def get_node(
     node_id: UUID,
     service: Annotated[ServiceRegistryDiscovery, Depends(get_service)],
     correlation_id: Annotated[UUID, Depends(get_correlation_id)],
-) -> ModelRegistryNodeView:
+) -> ModelRegistryNodeDetailView:
     """Get a single node by ID."""
 
     node, warnings = await service.get_node(

--- a/src/omnibase_infra/services/registry_api/service.py
+++ b/src/omnibase_infra/services/registry_api/service.py
@@ -45,6 +45,7 @@ from omnibase_infra.services.registry_api.models import (
     ModelRegistryDiscoveryResponse,
     ModelRegistryHealthResponse,
     ModelRegistryInstanceView,
+    ModelRegistryNodeDetailView,
     ModelRegistryNodeView,
     ModelRegistrySummary,
     ModelTopicSummary,
@@ -88,6 +89,83 @@ _default_widget_mapping_rel: str = str(
 DEFAULT_WIDGET_MAPPING_PATH: Path = (
     Path(__file__).parent.parent.parent / _default_widget_mapping_rel
 )
+
+
+def _build_node_display_name(proj: ModelRegistrationProjection) -> str:
+    """Return a human-friendly fallback label for a registry node."""
+    return f"onex-{proj.node_type.value}"
+
+
+def _build_capability_details(
+    proj: ModelRegistrationProjection,
+) -> dict[str, JsonType]:
+    """Return the approved phase-1 capability subset for API exposure."""
+    capabilities = proj.capabilities.model_dump(mode="json", exclude_none=True)
+    safe_keys = (
+        "postgres",
+        "read",
+        "write",
+        "database",
+        "transactions",
+        "processing",
+        "batch_size",
+        "max_batch",
+        "supported_types",
+        "routing",
+        "feature",
+    )
+    return {
+        key: capabilities[key]
+        for key in safe_keys
+        if key in capabilities and capabilities[key] not in (False, [], {}, None)
+    }
+
+
+def _build_registry_node_view_payload(
+    proj: ModelRegistrationProjection,
+) -> dict[str, object]:
+    """Build the shared projection-backed payload for registry node responses."""
+    node_type_str = proj.node_type.value.upper()
+    if node_type_str not in ("EFFECT", "COMPUTE", "REDUCER", "ORCHESTRATOR"):
+        node_type_str = "EFFECT"
+
+    return {
+        "node_id": proj.entity_id,
+        # Until registration_projections carry a canonical human-readable name,
+        # the stable registry label is the canonical entity identifier.
+        "name": str(proj.entity_id),
+        "service_name": None,
+        "namespace": proj.domain if proj.domain != "registration" else None,
+        "display_name": _build_node_display_name(proj),
+        "node_type": node_type_str,
+        "version": proj.node_version,
+        "state": proj.current_state.value,
+        "capabilities": proj.capability_tags,
+        "capability_details": _build_capability_details(proj),
+        "contract_type": proj.contract_type,
+        "contract_version": proj.contract_version,
+        "registered_at": proj.registered_at,
+        "last_heartbeat_at": proj.last_heartbeat_at,
+        "updated_at": proj.updated_at,
+    }
+
+
+def _build_registry_node_view(
+    proj: ModelRegistrationProjection,
+) -> ModelRegistryNodeView:
+    """Map a registration projection into the list/discovery node view."""
+    return ModelRegistryNodeView(**_build_registry_node_view_payload(proj))
+
+
+def _build_registry_node_detail_view(
+    proj: ModelRegistrationProjection,
+) -> ModelRegistryNodeDetailView:
+    """Map a registration projection into the detailed node view."""
+    return ModelRegistryNodeDetailView(
+        **_build_registry_node_view_payload(proj),
+        protocols=proj.protocols,
+        intent_types=proj.intent_types,
+    )
 
 
 class ServiceRegistryDiscovery:
@@ -310,33 +388,7 @@ class ServiceRegistryDiscovery:
 
                 # Convert to view models
                 for proj in projections_slice:
-                    # Map EnumNodeKind to API node_type string
-                    node_type_str = proj.node_type.value.upper()
-                    if node_type_str not in (
-                        "EFFECT",
-                        "COMPUTE",
-                        "REDUCER",
-                        "ORCHESTRATOR",
-                    ):
-                        node_type_str = "EFFECT"  # Fallback
-
-                    nodes.append(
-                        ModelRegistryNodeView(
-                            node_id=proj.entity_id,
-                            name=f"onex-{proj.node_type.value}",
-                            service_name=f"onex-{proj.node_type.value}-{str(proj.entity_id)[:8]}",
-                            namespace=proj.domain
-                            if proj.domain != "registration"
-                            else None,
-                            display_name=None,
-                            node_type=node_type_str,  # type: ignore[arg-type]
-                            version=proj.node_version,
-                            state=proj.current_state.value,
-                            capabilities=proj.capability_tags,
-                            registered_at=proj.registered_at,
-                            last_heartbeat_at=proj.last_heartbeat_at,
-                        )
-                    )
+                    nodes.append(_build_registry_node_view(proj))
 
             except Exception as e:
                 logger.exception(
@@ -365,7 +417,7 @@ class ServiceRegistryDiscovery:
         self,
         node_id: UUID,
         correlation_id: UUID | None = None,
-    ) -> tuple[ModelRegistryNodeView | None, list[ModelWarning]]:
+    ) -> tuple[ModelRegistryNodeDetailView | None, list[ModelWarning]]:
         """Get a single node by ID.
 
         Args:
@@ -398,23 +450,7 @@ class ServiceRegistryDiscovery:
             if proj is None:
                 return None, warnings
 
-            node_type_str = proj.node_type.value.upper()
-            if node_type_str not in ("EFFECT", "COMPUTE", "REDUCER", "ORCHESTRATOR"):
-                node_type_str = "EFFECT"
-
-            node = ModelRegistryNodeView(
-                node_id=proj.entity_id,
-                name=f"onex-{proj.node_type.value}",
-                service_name=f"onex-{proj.node_type.value}-{str(proj.entity_id)[:8]}",
-                namespace=proj.domain if proj.domain != "registration" else None,
-                display_name=None,
-                node_type=node_type_str,  # type: ignore[arg-type]
-                version=proj.node_version,
-                state=proj.current_state.value,
-                capabilities=proj.capability_tags,
-                registered_at=proj.registered_at,
-                last_heartbeat_at=proj.last_heartbeat_at,
-            )
+            node = _build_registry_node_detail_view(proj)
 
             return node, warnings
 
@@ -502,6 +538,15 @@ class ServiceRegistryDiscovery:
         )
         all_warnings.extend(instance_warnings)
 
+        instance_discovery_status = "available"
+        instance_discovery_message: str | None = None
+        if any(w.code == "NO_CONSUL_HANDLER" for w in instance_warnings):
+            instance_discovery_status = "unavailable"
+            instance_discovery_message = next(
+                (w.message for w in instance_warnings if w.code == "NO_CONSUL_HANDLER"),
+                None,
+            )
+
         # Build summary
         by_node_type: dict[str, int] = {}
         by_state: dict[str, int] = {}
@@ -530,6 +575,8 @@ class ServiceRegistryDiscovery:
             warnings=all_warnings,
             summary=summary,
             nodes=nodes,
+            instance_discovery_status=instance_discovery_status,  # type: ignore[arg-type]
+            instance_discovery_message=instance_discovery_message,
             live_instances=instances,
             pagination=pagination,
         )

--- a/tests/integration/projectors/test_registry_api_projection_tail_integration.py
+++ b/tests/integration/projectors/test_registry_api_projection_tail_integration.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for the registry API projection read tail.
+
+These tests validate the exact tail this branch changes:
+
+registration_projections -> ProjectionReaderRegistration
+-> ServiceRegistryDiscovery -> registry API response models
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.enums import EnumRegistrationState
+from omnibase_infra.models.projection import (
+    ModelRegistrationProjection,
+    ModelSequenceInfo,
+)
+from omnibase_infra.models.registration.model_node_capabilities import (
+    ModelNodeCapabilities,
+)
+from omnibase_infra.runtime import ProjectorShell
+from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
+
+if TYPE_CHECKING:
+    from omnibase_infra.projectors import ProjectionReaderRegistration
+
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+]
+
+
+def _make_projection() -> ModelRegistrationProjection:
+    """Create a registration projection with phase-1 and detail-only fields."""
+    now = datetime.now(UTC)
+    return ModelRegistrationProjection(
+        entity_id=UUID("44444444-4444-4444-4444-444444444444"),
+        domain="registration",
+        current_state=EnumRegistrationState.ACTIVE,
+        node_type=EnumNodeKind.COMPUTE,
+        node_version=ModelSemVer(major=3, minor=2, patch=1),
+        capabilities=ModelNodeCapabilities(
+            postgres=True,
+            read=True,
+            config={"dsn": "internal-only"},
+        ),
+        capability_tags=["postgres.storage", "registry.read"],
+        contract_type="compute",
+        contract_version="3.2.1",
+        protocols=["ProtocolDatabaseAdapter"],
+        intent_types=["registry.lookup"],
+        last_applied_event_id=uuid4(),
+        last_applied_offset=101,
+        registered_at=now,
+        updated_at=now,
+    )
+
+
+def _make_sequence(offset: int) -> ModelSequenceInfo:
+    """Create sequence info for persistence tests."""
+    return ModelSequenceInfo(sequence=offset, partition="0", offset=offset)
+
+
+async def _upsert_projection(
+    projector: ProjectorShell,
+    projection: ModelRegistrationProjection,
+) -> bool:
+    """Persist a registration projection through the declarative projector."""
+    values: dict[str, object] = {
+        "entity_id": projection.entity_id,
+        "domain": projection.domain,
+        "current_state": projection.current_state.value,
+        "node_type": projection.node_type.value,
+        "node_version": str(projection.node_version),
+        "capabilities": projection.capabilities.model_dump_json(),
+        "contract_type": projection.contract_type,
+        "intent_types": projection.intent_types,
+        "protocols": projection.protocols,
+        "capability_tags": projection.capability_tags,
+        "contract_version": projection.contract_version,
+        "liveness_deadline": projection.liveness_deadline,
+        "last_heartbeat_at": projection.last_heartbeat_at,
+        "last_applied_event_id": projection.last_applied_event_id,
+        "last_applied_offset": projection.last_applied_offset,
+        "registered_at": projection.registered_at,
+        "updated_at": projection.updated_at,
+    }
+    return await projector.upsert_partial(
+        aggregate_id=projection.entity_id,
+        values=values,
+        correlation_id=uuid4(),
+        conflict_columns=["entity_id", "domain"],
+    )
+
+
+class TestRegistryApiProjectionTail:
+    """Focused integration coverage for the registry projection read tail."""
+
+    async def test_list_and_detail_are_projection_backed(
+        self,
+        projector: ProjectorShell,
+        reader: ProjectionReaderRegistration,
+    ) -> None:
+        """List/detail should expose projection-backed identity and field policy."""
+        projection = _make_projection()
+
+        projection.last_applied_offset = _make_sequence(101).offset or 101
+        result = await _upsert_projection(projector, projection)
+        assert result is True
+
+        service = ServiceRegistryDiscovery(
+            container=MagicMock(),
+            projection_reader=reader,
+        )
+
+        nodes, pagination, warnings = await service.list_nodes(limit=10, offset=0)
+
+        assert warnings == []
+        assert pagination.total == 1
+        assert len(nodes) == 1
+
+        node = nodes[0]
+        assert node.node_id == projection.entity_id
+        assert node.name == str(projection.entity_id)
+        assert node.display_name == "onex-compute"
+        assert node.service_name is None
+        assert node.namespace is None
+        assert node.contract_type == "compute"
+        assert node.contract_version == "3.2.1"
+        assert node.capability_details == {"postgres": True, "read": True}
+        assert not hasattr(node, "protocols")
+        assert not hasattr(node, "intent_types")
+
+        detail, detail_warnings = await service.get_node(node_id=projection.entity_id)
+
+        assert detail_warnings == []
+        assert detail is not None
+        assert detail.node_id == projection.entity_id
+        assert detail.protocols == ["ProtocolDatabaseAdapter"]
+        assert detail.intent_types == ["registry.lookup"]
+
+    async def test_discovery_marks_instance_surface_as_degraded(
+        self,
+        projector: ProjectorShell,
+        reader: ProjectionReaderRegistration,
+    ) -> None:
+        """Discovery should explicitly mark post-Consul instance unavailability."""
+        projection = _make_projection()
+
+        projection.last_applied_offset = _make_sequence(101).offset or 101
+        result = await _upsert_projection(projector, projection)
+        assert result is True
+
+        service = ServiceRegistryDiscovery(
+            container=MagicMock(),
+            projection_reader=reader,
+        )
+
+        discovery = await service.get_discovery(limit=10, offset=0)
+
+        assert discovery.instance_discovery_status == "unavailable"
+        assert discovery.instance_discovery_message == (
+            "Service discovery not available (Consul removed)"
+        )
+        assert discovery.live_instances == []
+        assert discovery.summary.total_nodes == 1
+        assert discovery.summary.active_nodes == 1
+        assert discovery.summary.healthy_instances == 0
+        assert discovery.summary.unhealthy_instances == 0
+        assert any(w.code == "NO_CONSUL_HANDLER" for w in discovery.warnings)

--- a/tests/unit/services/registry_api/test_registry_discovery_semantics.py
+++ b/tests/unit/services/registry_api/test_registry_discovery_semantics.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for post-Consul registry discovery semantics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.enums import EnumRegistrationState
+from omnibase_infra.models.projection.model_registration_projection import (
+    ModelRegistrationProjection,
+)
+from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
+
+
+def _make_projection() -> ModelRegistrationProjection:
+    """Create a minimal active projection for discovery tests."""
+    now = datetime.now(UTC)
+    return ModelRegistrationProjection(
+        entity_id=uuid4(),
+        current_state=EnumRegistrationState.ACTIVE,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=ModelSemVer(major=1, minor=0, patch=0),
+        capability_tags=["registry.read"],
+        last_applied_event_id=uuid4(),
+        last_applied_offset=1,
+        registered_at=now,
+        updated_at=now,
+    )
+
+
+def _make_service() -> tuple[ServiceRegistryDiscovery, AsyncMock]:
+    """Create a registry service with a mocked projection reader."""
+    container = MagicMock()
+    reader = AsyncMock()
+    service = ServiceRegistryDiscovery(container=container, projection_reader=reader)
+    return service, reader
+
+
+@pytest.mark.unit
+class TestRegistryDiscoverySemantics:
+    """Verify discovery payload explicitly degrades legacy instance discovery."""
+
+    @pytest.mark.asyncio
+    async def test_get_discovery_marks_instance_discovery_unavailable(self) -> None:
+        """Discovery response should surface post-Consul instance unavailability."""
+        projection = _make_projection()
+        service, reader = _make_service()
+
+        async def mock_get_by_state(
+            state: EnumRegistrationState, limit: int = 10000, correlation_id=None
+        ) -> list[ModelRegistrationProjection]:
+            return [projection] if state == EnumRegistrationState.ACTIVE else []
+
+        reader.get_by_state.side_effect = mock_get_by_state
+
+        response = await service.get_discovery(limit=10, offset=0)
+
+        assert response.instance_discovery_status == "unavailable"
+        assert response.instance_discovery_message == (
+            "Service discovery not available (Consul removed)"
+        )
+        assert response.live_instances == []
+        assert response.summary.healthy_instances == 0
+        assert response.summary.unhealthy_instances == 0
+        assert any(w.code == "NO_CONSUL_HANDLER" for w in response.warnings)

--- a/tests/unit/services/registry_api/test_registry_node_identity.py
+++ b/tests/unit/services/registry_api/test_registry_node_identity.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for registry API node identity semantics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.enums import EnumRegistrationState
+from omnibase_infra.models.projection.model_registration_projection import (
+    ModelRegistrationProjection,
+)
+from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
+
+
+def _make_projection(
+    *,
+    entity_id: UUID | None = None,
+    domain: str = "registration",
+    node_type: EnumNodeKind = EnumNodeKind.EFFECT,
+    state: EnumRegistrationState = EnumRegistrationState.ACTIVE,
+) -> ModelRegistrationProjection:
+    """Create a minimal registration projection for registry API tests."""
+    now = datetime.now(UTC)
+    return ModelRegistrationProjection(
+        entity_id=entity_id or uuid4(),
+        domain=domain,
+        current_state=state,
+        node_type=node_type,
+        node_version=ModelSemVer(major=1, minor=1, patch=0),
+        capability_tags=["registry.read"],
+        last_applied_event_id=uuid4(),
+        last_applied_offset=1,
+        registered_at=now,
+        updated_at=now,
+    )
+
+
+def _make_service() -> tuple[ServiceRegistryDiscovery, AsyncMock]:
+    """Create a registry service with a mocked projection reader."""
+    container = MagicMock()
+    reader = AsyncMock()
+    service = ServiceRegistryDiscovery(container=container, projection_reader=reader)
+    return service, reader
+
+
+@pytest.mark.unit
+class TestRegistryNodeIdentity:
+    """Verify registry node responses do not treat legacy naming as canonical."""
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_uses_entity_id_as_stable_name(self) -> None:
+        """List responses use the canonical projection id for stable node naming."""
+        projection = _make_projection(
+            entity_id=UUID("11111111-1111-1111-1111-111111111111")
+        )
+        service, reader = _make_service()
+
+        async def mock_get_by_state(
+            state: EnumRegistrationState, limit: int = 10000, correlation_id=None
+        ) -> list[ModelRegistrationProjection]:
+            return [projection] if state == EnumRegistrationState.ACTIVE else []
+
+        reader.get_by_state.side_effect = mock_get_by_state
+
+        nodes, pagination, warnings = await service.list_nodes(limit=10, offset=0)
+
+        assert warnings == []
+        assert pagination.total == 1
+        assert len(nodes) == 1
+        assert nodes[0].node_id == projection.entity_id
+        assert nodes[0].name == str(projection.entity_id)
+        assert nodes[0].display_name == "onex-effect"
+        assert nodes[0].service_name is None
+        assert nodes[0].namespace is None
+
+    @pytest.mark.asyncio
+    async def test_get_node_preserves_non_registration_domain_as_namespace(
+        self,
+    ) -> None:
+        """Non-default projection domains remain explicit registry namespaces."""
+        projection = _make_projection(
+            entity_id=UUID("22222222-2222-2222-2222-222222222222"),
+            domain="market",
+            node_type=EnumNodeKind.ORCHESTRATOR,
+        )
+        service, reader = _make_service()
+        reader.get_entity_state.return_value = projection
+
+        node, warnings = await service.get_node(node_id=projection.entity_id)
+
+        assert warnings == []
+        assert node is not None
+        assert node.node_id == projection.entity_id
+        assert node.name == str(projection.entity_id)
+        assert node.display_name == "onex-orchestrator"
+        assert node.service_name is None
+        assert node.namespace == "market"
+        assert node.node_type == "ORCHESTRATOR"

--- a/tests/unit/services/registry_api/test_registry_node_projection_fields.py
+++ b/tests/unit/services/registry_api/test_registry_node_projection_fields.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for phase-1 projection-backed registry node fields."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.enums import EnumRegistrationState
+from omnibase_infra.models.projection.model_registration_projection import (
+    ModelRegistrationProjection,
+)
+from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
+
+
+def _make_projection() -> ModelRegistrationProjection:
+    """Create a projection with phase-1 and detail-only fields populated."""
+    now = datetime.now(UTC)
+    return ModelRegistrationProjection(
+        entity_id=UUID("33333333-3333-3333-3333-333333333333"),
+        current_state=EnumRegistrationState.ACTIVE,
+        node_type=EnumNodeKind.COMPUTE,
+        node_version=ModelSemVer(major=2, minor=3, patch=4),
+        capabilities={
+            "postgres": True,
+            "read": True,
+            "config": {"dsn": "hidden"},
+            "feature_flags": {},
+        },
+        capability_tags=["postgres.storage", "registry.read"],
+        contract_type="compute",
+        contract_version="2.3.4",
+        protocols=["ProtocolDatabaseAdapter", "ProtocolReadable"],
+        intent_types=["registry.lookup", "registry.sync"],
+        last_applied_event_id=uuid4(),
+        last_applied_offset=9,
+        registered_at=now,
+        updated_at=now,
+    )
+
+
+def _make_service() -> tuple[ServiceRegistryDiscovery, AsyncMock]:
+    """Create a registry service with a mocked projection reader."""
+    container = MagicMock()
+    reader = AsyncMock()
+    service = ServiceRegistryDiscovery(container=container, projection_reader=reader)
+    return service, reader
+
+
+@pytest.mark.unit
+class TestRegistryNodeProjectionFields:
+    """Verify list/detail exposure of approved projection-backed fields."""
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_exposes_phase1_fields_only(self) -> None:
+        """List nodes include phase-1 additions but omit detail-only fields."""
+        projection = _make_projection()
+        service, reader = _make_service()
+
+        async def mock_get_by_state(
+            state: EnumRegistrationState, limit: int = 10000, correlation_id=None
+        ) -> list[ModelRegistrationProjection]:
+            return [projection] if state == EnumRegistrationState.ACTIVE else []
+
+        reader.get_by_state.side_effect = mock_get_by_state
+
+        nodes, _, warnings = await service.list_nodes(limit=10, offset=0)
+
+        assert warnings == []
+        assert len(nodes) == 1
+        node = nodes[0]
+        assert node.contract_type == "compute"
+        assert node.contract_version == "2.3.4"
+        assert node.updated_at == projection.updated_at
+        assert node.capability_details == {"postgres": True, "read": True}
+        assert not hasattr(node, "protocols")
+        assert not hasattr(node, "intent_types")
+
+    @pytest.mark.asyncio
+    async def test_get_node_exposes_detail_only_fields(self) -> None:
+        """Node detail includes projection-backed protocols and intent types."""
+        projection = _make_projection()
+        service, reader = _make_service()
+        reader.get_entity_state.return_value = projection
+
+        node, warnings = await service.get_node(node_id=projection.entity_id)
+
+        assert warnings == []
+        assert node is not None
+        assert node.contract_type == "compute"
+        assert node.contract_version == "2.3.4"
+        assert node.capability_details == {"postgres": True, "read": True}
+        assert node.protocols == ["ProtocolDatabaseAdapter", "ProtocolReadable"]
+        assert node.intent_types == ["registry.lookup", "registry.sync"]


### PR DESCRIPTION
## Summary
- harden registry API node identity around canonical `node_id` instead of synthetic discovery names
- expose phase-1 projection-backed node fields and split list vs detail response semantics
- make post-Consul instance discovery degradation explicit in the discovery payload
- add focused unit and integration coverage for the `registration_projections -> ProjectionReaderRegistration -> ServiceRegistryDiscovery` tail

## Tickets
- OMN-9543
- OMN-9544
- OMN-9545
- OMN-9546

## Validation
- `PYTHONPATH=$PWD/src uv run pytest tests/unit/services/registry_api -q`
- `PYTHONPATH=$PWD/src uv run pytest tests/integration/projectors/test_registry_api_projection_tail_integration.py -q`

## Notes
- `node_id` remains a UUID and is the canonical registry identifier
- `service_name` is now an optional legacy compatibility field, not canonical registry identity
- this branch stays within `omnibase_infra` and does not do any `omnidash` implementation work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Node detail endpoint now returns protocol and intent type information
  * Added explicit instance discovery status to discovery responses with explanatory messaging

* **Updates**
  * Enhanced node identification with improved stable naming conventions
  * Extended node information with contract type, version, and capability details
  * Refined discovery response descriptions for legacy compatibility clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->