### PR TITLE
feat(OMN-9836): add omnidash-v2 to pull-all.sh

### DIFF
--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -18,6 +18,7 @@ REPOS=(
   omnibase_infra
   omnibase_spi
   omnidash
+  omnidash-v2
   omnigemini
   omniintelligence
   omnimarket


### PR DESCRIPTION
Closes OMN-9836. Adds omnidash-v2 to the REPOS array so pull-all syncs it alongside other registry repos.

Plan: docs/plans/2026-04-26-omnidash-v2-onboarding-and-contract-centralization.md § Task 14.

[skip-receipt-gate: operational script change, no dod_evidence block required for pull-all repo list addition]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation to include an additional component in routine pull operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->