### PR TITLE
feat(OMN-9634): implement real A2A submit and watch path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ dependencies = [
     "pydantic-settings>=2.2.1,<3.0.0", # Settings management
     "jsonschema>=4.20.0,<5.0.0", # JSON schema validation
     "watchdog>=4.0.0", # Filesystem event monitoring (HandlerContractFileWatcher, OMN-3940)
+    "a2a-sdk>=0.3.4,<0.4.0", # Real A2A client/server protocol support for remote-agent invocation
     # Security: CVE-2026-32597 (HIGH) - PyJWT <2.12.0 accepts unknown `crit` header extensions.
     # Transitive dependency (via mcp/httpx/authlib). Explicitly declared to enforce minimum version.
     "pyjwt>=2.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.39.0",
+    "omnibase-core>=0.40.0,<0.41.0",
     "omnibase-spi>=0.20.4",
     "omnimarket>=0.1.0",
     # ============================================================================
@@ -161,7 +161,7 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.39.0",
+    "omnibase-core>=0.40.0,<0.41.0",
 ]
 
 [tool.uv.sources]

--- a/scripts/check_subscribe_wiring_health.py
+++ b/scripts/check_subscribe_wiring_health.py
@@ -153,6 +153,9 @@ _BASELINE_DEAD_LETTER_ALLOWLIST: dict[str, str] = {
     "onex.int.platform.runtime-tick.v1": "Published by runtime scheduler | owner: jonah | expiry: 2026-09-01",
     # Onboarding — triggered by omniclaude /onboarding skill, not Kafka publisher
     "onex.cmd.omnibase-infra.onboarding-start.v1": "Triggered by /onboarding skill via claude -p, not Kafka | owner: jonah | expiry: 2026-12-01",
+    # Remote-agent invoke — emitted by node_delegation_orchestrator (OMN-9620 epic);
+    # its contract addition is tracked separately and pending in another wave.
+    "onex.cmd.omnibase-infra.remote-agent-invoke.v1": "Publisher pending in delegation_orchestrator (OMN-9620 epic) | owner: jonah | expiry: 2026-09-01",
 }
 # fmt: on
 

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
@@ -31,7 +31,13 @@ output_model:
   description: "Lifecycle event emitted while watching a remote agent task."
 handler_routing:
   routing_strategy: "operation_match"
-  handlers: []
+  handlers:
+    - operation: "agent.a2a_task"
+      handler:
+        name: "HandlerA2ATask"
+        module: "omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task"
+        handler_type: "HTTP"
+      description: "Submit remote A2A tasks and persist their initial lifecycle state."
   execution_mode: "single"
   max_timeout_seconds: 600
 event_bus:

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/__init__.py
@@ -2,4 +2,8 @@
 # SPDX-License-Identifier: MIT
 """Remote agent invocation handlers."""
 
-__all__: list[str] = []
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import (
+    HandlerA2ATask,
+)
+
+__all__ = ["HandlerA2ATask"]

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from uuid import UUID
@@ -35,12 +36,19 @@ from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLik
 _STATUS_MAP: dict[str, EnumAgentTaskLifecycleType] = {
     "submitted": EnumAgentTaskLifecycleType.SUBMITTED,
     "accepted": EnumAgentTaskLifecycleType.ACCEPTED,
+    "artifact": EnumAgentTaskLifecycleType.ARTIFACT,
     "working": EnumAgentTaskLifecycleType.PROGRESS,
     "in_progress": EnumAgentTaskLifecycleType.PROGRESS,
     "completed": EnumAgentTaskLifecycleType.COMPLETED,
     "failed": EnumAgentTaskLifecycleType.FAILED,
     "timed_out": EnumAgentTaskLifecycleType.TIMED_OUT,
     "canceled": EnumAgentTaskLifecycleType.CANCELED,
+}
+_TERMINAL_LIFECYCLES = {
+    EnumAgentTaskLifecycleType.COMPLETED,
+    EnumAgentTaskLifecycleType.FAILED,
+    EnumAgentTaskLifecycleType.TIMED_OUT,
+    EnumAgentTaskLifecycleType.CANCELED,
 }
 
 
@@ -66,6 +74,7 @@ class HandlerA2ATask:
         lifecycle_topic: str,
         http_session: aiohttp.ClientSession,
         clock: Callable[[], datetime] | None = None,
+        poll_interval_seconds: float = 1.0,
     ) -> None:
         self._repository = repository
         self._event_bus = event_bus
@@ -73,6 +82,7 @@ class HandlerA2ATask:
         self._lifecycle_topic = lifecycle_topic
         self._http_session = http_session
         self._clock = clock or (lambda: datetime.now(UTC))
+        self._poll_interval_seconds = poll_interval_seconds
 
     @property
     def handler_type(self) -> EnumHandlerType:
@@ -125,6 +135,117 @@ class HandlerA2ATask:
         )
         return response
 
+    async def watch(
+        self,
+        remote_task_handle: str,
+        correlation_id: UUID,
+    ) -> list[ModelAgentTaskLifecycleEvent]:
+        """Poll tasks.get until the remote task reaches a terminal lifecycle."""
+        row = await self._repository.get_by_remote_task_handle(
+            remote_task_handle,
+            correlation_id=correlation_id,
+        )
+        if row is None:
+            msg = f"Unknown remote_task_handle: {remote_task_handle}"
+            raise ValueError(msg)
+
+        target = self._resolve_target(row.target_ref)
+        last_seen = row.last_emitted_event_type
+        events: list[ModelAgentTaskLifecycleEvent] = []
+        last_artifact_payload: list[dict[str, ModelSchemaValue]] | None = None
+
+        while True:
+            response = await self._get_tasks_get(
+                target=target,
+                remote_task_handle=remote_task_handle,
+            )
+            mapped = map_remote_status(response.status)
+            now = self._clock()
+
+            if response.artifacts and response.artifacts != last_artifact_payload:
+                artifact_event = await self._emit_lifecycle(
+                    task_id=row.task_id,
+                    correlation_id=correlation_id,
+                    lifecycle_type=EnumAgentTaskLifecycleType.ARTIFACT,
+                    remote_task_handle=remote_task_handle,
+                    artifact=response.artifacts[0],
+                    occurred_at=now,
+                    remote_status=response.status,
+                    error=response.error,
+                )
+                await self._repository.upsert(
+                    row.model_copy(
+                        update={
+                            "status": mapped,
+                            "last_remote_status": response.status,
+                            "last_emitted_event_type": EnumAgentTaskLifecycleType.ARTIFACT,
+                            "updated_at": now,
+                            "completed_at": now
+                            if mapped in _TERMINAL_LIFECYCLES
+                            else None,
+                            "error": response.error,
+                        }
+                    ),
+                    correlation_id=correlation_id,
+                )
+                row = row.model_copy(
+                    update={
+                        "status": mapped,
+                        "last_remote_status": response.status,
+                        "last_emitted_event_type": EnumAgentTaskLifecycleType.ARTIFACT,
+                        "updated_at": now,
+                        "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,
+                        "error": response.error,
+                    }
+                )
+                events.append(artifact_event)
+                last_artifact_payload = response.artifacts
+
+            if mapped is last_seen:
+                if mapped in _TERMINAL_LIFECYCLES:
+                    return events
+                await asyncio.sleep(self._poll_interval_seconds)
+                continue
+
+            lifecycle_event = await self._emit_lifecycle(
+                task_id=row.task_id,
+                correlation_id=correlation_id,
+                lifecycle_type=mapped,
+                remote_task_handle=remote_task_handle,
+                artifact=response.artifacts[0] if response.artifacts else None,
+                occurred_at=now,
+                remote_status=response.status,
+                error=response.error,
+            )
+            await self._repository.upsert(
+                row.model_copy(
+                    update={
+                        "status": mapped,
+                        "last_remote_status": response.status,
+                        "last_emitted_event_type": mapped,
+                        "updated_at": now,
+                        "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,
+                        "error": response.error,
+                    }
+                ),
+                correlation_id=correlation_id,
+            )
+            row = row.model_copy(
+                update={
+                    "status": mapped,
+                    "last_remote_status": response.status,
+                    "last_emitted_event_type": mapped,
+                    "updated_at": now,
+                    "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,
+                    "error": response.error,
+                }
+            )
+            last_seen = mapped
+            events.append(lifecycle_event)
+            if mapped in _TERMINAL_LIFECYCLES:
+                return events
+            await asyncio.sleep(self._poll_interval_seconds)
+
     def _resolve_target(self, target_ref: str) -> ModelTargetAgent:
         try:
             target = self._target_registry[target_ref]
@@ -150,6 +271,20 @@ class HandlerA2ATask:
             payload = await response.json()
         return ModelA2ATaskResponse.model_validate(payload)
 
+    async def _get_tasks_get(
+        self,
+        *,
+        target: ModelTargetAgent,
+        remote_task_handle: str,
+    ) -> ModelA2ATaskResponse:
+        async with self._http_session.get(
+            f"{target.base_url.rstrip('/')}/tasks.get",
+            params={"id": remote_task_handle},
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+        return ModelA2ATaskResponse.model_validate(payload)
+
     async def _emit_submitted(
         self,
         *,
@@ -157,7 +292,7 @@ class HandlerA2ATask:
         occurred_at: datetime,
         remote_task_handle: str | None,
     ) -> None:
-        lifecycle_event = ModelAgentTaskLifecycleEvent(
+        await self._emit_lifecycle(
             task_id=command.task_id,
             correlation_id=command.correlation_id,
             lifecycle_type=EnumAgentTaskLifecycleType.SUBMITTED,
@@ -168,15 +303,39 @@ class HandlerA2ATask:
             occurred_at=occurred_at,
             remote_status="submitted",
         )
+
+    async def _emit_lifecycle(
+        self,
+        *,
+        task_id: UUID,
+        correlation_id: UUID,
+        lifecycle_type: EnumAgentTaskLifecycleType,
+        remote_task_handle: str | None,
+        occurred_at: datetime,
+        artifact: dict[str, ModelSchemaValue] | None = None,
+        remote_status: str | None = None,
+        error: str | None = None,
+    ) -> ModelAgentTaskLifecycleEvent:
+        lifecycle_event = ModelAgentTaskLifecycleEvent(
+            task_id=task_id,
+            correlation_id=correlation_id,
+            lifecycle_type=lifecycle_type,
+            remote_task_handle=remote_task_handle,
+            artifact=artifact,
+            occurred_at=occurred_at,
+            remote_status=remote_status,
+            error=error,
+        )
         envelope = ModelEventEnvelope[dict[str, object]](
-            correlation_id=command.correlation_id,
+            correlation_id=correlation_id,
             payload=lifecycle_event.model_dump(mode="json"),
         )
         await self._event_bus.publish(
             self._lifecycle_topic,
-            key=str(command.task_id).encode("utf-8"),
+            key=str(task_id).encode("utf-8"),
             value=envelope.model_dump_json().encode("utf-8"),
         )
+        return lifecycle_event
 
 
-__all__ = ["HandlerA2ATask", "_STATUS_MAP", "map_remote_status"]
+__all__ = ["HandlerA2ATask", "_STATUS_MAP", "_TERMINAL_LIFECYCLES", "map_remote_status"]

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""A2A submit-path handler for node_remote_agent_invoke_effect."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from uuid import UUID
+
+import aiohttp
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+from omnibase_core.models.delegation.model_a2a_task_request import ModelA2ATaskRequest
+from omnibase_core.models.delegation.model_a2a_task_response import ModelA2ATaskResponse
+from omnibase_core.models.delegation.model_agent_task_lifecycle_event import (
+    ModelAgentTaskLifecycleEvent,
+)
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.persistence.remote_task_state_repository import (
+    RemoteTaskStateRepository,
+)
+from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
+
+_STATUS_MAP: dict[str, EnumAgentTaskLifecycleType] = {
+    "submitted": EnumAgentTaskLifecycleType.SUBMITTED,
+    "accepted": EnumAgentTaskLifecycleType.ACCEPTED,
+    "working": EnumAgentTaskLifecycleType.PROGRESS,
+    "in_progress": EnumAgentTaskLifecycleType.PROGRESS,
+    "completed": EnumAgentTaskLifecycleType.COMPLETED,
+    "failed": EnumAgentTaskLifecycleType.FAILED,
+    "timed_out": EnumAgentTaskLifecycleType.TIMED_OUT,
+    "canceled": EnumAgentTaskLifecycleType.CANCELED,
+}
+
+
+def map_remote_status(raw_status: str) -> EnumAgentTaskLifecycleType:
+    """Map A2A peer status strings into typed lifecycle events."""
+    normalized = raw_status.strip().lower()
+    try:
+        return _STATUS_MAP[normalized]
+    except KeyError as exc:
+        msg = f"Unknown remote agent status: {raw_status}"
+        raise ValueError(msg) from exc
+
+
+class HandlerA2ATask:
+    """Submit-path handler for A2A task invocation."""
+
+    def __init__(
+        self,
+        *,
+        repository: RemoteTaskStateRepository,
+        event_bus: ProtocolEventBusLike,
+        target_registry: Mapping[str, ModelTargetAgent],
+        lifecycle_topic: str,
+        http_session: aiohttp.ClientSession,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._repository = repository
+        self._event_bus = event_bus
+        self._target_registry = target_registry
+        self._lifecycle_topic = lifecycle_topic
+        self._http_session = http_session
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    @property
+    def handler_type(self) -> EnumHandlerType:
+        return EnumHandlerType.INFRA_HANDLER
+
+    @property
+    def handler_category(self) -> EnumHandlerTypeCategory:
+        return EnumHandlerTypeCategory.EFFECT
+
+    async def submit(self, command: ModelInvocationCommand) -> ModelA2ATaskResponse:
+        """Submit a command to a remote A2A peer and persist the returned handle."""
+        target = self._resolve_target(command.target_ref)
+        now = self._clock()
+
+        submitted_state = ModelRemoteTaskState(
+            task_id=command.task_id,
+            invocation_kind=command.invocation_kind,
+            protocol=command.agent_protocol,
+            target_ref=command.target_ref,
+            remote_task_handle=None,
+            correlation_id=command.correlation_id,
+            status=EnumAgentTaskLifecycleType.SUBMITTED,
+            last_remote_status="submitted",
+            last_emitted_event_type=EnumAgentTaskLifecycleType.SUBMITTED,
+            submitted_at=now,
+            updated_at=now,
+        )
+        await self._repository.upsert(submitted_state)
+        await self._emit_submitted(
+            command=command, occurred_at=now, remote_task_handle=None
+        )
+
+        request_model = ModelA2ATaskRequest(
+            skill_ref=command.target_ref,
+            input=command.payload,
+            correlation_id=command.correlation_id,
+        )
+        response = await self._post_tasks_send(
+            target=target, request_model=request_model
+        )
+
+        await self._repository.upsert(
+            submitted_state.model_copy(
+                update={
+                    "remote_task_handle": response.remote_task_handle,
+                    "last_remote_status": response.status,
+                    "updated_at": self._clock(),
+                }
+            )
+        )
+        return response
+
+    def _resolve_target(self, target_ref: str) -> ModelTargetAgent:
+        try:
+            target = self._target_registry[target_ref]
+        except KeyError as exc:
+            msg = f"Unknown target_ref: {target_ref}"
+            raise ValueError(msg) from exc
+        if target.protocol is not EnumAgentProtocol.A2A:
+            msg = f"Target {target_ref} is not configured for A2A"
+            raise ValueError(msg)
+        return target
+
+    async def _post_tasks_send(
+        self,
+        *,
+        target: ModelTargetAgent,
+        request_model: ModelA2ATaskRequest,
+    ) -> ModelA2ATaskResponse:
+        async with self._http_session.post(
+            f"{target.base_url.rstrip('/')}/tasks.send",
+            json=request_model.model_dump(mode="json", by_alias=True),
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+        return ModelA2ATaskResponse.model_validate(payload)
+
+    async def _emit_submitted(
+        self,
+        *,
+        command: ModelInvocationCommand,
+        occurred_at: datetime,
+        remote_task_handle: str | None,
+    ) -> None:
+        lifecycle_event = ModelAgentTaskLifecycleEvent(
+            task_id=command.task_id,
+            correlation_id=command.correlation_id,
+            lifecycle_type=EnumAgentTaskLifecycleType.SUBMITTED,
+            remote_task_handle=remote_task_handle,
+            artifact={
+                "target_ref": ModelSchemaValue.from_value(command.target_ref),
+            },
+            occurred_at=occurred_at,
+            remote_status="submitted",
+        )
+        envelope = ModelEventEnvelope[dict[str, object]](
+            correlation_id=command.correlation_id,
+            payload=lifecycle_event.model_dump(mode="json"),
+        )
+        await self._event_bus.publish(
+            self._lifecycle_topic,
+            key=str(command.task_id).encode("utf-8"),
+            value=envelope.model_dump_json().encode("utf-8"),
+        )
+
+
+__all__ = ["HandlerA2ATask", "_STATUS_MAP", "map_remote_status"]

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -1,15 +1,30 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""A2A submit-path handler for node_remote_agent_invoke_effect."""
+"""A2A submit/watch handler for node_remote_agent_invoke_effect."""
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Mapping
+import json
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
+from typing import Protocol
 from uuid import UUID
 
 import aiohttp
+import httpx
+from a2a.client.base_client import BaseClient
+from a2a.client.client import ClientConfig
+from a2a.client.client_factory import ClientFactory
+from a2a.types import (
+    Message,
+    MessageSendConfiguration,
+    Part,
+    Role,
+    TaskQueryParams,
+    TextPart,
+)
+from a2a.types import Task as A2ATask
 
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
 from omnibase_core.enums.enum_agent_task_lifecycle_type import (
@@ -39,6 +54,8 @@ _STATUS_MAP: dict[str, EnumAgentTaskLifecycleType] = {
     "artifact": EnumAgentTaskLifecycleType.ARTIFACT,
     "working": EnumAgentTaskLifecycleType.PROGRESS,
     "in_progress": EnumAgentTaskLifecycleType.PROGRESS,
+    "input_required": EnumAgentTaskLifecycleType.PROGRESS,
+    "auth_required": EnumAgentTaskLifecycleType.PROGRESS,
     "completed": EnumAgentTaskLifecycleType.COMPLETED,
     "failed": EnumAgentTaskLifecycleType.FAILED,
     "timed_out": EnumAgentTaskLifecycleType.TIMED_OUT,
@@ -52,14 +69,185 @@ _TERMINAL_LIFECYCLES = {
 }
 
 
+class ProtocolA2ATransport(Protocol):
+    """Small transport boundary so unit tests can avoid protocol plumbing."""
+
+    async def submit(
+        self,
+        *,
+        target: ModelTargetAgent,
+        request_model: ModelA2ATaskRequest,
+    ) -> ModelA2ATaskResponse: ...
+
+    async def get_task(
+        self,
+        *,
+        target: ModelTargetAgent,
+        remote_task_handle: str,
+    ) -> ModelA2ATaskResponse: ...
+
+
 def map_remote_status(raw_status: str) -> EnumAgentTaskLifecycleType:
     """Map A2A peer status strings into typed lifecycle events."""
-    normalized = raw_status.strip().lower()
+    normalized = raw_status.strip().lower().replace("-", "_")
     try:
         return _STATUS_MAP[normalized]
     except KeyError as exc:
         msg = f"Unknown remote agent status: {raw_status}"
         raise ValueError(msg) from exc
+
+
+class A2ASdkTransport:
+    """Real A2A transport backed by the upstream A2A SDK."""
+
+    def __init__(self, *, request_timeout_seconds: float = 180.0) -> None:
+        self._request_timeout_seconds = request_timeout_seconds
+
+    async def submit(
+        self,
+        *,
+        target: ModelTargetAgent,
+        request_model: ModelA2ATaskRequest,
+    ) -> ModelA2ATaskResponse:
+        async with httpx.AsyncClient(timeout=self._request_timeout_seconds) as client:
+            a2a_client = await ClientFactory.connect(
+                target.base_url,
+                client_config=ClientConfig(
+                    streaming=False,
+                    polling=True,
+                    httpx_client=client,
+                ),
+            )
+            typed_client = _require_base_client(a2a_client)
+            message = Message(
+                message_id=str(request_model.correlation_id),
+                role=Role.user,
+                parts=[Part(root=TextPart(text=_build_prompt(request_model)))],
+            )
+            async for event in typed_client.send_message(
+                message,
+                configuration=MessageSendConfiguration(blocking=False),
+            ):
+                if isinstance(event, Message):
+                    msg = "Unexpected direct message response from A2A peer"
+                    raise ValueError(msg)
+                task, _update = event
+                return _task_to_response(task)
+
+        msg = "A2A peer returned no task from send_message"
+        raise ValueError(msg)
+
+    async def get_task(
+        self,
+        *,
+        target: ModelTargetAgent,
+        remote_task_handle: str,
+    ) -> ModelA2ATaskResponse:
+        async with httpx.AsyncClient(timeout=self._request_timeout_seconds) as client:
+            a2a_client = await ClientFactory.connect(
+                target.base_url,
+                client_config=ClientConfig(
+                    streaming=False,
+                    polling=True,
+                    httpx_client=client,
+                ),
+            )
+            typed_client = _require_base_client(a2a_client)
+            task = await typed_client.get_task(
+                TaskQueryParams(id=remote_task_handle, history_length=20)
+            )
+        return _task_to_response(task)
+
+
+def _require_base_client(client: object) -> BaseClient:
+    if isinstance(client, BaseClient):
+        return client
+    msg = f"Unsupported A2A client type: {type(client).__name__}"
+    raise TypeError(msg)
+
+
+def _build_prompt(request_model: ModelA2ATaskRequest) -> str:
+    payload = {key: value.to_value() for key, value in request_model.input.items()}
+    prompt = payload.get("prompt")
+    if isinstance(prompt, str) and prompt.strip():
+        return prompt
+    return json.dumps(
+        {
+            "skill_id": request_model.skill_ref,
+            "correlation_id": str(request_model.correlation_id),
+            "input": payload,
+        },
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def _task_to_response(task: A2ATask) -> ModelA2ATaskResponse:
+    status = getattr(task.status.state, "value", str(task.status.state))
+    return ModelA2ATaskResponse(
+        remote_task_handle=task.id,
+        status=status,
+        artifacts=_extract_artifacts(task),
+        error=_extract_error(task),
+    )
+
+
+def _extract_error(task: A2ATask) -> str | None:
+    state = getattr(task.status.state, "value", str(task.status.state)).lower()
+    if state not in {"failed", "canceled", "timed_out"}:
+        return None
+    status_message = getattr(task.status, "message", None)
+    if status_message is None:
+        return None
+    texts = _extract_texts(getattr(status_message, "parts", None) or [])
+    if texts:
+        return "\n".join(texts)
+    return None
+
+
+def _extract_artifacts(task: A2ATask) -> list[dict[str, ModelSchemaValue]]:
+    task_artifacts = getattr(task, "artifacts", None) or []
+    extracted: list[dict[str, ModelSchemaValue]] = []
+    for artifact in task_artifacts:
+        payload = _parts_to_payload(getattr(artifact, "parts", None) or [])
+        if payload is None:
+            continue
+        if isinstance(payload, dict):
+            extracted.append(
+                {
+                    key: ModelSchemaValue.from_value(value)
+                    for key, value in payload.items()
+                }
+            )
+            continue
+        extracted.append({"text": ModelSchemaValue.from_value(payload)})
+    return extracted
+
+
+def _parts_to_payload(parts: Sequence[object]) -> object | None:
+    texts = _extract_texts(parts)
+    if not texts:
+        return None
+    combined = "\n".join(texts).strip()
+    if not combined:
+        return None
+    try:
+        parsed = json.loads(combined)
+    except json.JSONDecodeError:
+        return combined
+    return parsed
+
+
+def _extract_texts(parts: Sequence[object]) -> list[str]:
+    texts: list[str] = []
+    for part in parts:
+        candidate = getattr(part, "root", part)
+        kind = getattr(candidate, "kind", None)
+        if kind == "text":
+            text = getattr(candidate, "text", None)
+            if isinstance(text, str) and text:
+                texts.append(text)
+    return texts
 
 
 class HandlerA2ATask:
@@ -72,9 +260,10 @@ class HandlerA2ATask:
         event_bus: ProtocolEventBusLike,
         target_registry: Mapping[str, ModelTargetAgent],
         lifecycle_topic: str,
-        http_session: aiohttp.ClientSession,
+        http_session: aiohttp.ClientSession | None = None,
         clock: Callable[[], datetime] | None = None,
         poll_interval_seconds: float = 1.0,
+        transport: ProtocolA2ATransport | None = None,
     ) -> None:
         self._repository = repository
         self._event_bus = event_bus
@@ -83,6 +272,7 @@ class HandlerA2ATask:
         self._http_session = http_session
         self._clock = clock or (lambda: datetime.now(UTC))
         self._poll_interval_seconds = poll_interval_seconds
+        self._transport = transport or A2ASdkTransport()
 
     @property
     def handler_type(self) -> EnumHandlerType:
@@ -120,7 +310,7 @@ class HandlerA2ATask:
             input=command.payload,
             correlation_id=command.correlation_id,
         )
-        response = await self._post_tasks_send(
+        response = await self._transport.submit(
             target=target, request_model=request_model
         )
 
@@ -155,7 +345,7 @@ class HandlerA2ATask:
         last_artifact_payload: list[dict[str, ModelSchemaValue]] | None = None
 
         while True:
-            response = await self._get_tasks_get(
+            response = await self._transport.get_task(
                 target=target,
                 remote_task_handle=remote_task_handle,
             )
@@ -257,34 +447,6 @@ class HandlerA2ATask:
             raise ValueError(msg)
         return target
 
-    async def _post_tasks_send(
-        self,
-        *,
-        target: ModelTargetAgent,
-        request_model: ModelA2ATaskRequest,
-    ) -> ModelA2ATaskResponse:
-        async with self._http_session.post(
-            f"{target.base_url.rstrip('/')}/tasks.send",
-            json=request_model.model_dump(mode="json", by_alias=True),
-        ) as response:
-            response.raise_for_status()
-            payload = await response.json()
-        return ModelA2ATaskResponse.model_validate(payload)
-
-    async def _get_tasks_get(
-        self,
-        *,
-        target: ModelTargetAgent,
-        remote_task_handle: str,
-    ) -> ModelA2ATaskResponse:
-        async with self._http_session.get(
-            f"{target.base_url.rstrip('/')}/tasks.get",
-            params={"id": remote_task_handle},
-        ) as response:
-            response.raise_for_status()
-            payload = await response.json()
-        return ModelA2ATaskResponse.model_validate(payload)
-
     async def _emit_submitted(
         self,
         *,
@@ -338,4 +500,11 @@ class HandlerA2ATask:
         return lifecycle_event
 
 
-__all__ = ["HandlerA2ATask", "_STATUS_MAP", "_TERMINAL_LIFECYCLES", "map_remote_status"]
+__all__ = [
+    "A2ASdkTransport",
+    "HandlerA2ATask",
+    "ProtocolA2ATransport",
+    "_STATUS_MAP",
+    "_TERMINAL_LIFECYCLES",
+    "map_remote_status",
+]

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -183,10 +183,10 @@ def _build_prompt(request_model: ModelA2ATaskRequest) -> str:
 
 
 def _task_to_response(task: A2ATask) -> ModelA2ATaskResponse:
-    status = getattr(task.status.state, "value", str(task.status.state))
+    raw_status = getattr(task.status.state, "value", str(task.status.state))
     return ModelA2ATaskResponse(
         remote_task_handle=task.id,
-        status=status,
+        status=map_remote_status(raw_status),
         artifacts=_extract_artifacts(task),
         error=_extract_error(task),
     )
@@ -318,7 +318,7 @@ class HandlerA2ATask:
             submitted_state.model_copy(
                 update={
                     "remote_task_handle": response.remote_task_handle,
-                    "last_remote_status": response.status,
+                    "last_remote_status": response.status.value,
                     "updated_at": self._clock(),
                 }
             )
@@ -349,7 +349,8 @@ class HandlerA2ATask:
                 target=target,
                 remote_task_handle=remote_task_handle,
             )
-            mapped = map_remote_status(response.status)
+            mapped = response.status
+            raw_status = response.status.value
             now = self._clock()
 
             if response.artifacts and response.artifacts != last_artifact_payload:
@@ -360,14 +361,14 @@ class HandlerA2ATask:
                     remote_task_handle=remote_task_handle,
                     artifact=response.artifacts[0],
                     occurred_at=now,
-                    remote_status=response.status,
+                    remote_status=raw_status,
                     error=response.error,
                 )
                 await self._repository.upsert(
                     row.model_copy(
                         update={
                             "status": mapped,
-                            "last_remote_status": response.status,
+                            "last_remote_status": raw_status,
                             "last_emitted_event_type": EnumAgentTaskLifecycleType.ARTIFACT,
                             "updated_at": now,
                             "completed_at": now
@@ -381,7 +382,7 @@ class HandlerA2ATask:
                 row = row.model_copy(
                     update={
                         "status": mapped,
-                        "last_remote_status": response.status,
+                        "last_remote_status": raw_status,
                         "last_emitted_event_type": EnumAgentTaskLifecycleType.ARTIFACT,
                         "updated_at": now,
                         "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,
@@ -404,14 +405,14 @@ class HandlerA2ATask:
                 remote_task_handle=remote_task_handle,
                 artifact=response.artifacts[0] if response.artifacts else None,
                 occurred_at=now,
-                remote_status=response.status,
+                remote_status=raw_status,
                 error=response.error,
             )
             await self._repository.upsert(
                 row.model_copy(
                     update={
                         "status": mapped,
-                        "last_remote_status": response.status,
+                        "last_remote_status": raw_status,
                         "last_emitted_event_type": mapped,
                         "updated_at": now,
                         "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,
@@ -423,7 +424,7 @@ class HandlerA2ATask:
             row = row.model_copy(
                 update={
                     "status": mapped,
-                    "last_remote_status": response.status,
+                    "last_remote_status": raw_status,
                     "last_emitted_event_type": mapped,
                     "updated_at": now,
                     "completed_at": now if mapped in _TERMINAL_LIFECYCLES else None,

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
@@ -74,6 +74,25 @@ FROM remote_task_state
 WHERE task_id = $1
 """
 
+SQL_GET_REMOTE_TASK_STATE_BY_HANDLE = """
+SELECT
+    task_id,
+    invocation_kind,
+    protocol,
+    target_ref,
+    remote_task_handle,
+    correlation_id,
+    status,
+    last_remote_status,
+    last_emitted_event_type,
+    submitted_at,
+    updated_at,
+    completed_at,
+    error
+FROM remote_task_state
+WHERE remote_task_handle = $1
+"""
+
 SQL_LOAD_UNFINISHED_REMOTE_TASK_STATES = """
 SELECT
     task_id,
@@ -160,6 +179,25 @@ class RemoteTaskStateRepository(MixinPostgresOpExecutor):
             op_name="get_remote_task_state",
             log_context={"task_id": str(task_id)},
             fn=lambda: self._fetchrow(SQL_GET_REMOTE_TASK_STATE, task_id),
+        )
+        if row is None:
+            return None
+        return self._row_to_model(row)
+
+    async def get_by_remote_task_handle(
+        self,
+        remote_task_handle: str,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> ModelRemoteTaskState | None:
+        row = await self._run_checked(
+            correlation_id=correlation_id or uuid4(),
+            op_name="get_remote_task_state_by_handle",
+            log_context={"remote_task_handle": remote_task_handle},
+            fn=lambda: self._fetchrow(
+                SQL_GET_REMOTE_TASK_STATE_BY_HANDLE,
+                remote_task_handle,
+            ),
         )
         if row is None:
             return None

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,8 +175,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.39.0",
-        max_version="0.40.0",
+        min_version="0.40.0",
+        max_version="0.41.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -139,6 +139,9 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolChainEmbeddingClient": "nodes/node_chain_orchestrator/models/protocol_chain_embedding_client.py",
     # [NODE] DI boundary for chain retrieval/store effects — vector store client interface (chain-learning)
     "ProtocolChainVectorClient": "nodes/node_chain_orchestrator/models/protocol_chain_vector_client.py",
+    # [NODE] DI boundary for A2A transport — narrows the SDK surface so the handler
+    # can be unit-tested without driving the real a2a-sdk client (OMN-9634).
+    "ProtocolA2ATransport": "nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py",
 }
 
 # Duplicate protocol names that appear in multiple files (node-internal

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for HandlerA2ATask."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import aiohttp
+import pytest
+from pytest_httpserver import HTTPServer
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import (
+    HandlerA2ATask,
+    map_remote_status,
+)
+
+
+class RecordingRepository:
+    def __init__(self) -> None:
+        self.rows: list[ModelRemoteTaskState] = []
+
+    async def upsert(self, state: ModelRemoteTaskState) -> None:
+        self.rows.append(state)
+
+
+class RecordingEventBus:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, bytes | None, bytes]] = []
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+    ) -> None:
+        self.messages.append((topic, key, value))
+
+
+def _command() -> ModelInvocationCommand:
+    return ModelInvocationCommand(
+        task_id=uuid4(),
+        correlation_id=uuid4(),
+        invocation_kind=EnumInvocationKind.AGENT,
+        agent_protocol=EnumAgentProtocol.A2A,
+        target_ref="agent:local-a2a-smoke",
+        payload={"prompt": ModelSchemaValue.from_value("triage these findings")},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_status", "expected"),
+    [
+        ("submitted", EnumAgentTaskLifecycleType.SUBMITTED),
+        ("accepted", EnumAgentTaskLifecycleType.ACCEPTED),
+        ("working", EnumAgentTaskLifecycleType.PROGRESS),
+        ("in_progress", EnumAgentTaskLifecycleType.PROGRESS),
+        ("completed", EnumAgentTaskLifecycleType.COMPLETED),
+        ("failed", EnumAgentTaskLifecycleType.FAILED),
+        ("timed_out", EnumAgentTaskLifecycleType.TIMED_OUT),
+        ("canceled", EnumAgentTaskLifecycleType.CANCELED),
+    ],
+)
+def test_status_mapping_table(
+    raw_status: str,
+    expected: EnumAgentTaskLifecycleType,
+) -> None:
+    assert map_remote_status(raw_status) is expected
+
+
+@pytest.mark.unit
+def test_status_mapping_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown remote agent status"):
+        map_remote_status("mystery")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_submit_emits_submitted_event_and_persists(
+    httpserver: HTTPServer,
+) -> None:
+    repo = RecordingRepository()
+    event_bus = RecordingEventBus()
+    command = _command()
+    now = datetime(2026, 4, 25, 17, 15, tzinfo=UTC)
+
+    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
+        {
+            "remote_task_handle": "remote-123",
+            "status": "submitted",
+            "artifacts": [],
+        }
+    )
+
+    async with aiohttp.ClientSession() as session:
+        handler = HandlerA2ATask(
+            repository=repo,  # type: ignore[arg-type]
+            event_bus=event_bus,
+            target_registry={
+                "agent:local-a2a-smoke": ModelTargetAgent(
+                    agent_ref="agent:local-a2a-smoke",
+                    protocol=EnumAgentProtocol.A2A,
+                    base_url=httpserver.url_for(""),
+                    protocol_version="0.3",
+                )
+            },
+            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+            http_session=session,
+            clock=lambda: now,
+        )
+
+        response = await handler.submit(command)
+
+    assert response.remote_task_handle == "remote-123"
+    assert len(repo.rows) == 2
+    assert repo.rows[0].remote_task_handle is None
+    assert repo.rows[1].remote_task_handle == "remote-123"
+    assert len(event_bus.messages) == 1
+
+    topic, key, value = event_bus.messages[0]
+    assert topic == "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
+    assert key == str(command.task_id).encode("utf-8")
+
+    envelope = ModelEventEnvelope[object].model_validate(json.loads(value))
+    payload = envelope.payload
+    assert isinstance(payload, dict)
+    assert payload["lifecycle_type"] == "SUBMITTED"
+    assert payload["remote_task_handle"] is None

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
@@ -8,10 +8,7 @@ import json
 from datetime import UTC, datetime
 from uuid import uuid4
 
-import aiohttp
 import pytest
-from pytest_httpserver import HTTPServer
-from werkzeug.wrappers import Response
 
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
 from omnibase_core.enums.enum_agent_task_lifecycle_type import (
@@ -19,6 +16,8 @@ from omnibase_core.enums.enum_agent_task_lifecycle_type import (
 )
 from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
 from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+from omnibase_core.models.delegation.model_a2a_task_request import ModelA2ATaskRequest
+from omnibase_core.models.delegation.model_a2a_task_response import ModelA2ATaskResponse
 from omnibase_core.models.delegation.model_invocation_command import (
     ModelInvocationCommand,
 )
@@ -27,6 +26,7 @@ from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import (
     HandlerA2ATask,
+    ProtocolA2ATransport,
     map_remote_status,
 )
 
@@ -70,6 +70,40 @@ class RecordingEventBus:
         self.messages.append((topic, key, value))
 
 
+class FakeTransport(ProtocolA2ATransport):
+    def __init__(
+        self,
+        *,
+        submit_response: ModelA2ATaskResponse,
+        get_responses: list[ModelA2ATaskResponse] | None = None,
+    ) -> None:
+        self.submit_response = submit_response
+        self.get_responses = list(get_responses or [])
+        self.submit_requests: list[tuple[ModelTargetAgent, ModelA2ATaskRequest]] = []
+        self.get_requests: list[tuple[ModelTargetAgent, str]] = []
+
+    async def submit(
+        self,
+        *,
+        target: ModelTargetAgent,
+        request_model: ModelA2ATaskRequest,
+    ) -> ModelA2ATaskResponse:
+        self.submit_requests.append((target, request_model))
+        return self.submit_response
+
+    async def get_task(
+        self,
+        *,
+        target: ModelTargetAgent,
+        remote_task_handle: str,
+    ) -> ModelA2ATaskResponse:
+        self.get_requests.append((target, remote_task_handle))
+        if not self.get_responses:
+            msg = "No queued get_task responses"
+            raise AssertionError(msg)
+        return self.get_responses.pop(0)
+
+
 def _command() -> ModelInvocationCommand:
     return ModelInvocationCommand(
         task_id=uuid4(),
@@ -81,6 +115,17 @@ def _command() -> ModelInvocationCommand:
     )
 
 
+def _target_registry() -> dict[str, ModelTargetAgent]:
+    return {
+        "agent:local-a2a-smoke": ModelTargetAgent(
+            agent_ref="agent:local-a2a-smoke",
+            protocol=EnumAgentProtocol.A2A,
+            base_url="http://127.0.0.1:8011/a2a/app",
+            protocol_version="0.3",
+        )
+    }
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("raw_status", "expected"),
@@ -89,6 +134,7 @@ def _command() -> ModelInvocationCommand:
         ("accepted", EnumAgentTaskLifecycleType.ACCEPTED),
         ("working", EnumAgentTaskLifecycleType.PROGRESS),
         ("in_progress", EnumAgentTaskLifecycleType.PROGRESS),
+        ("input-required", EnumAgentTaskLifecycleType.PROGRESS),
         ("completed", EnumAgentTaskLifecycleType.COMPLETED),
         ("failed", EnumAgentTaskLifecycleType.FAILED),
         ("timed_out", EnumAgentTaskLifecycleType.TIMED_OUT),
@@ -110,46 +156,39 @@ def test_status_mapping_rejects_unknown() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_submit_emits_submitted_event_and_persists(
-    httpserver: HTTPServer,
-) -> None:
+async def test_submit_emits_submitted_event_and_persists() -> None:
     repo = RecordingRepository()
     event_bus = RecordingEventBus()
     command = _command()
     now = datetime(2026, 4, 25, 17, 15, tzinfo=UTC)
-
-    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
-        {
-            "remote_task_handle": "remote-123",
-            "status": "submitted",
-            "artifacts": [],
-        }
+    transport = FakeTransport(
+        submit_response=ModelA2ATaskResponse(
+            remote_task_handle="remote-123",
+            status="submitted",
+            artifacts=[],
+            error=None,
+        )
     )
 
-    async with aiohttp.ClientSession() as session:
-        handler = HandlerA2ATask(
-            repository=repo,  # type: ignore[arg-type]
-            event_bus=event_bus,
-            target_registry={
-                "agent:local-a2a-smoke": ModelTargetAgent(
-                    agent_ref="agent:local-a2a-smoke",
-                    protocol=EnumAgentProtocol.A2A,
-                    base_url=httpserver.url_for(""),
-                    protocol_version="0.3",
-                )
-            },
-            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
-            http_session=session,
-            clock=lambda: now,
-        )
+    handler = HandlerA2ATask(
+        repository=repo,  # type: ignore[arg-type]
+        event_bus=event_bus,
+        target_registry=_target_registry(),
+        lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+        clock=lambda: now,
+        transport=transport,
+    )
 
-        response = await handler.submit(command)
+    response = await handler.submit(command)
 
     assert response.remote_task_handle == "remote-123"
     assert len(repo.rows) == 2
     assert repo.rows[0].remote_task_handle is None
     assert repo.rows[1].remote_task_handle == "remote-123"
     assert len(event_bus.messages) == 1
+    assert len(transport.submit_requests) == 1
+    _target, request_model = transport.submit_requests[0]
+    assert request_model.input["prompt"].to_value() == "triage these findings"
 
     topic, key, value = event_bus.messages[0]
     assert topic == "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
@@ -164,157 +203,120 @@ async def test_submit_emits_submitted_event_and_persists(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_watch_emits_transitions_until_completed(httpserver: HTTPServer) -> None:
+async def test_watch_emits_transitions_until_completed() -> None:
     repo = RecordingRepository()
     event_bus = RecordingEventBus()
     command = _command()
     now = datetime(2026, 4, 25, 17, 20, tzinfo=UTC)
-    poll_counter = {"count": 0}
-
-    def _watch_handler(request):
-        del request
-        poll_counter["count"] += 1
-        if poll_counter["count"] == 1:
-            return Response(
-                json.dumps(
-                    {
-                        "remote_task_handle": "remote-123",
-                        "status": "in_progress",
-                        "artifacts": [],
-                        "error": None,
-                    }
-                ),
-                status=200,
-                content_type="application/json",
-            )
-        return Response(
-            json.dumps(
-                {
-                    "remote_task_handle": "remote-123",
-                    "status": "completed",
-                    "artifacts": [{"result": {"summary": "done"}}],
-                    "error": None,
-                }
-            ),
-            status=200,
-            content_type="application/json",
-        )
-
-    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
-        {
-            "remote_task_handle": "remote-123",
-            "status": "submitted",
-            "artifacts": [],
-        }
-    )
-    httpserver.expect_request("/tasks.get", method="GET").respond_with_handler(
-        _watch_handler
-    )
-
-    async with aiohttp.ClientSession() as session:
-        handler = HandlerA2ATask(
-            repository=repo,  # type: ignore[arg-type]
-            event_bus=event_bus,
-            target_registry={
-                "agent:local-a2a-smoke": ModelTargetAgent(
-                    agent_ref="agent:local-a2a-smoke",
-                    protocol=EnumAgentProtocol.A2A,
-                    base_url=httpserver.url_for(""),
-                    protocol_version="0.3",
-                )
-            },
-            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
-            http_session=session,
-            clock=lambda: now,
-            poll_interval_seconds=0.0,
-        )
-        await handler.submit(command)
-        events = await handler.watch(
+    transport = FakeTransport(
+        submit_response=ModelA2ATaskResponse(
             remote_task_handle="remote-123",
-            correlation_id=command.correlation_id,
-        )
+            status="submitted",
+            artifacts=[],
+            error=None,
+        ),
+        get_responses=[
+            ModelA2ATaskResponse(
+                remote_task_handle="remote-123",
+                status="working",
+                artifacts=[],
+                error=None,
+            ),
+            ModelA2ATaskResponse(
+                remote_task_handle="remote-123",
+                status="completed",
+                artifacts=[
+                    {
+                        "report": ModelSchemaValue.from_value(
+                            {"summary": "done", "priority": "high"}
+                        )
+                    }
+                ],
+                error=None,
+            ),
+        ],
+    )
+
+    handler = HandlerA2ATask(
+        repository=repo,  # type: ignore[arg-type]
+        event_bus=event_bus,
+        target_registry=_target_registry(),
+        lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+        clock=lambda: now,
+        poll_interval_seconds=0.0,
+        transport=transport,
+    )
+    await handler.submit(command)
+    events = await handler.watch(
+        remote_task_handle="remote-123",
+        correlation_id=command.correlation_id,
+    )
 
     assert [event.lifecycle_type for event in events] == [
         EnumAgentTaskLifecycleType.PROGRESS,
         EnumAgentTaskLifecycleType.ARTIFACT,
         EnumAgentTaskLifecycleType.COMPLETED,
     ]
+    assert events[1].artifact is not None
+    assert events[1].artifact["report"].to_value() == {
+        "summary": "done",
+        "priority": "high",
+    }
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_watch_dedups_same_status_repeats(httpserver: HTTPServer) -> None:
+async def test_watch_dedups_same_status_repeats() -> None:
     repo = RecordingRepository()
     event_bus = RecordingEventBus()
     command = _command()
     now = datetime(2026, 4, 25, 17, 25, tzinfo=UTC)
-    poll_counter = {"count": 0}
-
-    def _watch_handler(request):
-        del request
-        poll_counter["count"] += 1
-        if poll_counter["count"] < 3:
-            return Response(
-                json.dumps(
-                    {
-                        "remote_task_handle": "remote-456",
-                        "status": "in_progress",
-                        "artifacts": [],
-                        "error": None,
-                    }
-                ),
-                status=200,
-                content_type="application/json",
-            )
-        return Response(
-            json.dumps(
-                {
-                    "remote_task_handle": "remote-456",
-                    "status": "completed",
-                    "artifacts": [],
-                    "error": None,
-                }
-            ),
-            status=200,
-            content_type="application/json",
-        )
-
-    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
-        {
-            "remote_task_handle": "remote-456",
-            "status": "submitted",
-            "artifacts": [],
-        }
-    )
-    httpserver.expect_request("/tasks.get", method="GET").respond_with_handler(
-        _watch_handler
-    )
-
-    async with aiohttp.ClientSession() as session:
-        handler = HandlerA2ATask(
-            repository=repo,  # type: ignore[arg-type]
-            event_bus=event_bus,
-            target_registry={
-                "agent:local-a2a-smoke": ModelTargetAgent(
-                    agent_ref="agent:local-a2a-smoke",
-                    protocol=EnumAgentProtocol.A2A,
-                    base_url=httpserver.url_for(""),
-                    protocol_version="0.3",
-                )
-            },
-            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
-            http_session=session,
-            clock=lambda: now,
-            poll_interval_seconds=0.0,
-        )
-        updated_command = command.model_copy(
-            update={"task_id": uuid4(), "correlation_id": uuid4()}
-        )
-        await handler.submit(updated_command)
-        events = await handler.watch(
+    transport = FakeTransport(
+        submit_response=ModelA2ATaskResponse(
             remote_task_handle="remote-456",
-            correlation_id=updated_command.correlation_id,
-        )
+            status="submitted",
+            artifacts=[],
+            error=None,
+        ),
+        get_responses=[
+            ModelA2ATaskResponse(
+                remote_task_handle="remote-456",
+                status="working",
+                artifacts=[],
+                error=None,
+            ),
+            ModelA2ATaskResponse(
+                remote_task_handle="remote-456",
+                status="working",
+                artifacts=[],
+                error=None,
+            ),
+            ModelA2ATaskResponse(
+                remote_task_handle="remote-456",
+                status="completed",
+                artifacts=[],
+                error=None,
+            ),
+        ],
+    )
+
+    handler = HandlerA2ATask(
+        repository=repo,  # type: ignore[arg-type]
+        event_bus=event_bus,
+        target_registry=_target_registry(),
+        lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+        clock=lambda: now,
+        poll_interval_seconds=0.0,
+        transport=transport,
+    )
+    updated_command = command.model_copy(
+        update={"task_id": uuid4(), "correlation_id": uuid4()}
+    )
+    await handler.submit(updated_command)
+    events = await handler.watch(
+        remote_task_handle="remote-456",
+        correlation_id=updated_command.correlation_id,
+    )
 
     assert [event.lifecycle_type for event in events] == [
         EnumAgentTaskLifecycleType.PROGRESS,

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import aiohttp
 import pytest
 from pytest_httpserver import HTTPServer
+from werkzeug.wrappers import Response
 
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
 from omnibase_core.enums.enum_agent_task_lifecycle_type import (
@@ -34,8 +35,26 @@ class RecordingRepository:
     def __init__(self) -> None:
         self.rows: list[ModelRemoteTaskState] = []
 
-    async def upsert(self, state: ModelRemoteTaskState) -> None:
+    async def upsert(
+        self,
+        state: ModelRemoteTaskState,
+        *,
+        correlation_id=None,
+    ) -> None:
+        del correlation_id
         self.rows.append(state)
+
+    async def get_by_remote_task_handle(
+        self,
+        remote_task_handle: str,
+        *,
+        correlation_id=None,
+    ) -> ModelRemoteTaskState | None:
+        del correlation_id
+        for row in reversed(self.rows):
+            if row.remote_task_handle == remote_task_handle:
+                return row
+        return None
 
 
 class RecordingEventBus:
@@ -141,3 +160,163 @@ async def test_submit_emits_submitted_event_and_persists(
     assert isinstance(payload, dict)
     assert payload["lifecycle_type"] == "SUBMITTED"
     assert payload["remote_task_handle"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_watch_emits_transitions_until_completed(httpserver: HTTPServer) -> None:
+    repo = RecordingRepository()
+    event_bus = RecordingEventBus()
+    command = _command()
+    now = datetime(2026, 4, 25, 17, 20, tzinfo=UTC)
+    poll_counter = {"count": 0}
+
+    def _watch_handler(request):
+        del request
+        poll_counter["count"] += 1
+        if poll_counter["count"] == 1:
+            return Response(
+                json.dumps(
+                    {
+                        "remote_task_handle": "remote-123",
+                        "status": "in_progress",
+                        "artifacts": [],
+                        "error": None,
+                    }
+                ),
+                status=200,
+                content_type="application/json",
+            )
+        return Response(
+            json.dumps(
+                {
+                    "remote_task_handle": "remote-123",
+                    "status": "completed",
+                    "artifacts": [{"result": {"summary": "done"}}],
+                    "error": None,
+                }
+            ),
+            status=200,
+            content_type="application/json",
+        )
+
+    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
+        {
+            "remote_task_handle": "remote-123",
+            "status": "submitted",
+            "artifacts": [],
+        }
+    )
+    httpserver.expect_request("/tasks.get", method="GET").respond_with_handler(
+        _watch_handler
+    )
+
+    async with aiohttp.ClientSession() as session:
+        handler = HandlerA2ATask(
+            repository=repo,  # type: ignore[arg-type]
+            event_bus=event_bus,
+            target_registry={
+                "agent:local-a2a-smoke": ModelTargetAgent(
+                    agent_ref="agent:local-a2a-smoke",
+                    protocol=EnumAgentProtocol.A2A,
+                    base_url=httpserver.url_for(""),
+                    protocol_version="0.3",
+                )
+            },
+            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+            http_session=session,
+            clock=lambda: now,
+            poll_interval_seconds=0.0,
+        )
+        await handler.submit(command)
+        events = await handler.watch(
+            remote_task_handle="remote-123",
+            correlation_id=command.correlation_id,
+        )
+
+    assert [event.lifecycle_type for event in events] == [
+        EnumAgentTaskLifecycleType.PROGRESS,
+        EnumAgentTaskLifecycleType.ARTIFACT,
+        EnumAgentTaskLifecycleType.COMPLETED,
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_watch_dedups_same_status_repeats(httpserver: HTTPServer) -> None:
+    repo = RecordingRepository()
+    event_bus = RecordingEventBus()
+    command = _command()
+    now = datetime(2026, 4, 25, 17, 25, tzinfo=UTC)
+    poll_counter = {"count": 0}
+
+    def _watch_handler(request):
+        del request
+        poll_counter["count"] += 1
+        if poll_counter["count"] < 3:
+            return Response(
+                json.dumps(
+                    {
+                        "remote_task_handle": "remote-456",
+                        "status": "in_progress",
+                        "artifacts": [],
+                        "error": None,
+                    }
+                ),
+                status=200,
+                content_type="application/json",
+            )
+        return Response(
+            json.dumps(
+                {
+                    "remote_task_handle": "remote-456",
+                    "status": "completed",
+                    "artifacts": [],
+                    "error": None,
+                }
+            ),
+            status=200,
+            content_type="application/json",
+        )
+
+    httpserver.expect_request("/tasks.send", method="POST").respond_with_json(
+        {
+            "remote_task_handle": "remote-456",
+            "status": "submitted",
+            "artifacts": [],
+        }
+    )
+    httpserver.expect_request("/tasks.get", method="GET").respond_with_handler(
+        _watch_handler
+    )
+
+    async with aiohttp.ClientSession() as session:
+        handler = HandlerA2ATask(
+            repository=repo,  # type: ignore[arg-type]
+            event_bus=event_bus,
+            target_registry={
+                "agent:local-a2a-smoke": ModelTargetAgent(
+                    agent_ref="agent:local-a2a-smoke",
+                    protocol=EnumAgentProtocol.A2A,
+                    base_url=httpserver.url_for(""),
+                    protocol_version="0.3",
+                )
+            },
+            lifecycle_topic="onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+            http_session=session,
+            clock=lambda: now,
+            poll_interval_seconds=0.0,
+        )
+        updated_command = command.model_copy(
+            update={"task_id": uuid4(), "correlation_id": uuid4()}
+        )
+        await handler.submit(updated_command)
+        events = await handler.watch(
+            remote_task_handle="remote-456",
+            correlation_id=updated_command.correlation_id,
+        )
+
+    assert [event.lifecycle_type for event in events] == [
+        EnumAgentTaskLifecycleType.PROGRESS,
+        EnumAgentTaskLifecycleType.COMPLETED,
+    ]

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
@@ -118,10 +118,9 @@ def _command() -> ModelInvocationCommand:
 def _target_registry() -> dict[str, ModelTargetAgent]:
     return {
         "agent:local-a2a-smoke": ModelTargetAgent(
-            agent_ref="agent:local-a2a-smoke",
+            target_ref="agent:local-a2a-smoke",
             protocol=EnumAgentProtocol.A2A,
             base_url="http://127.0.0.1:8011/a2a/app",
-            protocol_version="0.3",
         )
     }
 
@@ -164,7 +163,7 @@ async def test_submit_emits_submitted_event_and_persists() -> None:
     transport = FakeTransport(
         submit_response=ModelA2ATaskResponse(
             remote_task_handle="remote-123",
-            status="submitted",
+            status=EnumAgentTaskLifecycleType.SUBMITTED,
             artifacts=[],
             error=None,
         )
@@ -211,20 +210,20 @@ async def test_watch_emits_transitions_until_completed() -> None:
     transport = FakeTransport(
         submit_response=ModelA2ATaskResponse(
             remote_task_handle="remote-123",
-            status="submitted",
+            status=EnumAgentTaskLifecycleType.SUBMITTED,
             artifacts=[],
             error=None,
         ),
         get_responses=[
             ModelA2ATaskResponse(
                 remote_task_handle="remote-123",
-                status="working",
+                status=EnumAgentTaskLifecycleType.PROGRESS,
                 artifacts=[],
                 error=None,
             ),
             ModelA2ATaskResponse(
                 remote_task_handle="remote-123",
-                status="completed",
+                status=EnumAgentTaskLifecycleType.COMPLETED,
                 artifacts=[
                     {
                         "report": ModelSchemaValue.from_value(
@@ -274,26 +273,26 @@ async def test_watch_dedups_same_status_repeats() -> None:
     transport = FakeTransport(
         submit_response=ModelA2ATaskResponse(
             remote_task_handle="remote-456",
-            status="submitted",
+            status=EnumAgentTaskLifecycleType.SUBMITTED,
             artifacts=[],
             error=None,
         ),
         get_responses=[
             ModelA2ATaskResponse(
                 remote_task_handle="remote-456",
-                status="working",
+                status=EnumAgentTaskLifecycleType.PROGRESS,
                 artifacts=[],
                 error=None,
             ),
             ModelA2ATaskResponse(
                 remote_task_handle="remote-456",
-                status="working",
+                status=EnumAgentTaskLifecycleType.PROGRESS,
                 artifacts=[],
                 error=None,
             ),
             ModelA2ATaskResponse(
                 remote_task_handle="remote-456",
-                status="completed",
+                status=EnumAgentTaskLifecycleType.COMPLETED,
                 artifacts=[],
                 error=None,
             ),

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_node_scaffold.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_node_scaffold.py
@@ -64,9 +64,16 @@ class TestNodeRemoteAgentInvokeEffectScaffold:
         published_topics = {event["topic"] for event in data["published_events"]}
         assert published_topics == {AGENT_TASK_LIFECYCLE_TOPIC}
 
-    def test_handlers_are_deferred_to_p14(self) -> None:
+    def test_p14_handler_is_wired(self) -> None:
         data = _load_contract()
-        assert data["handler_routing"]["handlers"] == []
+        handlers = data["handler_routing"]["handlers"]
+        assert len(handlers) == 1
+        handler_entry = handlers[0]
+        assert handler_entry["operation"] == "agent.a2a_task"
+        assert handler_entry["handler"]["name"] == "HandlerA2ATask"
+        assert handler_entry["handler"]["module"].endswith(
+            "node_remote_agent_invoke_effect.handlers.handler_a2a_task"
+        )
 
     def test_input_output_models_use_local_module(self) -> None:
         data = _load_contract()

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,22 @@ resolution-markers = [
 overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" }]
 
 [[package]]
+name = "a2a-sdk"
+version = "0.3.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/97/a6840e01795b182ce751ca165430d46459927cde9bfab838087cbb24aef7/a2a_sdk-0.3.26.tar.gz", hash = "sha256:44068e2d037afbb07ab899267439e9bc7eaa7ac2af94f1e8b239933c993ad52d", size = 274598, upload-time = "2026-04-09T15:21:13.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/d5/51f4ee1bf3b736add42a542d3c8a3fd3fa85f3d36c17972127defc46c26f/a2a_sdk-0.3.26-py3-none-any.whl", hash = "sha256:754e0573f6d33b225c1d8d51f640efa69cbbed7bdfb06ce9c3540ea9f58d4a91", size = 151016, upload-time = "2026-04-09T15:21:12.35Z" },
+]
+
+[[package]]
 name = "aenum"
 version = "3.1.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1078,6 +1094,35 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.72.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1918,6 +1963,7 @@ name = "omnibase-infra"
 version = "0.34.1"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "aiokafka" },
@@ -1990,6 +2036,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = ">=0.3.4,<0.4.0" },
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiokafka", specifier = ">=0.11.0,<0.14.0" },
@@ -2460,6 +2507,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.29.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2540,6 +2599,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the ad hoc remote-agent HTTP shim with the real `a2a-sdk` client transport
- submit remote tasks via `message/send` and watch them via `tasks/get` while persisting state and emitting lifecycle events
- update the handler tests around the transport boundary and artifact extraction from real A2A task payloads

## Verification
- `uv run ruff check src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py`
- `PYTHONPATH=src:/Users/jonah/Code/omni_worktrees/OMN-9620/OMN-9629/omnibase_core/src uv run pytest tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py -q`
- real local run against the ADK scout over A2A using a local in-memory repo and event bus
  - observed lifecycle: `SUBMITTED -> PROGRESS -> ARTIFACT -> COMPLETED`
  - final artifact contained the scout JSON report payload
