### PR TITLE
fix(runtime): publish no-dispatcher messages to dlq [OMN-9649]

### DIFF
--- a/src/omnibase_infra/event_bus/mixin_kafka_dlq.py
+++ b/src/omnibase_infra/event_bus/mixin_kafka_dlq.py
@@ -146,6 +146,17 @@ class MixinKafkaDlq:
         self._dlq_callbacks: list[DlqCallbackType] = []
         self._dlq_callbacks_lock = asyncio.Lock()
 
+    def _resolve_dlq_topic(
+        self: ProtocolKafkaDlqHost,
+        dlq_topic: str | None = None,
+    ) -> str:
+        """Resolve the DLQ topic, preserving explicit bus configuration."""
+        if self._config.dead_letter_topic:
+            return self._config.dead_letter_topic
+        if dlq_topic:
+            return dlq_topic
+        return self._config.get_dlq_topic()
+
     @property
     def dlq_metrics(self) -> ModelDlqMetrics:
         """Get a deep copy of the current DLQ metrics.
@@ -213,6 +224,7 @@ class MixinKafkaDlq:
         correlation_id: UUID,
         *,
         consumer_group: str,
+        dlq_topic: str | None = None,
     ) -> None:
         """Publish failed message to dead letter queue with metrics and alerting.
 
@@ -235,6 +247,8 @@ class MixinKafkaDlq:
             correlation_id: Correlation ID for tracking
             consumer_group: Consumer group ID that processed the message.
                 Required for DLQ traceability.
+            dlq_topic: Optional category-specific DLQ topic. Explicit
+                ``dead_letter_topic`` config takes precedence when present.
 
         Note:
             This method logs errors if DLQ publishing fails but does not raise
@@ -255,10 +269,9 @@ class MixinKafkaDlq:
         start_time = datetime.now(UTC)
         error_type = type(error).__name__
 
-        # Get DLQ topic using convention-based resolution
-        # This supports both explicit dead_letter_topic config and automatic
-        # topic generation following ONEX conventions: <env>.dlq.<category>.v1
-        dlq_topic = self._config.get_dlq_topic()
+        # Explicit bus configuration wins; otherwise use caller-provided
+        # category routing before falling back to the default intents DLQ.
+        resolved_dlq_topic = self._resolve_dlq_topic(dlq_topic)
 
         # Sanitize error message to prevent credential leakage in DLQ
         sanitized_failure_reason = sanitize_error_message(error)
@@ -358,7 +371,7 @@ class MixinKafkaDlq:
                         "DLQ publish failed: producer not available",
                         extra={
                             "original_topic": original_topic,
-                            "dlq_topic": dlq_topic,
+                            "dlq_topic": resolved_dlq_topic,
                             "correlation_id": str(correlation_id),
                             "error_type": error_type,
                             "retry_count": failed_message.headers.retry_count,
@@ -369,6 +382,7 @@ class MixinKafkaDlq:
                     kafka_headers.extend(
                         [
                             ("original_topic", original_topic.encode("utf-8")),
+                            ("dlq_topic", resolved_dlq_topic.encode("utf-8")),
                             (
                                 "failure_reason",
                                 sanitized_failure_reason.encode("utf-8"),
@@ -386,7 +400,7 @@ class MixinKafkaDlq:
             if producer is not None and kafka_headers is not None:
                 await asyncio.wait_for(
                     producer.send_and_wait(
-                        dlq_topic,
+                        resolved_dlq_topic,
                         value=dlq_value,
                         key=failed_message.key,
                         headers=kafka_headers,
@@ -402,7 +416,7 @@ class MixinKafkaDlq:
                 "DLQ publish failed: message may be lost",
                 extra={
                     "original_topic": original_topic,
-                    "dlq_topic": dlq_topic,
+                    "dlq_topic": resolved_dlq_topic,
                     "correlation_id": str(correlation_id),
                     "error_type": error_type,
                     "dlq_error_type": dlq_error_type,
@@ -423,7 +437,7 @@ class MixinKafkaDlq:
                 "Message published to DLQ due to processing failure",
                 extra={
                     "original_topic": original_topic,
-                    "dlq_topic": dlq_topic,
+                    "dlq_topic": resolved_dlq_topic,
                     "correlation_id": str(correlation_id),
                     "error_type": error_type,
                     "error_message": sanitized_failure_reason,
@@ -481,7 +495,7 @@ class MixinKafkaDlq:
         )
         dlq_event = ModelDlqEvent(
             original_topic=original_topic,
-            dlq_topic=dlq_topic,
+            dlq_topic=resolved_dlq_topic,
             correlation_id=correlation_id,
             error_type=error_type,
             error_message=sanitized_failure_reason,
@@ -548,6 +562,7 @@ class MixinKafkaDlq:
         failure_type: str,
         *,
         consumer_group: str,
+        dlq_topic: str | None = None,
     ) -> None:
         """Publish raw Kafka message to DLQ when deserialization fails.
 
@@ -564,6 +579,8 @@ class MixinKafkaDlq:
             failure_type: Type of failure (e.g., "deserialization_error")
             consumer_group: Consumer group ID that processed the message.
                 Required for DLQ traceability.
+            dlq_topic: Optional category-specific DLQ topic. Explicit
+                ``dead_letter_topic`` config takes precedence when present.
 
         Note:
             This method logs errors if DLQ publishing fails but does not raise
@@ -585,10 +602,9 @@ class MixinKafkaDlq:
         start_time = datetime.now(UTC)
         error_type = type(error).__name__
 
-        # Get DLQ topic using convention-based resolution
-        # This supports both explicit dead_letter_topic config and automatic
-        # topic generation following ONEX conventions: <env>.dlq.<category>.v1
-        dlq_topic = self._config.get_dlq_topic()
+        # Explicit bus configuration wins; otherwise use caller-provided
+        # category routing before falling back to the default intents DLQ.
+        resolved_dlq_topic = self._resolve_dlq_topic(dlq_topic)
 
         # Sanitize error message
         sanitized_failure_reason = sanitize_error_message(error)
@@ -699,7 +715,7 @@ class MixinKafkaDlq:
                         "DLQ publish failed: producer not available for raw message",
                         extra={
                             "original_topic": original_topic,
-                            "dlq_topic": dlq_topic,
+                            "dlq_topic": resolved_dlq_topic,
                             "correlation_id": str(correlation_id),
                             "error_type": error_type,
                             "failure_type": failure_type,
@@ -710,6 +726,7 @@ class MixinKafkaDlq:
                     kafka_headers.extend(
                         [
                             ("original_topic", original_topic.encode("utf-8")),
+                            ("dlq_topic", resolved_dlq_topic.encode("utf-8")),
                             ("failure_type", failure_type.encode("utf-8")),
                             (
                                 "failure_reason",
@@ -728,7 +745,7 @@ class MixinKafkaDlq:
             if producer is not None and kafka_headers is not None:
                 await asyncio.wait_for(
                     producer.send_and_wait(
-                        dlq_topic,
+                        resolved_dlq_topic,
                         value=dlq_value,
                         key=dlq_key,
                         headers=kafka_headers,
@@ -744,7 +761,7 @@ class MixinKafkaDlq:
                 "DLQ publish failed for raw message: message may be lost",
                 extra={
                     "original_topic": original_topic,
-                    "dlq_topic": dlq_topic,
+                    "dlq_topic": resolved_dlq_topic,
                     "correlation_id": str(correlation_id),
                     "error_type": error_type,
                     "failure_type": failure_type,
@@ -765,7 +782,7 @@ class MixinKafkaDlq:
                 "Raw message published to DLQ due to deserialization/validation failure",
                 extra={
                     "original_topic": original_topic,
-                    "dlq_topic": dlq_topic,
+                    "dlq_topic": resolved_dlq_topic,
                     "correlation_id": str(correlation_id),
                     "error_type": error_type,
                     "error_message": sanitized_failure_reason,
@@ -780,7 +797,7 @@ class MixinKafkaDlq:
         message_offset_str = str(raw_offset) if raw_offset is not None else None
         dlq_event = ModelDlqEvent(
             original_topic=original_topic,
-            dlq_topic=dlq_topic,
+            dlq_topic=resolved_dlq_topic,
             correlation_id=correlation_id,
             error_type=error_type,
             error_message=sanitized_failure_reason,

--- a/src/omnibase_infra/event_bus/mixin_kafka_dlq.py
+++ b/src/omnibase_infra/event_bus/mixin_kafka_dlq.py
@@ -93,6 +93,10 @@ class ProtocolKafkaDlqHost(Protocol):
         """Invoke registered DLQ callbacks."""
         ...
 
+    def _resolve_dlq_topic(self, dlq_topic: str | None = None) -> str:
+        """Resolve explicit/configured DLQ topic routing."""
+        ...
+
 
 # Type alias for DLQ callback functions
 DlqCallbackType = Callable[[ModelDlqEvent], Awaitable[None]]

--- a/src/omnibase_infra/runtime/event_bus_subcontract_wiring.py
+++ b/src/omnibase_infra/runtime/event_bus_subcontract_wiring.py
@@ -102,12 +102,17 @@ from omnibase_core.protocols.event_bus.protocol_event_bus_subscriber import (
 from omnibase_core.protocols.event_bus.protocol_event_message import (
     ProtocolEventMessage,
 )
-from omnibase_infra.enums import EnumConsumerGroupPurpose, EnumInfraTransportType
+from omnibase_infra.enums import (
+    EnumConsumerGroupPurpose,
+    EnumDispatchStatus,
+    EnumInfraTransportType,
+)
 from omnibase_infra.errors import (
     ModelInfraErrorContext,
     ProtocolConfigurationError,
     RuntimeHostError,
 )
+from omnibase_infra.event_bus.topic_constants import get_dlq_topic_for_original
 from omnibase_infra.models import ModelNodeIdentity
 from omnibase_infra.models.event_bus import (
     ModelConsumerRetryConfig,
@@ -525,6 +530,7 @@ class EventBusSubcontractWiring(MixinConsumptionCounter):
         correlation_id: UUID,
         error_category: str,
         consumer_group: str,
+        dlq_topic: str | None = None,
     ) -> None:
         """Publish failed message to Dead Letter Queue.
 
@@ -540,6 +546,9 @@ class EventBusSubcontractWiring(MixinConsumptionCounter):
             consumer_group: The consumer group ID that was subscribed to this topic.
                 This should match the group_id used in wire_subscriptions() for
                 consistent traceability in DLQ messages.
+            dlq_topic: Optional category-specific DLQ topic. If omitted, the
+                topic is derived from the original topic before delegating to
+                the event bus.
         """
         if not self._dlq_config.enabled:
             self._logger.debug(
@@ -554,6 +563,7 @@ class EventBusSubcontractWiring(MixinConsumptionCounter):
         publish_dlq_fn = getattr(self._event_bus, "_publish_raw_to_dlq", None)
         if publish_dlq_fn is not None and callable(publish_dlq_fn):
             try:
+                resolved_dlq_topic = dlq_topic or get_dlq_topic_for_original(topic)
                 await publish_dlq_fn(
                     original_topic=topic,
                     raw_msg=message,
@@ -561,14 +571,16 @@ class EventBusSubcontractWiring(MixinConsumptionCounter):
                     correlation_id=correlation_id,
                     failure_type=f"{error_category}_error",
                     consumer_group=consumer_group,
+                    dlq_topic=resolved_dlq_topic,
                 )
                 self._logger.warning(
                     "dlq_published topic=%s error_category=%s error_type=%s "
-                    "correlation_id=%s",
+                    "correlation_id=%s dlq_topic=%s",
                     topic,
                     error_category,
                     type(error).__name__,
                     str(correlation_id),
+                    resolved_dlq_topic,
                 )
             except Exception as dlq_error:
                 self._logger.exception(
@@ -802,6 +814,34 @@ class EventBusSubcontractWiring(MixinConsumptionCounter):
                     type(result).__name__ if result else "None",
                     self._node_name,
                 )
+
+                if (
+                    result is not None
+                    and result.status == EnumDispatchStatus.NO_DISPATCHER
+                ):
+                    no_dispatcher_error = ProtocolConfigurationError(
+                        result.error_message
+                        or f"No dispatcher registered for message from topic '{topic}'",
+                        context=ModelInfraErrorContext.with_correlation(
+                            correlation_id=correlation_id,
+                            transport_type=EnumInfraTransportType.KAFKA,
+                            operation="event_bus_dispatch.no_dispatcher",
+                            target_name=topic,
+                        ),
+                    )
+                    await self._publish_to_dlq(
+                        topic,
+                        message,
+                        no_dispatcher_error,
+                        correlation_id,
+                        "content",
+                        consumer_group,
+                        dlq_topic=result.dlq_topic,
+                    )
+                    if self._should_commit_after_handler():
+                        await self._commit_offset(message, correlation_id)
+                    self._clear_retry_count(correlation_id)
+                    return
 
                 # Apply dispatch result (publish output events + delegate intents)
                 if self._result_applier is not None and result is not None:

--- a/src/omnibase_infra/services/topics.yaml
+++ b/src/omnibase_infra/services/topics.yaml
@@ -21,6 +21,10 @@ topics:
   - onex.evt.omnibase-infra.wiring-health-snapshot.v1
   # --- DLQ aggregation topic for omnidash (OMN-6136) ---
   - onex.evt.platform.dlq-message.v1
+  # --- Canonical runtime DLQ topics not owned by node contracts (OMN-9649) ---
+  - onex.dlq.intents.v1
+  - onex.dlq.events.v1
+  - onex.dlq.commands.v1
   # --- GitHub PR merged event (OMN-6726) ---
   - onex.evt.github.pr-merged.v1
   # --- Post-merge check chain result (OMN-6727) ---

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -52,9 +52,14 @@ _RE_EVENT_NAME = re.compile(r"^[a-z0-9._-]+$")
 _RE_PRODUCER = re.compile(r"^[a-z0-9-]+$")  # no underscores allowed
 
 # Regex to identify ONEX topic string literals in Python source code.
-# Matches: onex.<kind>.<producer>.<event-name>.<version>
+# Matches either:
+#   - 5-segment standard topics: onex.<kind>.<producer>.<event-name>.<version>
+#   - 4-segment DLQ topics: onex.dlq.<category>.<version>
 _RE_ONEX_TOPIC_LITERAL = re.compile(
-    r"^onex\.(evt|cmd|intent)\.[a-z0-9-]+\.[a-z0-9._-]+\.v\d+$"
+    r"^onex\.(?:"
+    r"(?:evt|cmd|intent)\.[a-z0-9-]+\.[a-z0-9._-]+\.v\d+"
+    r"|dlq\.[a-z0-9._-]+\.v\d+"
+    r")$"
 )
 
 # YAML keys to inspect — ordered by spec; always check ALL, no early break.

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -46,6 +46,7 @@ _APPROVED_PACKAGES: tuple[str, ...] = (
 )
 
 _VALID_KINDS: frozenset[str] = frozenset({"evt", "cmd", "intent"})
+_VALID_DLQ_CATEGORIES: frozenset[str] = frozenset({"intents", "events", "commands"})
 _RE_VERSION = re.compile(r"^v\d+$")
 _RE_EVENT_NAME = re.compile(r"^[a-z0-9._-]+$")
 _RE_PRODUCER = re.compile(r"^[a-z0-9-]+$")  # no underscores allowed
@@ -78,7 +79,7 @@ class ModelContractTopicEntry(BaseModel):
     """A single validated topic extracted from one or more contract.yaml files."""
 
     topic: str
-    kind: Literal["evt", "cmd", "intent"]
+    kind: Literal["evt", "cmd", "intent", "dlq"]
     producer: str
     event_name: str
     version: str  # e.g. "v1"
@@ -119,6 +120,31 @@ def _parse_topic(raw: str, source: Path) -> ModelContractTopicEntry | None:
     that check happens at a higher level (deduplication); here we only parse.
     """
     parts = raw.split(".")
+    if len(parts) == 4:
+        prefix, kind, category, version = parts
+        if prefix == "onex" and kind == "dlq":
+            if category not in _VALID_DLQ_CATEGORIES:
+                _warn(
+                    "Skipping malformed DLQ topic "
+                    f"(invalid category {category!r}, must be one of "
+                    f"{sorted(_VALID_DLQ_CATEGORIES)}): {raw!r} in {source}"
+                )
+                return None
+            if not _RE_VERSION.match(version):
+                _warn(
+                    f"Skipping malformed DLQ topic (invalid version {version!r}, "
+                    f"must match ^v\\d+$): {raw!r} in {source}"
+                )
+                return None
+            return ModelContractTopicEntry(
+                topic=raw,
+                kind="dlq",
+                producer="dlq",
+                event_name=category,
+                version=version,
+                source_contracts=(source,),
+            )
+
     if len(parts) != 5:
         _warn(
             f"Skipping malformed topic (expected 5 segments, got {len(parts)}): "
@@ -165,7 +191,7 @@ def _parse_topic(raw: str, source: Path) -> ModelContractTopicEntry | None:
 
     return ModelContractTopicEntry(
         topic=raw,
-        kind=cast("Literal['evt', 'cmd', 'intent']", kind),
+        kind=cast("Literal['evt', 'cmd', 'intent', 'dlq']", kind),
         producer=producer,
         event_name=event_name,
         version=version,

--- a/src/omnibase_infra/tools/topic_enum_generator.py
+++ b/src/omnibase_infra/tools/topic_enum_generator.py
@@ -80,6 +80,7 @@ _KIND_PREFIX: dict[str, str] = {
     "evt": "EVT_",
     "cmd": "CMD_",
     "intent": "INTENT_",
+    "dlq": "DLQ_",
 }
 
 # File header template (filled per producer)

--- a/tests/integration/runtime/test_dlq_topic_manifest_coverage.py
+++ b/tests/integration/runtime/test_dlq_topic_manifest_coverage.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime DLQ topic provisioning coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.tools.contract_topic_extractor import ContractTopicExtractor
+
+pytestmark = pytest.mark.integration
+
+
+def test_canonical_dlq_topics_are_in_service_manifest() -> None:
+    """Contract-first provisioning must include non-contract runtime DLQ topics."""
+    repo_root = Path(__file__).resolve().parents[3]
+    extractor = ContractTopicExtractor()
+
+    entries = extractor.extract_all(
+        contracts_root=repo_root / "src" / "omnibase_infra" / "nodes",
+        skill_manifests_roots=[repo_root / "src" / "omnibase_infra" / "services"],
+    )
+    topics = {entry.topic for entry in entries}
+
+    assert "onex.dlq.intents.v1" in topics
+    assert "onex.dlq.events.v1" in topics
+    assert "onex.dlq.commands.v1" in topics

--- a/tests/unit/runtime/test_event_bus_subcontract_wiring.py
+++ b/tests/unit/runtime/test_event_bus_subcontract_wiring.py
@@ -27,8 +27,10 @@ import pytest
 
 from omnibase_core.models.contracts.subcontracts import ModelEventBusSubcontract
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.errors import RuntimeHostError
 from omnibase_infra.event_bus.models import ModelEventHeaders, ModelEventMessage
+from omnibase_infra.models.dispatch import ModelDispatchResult
 from omnibase_infra.runtime.event_bus_subcontract_wiring import (
     EventBusSubcontractWiring,
     load_event_bus_subcontract,
@@ -549,6 +551,54 @@ class TestDispatchCallback:
         mock_event_bus._publish_raw_to_dlq.assert_called_once()
         call_kwargs = mock_event_bus._publish_raw_to_dlq.call_args.kwargs
         assert call_kwargs["failure_type"] == "content_error"
+        assert call_kwargs["dlq_topic"] == "onex.dlq.events.v1"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_callback_routes_no_dispatcher_result_to_derived_dlq(
+        self,
+        mock_event_bus: AsyncMock,
+        mock_dispatch_engine: AsyncMock,
+        sample_event_message: ModelEventMessage,
+    ) -> None:
+        """NO_DISPATCHER must be DLQ-published before offset commit."""
+        from omnibase_infra.models.event_bus import ModelDlqConfig
+
+        mock_event_bus._publish_raw_to_dlq = AsyncMock()
+        mock_event_bus.commit_offset = AsyncMock()
+        result_applier = AsyncMock()
+        correlation_id = uuid4()
+        mock_dispatch_engine.dispatch.return_value = ModelDispatchResult(
+            status=EnumDispatchStatus.NO_DISPATCHER,
+            topic="onex.evt.test.v1",
+            started_at=datetime.now(UTC),
+            correlation_id=correlation_id,
+            error_message="No dispatcher found for test.event",
+            dlq_topic="onex.dlq.events.v1",
+        )
+
+        wiring = EventBusSubcontractWiring(
+            event_bus=mock_event_bus,
+            dispatch_engine=mock_dispatch_engine,
+            environment="dev",
+            node_name="test-handler",
+            service="test-service",
+            version="v1",
+            result_applier=result_applier,
+            dlq_config=ModelDlqConfig(enabled=True, on_content_error="dlq_and_commit"),
+        )
+
+        callback = wiring._create_dispatch_callback(
+            "onex.evt.test.v1", "dev.test-handler"
+        )
+        await callback(sample_event_message)
+
+        mock_event_bus._publish_raw_to_dlq.assert_called_once()
+        call_kwargs = mock_event_bus._publish_raw_to_dlq.call_args.kwargs
+        assert call_kwargs["failure_type"] == "content_error"
+        assert call_kwargs["dlq_topic"] == "onex.dlq.events.v1"
+        assert call_kwargs["consumer_group"] == "dev.test-handler"
+        mock_event_bus.commit_offset.assert_called_once_with(sample_event_message)
+        result_applier.apply.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dispatch_callback_propagates_dispatch_errors(
@@ -1404,6 +1454,7 @@ class TestErrorClassification:
         mock_event_bus._publish_raw_to_dlq.assert_called_once()
         call_kwargs = mock_event_bus._publish_raw_to_dlq.call_args.kwargs
         assert call_kwargs["failure_type"] == "content_error"
+        assert call_kwargs["dlq_topic"] == "onex.dlq.events.v1"
 
     @pytest.mark.asyncio
     async def test_validation_error_classified_as_content_error(

--- a/tests/unit/tools/test_contract_topic_extractor_yaml.py
+++ b/tests/unit/tools/test_contract_topic_extractor_yaml.py
@@ -134,6 +134,38 @@ def test_extract_from_skill_manifests_returns_valid_entries(skills_root: Path) -
     assert [e.topic for e in entries] == sorted_topics
 
 
+@pytest.mark.unit
+def test_extract_from_skill_manifests_accepts_canonical_dlq_topics(
+    tmp_path: Path,
+) -> None:
+    """Service manifests may declare canonical four-segment runtime DLQ topics."""
+    services_root = tmp_path / "services"
+    services_root.mkdir()
+    (services_root / "topics.yaml").write_text(
+        textwrap.dedent(
+            """\
+            topics:
+              - onex.dlq.intents.v1
+              - onex.dlq.events.v1
+              - onex.dlq.commands.v1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_skill_manifests(services_root)
+    topics = {entry.topic for entry in entries}
+
+    assert topics == {
+        "onex.dlq.intents.v1",
+        "onex.dlq.events.v1",
+        "onex.dlq.commands.v1",
+    }
+    assert {entry.kind for entry in entries} == {"dlq"}
+    assert {entry.producer for entry in entries} == {"dlq"}
+
+
 # ---------------------------------------------------------------------------
 # Test 2: malformed topics are warned and skipped, not raised
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_python_source_topic_extraction.py
+++ b/tests/unit/tools/test_python_source_topic_extraction.py
@@ -311,6 +311,43 @@ def test_extract_all_without_supplementary_equals_extract(tmp_path: Path) -> Non
 
 
 @pytest.mark.unit
+def test_extract_python_source_includes_dlq_literals(tmp_path: Path) -> None:
+    """4-segment DLQ topic literals in Python source are extracted (OMN-9649).
+
+    Regression: prior `_RE_ONEX_TOPIC_LITERAL` only matched 5-segment
+    evt|cmd|intent topics, so hardcoded `onex.dlq.*` literals were silently
+    skipped even though `_parse_topic()` accepted them.
+    """
+    source = write_python_source(
+        tmp_path,
+        "dlq_constants.py",
+        """\
+        from typing import Final
+
+        DLQ_INTENTS: Final[str] = "onex.dlq.intents.v1"
+        DLQ_EVENTS: Final[str] = "onex.dlq.events.v1"
+        DLQ_COMMANDS: Final[str] = "onex.dlq.commands.v1"
+        # 5-segment topic still works alongside DLQ literals
+        EVENT_TOPIC: Final[str] = "onex.evt.platform.example.v1"
+        """,
+    )
+
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_python_sources([source])
+    topics = {e.topic for e in entries}
+
+    assert "onex.dlq.intents.v1" in topics
+    assert "onex.dlq.events.v1" in topics
+    assert "onex.dlq.commands.v1" in topics
+    assert "onex.evt.platform.example.v1" in topics
+
+    dlq_entries = [e for e in entries if e.kind == "dlq"]
+    assert len(dlq_entries) == 3
+    assert {e.event_name for e in dlq_entries} == {"intents", "events", "commands"}
+    assert {e.producer for e in dlq_entries} == {"dlq"}
+
+
+@pytest.mark.unit
 def test_actual_topic_constants_extractable() -> None:
     """The real topic_constants.py yields at least the known topic constants."""
     source = Path(


### PR DESCRIPTION
Closes OMN-9649.

## Summary
- Route `NO_DISPATCHER` dispatch results through the content DLQ path before committing offsets.
- Allow runtime DLQ publishing to honor derived category topics while preserving explicit `dead_letter_topic` config overrides.
- Declare canonical runtime DLQ topics in `services/topics.yaml` and teach the contract-first topic extractor to accept `onex.dlq.{intents,events,commands}.v1` infrastructure topics.

## Runtime Evidence
- Live `.201` effects runtime logs showed repeated `No dispatcher found for category 'event' ... routing to DLQ topic 'onex.dlq.events.v1'` messages.
- Live Redpanda had only `onex.dlq.intents.v1`; `onex.dlq.events.v1` and `onex.dlq.commands.v1` were absent from provisioned topics.
- Existing result applier ignored non-success dispatch statuses, so `NO_DISPATCHER` messages were committed without actual DLQ publish.

## Validation
- `uv run pytest tests/unit/runtime/test_event_bus_subcontract_wiring.py tests/unit/event_bus/test_topic_constants.py tests/unit/tools/test_contract_topic_extractor_yaml.py tests/unit/tools/test_contract_topic_extractor.py tests/integration/runtime/test_dlq_topic_manifest_coverage.py -q` -> 166 passed
- `uv run pytest tests/unit/event_bus/test_kafka_event_bus.py tests/integration/event_bus/test_dlq_integration.py -q` -> 118 passed, 8 skipped (Kafka integration env not enabled)
- `uv run pytest tests/unit/tools/test_topic_enum_generator.py tests/unit/tools/test_topic_constants_enum_coverage.py -q` -> 34 passed
- `uv run pytest tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_kafka_bootstrap_no_localhost_fallback_integration.py -q` -> 16 passed, 3 warnings
- Commit hooks and push hooks passed, including mypy and architecture layer validation.

## Receipt
- OMN-9649 receipt contract and evidence are included in `onex_change_control` PR #355; deploy/receipt gates should pass after the receipt PR merges or the gate re-evaluates against that evidence.

Refs OMN-9649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-specific Dead Letter Queue (DLQ) routing with canonical DLQ topics for intents, events, and commands.
  * Dispatch now routes unprocessed or NO_DISPATCHER messages to the resolved DLQ topic while preserving failure context and offset/commit behavior.

* **Tests**
  * Added integration and unit tests to validate DLQ topic discovery, manifest coverage, and dispatch-to-DLQ behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->