### PR TITLE
fix(OMN-9547): arm auto-merge explicitly as SQUASH to prevent silent queue drop

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -84,7 +84,7 @@ jobs:
           PR: ${{ steps.resolve.outputs.pr }}
         run: |
           set -euo pipefail
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Fix the `Enable Auto-Merge` workflow to arm with explicit `--squash`, preventing the silent queue-drop failure mode tracked in [OMN-9547](https://linear.app/omninode/issue/OMN-9547).

## Root Cause (empirically confirmed 2026-04-23)

When `gh pr merge --auto` is invoked without `--squash`/`--merge`/`--rebase`, the `enablePullRequestAutoMerge` GraphQL mutation falls back to the **repository default** merge method. Even after the OMN-9547 repo-settings fix forced `allow_merge_commit: false, allow_squash_merge: true, allow_rebase_merge: false`, PRs were still being armed as `MERGE` by this workflow. Observed today: omnimarket#388 armed as `MERGE` (`merge_method: "merge"` in REST auto_merge), which silently drops the PR from the SQUASH-only merge queue (`feedback_merge_queue_method_mismatch.md` pattern — the queue ruleset rejects the mismatched method without error and the PR sits armed-but-dropped).

## Fix

Pass `--squash` explicitly to `gh pr merge --auto`. The OMN-9548 guard (merged earlier today) was inverted to permit SQUASH and block only MERGE/REBASE — so explicit `--squash` is both required here and permitted by the guard.

## Evidence

- Empirical: omnimarket#388 observed armed as MERGE at 20:39Z today via the github-actions bot.
- Forensic chain documented in OMN-9547 description (GitHub API behavior, queue ruleset mismatch, prior fix attempts OMN-9348/OMN-9354/OMN-9433/OMN-8838 each addressed a symptom).
- Memory reference: `feedback_merge_queue_method_mismatch.md` — confirmed this exact failure mode on merge-queue repos.

## Test plan

- [ ] Workflow parses cleanly (syntax check via GitHub actions runner on PR open)
- [ ] After merge: next PR opened on this repo arms with `mergeMethod: SQUASH` (verify via `gh api repos/<owner>/<repo>/pulls/<N> --jq .auto_merge.merge_method` returns `squash`)
- [ ] Next PR enters the merge queue (not dropped silently)

## DoD evidence

Relates to OMN-9547 residual item 2 (re-arm 5 stalled PRs — already done in parallel task) and residual item 3 (guard audit — OMN-9548 shipped earlier). This PR addresses the ongoing failure mode in the auto-merge workflow itself.