### PR TITLE
feat(OMN-9755): SPI default handler-contract loader (concrete impl in infra per layering)

### DIFF
--- a/src/omnibase_infra/contracts/defaults/__init__.py
+++ b/src/omnibase_infra/contracts/defaults/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.contracts.defaults.loader import load_default_handler_contract
+
+__all__ = ["load_default_handler_contract"]

--- a/src/omnibase_infra/contracts/defaults/loader.py
+++ b/src/omnibase_infra/contracts/defaults/loader.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Concrete loader for SPI default handler contract YAML templates (OMN-9755).
+
+File I/O lives in omnibase_infra (concrete implementation layer).
+YAML data files remain in omnibase_spi/contracts/defaults/ (declarative data, no I/O).
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+
+import yaml
+
+from omnibase_core.models.contracts.model_handler_contract import ModelHandlerContract
+from omnibase_spi.exceptions import TemplateNotFoundError, TemplateParseError
+
+_VALID_TEMPLATES = frozenset(
+    {
+        "default_compute_handler.yaml",
+        "default_effect_handler.yaml",
+        "default_nondeterministic_compute_handler.yaml",
+        "default_github_pr_poller.yaml",
+    }
+)
+
+
+def load_default_handler_contract(template_name: str) -> ModelHandlerContract:
+    """Load and validate a default handler contract template from omnibase_spi.
+
+    Args:
+        template_name: Bare filename of the YAML template
+            (e.g. "default_effect_handler.yaml"). Absolute paths and
+            directory traversal sequences are rejected.
+
+    Returns:
+        Validated ModelHandlerContract instance.
+
+    Raises:
+        TemplateNotFoundError: If the template name is invalid or not in the
+            known template set.
+        TemplateParseError: If the file contains invalid YAML.
+    """
+    from pathlib import Path
+
+    name = Path(template_name)
+    # Reject paths that aren't bare filenames (traversal, absolute, subdirs).
+    if name.parts != (template_name,) or template_name not in _VALID_TEMPLATES:
+        raise TemplateNotFoundError(
+            f"Template not found: {template_name!r}",
+            context={"template_name": template_name},
+        )
+
+    try:
+        yaml_text = (
+            files("omnibase_spi.contracts.defaults")
+            .joinpath(template_name)
+            .read_text(encoding="utf-8")
+        )
+    except FileNotFoundError as exc:
+        raise TemplateNotFoundError(
+            f"Template not found: {template_name!r}",
+            context={"template_name": template_name},
+        ) from exc
+
+    try:
+        raw = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        raise TemplateParseError(
+            f"Invalid YAML in template: {template_name!r}",
+            context={"template_name": template_name},
+        ) from exc
+
+    return ModelHandlerContract.model_validate(raw)

--- a/tests/integration/test_spi_default_contract_loader.py
+++ b/tests/integration/test_spi_default_contract_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration test for the SPI default handler-contract loader (OMN-9755).
+
+Verifies that the concrete loader in omnibase_infra reads real YAML data from
+the installed omnibase_spi package via importlib.resources and returns a fully
+validated ModelHandlerContract — no mocking, no stubs.
+
+Integration Test Coverage gate: OMN-7005 (hard gate since 2026-04-13).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.contracts.model_handler_contract import ModelHandlerContract
+from omnibase_infra.contracts.defaults import load_default_handler_contract
+from omnibase_spi.exceptions import TemplateNotFoundError
+
+
+@pytest.mark.integration
+class TestSpiDefaultContractLoaderIntegration:
+    """End-to-end loader tests — exercises real importlib.resources package reads."""
+
+    def test_effect_template_loads_and_validates(self) -> None:
+        contract = load_default_handler_contract("default_effect_handler.yaml")
+        assert isinstance(contract, ModelHandlerContract)
+        assert contract.handler_id == "template.effect.default"
+
+    def test_compute_template_loads_and_validates(self) -> None:
+        contract = load_default_handler_contract("default_compute_handler.yaml")
+        assert isinstance(contract, ModelHandlerContract)
+        assert contract.handler_id == "template.compute.default"
+
+    def test_nondeterministic_compute_template_loads_and_validates(self) -> None:
+        contract = load_default_handler_contract(
+            "default_nondeterministic_compute_handler.yaml"
+        )
+        assert isinstance(contract, ModelHandlerContract)
+
+    def test_unknown_template_raises_template_not_found_error(self) -> None:
+        with pytest.raises(TemplateNotFoundError):
+            load_default_handler_contract("nonexistent.yaml")
+
+    def test_path_traversal_raises_template_not_found_error(self) -> None:
+        with pytest.raises(TemplateNotFoundError):
+            load_default_handler_contract("../../etc/passwd")

--- a/tests/unit/contracts/defaults/__init__.py
+++ b/tests/unit/contracts/defaults/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/contracts/defaults/test_loader.py
+++ b/tests/unit/contracts/defaults/test_loader.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the infra concrete loader for SPI default handler contract templates (OMN-9755)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.contracts.model_handler_contract import ModelHandlerContract
+from omnibase_infra.contracts.defaults import load_default_handler_contract
+from omnibase_spi.exceptions import TemplateNotFoundError
+
+
+@pytest.mark.unit
+class TestDefaultHandlerContractLoader:
+    def test_default_effect_contract_is_typed(self) -> None:
+        contract = load_default_handler_contract("default_effect_handler.yaml")
+        assert isinstance(contract, ModelHandlerContract)
+
+    def test_default_compute_contract_is_typed(self) -> None:
+        contract = load_default_handler_contract("default_compute_handler.yaml")
+        assert isinstance(contract, ModelHandlerContract)
+
+    def test_default_nondeterministic_compute_contract_is_typed(self) -> None:
+        contract = load_default_handler_contract(
+            "default_nondeterministic_compute_handler.yaml"
+        )
+        assert isinstance(contract, ModelHandlerContract)
+
+    def test_missing_template_raises_template_not_found_error(self) -> None:
+        with pytest.raises(TemplateNotFoundError):
+            load_default_handler_contract("nonexistent_template.yaml")
+
+    def test_path_traversal_rejected(self) -> None:
+        with pytest.raises(TemplateNotFoundError):
+            load_default_handler_contract("../../etc/passwd")
+
+    def test_absolute_path_rejected(self) -> None:
+        with pytest.raises(TemplateNotFoundError):
+            load_default_handler_contract("/etc/passwd")
+
+    def test_effect_contract_has_expected_handler_id(self) -> None:
+        contract = load_default_handler_contract("default_effect_handler.yaml")
+        assert contract.handler_id == "template.effect.default"
+
+    def test_compute_contract_has_expected_handler_id(self) -> None:
+        contract = load_default_handler_contract("default_compute_handler.yaml")
+        assert contract.handler_id == "template.compute.default"


### PR DESCRIPTION
## Summary

- Moves concrete file-I/O loader from `omnibase_spi` (PR #198, now closed) to `omnibase_infra` per CLAUDE.md layering rule #7: **compat → core → spi → infra**
- `omnibase_spi` is protocols/types only; concrete I/O belongs in `omnibase_infra`
- YAML data files remain in `omnibase_spi/contracts/defaults/` (declarative data — correct placement)
- Loader reads YAML via `importlib.resources` from the installed `omnibase_spi` package — no path-hardcoding, no I/O in spi

## Files

- `src/omnibase_infra/contracts/defaults/loader.py` — `load_default_handler_contract(template_name)` using `importlib.resources` + `ModelHandlerContract.model_validate()`
- `src/omnibase_infra/contracts/defaults/__init__.py` — re-exports loader
- `tests/unit/contracts/defaults/test_loader.py` — 8 unit tests (typed return, missing template, path traversal, absolute path)

## Ticket

OMN-9755 (Task 15b: Wire model_validate() in SPI default template loader)
Parent epic: OMN-9738

## References

- Closes architectural violation from `omnibase_spi` PR #198 (closed — wrong layer)
- CLAUDE.md Operating Rule #7 (Repo layering)
- OMN-9753 investigation doc (postscript added noting corrected placement)

## dod_evidence

- `src/omnibase_infra/contracts/defaults/loader.py` created — concrete loader in correct layer
- `load_default_handler_contract()` returns `ModelHandlerContract` (not raw dict)
- `TemplateNotFoundError` raised for missing/invalid templates, `TemplateParseError` for bad YAML
- Both exception types from `omnibase_spi.exceptions` (spi → infra import direction is correct)
- 8 unit tests: `tests/unit/contracts/defaults/test_loader.py` — all passed locally
- `pre-commit run --all-files` → all hooks passed (including ONEX Architecture Layer Validation, SPI purity)
- `mypy` → passed (pre-push hook)
- `uv run pytest tests/unit/contracts/defaults/ -v` → 8 passed, 0 failed

## Test plan

- [ ] CI green on all checks
- [ ] `feat(OMN-9755)` in title satisfies receipt-gate

Closes OMN-9755.