### PR TITLE
feat(OMN-9750): typed ModelLlmEndpointContract + loader (no runtime cutover yet)

### DIFF
--- a/src/omnibase_infra/models/contracts/__init__.py
+++ b/src/omnibase_infra/models/contracts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/models/contracts/enum_llm_endpoint_status.py
+++ b/src/omnibase_infra/models/contracts/enum_llm_endpoint_status.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Enum for LLM endpoint slot status values defined in llm_endpoints.yaml."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumLlmEndpointStatus(str, Enum):
+    """Closed set of slot status values from contracts/llm_endpoints.yaml."""
+
+    RUNNING = "running"
+    DISABLED = "disabled"
+    ON_DEMAND = "on_demand"
+    PLANNED = "planned"
+
+
+__all__ = ["EnumLlmEndpointStatus"]

--- a/src/omnibase_infra/models/contracts/model_llm_endpoint_contract.py
+++ b/src/omnibase_infra/models/contracts/model_llm_endpoint_contract.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Top-level envelope for contracts/llm_endpoints.yaml + YAML loader.
+
+First typed wrapper — runtime cutover (service_kernel.py) deferred.
+See OMN-9750. DO NOT wire into service_kernel.py in this PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.contracts.model_llm_endpoint_entry import (
+    ModelLlmEndpointEntry,
+)
+
+
+class ModelLlmEndpointContract(BaseModel):
+    """Top-level envelope for contracts/llm_endpoints.yaml.
+
+    First typed wrapper — runtime cutover deferred (OMN-9750).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    endpoints: list[ModelLlmEndpointEntry] = Field(
+        default_factory=list,
+        description="Ordered list of LLM inference endpoint slots.",
+    )
+
+    def running(self) -> list[ModelLlmEndpointEntry]:
+        """Return only slots with status=running."""
+        from omnibase_infra.models.contracts.enum_llm_endpoint_status import (
+            EnumLlmEndpointStatus,
+        )
+
+        return [e for e in self.endpoints if e.status == EnumLlmEndpointStatus.RUNNING]
+
+    def by_role(self, role: str) -> list[ModelLlmEndpointEntry]:
+        """Return all slots matching a given role."""
+        return [e for e in self.endpoints if e.role == role]
+
+
+def load_llm_endpoint_contract(yaml_path: Path) -> ModelLlmEndpointContract:
+    """Load and validate llm_endpoints.yaml into ModelLlmEndpointContract.
+
+    Raises:
+        FileNotFoundError: if yaml_path does not exist.
+        pydantic.ValidationError: if the YAML content fails schema validation.
+    """
+    raw = yaml.safe_load(yaml_path.read_text())
+    return ModelLlmEndpointContract.model_validate(raw)
+
+
+__all__ = [
+    "ModelLlmEndpointContract",
+    "ModelLlmEndpointEntry",
+    "load_llm_endpoint_contract",
+]

--- a/src/omnibase_infra/models/contracts/model_llm_endpoint_contract.py
+++ b/src/omnibase_infra/models/contracts/model_llm_endpoint_contract.py
@@ -51,7 +51,7 @@ def load_llm_endpoint_contract(yaml_path: Path) -> ModelLlmEndpointContract:
         FileNotFoundError: if yaml_path does not exist.
         pydantic.ValidationError: if the YAML content fails schema validation.
     """
-    raw = yaml.safe_load(yaml_path.read_text())
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
     return ModelLlmEndpointContract.model_validate(raw)
 
 

--- a/src/omnibase_infra/models/contracts/model_llm_endpoint_entry.py
+++ b/src/omnibase_infra/models/contracts/model_llm_endpoint_entry.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_infra.models.contracts.enum_llm_endpoint_status import (
     EnumLlmEndpointStatus,
@@ -61,6 +61,25 @@ class ModelLlmEndpointEntry(BaseModel):
         default=None, description="launchd label or null."
     )
     notes: str = Field(default="", description="Free-text operator notes.")
+
+    @model_validator(mode="after")
+    def _validate_running_required_fields(self) -> ModelLlmEndpointEntry:
+        if self.status == EnumLlmEndpointStatus.RUNNING:
+            missing = [
+                name
+                for name, value in (
+                    ("host", self.host),
+                    ("port", self.port),
+                    ("endpoint_url", self.endpoint_url),
+                    ("model_hf_id", self.model_hf_id),
+                )
+                if value is None
+            ]
+            if missing:
+                raise ValueError(
+                    "running endpoints require non-null fields: " + ", ".join(missing)
+                )
+        return self
 
 
 __all__ = ["ModelLlmEndpointEntry"]

--- a/src/omnibase_infra/models/contracts/model_llm_endpoint_entry.py
+++ b/src/omnibase_infra/models/contracts/model_llm_endpoint_entry.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Single LLM inference endpoint slot model from contracts/llm_endpoints.yaml."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.contracts.enum_llm_endpoint_status import (
+    EnumLlmEndpointStatus,
+)
+
+
+class ModelLlmEndpointEntry(BaseModel):
+    """Single LLM inference endpoint slot from llm_endpoints.yaml.
+
+    Fields mirror the STABLE-CANONICAL group defined in the contract header.
+    OPERATOR-ANNOTATION fields (hardware, context_window_budgeted, etc.) are
+    included as optional strings/ints for round-trip fidelity but are not
+    load-bearing for routing logic.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    slot_id: str = Field(..., description="Slot identifier.")  # ONEX_EXCLUDE: pattern_validator - slot_id is a human-readable natural key, not a UUID  # fmt: skip
+    host: str | None = Field(
+        default=None,
+        description="IP address; non-null when status=running.",
+    )
+    port: int | None = Field(
+        default=None,
+        description="Integer port; non-null when status=running.",
+    )
+    endpoint_url: str | None = Field(
+        default=None,
+        description="Resolved URL convenience field; non-null when status=running.",
+    )
+    url_env_var: str | None = Field(
+        default=None,
+        description="Model-named env var (legacy canonical read). Nullable for Docker-internal slots.",
+    )
+    role_env_alias: str | None = Field(
+        default=None,
+        description="Role-named env var alias. Nullable when not yet assigned.",
+    )
+    model_hf_id: str | None = Field(
+        default=None,
+        description="Exact HuggingFace model ID; non-null when status=running.",
+    )
+    role: str = Field(
+        ..., description="Role taxonomy value (closed set in contract header)."
+    )
+    status: EnumLlmEndpointStatus = Field(
+        ..., description="running | disabled | on_demand | planned."
+    )
+    hardware: str | None = Field(default=None, description="Human host description.")
+    context_window_budgeted: int | None = Field(
+        default=None, description="Current max-tokens cap."
+    )
+    launchd_unit_or_none: str | None = Field(
+        default=None, description="launchd label or null."
+    )
+    notes: str = Field(default="", description="Free-text operator notes.")
+
+
+__all__ = ["ModelLlmEndpointEntry"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3196,7 +3196,7 @@ pattern_exemptions:
   # slot_id is a human-readable natural key (e.g. "coder-5090") defined in
   # contracts/llm_endpoints.yaml. Changing to UUID would break round-trip
   # fidelity with the contract YAML and operator tooling.
-  - file_pattern: 'model_llm_endpoint_entry\.py'
+  - file_pattern: 'src/omnibase_infra/models/contracts/model_llm_endpoint_entry\.py'
     violation_pattern: "Field 'slot_id' should use UUID"
     reason: >
       slot_id is a human-readable canonical slot identifier (e.g. "coder-5090") defined in contracts/llm_endpoints.yaml. It is a stable natural key used in config, docs, and operator references - not an internal UUID.

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3190,6 +3190,20 @@ pattern_exemptions:
       - config/machines.yaml (Machine registry definitions)
       - CLAUDE.md (Registry Naming Conventions)
     ticket: OMN-7527
+  # ==========================================================================
+  # ModelLlmEndpointEntry slot_id Exemption (OMN-9750)
+  # ==========================================================================
+  # slot_id is a human-readable natural key (e.g. "coder-5090") defined in
+  # contracts/llm_endpoints.yaml. Changing to UUID would break round-trip
+  # fidelity with the contract YAML and operator tooling.
+  - file_pattern: 'model_llm_endpoint_entry\.py'
+    violation_pattern: "Field 'slot_id' should use UUID"
+    reason: >
+      slot_id is a human-readable canonical slot identifier (e.g. "coder-5090") defined in contracts/llm_endpoints.yaml. It is a stable natural key used in config, docs, and operator references - not an internal UUID.
+
+    documentation:
+      - contracts/llm_endpoints.yaml (slot_id field comment)
+    ticket: OMN-9750
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/integration/test_llm_endpoint_contract_integration.py
+++ b/tests/integration/test_llm_endpoint_contract_integration.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: load contracts/llm_endpoints.yaml via ModelLlmEndpointContract.
+
+Validates that the typed loader can parse the real contract file from the repo.
+No external infra required — this is a filesystem-only integration test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.models.contracts.enum_llm_endpoint_status import (
+    EnumLlmEndpointStatus,
+)
+from omnibase_infra.models.contracts.model_llm_endpoint_contract import (
+    load_llm_endpoint_contract,
+)
+
+_CONTRACTS_DIR = __import__("pathlib").Path(__file__).parent.parent.parent / "contracts"
+_LLM_ENDPOINTS_YAML = _CONTRACTS_DIR / "llm_endpoints.yaml"
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.skipif(
+    not _LLM_ENDPOINTS_YAML.exists(),
+    reason="contracts/llm_endpoints.yaml not present in this checkout",
+)
+def test_load_real_llm_endpoints_yaml() -> None:
+    contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+    assert isinstance(contract.endpoints, list)
+    assert len(contract.endpoints) > 0
+
+
+@pytest.mark.skipif(
+    not _LLM_ENDPOINTS_YAML.exists(),
+    reason="contracts/llm_endpoints.yaml not present in this checkout",
+)
+def test_running_filter_returns_subset() -> None:
+    contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+    running = contract.running()
+    for entry in running:
+        assert entry.status == EnumLlmEndpointStatus.RUNNING
+
+
+@pytest.mark.skipif(
+    not _LLM_ENDPOINTS_YAML.exists(),
+    reason="contracts/llm_endpoints.yaml not present in this checkout",
+)
+def test_all_entries_have_required_fields() -> None:
+    contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+    for entry in contract.endpoints:
+        assert entry.slot_id
+        assert entry.role
+        assert entry.status in EnumLlmEndpointStatus.__members__.values()

--- a/tests/unit/models/contracts/__init__.py
+++ b/tests/unit/models/contracts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/contracts/test_model_llm_endpoint_contract.py
+++ b/tests/unit/models/contracts/test_model_llm_endpoint_contract.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelLlmEndpointContract + ModelLlmEndpointEntry.
+
+Related tickets:
+    - OMN-9750: typed ModelLlmEndpointContract + loader (no runtime cutover)
+    - OMN-9738: parent epic — contract-model validation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.models.contracts.model_llm_endpoint_contract import (
+    ModelLlmEndpointContract,
+    ModelLlmEndpointEntry,
+    load_llm_endpoint_contract,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CONTRACTS_DIR = Path(__file__).parent.parent.parent.parent.parent / "contracts"
+_LLM_ENDPOINTS_YAML = _CONTRACTS_DIR / "llm_endpoints.yaml"
+
+
+# ---------------------------------------------------------------------------
+# ModelLlmEndpointEntry
+# ---------------------------------------------------------------------------
+
+
+class TestModelLlmEndpointEntry:
+    def test_minimal_running_entry(self) -> None:
+        entry = ModelLlmEndpointEntry(
+            slot_id="coder-5090",
+            host="192.168.86.201",
+            port=8000,
+            endpoint_url="http://192.168.86.201:8000",
+            url_env_var="LLM_CODER_URL",
+            role_env_alias="LLM_CODER_SLOW_URL",
+            model_hf_id="cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
+            role="coder_slow",
+            status="running",
+        )
+        assert entry.slot_id == "coder-5090"
+        assert entry.port == 8000
+        assert entry.status == "running"
+        assert entry.notes == ""
+
+    def test_planned_entry_nullable_fields(self) -> None:
+        entry = ModelLlmEndpointEntry(
+            slot_id="vision-planned",
+            host=None,
+            port=None,
+            endpoint_url=None,
+            url_env_var=None,
+            role_env_alias="LLM_VISION_URL",
+            model_hf_id=None,
+            role="vision",
+            status="planned",
+        )
+        assert entry.host is None
+        assert entry.port is None
+        assert entry.model_hf_id is None
+
+    def test_missing_slot_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointEntry.model_validate(  # type: ignore[call-arg]
+                {"role": "coder_slow", "status": "running"}
+            )
+
+    def test_missing_role_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointEntry.model_validate({"slot_id": "x", "status": "running"})
+
+    def test_missing_status_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointEntry.model_validate({"slot_id": "x", "role": "coder_slow"})
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointEntry.model_validate(
+                {
+                    "slot_id": "x",
+                    "role": "coder_slow",
+                    "status": "running",
+                    "unknown_field": "boom",
+                }
+            )
+
+    def test_frozen_immutability(self) -> None:
+        entry = ModelLlmEndpointEntry(slot_id="x", role="coder_slow", status="running")
+        with pytest.raises((ValidationError, TypeError)):
+            entry.slot_id = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ModelLlmEndpointContract
+# ---------------------------------------------------------------------------
+
+
+class TestModelLlmEndpointContract:
+    def test_empty_contract(self) -> None:
+        contract = ModelLlmEndpointContract()
+        assert contract.endpoints == []
+
+    def test_round_trip_minimal(self) -> None:
+        raw = {
+            "endpoints": [
+                {
+                    "slot_id": "coder-5090",
+                    "host": "192.168.86.201",
+                    "port": 8000,
+                    "endpoint_url": "http://192.168.86.201:8000",
+                    "url_env_var": "LLM_CODER_URL",
+                    "role_env_alias": None,
+                    "model_hf_id": "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
+                    "role": "coder_slow",
+                    "status": "running",
+                }
+            ]
+        }
+        contract = ModelLlmEndpointContract.model_validate(raw)
+        assert len(contract.endpoints) == 1
+        assert contract.endpoints[0].url_env_var == "LLM_CODER_URL"
+
+    def test_running_filter(self) -> None:
+        raw = {
+            "endpoints": [
+                {
+                    "slot_id": "a",
+                    "role": "coder_slow",
+                    "status": "running",
+                    "url_env_var": "LLM_CODER_URL",
+                },
+                {
+                    "slot_id": "b",
+                    "role": "vision",
+                    "status": "planned",
+                },
+            ]
+        }
+        contract = ModelLlmEndpointContract.model_validate(raw)
+        assert len(contract.running()) == 1
+        assert contract.running()[0].slot_id == "a"
+
+    def test_by_role_filter(self) -> None:
+        raw = {
+            "endpoints": [
+                {"slot_id": "a", "role": "coder_slow", "status": "running"},
+                {"slot_id": "b", "role": "embedding", "status": "running"},
+                {"slot_id": "c", "role": "coder_slow", "status": "disabled"},
+            ]
+        }
+        contract = ModelLlmEndpointContract.model_validate(raw)
+        coders = contract.by_role("coder_slow")
+        assert len(coders) == 2
+        assert all(e.role == "coder_slow" for e in coders)
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointContract.model_validate({"endpoints": [], "extra": "boom"})
+
+    def test_frozen_immutability(self) -> None:
+        contract = ModelLlmEndpointContract()
+        with pytest.raises((ValidationError, TypeError)):
+            contract.endpoints = []  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# load_llm_endpoint_contract — real YAML round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLlmEndpointContract:
+    def test_loads_real_yaml(self) -> None:
+        if not _LLM_ENDPOINTS_YAML.exists():
+            pytest.skip("contracts/llm_endpoints.yaml not present in worktree")
+        contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+        assert len(contract.endpoints) > 0
+
+    def test_real_yaml_has_running_slots(self) -> None:
+        if not _LLM_ENDPOINTS_YAML.exists():
+            pytest.skip("contracts/llm_endpoints.yaml not present in worktree")
+        contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+        assert len(contract.running()) > 0
+
+    def test_real_yaml_coder_slot_present(self) -> None:
+        if not _LLM_ENDPOINTS_YAML.exists():
+            pytest.skip("contracts/llm_endpoints.yaml not present in worktree")
+        contract = load_llm_endpoint_contract(_LLM_ENDPOINTS_YAML)
+        coders = contract.by_role("coder_slow")
+        assert any(e.url_env_var == "LLM_CODER_URL" for e in coders)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_llm_endpoint_contract(tmp_path / "nonexistent.yaml")

--- a/tests/unit/models/contracts/test_model_llm_endpoint_contract.py
+++ b/tests/unit/models/contracts/test_model_llm_endpoint_contract.py
@@ -92,8 +92,29 @@ class TestModelLlmEndpointEntry:
                 }
             )
 
+    def test_running_missing_required_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="running endpoints require non-null"):
+            ModelLlmEndpointEntry(slot_id="x", role="coder_slow", status="running")
+
+    def test_running_missing_subset_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="port, endpoint_url, model_hf_id"):
+            ModelLlmEndpointEntry(
+                slot_id="x",
+                role="coder_slow",
+                status="running",
+                host="192.168.86.201",
+            )
+
     def test_frozen_immutability(self) -> None:
-        entry = ModelLlmEndpointEntry(slot_id="x", role="coder_slow", status="running")
+        entry = ModelLlmEndpointEntry(
+            slot_id="x",
+            role="coder_slow",
+            status="running",
+            host="192.168.86.201",
+            port=8000,
+            endpoint_url="http://192.168.86.201:8000",
+            model_hf_id="org/model",
+        )
         with pytest.raises((ValidationError, TypeError)):
             entry.slot_id = "y"  # type: ignore[misc]
 
@@ -135,6 +156,10 @@ class TestModelLlmEndpointContract:
                     "slot_id": "a",
                     "role": "coder_slow",
                     "status": "running",
+                    "host": "192.168.86.201",
+                    "port": 8000,
+                    "endpoint_url": "http://192.168.86.201:8000",
+                    "model_hf_id": "org/model",
                     "url_env_var": "LLM_CODER_URL",
                 },
                 {
@@ -149,10 +174,16 @@ class TestModelLlmEndpointContract:
         assert contract.running()[0].slot_id == "a"
 
     def test_by_role_filter(self) -> None:
+        _running = {
+            "host": "192.168.86.201",
+            "port": 8000,
+            "endpoint_url": "http://192.168.86.201:8000",
+            "model_hf_id": "org/model",
+        }
         raw = {
             "endpoints": [
-                {"slot_id": "a", "role": "coder_slow", "status": "running"},
-                {"slot_id": "b", "role": "embedding", "status": "running"},
+                {"slot_id": "a", "role": "coder_slow", "status": "running", **_running},
+                {"slot_id": "b", "role": "embedding", "status": "running", **_running},
                 {"slot_id": "c", "role": "coder_slow", "status": "disabled"},
             ]
         }


### PR DESCRIPTION
## Summary

Implements OMN-9750 Task 12: typed Pydantic models and YAML loader for `contracts/llm_endpoints.yaml`. This is **preparatory type grounding only** — no wiring into `service_kernel.py` in this PR per explicit scope constraint.

Parent epic: OMN-9738

### Changes

- `enum_llm_endpoint_status.py` — `EnumLlmEndpointStatus(str, Enum)` with RUNNING / DISABLED / ON_DEMAND / PLANNED
- `model_llm_endpoint_entry.py` — single-slot model matching STABLE-CANONICAL fields from the contract header
- `model_llm_endpoint_contract.py` — envelope + `running()` / `by_role()` helpers + `load_llm_endpoint_contract()` loader
- `validation_exemptions.yaml` — `slot_id` exemption (human-readable canonical natural key, not a UUID)
- 17 unit tests: round-trip, filter helpers, real YAML load, error paths

### dod_evidence

```
ticket: OMN-9750
task: 12
evidence:
  - type: tests_passing
    detail: >
      17 unit tests in tests/unit/models/contracts/test_model_llm_endpoint_contract.py
      covering ModelLlmEndpointEntry, ModelLlmEndpointContract, and load_llm_endpoint_contract().
      All pre-commit hooks pass including ONEX Architecture Validation, Pattern Validation,
      Naming Convention Validation.
  - type: scope_constraint_respected
    detail: >
      service_kernel.py is not touched. Docstring in model_llm_endpoint_contract.py
      explicitly states "DO NOT wire into service_kernel.py in this PR."
```

[skip-receipt-gate: preparatory model PR — no runtime behavior change; service_kernel cutover deferred to follow-on ticket per OMN-9750 scope]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM endpoint contract models for validating and managing endpoint configurations via YAML.
  * Added filtering methods to query endpoints by status and role.

* **Tests**
  * Added integration tests for YAML contract loading.
  * Added unit tests for contract validation and filtering.

* **Chores**
  * Added license headers to modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->