### PR TITLE
fix(registration): register HandlerNodeHeartbeat under concrete class for auto-wiring Phase 0 (OMN-9463)

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
@@ -762,6 +762,9 @@ async def wire_registration_handlers(
 
         # Register HandlerNodeHeartbeat (requires projector)
         # Uses ProtocolNodeHeartbeat for protocol-based DI resolution.
+        # Also registered under the concrete class so the auto-wiring engine's
+        # Phase 0 async pre-resolution (get_service_async) can find it by
+        # concrete class name (OMN-9463).
         if projector is not None:
             from omnibase_infra.protocols.protocol_node_heartbeat import (
                 ProtocolNodeHeartbeat,
@@ -777,6 +780,15 @@ async def wire_registration_handlers(
                 scope=EnumInjectionScope.GLOBAL,
                 metadata={
                     "description": "Handler for NodeHeartbeatEvent",
+                    "version": str(semver_default),
+                },
+            )
+            await container.service_registry.register_instance(
+                interface=HandlerNodeHeartbeat,
+                instance=handler_heartbeat,
+                scope=EnumInjectionScope.GLOBAL,
+                metadata={
+                    "description": "Handler for NodeHeartbeatEvent (concrete class registration for auto-wiring Phase 0)",
                     "version": str(semver_default),
                 },
             )


### PR DESCRIPTION
## Summary
- Registers `HandlerNodeHeartbeat` under both `ProtocolNodeHeartbeat` (protocol interface) AND `HandlerNodeHeartbeat` (concrete class) in the container
- The auto-wiring engine's Phase 0 async pre-resolution calls `get_service_async(HandlerNodeHeartbeat)` but could only find it under the protocol interface
- Without this fix, Phase 0 misses the handler, falls through to the sync resolver, and hits `asyncio.run()` inside the running event loop

Closes OMN-9463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal service registration system to improve auto-wiring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->