### PR TITLE
feat(OMN-10081): add runtime local ingress transport

### DIFF
--- a/contracts/OMN-10081.yaml
+++ b/contracts/OMN-10081.yaml
@@ -1,0 +1,43 @@
+# OMN-10081 contract file for omnibase_infra deploy-gate (OMN-8912).
+# deploy-gate checks `contracts/<OMN-XXXX>.yaml` for a dod_evidence item whose
+# check_value contains one of 'docker exec', 'rpk topic produce', or 'deploy'.
+#
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: '1.0.0'
+ticket_id: OMN-10081
+summary: 'feat(OMN-10081): add runtime-owned local Unix-socket ingress transport'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Unit and integration tests for runtime local ingress
+    command: uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/integration/runtime/test_runtime_local_ingress.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks 1424 --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Contract artifact file present in repo
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-10081.yaml'
+  - id: dod-002
+    description: Unit and integration tests prove local runtime ingress dispatch
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/integration/runtime/test_runtime_local_ingress.py -q'
+  - id: dod-003
+    description: Runtime deploy validates local ingress socket dispatch after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'deploy omninode-runtime after merge, then send a local Unix-socket ingress request and verify it dispatches through the runtime host'

--- a/src/omnibase_infra/runtime/models/__init__.py
+++ b/src/omnibase_infra/runtime/models/__init__.py
@@ -139,6 +139,9 @@ from omnibase_infra.runtime.models.model_kafka_producer_config import (
 from omnibase_infra.runtime.models.model_lifecycle_result import (
     ModelLifecycleResult,
 )
+from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
+    ModelLocalRuntimeIngressConfig,
+)
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_materialized_resources import (
     ModelMaterializedResources,
@@ -248,6 +251,7 @@ __all__: list[str] = [
     "ModelHealthCheckResult",
     # NOTE: ModelIntentExecutionSummary excluded - import directly from module
     "ModelLifecycleResult",
+    "ModelLocalRuntimeIngressConfig",
     "ModelLoggingConfig",
     "ModelOptionalCorrelationId",
     "ModelOptionalString",

--- a/src/omnibase_infra/runtime/models/__init__.py
+++ b/src/omnibase_infra/runtime/models/__init__.py
@@ -142,6 +142,18 @@ from omnibase_infra.runtime.models.model_lifecycle_result import (
 from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
     ModelLocalRuntimeIngressConfig,
 )
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_health import (
+    ModelLocalRuntimeIngressHealth,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
+)
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_materialized_resources import (
     ModelMaterializedResources,
@@ -251,7 +263,11 @@ __all__: list[str] = [
     "ModelHealthCheckResult",
     # NOTE: ModelIntentExecutionSummary excluded - import directly from module
     "ModelLifecycleResult",
+    "ModelLocalRuntimeIngressError",
+    "ModelLocalRuntimeIngressHealth",
     "ModelLocalRuntimeIngressConfig",
+    "ModelLocalRuntimeIngressRequest",
+    "ModelLocalRuntimeIngressResponse",
     "ModelLoggingConfig",
     "ModelOptionalCorrelationId",
     "ModelOptionalString",

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
@@ -57,6 +57,13 @@ class ModelLocalRuntimeIngressConfig(BaseModel):
             raise ValueError("socket_path must be a non-empty string")
         return normalized
 
+    @field_validator("package_names", mode="before")
+    @classmethod
+    def _coerce_package_names(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
     @field_validator("package_names")
     @classmethod
     def _validate_package_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Local runtime ingress configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ModelLocalRuntimeIngressConfig(BaseModel):
+    """Configuration for the runtime-owned local command ingress."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    enabled: bool = Field(
+        default=False,
+        description="Whether the runtime should bind a local Unix-socket ingress.",
+    )
+    socket_path: str = Field(
+        default="/tmp/onex-runtime.sock",  # noqa: S108
+        min_length=1,
+        description="Unix-socket path for local runtime command ingress.",
+    )
+    socket_permissions: int = Field(
+        default=0o660,
+        ge=0,
+        le=0o777,
+        description="Unix permission mode applied to the socket file.",
+    )
+    socket_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        le=300,
+        description="Per-read timeout for local ingress client connections.",
+    )
+    max_payload_bytes: int = Field(
+        default=1_048_576,
+        gt=0,
+        le=16_777_216,
+        description="Maximum accepted request payload size in bytes.",
+    )
+    package_names: tuple[str, ...] = Field(
+        default=("omnibase_infra",),
+        description="Package roots scanned for runtime-executable node contracts.",
+    )
+
+    @field_validator("socket_path")
+    @classmethod
+    def _validate_socket_path(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("socket_path must be a non-empty string")
+        return normalized
+
+    @field_validator("package_names")
+    @classmethod
+    def _validate_package_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(part.strip() for part in value if part.strip())
+        if not normalized:
+            raise ValueError("package_names must contain at least one package name")
+        return normalized
+
+
+__all__ = ["ModelLocalRuntimeIngressConfig"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_error.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_error.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed error envelope for local runtime ingress responses."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelLocalRuntimeIngressError(BaseModel):
+    """Structured error for local runtime ingress responses."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    code: Literal[
+        "validation_error",
+        "unknown_node",
+        "runtime_unavailable",
+        "dispatch_timeout",
+        "dispatch_error",
+        "dispatch_result_missing",
+    ] = Field(..., description="Stable local ingress error code.")
+    message: str = Field(..., min_length=1, description="Human-readable error message.")
+    retryable: bool = Field(
+        default=False,
+        description="Whether callers may retry the same request without mutation.",
+    )
+    details: dict[str, JsonType] | None = Field(
+        default=None,
+        description="Additional typed diagnostic details for the caller.",
+    )
+
+
+__all__ = ["ModelLocalRuntimeIngressError"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_health.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_health.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed runtime health details for local runtime ingress."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelLocalRuntimeIngressHealth(BaseModel):
+    """Operational health details for the local runtime ingress."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    enabled: bool = Field(..., description="Whether local ingress is configured.")
+    running: bool = Field(..., description="Whether the socket server is serving.")
+    socket_path: str | None = Field(
+        default=None,
+        description="Bound socket path when local ingress is configured.",
+    )
+    route_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of local node routes exposed through the ingress.",
+    )
+    active_packages: tuple[str, ...] = Field(
+        default=(),
+        description="Resolved runtime packages scanned for ingress routes.",
+    )
+    request_model: str = Field(
+        default="ModelLocalRuntimeIngressRequest",
+        description="Stable request model name for client compatibility.",
+    )
+    response_model: str = Field(
+        default="ModelLocalRuntimeIngressResponse",
+        description="Stable response model name for client compatibility.",
+    )
+
+
+__all__ = ["ModelLocalRuntimeIngressHealth"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_request.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_request.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed request model for local runtime ingress."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.types import JsonType
+
+
+class ModelLocalRuntimeIngressRequest(BaseModel):
+    """Validated request envelope for local runtime ingress."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    node_alias: str = Field(
+        ..., min_length=1, description="Requested runtime node alias."
+    )
+    payload: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="JSON payload forwarded to the backing node handler.",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Optional caller-supplied correlation identifier.",
+    )
+    timeout_ms: int = Field(
+        default=300_000,
+        gt=0,
+        le=900_000,
+        description="Maximum local dispatch time before returning a timeout response.",
+    )
+
+    @field_validator("node_alias")
+    @classmethod
+    def _validate_node_alias(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("node_alias must be a non-empty string")
+        return normalized
+
+
+__all__ = ["ModelLocalRuntimeIngressRequest"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_response.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_response.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed response model for local runtime ingress."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+
+
+class ModelLocalRuntimeIngressResponse(BaseModel):
+    """Structured response returned to local runtime ingress callers."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    ok: bool = Field(..., description="Whether the request completed successfully.")
+    node_alias: str = Field(..., min_length=1, description="Requested node alias.")
+    resolved_node_name: str | None = Field(
+        default=None,
+        description="Resolved node directory name when the request is routable.",
+    )
+    contract_name: str | None = Field(
+        default=None,
+        description="Resolved contract name when the request is routable.",
+    )
+    topic: str | None = Field(
+        default=None,
+        description="Resolved command topic used for dispatch.",
+    )
+    terminal_event: str | None = Field(
+        default=None,
+        description="Declared terminal event for the resolved node contract.",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Resolved correlation identifier for the request.",
+    )
+    dispatch_result: ModelDispatchResult | None = Field(
+        default=None,
+        description="Dispatch result for successful runtime execution.",
+    )
+    error: ModelLocalRuntimeIngressError | None = Field(
+        default=None,
+        description="Structured error for rejected or failed requests.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_success_shape(self) -> ModelLocalRuntimeIngressResponse:
+        if self.ok and self.dispatch_result is None:
+            raise ValueError("ok responses must include dispatch_result")
+        if not self.ok and self.error is None:
+            raise ValueError("non-ok responses must include error")
+        return self
+
+
+__all__ = ["ModelLocalRuntimeIngressResponse"]

--- a/src/omnibase_infra/runtime/models/model_runtime_config.py
+++ b/src/omnibase_infra/runtime/models/model_runtime_config.py
@@ -57,6 +57,9 @@ from omnibase_infra.runtime.models.model_enabled_protocols_config import (
     ModelEnabledProtocolsConfig,
 )
 from omnibase_infra.runtime.models.model_event_bus_config import ModelEventBusConfig
+from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
+    ModelLocalRuntimeIngressConfig,
+)
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_shutdown_config import ModelShutdownConfig
 
@@ -160,6 +163,10 @@ class ModelRuntimeConfig(BaseModel):
     gateway: ModelGatewayConfig | None = Field(
         default=None,
         description="Gateway configuration for envelope signing and realm enforcement",
+    )
+    local_ingress: ModelLocalRuntimeIngressConfig = Field(
+        default_factory=ModelLocalRuntimeIngressConfig,
+        description="Configuration for the runtime-owned local command ingress.",
     )
 
 

--- a/src/omnibase_infra/runtime/models/model_runtime_config.py
+++ b/src/omnibase_infra/runtime/models/model_runtime_config.py
@@ -16,6 +16,7 @@ Currently Used by kernel.py:
     - consumer_group (alias: group_id): Used for EventBusInmemory.group
     - event_bus.environment: Used for EventBusInmemory.environment
     - shutdown.grace_period_seconds: Used for graceful shutdown timeout
+    - local_ingress: Used by RuntimeHostProcess to bind local command ingress
 
 Reserved for Future Use:
     - contract_version, name, description: Metadata fields for contract versioning
@@ -83,6 +84,7 @@ class ModelRuntimeConfig(BaseModel):
         shutdown: Shutdown configuration [ACTIVE - grace_period_seconds used]
         contract_registry: Contract registry configuration [ACTIVE]
         gateway: Gateway configuration for envelope signing and realm enforcement [RESERVED]
+        local_ingress: Local Unix-socket command ingress configuration [ACTIVE]
 
     Field Status Legend:
         [ACTIVE]   - Currently used by kernel.py

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -9,6 +9,7 @@ import importlib
 import json
 import logging
 import os
+import stat
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -79,7 +80,21 @@ def discover_runtime_local_ingress_routes(
             continue
 
         for contract_path in sorted(nodes_dir.glob("*/contract.yaml")):
-            raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+            try:
+                raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+            except yaml.YAMLError as exc:
+                logger.warning(
+                    "Skipping malformed local ingress contract",
+                    extra={"contract_path": str(contract_path), "error": str(exc)},
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Skipping unreadable local ingress contract",
+                    extra={"contract_path": str(contract_path), "error": str(exc)},
+                    exc_info=True,
+                )
+                continue
             if not isinstance(raw, dict):
                 continue
 
@@ -155,7 +170,7 @@ class RuntimeLocalIngressServer:
     async def start(self) -> None:
         socket_path = Path(self._socket_path)
         socket_path.parent.mkdir(parents=True, exist_ok=True)
-        socket_path.unlink(missing_ok=True)
+        _unlink_existing_socket(socket_path, raise_on_refusal=True)
 
         stream_limit = self._max_payload_bytes + 4096
         self._server = await asyncio.start_unix_server(
@@ -175,8 +190,7 @@ class RuntimeLocalIngressServer:
             self._server = None
 
         socket_path = Path(self._socket_path)
-        if socket_path.exists():
-            socket_path.unlink(missing_ok=True)
+        _unlink_existing_socket(socket_path, raise_on_refusal=False)
 
         logger.info("RuntimeLocalIngressServer stopped")
 
@@ -234,7 +248,7 @@ class RuntimeLocalIngressServer:
             )
 
         try:
-            request = ModelLocalRuntimeIngressRequest.model_validate(raw)
+            request = ModelLocalRuntimeIngressRequest.model_validate(raw, strict=False)
         except ValidationError as exc:
             node_alias = "unknown"
             if isinstance(raw, dict):
@@ -260,6 +274,35 @@ def _resolve_package_root(package_name: str) -> Path:
     if not isinstance(module_file, str) or not module_file:
         raise ValueError(f"Cannot resolve package root for '{package_name}'")
     return Path(module_file).resolve().parent
+
+
+def _unlink_existing_socket(
+    socket_path: Path,
+    *,
+    raise_on_refusal: bool,
+) -> None:
+    if not socket_path.exists() and not socket_path.is_symlink():
+        return
+
+    existing_stat = socket_path.lstat()
+    allowed_group_ids = set(os.getgroups()) | {os.getgid(), os.getegid()}
+    parent_group_id = socket_path.parent.stat().st_gid
+    is_owned_socket = (
+        stat.S_ISSOCK(existing_stat.st_mode)
+        and existing_stat.st_uid == os.getuid()
+        and existing_stat.st_gid in allowed_group_ids | {parent_group_id}
+    )
+    if is_owned_socket:
+        socket_path.unlink()
+        return
+
+    message = (
+        f"Refusing to unlink local ingress path {socket_path}: existing path is "
+        "not an owned Unix socket"
+    )
+    if raise_on_refusal:
+        raise FileExistsError(message)
+    logger.warning(message)
 
 
 def _safe_optional_string(value: object) -> str | None:

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -14,9 +14,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from omnibase_infra.runtime.event_bus_subcontract_wiring import (
     EventBusSubcontractWiring,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,7 +127,10 @@ class RuntimeLocalIngressServer:
     def __init__(
         self,
         socket_path: str,
-        request_handler: Callable[[dict[str, object]], Awaitable[dict[str, object]]],
+        request_handler: Callable[
+            [ModelLocalRuntimeIngressRequest],
+            Awaitable[ModelLocalRuntimeIngressResponse],
+        ],
         *,
         socket_timeout_seconds: float = 5.0,
         socket_permissions: int = 0o660,
@@ -186,7 +199,7 @@ class RuntimeLocalIngressServer:
                     break
 
                 response = await self._process_request_line(line)
-                writer.write(json.dumps(response).encode("utf-8") + b"\n")
+                writer.write(response.model_dump_json().encode("utf-8") + b"\n")
                 await writer.drain()
         except ConnectionResetError:
             pass
@@ -194,25 +207,51 @@ class RuntimeLocalIngressServer:
             writer.close()
             await writer.wait_closed()
 
-    async def _process_request_line(self, line: bytes) -> dict[str, object]:
+    async def _process_request_line(
+        self,
+        line: bytes,
+    ) -> ModelLocalRuntimeIngressResponse:
         if len(line) > self._max_payload_bytes:
-            return {
-                "ok": False,
-                "error": "Request exceeds max_payload_bytes",
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias="unknown",
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message="Request exceeds max_payload_bytes",
+                ),
+            )
 
         try:
             raw = json.loads(line.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return {"ok": False, "error": f"Invalid JSON request: {exc}"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias="unknown",
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message=f"Invalid JSON request: {exc}",
+                ),
+            )
 
-        if not isinstance(raw, dict):
-            return {
-                "ok": False,
-                "error": "Request must be a JSON object",
-            }
+        try:
+            request = ModelLocalRuntimeIngressRequest.model_validate(raw)
+        except ValidationError as exc:
+            node_alias = "unknown"
+            if isinstance(raw, dict):
+                raw_alias = raw.get("node_alias")
+                if isinstance(raw_alias, str):
+                    node_alias = raw_alias
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=node_alias,
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message="Invalid local runtime ingress request",
+                    details={"errors": json.loads(exc.json(include_url=False))},
+                ),
+            )
 
-        return await self._request_handler(raw)
+        return await self._request_handler(request)
 
 
 def _resolve_package_root(package_name: str) -> Path:

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -216,7 +216,7 @@ class RuntimeLocalIngressServer:
                 writer.write(response.model_dump_json().encode("utf-8") + b"\n")
                 await writer.drain()
         except ConnectionResetError:
-            pass
+            logger.debug("Local ingress client reset the Unix-socket connection")
         finally:
             writer.close()
             await writer.wait_closed()

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unix-socket transport for runtime-owned local command ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import logging
+import os
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.event_bus_subcontract_wiring import (
+    EventBusSubcontractWiring,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeLocalIngressRoute:
+    """Resolved route for a node exposed through the local runtime ingress."""
+
+    node_name: str
+    contract_name: str
+    command_topic: str
+    event_type: str | None
+    terminal_event: str | None
+    contract_path: str
+    package_name: str
+
+
+def parse_active_runtime_packages(
+    configured_packages: Sequence[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> tuple[str, ...]:
+    """Resolve active runtime packages, honoring ONEX_ACTIVE_RUNTIME_PACKAGES."""
+
+    env_map = os.environ if env is None else env
+    raw = env_map.get("ONEX_ACTIVE_RUNTIME_PACKAGES", "")
+    if raw.strip():
+        resolved = tuple(part.strip() for part in raw.split(",") if part.strip())
+        if resolved:
+            return resolved
+
+    normalized = tuple(part.strip() for part in configured_packages if part.strip())
+    if not normalized:
+        raise ValueError("No runtime packages configured for local ingress")
+    return normalized
+
+
+def discover_runtime_local_ingress_routes(
+    package_names: Sequence[str],
+) -> dict[str, RuntimeLocalIngressRoute]:
+    """Discover local-ingress routes from installed package node contracts."""
+
+    routes: dict[str, RuntimeLocalIngressRoute] = {}
+
+    for package_name in package_names:
+        package_root = _resolve_package_root(package_name)
+        nodes_dir = package_root / "nodes"
+        if not nodes_dir.is_dir():
+            continue
+
+        for contract_path in sorted(nodes_dir.glob("*/contract.yaml")):
+            raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                continue
+
+            contract_name = str(raw.get("name", "")).strip()
+            if not contract_name:
+                continue
+
+            event_bus_section = raw.get("event_bus")
+            if not isinstance(event_bus_section, dict):
+                continue
+            subscribe_topics = event_bus_section.get("subscribe_topics")
+            if not isinstance(subscribe_topics, list):
+                continue
+
+            command_topic = _select_command_topic(subscribe_topics)
+            if command_topic is None:
+                continue
+
+            node_dir_name = contract_path.parent.name
+            route = RuntimeLocalIngressRoute(
+                node_name=node_dir_name,
+                contract_name=contract_name,
+                command_topic=command_topic,
+                event_type=_derive_route_event_type(raw, command_topic),
+                terminal_event=_safe_optional_string(raw.get("terminal_event")),
+                contract_path=str(contract_path),
+                package_name=package_name,
+            )
+
+            for alias in (contract_name, node_dir_name):
+                existing = routes.get(alias)
+                if existing is not None and existing != route:
+                    raise ValueError(
+                        f"Duplicate local ingress route alias '{alias}' for "
+                        f"{existing.contract_path} and {route.contract_path}"
+                    )
+                routes[alias] = route
+
+    return routes
+
+
+class RuntimeLocalIngressServer:
+    """Async Unix-socket server for local runtime dispatch requests."""
+
+    def __init__(
+        self,
+        socket_path: str,
+        request_handler: Callable[[dict[str, object]], Awaitable[dict[str, object]]],
+        *,
+        socket_timeout_seconds: float = 5.0,
+        socket_permissions: int = 0o660,
+        max_payload_bytes: int = 1_048_576,
+    ) -> None:
+        self._socket_path = socket_path
+        self._request_handler = request_handler
+        self._socket_timeout_seconds = socket_timeout_seconds
+        self._socket_permissions = socket_permissions
+        self._max_payload_bytes = max_payload_bytes
+        self._server: asyncio.Server | None = None
+        self._shutdown_event = asyncio.Event()
+
+    @property
+    def is_running(self) -> bool:
+        return self._server is not None and self._server.is_serving()
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    async def start(self) -> None:
+        socket_path = Path(self._socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+
+        stream_limit = self._max_payload_bytes + 4096
+        self._server = await asyncio.start_unix_server(
+            self._handle_client,
+            path=self._socket_path,
+            limit=stream_limit,
+        )
+        socket_path.chmod(self._socket_permissions)
+        self._shutdown_event.clear()
+        logger.info("RuntimeLocalIngressServer listening on %s", self._socket_path)
+
+    async def stop(self) -> None:
+        self._shutdown_event.set()
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        socket_path = Path(self._socket_path)
+        if socket_path.exists():
+            socket_path.unlink(missing_ok=True)
+
+        logger.info("RuntimeLocalIngressServer stopped")
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while not self._shutdown_event.is_set():
+                try:
+                    line = await asyncio.wait_for(
+                        reader.readline(),
+                        timeout=self._socket_timeout_seconds,
+                    )
+                except TimeoutError:
+                    break
+
+                if not line:
+                    break
+
+                response = await self._process_request_line(line)
+                writer.write(json.dumps(response).encode("utf-8") + b"\n")
+                await writer.drain()
+        except ConnectionResetError:
+            pass
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _process_request_line(self, line: bytes) -> dict[str, object]:
+        if len(line) > self._max_payload_bytes:
+            return {
+                "ok": False,
+                "error": "Request exceeds max_payload_bytes",
+            }
+
+        try:
+            raw = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return {"ok": False, "error": f"Invalid JSON request: {exc}"}
+
+        if not isinstance(raw, dict):
+            return {
+                "ok": False,
+                "error": "Request must be a JSON object",
+            }
+
+        return await self._request_handler(raw)
+
+
+def _resolve_package_root(package_name: str) -> Path:
+    module = importlib.import_module(package_name)
+    module_file = getattr(module, "__file__", None)
+    if not isinstance(module_file, str) or not module_file:
+        raise ValueError(f"Cannot resolve package root for '{package_name}'")
+    return Path(module_file).resolve().parent
+
+
+def _safe_optional_string(value: object) -> str | None:
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    return None
+
+
+def _select_command_topic(subscribe_topics: list[object]) -> str | None:
+    normalized_topics = [
+        str(topic).strip()
+        for topic in subscribe_topics
+        if isinstance(topic, str) and topic.strip()
+    ]
+    for topic in normalized_topics:
+        if ".cmd." in topic:
+            return topic
+    return normalized_topics[0] if normalized_topics else None
+
+
+def _derive_route_event_type(
+    contract: dict[str, object],
+    command_topic: str,
+) -> str | None:
+    handler_routing = contract.get("handler_routing")
+    if isinstance(handler_routing, dict):
+        handlers = handler_routing.get("handlers")
+        if isinstance(handlers, list):
+            for handler_entry in handlers:
+                if isinstance(handler_entry, dict):
+                    raw_event_type = handler_entry.get("event_type")
+                    if isinstance(raw_event_type, str) and raw_event_type.strip():
+                        return raw_event_type.strip()
+
+    return EventBusSubcontractWiring._derive_event_type_from_topic(command_topic)
+
+
+__all__ = [
+    "RuntimeLocalIngressRoute",
+    "RuntimeLocalIngressServer",
+    "discover_runtime_local_ingress_routes",
+    "parse_active_runtime_packages",
+]

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -52,6 +52,7 @@ import random
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
@@ -59,8 +60,10 @@ from uuid import UUID, uuid4
 import yaml
 from pydantic import BaseModel, ValidationError
 
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums import (
     EnumConsumerGroupPurpose,
+    EnumDispatchStatus,
     EnumHandlerSourceMode,
     EnumHandlerTypeCategory,
     EnumInfraTransportType,
@@ -108,6 +111,7 @@ from omnibase_infra.runtime.health.health_published_events_map import (
 )
 from omnibase_infra.runtime.models import (
     ModelDuplicateResponse,
+    ModelLocalRuntimeIngressConfig,
     ModelRuntimeContractConfig,
 )
 from omnibase_infra.runtime.models.model_component_health import (
@@ -122,6 +126,12 @@ from omnibase_infra.runtime.protocol_lifecycle_executor import (
 )
 from omnibase_infra.runtime.runtime_contract_config_loader import (
     RuntimeContractConfigLoader,
+)
+from omnibase_infra.runtime.runtime_local_ingress import (
+    RuntimeLocalIngressRoute,
+    RuntimeLocalIngressServer,
+    discover_runtime_local_ingress_routes,
+    parse_active_runtime_packages,
 )
 from omnibase_infra.runtime.util_mcp_auth import inject_mcp_api_keys
 from omnibase_infra.runtime.util_wiring import wire_default_handlers
@@ -156,6 +166,9 @@ if TYPE_CHECKING:
     )
     from omnibase_infra.runtime.models.model_runtime_node_graph_config import (
         ModelRuntimeNodeGraphConfig,
+    )
+    from omnibase_infra.runtime.service_dispatch_result_applier import (
+        DispatchResultApplier,
     )
     from omnibase_infra.runtime.service_message_dispatch_engine import (
         MessageDispatchEngine,
@@ -869,6 +882,13 @@ class RuntimeHostProcess:
         # Extract configuration with defaults
         config = config or {}
 
+        local_ingress_config_raw = config.get("local_ingress", {})
+        if not isinstance(local_ingress_config_raw, dict):
+            raise ValueError("config.local_ingress must be a mapping when provided")
+        self._local_ingress_config = ModelLocalRuntimeIngressConfig.model_validate(
+            local_ingress_config_raw
+        )
+
         # Topic configuration (config overrides constructor args)
         self._input_topic: str = str(config.get("input_topic", input_topic))
         self._output_topic: str = str(config.get("output_topic", output_topic))
@@ -1192,6 +1212,9 @@ class RuntimeHostProcess:
         # Bridges contract-declared topics to Kafka subscriptions.
         # None until wired during start() when dispatch_engine is available.
         self._event_bus_wiring: EventBusSubcontractWiring | None = None
+        self._local_ingress_routes: dict[str, RuntimeLocalIngressRoute] = {}
+        self._local_ingress_server: RuntimeLocalIngressServer | None = None
+        self._local_ingress_dispatch_result_applier: DispatchResultApplier | None = None
 
         # Message dispatch engine for routing received messages (OMN-2050)
         # When set, contract-declared topics are routed through
@@ -1839,6 +1862,9 @@ class RuntimeHostProcess:
         if self._batch_publisher is not None:
             await self._batch_publisher.start()
 
+        # Step 5.75: Start local runtime ingress once dispatch routing is ready.
+        await self._start_local_ingress()
+
         self._is_running = True
 
         # Step 6: Publish introspection event with jitter (OMN-1930)
@@ -1929,6 +1955,12 @@ class RuntimeHostProcess:
             self._is_starting = False
 
         logger.info("Stopping RuntimeHostProcess")
+
+        # Stop local ingress first so new host-local work cannot enter while
+        # the runtime drains and shuts down.
+        if self._local_ingress_server is not None:
+            await self._local_ingress_server.stop()
+            self._local_ingress_server = None
 
         # Step 1: Unsubscribe from topics (stop receiving new messages)
         if self._subscription is not None:
@@ -2116,6 +2148,130 @@ class RuntimeHostProcess:
         self._is_running = False
 
         logger.info("RuntimeHostProcess stopped successfully")
+
+    async def _start_local_ingress(self) -> None:
+        """Start the runtime-owned local command ingress when enabled."""
+        if not self._local_ingress_config.enabled:
+            self._local_ingress_routes.clear()
+            return
+
+        if self._dispatch_engine is None:
+            raise ProtocolConfigurationError(
+                "local runtime ingress requires a dispatch_engine",
+                context=ModelInfraErrorContext(
+                    transport_type=EnumInfraTransportType.RUNTIME,
+                    operation="local_ingress.start",
+                ),
+            )
+
+        package_names = parse_active_runtime_packages(
+            self._local_ingress_config.package_names
+        )
+        self._local_ingress_routes = discover_runtime_local_ingress_routes(
+            package_names
+        )
+        self._local_ingress_dispatch_result_applier = (
+            await self._resolve_dispatch_result_applier_from_container()
+        )
+        self._local_ingress_server = RuntimeLocalIngressServer(
+            socket_path=self._local_ingress_config.socket_path,
+            request_handler=self._dispatch_local_ingress_request,
+            socket_timeout_seconds=self._local_ingress_config.socket_timeout_seconds,
+            socket_permissions=self._local_ingress_config.socket_permissions,
+            max_payload_bytes=self._local_ingress_config.max_payload_bytes,
+        )
+        await self._local_ingress_server.start()
+
+    async def _dispatch_local_ingress_request(
+        self,
+        request: dict[str, object],
+    ) -> dict[str, object]:
+        """Dispatch a local ingress request through the runtime dispatch engine."""
+        requested_node = request.get("node_name")
+        if not isinstance(requested_node, str) or not requested_node.strip():
+            return {"ok": False, "error": "node_name must be a non-empty string"}
+
+        payload = request.get("payload", {})
+        if not isinstance(payload, dict):
+            return {"ok": False, "error": "payload must be a JSON object"}
+
+        if self._dispatch_engine is None:
+            return {"ok": False, "error": "dispatch_engine is not configured"}
+        if not self._is_running and not self._is_starting:
+            return {"ok": False, "error": "runtime is not running"}
+        if self._is_draining or self._shutdown_requested.is_set():
+            return {"ok": False, "error": "runtime is draining"}
+
+        route = self._local_ingress_routes.get(requested_node.strip())
+        if route is None:
+            return {
+                "ok": False,
+                "error": f"Unknown local ingress node '{requested_node}'",
+            }
+
+        correlation_id = normalize_correlation_id(request.get("correlation_id"))
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=cast("object", payload),
+            correlation_id=correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=route.event_type,
+            source_tool="runtime-local-ingress",
+            target_tool=route.contract_name,
+        )
+
+        async with self._pending_lock:
+            self._pending_message_count += 1
+        try:
+            result = await self._dispatch_engine.dispatch(route.command_topic, envelope)
+            if (
+                self._local_ingress_dispatch_result_applier is not None
+                and result is not None
+            ):
+                await self._local_ingress_dispatch_result_applier.apply(
+                    result,
+                    correlation_id,
+                )
+
+            if result is None:
+                return {
+                    "ok": False,
+                    "error": "dispatch_engine returned no result",
+                    "node_name": requested_node,
+                    "topic": route.command_topic,
+                    "correlation_id": str(correlation_id),
+                }
+
+            return {
+                "ok": result.status != EnumDispatchStatus.NO_DISPATCHER,
+                "node_name": requested_node,
+                "resolved_node_name": route.node_name,
+                "contract_name": route.contract_name,
+                "topic": route.command_topic,
+                "terminal_event": route.terminal_event,
+                "correlation_id": str(correlation_id),
+                "dispatch_result": result.model_dump(mode="json"),
+            }
+        except Exception as exc:  # noqa: BLE001
+            sanitized_error = sanitize_error_message(exc)
+            logger.error(  # noqa: TRY400
+                "Local ingress dispatch failed",
+                extra={
+                    "node_name": requested_node,
+                    "topic": route.command_topic,
+                    "correlation_id": str(correlation_id),
+                    "error": sanitized_error,
+                },
+            )
+            return {
+                "ok": False,
+                "error": sanitized_error,
+                "node_name": requested_node,
+                "topic": route.command_topic,
+                "correlation_id": str(correlation_id),
+            }
+        finally:
+            async with self._pending_lock:
+                self._pending_message_count -= 1
 
     def _load_handler_source_config(self) -> ModelHandlerSourceConfig:
         """Load handler source configuration from runtime config.
@@ -4642,6 +4798,21 @@ class RuntimeHostProcess:
             return None
 
         return check_published_events_map_health(applier.published_events_map)
+
+    async def _resolve_dispatch_result_applier_from_container(
+        self,
+    ) -> DispatchResultApplier | None:
+        """Resolve DispatchResultApplier from the container service registry."""
+        from omnibase_infra.runtime.service_dispatch_result_applier import (
+            DispatchResultApplier,
+        )
+
+        if self._container is None:
+            return None
+        registry = self._container.service_registry
+        if registry is None:
+            return None
+        return await registry.try_resolve_service(DispatchResultApplier)
 
     async def readiness_check(
         self, correlation_id: UUID | None = None

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -112,6 +112,10 @@ from omnibase_infra.runtime.health.health_published_events_map import (
 from omnibase_infra.runtime.models import (
     ModelDuplicateResponse,
     ModelLocalRuntimeIngressConfig,
+    ModelLocalRuntimeIngressError,
+    ModelLocalRuntimeIngressHealth,
+    ModelLocalRuntimeIngressRequest,
+    ModelLocalRuntimeIngressResponse,
     ModelRuntimeContractConfig,
 )
 from omnibase_infra.runtime.models.model_component_health import (
@@ -1215,6 +1219,7 @@ class RuntimeHostProcess:
         self._local_ingress_routes: dict[str, RuntimeLocalIngressRoute] = {}
         self._local_ingress_server: RuntimeLocalIngressServer | None = None
         self._local_ingress_dispatch_result_applier: DispatchResultApplier | None = None
+        self._local_ingress_active_packages: tuple[str, ...] = ()
 
         # Message dispatch engine for routing received messages (OMN-2050)
         # When set, contract-declared topics are routed through
@@ -2153,6 +2158,7 @@ class RuntimeHostProcess:
         """Start the runtime-owned local command ingress when enabled."""
         if not self._local_ingress_config.enabled:
             self._local_ingress_routes.clear()
+            self._local_ingress_active_packages = ()
             return
 
         if self._dispatch_engine is None:
@@ -2167,6 +2173,7 @@ class RuntimeHostProcess:
         package_names = parse_active_runtime_packages(
             self._local_ingress_config.package_names
         )
+        self._local_ingress_active_packages = package_names
         self._local_ingress_routes = discover_runtime_local_ingress_routes(
             package_names
         )
@@ -2184,34 +2191,56 @@ class RuntimeHostProcess:
 
     async def _dispatch_local_ingress_request(
         self,
-        request: dict[str, object],
-    ) -> dict[str, object]:
+        request: ModelLocalRuntimeIngressRequest,
+    ) -> ModelLocalRuntimeIngressResponse:
         """Dispatch a local ingress request through the runtime dispatch engine."""
-        requested_node = request.get("node_name")
-        if not isinstance(requested_node, str) or not requested_node.strip():
-            return {"ok": False, "error": "node_name must be a non-empty string"}
-
-        payload = request.get("payload", {})
-        if not isinstance(payload, dict):
-            return {"ok": False, "error": "payload must be a JSON object"}
-
         if self._dispatch_engine is None:
-            return {"ok": False, "error": "dispatch_engine is not configured"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="dispatch_engine is not configured",
+                ),
+            )
         if not self._is_running and not self._is_starting:
-            return {"ok": False, "error": "runtime is not running"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="runtime is not running",
+                ),
+            )
         if self._is_draining or self._shutdown_requested.is_set():
-            return {"ok": False, "error": "runtime is draining"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="runtime is draining",
+                    retryable=True,
+                ),
+            )
 
-        route = self._local_ingress_routes.get(requested_node.strip())
+        route = self._local_ingress_routes.get(request.node_alias)
         if route is None:
-            return {
-                "ok": False,
-                "error": f"Unknown local ingress node '{requested_node}'",
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="unknown_node",
+                    message=f"Unknown local ingress node '{request.node_alias}'",
+                ),
+            )
 
-        correlation_id = normalize_correlation_id(request.get("correlation_id"))
+        correlation_id = normalize_correlation_id(request.correlation_id)
         envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
-            payload=cast("object", payload),
+            payload=cast("object", request.payload),
             correlation_id=correlation_id,
             envelope_timestamp=datetime.now(UTC),
             event_type=route.event_type,
@@ -2222,7 +2251,10 @@ class RuntimeHostProcess:
         async with self._pending_lock:
             self._pending_message_count += 1
         try:
-            result = await self._dispatch_engine.dispatch(route.command_topic, envelope)
+            result = await asyncio.wait_for(
+                self._dispatch_engine.dispatch(route.command_topic, envelope),
+                timeout=request.timeout_ms / 1000.0,
+            )
             if (
                 self._local_ingress_dispatch_result_applier is not None
                 and result is not None
@@ -2233,42 +2265,91 @@ class RuntimeHostProcess:
                 )
 
             if result is None:
-                return {
-                    "ok": False,
-                    "error": "dispatch_engine returned no result",
-                    "node_name": requested_node,
-                    "topic": route.command_topic,
-                    "correlation_id": str(correlation_id),
-                }
+                return ModelLocalRuntimeIngressResponse(
+                    ok=False,
+                    node_alias=request.node_alias,
+                    resolved_node_name=route.node_name,
+                    contract_name=route.contract_name,
+                    topic=route.command_topic,
+                    terminal_event=route.terminal_event,
+                    correlation_id=correlation_id,
+                    error=ModelLocalRuntimeIngressError(
+                        code="dispatch_result_missing",
+                        message="dispatch_engine returned no result",
+                    ),
+                )
 
-            return {
-                "ok": result.status != EnumDispatchStatus.NO_DISPATCHER,
-                "node_name": requested_node,
-                "resolved_node_name": route.node_name,
-                "contract_name": route.contract_name,
-                "topic": route.command_topic,
-                "terminal_event": route.terminal_event,
-                "correlation_id": str(correlation_id),
-                "dispatch_result": result.model_dump(mode="json"),
-            }
+            if result.status == EnumDispatchStatus.NO_DISPATCHER:
+                return ModelLocalRuntimeIngressResponse(
+                    ok=False,
+                    node_alias=request.node_alias,
+                    resolved_node_name=route.node_name,
+                    contract_name=route.contract_name,
+                    topic=route.command_topic,
+                    terminal_event=route.terminal_event,
+                    correlation_id=correlation_id,
+                    dispatch_result=result,
+                    error=ModelLocalRuntimeIngressError(
+                        code="dispatch_error",
+                        message=(
+                            result.error_message
+                            or f"No dispatcher registered for topic {route.command_topic}"
+                        ),
+                    ),
+                )
+
+            return ModelLocalRuntimeIngressResponse(
+                ok=True,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                dispatch_result=result,
+            )
+        except TimeoutError:
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="dispatch_timeout",
+                    message=(
+                        f"Local runtime ingress timed out after {request.timeout_ms} ms"
+                    ),
+                    retryable=True,
+                ),
+            )
         except Exception as exc:  # noqa: BLE001
             sanitized_error = sanitize_error_message(exc)
             logger.error(  # noqa: TRY400
                 "Local ingress dispatch failed",
                 extra={
-                    "node_name": requested_node,
+                    "node_alias": request.node_alias,
                     "topic": route.command_topic,
                     "correlation_id": str(correlation_id),
                     "error": sanitized_error,
                 },
             )
-            return {
-                "ok": False,
-                "error": sanitized_error,
-                "node_name": requested_node,
-                "topic": route.command_topic,
-                "correlation_id": str(correlation_id),
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="dispatch_error",
+                    message=sanitized_error,
+                    retryable=True,
+                ),
+            )
         finally:
             async with self._pending_lock:
                 self._pending_message_count -= 1
@@ -4736,6 +4817,13 @@ class RuntimeHostProcess:
             components.append(published_events_map_health.model_dump(mode="json"))
             if published_events_map_health.status == "unhealthy":
                 healthy = False
+        local_ingress_health = self._build_local_ingress_health()
+        local_ingress_component = self._build_local_ingress_component(
+            local_ingress_health
+        )
+        components.append(local_ingress_component.model_dump(mode="json"))
+        if local_ingress_component.status == "unhealthy":
+            healthy = False
 
         return {
             "healthy": healthy,
@@ -4762,8 +4850,43 @@ class RuntimeHostProcess:
             "handler_pools": pool_metrics,
             "no_handlers_registered": no_handlers_registered,
             "config_prefetch_status": self._config_prefetch_status,
+            "local_ingress": local_ingress_health.model_dump(mode="json"),
             "components": components,
         }
+
+    def _build_local_ingress_health(self) -> ModelLocalRuntimeIngressHealth:
+        """Build typed health details for local runtime ingress."""
+        return ModelLocalRuntimeIngressHealth(
+            enabled=self._local_ingress_config.enabled,
+            running=(
+                self._local_ingress_server.is_running
+                if self._local_ingress_server is not None
+                else False
+            ),
+            socket_path=(
+                self._local_ingress_config.socket_path
+                if self._local_ingress_config.enabled
+                else None
+            ),
+            route_count=len(self._local_ingress_routes),
+            active_packages=self._local_ingress_active_packages,
+        )
+
+    def _build_local_ingress_component(
+        self,
+        health: ModelLocalRuntimeIngressHealth,
+    ) -> ModelComponentHealth:
+        """Convert local ingress health to component health."""
+        details = health.model_dump(mode="json")
+        if not health.enabled:
+            return ModelComponentHealth.healthy("local_ingress", details=details)
+        if health.running:
+            return ModelComponentHealth.healthy("local_ingress", details=details)
+        return ModelComponentHealth.unhealthy(
+            "local_ingress",
+            error="Local runtime ingress is enabled but not serving",
+            details=details,
+        )
 
     async def _check_published_events_map(
         self,

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -89,6 +89,7 @@ from omnibase_infra.gateway import (
     load_public_key_from_pem,
 )
 from omnibase_infra.models import ModelNodeIdentity
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.models.runtime.model_resolved_dependencies import (
     ModelResolvedDependencies,
 )
@@ -2164,7 +2165,7 @@ class RuntimeHostProcess:
         if self._dispatch_engine is None:
             raise ProtocolConfigurationError(
                 "local runtime ingress requires a dispatch_engine",
-                context=ModelInfraErrorContext(
+                context=ModelInfraErrorContext.with_correlation(
                     transport_type=EnumInfraTransportType.RUNTIME,
                     operation="local_ingress.start",
                 ),
@@ -2194,21 +2195,23 @@ class RuntimeHostProcess:
         request: ModelLocalRuntimeIngressRequest,
     ) -> ModelLocalRuntimeIngressResponse:
         """Dispatch a local ingress request through the runtime dispatch engine."""
+        correlation_id = normalize_correlation_id(request.correlation_id)
         if self._dispatch_engine is None:
             return ModelLocalRuntimeIngressResponse(
                 ok=False,
                 node_alias=request.node_alias,
-                correlation_id=request.correlation_id,
+                correlation_id=correlation_id,
                 error=ModelLocalRuntimeIngressError(
                     code="runtime_unavailable",
                     message="dispatch_engine is not configured",
                 ),
             )
+        dispatch_engine = self._dispatch_engine
         if not self._is_running and not self._is_starting:
             return ModelLocalRuntimeIngressResponse(
                 ok=False,
                 node_alias=request.node_alias,
-                correlation_id=request.correlation_id,
+                correlation_id=correlation_id,
                 error=ModelLocalRuntimeIngressError(
                     code="runtime_unavailable",
                     message="runtime is not running",
@@ -2218,7 +2221,7 @@ class RuntimeHostProcess:
             return ModelLocalRuntimeIngressResponse(
                 ok=False,
                 node_alias=request.node_alias,
-                correlation_id=request.correlation_id,
+                correlation_id=correlation_id,
                 error=ModelLocalRuntimeIngressError(
                     code="runtime_unavailable",
                     message="runtime is draining",
@@ -2231,14 +2234,13 @@ class RuntimeHostProcess:
             return ModelLocalRuntimeIngressResponse(
                 ok=False,
                 node_alias=request.node_alias,
-                correlation_id=request.correlation_id,
+                correlation_id=correlation_id,
                 error=ModelLocalRuntimeIngressError(
                     code="unknown_node",
                     message=f"Unknown local ingress node '{request.node_alias}'",
                 ),
             )
 
-        correlation_id = normalize_correlation_id(request.correlation_id)
         envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
             payload=cast("object", request.payload),
             correlation_id=correlation_id,
@@ -2248,21 +2250,30 @@ class RuntimeHostProcess:
             target_tool=route.contract_name,
         )
 
-        async with self._pending_lock:
-            self._pending_message_count += 1
+        await self._handler_semaphore.acquire()
         try:
+            async with self._pending_lock:
+                self._pending_message_count += 1
+
+            async def _dispatch_and_apply_result() -> ModelDispatchResult | None:
+                dispatch_result = await dispatch_engine.dispatch(
+                    route.command_topic,
+                    envelope,
+                )
+                if (
+                    self._local_ingress_dispatch_result_applier is not None
+                    and dispatch_result is not None
+                ):
+                    await self._local_ingress_dispatch_result_applier.apply(
+                        dispatch_result,
+                        correlation_id,
+                    )
+                return dispatch_result
+
             result = await asyncio.wait_for(
-                self._dispatch_engine.dispatch(route.command_topic, envelope),
+                _dispatch_and_apply_result(),
                 timeout=request.timeout_ms / 1000.0,
             )
-            if (
-                self._local_ingress_dispatch_result_applier is not None
-                and result is not None
-            ):
-                await self._local_ingress_dispatch_result_applier.apply(
-                    result,
-                    correlation_id,
-                )
 
             if result is None:
                 return ModelLocalRuntimeIngressResponse(
@@ -2351,6 +2362,7 @@ class RuntimeHostProcess:
                 ),
             )
         finally:
+            self._handler_semaphore.release()
             async with self._pending_lock:
                 self._pending_message_count -= 1
 
@@ -4818,12 +4830,13 @@ class RuntimeHostProcess:
             if published_events_map_health.status == "unhealthy":
                 healthy = False
         local_ingress_health = self._build_local_ingress_health()
-        local_ingress_component = self._build_local_ingress_component(
-            local_ingress_health
-        )
-        components.append(local_ingress_component.model_dump(mode="json"))
-        if local_ingress_component.status == "unhealthy":
-            healthy = False
+        if local_ingress_health.enabled:
+            local_ingress_component = self._build_local_ingress_component(
+                local_ingress_health
+            )
+            components.append(local_ingress_component.model_dump(mode="json"))
+            if local_ingress_component.status == "unhealthy":
+                healthy = False
 
         return {
             "healthy": healthy,

--- a/tests/integration/runtime/test_runtime_local_ingress.py
+++ b/tests/integration/runtime/test_runtime_local_ingress.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime local ingress over a Unix socket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.runtime_local_ingress import (
+    RuntimeLocalIngressRoute,
+    RuntimeLocalIngressServer,
+)
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from tests.helpers.runtime_helpers import make_runtime_config
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_unix_socket_request_dispatches_through_runtime_host(
+    tmp_path: Path,
+) -> None:
+    socket_path = Path(f"/tmp/runtime-local-ingress-{uuid4().hex}.sock")  # noqa: S108
+    dispatch_result = ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        correlation_id=uuid4(),
+    )
+    dispatch_engine = AsyncMock()
+    dispatch_engine.dispatch = AsyncMock(return_value=dispatch_result)
+
+    process = RuntimeHostProcess(
+        config=make_runtime_config(local_ingress={"enabled": True}),
+        dispatch_engine=dispatch_engine,
+    )
+    process._is_running = True
+    process._local_ingress_routes = {
+        "session_orchestrator": RuntimeLocalIngressRoute(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+            contract_path="/tmp/node_session_orchestrator/contract.yaml",  # noqa: S108
+            package_name="omnimarket",
+        )
+    }
+    server = RuntimeLocalIngressServer(
+        str(socket_path),
+        process._dispatch_local_ingress_request,
+    )
+
+    await server.start()
+    try:
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        correlation_id = uuid4()
+        writer.write(
+            json.dumps(
+                {
+                    "node_alias": "session_orchestrator",
+                    "payload": {"dry_run": True},
+                    "correlation_id": str(correlation_id),
+                }
+            ).encode("utf-8")
+            + b"\n"
+        )
+        await writer.drain()
+        response = json.loads((await reader.readline()).decode("utf-8"))
+        writer.close()
+        await writer.wait_closed()
+
+        assert response["ok"] is True
+        assert response["correlation_id"] == str(correlation_id)
+        assert response["topic"] == "onex.cmd.omnimarket.session-orchestrator-start.v1"
+        dispatch_engine.dispatch.assert_awaited_once()
+    finally:
+        await server.stop()

--- a/tests/unit/models/test_model_serialization_roundtrip.py
+++ b/tests/unit/models/test_model_serialization_roundtrip.py
@@ -30,6 +30,8 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from omnibase_infra.enums import EnumDispatchStatus
+
 # -- Event bus models --
 from omnibase_infra.event_bus.models.model_dlq_event import ModelDlqEvent
 from omnibase_infra.event_bus.models.model_dlq_metrics import ModelDlqMetrics
@@ -38,6 +40,7 @@ from omnibase_infra.event_bus.models.model_event_bus_readiness import (
 )
 from omnibase_infra.event_bus.models.model_event_headers import ModelEventHeaders
 from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 
 # -- Runtime models --
 from omnibase_infra.runtime.models.model_batch_publisher_config import (
@@ -55,6 +58,21 @@ from omnibase_infra.runtime.models.model_duplicate_response import (
 )
 from omnibase_infra.runtime.models.model_failed_component import ModelFailedComponent
 from omnibase_infra.runtime.models.model_lifecycle_result import ModelLifecycleResult
+from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
+    ModelLocalRuntimeIngressConfig,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_health import (
+    ModelLocalRuntimeIngressHealth,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
+)
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_optional_string import ModelOptionalString
 from omnibase_infra.runtime.models.model_retry_policy import ModelRetryPolicy
@@ -319,6 +337,62 @@ def _make_runtime_tick() -> ModelRuntimeTick:
     )
 
 
+def _make_local_runtime_ingress_config() -> ModelLocalRuntimeIngressConfig:
+    return ModelLocalRuntimeIngressConfig(
+        enabled=True,
+        socket_path="/tmp/onex-runtime-roundtrip.sock",  # noqa: S108
+        package_names=("omnibase_infra", "omnimarket"),
+    )
+
+
+def _make_local_runtime_ingress_error() -> ModelLocalRuntimeIngressError:
+    return ModelLocalRuntimeIngressError(
+        code="dispatch_error",
+        message="dispatcher rejected request",
+        retryable=True,
+        details={"node_alias": "session_orchestrator"},
+    )
+
+
+def _make_local_runtime_ingress_health() -> ModelLocalRuntimeIngressHealth:
+    return ModelLocalRuntimeIngressHealth(
+        enabled=True,
+        running=True,
+        socket_path="/tmp/onex-runtime-roundtrip.sock",  # noqa: S108
+        route_count=1,
+        active_packages=("omnibase_infra", "omnimarket"),
+    )
+
+
+def _make_local_runtime_ingress_request() -> ModelLocalRuntimeIngressRequest:
+    return ModelLocalRuntimeIngressRequest(
+        node_alias="session_orchestrator",
+        payload={"dry_run": True},
+        correlation_id=uuid4(),
+        timeout_ms=30_000,
+    )
+
+
+def _make_local_runtime_ingress_response() -> ModelLocalRuntimeIngressResponse:
+    correlation_id = uuid4()
+    return ModelLocalRuntimeIngressResponse(
+        ok=True,
+        node_alias="session_orchestrator",
+        resolved_node_name="node_session_orchestrator",
+        contract_name="session_orchestrator",
+        topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        correlation_id=correlation_id,
+        dispatch_result=ModelDispatchResult(
+            status=EnumDispatchStatus.SUCCESS,
+            topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            correlation_id=correlation_id,
+        ),
+    )
+
+
 # ============================================================================
 # Factory registry: maps model class -> factory callable
 # ============================================================================
@@ -338,6 +412,11 @@ MODEL_FACTORIES: dict[type[BaseModel], Any] = {
     ModelFailedComponent: _make_failed_component,
     ModelLifecycleResult: _make_lifecycle_result,
     ModelLoggingConfig: _make_logging_config,
+    ModelLocalRuntimeIngressConfig: _make_local_runtime_ingress_config,
+    ModelLocalRuntimeIngressError: _make_local_runtime_ingress_error,
+    ModelLocalRuntimeIngressHealth: _make_local_runtime_ingress_health,
+    ModelLocalRuntimeIngressRequest: _make_local_runtime_ingress_request,
+    ModelLocalRuntimeIngressResponse: _make_local_runtime_ingress_response,
     ModelOptionalString: _make_optional_string,
     ModelRetryPolicy: _make_retry_policy,
     ModelRuntimeSchedulerConfig: _make_runtime_scheduler_config,

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.runtime_local_ingress import (
+    RuntimeLocalIngressServer,
+    discover_runtime_local_ingress_routes,
+    parse_active_runtime_packages,
+)
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from tests.helpers.runtime_helpers import make_runtime_config
+
+
+@pytest.mark.asyncio
+async def test_runtime_local_ingress_server_round_trip(tmp_path: Path) -> None:
+    socket_path = Path(f"/tmp/runtime-local-ingress-{uuid4().hex}.sock")  # noqa: S108
+    server = RuntimeLocalIngressServer(
+        str(socket_path),
+        AsyncMock(return_value={"ok": True, "status": "done"}),
+    )
+
+    await server.start()
+    try:
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        writer.write(b'{"node_name":"test","payload":{}}\n')
+        await writer.drain()
+        response = await reader.readline()
+        writer.close()
+        await writer.wait_closed()
+
+        assert json.loads(response.decode("utf-8")) == {"ok": True, "status": "done"}
+    finally:
+        await server.stop()
+
+
+def test_parse_active_runtime_packages_honors_env_override() -> None:
+    resolved = parse_active_runtime_packages(
+        ("omnibase_infra",),
+        env={"ONEX_ACTIVE_RUNTIME_PACKAGES": "omnibase_infra, omnimarket"},
+    )
+    assert resolved == ("omnibase_infra", "omnimarket")
+
+
+def test_discover_runtime_local_ingress_routes_registers_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_root = tmp_path / "fakepkg"
+    (package_root / "nodes" / "node_demo").mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "nodes" / "node_demo" / "contract.yaml").write_text(
+        """
+name: demo
+event_bus:
+  subscribe_topics:
+    - onex.cmd.demo.start.v1
+terminal_event: onex.evt.demo.completed.v1
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.runtime_local_ingress.importlib.import_module",
+        lambda _name: SimpleNamespace(__file__=str(package_root / "__init__.py")),
+    )
+
+    routes = discover_runtime_local_ingress_routes(("fakepkg",))
+
+    assert routes["demo"].command_topic == "onex.cmd.demo.start.v1"
+    assert routes["node_demo"].contract_name == "demo"
+    assert routes["demo"].terminal_event == "onex.evt.demo.completed.v1"
+
+
+def test_discover_runtime_local_ingress_routes_rejects_duplicate_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_one = tmp_path / "pkg1"
+    package_two = tmp_path / "pkg2"
+    for root in (package_one, package_two):
+        root.mkdir(parents=True)
+        (root / "__init__.py").write_text("", encoding="utf-8")
+        (root / "nodes" / "node_same").mkdir(parents=True)
+    (package_one / "nodes" / "node_same" / "contract.yaml").write_text(
+        "name: same\nevent_bus:\n  subscribe_topics:\n    - onex.cmd.alpha.start.v1\n",
+        encoding="utf-8",
+    )
+    (package_two / "nodes" / "node_same" / "contract.yaml").write_text(
+        "name: same\nevent_bus:\n  subscribe_topics:\n    - onex.cmd.beta.start.v1\n",
+        encoding="utf-8",
+    )
+
+    def _import_module(name: str) -> object:
+        root = package_one if name == "pkg1" else package_two
+        return SimpleNamespace(__file__=str(root / "__init__.py"))
+
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.runtime_local_ingress.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(ValueError, match="Duplicate local ingress route alias 'same'"):
+        discover_runtime_local_ingress_routes(("pkg1", "pkg2"))
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
+    dispatch_result = ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        correlation_id=uuid4(),
+    )
+    dispatch_engine = AsyncMock()
+    dispatch_engine.dispatch = AsyncMock(return_value=dispatch_result)
+
+    process = RuntimeHostProcess(
+        config=make_runtime_config(),
+        dispatch_engine=dispatch_engine,
+    )
+    process._is_running = True
+    process._local_ingress_routes = {
+        "session_orchestrator": SimpleNamespace(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        )
+    }
+    process._local_ingress_dispatch_result_applier = SimpleNamespace(apply=AsyncMock())
+
+    response = await process._dispatch_local_ingress_request(
+        {
+            "node_name": "session_orchestrator",
+            "payload": {"dry_run": True},
+            "correlation_id": str(uuid4()),
+        }
+    )
+
+    assert response["ok"] is True
+    assert response["topic"] == "onex.cmd.omnimarket.session-orchestrator-start.v1"
+    dispatch_engine.dispatch.assert_awaited()
+    process._local_ingress_dispatch_result_applier.apply.assert_awaited()

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -28,7 +28,6 @@ from omnibase_infra.runtime.runtime_local_ingress import (
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
-from omnibase_infra.runtime.service_dispatch_result_applier import DispatchResultApplier
 from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
 from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
 
@@ -223,9 +222,7 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
         "session_orchestrator": _session_orchestrator_route()
     }
     applier = SimpleNamespace(apply=AsyncMock())
-    process._local_ingress_dispatch_result_applier = cast(
-        "DispatchResultApplier", applier
-    )
+    process._local_ingress_dispatch_result_applier = cast("object", applier)
 
     response = await process._dispatch_local_ingress_request(
         ModelLocalRuntimeIngressRequest(

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -8,7 +8,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -28,6 +28,7 @@ from omnibase_infra.runtime.runtime_local_ingress import (
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
+from omnibase_infra.runtime.service_dispatch_result_applier import DispatchResultApplier
 from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
 from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
 
@@ -222,7 +223,9 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
         "session_orchestrator": _session_orchestrator_route()
     }
     applier = SimpleNamespace(apply=AsyncMock())
-    process._local_ingress_dispatch_result_applier = cast("Any", applier)
+    process._local_ingress_dispatch_result_applier = cast(
+        "DispatchResultApplier", applier
+    )
 
     response = await process._dispatch_local_ingress_request(
         ModelLocalRuntimeIngressRequest(

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -8,6 +8,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -17,16 +18,32 @@ from pydantic import ValidationError
 from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.runtime.models import (
+    ModelLocalRuntimeIngressConfig,
     ModelLocalRuntimeIngressRequest,
     ModelLocalRuntimeIngressResponse,
 )
 from omnibase_infra.runtime.runtime_local_ingress import (
+    RuntimeLocalIngressRoute,
     RuntimeLocalIngressServer,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
 from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
 from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
+
+pytestmark = pytest.mark.unit
+
+
+def _session_orchestrator_route() -> RuntimeLocalIngressRoute:
+    return RuntimeLocalIngressRoute(
+        node_name="node_session_orchestrator",
+        contract_name="session_orchestrator",
+        command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        event_type="omnimarket.session-orchestrator-start",
+        terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        contract_path="/tmp/node_session_orchestrator/contract.yaml",  # noqa: S108
+        package_name="omnimarket",
+    )
 
 
 @pytest.mark.asyncio
@@ -66,6 +83,23 @@ async def test_runtime_local_ingress_server_round_trip(tmp_path: Path) -> None:
         await server.stop()
 
 
+@pytest.mark.asyncio
+async def test_runtime_local_ingress_server_refuses_non_socket_path(
+    tmp_path: Path,
+) -> None:
+    socket_path = tmp_path / "runtime-local-ingress.sock"
+    socket_path.write_text("do not unlink", encoding="utf-8")
+    server = RuntimeLocalIngressServer(
+        str(socket_path),
+        AsyncMock(),
+    )
+
+    with pytest.raises(FileExistsError, match="not an owned Unix socket"):
+        await server.start()
+
+    assert socket_path.read_text(encoding="utf-8") == "do not unlink"
+
+
 def test_local_runtime_ingress_request_rejects_blank_node_name() -> None:
     with pytest.raises(ValidationError, match="node_alias must be a non-empty string"):
         ModelLocalRuntimeIngressRequest(node_alias="   ")
@@ -77,6 +111,14 @@ def test_parse_active_runtime_packages_honors_env_override() -> None:
         env={"ONEX_ACTIVE_RUNTIME_PACKAGES": "omnibase_infra, omnimarket"},
     )
     assert resolved == ("omnibase_infra", "omnimarket")
+
+
+def test_local_runtime_ingress_config_accepts_yaml_list_package_names() -> None:
+    config = ModelLocalRuntimeIngressConfig.model_validate(
+        {"package_names": ["omnibase_infra", "omnimarket"]}
+    )
+
+    assert config.package_names == ("omnibase_infra", "omnimarket")
 
 
 def test_discover_runtime_local_ingress_routes_registers_aliases(
@@ -106,6 +148,25 @@ terminal_event: onex.evt.demo.completed.v1
     assert routes["demo"].command_topic == "onex.cmd.demo.start.v1"
     assert routes["node_demo"].contract_name == "demo"
     assert routes["demo"].terminal_event == "onex.evt.demo.completed.v1"
+
+
+def test_discover_runtime_local_ingress_routes_skips_malformed_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_root = tmp_path / "fakepkg"
+    (package_root / "nodes" / "node_bad").mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "nodes" / "node_bad" / "contract.yaml").write_text(
+        "name: [unterminated",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.runtime_local_ingress.importlib.import_module",
+        lambda _name: SimpleNamespace(__file__=str(package_root / "__init__.py")),
+    )
+
+    assert discover_runtime_local_ingress_routes(("fakepkg",)) == {}
 
 
 def test_discover_runtime_local_ingress_routes_rejects_duplicate_alias(
@@ -158,15 +219,10 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
     )
     process._is_running = True
     process._local_ingress_routes = {
-        "session_orchestrator": SimpleNamespace(
-            node_name="node_session_orchestrator",
-            contract_name="session_orchestrator",
-            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
-            event_type="omnimarket.session-orchestrator-start",
-            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
-        )
+        "session_orchestrator": _session_orchestrator_route()
     }
-    process._local_ingress_dispatch_result_applier = SimpleNamespace(apply=AsyncMock())
+    applier = SimpleNamespace(apply=AsyncMock())
+    process._local_ingress_dispatch_result_applier = cast("Any", applier)
 
     response = await process._dispatch_local_ingress_request(
         ModelLocalRuntimeIngressRequest(
@@ -179,7 +235,51 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
     assert response.ok is True
     assert response.topic == "onex.cmd.omnimarket.session-orchestrator-start.v1"
     dispatch_engine.dispatch.assert_awaited()
-    process._local_ingress_dispatch_result_applier.apply.assert_awaited()
+    applier.apply.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_dispatch_local_ingress_uses_handler_semaphore() -> (
+    None
+):
+    dispatch_result = ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        correlation_id=uuid4(),
+    )
+    dispatch_engine = AsyncMock()
+    dispatch_engine.dispatch = AsyncMock(return_value=dispatch_result)
+
+    process = RuntimeHostProcess(
+        config=make_runtime_config(),
+        dispatch_engine=dispatch_engine,
+    )
+    process._is_running = True
+    process._handler_semaphore = asyncio.Semaphore(1)
+    await process._handler_semaphore.acquire()
+    process._local_ingress_routes = {
+        "session_orchestrator": _session_orchestrator_route()
+    }
+
+    task = asyncio.create_task(
+        process._dispatch_local_ingress_request(
+            ModelLocalRuntimeIngressRequest(
+                node_alias="session_orchestrator",
+                payload={"dry_run": True},
+                correlation_id=uuid4(),
+            )
+        )
+    )
+    await asyncio.sleep(0)
+    dispatch_engine.dispatch.assert_not_awaited()
+
+    process._handler_semaphore.release()
+    response = await task
+
+    assert response.ok is True
+    dispatch_engine.dispatch.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -204,13 +304,7 @@ async def test_runtime_host_process_dispatch_local_ingress_request_times_out() -
     )
     process._is_running = True
     process._local_ingress_routes = {
-        "session_orchestrator": SimpleNamespace(
-            node_name="node_session_orchestrator",
-            contract_name="session_orchestrator",
-            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
-            event_type="omnimarket.session-orchestrator-start",
-            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
-        )
+        "session_orchestrator": _session_orchestrator_route()
     }
 
     response = await process._dispatch_local_ingress_request(
@@ -236,22 +330,15 @@ async def test_runtime_health_includes_local_ingress_details() -> None:
     process._is_running = True
     process._local_ingress_active_packages = ("omnibase_infra", "omnimarket")
     process._local_ingress_routes = {
-        "session_orchestrator": SimpleNamespace(
-            node_name="node_session_orchestrator",
-            contract_name="session_orchestrator",
-            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
-            event_type="omnimarket.session-orchestrator-start",
-            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
-        )
+        "session_orchestrator": _session_orchestrator_route()
     }
 
     health = await process.health_check()
 
     assert "local_ingress" in health
-    local_ingress = health["local_ingress"]
+    local_ingress = cast("dict[str, object]", health["local_ingress"])
     assert local_ingress["enabled"] is True
     assert local_ingress["route_count"] == 1
     assert "components" in health
-    assert any(
-        component["name"] == "local_ingress" for component in health["components"]
-    )
+    components = cast("list[dict[str, object]]", health["components"])
+    assert any(component["name"] == "local_ingress" for component in components)

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -12,16 +12,21 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.models import (
+    ModelLocalRuntimeIngressRequest,
+    ModelLocalRuntimeIngressResponse,
+)
 from omnibase_infra.runtime.runtime_local_ingress import (
     RuntimeLocalIngressServer,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
 from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
-from tests.helpers.runtime_helpers import make_runtime_config
+from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
 
 
 @pytest.mark.asyncio
@@ -29,21 +34,41 @@ async def test_runtime_local_ingress_server_round_trip(tmp_path: Path) -> None:
     socket_path = Path(f"/tmp/runtime-local-ingress-{uuid4().hex}.sock")  # noqa: S108
     server = RuntimeLocalIngressServer(
         str(socket_path),
-        AsyncMock(return_value={"ok": True, "status": "done"}),
+        AsyncMock(
+            return_value=ModelLocalRuntimeIngressResponse(
+                ok=True,
+                node_alias="test",
+                resolved_node_name="node_test",
+                dispatch_result=ModelDispatchResult(
+                    status=EnumDispatchStatus.SUCCESS,
+                    topic="onex.cmd.test.start.v1",
+                    started_at=datetime.now(UTC),
+                    completed_at=datetime.now(UTC),
+                    correlation_id=uuid4(),
+                ),
+            )
+        ),
     )
 
     await server.start()
     try:
         reader, writer = await asyncio.open_unix_connection(str(socket_path))
-        writer.write(b'{"node_name":"test","payload":{}}\n')
+        writer.write(b'{"node_alias":"test","payload":{}}\n')
         await writer.drain()
         response = await reader.readline()
         writer.close()
         await writer.wait_closed()
 
-        assert json.loads(response.decode("utf-8")) == {"ok": True, "status": "done"}
+        decoded = json.loads(response.decode("utf-8"))
+        assert decoded["ok"] is True
+        assert decoded["node_alias"] == "test"
     finally:
         await server.stop()
+
+
+def test_local_runtime_ingress_request_rejects_blank_node_name() -> None:
+    with pytest.raises(ValidationError, match="node_alias must be a non-empty string"):
+        ModelLocalRuntimeIngressRequest(node_alias="   ")
 
 
 def test_parse_active_runtime_packages_honors_env_override() -> None:
@@ -144,14 +169,89 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
     process._local_ingress_dispatch_result_applier = SimpleNamespace(apply=AsyncMock())
 
     response = await process._dispatch_local_ingress_request(
-        {
-            "node_name": "session_orchestrator",
-            "payload": {"dry_run": True},
-            "correlation_id": str(uuid4()),
-        }
+        ModelLocalRuntimeIngressRequest(
+            node_alias="session_orchestrator",
+            payload={"dry_run": True},
+            correlation_id=uuid4(),
+        )
     )
 
-    assert response["ok"] is True
-    assert response["topic"] == "onex.cmd.omnimarket.session-orchestrator-start.v1"
+    assert response.ok is True
+    assert response.topic == "onex.cmd.omnimarket.session-orchestrator-start.v1"
     dispatch_engine.dispatch.assert_awaited()
     process._local_ingress_dispatch_result_applier.apply.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_dispatch_local_ingress_request_times_out() -> None:
+    async def _sleepy_dispatch(
+        *_args: object, **_kwargs: object
+    ) -> ModelDispatchResult:
+        await asyncio.sleep(0.05)
+        return ModelDispatchResult(
+            status=EnumDispatchStatus.SUCCESS,
+            topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            correlation_id=uuid4(),
+        )
+
+    dispatch_engine = AsyncMock()
+    dispatch_engine.dispatch = AsyncMock(side_effect=_sleepy_dispatch)
+    process = RuntimeHostProcess(
+        config=make_runtime_config(local_ingress={"enabled": True}),
+        dispatch_engine=dispatch_engine,
+    )
+    process._is_running = True
+    process._local_ingress_routes = {
+        "session_orchestrator": SimpleNamespace(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        )
+    }
+
+    response = await process._dispatch_local_ingress_request(
+        ModelLocalRuntimeIngressRequest(
+            node_alias="session_orchestrator",
+            payload={"dry_run": True},
+            timeout_ms=1,
+        )
+    )
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "dispatch_timeout"
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_includes_local_ingress_details() -> None:
+    process = RuntimeHostProcess(
+        config=make_runtime_config(local_ingress={"enabled": True}),
+        dispatch_engine=AsyncMock(),
+    )
+    seed_mock_handlers(process)
+    process._is_running = True
+    process._local_ingress_active_packages = ("omnibase_infra", "omnimarket")
+    process._local_ingress_routes = {
+        "session_orchestrator": SimpleNamespace(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        )
+    }
+
+    health = await process.health_check()
+
+    assert "local_ingress" in health
+    local_ingress = health["local_ingress"]
+    assert local_ingress["enabled"] is True
+    assert local_ingress["route_count"] == 1
+    assert "components" in health
+    assert any(
+        component["name"] == "local_ingress" for component in health["components"]
+    )


### PR DESCRIPTION
## Summary
- add a runtime-owned Unix socket ingress for local node dispatch
- discover node routes from active runtime packages and route requests through the dispatch engine
- cover ingress transport, route discovery, and host dispatch with focused unit tests

## Verification
- uv run pytest tests/unit/runtime/test_runtime_local_ingress.py -q
- uv run pytest tests/unit/runtime/test_service_health.py -q
- uv run pytest tests/unit/runtime/test_runtime_host_process.py -q
- uv run ruff check src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py src/omnibase_infra/runtime/runtime_local_ingress.py src/omnibase_infra/runtime/models/model_runtime_config.py src/omnibase_infra/runtime/models/__init__.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_runtime_local_ingress.py
- uv run ruff format --check src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py src/omnibase_infra/runtime/runtime_local_ingress.py src/omnibase_infra/runtime/models/model_runtime_config.py src/omnibase_infra/runtime/models/__init__.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_runtime_local_ingress.py
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local runtime ingress: configurable Unix-socket command ingress with route discovery, request routing, health reporting, and lifecycle-managed start/stop
  * Introduced validated request/response/error/health/config models and a runtime config option for local ingress; enforces payload limits, timeouts, and structured JSON responses

* **Tests**
  * Added unit and integration tests covering server lifecycle, NDJSON I/O, route discovery, config parsing, dispatch integration, timeouts, and health checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Ticket: OMN-10081