### PR TITLE
fix(infra): OMN-9154 import DEFAULT_INTROSPECTION_TOPIC from model SoT

### DIFF
--- a/src/omnibase_infra/cli/infra_test/introspect.py
+++ b/src/omnibase_infra/cli/infra_test/introspect.py
@@ -19,11 +19,11 @@ import click
 from rich.console import Console
 
 from omnibase_infra.cli.infra_test._helpers import get_broker
-from omnibase_infra.enums.generated.enum_platform_topic import EnumPlatformTopic
+from omnibase_infra.models.discovery.model_introspection_config import (
+    DEFAULT_INTROSPECTION_TOPIC,
+)
 
 console = Console()
-
-DEFAULT_INTROSPECTION_TOPIC = EnumPlatformTopic.EVT_NODE_INTROSPECTION_V1.value
 
 
 def _build_introspection_payload(

--- a/tests/unit/cli/infra_test/test_introspect.py
+++ b/tests/unit/cli/infra_test/test_introspect.py
@@ -10,7 +10,12 @@ from uuid import UUID
 import click
 import pytest
 
+from omnibase_infra.cli.infra_test import introspect as introspect_cli
 from omnibase_infra.cli.infra_test.introspect import _build_introspection_payload
+from omnibase_infra.models.discovery.model_introspection_config import (
+    DEFAULT_INTROSPECTION_TOPIC as MODEL_DEFAULT_INTROSPECTION_TOPIC,
+)
+from omnibase_infra.topics import SUFFIX_NODE_INTROSPECTION
 
 
 @pytest.mark.unit
@@ -119,3 +124,19 @@ class TestBuildIntrospectionPayload:
         """Non-numeric version string raises click.BadParameter."""
         with pytest.raises(click.BadParameter, match="Invalid version"):
             _build_introspection_payload(version="abc")
+
+
+@pytest.mark.unit
+class TestDefaultIntrospectionTopicSoT:
+    """Guard against drift between the CLI default and the canonical topic source."""
+
+    def test_cli_default_matches_model_default(self) -> None:
+        """CLI default must be imported from the canonical model module (OMN-9154)."""
+        assert (
+            introspect_cli.DEFAULT_INTROSPECTION_TOPIC
+            is MODEL_DEFAULT_INTROSPECTION_TOPIC
+        )
+
+    def test_cli_default_matches_topic_suffix(self) -> None:
+        """Canonical model default must resolve to SUFFIX_NODE_INTROSPECTION."""
+        assert introspect_cli.DEFAULT_INTROSPECTION_TOPIC == SUFFIX_NODE_INTROSPECTION


### PR DESCRIPTION
## Summary

Ticket: [OMN-9154](https://linear.app/omninode/issue/OMN-9154) — replace `DEFAULT_INTROSPECTION_TOPIC` hardcoded literal in `cli/infra_test/introspect.py` with import from the canonical source.

The original hardcoded literal was removed in a prior PR (OMN-7226), but the CLI still held its own copy of `DEFAULT_INTROSPECTION_TOPIC` derived from the generated `EnumPlatformTopic`. This PR:

- Imports `DEFAULT_INTROSPECTION_TOPIC` directly from `omnibase_infra.models.discovery.model_introspection_config` (the canonical model-level default that resolves to `SUFFIX_NODE_INTROSPECTION`), removing the CLI-layer duplicate.
- Adds two unit tests under `TestDefaultIntrospectionTopicSoT` that guard against drift:
  - CLI default is the same object as the model default.
  - Both resolve to `SUFFIX_NODE_INTROSPECTION`.

## Acceptance criteria

- [x] Literal removed (already done in OMN-7226; this PR also removes the CLI-layer enum copy).
- [x] Import path from SoT module (`model_introspection_config.DEFAULT_INTROSPECTION_TOPIC`).
- [x] Unit test verifies default value matches canonical source (`TestDefaultIntrospectionTopicSoT`).

## Scope note

The `envvar="ONEX_INTROSPECTION_TOPIC"` operator-override knob on line 104 is intentionally left in place. The allowlist-vs-ban decision for `*_TOPIC` envvars is the responsibility of OMN-9151 child #1 (validator) and is out of scope here.

## dod_evidence

- `tests/unit/cli/infra_test/test_introspect.py::TestDefaultIntrospectionTopicSoT` (2 tests, both PASS)
- Full unit suite for `tests/unit/cli tests/unit/mixins/test_mixin_node_introspection.py tests/unit/models/discovery`: 418 PASS
- pre-commit run on changed files: PASS (including Topic Naming Lint, AI-slop check, topic drift check)

## Test plan

- [x] `uv run pytest tests/unit/cli/infra_test/test_introspect.py -v` — 18/18 PASS
- [x] `uv run pytest tests/unit/cli tests/unit/mixins/test_mixin_node_introspection.py tests/unit/models/discovery -v` — 418/418 PASS
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] `pre-commit run --files ...` — all hooks passed
- [ ] CI green on PR