### PR TITLE
fix(runtime): derive Infisical shared folders [OMN-9395]

### DIFF
--- a/scripts/provision-infisical.py
+++ b/scripts/provision-infisical.py
@@ -33,6 +33,8 @@ import secrets
 import sys
 from pathlib import Path
 
+import yaml
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
@@ -43,10 +45,12 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _ENV_FILE = Path.home() / ".omnibase" / ".env"
 _IDENTITY_FILE = _PROJECT_ROOT / ".infisical-identity"
 _ADMIN_TOKEN_FILE = _PROJECT_ROOT / ".infisical-admin-token"
+_REGISTRY_PATH = _PROJECT_ROOT / "config" / "shared_key_registry.yaml"
 
 # Shared utility — avoids duplicating the parser in every Infisical script.
 # Ensure the scripts dir is on the path so the import resolves from any cwd.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 from _infisical_util import _parse_env_file
 
 
@@ -283,30 +287,65 @@ def _create_client_secret(
     }
 
 
+def _folder_slug_from_shared_path(path: str) -> str:
+    """Return the transport slug from a registry path like ``/shared/db/``."""
+    parts = path.strip("/").split("/")
+    if len(parts) != 2 or parts[0] != "shared" or not parts[1]:
+        msg = (
+            f"Expected shared Infisical folder path like /shared/<name>/, got {path!r}"
+        )
+        raise ValueError(msg)
+    return parts[1]
+
+
+def _shared_folder_slugs_from_registry(
+    registry_path: Path = _REGISTRY_PATH,
+) -> tuple[str, ...]:
+    """Load shared folder slugs from the authoritative shared key registry."""
+    if not registry_path.exists():
+        raise FileNotFoundError(f"Shared key registry not found: {registry_path}")
+    with registry_path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        msg = f"Registry file is empty or not a YAML mapping: {registry_path}"
+        raise ValueError(msg)
+    shared = data.get("shared")
+    if not isinstance(shared, dict):
+        msg = f"Registry missing shared mapping: {registry_path}"
+        raise ValueError(msg)
+    return tuple(sorted({_folder_slug_from_shared_path(path) for path in shared}))
+
+
+def _default_shared_folder_slugs() -> tuple[str, ...]:
+    """Return every shared folder required by seeding or runtime prefetch."""
+    from omnibase_infra.runtime.config_discovery.transport_config_map import (
+        TransportConfigMap,
+    )
+
+    registry_slugs = set(_shared_folder_slugs_from_registry())
+    prefetch_slugs = {
+        _folder_slug_from_shared_path(spec.infisical_folder)
+        for spec in TransportConfigMap().all_shared_specs()
+    }
+    return tuple(sorted(registry_slugs | prefetch_slugs))
+
+
 def _create_infisical_folders(
     client: object,  # type: ignore[type-arg]
     addr: str,
     token: str,
     project_id: str,
     environments: tuple[str, ...] = ("dev", "staging", "prod"),
-    transport_folders: tuple[str, ...] = (
-        "consul",
-        "db",
-        "http",
-        "mcp",
-        "graph",
-        "env",
-        "kafka",
-        "vault",
-        "qdrant",
-        "auth",  # Keycloak OIDC config (added for Keycloak integration)
-    ),
+    transport_folders: tuple[str, ...] | None = None,
 ) -> None:
     """Create the /shared/<transport> folder structure in every environment.
 
     Infisical requires folders to exist before secrets can be written into them.
     Folders that already exist are silently skipped (the API returns the existing one).
     """
+    if transport_folders is None:
+        transport_folders = _default_shared_folder_slugs()
+
     for env in environments:
         # Create /shared root
         resp = client.post(  # type: ignore[attr-defined]

--- a/tests/integration/runtime/test_infisical_shared_folder_coverage.py
+++ b/tests/integration/runtime/test_infisical_shared_folder_coverage.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for Infisical shared folder provisioning."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.runtime.config_discovery.transport_config_map import (
+    TransportConfigMap,
+)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _PROJECT_ROOT / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_provision_mod = importlib.import_module("provision-infisical")
+
+
+def _folder_slug_from_shared_path(path: str) -> str:
+    return path.strip("/").split("/")[1]
+
+
+@pytest.mark.integration
+def test_infisical_provisioning_covers_registry_and_runtime_prefetch_folders() -> None:
+    """Provisioning must create every folder used by seed-shared and prefetch."""
+    provisioned_folders = set(_provision_mod._default_shared_folder_slugs())
+
+    registry_data = yaml.safe_load(
+        (_PROJECT_ROOT / "config" / "shared_key_registry.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    registry_folders = {
+        _folder_slug_from_shared_path(path) for path in registry_data["shared"]
+    }
+    prefetch_folders = {
+        _folder_slug_from_shared_path(spec.infisical_folder)
+        for spec in TransportConfigMap().all_shared_specs()
+    }
+
+    assert registry_folders | prefetch_folders <= provisioned_folders
+    assert "filesystem" in provisioned_folders

--- a/tests/unit/scripts/test_provision_infisical.py
+++ b/tests/unit/scripts/test_provision_infisical.py
@@ -32,6 +32,8 @@ import importlib
 _provision_mod = importlib.import_module("provision-infisical")
 
 _create_infisical_folders = _provision_mod._create_infisical_folders
+_default_shared_folder_slugs = _provision_mod._default_shared_folder_slugs
+_shared_folder_slugs_from_registry = _provision_mod._shared_folder_slugs_from_registry
 _main = _provision_mod.main
 
 
@@ -112,6 +114,65 @@ class TestCreateInfisicalFoldersIdempotency:
         log_text = caplog.text
         assert "[idempotent]" in log_text
         assert "[created]" not in log_text
+
+    def test_default_folder_creation_uses_registry_and_transport_map(self) -> None:
+        """Default provisioning must include all registry and runtime-prefetch folders."""
+        client = MagicMock()
+        client.post.return_value = _make_httpx_response(201)
+
+        _create_infisical_folders(
+            client,
+            "http://localhost:8880",
+            "tok",
+            "proj-id",
+            environments=("prod",),
+        )
+
+        created_folder_names = {
+            call.kwargs["json"]["name"]
+            for call in client.post.call_args_list
+            if call.kwargs["json"].get("path") == "/shared"
+        }
+
+        assert "filesystem" in created_folder_names
+
+
+@pytest.mark.unit
+class TestSharedFolderRegistry:
+    """Shared Infisical folders must be derived from typed source-of-truth maps."""
+
+    def test_shared_folder_slugs_from_registry(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "shared_key_registry.yaml"
+        registry_path.write_text(
+            """
+version: "1.1"
+shared:
+  /shared/db/:
+    - POSTGRES_HOST
+  /shared/filesystem/:
+    - FS_BASE_PATH
+bootstrap_only:
+  - POSTGRES_PASSWORD
+identity_defaults:
+  - POSTGRES_DATABASE
+""",
+            encoding="utf-8",
+        )
+
+        assert _shared_folder_slugs_from_registry(registry_path) == (
+            "db",
+            "filesystem",
+        )
+
+    def test_default_shared_folder_slugs_include_runtime_prefetch_and_seed_folders(
+        self,
+    ) -> None:
+        folders = set(_default_shared_folder_slugs())
+
+        assert "filesystem" in folders
+        assert "llm" in folders
+        assert "valkey" in folders
+        assert "auth" in folders
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes OMN-9395.

## Summary
- Derive Infisical `/shared/<transport>` folders from `config/shared_key_registry.yaml` plus `TransportConfigMap` instead of a stale hardcoded list.
- Ensures runtime-prefetch folders such as `/shared/filesystem/` are provisioned for `FS_BASE_PATH`, alongside registry-backed folders like `auth`, `env`, `llm`, and `valkey`.
- Adds unit and integration regression coverage so provisioning stays aligned with seeded config and runtime prefetch config.

## Live Runtime Evidence
- `.201` runtime health currently reports `config_prefetch_status=degraded_error` on both runtime profiles.
- Infisical is reachable, but logs show `Folder with path '/shared/filesystem' in environment with slug 'prod' not found` while runtime prefetch requests `FS_BASE_PATH`.\n- `TransportConfigMap` already declares `EnumInfraTransportType.FILESYSTEM: ("FS_BASE_PATH",)`, so the issue is provisioning coverage, not a missing typed runtime config contract.\n\n## Validation\n- `uv run ruff format scripts/provision-infisical.py tests/unit/scripts/test_provision_infisical.py tests/integration/runtime/test_infisical_shared_folder_coverage.py`\n- `uv run ruff check scripts/provision-infisical.py tests/unit/scripts/test_provision_infisical.py tests/integration/runtime/test_infisical_shared_folder_coverage.py`\n- `uv run pytest tests/unit/scripts/test_provision_infisical.py tests/integration/runtime/test_infisical_shared_folder_coverage.py -q`\n- Commit hooks passed without `--no-verify`.\n\n## Deployment Note\nThis PR changes provisioning code only. Clearing the live `.201` health degradation still requires running the provisioning/seed flow or otherwise creating the missing Infisical folder/key through the approved runtime deployment path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating provisioning coverage across shared folders
  * Added unit tests verifying provisioning helper function logic

* **Chores**
  * Provisioning system now uses a configuration registry for dynamic folder management instead of hard-coded values
  * Improved system maintainability through data-driven configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->