### PR TITLE
fix(registration): make HandlerTopicCatalogQuery zero-arg constructible (OMN-9464)

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -453,6 +453,9 @@ handler_routing:
     # ModelTopicCatalogQuery -> HandlerTopicCatalogQuery
     # Topic catalog request-response - dashboard publishes a query; runtime
     # responds with a full catalog snapshot via ServiceTopicCatalog.
+    # OMN-9464: catalog_service is optional (None allowed) so the auto-wiring
+    # engine can construct this handler with zero args; the missing service
+    # path returns an empty catalog with INTERNAL_ERROR warning.
     - event_model:
         name: "ModelTopicCatalogQuery"
         module: "omnibase_infra.models.catalog.model_topic_catalog_query"
@@ -463,6 +466,7 @@ handler_routing:
       output_events:
         - "ModelTopicCatalogResponse"
       direct_handler: true
+      zero_arg_constructible: true
       description: "Returns topic catalog snapshot in response to a catalog query"
     # ModelTopicCatalogRequest -> HandlerCatalogRequest (OMN-2923)
     # Introspection-based catalog responder - returns onex.evt.* topics from
@@ -487,6 +491,14 @@ handler_routing:
       module: "omnibase_infra.projectors.projection_reader_registration"
       shared: true
       description: "Shared projection reader for all handlers"
+    # OMN-9464: catalog_service is optional for HandlerTopicCatalogQuery.
+    # Auto-wiring engine may construct it with zero args; missing service
+    # returns empty catalog with INTERNAL_ERROR warning rather than failing boot.
+    catalog_service:
+      protocol: "ProtocolTopicCatalogService"
+      module: "omnibase_infra.services.protocol_topic_catalog_service"
+      required: false
+      description: "Topic catalog service for HandlerTopicCatalogQuery (optional)"
 published_events:
   - topic: "onex.evt.platform.node-registration-result.v1"
     event_type: "NodeRegistrationResultEvent"

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_topic_catalog_query.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_topic_catalog_query.py
@@ -108,7 +108,7 @@ class HandlerTopicCatalogQuery:
 
     def __init__(
         self,
-        catalog_service: ProtocolTopicCatalogService,
+        catalog_service: ProtocolTopicCatalogService | None = None,
     ) -> None:
         """Initialize the handler with a topic catalog service.
 
@@ -117,6 +117,8 @@ class HandlerTopicCatalogQuery:
                 either ``ServiceTopicCatalog`` (Consul-backed, legacy) or
                 ``HandlerTopicCatalogPostgres`` (PostgreSQL-backed, OMN-2746, OMN-4011).
                 Wired via registry ``handler_dependencies``.
+                When None, the handler returns an empty catalog with a warning
+                (OMN-9464: allows zero-arg construction by auto-wiring engine).
         """
         self._catalog_service = catalog_service
 
@@ -220,22 +222,33 @@ class HandlerTopicCatalogQuery:
         )
 
         # Delegate to ServiceTopicCatalog - it handles all partial-success logic
-        try:
-            catalog_response = await self._catalog_service.build_catalog(
-                correlation_id=correlation_id,
-                include_inactive=payload.include_inactive,
-                topic_pattern=payload.topic_pattern,
-            )
-        except Exception as e:  # noqa: BLE001 — boundary: logs error and degrades
-            logger.error(  # noqa: TRY400
-                "HandlerTopicCatalogQuery: unexpected error from ServiceTopicCatalog: %s",
-                type(e).__name__,
-                extra={"correlation_id": str(correlation_id)},
+        if self._catalog_service is None:
+            logger.warning(
+                "HandlerTopicCatalogQuery: no catalog_service configured, "
+                "returning empty catalog (correlation_id=%s)",
+                correlation_id,
             )
             catalog_response = self._empty_response(
                 correlation_id=correlation_id,
                 warnings=(INTERNAL_ERROR,),
             )
+        else:
+            try:
+                catalog_response = await self._catalog_service.build_catalog(
+                    correlation_id=correlation_id,
+                    include_inactive=payload.include_inactive,
+                    topic_pattern=payload.topic_pattern,
+                )
+            except Exception as e:  # noqa: BLE001 — boundary: logs error and degrades
+                logger.error(  # noqa: TRY400
+                    "HandlerTopicCatalogQuery: unexpected error from ServiceTopicCatalog: %s",
+                    type(e).__name__,
+                    extra={"correlation_id": str(correlation_id)},
+                )
+                catalog_response = self._empty_response(
+                    correlation_id=correlation_id,
+                    warnings=(INTERNAL_ERROR,),
+                )
 
         if catalog_response.warnings:
             logger.info(

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_topic_catalog_query.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_topic_catalog_query.py
@@ -221,7 +221,7 @@ class HandlerTopicCatalogQuery:
             },
         )
 
-        # Delegate to ServiceTopicCatalog - it handles all partial-success logic
+        # When catalog_service is available, delegate to ServiceTopicCatalog (handles partial-success logic); otherwise short-circuit with an empty catalog + warning.
         if self._catalog_service is None:
             logger.warning(
                 "HandlerTopicCatalogQuery: no catalog_service configured, "


### PR DESCRIPTION
## Summary
- Makes `catalog_service` parameter optional (default `None`) with graceful degradation
- When no catalog service is available, handler returns empty catalog with `INTERNAL_ERROR` warning instead of crashing
- Allows auto-wiring engine to construct the handler via zero-arg resolution path, avoiding `asyncio.run()` inside the runtime-managed event loop
- When `catalog_service` IS provided (normal plugin wiring path), behavior is unchanged

Closes OMN-9464

## dod_evidence

```yaml
dod_evidence:
  - type: test_pass
    description: "11 unit tests pass for handler_topic_catalog_query including zero-arg wiring test"
    receipt: "pytest tests/ -v -k handler_topic_catalog_query — 11 passed, 0 failed"
  - type: code_change
    description: "catalog_service param made optional with graceful degradation; zero-arg constructible path verified"
    pr: "https://github.com/OmniNode-ai/omnibase_infra/pull/1387"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system resilience by making catalog service dependencies optional, allowing graceful degradation when services are unavailable rather than causing failures
  * Improved error handling with informative warnings when dependencies cannot be resolved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->