### PR TITLE
fix(runtime): consolidate registration subscription ownership [OMN-9557]

### DIFF
--- a/contracts/OMN-9557.yaml
+++ b/contracts/OMN-9557.yaml
@@ -1,0 +1,43 @@
+# OMN-9557 contract file present in omnibase_infra for deploy-gate (OMN-8912).
+# deploy-gate checks `contracts/<OMN-XXXX>.yaml` for a dod_evidence item whose
+# check_value contains one of 'docker exec', 'rpk topic produce', or 'deploy'.
+#
+# The canonical ticket contract (schema-validated via onex_change_control
+# ModelTicketContract) lives at onex_change_control/contracts/OMN-9557.yaml.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: '1.0.0'
+ticket_id: OMN-9557
+summary: 'fix(runtime): consolidate registration subscription ownership'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: Targeted runtime subscription ownership tests pass for omnibase_infra PR #1394
+    command: 'uv run pytest tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/unit/runtime/test_kernel.py::TestBootstrap::test_bootstrap_defers_auto_wiring_subscriptions_until_after_freeze -v'
+  - kind: ci
+    description: CI passes on omnibase_infra PR #1394
+    command: 'gh pr checks 1394 --repo OmniNode-ai/omnibase_infra'
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: PR opened against the OMN-9550 stacked base branch
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'gh pr view 1394 --repo OmniNode-ai/omnibase_infra --json baseRefName -q .baseRefName | grep -x jonah/omn-9550-defer-autowire-subscriptions'
+  - id: dod-002
+    description: Contract artifact file present in repo
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-9557.yaml'
+  - id: dod-003
+    description: Runtime deploy verifies registration subscriptions are owned by generic contract auto-wiring
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'docker exec omninode-runtime python -c "from omnibase_infra.nodes.node_registration_orchestrator.plugin import ServiceRegistration; assert hasattr(ServiceRegistration, ''prepare_result_applier'')"'

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -104,6 +104,9 @@ if TYPE_CHECKING:
         EventBusSubcontractWiring,
     )
     from omnibase_infra.runtime.projector_shell import ProjectorShell
+    from omnibase_infra.runtime.service_dispatch_result_applier import (
+        DispatchResultApplier,
+    )
     from omnibase_infra.runtime.service_intent_executor import IntentExecutor
 
 from omnibase_infra.enums import EnumInfraTransportType
@@ -228,6 +231,7 @@ class ServiceRegistration:
         self._registration_storage: HandlerRegistrationStoragePostgres | None = None
         self._snapshot_publisher: SnapshotPublisherRegistration | None = None
         self._wiring: EventBusSubcontractWiring | None = None
+        self._result_applier: DispatchResultApplier | None = None
         self._shutdown_in_progress: bool = False
         self._handler_wiring_succeeded: bool = False
 
@@ -255,6 +259,11 @@ class ServiceRegistration:
     def snapshot_publisher(self) -> SnapshotPublisherRegistration | None:
         """Return the snapshot publisher (for external access)."""
         return self._snapshot_publisher
+
+    @property
+    def result_applier(self) -> DispatchResultApplier | None:
+        """Return the registration dispatch result applier."""
+        return self._result_applier
 
     def should_activate(self, config: ModelDomainPluginConfig) -> bool:
         """Check if Registration should activate based on environment.
@@ -1026,75 +1035,49 @@ class ServiceRegistration:
             ),
         )
 
-    async def start_consumers(
+    async def prepare_result_applier(
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:
-        """Start event consumers via EventBusSubcontractWiring.
+        """Prepare registration result application for auto-wired consumers.
 
-        Reads subscribe_topics from the registration orchestrator contract
-        and wires Kafka subscriptions through EventBusSubcontractWiring.
-        Messages are deserialized and dispatched through the frozen
-        MessageDispatchEngine. Output events are published by the
-        DispatchResultApplier.
-
-        Requires config.node_identity and config.dispatch_engine to be set.
+        Generic contract auto-wiring owns registration event-bus subscriptions.
+        This plugin still owns the registration-domain output side: topic
+        routing, intent effects, and the DispatchResultApplier that publishes
+        events and executes intents returned by registration handlers.
 
         Args:
-            config: Plugin configuration with event_bus, node_identity,
-                and dispatch_engine.
+            config: Plugin configuration with container and event bus.
 
         Returns:
-            Result with unsubscribe_callbacks for cleanup.
+            Result indicating whether result application services are ready.
         """
         start_time = time.time()
         correlation_id = config.correlation_id
 
-        # Guard: do not start consumers if handler wiring failed. Starting
-        # consumers without wired handlers would route messages to an empty
-        # dispatch engine, causing silent message loss or RuntimeHostError.
+        if self._result_applier is not None:
+            return ModelDomainPluginResult(
+                plugin_id=self.plugin_id,
+                success=True,
+                message="Registration result applier already prepared",
+                duration_seconds=0.0,
+            )
+
         if not self._handler_wiring_succeeded:
             logger.warning(
-                "Skipping consumer startup: handler wiring did not succeed "
+                "Skipping result-applier preparation: handler wiring did not succeed "
                 "for plugin '%s' (correlation_id=%s)",
                 self.plugin_id,
                 correlation_id,
             )
             return ModelDomainPluginResult.skipped(
                 plugin_id=self.plugin_id,
-                reason="Handler wiring did not succeed — consumers not started",
-            )
-
-        if config.dispatch_engine is None:
-            return ModelDomainPluginResult.skipped(
-                plugin_id=self.plugin_id,
-                reason="dispatch_engine not available",
-            )
-
-        # Check for subscribe capability via runtime-checkable protocol.
-        # ProtocolEventBusSubscriber is @runtime_checkable, so isinstance works
-        # without coupling to concrete InMemoryEventBus / KafkaEventBus.
-        from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
-            ProtocolEventBusSubscriber,
-        )
-
-        if not isinstance(config.event_bus, ProtocolEventBusSubscriber):
-            return ModelDomainPluginResult.skipped(
-                plugin_id=self.plugin_id,
-                reason="Event bus does not support subscribe",
-            )
-
-        if config.node_identity is None:
-            return ModelDomainPluginResult.skipped(
-                plugin_id=self.plugin_id,
-                reason="node_identity not set (required for consumer subscription)",
+                reason="Handler wiring did not succeed — result applier not prepared",
             )
 
         try:
             from omnibase_core.enums import EnumInjectionScope
             from omnibase_infra.runtime.event_bus_subcontract_wiring import (
-                EventBusSubcontractWiring,
-                load_event_bus_subcontract,
                 load_published_events_map,
             )
             from omnibase_infra.runtime.service_dispatch_result_applier import (
@@ -1104,20 +1087,7 @@ class ServiceRegistration:
                 IntentExecutor,
             )
 
-            # Load event_bus subcontract from registration orchestrator contract
             contract_path = Path(__file__).parent / "contract.yaml"
-            subcontract = load_event_bus_subcontract(contract_path, logger=logger)
-
-            if subcontract is None:
-                return ModelDomainPluginResult.skipped(
-                    plugin_id=self.plugin_id,
-                    reason=f"No event_bus subcontract in {contract_path}",
-                )
-
-            # Load per-event-type topic routing from contract published_events
-            # (OMN-5132).  Maps event_type names to their declared Kafka topics
-            # so DispatchResultApplier can route each output event to the correct
-            # topic instead of a single output_topic fallback.
             published_events_map = load_published_events_map(
                 contract_path, logger=logger
             )
@@ -1179,6 +1149,7 @@ class ServiceRegistration:
                 topic_router=_TOPIC_ROUTER,
                 output_topic_map=published_events_map,
             )
+            self._result_applier = result_applier
 
             # Register DispatchResultApplier in the DI container for the same
             # container-based DI consistency.
@@ -1197,72 +1168,24 @@ class ServiceRegistration:
                     correlation_id,
                 )
 
-            # Create EventBusSubcontractWiring with dispatch engine and result applier
-            self._wiring = EventBusSubcontractWiring(
-                event_bus=config.event_bus,
-                dispatch_engine=config.dispatch_engine,
-                environment=config.node_identity.env,
-                node_name=config.node_identity.node_name,
-                service=config.node_identity.service,
-                version=config.node_identity.version,
-                result_applier=result_applier,
-            )
-
-            # Register EventBusSubcontractWiring in the DI container for
-            # consistent service resolution and discoverability.
-            if config.container.service_registry is not None:
-                await config.container.service_registry.register_instance(
-                    interface=EventBusSubcontractWiring,
-                    instance=self._wiring,
-                    scope=EnumInjectionScope.GLOBAL,
-                    metadata={
-                        "description": "Event bus subcontract wiring for registration domain",
-                        "plugin_id": self.plugin_id,
-                    },
-                )
-                logger.debug(
-                    "Registered EventBusSubcontractWiring in container "
-                    "(correlation_id=%s)",
-                    correlation_id,
-                )
-
-            # Wire subscriptions from contract-declared topics
-            await self._wiring.wire_subscriptions(
-                subcontract=subcontract,
-                node_name="registration-orchestrator",
-            )
-
             logger.info(
-                "Registration consumers started via EventBusSubcontractWiring "
+                "Registration result applier prepared for auto-wired consumers "
                 "(correlation_id=%s)",
                 correlation_id,
-                extra={
-                    "subscribe_topics": subcontract.subscribe_topics,
-                    "topic_count": len(subcontract.subscribe_topics)
-                    if subcontract.subscribe_topics
-                    else 0,
-                },
             )
 
             duration = time.time() - start_time
-
-            # Cleanup callback wraps the wiring cleanup
-            async def _cleanup_wiring() -> None:
-                if self._wiring is not None:
-                    await self._wiring.cleanup()
-
             return ModelDomainPluginResult(
                 plugin_id=self.plugin_id,
                 success=True,
-                message="Registration consumers started via EventBusSubcontractWiring",
+                message="Registration result applier prepared",
                 duration_seconds=duration,
-                unsubscribe_callbacks=[_cleanup_wiring],
             )
 
         except Exception as e:
             duration = time.time() - start_time
             logger.exception(
-                "Failed to start registration consumers (correlation_id=%s)",
+                "Failed to prepare registration result applier (correlation_id=%s)",
                 correlation_id,
             )
             return ModelDomainPluginResult.failed(
@@ -1270,6 +1193,38 @@ class ServiceRegistration:
                 error_message=sanitize_error_message(e),
                 duration_seconds=duration,
             )
+
+    async def start_consumers(
+        self,
+        config: ModelDomainPluginConfig,
+    ) -> ModelDomainPluginResult:
+        """Skip plugin-local registration subscriptions.
+
+        Generic contract auto-wiring owns registration subscriptions because
+        ``node_registration_orchestrator/contract.yaml`` declares both
+        ``event_bus.subscribe_topics`` and ``handler_routing``. The plugin
+        prepares the registration DispatchResultApplier separately so
+        auto-wired callbacks can apply handler outputs without creating a
+        second consumer family.
+
+        Args:
+            config: Plugin configuration.
+
+        Returns:
+            A skipped-success result documenting the single-authority boundary.
+        """
+        if self._result_applier is None:
+            prepare_result = await self.prepare_result_applier(config)
+            if not prepare_result.success:
+                return prepare_result
+
+        return ModelDomainPluginResult.skipped(
+            plugin_id=self.plugin_id,
+            reason=(
+                "generic contract auto-wiring owns registration event-bus "
+                "subscriptions (OMN-9557)"
+            ),
+        )
 
     async def _wire_intent_effects(
         self,

--- a/src/omnibase_infra/protocols/__init__.py
+++ b/src/omnibase_infra/protocols/__init__.py
@@ -71,6 +71,9 @@ from omnibase_infra.protocols.protocol_capability_projection import (
 from omnibase_infra.protocols.protocol_capability_query import ProtocolCapabilityQuery
 from omnibase_infra.protocols.protocol_container_aware import ProtocolContainerAware
 from omnibase_infra.protocols.protocol_dispatch_engine import ProtocolDispatchEngine
+from omnibase_infra.protocols.protocol_dispatch_result_applier import (
+    ProtocolDispatchResultApplier,
+)
 from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 from omnibase_infra.protocols.protocol_event_projector import ProtocolEventProjector
 from omnibase_infra.protocols.protocol_idempotency_store import (
@@ -113,6 +116,7 @@ __all__: list[str] = [
     "ProtocolCapabilityQuery",
     "ProtocolContainerAware",
     "ProtocolDispatchEngine",
+    "ProtocolDispatchResultApplier",
     "ProtocolEventBusLike",
     "ProtocolEventProjector",
     "ProtocolIdempotencyStore",

--- a/src/omnibase_infra/protocols/protocol_dispatch_result_applier.py
+++ b/src/omnibase_infra/protocols/protocol_dispatch_result_applier.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Protocol for applying dispatch results emitted by auto-wired handlers."""
+
+from __future__ import annotations
+
+__all__ = ["ProtocolDispatchResultApplier"]
+
+from typing import TYPE_CHECKING, Protocol
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from omnibase_infra.models.dispatch.model_dispatch_result import (
+        ModelDispatchResult,
+    )
+
+
+class ProtocolDispatchResultApplier(Protocol):
+    """Applies a handler dispatch result to its output/effect path."""
+
+    async def apply(
+        self,
+        result: ModelDispatchResult,
+        correlation_id: UUID | None = None,
+    ) -> None: ...

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -27,7 +27,7 @@ import logging
 import os
 import re
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
@@ -45,6 +45,9 @@ from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
 from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
 from omnibase_core.services.service_local_handler_ownership_query import (
     ServiceLocalHandlerOwnershipQuery,
+)
+from omnibase_infra.protocols.protocol_dispatch_result_applier import (
+    ProtocolDispatchResultApplier,
 )
 from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
     EnumQuarantineReason,
@@ -258,11 +261,11 @@ class PreparedContractWiring:
     _commit_contract_wiring returns skip_result directly in that case.
     """
 
-    contract: object  # ModelDiscoveredContract
+    contract: ModelDiscoveredContract
     prepared_wirings: list[PreparedWiring]
     subscription_topics: list[str]  # topics to subscribe after commit
     environment: str
-    skip_result: object = None  # ModelContractWiringResult | None
+    skip_result: ModelContractWiringResult | None = None
 
 
 def _import_handler_class(module_path: str, class_name: str) -> type:
@@ -510,11 +513,13 @@ def _make_projection_dispatch_callback(
 def _make_event_bus_callback(
     topic: str,
     dispatch_engine: ProtocolDispatchEngine,
+    result_applier: ProtocolDispatchResultApplier | None = None,
 ) -> Callable[..., Awaitable[None]]:
     """Create a Kafka on_message callback that deserializes and dispatches to engine.
 
     Mirrors EventBusSubcontractWiring._create_dispatch_callback but stripped of
-    DLQ/idempotency concerns — auto-wired nodes rely on the simplified path.
+    DLQ/idempotency concerns. When a result applier is supplied, dispatcher
+    outputs are applied on the same auto-wired path that owns the subscription.
     """
     import json
 
@@ -540,7 +545,9 @@ def _make_event_bus_callback(
                     )
                     return
                 envelope = message
-            await dispatch_engine.dispatch(topic, envelope)
+            result = await dispatch_engine.dispatch(topic, envelope)
+            if result_applier is not None and result is not None:
+                await result_applier.apply(result, envelope.correlation_id)
         except Exception as exc:  # noqa: BLE001 — boundary: log and discard; unsubscribe unavailable here
             logger.error(
                 "Auto-wiring callback error: topic=%s error_type=%s error=%s",
@@ -656,6 +663,8 @@ async def wire_from_manifest(
     container: object | None = None,
     *,
     subscribe_immediately: bool = True,
+    result_appliers_by_contract: Mapping[str, ProtocolDispatchResultApplier]
+    | None = None,
 ) -> ModelAutoWiringReport:
     """Wire all discovered contracts into the dispatch engine and event bus.
 
@@ -686,6 +695,9 @@ async def wire_from_manifest(
             during this call. When False, only dispatchers/routes are registered;
             callers must invoke ``subscribe_wired_contract_topics()`` after the
             dispatch engine is frozen.
+        result_appliers_by_contract: Optional per-contract dispatch result
+            appliers. Only contracts present in this mapping apply dispatcher
+            outputs from auto-wired callbacks.
 
     Returns:
         A :class:`ModelAutoWiringReport` with per-contract outcomes.
@@ -802,6 +814,7 @@ async def wire_from_manifest(
             dispatch_engine,
             event_bus,
             subscribe_immediately=subscribe_immediately,
+            result_applier=(result_appliers_by_contract or {}).get(pcw.contract.name),
         )
         results.append(result)
 
@@ -863,6 +876,8 @@ async def subscribe_wired_contract_topics(
     dispatch_engine: ProtocolDispatchEngine,
     event_bus: object | None,
     environment: str = "dev",
+    result_appliers_by_contract: Mapping[str, ProtocolDispatchResultApplier]
+    | None = None,
 ) -> dict[str, tuple[str, ...]]:
     """Subscribe Kafka topics for contracts that already wired successfully.
 
@@ -887,6 +902,7 @@ async def subscribe_wired_contract_topics(
             dispatch_engine=dispatch_engine,
             event_bus=event_bus,
             environment=environment,
+            result_applier=(result_appliers_by_contract or {}).get(contract.name),
         )
         subscriptions_by_contract[contract.name] = tuple(topics_subscribed)
 
@@ -987,6 +1003,7 @@ async def _commit_contract_wiring(
     event_bus: object | None,
     *,
     subscribe_immediately: bool = True,
+    result_applier: ProtocolDispatchResultApplier | None = None,
 ) -> ModelContractWiringResult:
     """Commit a validated PreparedContractWiring to the engine and event bus.
 
@@ -1046,6 +1063,7 @@ async def _commit_contract_wiring(
                 dispatch_engine=dispatch_engine,
                 event_bus=event_bus,
                 environment=pcw.environment,
+                result_applier=result_applier,
             )
         )
 
@@ -1092,6 +1110,7 @@ async def _subscribe_contract_topics(
     dispatch_engine: object,
     event_bus: object,
     environment: str,
+    result_applier: ProtocolDispatchResultApplier | None = None,
 ) -> list[str]:
     """Subscribe all declared event-bus topics for a wired contract."""
     if contract.event_bus is None or not contract.event_bus.subscribe_topics:
@@ -1116,7 +1135,11 @@ async def _subscribe_contract_topics(
 
     topics_subscribed: list[str] = []
     for topic in contract.event_bus.subscribe_topics:
-        callback = _make_event_bus_callback(topic, dispatch_engine)  # type: ignore[arg-type]
+        callback = _make_event_bus_callback(
+            topic,
+            dispatch_engine,  # type: ignore[arg-type]
+            result_applier=result_applier,
+        )
         await typed_bus.subscribe(
             topic=topic,
             node_identity=node_identity,

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1888,6 +1888,7 @@ async def bootstrap() -> int:
         # could modify the engine while an early plugin's consumer is already
         # dispatching messages through it.
         plugin_activation_start = time.time()
+        auto_wiring_result_appliers = {}
 
         # --- Kernel-native: ServiceRegistration lifecycle (OMN-7115) ---
         # ServiceRegistration runs its lifecycle directly, not through the
@@ -1933,6 +1934,28 @@ async def bootstrap() -> int:
                         "ServiceRegistration wiring completed (correlation_id=%s)",
                         correlation_id,
                     )
+                    result_prepare = await registration_service.prepare_result_applier(
+                        plugin_config,
+                    )
+                    if (
+                        result_prepare.success
+                        and registration_service.result_applier is not None
+                    ):
+                        auto_wiring_result_appliers[
+                            "node_registration_orchestrator"
+                        ] = registration_service.result_applier
+                        logger.info(
+                            "ServiceRegistration result applier registered for "
+                            "contract auto-wiring (correlation_id=%s)",
+                            correlation_id,
+                        )
+                    else:
+                        logger.warning(
+                            "ServiceRegistration result applier unavailable for "
+                            "contract auto-wiring: %s (correlation_id=%s)",
+                            result_prepare.get_error_message_or_default(),
+                            correlation_id,
+                        )
                 else:
                     logger.warning(
                         "ServiceRegistration handler wiring failed: %s "
@@ -2213,6 +2236,7 @@ async def bootstrap() -> int:
                     environment=environment,
                     container=container,
                     subscribe_immediately=False,
+                    result_appliers_by_contract=auto_wiring_result_appliers,
                 )
 
                 auto_wiring_duration = time.time() - auto_wiring_start
@@ -2284,6 +2308,7 @@ async def bootstrap() -> int:
                 dispatch_engine=dispatch_engine,
                 event_bus=event_bus,
                 environment=environment,
+                result_appliers_by_contract=auto_wiring_result_appliers,
             )
             for contract_name, topics in auto_wired_subscriptions.items():
                 for topic in topics:

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
@@ -165,3 +165,32 @@ async def test_wire_dispatchers_is_idempotent_across_repeat_calls() -> None:
     engine = config.dispatch_engine
     assert engine is not None
     engine.register_dispatcher.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_start_consumers_skips_plugin_local_event_bus_wiring() -> None:
+    """start_consumers() must not create a second registration consumer family.
+
+    Generic contract auto-wiring owns registration subscriptions. The plugin
+    only prepares the DispatchResultApplier needed to apply outputs from the
+    auto-wired callbacks.
+    """
+    plugin = ServiceRegistration()
+    plugin._handler_wiring_succeeded = True
+    config = _make_plugin_config()
+    assert config.container.service_registry is not None
+    config.container.service_registry.register_instance = AsyncMock()
+
+    with (
+        patch.object(plugin, "_wire_intent_effects", new=AsyncMock()),
+        patch(
+            "omnibase_infra.runtime.event_bus_subcontract_wiring.EventBusSubcontractWiring",
+        ) as wiring_cls,
+    ):
+        result = await plugin.start_consumers(config)
+
+    assert result.success is True
+    assert "auto-wiring" in result.message.lower()
+    assert plugin.result_applier is not None
+    wiring_cls.assert_not_called()

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -311,3 +311,38 @@ class TestMakeEventBusCallbackFallbackPath:
         dispatch_engine.dispatch.assert_called_once()
         _, call_envelope = dispatch_engine.dispatch.call_args.args
         assert isinstance(call_envelope, ModelEventEnvelope)
+
+    @pytest.mark.asyncio
+    async def test_valid_envelope_result_is_applied_when_applier_supplied(
+        self,
+    ) -> None:
+        """Auto-wired callbacks apply dispatcher results when ownership supplies an applier."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        dispatch_result = MagicMock()
+        dispatch_engine = MagicMock()
+        dispatch_engine.dispatch = AsyncMock(return_value=dispatch_result)
+
+        result_applier = MagicMock()
+        result_applier.apply = AsyncMock()
+
+        callback = _make_event_bus_callback(
+            "onex.cmd.test.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+            result_applier=result_applier,
+        )
+
+        envelope = ModelEventEnvelope[object].model_construct(
+            event_type="onex.cmd.test.v1",
+            payload={},
+            correlation_id=None,
+        )
+        await callback(envelope)
+
+        dispatch_engine.dispatch.assert_called_once()
+        result_applier.apply.assert_awaited_once_with(dispatch_result, None)


### PR DESCRIPTION
## Summary
- Move registration event-bus subscription ownership to generic contract auto-wiring.
- Keep `ServiceRegistration` responsible for registration-domain output application by preparing a `DispatchResultApplier` for auto-wired callbacks.
- Remove plugin-local `EventBusSubcontractWiring` startup for registration so the runtime does not create a second consumer family for the same contract topics.

## Stacking
- Stacked on #1388 / OMN-9550 because this depends on post-freeze auto-wired subscription startup.
- After #1388 merges, this branch should be retargeted to `main` or rebased onto updated `main`.

## Validation
- `uv run pytest tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/unit/runtime/test_kernel.py::TestBootstrap::test_bootstrap_defers_auto_wiring_subscriptions_until_after_freeze -v`
- `uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/service_kernel.py src/omnibase_infra/protocols/protocol_dispatch_result_applier.py`
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/service_kernel.py src/omnibase_infra/protocols/protocol_dispatch_result_applier.py src/omnibase_infra/protocols/__init__.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py`
- `pre-commit run --files src/omnibase_infra/runtime/auto_wiring/handler_wiring.py src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/service_kernel.py src/omnibase_infra/protocols/protocol_dispatch_result_applier.py src/omnibase_infra/protocols/__init__.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py`

## Integration Note
- Attempted `uv run pytest tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py tests/integration/registration/e2e/test_topic_catalog_e2e.py tests/integration/registration/e2e/test_two_way_registration_e2e.py -q`.
- Result: 19 passed, 19 skipped, 12 errors due local Postgres fixture setup failing with `OSError: [Errno 65] No route to host`; no code assertion failure was reached.
