### PR TITLE
feat(OMN-9633): add remote task state repository

### DIFF
--- a/docker/migrations/forward/069_create_remote_task_state.sql
+++ b/docker/migrations/forward/069_create_remote_task_state.sql
@@ -1,0 +1,63 @@
+-- Migration: 069_create_remote_task_state
+-- Description: Persisted remote task lifecycle state for A2A delegation bridge resumption.
+-- Idempotency: CREATE TABLE/INDEX use IF NOT EXISTS; safe to re-apply.
+
+CREATE TABLE IF NOT EXISTS remote_task_state (
+    task_id                  UUID         NOT NULL,
+    invocation_kind          TEXT         NOT NULL,
+    protocol                 TEXT,
+    target_ref               TEXT         NOT NULL,
+    remote_task_handle       TEXT,
+    correlation_id           UUID         NOT NULL,
+    status                   TEXT         NOT NULL,
+    last_remote_status       TEXT,
+    last_emitted_event_type  TEXT,
+    submitted_at             TIMESTAMPTZ  NOT NULL,
+    updated_at               TIMESTAMPTZ  NOT NULL,
+    completed_at             TIMESTAMPTZ,
+    error                    TEXT,
+
+    CONSTRAINT pk_remote_task_state PRIMARY KEY (task_id),
+    CONSTRAINT chk_remote_task_state_invocation_kind
+        CHECK (invocation_kind IN ('agent', 'model')),
+    CONSTRAINT chk_remote_task_state_protocol
+        CHECK (protocol IS NULL OR protocol IN ('A2A')),
+    CONSTRAINT chk_remote_task_state_status
+        CHECK (
+            status IN (
+                'SUBMITTED',
+                'ACCEPTED',
+                'PROGRESS',
+                'ARTIFACT',
+                'COMPLETED',
+                'FAILED',
+                'TIMED_OUT',
+                'CANCELED'
+            )
+        ),
+    CONSTRAINT chk_remote_task_state_last_emitted
+        CHECK (
+            last_emitted_event_type IS NULL OR last_emitted_event_type IN (
+                'SUBMITTED',
+                'ACCEPTED',
+                'PROGRESS',
+                'ARTIFACT',
+                'COMPLETED',
+                'FAILED',
+                'TIMED_OUT',
+                'CANCELED'
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_task_state_status
+    ON remote_task_state (status);
+
+CREATE INDEX IF NOT EXISTS idx_remote_task_state_correlation_id
+    ON remote_task_state (correlation_id);
+
+UPDATE public.db_metadata
+SET migrations_complete = TRUE,
+    schema_version = '069',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/rollback/rollback_069_create_remote_task_state.sql
+++ b/docker/migrations/rollback/rollback_069_create_remote_task_state.sql
@@ -1,0 +1,8 @@
+-- ROLLBACK: Drop remote_task_state table
+
+DROP TABLE IF EXISTS remote_task_state;
+
+UPDATE public.db_metadata
+SET schema_version = '068',
+    updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,9 +166,9 @@ override-dependencies = [
 [tool.uv.sources]
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
-# Pinned to core main post-OMN-9196 (resolver models + enum_handler_resolution_outcome).
-# PyPI release v0.39.0 (2026-04-06) predates PR 846 — switch back after v0.40.0 ships.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "9d64d5a3944477093824a53ca931fd17a4b6a8e1" }
+# Pinned to core main post-OMN-9637 (delegation models — ModelRemoteTaskState et al.).
+# PyPI release v0.39.0 (2026-04-06) predates PR 912 — switch back after v0.40.0 ships.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "6a65f885303e29b4ddc36a66a0cb860537f47316" }
 # Pinned to spi main post-OMN-9197 (ProtocolHandlerResolver + ProtocolHandlerOwnershipQuery).
 # PyPI release v0.20.4 (2026-04-03) predates PR 186 — switch back after v0.20.5 ships.
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", rev = "a9380008fb4a2f2a784d374389260d896455c3b2" }

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/__init__.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Persistence helpers for node_remote_agent_invoke_effect."""
+
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.persistence.remote_task_state_repository import (
+    RemoteTaskStateRepository,
+)
+
+__all__ = ["RemoteTaskStateRepository"]

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
@@ -216,13 +216,20 @@ class RemoteTaskStateRepository(MixinPostgresOpExecutor):
         if backend_result.success:
             return result_holder["value"]
 
+        retriable: bool | None = None
+        if backend_result.error_code is not None:
+            try:
+                retriable = EnumPostgresErrorCode(
+                    backend_result.error_code
+                ).is_retriable
+            except ValueError:
+                retriable = None
+
         raise RepositoryExecutionError(
             backend_result.error or f"{op_name} failed",
             op_name=op_name,
             table="remote_task_state",
-            retriable=backend_result.error_code.is_retriable
-            if backend_result.error_code is not None
-            else None,
+            retriable=retriable,
             context=self._context(correlation_id, op_name),
         )
 

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""PostgreSQL persistence for remote agent task state."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, TypeVar, cast
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_infra.enums import EnumInfraTransportType, EnumPostgresErrorCode
+from omnibase_infra.errors import ModelInfraErrorContext, RepositoryExecutionError
+from omnibase_infra.mixins.mixin_postgres_op_executor import MixinPostgresOpExecutor
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+SQL_UPSERT_REMOTE_TASK_STATE = """
+INSERT INTO remote_task_state (
+    task_id,
+    invocation_kind,
+    protocol,
+    target_ref,
+    remote_task_handle,
+    correlation_id,
+    status,
+    last_remote_status,
+    last_emitted_event_type,
+    submitted_at,
+    updated_at,
+    completed_at,
+    error
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+)
+ON CONFLICT (task_id) DO UPDATE SET
+    invocation_kind = EXCLUDED.invocation_kind,
+    protocol = EXCLUDED.protocol,
+    target_ref = EXCLUDED.target_ref,
+    remote_task_handle = EXCLUDED.remote_task_handle,
+    correlation_id = EXCLUDED.correlation_id,
+    status = EXCLUDED.status,
+    last_remote_status = EXCLUDED.last_remote_status,
+    last_emitted_event_type = EXCLUDED.last_emitted_event_type,
+    submitted_at = EXCLUDED.submitted_at,
+    updated_at = EXCLUDED.updated_at,
+    completed_at = EXCLUDED.completed_at,
+    error = EXCLUDED.error
+RETURNING task_id
+"""
+
+SQL_GET_REMOTE_TASK_STATE = """
+SELECT
+    task_id,
+    invocation_kind,
+    protocol,
+    target_ref,
+    remote_task_handle,
+    correlation_id,
+    status,
+    last_remote_status,
+    last_emitted_event_type,
+    submitted_at,
+    updated_at,
+    completed_at,
+    error
+FROM remote_task_state
+WHERE task_id = $1
+"""
+
+SQL_LOAD_UNFINISHED_REMOTE_TASK_STATES = """
+SELECT
+    task_id,
+    invocation_kind,
+    protocol,
+    target_ref,
+    remote_task_handle,
+    correlation_id,
+    status,
+    last_remote_status,
+    last_emitted_event_type,
+    submitted_at,
+    updated_at,
+    completed_at,
+    error
+FROM remote_task_state
+WHERE status NOT IN ('COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELED')
+ORDER BY submitted_at ASC
+"""
+
+
+class RemoteTaskStateRepository(MixinPostgresOpExecutor):
+    """Persistence adapter for restart-safe remote task resumption."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def upsert(
+        self,
+        state: ModelRemoteTaskState,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> None:
+        op_correlation_id = correlation_id or state.correlation_id
+
+        async def _op() -> None:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    SQL_UPSERT_REMOTE_TASK_STATE,
+                    state.task_id,
+                    state.invocation_kind.value,
+                    state.protocol.value if state.protocol is not None else None,
+                    state.target_ref,
+                    state.remote_task_handle,
+                    state.correlation_id,
+                    state.status.value,
+                    state.last_remote_status,
+                    (
+                        state.last_emitted_event_type.value
+                        if state.last_emitted_event_type is not None
+                        else None
+                    ),
+                    state.submitted_at,
+                    state.updated_at,
+                    state.completed_at,
+                    state.error,
+                )
+            if row is None:
+                raise RepositoryExecutionError(
+                    "remote_task_state upsert returned no row",
+                    op_name="upsert_remote_task_state",
+                    table="remote_task_state",
+                    sql_fingerprint="INSERT INTO remote_task_state ... ON CONFLICT (task_id) DO UPDATE",
+                    context=self._context(
+                        op_correlation_id, "upsert_remote_task_state"
+                    ),
+                )
+
+        await self._run_checked(
+            correlation_id=op_correlation_id,
+            op_name="upsert_remote_task_state",
+            log_context={"task_id": str(state.task_id)},
+            fn=_op,
+        )
+
+    async def get(
+        self,
+        task_id: UUID,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> ModelRemoteTaskState | None:
+        row = await self._run_checked(
+            correlation_id=correlation_id or uuid4(),
+            op_name="get_remote_task_state",
+            log_context={"task_id": str(task_id)},
+            fn=lambda: self._fetchrow(SQL_GET_REMOTE_TASK_STATE, task_id),
+        )
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    async def load_unfinished(
+        self,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> list[ModelRemoteTaskState]:
+        rows = await self._run_checked(
+            correlation_id=correlation_id or uuid4(),
+            op_name="load_unfinished_remote_task_states",
+            log_context={"table": "remote_task_state"},
+            fn=lambda: self._fetch(SQL_LOAD_UNFINISHED_REMOTE_TASK_STATES),
+        )
+        return [self._row_to_model(row) for row in rows]
+
+    async def _fetchrow(
+        self,
+        sql: str,
+        *params: object,
+    ) -> asyncpg.Record | None:
+        async with self._pool.acquire() as conn:
+            return await conn.fetchrow(sql, *params)
+
+    async def _fetch(
+        self,
+        sql: str,
+        *params: object,
+    ) -> Sequence[asyncpg.Record]:
+        async with self._pool.acquire() as conn:
+            return cast("Sequence[asyncpg.Record]", await conn.fetch(sql, *params))
+
+    async def _run_checked(
+        self,
+        *,
+        correlation_id: UUID,
+        op_name: str,
+        log_context: dict[str, object],
+        fn: Callable[[], Awaitable[T]],
+    ) -> T:
+        result_holder: dict[str, T] = {}
+
+        async def _wrapped() -> None:
+            result_holder["value"] = await fn()
+
+        backend_result = await self._execute_postgres_op(
+            op_error_code=EnumPostgresErrorCode.UPSERT_ERROR,
+            correlation_id=correlation_id,
+            log_context=log_context,
+            fn=_wrapped,
+        )
+        if backend_result.success:
+            return result_holder["value"]
+
+        raise RepositoryExecutionError(
+            backend_result.error or f"{op_name} failed",
+            op_name=op_name,
+            table="remote_task_state",
+            retriable=backend_result.error_code.is_retriable
+            if backend_result.error_code is not None
+            else None,
+            context=self._context(correlation_id, op_name),
+        )
+
+    def _context(
+        self,
+        correlation_id: UUID,
+        operation: str,
+    ) -> ModelInfraErrorContext:
+        return ModelInfraErrorContext(
+            transport_type=EnumInfraTransportType.DATABASE,
+            operation=operation,
+            correlation_id=correlation_id,
+            target_name="remote_task_state",
+        )
+
+    @staticmethod
+    def _row_to_model(row: asyncpg.Record) -> ModelRemoteTaskState:
+        return ModelRemoteTaskState.model_validate(dict(row))
+
+
+__all__ = ["RemoteTaskStateRepository"]

--- a/tests/integration/db/test_remote_task_state_repository.py
+++ b/tests/integration/db/test_remote_task_state_repository.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for RemoteTaskStateRepository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.persistence import (
+    RemoteTaskStateRepository,
+)
+from tests.helpers.util_postgres import PostgresConfig
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres, pytest.mark.asyncio]
+
+MIGRATION_SQL = (
+    Path(__file__).resolve().parents[3]
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "069_create_remote_task_state.sql"
+).read_text()
+
+
+@pytest.fixture
+async def postgres_pool():
+    config = PostgresConfig.from_env()
+    if not config.is_configured:
+        pytest.skip(
+            "PostgreSQL not configured (set OMNIBASE_INFRA_DB_URL or POSTGRES_HOST/POSTGRES_PASSWORD)"
+        )
+
+    import asyncpg
+
+    pool = await asyncpg.create_pool(
+        config.build_dsn(), min_size=1, max_size=5, timeout=10.0
+    )
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(MIGRATION_SQL)
+            await conn.execute("TRUNCATE TABLE remote_task_state")
+        yield pool
+    finally:
+        await pool.close()
+
+
+def _row(*, status: EnumAgentTaskLifecycleType) -> ModelRemoteTaskState:
+    now = datetime.now(UTC)
+    completed_at = (
+        now
+        if status
+        in {
+            EnumAgentTaskLifecycleType.COMPLETED,
+            EnumAgentTaskLifecycleType.FAILED,
+            EnumAgentTaskLifecycleType.TIMED_OUT,
+            EnumAgentTaskLifecycleType.CANCELED,
+        }
+        else None
+    )
+    return ModelRemoteTaskState(
+        task_id=uuid4(),
+        invocation_kind=EnumInvocationKind.AGENT,
+        protocol=EnumAgentProtocol.A2A,
+        target_ref="agent:local-a2a-smoke",
+        remote_task_handle=f"remote:{uuid4()}",
+        correlation_id=uuid4(),
+        status=status,
+        last_remote_status=status.value.lower(),
+        last_emitted_event_type=status,
+        submitted_at=now,
+        updated_at=now,
+        completed_at=completed_at,
+        error="terminal failure"
+        if status is EnumAgentTaskLifecycleType.FAILED
+        else None,
+    )
+
+
+async def test_upsert_then_load_unfinished(postgres_pool) -> None:
+    repo = RemoteTaskStateRepository(postgres_pool)
+    row = _row(status=EnumAgentTaskLifecycleType.SUBMITTED)
+
+    await repo.upsert(row)
+
+    loaded = await repo.get(row.task_id)
+    unfinished = await repo.load_unfinished()
+
+    assert loaded == row
+    assert unfinished == [row]
+
+
+async def test_terminal_status_excluded_from_unfinished(postgres_pool) -> None:
+    repo = RemoteTaskStateRepository(postgres_pool)
+    submitted = _row(status=EnumAgentTaskLifecycleType.SUBMITTED)
+    completed = _row(status=EnumAgentTaskLifecycleType.COMPLETED)
+    failed = _row(status=EnumAgentTaskLifecycleType.FAILED)
+
+    await repo.upsert(submitted)
+    await repo.upsert(completed)
+    await repo.upsert(failed)
+
+    unfinished = await repo.load_unfinished()
+
+    assert unfinished == [submitted]

--- a/tests/integration/nodes/test_node_remote_agent_invoke_effect_integration.py
+++ b/tests/integration/nodes/test_node_remote_agent_invoke_effect_integration.py
@@ -19,9 +19,13 @@ from omnibase_core.enums.enum_agent_task_lifecycle_type import (
 )
 from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
 from omnibase_core.models.common.model_schema_value import ModelSchemaValue
-from omnibase_core.models.delegation import (
+from omnibase_core.models.delegation.model_agent_task_lifecycle_event import (
     ModelAgentTaskLifecycleEvent,
+)
+from omnibase_core.models.delegation.model_invocation_command import (
     ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_remote_task_state import (
     ModelRemoteTaskState,
 )
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope

--- a/tests/unit/db/test_migration_069.py
+++ b/tests/unit/db/test_migration_069.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for migration 069: create remote_task_state."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+MIGRATION_FILE = (
+    REPO_ROOT / "docker" / "migrations" / "forward" / "069_create_remote_task_state.sql"
+)
+ROLLBACK_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "rollback"
+    / "rollback_069_create_remote_task_state.sql"
+)
+
+
+def _strip_comments(sql: str) -> str:
+    sql = re.sub(r"--[^\n]*", "", sql)
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    return sql
+
+
+@pytest.mark.unit
+def test_migration_069_files_exist() -> None:
+    assert MIGRATION_FILE.exists()
+    assert ROLLBACK_FILE.exists()
+
+
+@pytest.mark.unit
+def test_migration_069_creates_remote_task_state_table() -> None:
+    sql = _strip_comments(MIGRATION_FILE.read_text())
+    assert "CREATE TABLE IF NOT EXISTS remote_task_state" in sql
+    assert "target_ref" in sql
+    assert "remote_task_handle" in sql
+    assert "idx_remote_task_state_status" in sql
+    assert "idx_remote_task_state_correlation_id" in sql
+    assert "schema_version = '069'" in sql
+
+
+@pytest.mark.unit
+def test_migration_069_declares_lifecycle_check_constraints() -> None:
+    sql = _strip_comments(MIGRATION_FILE.read_text())
+    assert "chk_remote_task_state_status" in sql
+    assert "chk_remote_task_state_last_emitted" in sql
+    assert "TIMED_OUT" in sql
+    assert "CANCELED" in sql
+
+
+@pytest.mark.unit
+def test_migration_069_rollback_reverts_schema_version() -> None:
+    sql = _strip_comments(ROLLBACK_FILE.read_text())
+    assert "DROP TABLE IF EXISTS remote_task_state" in sql
+    assert "schema_version = '068'" in sql

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=9d64d5a3944477093824a53ca931fd17a4b6a8e1" }]
+overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" }]
 
 [[package]]
 name = "aenum"
@@ -1898,8 +1898,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.39.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=9d64d5a3944477093824a53ca931fd17a4b6a8e1#9d64d5a3944477093824a53ca931fd17a4b6a8e1" }
+version = "0.40.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316#6a65f885303e29b4ddc36a66a0cb860537f47316" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2007,7 +2007,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=9d64d5a3944477093824a53ca931fd17a4b6a8e1" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=a9380008fb4a2f2a784d374389260d896455c3b2" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- add the  migration and rollback
- add a Postgres-backed  for upsert/get/load_unfinished
- cover the migration and repository with unit and live-Postgres integration tests

## Verification
- All checks passed!
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0 -- /Users/jonah/Code/omni_worktrees/OMN-9620/OMN-9632/omnibase_infra/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /Users/jonah/Code/omni_worktrees/OMN-9620/OMN-9632/omnibase_infra
configfile: pyproject.toml
plugins: anyio-4.12.1, hypothesis-6.151.6, mock-3.15.1, locust-2.43.3, xdist-3.8.0, split-0.11.0, timeout-2.4.0, cov-6.3.0, pytest_httpserver-1.1.5, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 6 items

tests/unit/db/test_migration_069.py::test_migration_069_files_exist PASSED [ 16%]
tests/unit/db/test_migration_069.py::test_migration_069_creates_remote_task_state_table PASSED [ 33%]
tests/unit/db/test_migration_069.py::test_migration_069_declares_lifecycle_check_constraints PASSED [ 50%]
tests/unit/db/test_migration_069.py::test_migration_069_rollback_reverts_schema_version PASSED [ 66%]
tests/integration/db/test_remote_task_state_repository.py::test_upsert_then_load_unfinished PASSED [ 83%]
tests/integration/db/test_remote_task_state_repository.py::test_terminal_status_excluded_from_unfinished PASSED [100%]

============================== 6 passed in 0.20s ===============================
