### PR TITLE
fix(runtime): guard llm endpoint env drift [OMN-9647]

### DIFF
--- a/contracts/llm_endpoints.yaml
+++ b/contracts/llm_endpoints.yaml
@@ -68,7 +68,7 @@ endpoints:
     host: 192.168.86.201
     port: 8100
     endpoint_url: http://192.168.86.201:8100
-    url_env_var: null
+    url_env_var: LLM_EMBEDDING_URL
     role_env_alias: null
     model_hf_id: Alibaba-NLP/gte-Qwen2-1.5B-instruct
     role: embedding
@@ -76,7 +76,7 @@ endpoints:
     hardware: RTX 4090 (.201)
     context_window_budgeted: 8192
     launchd_unit_or_none: null
-    notes: Docker-internal embeddings; no env-var exposure outside Docker network.
+    notes: Canonical runtime embedding endpoint for LLM_EMBEDDING_URL.
   - slot_id: reasoning-deepseek-32b
     host: 192.168.86.200
     port: 8101
@@ -114,7 +114,7 @@ endpoints:
     host: 192.168.86.200
     port: 8100
     endpoint_url: http://192.168.86.200:8100
-    url_env_var: LLM_EMBEDDING_URL
+    url_env_var: null
     role_env_alias: null
     model_hf_id: mlx-community/Qwen3-Embedding-8B-4bit-DWQ
     role: embedding
@@ -125,6 +125,7 @@ endpoints:
     notes: |
       Stopped 2026-04-18 to free RAM. Restart:
       `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.mlx.embeddings.plist`.
+      Historical LLM_EMBEDDING_URL owner; disabled slots must not own runtime env vars.
   - slot_id: second-opinion-gemma
     host: 192.168.86.200
     port: 8103

--- a/docker/catalog/model_registry.yaml
+++ b/docker/catalog/model_registry.yaml
@@ -75,7 +75,7 @@ models:
     context_window: 8192
     seed_cost_per_1k_tokens: 0.0
     seed_tokens_per_sec: 50
-    hardware: "M2 Ultra"
+    hardware: "RTX 4090"
     tier: local
   - model_key: "claude-sonnet"
     provider: anthropic

--- a/scripts/check_llm_endpoint_env_contract.py
+++ b/scripts/check_llm_endpoint_env_contract.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Validate LLM endpoint env values against the canonical endpoint contract."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_CONTRACT = _REPO_ROOT / "contracts" / "llm_endpoints.yaml"
+_DEFAULT_ENV_VARS = (
+    "LLM_CODER_URL",
+    "LLM_CODER_FAST_URL",
+    "LLM_EMBEDDING_URL",
+    "LLM_DEEPSEEK_R1_URL",
+)
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key.strip()] = value.strip().strip("'\"")
+    return env
+
+
+def _load_endpoints(path: Path) -> list[dict[str, Any]]:
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict) or not isinstance(data.get("endpoints"), list):
+        msg = f"{path} must contain a top-level endpoints list"
+        raise ValueError(msg)
+    return data["endpoints"]
+
+
+def validate(
+    env: dict[str, str],
+    endpoints: list[dict[str, Any]],
+    env_vars: tuple[str, ...],
+) -> list[str]:
+    """Return validation errors for configured endpoint env vars."""
+    by_env = {
+        str(endpoint["url_env_var"]): endpoint
+        for endpoint in endpoints
+        if endpoint.get("url_env_var")
+    }
+    by_url = {
+        str(endpoint["endpoint_url"]).rstrip("/"): endpoint
+        for endpoint in endpoints
+        if endpoint.get("endpoint_url")
+    }
+
+    errors: list[str] = []
+    for env_var in env_vars:
+        value = env.get(env_var, "").strip().rstrip("/")
+        if not value:
+            continue
+
+        expected = by_env.get(env_var)
+        if expected is None:
+            errors.append(f"{env_var} is not assigned to a canonical endpoint slot")
+            continue
+
+        if expected.get("status") != "running":
+            errors.append(
+                f"{env_var} is assigned to non-running slot {expected.get('slot_id')!r}"
+            )
+            continue
+
+        expected_url = str(expected.get("endpoint_url", "")).rstrip("/")
+        if value != expected_url:
+            actual = by_url.get(value)
+            actual_status = actual.get("status") if actual else "unknown"
+            actual_slot = actual.get("slot_id") if actual else "not in contract"
+            errors.append(
+                f"{env_var}={value} does not match canonical running slot "
+                f"{expected['slot_id']!r} ({expected_url}); actual slot="
+                f"{actual_slot!r} status={actual_status!r}"
+            )
+            continue
+
+        actual = by_url.get(value)
+        if actual and actual.get("status") != "running":
+            errors.append(
+                f"{env_var} points at non-running slot {actual.get('slot_id')!r}"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=_DEFAULT_CONTRACT,
+        help="Path to contracts/llm_endpoints.yaml",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        help="Optional .env file to validate instead of the process environment",
+    )
+    parser.add_argument(
+        "--env-var",
+        action="append",
+        dest="env_vars",
+        help="Env var to validate; repeatable. Defaults to runtime LLM URL vars.",
+    )
+    args = parser.parse_args(argv)
+
+    env = _load_env_file(args.env_file) if args.env_file else dict(os.environ)
+    env_vars = tuple(args.env_vars) if args.env_vars else _DEFAULT_ENV_VARS
+    errors = validate(env, _load_endpoints(args.contract), env_vars)
+
+    if errors:
+        print("LLM endpoint env contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("LLM endpoint env contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_llm_endpoints.sh
+++ b/scripts/check_llm_endpoints.sh
@@ -6,11 +6,11 @@
 #
 # Required endpoints (must be reachable or script exits 1):
 #   LLM_CODER_URL       — Qwen3-Coder-30B (port 8000)
-#   LLM_DEEPSEEK_R1_URL — DeepSeek-R1-14B  (port 8001)
+#   LLM_DEEPSEEK_R1_URL — DeepSeek-R1-32B  (port 8101)
+#   LLM_EMBEDDING_URL   — embedding model, when configured
 #
 # Optional endpoints (failures are warned, not fatal):
 #   LLM_CODER_FAST_URL  — fast coder (port 8001 alias)
-#   LLM_EMBEDDING_URL   — embedding model
 #
 # Usage:
 #   bash scripts/check_llm_endpoints.sh
@@ -79,7 +79,7 @@ if [[ -n "${LLM_CODER_FAST_URL:-}" ]]; then
 fi
 
 if [[ -n "${LLM_EMBEDDING_URL:-}" ]]; then
-  _probe "embedding (LLM_EMBEDDING_URL)" "$LLM_EMBEDDING_URL" false
+  _probe "embedding (LLM_EMBEDDING_URL)" "$LLM_EMBEDDING_URL" true
 fi
 
 echo ""

--- a/tests/scripts/test_check_llm_endpoint_env_contract.py
+++ b/tests/scripts/test_check_llm_endpoint_env_contract.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the LLM endpoint env contract guard."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_llm_endpoint_env_contract.py"
+
+
+def _run_check(env_file: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python", str(_SCRIPT), "--env-file", str(env_file)],
+        cwd=_REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.unit
+def test_rejects_disabled_embedding_endpoint(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LLM_CODER_URL=http://192.168.86.201:8000",
+                "LLM_CODER_FAST_URL=http://192.168.86.201:8001",
+                "LLM_EMBEDDING_URL=http://192.168.86.200:8100",
+                "LLM_DEEPSEEK_R1_URL=http://192.168.86.200:8101",
+            ]
+        )
+    )
+
+    result = _run_check(env_file)
+
+    assert result.returncode == 1
+    assert "LLM_EMBEDDING_URL=http://192.168.86.200:8100" in result.stderr
+    assert "status='disabled'" in result.stderr
+
+
+@pytest.mark.unit
+def test_accepts_running_embedding_endpoint(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LLM_CODER_URL=http://192.168.86.201:8000",
+                "LLM_CODER_FAST_URL=http://192.168.86.201:8001",
+                "LLM_EMBEDDING_URL=http://192.168.86.201:8100",
+                "LLM_DEEPSEEK_R1_URL=http://192.168.86.200:8101",
+            ]
+        )
+    )
+
+    result = _run_check(env_file)
+
+    assert result.returncode == 0
+    assert "passed" in result.stdout

--- a/tests/unit/contracts/test_llm_endpoints_contract.py
+++ b/tests/unit/contracts/test_llm_endpoints_contract.py
@@ -67,6 +67,14 @@ _ROLE_TAXONOMY: frozenset[str] = frozenset(
 _PLANNED_NULLABLE_FIELDS: frozenset[str] = frozenset(
     ["host", "port", "endpoint_url", "model_hf_id"]
 )
+_RUNTIME_REQUIRED_URL_ENV_VARS: frozenset[str] = frozenset(
+    [
+        "LLM_CODER_URL",
+        "LLM_CODER_FAST_URL",
+        "LLM_EMBEDDING_URL",
+        "LLM_DEEPSEEK_R1_URL",
+    ]
+)
 
 
 def _load_endpoints() -> list[dict[str, Any]]:
@@ -125,3 +133,25 @@ class TestLlmEndpointsContract:
         assert ep["url_env_var"] == "LLM_QWEN3_NEXT_URL"
         assert ep["role_env_alias"] == "LLM_REASONING_FAST_URL"
         assert ep["role"] == "reasoning_fast"
+
+    def test_runtime_required_env_vars_are_owned_by_running_slots(self) -> None:
+        """Runtime-required URL env vars must point at running canonical slots."""
+        by_env = {
+            ep["url_env_var"]: ep
+            for ep in _load_endpoints()
+            if ep.get("url_env_var") is not None
+        }
+
+        for env_var in _RUNTIME_REQUIRED_URL_ENV_VARS:
+            ep = by_env.get(env_var)
+            assert ep is not None, f"{env_var} is not assigned to any endpoint slot"
+            assert ep["status"] == "running", (
+                f"{env_var} is assigned to non-running slot {ep['slot_id']!r}"
+            )
+
+    def test_disabled_slots_do_not_own_runtime_url_env_vars(self) -> None:
+        for ep in _load_endpoints():
+            if ep["status"] == "disabled":
+                assert ep["url_env_var"] is None, (
+                    f"disabled slot {ep['slot_id']!r} must not own url_env_var"
+                )


### PR DESCRIPTION
## Summary
- moves `LLM_EMBEDDING_URL` ownership in `contracts/llm_endpoints.yaml` from disabled `.200:8100` to running `.201:8100`
- adds `scripts/check_llm_endpoint_env_contract.py` to reject env URLs that drift from the canonical running endpoint contract
- tightens `scripts/check_llm_endpoints.sh` so a configured embedding endpoint being down fails the runtime health probe

## Live Evidence
- `.201:8100/health` and `/v1/models` are reachable and serve `Alibaba-NLP/gte-Qwen2-1.5B-instruct`
- live `.201` env currently sets `LLM_EMBEDDING_URL=http://192.168.86.200:8100`, which this guard rejects as disabled-slot drift
- no live env mutation or runtime restart was performed

## Validation
- `uv run ruff format scripts/check_llm_endpoint_env_contract.py tests/scripts/test_check_llm_endpoint_env_contract.py tests/unit/contracts/test_llm_endpoints_contract.py`
- `uv run ruff check scripts/check_llm_endpoint_env_contract.py tests/scripts/test_check_llm_endpoint_env_contract.py tests/unit/contracts/test_llm_endpoints_contract.py`
- `uv run pytest tests/unit/contracts/test_llm_endpoints_contract.py tests/scripts/test_check_llm_endpoint_env_contract.py tests/unit/docker/test_model_registry_health_paths.py -q`
- `TIMEOUT=3 LLM_CODER_URL=http://192.168.86.201:8000 LLM_CODER_FAST_URL=http://192.168.86.201:8001 LLM_EMBEDDING_URL=http://192.168.86.201:8100 LLM_DEEPSEEK_R1_URL=http://192.168.86.200:8101 bash scripts/check_llm_endpoints.sh`

## Deployment Note
This PR only prevents recurrence. Fixing the current live breaker still requires an approved runtime env correction/redeploy: `LLM_EMBEDDING_URL=http://192.168.86.201:8100`.

OMN-9647