### PR TITLE
fix(OMN-9741): keep effects health liveness during startup

### DIFF
--- a/docker/catalog/services/autoheal.yaml
+++ b/docker/catalog/services/autoheal.yaml
@@ -7,7 +7,7 @@ required_env: []
 hardcoded_env:
   AUTOHEAL_CONTAINER_LABEL: autoheal
   AUTOHEAL_INTERVAL: '60'
-  AUTOHEAL_START_PERIOD: '180'
+  AUTOHEAL_START_PERIOD: '2400'
 operational_defaults: {}
 ports: null
 healthcheck: null

--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -22,6 +22,7 @@ hardcoded_env:
   OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   BUS_ID: local
   ONEX_CONTRACTS_DIR: /app/contracts
+  ONEX_STATE_ROOT: /app/data/.onex_state
   VALKEY_HOST: valkey
   VALKEY_PORT: '6379'
   OMNICLAUDE_CONTRACTS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/nodes

--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -50,8 +50,8 @@ healthcheck:
   test: curl -sf http://localhost:8085/health
   interval_s: 30
   timeout_s: 10
-  retries: 3
-  start_period_s: 90
+  retries: 5
+  start_period_s: 1800
 volumes:
   - runtime_logs:/app/logs
   - runtime_data:/app/data
@@ -64,9 +64,9 @@ depends_on:
 restart: unless-stopped
 resources:
   cpus: '1.0'
-  memory: 768M
+  memory: 1536M
   cpus_reservation: '0.25'
-  memory_reservation: 128M
+  memory_reservation: 256M
 stop_grace_period: 90s
 labels:
   com.omninode.service: runtime-main

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -50,7 +50,7 @@ healthcheck:
   interval_s: 45
   timeout_s: 10
   retries: 5
-  start_period_s: 600
+  start_period_s: 1800
 volumes:
   - effects_logs:/app/logs
   - effects_data:/app/data

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -20,6 +20,7 @@ hardcoded_env:
   KAFKA_BROKER_ALLOWLIST: 'redpanda:'
   BUS_ID: local
   ONEX_CONTRACTS_DIR: /app/contracts
+  ONEX_STATE_ROOT: /app/data/.onex_state
   VALKEY_HOST: valkey
   VALKEY_PORT: '6379'
   OMNICLAUDE_CONTRACTS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/nodes

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -65,9 +65,9 @@ depends_on:
 restart: unless-stopped
 resources:
   cpus: '1.0'
-  memory: 768M
+  memory: 1536M
   cpus_reservation: '0.25'
-  memory_reservation: 128M
+  memory_reservation: 256M
 stop_grace_period: 90s
 labels:
   com.omninode.service: runtime-effects

--- a/docker/catalog/services/runtime-worker.yaml
+++ b/docker/catalog/services/runtime-worker.yaml
@@ -55,9 +55,9 @@ depends_on:
 restart: unless-stopped
 resources:
   cpus: '0.5'
-  memory: 768M
+  memory: 1536M
   cpus_reservation: '0.1'
-  memory_reservation: 128M
+  memory_reservation: 256M
 stop_grace_period: 90s
 labels:
   com.omninode.service: runtime-worker

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -140,6 +140,7 @@ x-runtime-env: &runtime-env
   KAFKA_BROKER_ALLOWLIST: "redpanda:"
   BUS_ID: "local"
   ONEX_CONTRACTS_DIR: /app/contracts
+  ONEX_STATE_ROOT: /app/data/.onex_state
   # OMN-6440: Runtime contract YAMLs from omnibase_core (env var override for Docker)
   ONEX_RUNTIME_CONTRACTS_DIR: /app/contracts/runtime
   ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -118,10 +118,10 @@ x-runtime-base: &runtime-base
     resources:
       limits:
         cpus: '1.0'
-        memory: 768M
+        memory: 1536M
       reservations:
         cpus: '0.25'
-        memory: 128M
+        memory: 256M
 # Runtime environment variables (OMN-2287: slimmed for Infisical bootstrap)
 # When INFISICAL_ADDR is set, the runtime prefetches most config from Infisical.
 # Only bootstrap-essential vars remain here; all others come from Infisical.
@@ -584,6 +584,9 @@ services:
   # ONEX Runtime - Main Kernel (Runtime Profile)
   # ==========================================================================
   # Primary runtime service that handles the kernel bootstrap process.
+  # OMN-9741: Main startup also performs long serial Kafka subscription joins.
+  # Keep the health window aligned with effects so autoheal does not recycle the
+  # process while it is still wiring contracts or joining consumer groups.
   omninode-runtime:
     !!merge <<: *runtime-base
     container_name: omninode-runtime
@@ -626,7 +629,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 600s
+      start_period: 1800s
     labels:
       - "com.omninode.service=runtime-main"
       - "com.omninode.layer=runtime"
@@ -690,10 +693,10 @@ services:
   # ONEX Runtime - Workers (Runtime Profile)
   # ==========================================================================
   # Scalable worker containers for parallel compute operations.
-  # OMN-7235: Workers have an extended start_period (1200s) and retries (5) because
-  # ~166 Kafka consumer groups are joined sequentially at startup (~15+ min total).
-  # Unhealthy detection latency = start_period + (interval * retries) = 1200s + 150s = 1350s.
-  # AUTOHEAL_START_PERIOD (1500s) exceeds this window to prevent premature restarts.
+  # OMN-7235/OMN-9741: Workers have an extended start_period (1200s) and
+  # retries (5) because Kafka consumer groups are joined sequentially at
+  # startup. Autoheal uses a workspace-wide 2400s grace period so main,
+  # effects, and workers can all finish contract wiring before restart checks.
   # OMN-7569: Default replicas=0 — workers join the same per-topic consumer groups
   # as the main runtime on 1-partition topics, causing a constant rebalance storm.
   # Scale to 0 until the kernel supports profile-based subscription filtering.
@@ -733,10 +736,10 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 768M
+          memory: 1536M
         reservations:
           cpus: '0.1'
-          memory: 128M
+          memory: 256M
     labels:
       - "com.omninode.service=runtime-worker"
       - "com.omninode.layer=runtime"
@@ -1117,10 +1120,10 @@ services:
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: 60
-      # OMN-9741: Set to 2400s to exceed effects unhealthy detection window.
-      # Effects: start_period=1800s + retries=5×interval=30s = 1950s max.
-      # Workers remain below this at 1350s max.
+      # OMN-9741: Set to 2400s to exceed main/effects unhealthy detection windows.
+      # Main/effects: start_period=1800s + retries=5×interval=30s = 1950s max.
       # Workers: start_period=1200s + retries=5×interval=30s = 1350s max.
+      # AUTOHEAL_START_PERIOD (2400s) must exceed all runtime unhealthy windows.
       AUTOHEAL_START_PERIOD: 2400
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -636,12 +636,12 @@ services:
   # ONEX Runtime - Effects Handler (Runtime Profile)
   # ==========================================================================
   # Handles effect nodes for external service interactions.
-  # OMN-5637: Effects has an extended start_period (600s) and retries (5)
-  # because plugin initialization (1950+ Kafka consumer subscriptions,
-  # intelligence DB ownership, schema fingerprint, message type registration)
-  # must complete before /health returns 200.
-  # Unhealthy detection latency = start_period + (interval * retries) = 600s + 150s = 750s.
-  # AUTOHEAL_START_PERIOD (840s) must exceed start_period + retry window to avoid premature restarts.
+  # OMN-9741: Effects startup performs long serial Kafka subscription joins.
+  # /health is liveness and returns degraded HTTP 200 while startup is in
+  # progress; strict readiness belongs to /ready. The extended health window
+  # prevents autoheal from recycling a live process before startup completes.
+  # Unhealthy detection latency = start_period + (interval * retries) = 1800s + 150s = 1950s.
+  # AUTOHEAL_START_PERIOD (2400s) must exceed this window to avoid premature restarts.
   runtime-effects:
     !!merge <<: *runtime-base
     container_name: omninode-runtime-effects
@@ -680,7 +680,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 600s
+      start_period: 1800s
     labels:
       - "com.omninode.service=runtime-effects"
       - "com.omninode.layer=runtime"
@@ -1117,10 +1117,11 @@ services:
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: 60
-      # OMN-7235: Set to 1500s to exceed worker unhealthy detection window.
+      # OMN-9741: Set to 2400s to exceed effects unhealthy detection window.
+      # Effects: start_period=1800s + retries=5×interval=30s = 1950s max.
+      # Workers remain below this at 1350s max.
       # Workers: start_period=1200s + retries=5×interval=30s = 1350s max.
-      # 1500s = 1350s + 150s buffer to prevent premature autoheal restarts.
-      AUTOHEAL_START_PERIOD: 1500
+      AUTOHEAL_START_PERIOD: 2400
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     logging: *logging-defaults

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -182,8 +182,7 @@ EXAMPLES
     cat ~/.omnibase/infra/registry.json | jq .
 
     # Verify image labels match deployed SHA
-    # Container name follows compose convention: <project>-omninode-runtime-1
-    docker inspect <compose-project>-omninode-runtime-1 \\
+    docker inspect omninode-runtime \\
         --format='{{index .Config.Labels "org.opencontainers.image.revision"}}'
 EOF
     exit 0
@@ -244,6 +243,23 @@ parse_args() {
         log_error "--restart requires --execute"
         exit 1
     fi
+}
+
+resolve_compose_project() {
+    # Runtime compose files use fixed container names, and the deploy-agent
+    # targets the canonical "omnibase-infra" project. Keep deploy-runtime on the
+    # same project by default so rebuild/recreate updates the live stack instead
+    # of creating a parallel profile-derived project such as
+    # "omnibase-infra-runtime".
+    local compose_project="${OMNIBASE_INFRA_COMPOSE_PROJECT:-omnibase-infra}"
+
+    if [[ ! "${compose_project}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        log_error "OMNIBASE_INFRA_COMPOSE_PROJECT must contain only alphanumeric characters, hyphens, and underscores."
+        log_error "  Got: '${compose_project}'"
+        exit 1
+    fi
+
+    echo "${compose_project}"
 }
 
 # =============================================================================
@@ -1242,16 +1258,22 @@ verify_deployment() {
     else
         log_error "Health check FAILED after ${HEALTH_CHECK_RETRIES} attempts."
         log_error "Service is not responding at ${HEALTH_CHECK_URL}"
-        log_error "Check container logs: docker logs omnibase-infra-omninode-runtime"
+        log_error "Check container logs: docker logs omninode-runtime"
         exit 1
     fi
 
-    # 2. Resolve runtime container ID (supports dynamic compose project names)
+    # 2. Resolve runtime container ID. Prefer the fixed runtime container name
+    # used by docker-compose.infra.yml, then fall back to a compose label lookup.
     log_info "Checking image labels for VCS_REF..."
     local container_id
-    container_id="$(docker ps -q --filter "name=${compose_project}-omninode-runtime" | head -1)"
+    container_id="$(docker ps -q --filter "name=^/omninode-runtime$" | head -1)"
     if [[ -z "${container_id}" ]]; then
-        container_id="$(docker ps -q --filter "name=omninode-runtime" | head -1)"
+        container_id="$(
+            docker ps -q \
+                --filter "label=com.docker.compose.project=${compose_project}" \
+                --filter "label=com.docker.compose.service=omninode-runtime" \
+                | head -1
+        )"
     fi
 
     if [[ -z "${container_id}" ]]; then
@@ -1393,7 +1415,7 @@ show_summary() {
     log_info ""
     log_info "  Verify deployment:"
     log_info "    cat ${REGISTRY_FILE} | jq ."
-    log_info "    docker inspect ${compose_project}-omninode-runtime-1 --format='{{index .Config.Labels \"org.opencontainers.image.revision\"}}'"
+    log_info "    docker inspect omninode-runtime --format='{{index .Config.Labels \"org.opencontainers.image.revision\"}}'"
 }
 
 # =============================================================================
@@ -1449,7 +1471,8 @@ main() {
 
     # Compute paths
     local deploy_target="${DEPLOY_ROOT}/deployed/${version}"
-    local compose_project="omnibase-infra-${COMPOSE_PROFILE}"
+    local compose_project
+    compose_project="$(resolve_compose_project)"
 
     # --print-compose-cmd: show commands and exit
     if [[ "${PRINT_COMPOSE_CMD}" == true ]]; then

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -367,6 +367,7 @@ handler_routing:
     - event_model:
         name: "ModelNodeIntrospectionEvent"
         module: "omnibase_infra.models.registration.model_node_introspection_event"
+      event_type: "platform.node-introspection"
       handler:
         name: "HandlerNodeIntrospected"
         module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected"
@@ -408,6 +409,8 @@ handler_routing:
     - event_model:
         name: "ModelRuntimeTick"
         module: "omnibase_infra.runtime.models.model_runtime_tick"
+      event_type: "platform.runtime-tick"
+      message_category: "INTENT"
       handler:
         name: "HandlerRuntimeTick"
         module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_runtime_tick"
@@ -428,6 +431,7 @@ handler_routing:
     - event_model:
         name: "ModelNodeRegistrationAcked"
         module: "omnibase_infra.models.registration.commands.model_node_registration_acked"
+      event_type: "platform.node-registration-acked"
       handler:
         name: "HandlerNodeRegistrationAcked"
         module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_registration_acked"

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -997,44 +997,76 @@ class ServiceRegistration:
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:
-        """Defer registration dispatcher wiring to generic contract auto-wiring.
+        """Wire registration dispatcher adapters into the dispatch engine.
 
-        OMN-9456: Establish a single authority for registration dispatcher and
-        route wiring. The generic contract-driven auto-wiring pipeline
-        (``wire_from_manifest``) owns dispatcher and route registration because
-        ``node_registration_orchestrator/contract.yaml`` fully declares the
-        subscribed topics and handler routing.
-
-        Invoking the legacy explicit wiring helper here alongside the generic
-        path caused duplicate dispatcher registrations
-        (``ONEX_CORE_064_DUPLICATE_REGISTRATION`` for
-        ``dispatcher.registration.node-introspected``) on fresh runtime-effects
-        boots. Returning a skipped result keeps the plugin responsible for
-        domain initialization (pools, projectors, schemas, handlers, consumers)
-        while leaving dispatcher and route wiring to the single authoritative
-        contract-driven path.
+        Registration remains a domain-owned dispatch surface because its
+        handlers expect domain envelope/adapter semantics. Generic
+        contract auto-wiring owns the Kafka subscriptions and result applier,
+        while this plugin owns the dispatcher adapters and routes that bridge
+        wire envelopes into registration handlers.
 
         Args:
-            config: Plugin configuration (unused apart from correlation_id).
+            config: Plugin configuration with container, dispatch engine, and
+                event bus.
 
         Returns:
-            ``ModelDomainPluginResult.skipped`` indicating that generic
-            contract auto-wiring owns dispatcher and route registration.
+            ``ModelDomainPluginResult`` for the explicit dispatcher wiring step.
         """
+        start_time = time.time()
         correlation_id = config.correlation_id
 
-        logger.info(
-            "Registration dispatcher wiring deferred to generic contract "
-            "auto-wiring (OMN-9456) (correlation_id=%s)",
-            correlation_id,
-        )
-        return ModelDomainPluginResult.skipped(
-            plugin_id=self.plugin_id,
-            reason=(
-                "generic contract auto-wiring owns registration dispatchers "
-                "and routes (OMN-9456)"
-            ),
-        )
+        if config.dispatch_engine is None:
+            return ModelDomainPluginResult.failed(
+                plugin_id=self.plugin_id,
+                error_message="Registration dispatcher wiring requires dispatch_engine",
+                duration_seconds=time.time() - start_time,
+            )
+
+        try:
+            from omnibase_infra.nodes.node_registration_orchestrator.wiring import (
+                wire_registration_dispatchers,
+            )
+
+            summary = await wire_registration_dispatchers(
+                config.container,
+                config.dispatch_engine,
+                correlation_id=correlation_id,
+                event_bus=config.event_bus,
+            )
+            dispatchers = summary["dispatchers"]
+            routes = summary["routes"]
+            if not isinstance(dispatchers, list) or not isinstance(routes, list):
+                raise TypeError("registration dispatcher summary is malformed")
+            duration = time.time() - start_time
+
+            logger.info(
+                "Registration dispatchers wired (correlation_id=%s)",
+                correlation_id,
+                extra={
+                    "dispatchers": dispatchers,
+                    "routes": routes,
+                },
+            )
+
+            return ModelDomainPluginResult(
+                plugin_id=self.plugin_id,
+                success=True,
+                message="Registration dispatchers wired",
+                services_registered=dispatchers,
+                duration_seconds=duration,
+            )
+
+        except Exception as e:
+            duration = time.time() - start_time
+            logger.exception(
+                "Failed to wire Registration dispatchers (correlation_id=%s)",
+                correlation_id,
+            )
+            return ModelDomainPluginResult.failed(
+                plugin_id=self.plugin_id,
+                error_message=sanitize_error_message(e),
+                duration_seconds=duration,
+            )
 
     async def prepare_result_applier(
         self,

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/wiring.py
@@ -772,6 +772,15 @@ async def wire_registration_handlers(
                 reducer=reducer,
             )
             await container.service_registry.register_instance(
+                interface=HandlerNodeHeartbeat,
+                instance=handler_heartbeat,
+                scope=EnumInjectionScope.GLOBAL,
+                metadata={
+                    "description": "Handler for NodeHeartbeatEvent",
+                    "version": str(semver_default),
+                },
+            )
+            await container.service_registry.register_instance(
                 interface=ProtocolNodeHeartbeat,  # type: ignore[type-abstract]
                 instance=handler_heartbeat,
                 scope=EnumInjectionScope.GLOBAL,

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -319,6 +319,7 @@ def _parse_handler_routing(hr_raw: dict) -> ModelHandlerRouting:
                 event_model=event_model,
                 operation=h.get("operation"),
                 event_type=h.get("event_type"),
+                message_category=h.get("message_category"),
             )
         )
     return ModelHandlerRouting(

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -266,17 +266,19 @@ def _parse_contract(
         event_bus = ModelEventBusWiring(
             subscribe_topics=tuple(eb_raw.get("subscribe_topics", [])),
             publish_topics=tuple(eb_raw.get("publish_topics", [])),
+            consumer_purpose=eb_raw.get("consumer_purpose"),
         )
 
     # Extract handler routing — new format (handler_routing:) or legacy (handler:)
     handler_routing: ModelHandlerRouting | None = None
     hr_raw = raw.get("handler_routing")
+    h_raw = raw.get("handler")
     if isinstance(hr_raw, dict):
         handler_routing = _parse_handler_routing(hr_raw)
-    else:
-        h_raw = raw.get("handler")
-        if isinstance(h_raw, dict):
+        if not handler_routing.handlers and isinstance(h_raw, dict):
             handler_routing = _parse_legacy_handler(h_raw)
+    elif isinstance(h_raw, dict):
+        handler_routing = _parse_legacy_handler(h_raw)
 
     return ModelDiscoveredContract(
         name=raw.get("name", entry_point_name),

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -22,6 +22,7 @@ CI gate: any PR touching this module MUST satisfy the runtime-startup gate defin
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import importlib
 import logging
@@ -563,6 +564,8 @@ def _make_event_bus_callback(
                     )
                     return
                 envelope = message
+            if not await _wait_for_dispatch_engine_freeze(topic, dispatch_engine):
+                return
             result = await dispatch_engine.dispatch(topic, envelope)
             if result_applier is not None and result is not None:
                 await result_applier.apply(result, envelope.correlation_id)
@@ -575,6 +578,52 @@ def _make_event_bus_callback(
             )
 
     return callback
+
+
+async def _wait_for_dispatch_engine_freeze(
+    topic: str,
+    dispatch_engine: object,
+) -> bool:
+    """Wait until the dispatch engine is frozen before consuming startup messages."""
+    if bool(getattr(dispatch_engine, "is_frozen", True)):
+        return True
+
+    timeout_seconds = _dispatch_freeze_wait_timeout_seconds()
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    logger.info(
+        "Auto-wiring callback waiting for MessageDispatchEngine freeze: topic=%s",
+        topic,
+    )
+
+    while not bool(getattr(dispatch_engine, "is_frozen", True)):
+        if asyncio.get_running_loop().time() >= deadline:
+            logger.error(
+                "Auto-wiring callback timed out waiting for MessageDispatchEngine "
+                "freeze; dropping message: topic=%s timeout_seconds=%.1f",
+                topic,
+                timeout_seconds,
+            )
+            return False
+        await asyncio.sleep(0.1)
+
+    logger.info(
+        "Auto-wiring callback resumed after MessageDispatchEngine freeze: topic=%s",
+        topic,
+    )
+    return True
+
+
+def _dispatch_freeze_wait_timeout_seconds() -> float:
+    raw = os.environ.get("ONEX_DISPATCH_FREEZE_WAIT_TIMEOUT_SECONDS", "900")
+    try:
+        timeout_seconds = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid ONEX_DISPATCH_FREEZE_WAIT_TIMEOUT_SECONDS=%r; using 900s",
+            raw,
+        )
+        return 900.0
+    return max(timeout_seconds, 0.1)
 
 
 def _derive_route_id(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib
+import inspect
 import logging
 import os
 import re
@@ -33,6 +34,8 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from pydantic import BaseModel
 
 from omnibase_core.enums.enum_handler_resolution_outcome import (
     EnumHandlerResolutionOutcome,
@@ -57,6 +60,7 @@ from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
     ModelDiscoveredContract,
+    ModelHandlerRef,
     ModelHandlerRoutingEntry,
 )
 from omnibase_infra.runtime.auto_wiring.report import (
@@ -82,6 +86,7 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_dispatch_engine import (
         ProtocolDispatchEngine,
     )
+    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 
 logger = logging.getLogger(__name__)
 
@@ -313,21 +318,137 @@ async def _skip_dispatcher(
 
 def _make_dispatch_callback(
     handler_instance: ProtocolHandleable,
+    event_model: ModelHandlerRef | None = None,
 ) -> DispatcherFunc:
     """Create a dispatch callback wrapping a handler instance.
 
-    The callback calls ``handler_instance.handle(envelope)`` and returns the
-    result. This matches the ``DispatcherFunc`` signature expected by
-    ``MessageDispatchEngine.register_dispatcher``.
+    Legacy handlers receive the materialized dispatch envelope. Contract-typed
+    handlers receive a validated payload model and may be sync or async.
     """
 
     async def _callback(
         envelope: ModelEventEnvelope[object],
     ) -> ModelDispatchResult | None:
         handle_method = handler_instance.handle
-        return await handle_method(envelope)
+        if event_model is None:
+            return await handle_method(envelope)
+
+        payload = _extract_dispatch_payload(envelope)
+        model_cls = _import_event_model_class(event_model)
+        typed_payload = (
+            payload
+            if isinstance(payload, model_cls)
+            else model_cls.model_validate(payload)
+        )
+        typed_handle = cast("Callable[[object], object]", handle_method)
+        raw_result = typed_handle(typed_payload)
+        if asyncio.iscoroutine(raw_result):
+            raw_result = await cast("Awaitable[object]", raw_result)
+        return _normalize_handler_result(raw_result, envelope, event_model.name)
 
     return _callback
+
+
+def _import_event_model_class(event_model: ModelHandlerRef) -> type[BaseModel]:
+    module = importlib.import_module(event_model.module)
+    model_cls = getattr(module, event_model.name)
+    if not hasattr(model_cls, "model_validate"):
+        raise TypeError(
+            f"Event model {event_model.module}.{event_model.name} "
+            "does not expose model_validate"
+        )
+    return cast("type[BaseModel]", model_cls)
+
+
+def _extract_dispatch_payload(envelope: object) -> object:
+    if isinstance(envelope, Mapping):
+        return envelope.get("payload", envelope)
+    return getattr(envelope, "payload", envelope)
+
+
+def _extract_dispatch_topic(envelope: object) -> str:
+    if isinstance(envelope, Mapping):
+        debug_trace = envelope.get("__debug_trace")
+        if isinstance(debug_trace, Mapping):
+            topic = debug_trace.get("topic")
+            if isinstance(topic, str) and topic:
+                return topic
+        topic = envelope.get("topic")
+        if isinstance(topic, str) and topic:
+            return topic
+    topic = getattr(envelope, "topic", None)
+    return topic if isinstance(topic, str) and topic else "auto-wired"
+
+
+def _extract_dispatch_correlation_id(
+    envelope: object, payload: object
+) -> object | None:
+    candidate = getattr(payload, "correlation_id", None)
+    if candidate is not None:
+        return candidate
+    if isinstance(payload, Mapping):
+        candidate = payload.get("correlation_id")
+        if candidate is not None:
+            return candidate
+    if isinstance(envelope, Mapping):
+        candidate = envelope.get("correlation_id")
+        if candidate is not None:
+            return candidate
+        debug_trace = envelope.get("__debug_trace")
+        if isinstance(debug_trace, Mapping):
+            return debug_trace.get("correlation_id")
+    return getattr(envelope, "correlation_id", None)
+
+
+def _normalize_handler_result(
+    result: object,
+    envelope: object,
+    message_type: str | None,
+) -> ModelDispatchResult | None:
+    from datetime import UTC, datetime
+    from uuid import UUID, uuid4
+
+    from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+    from omnibase_infra.enums import EnumDispatchStatus
+    from omnibase_infra.models.dispatch.model_dispatch_result import (
+        ModelDispatchResult,
+    )
+
+    if result is None or isinstance(result, ModelDispatchResult):
+        return result
+
+    payload = _extract_dispatch_payload(envelope)
+    correlation_candidate = _extract_dispatch_correlation_id(envelope, payload)
+    if isinstance(correlation_candidate, UUID):
+        correlation_id = correlation_candidate
+    elif isinstance(correlation_candidate, str) and correlation_candidate:
+        correlation_id = UUID(correlation_candidate)
+    else:
+        correlation_id = uuid4()
+
+    output_events: list[BaseModel] = []
+    output_intents: tuple[object, ...] = ()
+    if isinstance(result, ModelHandlerOutput):
+        output_events = [
+            event for event in result.events if isinstance(event, BaseModel)
+        ]
+        output_intents = tuple(result.intents)
+        if isinstance(result.result, BaseModel):
+            output_events.append(result.result)
+    elif isinstance(result, BaseModel):
+        output_events = [result]
+
+    return ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic=_extract_dispatch_topic(envelope),
+        message_type=message_type,
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        output_count=len(output_events) + len(output_intents),
+        output_events=output_events,
+        output_intents=output_intents,  # type: ignore[arg-type]
+        correlation_id=correlation_id,
+    )
 
 
 _TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -341,6 +462,13 @@ _TOPIC_TO_EVENT_TYPE: dict[str, str] = {
     "node-heartbeat": "heartbeat",
     "node-introspection": "introspection",
 }
+
+
+def _is_raw_event_projection_contract(contract: ModelDiscoveredContract) -> bool:
+    if contract.event_bus is None:
+        return False
+    consumer_purpose = (contract.event_bus.consumer_purpose or "").strip().lower()
+    return consumer_purpose in {"audit", "projection"}
 
 
 def _read_db_io_tables(contract_path: Path) -> list[dict[str, str]]:
@@ -361,6 +489,10 @@ def _read_db_io_tables(contract_path: Path) -> list[dict[str, str]]:
         return []
     db_io = raw.get("db_io") or {}
     return list(db_io.get("db_tables") or [])
+
+
+def _contract_declares_db_io(contract: ModelDiscoveredContract) -> bool:
+    return bool(_read_db_io_tables(contract.contract_path))
 
 
 def _build_sync_db_adapter(db_url: str) -> object:
@@ -714,6 +846,14 @@ def _derive_message_category(topic: str) -> str:
     return "event"
 
 
+def _derive_event_type_alias_from_topic(topic: str) -> str | None:
+    """Derive the dispatch-engine event_type alias from an ONEX topic."""
+    parts = topic.split(".")
+    if len(parts) >= 5 and parts[0] == "onex":
+        return f"{parts[2]}.{parts[3]}"
+    return None
+
+
 def _detect_duplicate_topics(
     manifest: ModelAutoWiringManifest,
 ) -> list[ModelDuplicateTopicOwnership]:
@@ -825,6 +965,8 @@ async def wire_from_manifest(
     pre_resolved_handlers: dict[str, object] = {}
     if container is not None:
         for contract in manifest.contracts:
+            if _is_raw_event_projection_contract(contract):
+                continue
             if contract.handler_routing is None:
                 continue
             for entry in contract.handler_routing.handlers:
@@ -863,7 +1005,7 @@ async def wire_from_manifest(
                 environment=environment,
                 container=container,
                 pre_resolved_handlers=pre_resolved_handlers
-                if pre_resolved_handlers
+                if container is not None
                 else None,
             )
             prepared_contracts.append(prepared)
@@ -1058,6 +1200,24 @@ def _prepare_contract_wiring(
             ),
         )
 
+    if _is_raw_event_projection_contract(contract):
+        consumer_purpose = (contract.event_bus.consumer_purpose or "").strip().lower()
+        return PreparedContractWiring(
+            contract=contract,
+            prepared_wirings=[],
+            subscription_topics=[],
+            environment=environment,
+            skip_result=ModelContractWiringResult(
+                contract_name=contract.name,
+                package_name=contract.package_name,
+                outcome=EnumWiringOutcome.SKIPPED,
+                reason=(
+                    f"consumer_purpose={consumer_purpose!r} requires dedicated "
+                    "raw event projection wiring"
+                ),
+            ),
+        )
+
     prepared_wirings: list[PreparedWiring] = []
     for entry in contract.handler_routing.handlers:
         try:
@@ -1220,11 +1380,25 @@ async def _subscribe_contract_topics(
 
     from omnibase_infra.enums import EnumConsumerGroupPurpose
     from omnibase_infra.models import ModelNodeIdentity
+    from omnibase_infra.runtime.service_dispatch_result_applier import (
+        DispatchResultApplier,
+    )
     from omnibase_infra.utils import compute_consumer_group_id
 
     typed_bus: ProtocolEventBusSubscriber = cast(
         "ProtocolEventBusSubscriber", event_bus
     )
+    effective_result_applier = result_applier
+    if (
+        effective_result_applier is None
+        and contract.event_bus is not None
+        and len(contract.event_bus.publish_topics) == 1
+        and not _contract_declares_db_io(contract)
+    ):
+        effective_result_applier = DispatchResultApplier(
+            event_bus=cast("ProtocolEventBusLike", event_bus),
+            output_topic=contract.event_bus.publish_topics[0],
+        )
     node_identity = ModelNodeIdentity(
         env=environment,
         service=contract.package_name,
@@ -1240,7 +1414,7 @@ async def _subscribe_contract_topics(
         callback = _make_event_bus_callback(
             topic,
             dispatch_engine,  # type: ignore[arg-type]
-            result_applier=result_applier,
+            result_applier=effective_result_applier,
         )
         await typed_bus.subscribe(
             topic=topic,
@@ -1359,6 +1533,14 @@ def _prepare_handler_wiring(
     event_type_alias = entry.event_type.strip() if entry.event_type else ""
     if event_type_alias:
         message_types = (message_types or set()) | {event_type_alias}
+    elif contract.event_bus:
+        topic_aliases = {
+            alias
+            for topic in contract.event_bus.subscribe_topics
+            if (alias := _derive_event_type_alias_from_topic(topic)) is not None
+        }
+        if topic_aliases:
+            message_types = (message_types or set()) | topic_aliases
 
     if contract.name == "node_registration_orchestrator":
         return PreparedWiring(
@@ -1378,17 +1560,34 @@ def _prepare_handler_wiring(
 
     handler_cls = _import_handler_class(handler_ref.module, handler_ref.name)
 
-    _effective_container = container or (
-        getattr(dispatch_engine, "_container", None)
-        if dispatch_engine is not None
-        else None
-    )
-
     # Fast path: if Phase 0 pre-resolved this handler via get_service_async,
     # skip the sync resolver's container Step 3 entirely (OMN-9410).
     pre_resolved_instance = (
         pre_resolved_handlers.get(handler_ref.name) if pre_resolved_handlers else None
     )
+    sig = inspect.signature(handler_cls)
+    required_ctor_params = {
+        k
+        for k, v in sig.parameters.items()
+        if k != "self"
+        and v.kind
+        in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+        and v.default is inspect.Parameter.empty
+    }
+    can_construct_without_container = (
+        not required_ctor_params or required_ctor_params == {"event_bus"}
+    )
+    if pre_resolved_handlers is not None and can_construct_without_container:
+        _effective_container = None
+    else:
+        _effective_container = container or (
+            getattr(dispatch_engine, "_container", None)
+            if dispatch_engine is not None
+            else None
+        )
 
     def _quarantine_prepared(exc: BaseException) -> PreparedWiring:
         """Return a containment-only PreparedWiring for an async-incompat handler.
@@ -1504,7 +1703,7 @@ def _prepare_handler_wiring(
             [t.get("name") for t in db_tables],
         )
     else:
-        callback = _make_dispatch_callback(handler_instance)
+        callback = _make_dispatch_callback(handler_instance, entry.event_model)
     dispatcher_id = _derive_dispatcher_id(
         contract.name, handler_ref.name, entry.operation
     )

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -27,6 +27,7 @@ import hashlib
 import importlib
 import inspect
 import logging
+import math
 import os
 import re
 from collections import defaultdict
@@ -54,6 +55,7 @@ from omnibase_core.services.service_local_handler_ownership_query import (
 from omnibase_infra.protocols.protocol_dispatch_result_applier import (
     ProtocolDispatchResultApplier,
 )
+from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
     EnumQuarantineReason,
 )
@@ -86,7 +88,6 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_dispatch_engine import (
         ProtocolDispatchEngine,
     )
-    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 
 logger = logging.getLogger(__name__)
 
@@ -755,6 +756,12 @@ def _dispatch_freeze_wait_timeout_seconds() -> float:
             raw,
         )
         return 900.0
+    if not math.isfinite(timeout_seconds):
+        logger.warning(
+            "Invalid ONEX_DISPATCH_FREEZE_WAIT_TIMEOUT_SECONDS=%r; using 900s",
+            raw,
+        )
+        return 900.0
     return max(timeout_seconds, 0.1)
 
 
@@ -1396,7 +1403,7 @@ async def _subscribe_contract_topics(
         and not _contract_declares_db_io(contract)
     ):
         effective_result_applier = DispatchResultApplier(
-            event_bus=cast("ProtocolEventBusLike", event_bus),
+            event_bus=cast(ProtocolEventBusLike, event_bus),  # noqa: TC006
             output_topic=contract.event_bus.publish_topics[0],
         )
     node_identity = ModelNodeIdentity(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1332,6 +1332,50 @@ def _prepare_handler_wiring(
     from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
 
     handler_ref = entry.handler
+
+    # Determine category/message types before importing or constructing the
+    # handler. Some domain-owned contracts use auto-wiring for subscriptions
+    # only; those entries must report accurate metadata while avoiding generic
+    # direct-handler dispatcher registration.
+    _category_str_early = "event"
+    if entry.message_category:
+        _category_str_early = entry.message_category.strip().lower()
+    elif contract.event_bus and contract.event_bus.subscribe_topics:
+        _category_str_early = _derive_message_category(
+            contract.event_bus.subscribe_topics[0]
+        )
+    _early_category = EnumMessageCategory(_category_str_early)
+
+    message_types: set[str] | None = None
+    if entry.event_model is not None:
+        message_types = {entry.event_model.name}
+    # OMN-9215: index the dispatcher under the contract-declared event_type alias
+    # in addition to the Pydantic class name. Publishers set
+    # ModelEventEnvelope.event_type to the dot-path string; without this alias,
+    # the dispatcher lookup falls back to type(payload).__name__ which resolves
+    # to "dict" on object-erased envelopes and never matches the class-name key.
+    # Strip surrounding whitespace so registration matches the dispatch-engine
+    # normalization (service_message_dispatch_engine.py normalizes via .strip()).
+    event_type_alias = entry.event_type.strip() if entry.event_type else ""
+    if event_type_alias:
+        message_types = (message_types or set()) | {event_type_alias}
+
+    if contract.name == "node_registration_orchestrator":
+        return PreparedWiring(
+            dispatcher_id="",
+            dispatcher=_skip_dispatcher,
+            category=_early_category,
+            message_types=message_types,
+            handler_name=handler_ref.name,
+            handler_module=handler_ref.module,
+            resolution_outcome=(
+                EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+            ),
+            skip_reason=(
+                "registration domain plugin owns explicit dispatcher adapters"
+            ),
+        )
+
     handler_cls = _import_handler_class(handler_ref.module, handler_ref.name)
 
     _effective_container = container or (
@@ -1345,18 +1389,6 @@ def _prepare_handler_wiring(
     pre_resolved_instance = (
         pre_resolved_handlers.get(handler_ref.name) if pre_resolved_handlers else None
     )
-
-    # Determine category up-front so the quarantine sentinel below (which
-    # bypasses the regular resolve/construct path) can still carry consistent
-    # reporting metadata.
-    _category_str_early = "event"
-    if entry.message_category:
-        _category_str_early = entry.message_category.strip().lower()
-    elif contract.event_bus and contract.event_bus.subscribe_topics:
-        _category_str_early = _derive_message_category(
-            contract.event_bus.subscribe_topics[0]
-        )
-    _early_category = EnumMessageCategory(_category_str_early)
 
     def _quarantine_prepared(exc: BaseException) -> PreparedWiring:
         """Return a containment-only PreparedWiring for an async-incompat handler.
@@ -1430,20 +1462,6 @@ def _prepare_handler_wiring(
     # _early_category was computed up-front so the quarantine sentinel could
     # carry consistent reporting metadata; reuse it here for the live path.
     category = _early_category
-
-    message_types: set[str] | None = None
-    if entry.event_model is not None:
-        message_types = {entry.event_model.name}
-    # OMN-9215: index the dispatcher under the contract-declared event_type alias
-    # in addition to the Pydantic class name. Publishers set
-    # ModelEventEnvelope.event_type to the dot-path string; without this alias,
-    # the dispatcher lookup falls back to type(payload).__name__ which resolves
-    # to "dict" on object-erased envelopes and never matches the class-name key.
-    # Strip surrounding whitespace so registration matches the dispatch-engine
-    # normalization (service_message_dispatch_engine.py normalizes via .strip()).
-    event_type_alias = entry.event_type.strip() if entry.event_type else ""
-    if event_type_alias:
-        message_types = (message_types or set()) | {event_type_alias}
 
     if (
         resolution.outcome

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1349,8 +1349,10 @@ def _prepare_handler_wiring(
     # Determine category up-front so the quarantine sentinel below (which
     # bypasses the regular resolve/construct path) can still carry consistent
     # reporting metadata.
-    _category_str_early = "EVENT"
-    if contract.event_bus and contract.event_bus.subscribe_topics:
+    _category_str_early = "event"
+    if entry.message_category:
+        _category_str_early = entry.message_category.strip().lower()
+    elif contract.event_bus and contract.event_bus.subscribe_topics:
         _category_str_early = _derive_message_category(
             contract.event_bus.subscribe_topics[0]
         )

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -55,7 +55,6 @@ from omnibase_core.services.service_local_handler_ownership_query import (
 from omnibase_infra.protocols.protocol_dispatch_result_applier import (
     ProtocolDispatchResultApplier,
 )
-from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
     EnumQuarantineReason,
 )
@@ -88,6 +87,7 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_dispatch_engine import (
         ProtocolDispatchEngine,
     )
+    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 
 logger = logging.getLogger(__name__)
 

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -55,6 +55,7 @@ from omnibase_core.services.service_local_handler_ownership_query import (
 from omnibase_infra.protocols.protocol_dispatch_result_applier import (
     ProtocolDispatchResultApplier,
 )
+from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
     EnumQuarantineReason,
 )
@@ -87,7 +88,6 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_dispatch_engine import (
         ProtocolDispatchEngine,
     )
-    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
 
 logger = logging.getLogger(__name__)
 
@@ -1402,8 +1402,14 @@ async def _subscribe_contract_topics(
         and len(contract.event_bus.publish_topics) == 1
         and not _contract_declares_db_io(contract)
     ):
+        # ProtocolEventBusLike is @runtime_checkable; isinstance both narrows
+        # the type for mypy and provides a runtime use of the import (avoiding
+        # CodeQL py/unused-import false positive when cast() is the only ref).
+        assert isinstance(event_bus, ProtocolEventBusLike), (
+            f"event_bus must implement ProtocolEventBusLike, got {type(event_bus).__name__}"
+        )
         effective_result_applier = DispatchResultApplier(
-            event_bus=cast("ProtocolEventBusLike", event_bus),
+            event_bus=event_bus,
             output_topic=contract.event_bus.publish_topics[0],
         )
     node_identity = ModelNodeIdentity(

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1403,7 +1403,7 @@ async def _subscribe_contract_topics(
         and not _contract_declares_db_io(contract)
     ):
         effective_result_applier = DispatchResultApplier(
-            event_bus=cast(ProtocolEventBusLike, event_bus),  # noqa: TC006
+            event_bus=cast("ProtocolEventBusLike", event_bus),
             output_topic=contract.event_bus.publish_topics[0],
         )
     node_identity = ModelNodeIdentity(
@@ -1547,7 +1547,7 @@ def _prepare_handler_wiring(
             if (alias := _derive_event_type_alias_from_topic(topic)) is not None
         }
         if topic_aliases:
-            message_types = (message_types or set()) | topic_aliases
+            message_types = (message_types or set()).union(topic_aliases)
 
     if contract.name == "node_registration_orchestrator":
         return PreparedWiring(

--- a/src/omnibase_infra/runtime/auto_wiring/models/model_event_bus_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/models/model_event_bus_wiring.py
@@ -20,3 +20,7 @@ class ModelEventBusWiring(BaseModel):
         default_factory=tuple,
         description="Topics this node publishes to",
     )
+    consumer_purpose: str | None = Field(
+        default=None,
+        description="Optional contract-declared consumer purpose",
+    )

--- a/src/omnibase_infra/runtime/auto_wiring/models/model_handler_routing_entry.py
+++ b/src/omnibase_infra/runtime/auto_wiring/models/model_handler_routing_entry.py
@@ -34,3 +34,12 @@ class ModelHandlerRoutingEntry(BaseModel):
             "Python class name on the wire (OMN-9215)."
         ),
     )
+    message_category: str | None = Field(
+        default=None,
+        description=(
+            "Optional per-handler message category override from contract YAML "
+            "(EVENT, COMMAND, or INTENT). Required for mixed-topic contracts so "
+            "command handlers do not inherit the category of the contract's first "
+            "subscribed topic."
+        ),
+    )

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -198,6 +198,21 @@ wire_handlers = wire_default_handlers
 
 logger = logging.getLogger(__name__)
 
+_RAW_EVENT_PROJECTION_CONSUMER_PURPOSES: frozenset[str] = frozenset(
+    {"audit", "projection"}
+)
+
+
+def _requires_raw_event_projection_wiring(event_bus_section: object) -> bool:
+    """Return True when generic event-bus wiring must not consume this contract."""
+    if not isinstance(event_bus_section, dict):
+        return False
+    consumer_purpose = event_bus_section.get("consumer_purpose")
+    if not isinstance(consumer_purpose, str):
+        return False
+    return consumer_purpose.strip().lower() in _RAW_EVENT_PROJECTION_CONSUMER_PURPOSES
+
+
 # Mapping from EnumHandlerTypeCategory to LiteralHandlerKind for descriptor creation.
 # COMPUTE and EFFECT map directly to their string values.
 # NONDETERMINISTIC_COMPUTE maps to "compute" because it is architecturally pure
@@ -530,6 +545,16 @@ async def _wire_package_node_subscriptions(
             "subscribe_topics"
         ):
             skipped_no_topics += 1
+            continue
+
+        if _requires_raw_event_projection_wiring(event_bus_section):
+            skipped_no_topics += 1
+            logger.info(
+                "Skipping package-node subscription for raw projection consumer: "
+                "node=%s consumer_purpose=%s",
+                node_name,
+                event_bus_section.get("consumer_purpose"),
+            )
             continue
 
         if node_name in already_wired_names:
@@ -2975,6 +3000,13 @@ class RuntimeHostProcess:
         event_bus_data = descriptor.contract_config.get("event_bus")
         if not event_bus_data or not isinstance(event_bus_data, dict):
             return
+        if _requires_raw_event_projection_wiring(event_bus_data):
+            logger.info(
+                "Skipping live handler subscription for raw projection consumer: "
+                "node=%s",
+                node_name,
+            )
+            return
 
         from omnibase_core.models.contracts.subcontracts import (
             ModelEventBusSubcontract,
@@ -4985,6 +5017,21 @@ class RuntimeHostProcess:
                 continue
 
             contract_path = Path(contract_path_str)
+            try:
+                raw_contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001 - loader below reports malformed contracts
+                raw_contract = None
+            if _requires_raw_event_projection_wiring(
+                raw_contract.get("event_bus")
+                if isinstance(raw_contract, dict)
+                else None
+            ):
+                logger.info(
+                    "Skipping event_bus subcontract wiring for raw projection consumer: "
+                    "handler=%s",
+                    descriptor.name or handler_type,
+                )
+                continue
 
             # Load event_bus subcontract from contract YAML
             subcontract = load_event_bus_subcontract(contract_path, logger)

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1093,6 +1093,9 @@ class RuntimeHostProcess:
 
         # Runtime state
         self._is_running: bool = False
+        # True while start() is actively progressing toward _is_running=True.
+        # Health uses this to distinguish startup liveness from readiness.
+        self._is_starting: bool = False
 
         # Subscription handle (callable to unsubscribe)
         self._subscription: Callable[[], Awaitable[None]] | None = None
@@ -1538,6 +1541,24 @@ class RuntimeHostProcess:
             return self._pending_message_count == 0
 
     async def start(self) -> None:
+        """Start the runtime host with explicit startup-state tracking."""
+        if self._is_running or self._is_starting:
+            logger.debug(
+                "RuntimeHostProcess already running or starting, skipping",
+                extra={
+                    "is_running": self._is_running,
+                    "is_starting": self._is_starting,
+                },
+            )
+            return
+
+        self._is_starting = True
+        try:
+            await self._start_runtime()
+        finally:
+            self._is_starting = False
+
+    async def _start_runtime(self) -> None:
         """Start the runtime host.
 
         Performs the following steps:
@@ -1576,10 +1597,6 @@ class RuntimeHostProcess:
             ArchitectureViolationError: If architecture validation fails with
                 blocking violations (ERROR severity).
         """
-        if self._is_running:
-            logger.debug("RuntimeHostProcess already started, skipping")
-            return
-
         logger.info(
             "Starting RuntimeHostProcess",
             extra={
@@ -4456,9 +4473,13 @@ class RuntimeHostProcess:
         # A runtime with no handlers cannot process any events and should be unhealthy
         no_handlers_registered = len(self._handlers) == 0
 
-        # Degraded state: process is running but some handlers failed to instantiate
-        # This means the system is operational but with reduced functionality
-        degraded = self._is_running and has_failed_handlers
+        # Degraded state:
+        # - running with failed handlers (reduced functionality)
+        # - actively starting with a live event bus (liveness OK, not ready yet)
+        startup_in_progress = (
+            self._is_starting and not self._is_running and event_bus_healthy
+        )
+        degraded = (self._is_running and has_failed_handlers) or startup_in_progress
 
         # Overall health is True only if running, event bus is healthy,
         # no handlers failed to instantiate, all registered handlers are healthy,
@@ -4491,6 +4512,7 @@ class RuntimeHostProcess:
         return {
             "healthy": healthy,
             "degraded": degraded,
+            "startup_in_progress": startup_in_progress,
             "is_running": self._is_running,
             "is_draining": self._is_draining,
             "pending_message_count": self._pending_message_count,

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1859,9 +1859,15 @@ class RuntimeHostProcess:
             - Connections shutdown before connection pools
             - Downstream resources shutdown before upstream resources
         """
-        if not self._is_running:
+        if not self._is_running and not self._is_starting:
             logger.debug("RuntimeHostProcess already stopped, skipping")
             return
+
+        if self._is_starting:
+            logger.warning(
+                "RuntimeHostProcess stop() called during startup — "
+                "startup will complete before shutdown proceeds"
+            )
 
         logger.info("Stopping RuntimeHostProcess")
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -51,6 +51,7 @@ import os
 import random
 import time
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
@@ -1121,6 +1122,8 @@ class RuntimeHostProcess:
         # True while start() is actively progressing toward _is_running=True.
         # Health uses this to distinguish startup liveness from readiness.
         self._is_starting: bool = False
+        self._startup_task: asyncio.Task[None] | None = None
+        self._shutdown_requested: asyncio.Event = asyncio.Event()
 
         # Subscription handle (callable to unsubscribe)
         self._subscription: Callable[[], Awaitable[None]] | None = None
@@ -1567,9 +1570,9 @@ class RuntimeHostProcess:
 
     async def start(self) -> None:
         """Start the runtime host with explicit startup-state tracking."""
-        if self._is_running or self._is_starting:
+        if self._is_running:
             logger.debug(
-                "RuntimeHostProcess already running or starting, skipping",
+                "RuntimeHostProcess already running, skipping",
                 extra={
                     "is_running": self._is_running,
                     "is_starting": self._is_starting,
@@ -1577,10 +1580,29 @@ class RuntimeHostProcess:
             )
             return
 
+        if self._startup_task is not None and not self._startup_task.done():
+            logger.debug("RuntimeHostProcess startup already in progress, waiting")
+            await self._startup_task
+            return
+
+        self._shutdown_requested.clear()
         self._is_starting = True
+        startup_task = asyncio.create_task(self._start_runtime())
+        self._startup_task = startup_task
         try:
-            await self._start_runtime()
+            await startup_task
+        except asyncio.CancelledError:
+            self._is_running = False
+            if self._shutdown_requested.is_set():
+                logger.info("RuntimeHostProcess startup cancelled by shutdown")
+                return
+            raise
+        except Exception:
+            self._is_running = False
+            raise
         finally:
+            if self._startup_task is startup_task:
+                self._startup_task = None
             self._is_starting = False
 
     async def _start_runtime(self) -> None:
@@ -1888,11 +1910,20 @@ class RuntimeHostProcess:
             logger.debug("RuntimeHostProcess already stopped, skipping")
             return
 
-        if self._is_starting:
+        self._shutdown_requested.set()
+
+        startup_task = self._startup_task
+        if startup_task is not None and not startup_task.done():
             logger.warning(
                 "RuntimeHostProcess stop() called during startup — "
-                "startup will complete before shutdown proceeds"
+                "cancelling startup before shutdown proceeds"
             )
+            if startup_task is not asyncio.current_task():
+                startup_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await startup_task
+            self._startup_task = None
+            self._is_starting = False
 
         logger.info("Stopping RuntimeHostProcess")
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1920,10 +1920,11 @@ class RuntimeHostProcess:
             )
             if startup_task is not asyncio.current_task():
                 startup_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    # CodeQL flags bare-await as "no effect" — the await IS the
-                    # effect (drains the cancelled task before shutdown proceeds).
-                    await startup_task  # codeql[py/ineffectual-statement]
+                try:
+                    await startup_task
+                except asyncio.CancelledError:
+                    # Expected: drain the cancelled startup task before shutdown.
+                    pass
             self._startup_task = None
             self._is_starting = False
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1921,7 +1921,9 @@ class RuntimeHostProcess:
             if startup_task is not asyncio.current_task():
                 startup_task.cancel()
                 with suppress(asyncio.CancelledError):
-                    _ = await startup_task
+                    # CodeQL flags bare-await as "no effect" — the await IS the
+                    # effect (drains the cancelled task before shutdown proceeds).
+                    await startup_task  # codeql[py/ineffectual-statement]
             self._startup_task = None
             self._is_starting = False
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1921,7 +1921,7 @@ class RuntimeHostProcess:
             if startup_task is not asyncio.current_task():
                 startup_task.cancel()
                 with suppress(asyncio.CancelledError):
-                    await startup_task
+                    _ = await startup_task
             self._startup_task = None
             self._is_starting = False
 

--- a/src/omnibase_infra/services/service_health.py
+++ b/src/omnibase_infra/services/service_health.py
@@ -895,7 +895,7 @@ class ServiceHealth:
                     status="degraded",
                     runtime_attached=False,
                     startup_in_progress=True,
-                    is_running=self.is_running,
+                    is_running=False,
                     event_bus_healthy=False,
                 )
                 response = ModelHealthCheckResponse.success(
@@ -906,7 +906,7 @@ class ServiceHealth:
                         {
                             "healthy": False,
                             "degraded": True,
-                            "is_running": self.is_running,
+                            "is_running": False,
                             "runtime_attached": False,
                             "startup_phase": "runtime_pending",
                         },

--- a/src/omnibase_infra/services/service_health.py
+++ b/src/omnibase_infra/services/service_health.py
@@ -943,16 +943,6 @@ class ServiceHealth:
             is_running = bool(health_details.get("is_running", False))
             event_bus_healthy = bool(health_details.get("event_bus_healthy", False))
 
-            if (
-                not is_healthy
-                and not is_degraded
-                and not startup_in_progress
-                and not is_running
-                and event_bus_healthy
-            ):
-                startup_in_progress = True
-                is_degraded = True
-
             if is_healthy:
                 status: Literal["healthy", "degraded", "unhealthy"] = "healthy"
                 http_status = 200

--- a/src/omnibase_infra/services/service_health.py
+++ b/src/omnibase_infra/services/service_health.py
@@ -293,6 +293,17 @@ class ServiceHealth:
 
         # OMN-519: Track last successful health check timestamps per component
         self._last_healthy_timestamps: dict[str, str] = {}
+        # Track health phase transitions so frequent probes do not flood logs.
+        self._last_health_probe_signature: (
+            tuple[
+                str,
+                bool,
+                bool,
+                bool,
+                bool,
+            ]
+            | None
+        ) = None
 
         logger.debug(
             "ServiceHealth initialized",
@@ -388,6 +399,47 @@ class ServiceHealth:
                 context=context,
             )
         return self._runtime
+
+    def attach_runtime(self, runtime: RuntimeHostProcess) -> None:
+        """Attach a runtime after early health-server startup."""
+        self._runtime = runtime
+        logger.info(
+            "ServiceHealth attached runtime after early startup",
+            extra={"port": self._port, "host": self._host},
+        )
+
+    def _log_health_transition(
+        self,
+        *,
+        status: str,
+        runtime_attached: bool,
+        startup_in_progress: bool,
+        is_running: bool,
+        event_bus_healthy: bool,
+    ) -> None:
+        """Log health state transitions once per distinct phase."""
+        signature = (
+            status,
+            runtime_attached,
+            startup_in_progress,
+            is_running,
+            event_bus_healthy,
+        )
+        if signature == self._last_health_probe_signature:
+            return
+        self._last_health_probe_signature = signature
+        logger.info(
+            "ServiceHealth health probe state changed",
+            extra={
+                "status": status,
+                "runtime_attached": runtime_attached,
+                "startup_in_progress": startup_in_progress,
+                "is_running": is_running,
+                "event_bus_healthy": event_bus_healthy,
+                "port": self._port,
+                "host": self._host,
+            },
+        )
 
     @classmethod
     async def create_from_container(
@@ -838,6 +890,34 @@ class ServiceHealth:
         _ = request
 
         try:
+            if self._runtime is None:
+                self._log_health_transition(
+                    status="degraded",
+                    runtime_attached=False,
+                    startup_in_progress=True,
+                    is_running=self.is_running,
+                    event_bus_healthy=False,
+                )
+                response = ModelHealthCheckResponse.success(
+                    status="degraded",
+                    version=self._version,
+                    details=cast(
+                        "dict[str, JsonType]",
+                        {
+                            "healthy": False,
+                            "degraded": True,
+                            "is_running": self.is_running,
+                            "runtime_attached": False,
+                            "startup_phase": "runtime_pending",
+                        },
+                    ),
+                )
+                return web.Response(
+                    text=response.model_dump_json(exclude_none=True),
+                    status=200,
+                    content_type="application/json",
+                )
+
             # Get health status from runtime
             health_details = await self.runtime.health_check()
 
@@ -859,6 +939,19 @@ class ServiceHealth:
             # Determine overall status based on health check results
             is_healthy = bool(health_details.get("healthy", False))
             is_degraded = bool(health_details.get("degraded", False))
+            startup_in_progress = bool(health_details.get("startup_in_progress", False))
+            is_running = bool(health_details.get("is_running", False))
+            event_bus_healthy = bool(health_details.get("event_bus_healthy", False))
+
+            if (
+                not is_healthy
+                and not is_degraded
+                and not startup_in_progress
+                and not is_running
+                and event_bus_healthy
+            ):
+                startup_in_progress = True
+                is_degraded = True
 
             if is_healthy:
                 status: Literal["healthy", "degraded", "unhealthy"] = "healthy"
@@ -892,11 +985,21 @@ class ServiceHealth:
                 status = "unhealthy"
                 http_status = 503
 
+            self._log_health_transition(
+                status=status,
+                runtime_attached=True,
+                startup_in_progress=startup_in_progress,
+                is_running=is_running,
+                event_bus_healthy=event_bus_healthy,
+            )
+
             # OMN-519: Add component breakdown to health response details
             components = self._build_component_health(health_details)
             enriched_details = dict(health_details)
+            enriched_details["degraded"] = is_degraded
+            enriched_details["startup_in_progress"] = startup_in_progress
             enriched_details["components"] = {
-                name: comp.model_dump(exclude_none=True)  # noqa: model-dump-bare
+                name: comp.model_dump(mode="json", exclude_none=True)
                 for name, comp in components.items()
             }
 

--- a/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
+++ b/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
@@ -1,20 +1,18 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Integration tests for single-authority dispatcher wiring in registration plugin (OMN-9456).
+"""Integration tests for single-authority dispatcher wiring in registration plugin.
 
-Verifies that the ServiceRegistration plugin's wire_dispatchers() correctly
-defers to generic contract-driven auto-wiring, and that the registration
-contract.yaml declares the subscribe_topics and handler_routing needed for
-auto-wiring to own the dispatcher and route registration.
+Verifies that ServiceRegistration owns explicit dispatcher adapters while
+generic contract-driven auto-wiring owns event-bus subscriptions.
 
 The duplicate-registration error (ONEX_CORE_064_DUPLICATE_REGISTRATION)
 arose because both the legacy explicit path and the generic contract-driven
 path registered dispatchers for the same contract.  This integration suite
 confirms that:
 
-1. The contract.yaml has the fields that justify auto-wiring ownership.
+1. The contract.yaml has the fields that justify auto-wiring subscription ownership.
 2. The plugin can be imported and instantiated without side effects.
-3. No dispatcher registrations happen via the plugin path.
+3. Dispatcher adapter registration happens through the domain wiring helper.
 
 Fixtures from conftest.py:
     contract_data: parsed YAML content of node_registration_orchestrator/contract.yaml
@@ -22,7 +20,7 @@ Fixtures from conftest.py:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,10 +28,10 @@ pytestmark = pytest.mark.integration
 
 
 class TestContractDeclaresSubscribeTopics:
-    """The contract must declare event_bus.subscribe_topics — required for auto-wiring ownership.
+    """The contract must declare event_bus.subscribe_topics.
 
     The runtime reads event_bus.subscribe_topics to wire consumer subscriptions.
-    Generic auto-wiring owns dispatcher registration for this node because the
+    Generic auto-wiring owns subscription setup for this node because the
     contract fully declares this field.
     """
 
@@ -91,7 +89,7 @@ class TestContractDeclaresHandlerRouting:
 
 
 class TestPluginWireDispatchersNoDuplicateRegistration:
-    """The plugin.wire_dispatchers() must not register any dispatchers or routes directly."""
+    """The plugin.wire_dispatchers() delegates to explicit dispatcher adapters."""
 
     def test_plugin_importable(self) -> None:
         """ServiceRegistration can be imported without side effects."""
@@ -112,12 +110,12 @@ class TestPluginWireDispatchersNoDuplicateRegistration:
         assert plugin.plugin_id == "registration"
 
     @pytest.mark.asyncio
-    async def test_wire_dispatchers_skips_without_touching_engine(self) -> None:
-        """wire_dispatchers() returns skipped and does not register against dispatch engine.
+    async def test_wire_dispatchers_delegates_to_domain_wiring_helper(self) -> None:
+        """wire_dispatchers() delegates adapter registration to domain wiring.
 
-        This is the integration-level guard for OMN-9456: the plugin must never
-        directly call register_dispatcher or register_route because doing so
-        alongside the generic auto-wiring path produces duplicate dispatcher IDs.
+        Generic auto-wiring still owns subscriptions. The registration plugin
+        owns the adapter layer because registration handlers expect domain
+        envelope semantics rather than raw dict envelopes.
         """
         from dataclasses import dataclass
         from uuid import uuid4
@@ -152,14 +150,25 @@ class TestPluginWireDispatchersNoDuplicateRegistration:
         )
 
         plugin = ServiceRegistration()
-        result = await plugin.wire_dispatchers(config)
+        with patch(
+            "omnibase_infra.nodes.node_registration_orchestrator.wiring"
+            ".wire_registration_dispatchers",
+            new=AsyncMock(
+                return_value={
+                    "dispatchers": ["dispatcher.registration.catalog-request"],
+                    "routes": ["route.registration.catalog-request"],
+                    "status": "success",
+                }
+            ),
+        ) as wire_registration_dispatchers:
+            result = await plugin.wire_dispatchers(config)
 
-        # Skipped result is a success (kernel treats it as "nothing to do here")
-        assert result.success is True, (
-            "wire_dispatchers() returned a failure result — "
-            "the plugin must return a skipped success to avoid alarming the kernel"
+        assert result.success is True
+        assert result.message == "Registration dispatchers wired"
+        assert result.services_registered == ["dispatcher.registration.catalog-request"]
+        wire_registration_dispatchers.assert_awaited_once_with(
+            config.container,
+            config.dispatch_engine,
+            correlation_id=config.correlation_id,
+            event_bus=config.event_bus,
         )
-
-        # No dispatcher or route was registered via the plugin path
-        engine.register_dispatcher.assert_not_called()
-        engine.register_route.assert_not_called()

--- a/tests/integration/runtime/test_async_container_pre_resolution_integration.py
+++ b/tests/integration/runtime/test_async_container_pre_resolution_integration.py
@@ -123,7 +123,14 @@ async def test_async_pre_resolution_succeeds_when_sync_raises_runtime_error() ->
 @pytest.mark.asyncio
 async def test_async_pre_resolution_miss_falls_through_to_zero_arg() -> None:
     """When get_service_async misses (ServiceResolutionError), a zero-arg handler
-    wires via the zero-arg fallback path — no failure [OMN-9410].
+    wires via the construct-without-container fast path — no sync get_service
+    fallback is needed because the handler has no required ctor params.
+
+    This guards the optimization in handler_wiring._prepare_handler_wiring
+    (``can_construct_without_container``) which short-circuits the sync
+    container resolver when ``required_ctor_params`` is empty (or only
+    {"event_bus"}). Adding a sync fallback for this case would re-introduce
+    the OMN-9410 ``asyncio.run()`` reentrancy hazard inside event-loop boots.
     """
 
     class _HandlerZeroArg:
@@ -177,4 +184,4 @@ async def test_async_pre_resolution_miss_falls_through_to_zero_arg() -> None:
     assert report.total_failed == 0
     assert report.total_wired == 1
     container.get_service_async.assert_called_once_with(_HandlerZeroArg)
-    container.get_service.assert_called_once_with(_HandlerZeroArg)
+    container.get_service.assert_not_called()

--- a/tests/integration/test_handler_event_type_alias_integration.py
+++ b/tests/integration/test_handler_event_type_alias_integration.py
@@ -125,11 +125,18 @@ def test_registration_emits_alias_matching_dispatch_engine_normalization() -> No
 
 
 @pytest.mark.integration
-def test_alias_absent_falls_back_to_class_name_only() -> None:
-    """OMN-9215 fix must not leak: no alias declared → class-name key only.
+def test_alias_absent_falls_back_to_class_name_and_topic_derived_alias() -> None:
+    """OMN-9215 fix must not leak: no alias declared → class-name key plus
+    topic-derived alias.
 
-    Regression guard: the strip() addition must not accidentally synthesize
-    an alias where none was declared.
+    When the contract omits an explicit ``event_type`` alias, registration
+    must still register the class-name key (``ModelFooCommand``) AND the
+    topic-suffix-derived alias (``platform.foo-start``). The latter was added
+    to support installed market-package handlers whose envelopes arrive with
+    the dispatch-engine-rewritten topic-derived event_type (OMN-9648). The
+    strip() guard from OMN-9215 still must not synthesize an alias from an
+    explicit-but-empty value, which is covered by the unit test
+    ``test_message_types_omits_alias_when_only_whitespace``.
     """
 
     class _FakeHandler:
@@ -156,4 +163,4 @@ def test_alias_absent_falls_back_to_class_name_only() -> None:
             container=None,
         )
 
-    assert prepared.message_types == {"ModelFooCommand"}
+    assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}

--- a/tests/integration/test_omn_9600_path_defaults.py
+++ b/tests/integration/test_omn_9600_path_defaults.py
@@ -20,6 +20,9 @@ Integration Test Coverage gate: OMN-7005 (hard gate since 2026-04-13).
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from omnibase_infra.adapters.project_tracker.local_stub_project_tracker import (
@@ -29,62 +32,46 @@ from omnibase_infra.services.agent_registry.registry import AgentRegistry
 
 
 @pytest.mark.integration
-def test_local_stub_project_tracker_default_is_workspace_local(
-    tmp_path: pytest.TempPathFactory,
-) -> None:
+def test_local_stub_project_tracker_default_is_workspace_local() -> None:
     """Default state_root must not reference Path.home()."""
-    tracker = LocalStubProjectTracker.__new__(LocalStubProjectTracker)
-    # Call __init__ without args to trigger the default path logic
-    # We intercept before mkdir calls by patching _state_root directly
-    import threading
+    tracker = LocalStubProjectTracker()
 
-    tracker._lock = threading.Lock()
-    # Instantiate with a tmp override so no disk writes happen
-    tracker_with_default = LocalStubProjectTracker.__new__(LocalStubProjectTracker)
-
-    # Inspect the __init__ default without actually creating dirs by reading source
-    import inspect
-
-    source = inspect.getsource(LocalStubProjectTracker.__init__)
-    assert "Path.home()" not in source, (
+    assert Path.home() not in tracker._state_root.parents
+    assert tracker._state_root == Path(".onex_state") / "local-tracker"
+    assert ".onex_state" in tracker._state_root.parts, (
         "LocalStubProjectTracker.__init__ must not reference Path.home() — "
         "defaults must be workspace-local per OMN-9600"
-    )
-    assert ".onex_state" in source, (
-        "LocalStubProjectTracker.__init__ must default to .onex_state"
     )
 
 
 @pytest.mark.integration
 def test_agent_registry_default_is_workspace_local() -> None:
     """Default state_dir must not reference Path.home()."""
-    import inspect
+    with patch.object(Path, "mkdir") as mkdir:
+        registry = AgentRegistry()
 
-    source = inspect.getsource(AgentRegistry.__init__)
-    assert "Path.home()" not in source, (
+    mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    assert Path.home() not in registry._state_dir.parents
+    assert registry._state_dir == Path(".onex_state")
+    assert ".onex_state" in registry._state_dir.parts, (
         "AgentRegistry.__init__ must not reference Path.home() — "
         "defaults must be workspace-local per OMN-9600"
     )
-    assert ".onex_state" in source, "AgentRegistry.__init__ must default to .onex_state"
 
 
 @pytest.mark.integration
 def test_local_stub_project_tracker_state_root_under_workspace(
-    tmp_path: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
     """When instantiated with a provided path, state_root resolves correctly."""
-    from pathlib import Path
-
     tracker = LocalStubProjectTracker(state_root=tmp_path)
     assert tracker._state_root == Path(tmp_path)
 
 
 @pytest.mark.integration
 def test_agent_registry_state_dir_under_workspace(
-    tmp_path: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
     """When instantiated with a provided path, state_dir resolves correctly."""
-    from pathlib import Path
-
     registry = AgentRegistry(state_dir=tmp_path)
     assert registry._state_dir == Path(tmp_path)

--- a/tests/integration/test_omn_9741_health_liveness.py
+++ b/tests/integration/test_omn_9741_health_liveness.py
@@ -46,6 +46,7 @@ async def test_health_endpoint_returns_200_degraded_when_runtime_not_attached() 
     assert body["status"] == "degraded", (
         f"Expected status=degraded when runtime not attached, got {body['status']}"
     )
+    assert body["details"]["is_running"] is False
     assert body["details"]["startup_phase"] == "runtime_pending"
     assert body["details"]["runtime_attached"] is False
 

--- a/tests/integration/test_omn_9741_health_liveness.py
+++ b/tests/integration/test_omn_9741_health_liveness.py
@@ -8,68 +8,98 @@ attached (subscription startup in progress), the /health endpoint must return
 HTTP 200 with status=degraded rather than HTTP 503, so Docker/autoheal does
 not recycle a live effects process during long Kafka subscription setup.
 
-After the fix:
-- ServiceHealth with no runtime attached returns HTTP 200, status=degraded
-- ServiceHealth.attach_runtime() wires the runtime after early startup
-- RuntimeHostProcess.health_check() reports startup_in_progress=True when
-  event_bus_healthy=True but runtime is not yet running
-
 Ticket: OMN-9741
 Integration Test Coverage gate: OMN-7005 (hard gate since 2026-04-13).
 """
 
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+from aiohttp import web
 
 from omnibase_infra.services.service_health import ServiceHealth
 
 
 @pytest.mark.integration
-def test_service_health_runtime_none_returns_degraded_not_503() -> None:
-    """Health endpoint must not report 503 when runtime is not yet attached.
+@pytest.mark.asyncio
+async def test_health_endpoint_returns_200_degraded_when_runtime_not_attached() -> None:
+    """Health endpoint must return HTTP 200 degraded when runtime is not yet attached.
 
-    Docker autoheal kills containers on HTTP 503. During long Kafka
-    subscription startup, runtime is None — the endpoint must return
-    degraded (HTTP 200), not unhealthy (HTTP 503).
+    This is the liveness invariant for OMN-9741: Docker autoheal kills containers
+    on HTTP 503. During Kafka subscription startup, runtime is None — the endpoint
+    must return degraded (HTTP 200), not unhealthy (HTTP 503).
     """
-    from unittest.mock import MagicMock
-
     container = MagicMock()
     server = ServiceHealth(container=container)
-    assert server._runtime is None
+    mock_request = MagicMock(spec=web.Request)
+
+    response = await server._handle_health(mock_request)
+
+    assert response.status == 200, (
+        f"Expected HTTP 200 (degraded) when runtime not attached, got {response.status}. "
+        "Docker autoheal would kill a container returning 503 during startup."
+    )
+    body = json.loads(response.text)
+    assert body["status"] == "degraded", (
+        f"Expected status=degraded when runtime not attached, got {body['status']}"
+    )
+    assert body["details"]["startup_phase"] == "runtime_pending"
+    assert body["details"]["runtime_attached"] is False
 
 
 @pytest.mark.integration
-def test_service_health_attach_runtime_wires_runtime() -> None:
-    """attach_runtime() must set _runtime so later health_check() calls succeed."""
-    from unittest.mock import MagicMock
-
-    container = MagicMock()
+@pytest.mark.asyncio
+async def test_health_endpoint_returns_200_healthy_after_attach_runtime() -> None:
+    """Health endpoint returns 200 healthy once attach_runtime() is called and runtime is healthy."""
     mock_runtime = MagicMock()
+    mock_runtime.health_check = AsyncMock(
+        return_value={
+            "healthy": True,
+            "degraded": False,
+            "startup_in_progress": False,
+            "is_running": True,
+            "event_bus_healthy": True,
+            "handlers": {},
+            "failed_handlers": {},
+        }
+    )
+    container = MagicMock()
     server = ServiceHealth(container=container)
-    assert server._runtime is None
-
     server.attach_runtime(mock_runtime)
-    assert server._runtime is mock_runtime
+    mock_request = MagicMock(spec=web.Request)
+
+    response = await server._handle_health(mock_request)
+
+    assert response.status == 200
+    body = json.loads(response.text)
+    assert body["status"] == "healthy"
 
 
 @pytest.mark.integration
-def test_service_health_no_runtime_startup_phase_in_source() -> None:
-    """The startup_phase=runtime_pending detail must be present in the code path.
-
-    This ensures the /health handler explicitly sets startup_phase so
-    monitoring tools can distinguish between 'degraded due to startup' and
-    'degraded due to error'.
-    """
-    import inspect
-
-    source = inspect.getsource(ServiceHealth._handle_health)
-    assert "runtime_pending" in source, (
-        "ServiceHealth._handle_health must return startup_phase='runtime_pending' "
-        "when runtime is not attached — required for OMN-9741 monitoring contract"
+@pytest.mark.asyncio
+async def test_health_endpoint_returns_200_degraded_during_runtime_startup() -> None:
+    """Health endpoint returns degraded 200 when runtime reports startup_in_progress."""
+    mock_runtime = MagicMock()
+    mock_runtime.health_check = AsyncMock(
+        return_value={
+            "healthy": False,
+            "degraded": True,
+            "startup_in_progress": True,
+            "is_running": False,
+            "event_bus_healthy": True,
+            "handlers": {},
+            "failed_handlers": {},
+        }
     )
-    assert "startup_in_progress" in source, (
-        "ServiceHealth._handle_health must include startup_in_progress in the "
-        "degraded response details (OMN-9741)"
-    )
+    server = ServiceHealth(runtime=mock_runtime)
+    mock_request = MagicMock(spec=web.Request)
+
+    response = await server._handle_health(mock_request)
+
+    assert response.status == 200
+    body = json.loads(response.text)
+    assert body["status"] == "degraded"
+    assert body["details"]["startup_in_progress"] is True

--- a/tests/integration/test_omn_9741_health_liveness.py
+++ b/tests/integration/test_omn_9741_health_liveness.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration proof for OMN-9741 effects health liveness during startup.
+
+OMN-9741 fixes the health liveness contract: when the runtime is not yet
+attached (subscription startup in progress), the /health endpoint must return
+HTTP 200 with status=degraded rather than HTTP 503, so Docker/autoheal does
+not recycle a live effects process during long Kafka subscription setup.
+
+After the fix:
+- ServiceHealth with no runtime attached returns HTTP 200, status=degraded
+- ServiceHealth.attach_runtime() wires the runtime after early startup
+- RuntimeHostProcess.health_check() reports startup_in_progress=True when
+  event_bus_healthy=True but runtime is not yet running
+
+Ticket: OMN-9741
+Integration Test Coverage gate: OMN-7005 (hard gate since 2026-04-13).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.services.service_health import ServiceHealth
+
+
+@pytest.mark.integration
+def test_service_health_runtime_none_returns_degraded_not_503() -> None:
+    """Health endpoint must not report 503 when runtime is not yet attached.
+
+    Docker autoheal kills containers on HTTP 503. During long Kafka
+    subscription startup, runtime is None — the endpoint must return
+    degraded (HTTP 200), not unhealthy (HTTP 503).
+    """
+    from unittest.mock import MagicMock
+
+    container = MagicMock()
+    server = ServiceHealth(container=container)
+    assert server._runtime is None
+
+
+@pytest.mark.integration
+def test_service_health_attach_runtime_wires_runtime() -> None:
+    """attach_runtime() must set _runtime so later health_check() calls succeed."""
+    from unittest.mock import MagicMock
+
+    container = MagicMock()
+    mock_runtime = MagicMock()
+    server = ServiceHealth(container=container)
+    assert server._runtime is None
+
+    server.attach_runtime(mock_runtime)
+    assert server._runtime is mock_runtime
+
+
+@pytest.mark.integration
+def test_service_health_no_runtime_startup_phase_in_source() -> None:
+    """The startup_phase=runtime_pending detail must be present in the code path.
+
+    This ensures the /health handler explicitly sets startup_phase so
+    monitoring tools can distinguish between 'degraded due to startup' and
+    'degraded due to error'.
+    """
+    import inspect
+
+    source = inspect.getsource(ServiceHealth._handle_health)
+    assert "runtime_pending" in source, (
+        "ServiceHealth._handle_health must return startup_phase='runtime_pending' "
+        "when runtime is not attached — required for OMN-9741 monitoring contract"
+    )
+    assert "startup_in_progress" in source, (
+        "ServiceHealth._handle_health must include startup_in_progress in the "
+        "degraded response details (OMN-9741)"
+    )

--- a/tests/scripts/test_deploy_runtime_no_env_file.py
+++ b/tests/scripts/test_deploy_runtime_no_env_file.py
@@ -81,3 +81,22 @@ def test_sources_omnibase_env_at_top() -> None:
         f"source ~/.omnibase/.env found at line {line_number}, "
         "expected within first 50 lines of script"
     )
+
+
+@pytest.mark.unit
+def test_compose_project_defaults_to_live_runtime_project() -> None:
+    """deploy-runtime.sh must target the canonical live runtime compose project."""
+    text = "\n".join(_read_script_lines())
+
+    assert "OMNIBASE_INFRA_COMPOSE_PROJECT:-omnibase-infra" in text
+    assert 'local compose_project="omnibase-infra-${COMPOSE_PROFILE}"' not in text
+
+
+@pytest.mark.unit
+def test_verify_deployment_uses_fixed_runtime_container_name() -> None:
+    """deploy-runtime.sh must inspect the fixed omninode-runtime container first."""
+    text = "\n".join(_read_script_lines())
+
+    assert "name=^/omninode-runtime$" in text
+    assert "${compose_project}-omninode-runtime-1" not in text
+    assert '${compose_project}-omninode-runtime" | head -1' not in text

--- a/tests/unit/docker/test_docker_performance.py
+++ b/tests/unit/docker/test_docker_performance.py
@@ -11,6 +11,8 @@ These tests verify Docker configuration follows performance best practices:
 from __future__ import annotations
 
 import re
+from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -21,6 +23,47 @@ from tests.unit.docker.conftest import COMPOSE_FILE_PATH, DOCKER_DIR
 
 # Explicit marker for documentation (also auto-applied by tests/unit/conftest.py)
 pytestmark = [pytest.mark.unit]
+
+RUNTIME_STARTUP_SERVICES = ("omninode-runtime", "runtime-effects", "runtime-worker")
+
+
+def _duration_seconds(value: object) -> int:
+    """Parse a compose/catalog duration value into seconds."""
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        raise AssertionError(f"Unsupported duration value: {value!r}")
+
+    match = re.fullmatch(r"(\d+)([smh]?)", value.strip())
+    if match is None:
+        raise AssertionError(f"Unsupported duration value: {value!r}")
+
+    amount = int(match.group(1))
+    unit = match.group(2) or "s"
+    multipliers = {"s": 1, "m": 60, "h": 3600}
+    return amount * multipliers[unit]
+
+
+def _memory_mib(value: object) -> int:
+    """Parse a compose/catalog memory value into MiB."""
+    if isinstance(value, int):
+        return value // (1024 * 1024)
+    if not isinstance(value, str):
+        raise AssertionError(f"Unsupported memory value: {value!r}")
+
+    match = re.fullmatch(r"(\d+)([kKmMgG]?)", value.strip())
+    if match is None:
+        raise AssertionError(f"Unsupported memory value: {value!r}")
+
+    amount = int(match.group(1))
+    unit = match.group(2).upper() or "B"
+    multipliers = {"B": 1 / (1024 * 1024), "K": 1 / 1024, "M": 1, "G": 1024}
+    return int(amount * multipliers[unit])
+
+
+def _load_catalog_service(docker_dir: Path, service_name: str) -> dict[str, Any]:
+    catalog_path = docker_dir / "catalog" / "services" / f"{service_name}.yaml"
+    return yaml.safe_load(catalog_path.read_text())
 
 
 @pytest.mark.unit
@@ -144,6 +187,74 @@ class TestDockerComposePerformance:
         assert "reservations:" in content
         # Reservations should be lower than limits
         assert content.count("reservations:") > 0
+
+    def test_runtime_startup_health_windows_cover_contract_wiring(self) -> None:
+        """Verify runtime startup health windows outrun contract wiring."""
+        content = yaml.safe_load(COMPOSE_FILE_PATH.read_text())
+        services = content["services"]
+        autoheal_start_period = _duration_seconds(
+            services["autoheal"]["environment"]["AUTOHEAL_START_PERIOD"]
+        )
+        minimum_start_periods = {
+            "omninode-runtime": 1800,
+            "runtime-effects": 1800,
+            "runtime-worker": 1200,
+        }
+
+        for service_name in RUNTIME_STARTUP_SERVICES:
+            healthcheck = services[service_name]["healthcheck"]
+            start_period = _duration_seconds(healthcheck["start_period"])
+            interval = _duration_seconds(healthcheck["interval"])
+            retries = int(healthcheck["retries"])
+            unhealthy_detection_window = start_period + (interval * retries)
+
+            assert start_period >= minimum_start_periods[service_name]
+            assert retries >= 5
+            assert autoheal_start_period > unhealthy_detection_window, (
+                f"{service_name} autoheal grace period must exceed Docker's "
+                "unhealthy detection window"
+            )
+
+    def test_runtime_startup_services_have_memory_headroom(self) -> None:
+        """Verify runtime startup services keep enough memory headroom."""
+        content = yaml.safe_load(COMPOSE_FILE_PATH.read_text())
+
+        for service_name in RUNTIME_STARTUP_SERVICES:
+            resources = content["services"][service_name]["deploy"]["resources"]
+            memory_limit = _memory_mib(resources["limits"]["memory"])
+            memory_reservation = _memory_mib(resources["reservations"]["memory"])
+
+            assert memory_limit >= 1536, (
+                f"{service_name} needs runtime contract-wiring headroom"
+            )
+            assert memory_reservation >= 256
+
+    def test_runtime_catalog_matches_startup_guardrails(self) -> None:
+        """Verify service catalog carries the same runtime startup guardrails."""
+        autoheal = _load_catalog_service(DOCKER_DIR, "autoheal")
+        autoheal_start_period = _duration_seconds(
+            autoheal["hardcoded_env"]["AUTOHEAL_START_PERIOD"]
+        )
+        minimum_start_periods = {
+            "omninode-runtime": 1800,
+            "runtime-effects": 1800,
+            "runtime-worker": 1200,
+        }
+
+        for service_name in RUNTIME_STARTUP_SERVICES:
+            service = _load_catalog_service(DOCKER_DIR, service_name)
+            healthcheck = service["healthcheck"]
+            resources = service["resources"]
+            start_period = _duration_seconds(healthcheck["start_period_s"])
+            interval = _duration_seconds(healthcheck["interval_s"])
+            retries = int(healthcheck["retries"])
+            unhealthy_detection_window = start_period + (interval * retries)
+
+            assert start_period >= minimum_start_periods[service_name]
+            assert retries >= 5
+            assert autoheal_start_period > unhealthy_detection_window
+            assert _memory_mib(resources["memory"]) >= 1536
+            assert _memory_mib(resources["memory_reservation"]) >= 256
 
 
 @pytest.mark.unit

--- a/tests/unit/docker/test_docker_performance.py
+++ b/tests/unit/docker/test_docker_performance.py
@@ -25,6 +25,11 @@ from tests.unit.docker.conftest import COMPOSE_FILE_PATH, DOCKER_DIR
 pytestmark = [pytest.mark.unit]
 
 RUNTIME_STARTUP_SERVICES = ("omninode-runtime", "runtime-effects", "runtime-worker")
+MINIMUM_START_PERIODS = {
+    "omninode-runtime": 1800,
+    "runtime-effects": 1800,
+    "runtime-worker": 1200,
+}
 
 
 def _duration_seconds(value: object) -> int:
@@ -195,12 +200,6 @@ class TestDockerComposePerformance:
         autoheal_start_period = _duration_seconds(
             services["autoheal"]["environment"]["AUTOHEAL_START_PERIOD"]
         )
-        minimum_start_periods = {
-            "omninode-runtime": 1800,
-            "runtime-effects": 1800,
-            "runtime-worker": 1200,
-        }
-
         for service_name in RUNTIME_STARTUP_SERVICES:
             healthcheck = services[service_name]["healthcheck"]
             start_period = _duration_seconds(healthcheck["start_period"])
@@ -208,7 +207,7 @@ class TestDockerComposePerformance:
             retries = int(healthcheck["retries"])
             unhealthy_detection_window = start_period + (interval * retries)
 
-            assert start_period >= minimum_start_periods[service_name]
+            assert start_period >= MINIMUM_START_PERIODS[service_name]
             assert retries >= 5
             assert autoheal_start_period > unhealthy_detection_window, (
                 f"{service_name} autoheal grace period must exceed Docker's "
@@ -235,12 +234,6 @@ class TestDockerComposePerformance:
         autoheal_start_period = _duration_seconds(
             autoheal["hardcoded_env"]["AUTOHEAL_START_PERIOD"]
         )
-        minimum_start_periods = {
-            "omninode-runtime": 1800,
-            "runtime-effects": 1800,
-            "runtime-worker": 1200,
-        }
-
         for service_name in RUNTIME_STARTUP_SERVICES:
             service = _load_catalog_service(DOCKER_DIR, service_name)
             healthcheck = service["healthcheck"]
@@ -250,7 +243,7 @@ class TestDockerComposePerformance:
             retries = int(healthcheck["retries"])
             unhealthy_detection_window = start_period + (interval * retries)
 
-            assert start_period >= minimum_start_periods[service_name]
+            assert start_period >= MINIMUM_START_PERIODS[service_name]
             assert retries >= 5
             assert autoheal_start_period > unhealthy_detection_window
             assert _memory_mib(resources["memory"]) >= 1536

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Unit tests for ServiceRegistration.wire_dispatchers deferral (OMN-9456).
+"""Unit tests for ServiceRegistration.wire_dispatchers registration ownership.
 
-Verifies that the registration domain plugin defers dispatcher and route
-wiring to the generic contract-driven auto-wiring pipeline, rather than
-calling the legacy explicit ``wire_registration_dispatchers`` helper.
+Verifies that the registration domain plugin owns explicit dispatcher adapter
+wiring while generic contract-driven auto-wiring owns subscriptions.
 
 Historical context
 ------------------
@@ -13,9 +12,9 @@ contract auto-wiring path against the same registration contract produced
 ``ONEX_CORE_064_DUPLICATE_REGISTRATION`` errors for dispatcher
 ``dispatcher.registration.node-introspected`` on fresh runtime-effects boots.
 
-These tests pin the single-authority invariant: the plugin's
-``wire_dispatchers`` method MUST return a skipped result and MUST NOT
-invoke the explicit wiring helper.
+These tests pin the corrected ownership invariant: the plugin's
+``wire_dispatchers`` method invokes the explicit wiring helper, and
+auto-wiring skips generic direct-handler dispatchers for this domain.
 """
 
 from __future__ import annotations
@@ -49,12 +48,9 @@ class _DummyNodeIdentity:
 def _make_plugin_config() -> ModelDomainPluginConfig:
     """Build a plugin config with the fields required by wire_dispatchers().
 
-    The legacy implementation read ``container.service_registry``,
-    ``dispatch_engine``, ``event_bus``, and ``correlation_id`` before
-    delegating to the explicit wiring helper. The deferred implementation
-    only needs ``correlation_id`` for logging; the remaining fields are
-    populated with plausible doubles so the invariant holds regardless of
-    whether the plugin inspects them defensively in the future.
+    The implementation reads ``container``, ``dispatch_engine``,
+    ``event_bus``, and ``correlation_id`` before delegating to the explicit
+    wiring helper.
     """
     container = MagicMock()
     container.service_registry = MagicMock()
@@ -77,94 +73,94 @@ def _make_plugin_config() -> ModelDomainPluginConfig:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_returns_skipped_result() -> None:
-    """wire_dispatchers() must return a skipped success result.
-
-    Generic contract auto-wiring is the single authority for registration
-    dispatchers and routes after OMN-9456; the plugin's wire_dispatchers()
-    is a pass-through.
-    """
-    plugin = ServiceRegistration()
-    config = _make_plugin_config()
-
-    result = await plugin.wire_dispatchers(config)
-
-    # Skipped results carry success=True so the kernel does not treat them
-    # as failure (see ModelDomainPluginResult.skipped semantics).
-    assert result.success is True
-    assert result.plugin_id == "registration"
-    assert result.message.lower().startswith("plugin registration skipped")
-    # The reason must make the single-authority intent explicit for
-    # operators reading kernel logs.
-    reason_lower = result.message.lower()
-    assert "auto-wiring" in reason_lower or "auto wiring" in reason_lower
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_wire_dispatchers_does_not_invoke_legacy_helper() -> None:
-    """wire_dispatchers() must NOT call wire_registration_dispatchers().
-
-    The legacy helper is what registered the colliding
-    ``dispatcher.registration.node-introspected`` dispatcher ID alongside
-    the generic auto-wiring path. Deferring means the helper is not
-    invoked on the kernel-native activation path at all.
-    """
+async def test_wire_dispatchers_returns_wired_result() -> None:
+    """wire_dispatchers() returns a success result from explicit adapter wiring."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
 
     with patch(
         f"{_WIRING_MOD}.wire_registration_dispatchers",
-        new=AsyncMock(),
-    ) as mock_legacy_wire:
+        new=AsyncMock(
+            return_value={
+                "dispatchers": ["dispatcher.registration.catalog-request"],
+                "routes": ["route.registration.catalog-request"],
+                "status": "success",
+            }
+        ),
+    ):
+        result = await plugin.wire_dispatchers(config)
+
+    assert result.success is True
+    assert result.plugin_id == "registration"
+    assert result.message == "Registration dispatchers wired"
+    assert result.services_registered == ["dispatcher.registration.catalog-request"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_dispatchers_invokes_explicit_helper() -> None:
+    """wire_dispatchers() delegates to registration's dispatcher adapters."""
+    plugin = ServiceRegistration()
+    config = _make_plugin_config()
+
+    with patch(
+        f"{_WIRING_MOD}.wire_registration_dispatchers",
+        new=AsyncMock(
+            return_value={
+                "dispatchers": ["dispatcher.registration.catalog-request"],
+                "routes": ["route.registration.catalog-request"],
+                "status": "success",
+            }
+        ),
+    ) as mock_wire:
         await plugin.wire_dispatchers(config)
 
-    mock_legacy_wire.assert_not_called()
+    mock_wire.assert_awaited_once_with(
+        config.container,
+        config.dispatch_engine,
+        correlation_id=config.correlation_id,
+        event_bus=config.event_bus,
+    )
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_does_not_touch_dispatch_engine() -> None:
-    """wire_dispatchers() must register zero dispatchers and zero routes.
-
-    This guards against regressions where the plugin accidentally
-    reintroduces direct ``dispatch_engine.register_dispatcher`` /
-    ``register_route`` calls — the exact class of bug that produced the
-    duplicate-registration error in OMN-9456.
-    """
+async def test_wire_dispatchers_fails_without_dispatch_engine() -> None:
+    """wire_dispatchers() must fail fast without a dispatch engine."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
-    engine = config.dispatch_engine
-    assert engine is not None  # mypy/runtime guard — see _make_plugin_config
+    config.dispatch_engine = None
 
-    await plugin.wire_dispatchers(config)
+    result = await plugin.wire_dispatchers(config)
 
-    engine.register_dispatcher.assert_not_called()  # type: ignore[attr-defined]
-    engine.register_route.assert_not_called()  # type: ignore[attr-defined]
+    assert result.success is False
+    assert result.error_message is not None
+    assert "dispatch_engine" in result.error_message
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_is_idempotent_across_repeat_calls() -> None:
-    """Calling wire_dispatchers() twice is safe — no duplicate registrations.
-
-    The kernel-native activation path invokes registration_service
-    .wire_dispatchers() explicitly; a defensive second call (e.g. from a
-    retry or a test harness) must not cause the duplicate-registration
-    error recorded in the ticket. Because the method is a pure skip, this
-    is trivially true — this test pins the invariant.
-    """
+async def test_wire_dispatchers_delegates_each_repeat_call() -> None:
+    """Repeat calls delegate to the explicit helper each time."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
 
-    first = await plugin.wire_dispatchers(config)
-    second = await plugin.wire_dispatchers(config)
+    with patch(
+        f"{_WIRING_MOD}.wire_registration_dispatchers",
+        new=AsyncMock(
+            return_value={
+                "dispatchers": ["dispatcher.registration.catalog-request"],
+                "routes": ["route.registration.catalog-request"],
+                "status": "success",
+            }
+        ),
+    ) as mock_wire:
+        first = await plugin.wire_dispatchers(config)
+        second = await plugin.wire_dispatchers(config)
 
     assert first.success is True
     assert second.success is True
-    engine = config.dispatch_engine
-    assert engine is not None
-    engine.register_dispatcher.assert_not_called()  # type: ignore[attr-defined]
+    assert mock_wire.await_count == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/auto_wiring/test_discovery.py
+++ b/tests/unit/runtime/auto_wiring/test_discovery.py
@@ -45,6 +45,7 @@ def _make_contract_yaml(
                 - "onex.evt.platform.test-input.v1"
               publish_topics:
                 - "onex.evt.platform.test-output.v1"
+              consumer_purpose: "consume"
         """)
 
     contract_path = tmp_path / "contract.yaml"
@@ -108,6 +109,44 @@ class TestParseContract:
         assert result.event_bus is not None
         assert result.event_bus.subscribe_topics == ("onex.evt.platform.test-input.v1",)
         assert result.event_bus.publish_topics == ("onex.evt.platform.test-output.v1",)
+        assert result.event_bus.consumer_purpose == "consume"
+
+    @pytest.mark.unit
+    def test_falls_back_to_legacy_handler_when_default_handler_has_no_entries(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "contract.yaml"
+        path.write_text(
+            dedent("""\
+                name: ledger_orchestrator
+                node_type: orchestrator
+                handler:
+                  module: omnimarket.handlers.ledger
+                  class: HandlerLedger
+                  input_model: omnimarket.models.ModelLedgerTickCommand
+                handler_routing:
+                  default_handler: omnimarket.handlers.ledger:HandlerLedger
+                event_bus:
+                  subscribe_topics:
+                    - onex.cmd.omnimarket.ledger-tick.v1
+                  publish_topics:
+                    - onex.cmd.omnimarket.ledger-append.v1
+            """)
+        )
+
+        result = _parse_contract(
+            contract_path=path,
+            entry_point_name="ledger_orchestrator",
+            package_name="omnimarket",
+            package_version="0.2.0",
+        )
+
+        assert result.handler_routing is not None
+        assert len(result.handler_routing.handlers) == 1
+        entry = result.handler_routing.handlers[0]
+        assert entry.handler.name == "HandlerLedger"
+        assert entry.event_model is not None
+        assert entry.event_model.name == "ModelLedgerTickCommand"
 
     @pytest.mark.unit
     def test_raises_on_non_dict_yaml(self, tmp_path: Path) -> None:

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -246,6 +246,53 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.category is EnumMessageCategory.COMMAND
 
     @pytest.mark.unit
+    def test_registration_contract_skips_generic_direct_handler_dispatcher(
+        self,
+    ) -> None:
+        """Registration auto-wiring owns subscriptions, not generic dispatchers."""
+        from omnibase_core.enums.enum_handler_resolution_outcome import (
+            EnumHandlerResolutionOutcome,
+        )
+        from omnibase_infra.enums import EnumMessageCategory
+
+        contract = _make_contract_with_event_type_alias(
+            event_model_name="ModelTopicCatalogRequest",
+            event_type_alias="platform.request-introspection",
+            message_category="COMMAND",
+            node_name="node_registration_orchestrator",
+        )
+        entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class"
+        ) as import_handler:
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+
+        import_handler.assert_not_called()
+        assert prepared.is_skip is True
+        assert prepared.category is EnumMessageCategory.COMMAND
+        assert prepared.message_types == {
+            "ModelTopicCatalogRequest",
+            "platform.request-introspection",
+        }
+        assert (
+            prepared.resolution_outcome
+            is EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+        )
+        assert "explicit dispatcher adapters" in prepared.skip_reason
+
+    @pytest.mark.unit
     def test_message_types_only_class_name_when_no_alias(self) -> None:
         """Absent event_type alias: message_types == {event_model.name} — unchanged."""
         contract = _make_contract_with_event_type_alias(

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -49,6 +49,7 @@ def _make_contract_with_event_type_alias(
     *,
     event_model_name: str,
     event_type_alias: str | None,
+    message_category: str | None = None,
     node_name: str = "node_local",
 ) -> ModelDiscoveredContract:
     event_model = ModelHandlerRef(name=event_model_name, module="fake.models")
@@ -59,6 +60,8 @@ def _make_contract_with_event_type_alias(
     }
     if event_type_alias is not None:
         entry_kwargs["event_type"] = event_type_alias
+    if message_category is not None:
+        entry_kwargs["message_category"] = message_category
 
     return ModelDiscoveredContract(
         name=node_name,
@@ -95,6 +98,15 @@ class TestModelHandlerRoutingEntryAcceptsEventType:
             event_type="platform.foo-start",
         )
         assert entry.event_type == "platform.foo-start"
+
+    @pytest.mark.unit
+    def test_message_category_can_be_set(self) -> None:
+        entry = ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name="HandlerFoo", module="fake.module"),
+            event_model=ModelHandlerRef(name="ModelFooCommand", module="fake.models"),
+            message_category="COMMAND",
+        )
+        assert entry.message_category == "COMMAND"
 
 
 class TestPrepareHandlerWiringIncludesEventTypeAlias:
@@ -196,6 +208,44 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {"ModelFooCommand"}
 
     @pytest.mark.unit
+    def test_message_category_overrides_contract_first_topic_category(self) -> None:
+        """Mixed-topic contracts must route command handlers as commands.
+
+        The registration contract subscribes to event topics first, then command
+        topics. Before this regression fix, every handler inherited the first
+        topic category, so request-introspection commands were registered as
+        event routes and DLQ'd at runtime.
+        """
+        from omnibase_infra.enums import EnumMessageCategory
+
+        contract = _make_contract_with_event_type_alias(
+            event_model_name="ModelFooCommand",
+            event_type_alias="platform.foo-start",
+            message_category="COMMAND",
+        )
+        entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
+        handler_cls = _make_zero_arg_handler_cls()
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=handler_cls,
+        ):
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+
+        assert prepared.category is EnumMessageCategory.COMMAND
+
+    @pytest.mark.unit
     def test_message_types_only_class_name_when_no_alias(self) -> None:
         """Absent event_type alias: message_types == {event_model.name} — unchanged."""
         contract = _make_contract_with_event_type_alias(
@@ -244,6 +294,7 @@ class TestContractDiscoveryParsesEventType:
                         "module": "fake.models",
                     },
                     "event_type": "platform.foo-start",
+                    "message_category": "COMMAND",
                 },
             ],
         }
@@ -252,9 +303,12 @@ class TestContractDiscoveryParsesEventType:
 
         assert len(parsed.handlers) == 1
         assert parsed.handlers[0].event_type == "platform.foo-start"
+        assert parsed.handlers[0].message_category == "COMMAND"
 
     @pytest.mark.unit
-    def test_parse_handler_routing_defaults_event_type_to_none(self) -> None:
+    def test_parse_handler_routing_defaults_event_type_and_category_to_none(
+        self,
+    ) -> None:
         from omnibase_infra.runtime.auto_wiring.discovery import _parse_handler_routing
 
         hr_raw = {
@@ -270,3 +324,4 @@ class TestContractDiscoveryParsesEventType:
         parsed = _parse_handler_routing(hr_raw)
 
         assert parsed.handlers[0].event_type is None
+        assert parsed.handlers[0].message_category is None

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -181,7 +181,15 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
 
     @pytest.mark.unit
     def test_message_types_omits_alias_when_only_whitespace(self) -> None:
-        """A whitespace-only alias reduces to empty and is not registered."""
+        """A whitespace-only alias reduces to empty and the topic-derived
+        alias is registered instead.
+
+        The contract supplies subscribe_topics=("onex.cmd.platform.foo-start.v1",)
+        so when the explicit event_type alias is empty after stripping, the
+        wiring derives the routing alias from the topic suffix
+        ("platform.foo-start") to match the dispatch-engine envelope rewrite
+        introduced in OMN-9648 (derive auto-wired event types from topic).
+        """
         contract = _make_contract_with_event_type_alias(
             event_model_name="ModelFooCommand",
             event_type_alias="   ",
@@ -205,7 +213,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand"}
+        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
 
     @pytest.mark.unit
     def test_message_category_overrides_contract_first_topic_category(self) -> None:
@@ -293,8 +301,15 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert "explicit dispatcher adapters" in prepared.skip_reason
 
     @pytest.mark.unit
-    def test_message_types_only_class_name_when_no_alias(self) -> None:
-        """Absent event_type alias: message_types == {event_model.name} — unchanged."""
+    def test_message_types_includes_topic_derived_alias_when_no_explicit_alias(
+        self,
+    ) -> None:
+        """Absent event_type alias: message_types is augmented by the topic
+        suffix-derived alias for each subscribe topic, so installed market
+        package handlers can route envelopes that arrive with the
+        topic-derived event_type set by the dispatch-engine envelope rewrite
+        (OMN-9648). Class-name remains as a fallback key.
+        """
         contract = _make_contract_with_event_type_alias(
             event_model_name="ModelFooCommand",
             event_type_alias=None,
@@ -318,7 +333,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand"}
+        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
 
 
 class TestContractDiscoveryParsesEventType:

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
+from pydantic import BaseModel
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _derive_dispatcher_id,
@@ -36,6 +38,16 @@ from omnibase_infra.runtime.auto_wiring.report import (
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+class FakeTypedPayload(BaseModel):
+    correlation_id: UUID
+    value: str
+
+
+class FakeTypedOutput(BaseModel):
+    correlation_id: UUID
+    result: str
 
 
 def _make_contract_version() -> ModelContractVersion:
@@ -70,6 +82,7 @@ def _make_contract(
     subscribe_topics: tuple[str, ...] = ("onex.evt.platform.test-input.v1",),
     publish_topics: tuple[str, ...] = (),
     handler_routing: ModelHandlerRouting | None = None,
+    consumer_purpose: str | None = None,
 ) -> ModelDiscoveredContract:
     return ModelDiscoveredContract(
         name=name,
@@ -81,6 +94,7 @@ def _make_contract(
         event_bus=ModelEventBusWiring(
             subscribe_topics=subscribe_topics,
             publish_topics=publish_topics,
+            consumer_purpose=consumer_purpose,
         ),
         handler_routing=handler_routing,
     )
@@ -190,6 +204,50 @@ class TestMakeDispatchCallback:
         handler.handle.assert_called_once_with(envelope)
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_callback_validates_typed_payload_and_normalizes_sync_result(
+        self,
+    ) -> None:
+        received: list[FakeTypedPayload] = []
+
+        class Handler:
+            def handle(self, payload: FakeTypedPayload) -> FakeTypedOutput:
+                received.append(payload)
+                return FakeTypedOutput(
+                    correlation_id=payload.correlation_id,
+                    result=f"handled:{payload.value}",
+                )
+
+        correlation_id = UUID("11111111-1111-4111-8111-111111111111")
+        callback = _make_dispatch_callback(
+            Handler(),
+            ModelHandlerRef(
+                name="FakeTypedPayload",
+                module=__name__,
+            ),
+        )
+
+        result = await callback(
+            {
+                "payload": {
+                    "correlation_id": str(correlation_id),
+                    "value": "market",
+                },
+                "__debug_trace": {
+                    "topic": "onex.cmd.omnimarket.ledger-tick.v1",
+                    "correlation_id": str(correlation_id),
+                },
+            }
+        )
+
+        assert len(received) == 1
+        assert received[0].value == "market"
+        assert result is not None
+        assert result.correlation_id == correlation_id
+        assert len(result.output_events) == 1
+        assert isinstance(result.output_events[0], FakeTypedOutput)
+        assert result.output_events[0].result == "handled:market"
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: duplicate detection
@@ -282,6 +340,54 @@ class TestWireFromManifest:
         assert report.total_skipped == 1
 
     @pytest.mark.asyncio
+    async def test_skip_raw_projection_consumer_purpose(self) -> None:
+        contract = _make_contract(
+            name="node_ledger_projection_compute",
+            consumer_purpose="audit",
+            handler_routing=_make_handler_routing(
+                handler_name="HandlerLedgerProjection",
+                handler_module="fake.module",
+            ),
+        )
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MagicMock()
+
+        report = await wire_from_manifest(manifest, engine)
+
+        assert report.total_skipped == 1
+        assert report.total_wired == 0
+        assert report.results[0].outcome == EnumWiringOutcome.SKIPPED
+        assert "raw event projection wiring" in str(report.results[0].reason)
+
+    @pytest.mark.asyncio
+    async def test_skip_raw_projection_before_container_preresolve(self) -> None:
+        contract = _make_contract(
+            name="node_ledger_projection_compute",
+            consumer_purpose="audit",
+            handler_routing=_make_handler_routing(
+                handler_name="HandlerLedgerProjection",
+                handler_module="fake.module",
+            ),
+        )
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+
+        class FakeContainer:
+            async def get_service_async(self, handler_cls: type) -> object | None:
+                return None
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class"
+        ) as import_handler:
+            report = await wire_from_manifest(
+                manifest,
+                MagicMock(),
+                container=FakeContainer(),
+            )
+
+        assert report.total_skipped == 1
+        import_handler.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_wire_success(self) -> None:
         """Test successful wiring with a mock handler class."""
         from omnibase_infra.runtime.service_message_dispatch_engine import (
@@ -314,6 +420,43 @@ class TestWireFromManifest:
         assert report.total_failed == 0
         assert len(report.results[0].dispatchers_registered) == 1
         assert len(report.results[0].routes_registered) >= 1
+
+    @pytest.mark.asyncio
+    async def test_container_miss_after_async_preresolve_falls_through_to_zero_arg(
+        self,
+    ) -> None:
+        """Unregistered zero-arg handlers must not re-enter sync container lookup."""
+        from omnibase_infra.runtime.service_message_dispatch_engine import (
+            MessageDispatchEngine,
+        )
+
+        handler_routing = _make_handler_routing(
+            handler_name="FakeHandler",
+            handler_module="fake.module",
+        )
+        contract = _make_contract(handler_routing=handler_routing)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        class FakeContainer:
+            get_service = MagicMock(side_effect=RuntimeError("asyncio.run blocked"))
+
+            async def get_service_async(self, handler_cls: type) -> object | None:
+                return None
+
+        class FakeHandler:
+            async def handle(self, envelope: object) -> None:
+                return None
+
+        container = FakeContainer()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=FakeHandler,
+        ):
+            report = await wire_from_manifest(manifest, engine, container=container)
+
+        assert report.total_wired == 1
+        container.get_service.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_wire_failure_import_error_strict_mode_raises(self) -> None:

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -7,6 +7,7 @@ These tests were written BEFORE the fix and must fail on the unfixed codebase.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -399,3 +400,67 @@ class TestMakeEventBusCallbackFallbackPath:
 
         assert len(heartbeat_handlers) == 1
         assert heartbeat_handlers[0]["event_type"] == "platform.node-heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_callback_waits_for_dispatch_engine_freeze(self) -> None:
+        """Startup messages must not dispatch before the engine is frozen."""
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        class FakeDispatchEngine:
+            def __init__(self) -> None:
+                self.is_frozen = False
+                self.dispatch = AsyncMock()
+
+        dispatch_engine = FakeDispatchEngine()
+        callback = _make_event_bus_callback(
+            "onex.cmd.test.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+        )
+        envelope = ModelEventEnvelope[object].model_construct(
+            event_type="onex.cmd.test.v1",
+            payload={},
+        )
+
+        task = asyncio.create_task(callback(envelope))
+        await asyncio.sleep(0.2)
+        dispatch_engine.dispatch.assert_not_called()
+
+        dispatch_engine.is_frozen = True
+        await asyncio.wait_for(task, timeout=2)
+
+        dispatch_engine.dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_callback_drops_after_freeze_wait_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A permanently unfrozen engine should not raise from the callback boundary."""
+        from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _make_event_bus_callback,
+        )
+
+        class FakeDispatchEngine:
+            is_frozen = False
+
+            def __init__(self) -> None:
+                self.dispatch = AsyncMock()
+
+        monkeypatch.setenv("ONEX_DISPATCH_FREEZE_WAIT_TIMEOUT_SECONDS", "0.1")
+        dispatch_engine = FakeDispatchEngine()
+        callback = _make_event_bus_callback(
+            "onex.cmd.test.v1",
+            dispatch_engine,  # type: ignore[arg-type]
+        )
+        envelope = ModelEventEnvelope[object].model_construct(
+            event_type="onex.cmd.test.v1",
+            payload={},
+        )
+
+        await callback(envelope)
+
+        dispatch_engine.dispatch.assert_not_called()

--- a/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring_subscribe.py
@@ -464,3 +464,18 @@ class TestMakeEventBusCallbackFallbackPath:
         await callback(envelope)
 
         dispatch_engine.dispatch.assert_not_called()
+
+    @pytest.mark.unit
+    def test_freeze_wait_timeout_rejects_non_finite_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-finite timeout values must fall back instead of disabling timeout."""
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _dispatch_freeze_wait_timeout_seconds,
+        )
+
+        for raw in ("nan", "inf", "-inf"):
+            monkeypatch.setenv("ONEX_DISPATCH_FREEZE_WAIT_TIMEOUT_SECONDS", raw)
+
+            assert _dispatch_freeze_wait_timeout_seconds() == 900.0

--- a/tests/unit/runtime/test_container_wiring_registration.py
+++ b/tests/unit/runtime/test_container_wiring_registration.py
@@ -82,6 +82,7 @@ class TestWireRegistrationHandlers:
         assert HandlerRuntimeTick in registered_interfaces
         assert HandlerNodeRegistrationAcked in registered_interfaces
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_registers_heartbeat_under_concrete_and_protocol_interfaces(
         self,

--- a/tests/unit/runtime/test_container_wiring_registration.py
+++ b/tests/unit/runtime/test_container_wiring_registration.py
@@ -83,6 +83,38 @@ class TestWireRegistrationHandlers:
         assert HandlerNodeRegistrationAcked in registered_interfaces
 
     @pytest.mark.asyncio
+    async def test_registers_heartbeat_under_concrete_and_protocol_interfaces(
+        self,
+    ) -> None:
+        """Heartbeat must be pre-resolvable by concrete class for auto-wiring."""
+        from omnibase_infra.nodes.node_registration_orchestrator.handlers import (
+            HandlerNodeHeartbeat,
+        )
+        from omnibase_infra.protocols.protocol_node_heartbeat import (
+            ProtocolNodeHeartbeat,
+        )
+
+        registered_interfaces: list[type] = []
+
+        async def capture_register(interface: type, **kwargs) -> None:
+            registered_interfaces.append(interface)
+
+        mock_registry = MagicMock()
+        mock_registry.register_instance = AsyncMock(side_effect=capture_register)
+
+        mock_container = MagicMock()
+        mock_container.service_registry = mock_registry
+
+        await wire_registration_handlers(
+            mock_container,
+            MagicMock(),
+            projector=MagicMock(),
+        )
+
+        assert HandlerNodeHeartbeat in registered_interfaces
+        assert ProtocolNodeHeartbeat in registered_interfaces
+
+    @pytest.mark.asyncio
     async def test_custom_liveness_interval_passed_to_handler(self) -> None:
         """Test that custom liveness interval is passed to ack handler."""
         # Track registration calls

--- a/tests/unit/runtime/test_node_subscription_wiring.py
+++ b/tests/unit/runtime/test_node_subscription_wiring.py
@@ -202,6 +202,49 @@ class TestPackageNodeSubscriptionWiring:
         assert skipped_no_topics == 2
 
     @pytest.mark.asyncio
+    async def test_raw_projection_consumer_purpose_not_wired(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """Audit/projection consumers require a raw-message projection path."""
+        node = tmp_path / "nodes" / "node_audit_projection" / "contract.yaml"
+        node.parent.mkdir(parents=True)
+        node.write_text(
+            textwrap.dedent("""\
+            name: "node_audit_projection"
+            node_type: "COMPUTE_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.evt.platform.node-heartbeat.v1"
+              consumer_purpose: "audit"
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+
+        (
+            wired,
+            _skipped_existing,
+            skipped_no_topics,
+        ) = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 0
+        assert skipped_no_topics == 1
+        mock_event_bus_wiring.wire_subscriptions.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_subscription_wiring_is_idempotent(
         self, tmp_nodes_dir: Path, mock_event_bus_wiring: MagicMock
     ) -> None:

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -1420,6 +1420,25 @@ class TestRuntimeHostProcessHealthCheck:
         assert health["is_running"] is False
 
     @pytest.mark.asyncio
+    async def test_health_check_degraded_while_starting(self) -> None:
+        """Test that health_check reports degraded liveness during startup."""
+
+        process = RuntimeHostProcess(config=make_runtime_config())
+        process._is_starting = True
+
+        with patch.object(
+            process._event_bus,
+            "health_check",
+            AsyncMock(return_value={"healthy": True}),
+        ):
+            health = await process.health_check()
+
+        assert health["healthy"] is False
+        assert health["degraded"] is True
+        assert health["startup_in_progress"] is True
+        assert health["is_running"] is False
+
+    @pytest.mark.asyncio
     async def test_health_check_includes_handler_health(
         self,
         mock_handler: MockHandler,
@@ -1810,24 +1829,30 @@ class TestRuntimeHostProcessLogWarnings:
             async def noop_populate() -> None:
                 pass
 
+            async def noop_prefetch() -> None:
+                process._config_prefetch_status = "skipped"
+
             with patch.object(
                 process, "_populate_handlers_from_registry", noop_populate
             ):
-                with patch.object(process, "_handlers", {"http": mock_handler}):
-                    await process.start()
+                with patch.object(
+                    process, "_prefetch_config_from_infisical", noop_prefetch
+                ):
+                    with patch.object(process, "_handlers", {"http": mock_handler}):
+                        await process.start()
 
-                    try:
-                        # Normal operation - process an envelope
-                        await process._handle_envelope(
-                            {
-                                "operation": "http.get",
-                                "payload": {"url": "https://example.com"},
-                                "correlation_id": uuid4(),
-                                "handler_type": "http",
-                            }
-                        )
-                    finally:
-                        await process.stop()
+                        try:
+                            # Normal operation - process an envelope
+                            await process._handle_envelope(
+                                {
+                                    "operation": "http.get",
+                                    "payload": {"url": "https://example.com"},
+                                    "correlation_id": uuid4(),
+                                    "handler_type": "http",
+                                }
+                            )
+                        finally:
+                            await process.stop()
 
         # Filter for warnings from our module
         runtime_warnings = filter_handler_warnings(caplog.records, self.RUNTIME_MODULE)

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -786,6 +786,36 @@ class TestRuntimeHostProcessLifecycle:
 
         assert process.is_running is False
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_stop_cancels_in_progress_startup_before_shutdown(self) -> None:
+        """stop() must not tear resources down while startup keeps running."""
+
+        process = RuntimeHostProcess(config=make_runtime_config())
+        startup_entered = asyncio.Event()
+        startup_cancelled = asyncio.Event()
+        never_complete = asyncio.Event()
+
+        async def blocking_start_runtime() -> None:
+            startup_entered.set()
+            try:
+                await never_complete.wait()
+            except asyncio.CancelledError:
+                startup_cancelled.set()
+                raise
+
+        with patch.object(process, "_start_runtime", blocking_start_runtime):
+            start_task = asyncio.create_task(process.start())
+            await startup_entered.wait()
+
+            await process.stop()
+            await start_task
+
+        assert startup_cancelled.is_set()
+        assert process._startup_task is None
+        assert process._is_starting is False
+        assert process.is_running is False
+
     @pytest.mark.asyncio
     async def test_stop_calls_shutdown_on_all_handlers(self) -> None:
         """Test that stop() calls shutdown() on all registered handlers.

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -809,7 +809,7 @@ class TestRuntimeHostProcessLifecycle:
             await startup_entered.wait()
 
             await process.stop()
-            await start_task
+            _ = await start_task
 
         assert startup_cancelled.is_set()
         assert process._startup_task is None

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -809,7 +809,9 @@ class TestRuntimeHostProcessLifecycle:
             await startup_entered.wait()
 
             await process.stop()
-            await start_task  # codeql[py/ineffectual-statement]
+            # Drain the start_task after stop() so its done state is observable.
+            done, _pending = await asyncio.wait({start_task})
+            assert start_task in done
 
         assert startup_cancelled.is_set()
         assert process._startup_task is None

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -809,7 +809,7 @@ class TestRuntimeHostProcessLifecycle:
             await startup_entered.wait()
 
             await process.stop()
-            _ = await start_task
+            await start_task  # codeql[py/ineffectual-statement]
 
         assert startup_cancelled.is_set()
         assert process._startup_task is None

--- a/tests/unit/runtime/test_service_health.py
+++ b/tests/unit/runtime/test_service_health.py
@@ -344,6 +344,7 @@ class TestServiceHealthEndpoints:
         assert len(transition_logs) == 1
         assert transition_logs[0].kwargs["extra"]["runtime_attached"] is False
         assert transition_logs[0].kwargs["extra"]["startup_in_progress"] is True
+        assert transition_logs[0].kwargs["extra"]["is_running"] is False
 
     @pytest.mark.asyncio
     async def test_health_endpoint_treats_attached_startup_as_degraded(self) -> None:

--- a/tests/unit/runtime/test_service_health.py
+++ b/tests/unit/runtime/test_service_health.py
@@ -295,6 +295,81 @@ class TestServiceHealthEndpoints:
         assert '"status":"unhealthy"' in response_text
         assert "Health check failed" in response_text
 
+    @pytest.mark.asyncio
+    async def test_health_endpoint_logs_startup_transition_once(self) -> None:
+        """Test /health logs startup transition only once for repeated probes."""
+        mock_runtime = MagicMock()
+        mock_runtime.health_check = AsyncMock(
+            return_value={
+                "healthy": False,
+                "degraded": True,
+                "startup_in_progress": True,
+                "is_running": False,
+                "event_bus_healthy": True,
+            }
+        )
+
+        server = ServiceHealth(runtime=mock_runtime, version="1.0.0")
+        mock_request = MagicMock(spec=web.Request)
+
+        with patch("omnibase_infra.services.service_health.logger.info") as mock_info:
+            await server._handle_health(mock_request)
+            await server._handle_health(mock_request)
+
+        transition_logs = [
+            call
+            for call in mock_info.call_args_list
+            if call.args and call.args[0] == "ServiceHealth health probe state changed"
+        ]
+        assert len(transition_logs) == 1
+        assert transition_logs[0].kwargs["extra"]["startup_in_progress"] is True
+        assert transition_logs[0].kwargs["extra"]["event_bus_healthy"] is True
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_logs_runtime_pending_transition(self) -> None:
+        """Test /health logs the pre-attachment startup phase."""
+        mock_container = MagicMock()
+        server = ServiceHealth(container=mock_container)
+        mock_request = MagicMock(spec=web.Request)
+
+        with patch("omnibase_infra.services.service_health.logger.info") as mock_info:
+            response = await server._handle_health(mock_request)
+
+        assert response.status == 200
+        transition_logs = [
+            call
+            for call in mock_info.call_args_list
+            if call.args and call.args[0] == "ServiceHealth health probe state changed"
+        ]
+        assert len(transition_logs) == 1
+        assert transition_logs[0].kwargs["extra"]["runtime_attached"] is False
+        assert transition_logs[0].kwargs["extra"]["startup_in_progress"] is True
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_treats_attached_startup_as_degraded(self) -> None:
+        """Test /health returns degraded 200 during attached startup fallback."""
+        mock_runtime = MagicMock()
+        mock_runtime.health_check = AsyncMock(
+            return_value={
+                "healthy": False,
+                "degraded": False,
+                "is_running": False,
+                "event_bus_healthy": True,
+            }
+        )
+
+        server = ServiceHealth(runtime=mock_runtime, version="1.0.0")
+        mock_request = MagicMock(spec=web.Request)
+
+        response = await server._handle_health(mock_request)
+
+        assert response.status == 200
+        response_text = response.text
+        assert response_text is not None
+        assert '"status":"degraded"' in response_text
+        assert '"startup_in_progress":true' in response_text
+        assert '"degraded":true' in response_text
+
 
 @pytest.mark.unit
 class TestServiceHealthIntegration:
@@ -877,27 +952,34 @@ class TestServiceHealthContainerInjection:
         assert server.container is server.container
 
     @pytest.mark.asyncio
-    async def test_health_endpoint_raises_when_runtime_not_resolved(self) -> None:
-        """Test health endpoint behavior when runtime was never resolved.
-
-        When ServiceHealth is initialized with container-only (no runtime)
-        and create_from_container was not used, the health endpoint should
-        raise ProtocolConfigurationError when trying to access runtime.
-        """
+    async def test_health_endpoint_degrades_when_runtime_not_resolved(self) -> None:
+        """Container-only startup should still expose a live /health endpoint."""
         mock_container = MagicMock(spec=ModelONEXContainer)
         server = ServiceHealth(container=mock_container)
+        server._is_running = True
 
         mock_request = MagicMock(spec=web.Request)
 
-        # Health endpoint should return 503 with error details
         response = await server._handle_health(mock_request)
 
-        assert response.status == 503
+        assert response.status == 200
         response_text = response.text
         assert response_text is not None
-        assert '"status":"unhealthy"' in response_text
-        # The error should mention runtime not available
-        assert "RuntimeHostProcess not available" in response_text
+        assert '"status":"degraded"' in response_text
+        assert '"runtime_attached":false' in response_text
+        assert '"startup_phase":"runtime_pending"' in response_text
+
+    def test_attach_runtime_sets_runtime_for_later_checks(self) -> None:
+        """attach_runtime should support early health bind before runtime creation."""
+        mock_container = MagicMock(spec=ModelONEXContainer)
+        mock_runtime = MagicMock()
+
+        server = ServiceHealth(container=mock_container)
+        assert server._runtime is None
+
+        server.attach_runtime(mock_runtime)
+
+        assert server.runtime is mock_runtime
 
     @pytest.mark.asyncio
     async def test_container_with_service_registry_returning_wrong_type(self) -> None:

--- a/tests/unit/runtime/test_service_health.py
+++ b/tests/unit/runtime/test_service_health.py
@@ -347,12 +347,13 @@ class TestServiceHealthEndpoints:
 
     @pytest.mark.asyncio
     async def test_health_endpoint_treats_attached_startup_as_degraded(self) -> None:
-        """Test /health returns degraded 200 during attached startup fallback."""
+        """Test /health returns degraded 200 when runtime reports startup_in_progress."""
         mock_runtime = MagicMock()
         mock_runtime.health_check = AsyncMock(
             return_value={
                 "healthy": False,
-                "degraded": False,
+                "degraded": True,
+                "startup_in_progress": True,
                 "is_running": False,
                 "event_bus_healthy": True,
             }


### PR DESCRIPTION
## Summary
Closes OMN-9741.

[skip-receipt-gate: runtime liveness fix — OMN-9741 ticket was created after the branch; dod_evidence in PR body below]

- Treat runtime startup with a healthy event bus as degraded liveness over HTTP 200 so Docker/autoheal does not recycle a live effects process during long subscription startup.
- Keep strict readiness on `/ready` and expose `startup_in_progress` in health details.
- Extend runtime-effects health and autoheal windows to match measured .201 startup behavior.
- Fix: stop() now logs a warning when called during startup instead of silently returning (CodeRabbit CR1)
- Fix: remove redundant event_bus_healthy inference in _handle_health — runtime already sets startup_in_progress (CodeRabbit CR2)

## Verification
- `uv run pytest tests/unit/runtime/test_service_health.py tests/unit/runtime/test_runtime_host_process.py -q` -> 144 passed
- `uv run pytest tests/integration/test_omn_9741_health_liveness.py -v` -> 3 passed
- `uv run ruff check src/omnibase_infra/services/service_health.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_service_health.py tests/integration/test_omn_9741_health_liveness.py`
- `docker compose -f docker/docker-compose.infra.yml config --quiet`
- `git diff --check`

## Runtime evidence
- .201 `8085/health`: healthy, running, config_prefetch_status=ok
- .201 `8086/health`: healthy, running, config_prefetch_status=ok
- .201 autoheal: healthy

Related plan: omni_home docs/plans/2026-04-25-platform-hardening-and-correctness.md Track E3c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-handler message category support for routing and improved wiring behavior that ensures concrete heartbeat handler registration.

* **Bug Fixes**
  * Health endpoint now reports degraded (200) during startup windows and avoids false unhealthy reports; startup progress is exposed.

* **Chores**
  * Increased container memory allocations and extended startup/health grace periods (including autoheal).

* **Tests**
  * Added unit and integration tests covering startup liveness, health transitions, wiring, and dispatch freeze behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->