### PR TITLE
fix(runtime): route auto-wired heartbeat events by topic-derived type [OMN-9648]

### DIFF
--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -444,6 +444,7 @@ handler_routing:
     - event_model:
         name: "ModelNodeHeartbeatEvent"
         module: "omnibase_infra.models.registration.model_node_heartbeat_event"
+      event_type: "platform.node-heartbeat"
       handler:
         name: "HandlerNodeHeartbeat"
         module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_heartbeat"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -525,6 +525,12 @@ def _make_event_bus_callback(
 
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 
+    def _derive_event_type_from_topic(topic: str) -> str | None:
+        parts = topic.split(".")
+        if len(parts) >= 5 and parts[0] == "onex":
+            return f"{parts[2]}.{parts[3]}"
+        return None
+
     async def callback(message: object) -> None:
         try:
             raw = getattr(message, "value", None)
@@ -535,6 +541,17 @@ def _make_event_bus_callback(
                 envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
                     object
                 ].model_validate(data)
+                explicit_event_type = data.get("event_type")
+                if explicit_event_type:
+                    envelope = envelope.model_copy(
+                        update={"event_type": explicit_event_type}
+                    )
+                else:
+                    derived_event_type = _derive_event_type_from_topic(topic)
+                    if derived_event_type is not None:
+                        envelope = envelope.model_copy(
+                            update={"event_type": derived_event_type}
+                        )
             else:
                 if not isinstance(message, ModelEventEnvelope):
                     logger.warning(

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     subscribe_wired_contract_topics,
@@ -313,6 +314,37 @@ class TestMakeEventBusCallbackFallbackPath:
         assert isinstance(call_envelope, ModelEventEnvelope)
 
     @pytest.mark.asyncio
+    async def test_raw_message_derives_event_type_from_topic(self) -> None:
+        """Object-erased Kafka envelopes must still route by topic-derived event_type."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        dispatch_engine = MagicMock()
+        dispatch_engine.dispatch = AsyncMock()
+
+        callback = _make_event_bus_callback(
+            "onex.evt.platform.node-heartbeat.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+        )
+
+        envelope = ModelEventEnvelope[object].model_construct(
+            payload={"node_id": "runtime_config"},
+            correlation_id=None,
+        )
+        message = SimpleNamespace(value=envelope.model_dump_json().encode())
+
+        await callback(message)
+
+        dispatch_engine.dispatch.assert_called_once()
+        _, call_envelope = dispatch_engine.dispatch.call_args.args
+        assert call_envelope.event_type == "platform.node-heartbeat"
+
+    @pytest.mark.asyncio
     async def test_valid_envelope_result_is_applied_when_applier_supplied(
         self,
     ) -> None:
@@ -346,3 +378,24 @@ class TestMakeEventBusCallbackFallbackPath:
 
         dispatch_engine.dispatch.assert_called_once()
         result_applier.apply.assert_awaited_once_with(dispatch_result, None)
+
+    def test_registration_heartbeat_handler_declares_wire_event_type(self) -> None:
+        """The heartbeat handler must match the event_type derived from the Kafka topic."""
+        contract_path = (
+            Path(__file__).parents[4]
+            / "src"
+            / "omnibase_infra"
+            / "nodes"
+            / "node_registration_orchestrator"
+            / "contract.yaml"
+        )
+        contract = yaml.safe_load(contract_path.read_text())
+
+        heartbeat_handlers = [
+            handler
+            for handler in contract["handler_routing"]["handlers"]
+            if handler["handler"]["name"] == "HandlerNodeHeartbeat"
+        ]
+
+        assert len(heartbeat_handlers) == 1
+        assert heartbeat_handlers[0]["event_type"] == "platform.node-heartbeat"


### PR DESCRIPTION
## Summary
- Derive `event_type` from ONEX topic names for raw auto-wired Kafka callbacks, matching the legacy `EventBusSubcontractWiring` behavior.
- Declare `platform.node-heartbeat` on the registration heartbeat handler so object-erased heartbeat envelopes do not route as `message_type=dict`.
- Adds focused regression coverage for topic-derived event type routing and the registration heartbeat contract declaration.

## Runtime Evidence
- Read-only `.201` probe on 2026-04-24T18:48Z found 1,744 `NO_DISPATCHER` results in 20 minutes, all on `onex.evt.platform.node-heartbeat.v1`.
- Failures were split across `local.runtime_config.node_registration_orchestrator.consume.v1`, `node_contract_registry_reducer.consume.v1`, `node_ledger_projection_compute.consume.v1`, and the legacy `registration-orchestrator.consume.1.0.0` group.
- Log message type was `dict`, showing object-erased envelopes were not getting a contract/wire routing key before dispatch.

## Stacking
- Stacked on `jonah/omn-9550-defer-autowire-subscriptions` because this depends on the OMN-9550/OMN-9557 registration ownership stack.
- Retarget/rebase after the OMN-9550/OMN-9557 stack lands on `main`.

## Validation
- `uv run pytest tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py -q` -> `16 passed`
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py` -> `All checks passed!`
- `uv run ruff format --check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py` -> `2 files already formatted`
- `python - <<'PY' ... yaml.safe_load(contract.yaml) ... PY` -> `contract yaml ok`
- Commit hooks and push hooks passed without bypass.

Refs OMN-9648
