### PR TITLE
chore(runtime): clean up stale ONEX_OUTPUT_TOPIC refs from source docs [OMN-9409]

### DIFF
--- a/contracts/runtime/runtime_config.yaml
+++ b/contracts/runtime/runtime_config.yaml
@@ -13,8 +13,9 @@
 # Only ONEX_ENVIRONMENT and ONEX_EVENT_BUS_TYPE override contract values
 # at runtime (applied by bootstrap after config loading).
 #
-# When this file does NOT exist, the kernel falls back to env vars and
-# model defaults: ONEX_INPUT_TOPIC, ONEX_OUTPUT_TOPIC, ONEX_GROUP_ID.
+# When this file does NOT exist, the kernel falls back to ONEX_GROUP_ID and
+# model defaults. Topics are ALWAYS derived from contract event_bus
+# declarations (OMN-8784); there is no env-var override for topics.
 #
 # =============================================================================
 # ENVIRONMENT VARIABLES:
@@ -27,9 +28,10 @@
 #                         through this contract)
 #
 # Fallback defaults (only when this file is absent):
-#   ONEX_INPUT_TOPIC    - Default input_topic
-#   ONEX_OUTPUT_TOPIC   - Default output_topic
 #   ONEX_GROUP_ID       - Default group_id
+#
+# Removed (OMN-8784) — kernel hard-fails if set:
+#   ONEX_INPUT_TOPIC, ONEX_OUTPUT_TOPIC
 #
 # =============================================================================
 # FIELD STATUS LEGEND:
@@ -43,9 +45,11 @@ contract_version: "1.0.0"
 name: "runtime_config"
 description: "Configuration for ONEX runtime kernel"
 # Topic configuration [ACTIVE - used by RuntimeHostProcess]
-# These values take precedence when this file is loaded. ONEX_INPUT_TOPIC,
-# ONEX_OUTPUT_TOPIC, ONEX_GROUP_ID are only used as fallback defaults when
-# this config file is absent (see load_runtime_config in service_kernel.py).
+# These values take precedence when this file is loaded. Topics are ALWAYS
+# derived from contract declarations — ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC
+# were removed (OMN-8784). Only ONEX_GROUP_ID is accepted as a fallback
+# default when this config file is absent (see load_runtime_config in
+# service_kernel.py).
 input_topic: "onex.evt.platform.node-introspection.v1"
 output_topic: "onex.evt.platform.registration-completed.v1"
 group_id: "onex-runtime"

--- a/docker/README.md
+++ b/docker/README.md
@@ -546,9 +546,9 @@ These variables must be set explicitly. The runtime will fail to start if they a
 | `RUNTIME_MAIN_PORT`          | `8085`                             | Main runtime exposed port              |
 | `RUNTIME_EFFECTS_PORT`       | `8086`                             | Effects runtime exposed port           |
 | **Topics**                   |                                    |                                        |
-| `ONEX_INPUT_TOPIC`           | `requests`                         | Input topic for main runtime           |
-| `ONEX_OUTPUT_TOPIC`          | `responses`                        | Output topic for main runtime          |
 | `ONEX_GROUP_ID`              | `onex-runtime-main`                | Consumer group for main runtime        |
+| *ONEX_INPUT_TOPIC*           | *removed (OMN-8784)*               | *Topics come from node `contract.yaml` event_bus; kernel hard-fails if set* |
+| *ONEX_OUTPUT_TOPIC*          | *removed (OMN-8784)*               | *Topics come from node `contract.yaml` event_bus; kernel hard-fails if set* |
 | **OpenTelemetry**            |                                    |                                        |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`| `http://localhost:4317`            | OTLP exporter endpoint                 |
 | `OTEL_SERVICE_NAME`          | `omninode-runtime`                 | Service name for tracing               |

--- a/docker/env-example-full.txt
+++ b/docker/env-example-full.txt
@@ -160,9 +160,9 @@ POSTGRES_PASSWORD=__REPLACE_WITH_SECURE_PASSWORD__
 # Host port mapping for the main runtime service
 # RUNTIME_MAIN_PORT=8085
 
-# Kafka topics for main runtime
-# ONEX_INPUT_TOPIC=requests
-# ONEX_OUTPUT_TOPIC=responses
+# OMN-8784: ONEX_INPUT_TOPIC and ONEX_OUTPUT_TOPIC were removed. Topics are
+# derived from each node's contract.yaml event_bus declaration; setting
+# either env var now raises ProtocolConfigurationError at kernel bootstrap.
 
 # Consumer group ID for main runtime
 # ONEX_GROUP_ID=onex-runtime-main

--- a/docs/env-example-full.txt
+++ b/docs/env-example-full.txt
@@ -257,25 +257,19 @@ ONEX_GROUP_ID=onex-runtime-main
 # Example: 8085 (standard), 8080 (common alternative), 3000 (Node.js convention)
 ONEX_HTTP_PORT=8085
 
-# Kafka input topic for main runtime
-# Default: requests
-# Example: requests (dev), prod.requests (production)
-ONEX_INPUT_TOPIC=requests
+# OMN-8784: ONEX_INPUT_TOPIC was removed from the kernel. Topics are now
+# derived from each node's contract.yaml event_bus declaration. Setting this
+# var now raises ProtocolConfigurationError at kernel bootstrap.
 
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # Default: INFO
 # Example: DEBUG (verbose), INFO (standard), WARNING (quiet)
 ONEX_LOG_LEVEL=INFO
 
-# Kafka output topic for main runtime
-# Default: responses
-# Example: responses (dev), prod.responses (production)
-ONEX_OUTPUT_TOPIC=responses
-
-# Effects runtime Kafka topics (optional)
-# Default: effect-requests, effect-responses, onex-runtime-effects
-# ONEX_EFFECTS_INPUT_TOPIC=effect-requests
-# ONEX_EFFECTS_OUTPUT_TOPIC=effect-responses
+# OMN-8784: ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC were removed from the kernel.
+# Topics are now derived from each node's contract.yaml event_bus declaration.
+# Setting either var raises ProtocolConfigurationError at kernel bootstrap.
+# The same rule applies to any future ONEX_EFFECTS_*_TOPIC overrides.
 # ONEX_EFFECTS_GROUP_ID=onex-runtime-effects
 
 # Worker runtime Kafka topics (optional)

--- a/docs/standards/TOPIC_TAXONOMY.md
+++ b/docs/standards/TOPIC_TAXONOMY.md
@@ -84,11 +84,7 @@ full_topic = compose_full_topic(tenant="dev", namespace="myservice", suffix=suff
 # -> "dev.myservice.onex.evt.platform.node-registration.v1"
 ```
 
-**E2E tests use suffixes directly** (no prefix) when interacting with the local Docker infrastructure. The topic `onex.evt.platform.node-introspection.v1` is used as-is in `.env.docker`:
-
-```bash
-ONEX_INPUT_TOPIC=onex.evt.platform.node-introspection.v1
-```
+**E2E tests use suffixes directly** (no prefix) when interacting with the local Docker infrastructure. The topic `onex.evt.platform.node-introspection.v1` is used as-is. Note that as of OMN-8784 the runtime kernel no longer reads `ONEX_INPUT_TOPIC` / `ONEX_OUTPUT_TOPIC` — topics are derived from each node's `contract.yaml` `event_bus` declaration and setting those env vars raises `ProtocolConfigurationError` at bootstrap.
 
 **`TopicProvisioner`** at runtime startup creates topics from `ALL_PROVISIONED_TOPIC_SPECS`, using the suffix as the full Kafka topic name (no additional prefix in the current deployment model).
 

--- a/docs/testing/INTEGRATION_TESTING.md
+++ b/docs/testing/INTEGRATION_TESTING.md
@@ -71,9 +71,9 @@ KAFKA_BOOTSTRAP_SERVERS=localhost:19092
 RUNTIME_HOST=localhost
 RUNTIME_PORT=8085
 
-# Topic overrides (match runtime container contract.yaml)
-ONEX_INPUT_TOPIC=onex.evt.platform.node-introspection.v1
-ONEX_OUTPUT_TOPIC=onex.evt.platform.registration-completed.v1
+# Topics are derived from each node's contract.yaml event_bus declaration
+# (OMN-8784). ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC env vars were removed and
+# setting them now raises ProtocolConfigurationError at kernel bootstrap.
 
 # Enable runtime E2E processing tests
 RUNTIME_E2E_PROCESSING_ENABLED=true

--- a/src/omnibase_infra/runtime/models/model_runtime_config.py
+++ b/src/omnibase_infra/runtime/models/model_runtime_config.py
@@ -27,11 +27,13 @@ Reserved for Future Use:
       (currently kernel.py uses ONEX_LOG_LEVEL env var directly)
 
 Environment Variable Overrides:
-    ONEX_INPUT_TOPIC  - Overrides input_topic
-    ONEX_OUTPUT_TOPIC - Overrides output_topic
     ONEX_GROUP_ID     - Overrides group_id/consumer_group
     ONEX_ENVIRONMENT  - Overrides event_bus.environment
     ONEX_LOG_LEVEL    - Used directly by kernel (not via this model)
+
+Removed (OMN-8784) — kernel hard-fails if set:
+    ONEX_INPUT_TOPIC, ONEX_OUTPUT_TOPIC — topics are declared in each node's
+    contract.yaml event_bus.subscribe_topics / event_bus.publish_topics.
 
 Example:
     >>> config = ModelRuntimeConfig(

--- a/tests/integration/registration/e2e/conftest.py
+++ b/tests/integration/registration/e2e/conftest.py
@@ -740,11 +740,10 @@ async def introspectable_test_node(
             self.health_url = f"http://localhost:8080/{node_id}/health"
             self.api_url = f"http://localhost:8080/{node_id}/api"
 
-            # Get topic from environment or use contract.yaml default
-            # The runtime subscribes to: onex.evt.platform.node-introspection.v1
-            introspection_topic = os.getenv(
-                "ONEX_INPUT_TOPIC", "onex.evt.platform.node-introspection.v1"
-            )
+            # OMN-8784 removed ONEX_INPUT_TOPIC; the runtime derives its
+            # subscribe topic from the node contract's event_bus.subscribe_topics.
+            # The test uses the same contract-declared topic directly.
+            introspection_topic = "onex.evt.platform.node-introspection.v1"
             config = ModelIntrospectionConfig(
                 node_id=node_id,
                 node_type=node_type,

--- a/tests/integration/registration/e2e/test_runtime_e2e.py
+++ b/tests/integration/registration/e2e/test_runtime_e2e.py
@@ -80,11 +80,11 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Topic Configuration
 # =============================================================================
-# Get topic from environment or use docker-compose default
-# The runtime container subscribes to the ONEX 5-segment topic from contract.yaml
-RUNTIME_INPUT_TOPIC = os.getenv(
-    "ONEX_INPUT_TOPIC", "onex.evt.platform.node-introspection.v1"
-)
+# The runtime container subscribes to the topic declared in the node's
+# contract.yaml event_bus.subscribe_topics. OMN-8784 removed the
+# ONEX_INPUT_TOPIC env-var override, so the test hardcodes the same
+# contract-declared topic here.
+RUNTIME_INPUT_TOPIC = "onex.evt.platform.node-introspection.v1"
 
 # =============================================================================
 # CI Environment Timing Configuration
@@ -174,7 +174,8 @@ SKIP_PROCESSING_REASON = (
     "Runtime event processing tests require explicit opt-in. "
     "The runtime health check passed, but event processing verification is disabled. "
     "Set RUNTIME_E2E_PROCESSING_ENABLED=true to enable these tests after verifying: "
-    "1) Runtime is consuming from Kafka topic (ONEX_INPUT_TOPIC), "
+    "1) Runtime is consuming from the Kafka topic declared in the node "
+    "contract's event_bus.subscribe_topics (OMN-8784 removed ONEX_INPUT_TOPIC), "
     "2) Runtime is writing projections to PostgreSQL, "
     "3) Full E2E pipeline is operational. "
     "Without this, tests would wait 60-120s before timing out."
@@ -193,7 +194,8 @@ RUNTIME_OUTPUT_EVENTS_ENABLED = os.getenv(
 SKIP_OUTPUT_EVENTS_REASON = (
     "Runtime output event tests require explicit opt-in. "
     "Set RUNTIME_E2E_OUTPUT_EVENTS_ENABLED=true to enable these tests after verifying: "
-    "1) Runtime is configured to publish completion events to ONEX_OUTPUT_TOPIC, "
+    "1) Runtime publishes completion events to the topic declared in the node "
+    "contract's event_bus.publish_topics (OMN-8784 removed ONEX_OUTPUT_TOPIC), "
     "2) The output topic exists and is accessible. "
     "Without this flag, tests would wait and timeout."
 )
@@ -455,10 +457,11 @@ class TestRuntimeE2EFlow:
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     pass
 
-        # Subscribe to completion topic (matches docker-compose.e2e.yml ONEX_OUTPUT_TOPIC)
-        output_topic = os.getenv(
-            "ONEX_OUTPUT_TOPIC", "onex.evt.registration-completed.v1"
-        )
+        # Subscribe to the registration-completed topic. OMN-8784 removed
+        # ONEX_OUTPUT_TOPIC; the runtime derives its publish topic from the
+        # node contract's event_bus.publish_topics, so the test uses the
+        # contract-declared topic name directly.
+        output_topic = "onex.evt.registration-completed.v1"
         group_id = f"e2e-runtime-{unique_node_id.hex[:8]}"
 
         unsub = await real_kafka_event_bus.subscribe(

--- a/tests/unit/runtime/test_stale_topic_env_var_docs_removal.py
+++ b/tests/unit/runtime/test_stale_topic_env_var_docs_removal.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-9409: Stale ONEX_OUTPUT_TOPIC / ONEX_INPUT_TOPIC refs must stay removed.
+
+OMN-8784 removed `ONEX_INPUT_TOPIC` and `ONEX_OUTPUT_TOPIC` from the runtime
+kernel; topics are now derived from each node's `contract.yaml`
+`event_bus.subscribe_topics` / `event_bus.publish_topics`. Setting either env
+var now raises `ProtocolConfigurationError` at kernel bootstrap.
+
+This test locks in OMN-9409's documentation cleanup: if someone re-introduces
+an *active-looking* reference (uncommented assignment in env example files,
+`os.getenv("ONEX_*_TOPIC", ...)` in integration test helpers, or a live table
+row in operator docs), the next deploy-from-main would create containers with
+`ONEX_*_TOPIC` baked in and trigger the crash loop documented in OMN-9409.
+
+Historical / deprecation references (comments, docstrings, deprecated-guard
+unit tests, and this file itself) are allowed — the scan looks for patterns
+that would regress the removal.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Env-example-style files must not define ONEX_*_TOPIC as a live default.
+# An uncommented `ONEX_INPUT_TOPIC=...` or `ONEX_OUTPUT_TOPIC=...` at the start
+# of a line re-introduces the banned env var on the next deploy.
+ENV_EXAMPLE_FILES: tuple[str, ...] = (
+    "docker/env-example-full.txt",
+    "docs/env-example-full.txt",
+)
+ACTIVE_ENV_ASSIGNMENT = re.compile(r"(?m)^(ONEX_INPUT_TOPIC|ONEX_OUTPUT_TOPIC)\s*=")
+
+# E2E integration test helpers must not use ONEX_*_TOPIC as an override knob.
+# The kernel rejects these vars, so `os.getenv("ONEX_*_TOPIC", default)` is a
+# foot-gun: tests would either silently fall back to `default` (misleading)
+# or poison a runtime container that reads the same env and crash it.
+INTEGRATION_TEST_FILES: tuple[str, ...] = (
+    "tests/integration/registration/e2e/test_runtime_e2e.py",
+    "tests/integration/registration/e2e/conftest.py",
+)
+ENV_OVERRIDE_READ = re.compile(
+    r'os\.(?:getenv|environ\.get|environ\s*\[)\s*\(?\s*["\']'
+    r"(ONEX_INPUT_TOPIC|ONEX_OUTPUT_TOPIC)"
+    r"['\"]"
+)
+
+
+class TestStaleTopicEnvVarDocsRemoval:
+    """Guard OMN-8784's removal against regressions at the edges the kernel
+    test (test_kernel_topic_env_var_removal.py) does not cover: env example
+    files and integration-test helpers."""
+
+    @pytest.mark.parametrize("rel_path", ENV_EXAMPLE_FILES)
+    def test_no_active_env_assignment(self, rel_path: str) -> None:
+        path = REPO_ROOT / rel_path
+        assert path.exists(), f"env example file missing: {rel_path}"
+        content = path.read_text(encoding="utf-8")
+        matches = ACTIVE_ENV_ASSIGNMENT.findall(content)
+        assert not matches, (
+            f"{rel_path} contains active ONEX_*_TOPIC assignment(s): "
+            f"{matches}. OMN-8784 removed these env vars; OMN-9409 cleaned up "
+            "the stale defaults. Re-introducing an uncommented default would "
+            "cause the next deploy to bake the banned env var into the "
+            "runtime container and trigger a crash loop."
+        )
+
+    @pytest.mark.parametrize("rel_path", INTEGRATION_TEST_FILES)
+    def test_no_env_override_read(self, rel_path: str) -> None:
+        path = REPO_ROOT / rel_path
+        assert path.exists(), f"integration test file missing: {rel_path}"
+        content = path.read_text(encoding="utf-8")
+        matches = ENV_OVERRIDE_READ.findall(content)
+        assert not matches, (
+            f"{rel_path} reads ONEX_*_TOPIC from the environment: {matches}. "
+            "Use the contract-declared topic string directly — the kernel "
+            "hard-fails if ONEX_INPUT_TOPIC or ONEX_OUTPUT_TOPIC is set "
+            "(OMN-8784), so an override knob is a foot-gun."
+        )

--- a/tests/unit/runtime/test_stale_topic_env_var_docs_removal.py
+++ b/tests/unit/runtime/test_stale_topic_env_var_docs_removal.py
@@ -7,15 +7,20 @@ kernel; topics are now derived from each node's `contract.yaml`
 `event_bus.subscribe_topics` / `event_bus.publish_topics`. Setting either env
 var now raises `ProtocolConfigurationError` at kernel bootstrap.
 
-This test locks in OMN-9409's documentation cleanup: if someone re-introduces
-an *active-looking* reference (uncommented assignment in env example files,
-`os.getenv("ONEX_*_TOPIC", ...)` in integration test helpers, or a live table
-row in operator docs), the next deploy-from-main would create containers with
-`ONEX_*_TOPIC` baked in and trigger the crash loop documented in OMN-9409.
+This test locks in OMN-9409's documentation cleanup against two regression
+paths: uncommented `ONEX_*_TOPIC=...` assignments in env-example files, and
+`os.getenv("ONEX_*_TOPIC", ...)` / `os.environ[...]` reads in integration
+test helpers. Either would re-introduce the banned env var on the next
+deploy and trigger the crash loop documented in OMN-9409.
+
+Scope note: operator-facing docs (e.g. `docker/README.md`,
+`docs/testing/INTEGRATION_TESTING.md`) are NOT enforced here — they were
+updated manually as part of OMN-9409 and are reviewed per-PR. This test
+guards only the machine-readable surfaces that flow into running containers.
 
 Historical / deprecation references (comments, docstrings, deprecated-guard
-unit tests, and this file itself) are allowed — the scan looks for patterns
-that would regress the removal.
+unit tests, and this file itself) are allowed — both scans skip commented
+lines so that doc-style references in source files cannot false-fail.
 """
 
 from __future__ import annotations
@@ -36,7 +41,7 @@ ENV_EXAMPLE_FILES: tuple[str, ...] = (
     "docker/env-example-full.txt",
     "docs/env-example-full.txt",
 )
-ACTIVE_ENV_ASSIGNMENT = re.compile(r"(?m)^(ONEX_INPUT_TOPIC|ONEX_OUTPUT_TOPIC)\s*=")
+ACTIVE_ENV_ASSIGNMENT = re.compile(r"^(ONEX_INPUT_TOPIC|ONEX_OUTPUT_TOPIC)\s*=")
 
 # E2E integration test helpers must not use ONEX_*_TOPIC as an override knob.
 # The kernel rejects these vars, so `os.getenv("ONEX_*_TOPIC", default)` is a
@@ -51,6 +56,18 @@ ENV_OVERRIDE_READ = re.compile(
     r"(ONEX_INPUT_TOPIC|ONEX_OUTPUT_TOPIC)"
     r"['\"]"
 )
+PYTHON_COMMENT_PREFIX = re.compile(r"^\s*#")
+
+
+def _iter_active_lines(content: str, comment_prefix: re.Pattern[str]) -> list[str]:
+    """Yield only non-blank, non-comment lines so doc-style references in
+    comments (e.g. 'ONEX_OUTPUT_TOPIC removed in OMN-8784') do not trip
+    regexes that legitimately match live code."""
+    return [
+        line
+        for line in content.splitlines()
+        if line.strip() and not comment_prefix.match(line)
+    ]
 
 
 class TestStaleTopicEnvVarDocsRemoval:
@@ -63,7 +80,13 @@ class TestStaleTopicEnvVarDocsRemoval:
         path = REPO_ROOT / rel_path
         assert path.exists(), f"env example file missing: {rel_path}"
         content = path.read_text(encoding="utf-8")
-        matches = ACTIVE_ENV_ASSIGNMENT.findall(content)
+        # Dotenv-style files use `#` for comments (same prefix as Python).
+        active_lines = _iter_active_lines(content, PYTHON_COMMENT_PREFIX)
+        matches = [
+            m.group(1)
+            for line in active_lines
+            if (m := ACTIVE_ENV_ASSIGNMENT.match(line))
+        ]
         assert not matches, (
             f"{rel_path} contains active ONEX_*_TOPIC assignment(s): "
             f"{matches}. OMN-8784 removed these env vars; OMN-9409 cleaned up "
@@ -77,7 +100,10 @@ class TestStaleTopicEnvVarDocsRemoval:
         path = REPO_ROOT / rel_path
         assert path.exists(), f"integration test file missing: {rel_path}"
         content = path.read_text(encoding="utf-8")
-        matches = ENV_OVERRIDE_READ.findall(content)
+        # Python `#` comments — a commented `os.getenv("ONEX_*_TOPIC")`
+        # discussing the removed env var must not fail the test.
+        active_source = "\n".join(_iter_active_lines(content, PYTHON_COMMENT_PREFIX))
+        matches = ENV_OVERRIDE_READ.findall(active_source)
         assert not matches, (
             f"{rel_path} reads ONEX_*_TOPIC from the environment: {matches}. "
             "Use the contract-declared topic string directly — the kernel "


### PR DESCRIPTION
## Summary

Three source files still advertised `ONEX_OUTPUT_TOPIC` / `ONEX_INPUT_TOPIC` as active runtime-config knobs even though the runtime kernel now rejects them at bootstrap (topics are declared in each node's `contract.yaml` `event_bus` section). Following the old doc surfaces would bake crash-loop triggers into a deployment.

- `docker/README.md`: table row for `ONEX_OUTPUT_TOPIC` updated to mark it as removed with a note that topics come from `contract.yaml`
- `docs/testing/INTEGRATION_TESTING.md`: active example `ONEX_OUTPUT_TOPIC=onex.evt.platform.registration-completed.v1` replaced with a note that the var was removed and env overrides no longer work
- `src/omnibase_infra/runtime/models/model_runtime_config.py`: docstring line `ONEX_OUTPUT_TOPIC - Overrides output_topic` updated to state the var was removed and topics are declared in `contract.yaml` (docstring-only change, no code logic)

Additional cleanup in the same commit (env-example files, integration test helpers, unit regression test) guards against re-introducing these vars.

Closes OMN-9409.

## Test plan

- [x] `uv run ruff format src/ && uv run ruff check --fix src/` — all checks pass
- [x] `pre-commit run --all-files` — all 43 hooks pass (including no-hardcoded-topic-strings, topic-naming-lint, contract-parity)
- [x] Unit regression test `tests/unit/runtime/test_stale_topic_env_var_docs_removal.py` guards env-example files + integration test helpers against re-introducing the banned vars (4/4 pass)
- [x] CodeRabbit minor feedback addressed in e22100e2 — docstring scope clarified; both regex scans now skip commented lines so doc-style references cannot false-fail

## Summary by CodeRabbit

* **Refactor**
  * Environment variables for direct topic overrides are no longer supported; kernel will fail at startup if set. Kafka topics now sourced exclusively from contract declarations.

* **Documentation**
  * Updated configuration guides to reflect contract-based topic configuration across all runtime environments.

* **Tests**
  * Added validation to prevent regression of removed environment variable support.
