### PR TITLE
feat(OMN-9631): add remote task state migration

### DIFF
--- a/docker/migrations/forward/069_create_remote_task_state.sql
+++ b/docker/migrations/forward/069_create_remote_task_state.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- MIGRATION: Create remote_task_state table
+-- =============================================================================
+-- Ticket: OMN-9631
+-- Epic: OMN-9620 (A2A Delegation Bridge)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   Creates durable state for remote agent task invocations. This table lets
+--   node_remote_agent_invoke_effect resume unfinished remote tasks after restart.
+--
+-- IDEMPOTENCY:
+--   - CREATE TABLE IF NOT EXISTS is safe to re-run.
+--   - CREATE INDEX IF NOT EXISTS is safe to re-run.
+--
+-- ROLLBACK:
+--   docker/migrations/rollback/rollback_069_drop_remote_task_state.sql
+--
+-- NOTE:
+--   Planned as migration 068, but origin/main already uses 068 for
+--   landing_content_projection. This migration uses the next available number.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.remote_task_state (
+    task_id UUID PRIMARY KEY,
+    invocation_kind TEXT NOT NULL,
+    protocol TEXT,
+    target_ref TEXT NOT NULL,
+    remote_task_handle TEXT,
+    correlation_id UUID NOT NULL,
+    status TEXT NOT NULL,
+    last_remote_status TEXT,
+    last_emitted_event_type TEXT,
+    submitted_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    error TEXT,
+
+    CONSTRAINT remote_task_state_invocation_kind_check CHECK (
+        invocation_kind IN ('agent', 'model')
+    ),
+    CONSTRAINT remote_task_state_protocol_check CHECK (
+        protocol IS NULL OR protocol IN ('A2A')
+    ),
+    CONSTRAINT remote_task_state_status_check CHECK (
+        status IN (
+            'SUBMITTED',
+            'ACCEPTED',
+            'PROGRESS',
+            'ARTIFACT',
+            'COMPLETED',
+            'FAILED',
+            'TIMED_OUT',
+            'CANCELED'
+        )
+    ),
+    CONSTRAINT remote_task_state_last_emitted_event_type_check CHECK (
+        last_emitted_event_type IS NULL OR last_emitted_event_type IN (
+            'SUBMITTED',
+            'ACCEPTED',
+            'PROGRESS',
+            'ARTIFACT',
+            'COMPLETED',
+            'FAILED',
+            'TIMED_OUT',
+            'CANCELED'
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_task_state_status
+    ON public.remote_task_state (status);
+
+CREATE INDEX IF NOT EXISTS idx_remote_task_state_correlation_id
+    ON public.remote_task_state (correlation_id);
+
+COMMENT ON TABLE public.remote_task_state IS
+    'Durable remote agent task state for A2A delegation bridge restart recovery. '
+    'Rows are created and updated by node_remote_agent_invoke_effect. (OMN-9631)';
+
+-- Update migration sentinel
+UPDATE public.db_metadata
+SET migrations_complete = TRUE,
+    schema_version = '069',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/rollback/rollback_069_drop_remote_task_state.sql
+++ b/docker/migrations/rollback/rollback_069_drop_remote_task_state.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- ROLLBACK: Drop remote_task_state table
+-- =============================================================================
+-- Ticket: OMN-9631
+
+DROP TABLE IF EXISTS public.remote_task_state;
+
+-- Revert migration sentinel
+UPDATE public.db_metadata
+SET schema_version = '068',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:f0c5cd4d7bb312dcd284da8b2120106320985fef1905975cd7b64d568a9aa163
-generated_at: 2026-04-25T05:19:40Z
-migration_file_count: 54
+sha256:6df031f1acb2cc0524a838a9ee26338fee97ef6d1f1ce0abe9e0b707af37e529
+generated_at: 2026-04-25T15:41:01Z
+migration_file_count: 55

--- a/tests/unit/db/test_migration_069.py
+++ b/tests/unit/db/test_migration_069.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for migration 069: create remote_task_state table (OMN-9631)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+MIGRATION_FILE = (
+    REPO_ROOT / "docker" / "migrations" / "forward" / "069_create_remote_task_state.sql"
+)
+ROLLBACK_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "rollback"
+    / "rollback_069_drop_remote_task_state.sql"
+)
+
+REQUIRED_COLUMNS = [
+    "task_id",
+    "invocation_kind",
+    "protocol",
+    "target_ref",
+    "remote_task_handle",
+    "correlation_id",
+    "status",
+    "last_remote_status",
+    "last_emitted_event_type",
+    "submitted_at",
+    "updated_at",
+    "completed_at",
+    "error",
+]
+
+LIFECYCLE_VALUES = [
+    "SUBMITTED",
+    "ACCEPTED",
+    "PROGRESS",
+    "ARTIFACT",
+    "COMPLETED",
+    "FAILED",
+    "TIMED_OUT",
+    "CANCELED",
+]
+
+
+def _strip_comments(sql: str) -> str:
+    sql = re.sub(r"--[^\n]*", "", sql)
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    return sql
+
+
+@pytest.mark.unit
+class TestMigration069Files:
+    """Validate that required migration files exist."""
+
+    def test_migration_file_exists(self) -> None:
+        assert MIGRATION_FILE.exists(), f"Migration file not found: {MIGRATION_FILE}"
+
+    def test_rollback_file_exists(self) -> None:
+        assert ROLLBACK_FILE.exists(), f"Rollback file not found: {ROLLBACK_FILE}"
+
+
+@pytest.mark.unit
+class TestMigration069Schema:
+    """Validate the remote_task_state schema declared by migration 069."""
+
+    def test_creates_remote_task_state_table(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+public\.remote_task_state\b",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must CREATE TABLE IF NOT EXISTS public.remote_task_state"
+
+    def test_required_columns_present(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        for column in REQUIRED_COLUMNS:
+            assert re.search(rf"\b{column}\b", sql), (
+                f"Migration must declare column {column}"
+            )
+
+    def test_task_id_is_uuid_primary_key(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\btask_id\s+UUID\s+PRIMARY\s+KEY\b",
+            sql,
+            re.IGNORECASE,
+        ), "task_id must be UUID PRIMARY KEY"
+
+    def test_invocation_kind_constraint_matches_core_values(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert "'agent'" in sql
+        assert "'model'" in sql
+        assert "remote_task_state_invocation_kind_check" in sql
+
+    def test_protocol_constraint_matches_current_core_values(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert "remote_task_state_protocol_check" in sql
+        assert "'A2A'" in sql
+        assert "'MCP'" not in sql
+        assert "'HTTP'" not in sql
+
+    def test_status_constraint_contains_lifecycle_values(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert "remote_task_state_status_check" in sql
+        for value in LIFECYCLE_VALUES:
+            assert f"'{value}'" in sql
+
+    def test_last_emitted_event_type_constraint_contains_lifecycle_values(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert "remote_task_state_last_emitted_event_type_check" in sql
+        for value in LIFECYCLE_VALUES:
+            assert f"'{value}'" in sql
+
+    def test_timestamps_have_no_default_now(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        for column in ("submitted_at", "updated_at", "completed_at"):
+            declaration = re.search(
+                rf"\b{column}\b[^,\n]*",
+                sql,
+                re.IGNORECASE,
+            )
+            assert declaration, f"Missing timestamp column {column}"
+            assert "DEFAULT NOW()" not in declaration.group(0).upper()
+
+
+@pytest.mark.unit
+class TestMigration069Indexes:
+    """Validate required indexes for query paths."""
+
+    def test_status_index_present(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bCREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_remote_task_state_status\b",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must declare idx_remote_task_state_status"
+
+    def test_correlation_id_index_present(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bCREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_remote_task_state_correlation_id\b",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must declare idx_remote_task_state_correlation_id"
+
+
+@pytest.mark.unit
+class TestMigration069Sentinel:
+    """Validate migration sentinel updates."""
+
+    def test_migration_updates_sentinel(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bUPDATE\b[^;]*\bdb_metadata\b",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must UPDATE db_metadata"
+        assert re.search(
+            r"\bmigrations_complete\s*=\s*TRUE\b",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must set migrations_complete = TRUE"
+
+    def test_migration_sets_schema_version(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bschema_version\s*=\s*'069'",
+            sql,
+            re.IGNORECASE,
+        ), "Migration must set schema_version = '069'"
+
+
+@pytest.mark.unit
+class TestMigration069Rollback:
+    """Validate rollback SQL."""
+
+    def test_rollback_drops_table(self) -> None:
+        sql = _strip_comments(ROLLBACK_FILE.read_text())
+        assert re.search(
+            r"\bDROP\s+TABLE\s+IF\s+EXISTS\s+public\.remote_task_state\b",
+            sql,
+            re.IGNORECASE,
+        ), "Rollback must DROP TABLE IF EXISTS public.remote_task_state"
+
+    def test_rollback_reverts_schema_version(self) -> None:
+        sql = _strip_comments(ROLLBACK_FILE.read_text())
+        assert re.search(
+            r"\bschema_version\s*=\s*'068'",
+            sql,
+            re.IGNORECASE,
+        ), "Rollback must revert schema_version to '068'"


### PR DESCRIPTION
## Summary
- add remote_task_state migration as 069 because 068 is already used on main
- add rollback for dropping remote_task_state and reverting schema_version to 068
- add unit coverage for schema shape, constraints, indexes, sentinel, and rollback

## Verification
- `uv run pytest tests/unit/db/test_migration_069.py -v` -> 16 passed
- `uv run pytest tests/unit/db/test_migration_068.py tests/unit/db/test_migration_069.py -v` -> 31 passed
- `uv run ruff check tests/unit/db/test_migration_069.py` -> passed
- `uv run ruff format --check tests/unit/db/test_migration_069.py` -> passed
- commit pre-commit suite -> passed
- schema fingerprint re-stamped (55 migrations, artifact was at 54)

## Notes
- The original ticket named migration 068, but main already has `068_create_landing_content_projection.sql`, so this PR uses 069.
- The table uses `target_ref` to match `ModelRemoteTaskState` from the A2A core model stack.
- The protocol CHECK currently allows `A2A` only, matching the current `EnumAgentProtocol`.

Closes OMN-9631.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a durable remote task state table to support reliable remote task invocation recovery, plus a rollback to remove it if needed.
  * Updated migration fingerprint/metadata to include the new migration.
* **Tests**
  * Added comprehensive unit tests validating the forward migration, rollback, indexes, constraints, and migration sentinel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->