### PR TITLE
feat(OMN-10082): type local runtime ingress protocol

### DIFF
--- a/src/omnibase_infra/runtime/models/__init__.py
+++ b/src/omnibase_infra/runtime/models/__init__.py
@@ -142,6 +142,18 @@ from omnibase_infra.runtime.models.model_lifecycle_result import (
 from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
     ModelLocalRuntimeIngressConfig,
 )
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_health import (
+    ModelLocalRuntimeIngressHealth,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
+)
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_materialized_resources import (
     ModelMaterializedResources,
@@ -251,7 +263,11 @@ __all__: list[str] = [
     "ModelHealthCheckResult",
     # NOTE: ModelIntentExecutionSummary excluded - import directly from module
     "ModelLifecycleResult",
+    "ModelLocalRuntimeIngressError",
+    "ModelLocalRuntimeIngressHealth",
     "ModelLocalRuntimeIngressConfig",
+    "ModelLocalRuntimeIngressRequest",
+    "ModelLocalRuntimeIngressResponse",
     "ModelLoggingConfig",
     "ModelOptionalCorrelationId",
     "ModelOptionalString",

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_error.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_error.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed error envelope for local runtime ingress responses."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelLocalRuntimeIngressError(BaseModel):
+    """Structured error for local runtime ingress responses."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    code: Literal[
+        "validation_error",
+        "unknown_node",
+        "runtime_unavailable",
+        "dispatch_timeout",
+        "dispatch_error",
+        "dispatch_result_missing",
+    ] = Field(..., description="Stable local ingress error code.")
+    message: str = Field(..., min_length=1, description="Human-readable error message.")
+    retryable: bool = Field(
+        default=False,
+        description="Whether callers may retry the same request without mutation.",
+    )
+    details: dict[str, JsonType] | None = Field(
+        default=None,
+        description="Additional typed diagnostic details for the caller.",
+    )
+
+
+__all__ = ["ModelLocalRuntimeIngressError"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_health.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_health.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed runtime health details for local runtime ingress."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelLocalRuntimeIngressHealth(BaseModel):
+    """Operational health details for the local runtime ingress."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    enabled: bool = Field(..., description="Whether local ingress is configured.")
+    running: bool = Field(..., description="Whether the socket server is serving.")
+    socket_path: str | None = Field(
+        default=None,
+        description="Bound socket path when local ingress is configured.",
+    )
+    route_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of local node routes exposed through the ingress.",
+    )
+    active_packages: tuple[str, ...] = Field(
+        default=(),
+        description="Resolved runtime packages scanned for ingress routes.",
+    )
+    request_model: str = Field(
+        default="ModelLocalRuntimeIngressRequest",
+        description="Stable request model name for client compatibility.",
+    )
+    response_model: str = Field(
+        default="ModelLocalRuntimeIngressResponse",
+        description="Stable response model name for client compatibility.",
+    )
+
+
+__all__ = ["ModelLocalRuntimeIngressHealth"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_request.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_request.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed request model for local runtime ingress."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.types import JsonType
+
+
+class ModelLocalRuntimeIngressRequest(BaseModel):
+    """Validated request envelope for local runtime ingress."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    node_alias: str = Field(
+        ..., min_length=1, description="Requested runtime node alias."
+    )
+    payload: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="JSON payload forwarded to the backing node handler.",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Optional caller-supplied correlation identifier.",
+    )
+    timeout_ms: int = Field(
+        default=300_000,
+        gt=0,
+        le=900_000,
+        description="Maximum local dispatch time before returning a timeout response.",
+    )
+
+    @field_validator("node_alias")
+    @classmethod
+    def _validate_node_alias(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("node_alias must be a non-empty string")
+        return normalized
+
+
+__all__ = ["ModelLocalRuntimeIngressRequest"]

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_response.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_response.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed response model for local runtime ingress."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+
+
+class ModelLocalRuntimeIngressResponse(BaseModel):
+    """Structured response returned to local runtime ingress callers."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    ok: bool = Field(..., description="Whether the request completed successfully.")
+    node_alias: str = Field(..., min_length=1, description="Requested node alias.")
+    resolved_node_name: str | None = Field(
+        default=None,
+        description="Resolved node directory name when the request is routable.",
+    )
+    contract_name: str | None = Field(
+        default=None,
+        description="Resolved contract name when the request is routable.",
+    )
+    topic: str | None = Field(
+        default=None,
+        description="Resolved command topic used for dispatch.",
+    )
+    terminal_event: str | None = Field(
+        default=None,
+        description="Declared terminal event for the resolved node contract.",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Resolved correlation identifier for the request.",
+    )
+    dispatch_result: ModelDispatchResult | None = Field(
+        default=None,
+        description="Dispatch result for successful runtime execution.",
+    )
+    error: ModelLocalRuntimeIngressError | None = Field(
+        default=None,
+        description="Structured error for rejected or failed requests.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_success_shape(self) -> ModelLocalRuntimeIngressResponse:
+        if self.ok and self.dispatch_result is None:
+            raise ValueError("ok responses must include dispatch_result")
+        if not self.ok and self.error is None:
+            raise ValueError("non-ok responses must include error")
+        return self
+
+
+__all__ = ["ModelLocalRuntimeIngressResponse"]

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -14,9 +14,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from omnibase_infra.runtime.event_bus_subcontract_wiring import (
     EventBusSubcontractWiring,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,7 +127,10 @@ class RuntimeLocalIngressServer:
     def __init__(
         self,
         socket_path: str,
-        request_handler: Callable[[dict[str, object]], Awaitable[dict[str, object]]],
+        request_handler: Callable[
+            [ModelLocalRuntimeIngressRequest],
+            Awaitable[ModelLocalRuntimeIngressResponse],
+        ],
         *,
         socket_timeout_seconds: float = 5.0,
         socket_permissions: int = 0o660,
@@ -186,7 +199,7 @@ class RuntimeLocalIngressServer:
                     break
 
                 response = await self._process_request_line(line)
-                writer.write(json.dumps(response).encode("utf-8") + b"\n")
+                writer.write(response.model_dump_json().encode("utf-8") + b"\n")
                 await writer.drain()
         except ConnectionResetError:
             pass
@@ -194,25 +207,51 @@ class RuntimeLocalIngressServer:
             writer.close()
             await writer.wait_closed()
 
-    async def _process_request_line(self, line: bytes) -> dict[str, object]:
+    async def _process_request_line(
+        self,
+        line: bytes,
+    ) -> ModelLocalRuntimeIngressResponse:
         if len(line) > self._max_payload_bytes:
-            return {
-                "ok": False,
-                "error": "Request exceeds max_payload_bytes",
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias="unknown",
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message="Request exceeds max_payload_bytes",
+                ),
+            )
 
         try:
             raw = json.loads(line.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return {"ok": False, "error": f"Invalid JSON request: {exc}"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias="unknown",
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message=f"Invalid JSON request: {exc}",
+                ),
+            )
 
-        if not isinstance(raw, dict):
-            return {
-                "ok": False,
-                "error": "Request must be a JSON object",
-            }
+        try:
+            request = ModelLocalRuntimeIngressRequest.model_validate(raw)
+        except ValidationError as exc:
+            node_alias = "unknown"
+            if isinstance(raw, dict):
+                raw_alias = raw.get("node_alias")
+                if isinstance(raw_alias, str):
+                    node_alias = raw_alias
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=node_alias,
+                error=ModelLocalRuntimeIngressError(
+                    code="validation_error",
+                    message="Invalid local runtime ingress request",
+                    details={"errors": json.loads(exc.json(include_url=False))},
+                ),
+            )
 
-        return await self._request_handler(raw)
+        return await self._request_handler(request)
 
 
 def _resolve_package_root(package_name: str) -> Path:

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -112,6 +112,10 @@ from omnibase_infra.runtime.health.health_published_events_map import (
 from omnibase_infra.runtime.models import (
     ModelDuplicateResponse,
     ModelLocalRuntimeIngressConfig,
+    ModelLocalRuntimeIngressError,
+    ModelLocalRuntimeIngressHealth,
+    ModelLocalRuntimeIngressRequest,
+    ModelLocalRuntimeIngressResponse,
     ModelRuntimeContractConfig,
 )
 from omnibase_infra.runtime.models.model_component_health import (
@@ -1215,6 +1219,7 @@ class RuntimeHostProcess:
         self._local_ingress_routes: dict[str, RuntimeLocalIngressRoute] = {}
         self._local_ingress_server: RuntimeLocalIngressServer | None = None
         self._local_ingress_dispatch_result_applier: DispatchResultApplier | None = None
+        self._local_ingress_active_packages: tuple[str, ...] = ()
 
         # Message dispatch engine for routing received messages (OMN-2050)
         # When set, contract-declared topics are routed through
@@ -2153,6 +2158,7 @@ class RuntimeHostProcess:
         """Start the runtime-owned local command ingress when enabled."""
         if not self._local_ingress_config.enabled:
             self._local_ingress_routes.clear()
+            self._local_ingress_active_packages = ()
             return
 
         if self._dispatch_engine is None:
@@ -2167,6 +2173,7 @@ class RuntimeHostProcess:
         package_names = parse_active_runtime_packages(
             self._local_ingress_config.package_names
         )
+        self._local_ingress_active_packages = package_names
         self._local_ingress_routes = discover_runtime_local_ingress_routes(
             package_names
         )
@@ -2184,34 +2191,56 @@ class RuntimeHostProcess:
 
     async def _dispatch_local_ingress_request(
         self,
-        request: dict[str, object],
-    ) -> dict[str, object]:
+        request: ModelLocalRuntimeIngressRequest,
+    ) -> ModelLocalRuntimeIngressResponse:
         """Dispatch a local ingress request through the runtime dispatch engine."""
-        requested_node = request.get("node_name")
-        if not isinstance(requested_node, str) or not requested_node.strip():
-            return {"ok": False, "error": "node_name must be a non-empty string"}
-
-        payload = request.get("payload", {})
-        if not isinstance(payload, dict):
-            return {"ok": False, "error": "payload must be a JSON object"}
-
         if self._dispatch_engine is None:
-            return {"ok": False, "error": "dispatch_engine is not configured"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="dispatch_engine is not configured",
+                ),
+            )
         if not self._is_running and not self._is_starting:
-            return {"ok": False, "error": "runtime is not running"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="runtime is not running",
+                ),
+            )
         if self._is_draining or self._shutdown_requested.is_set():
-            return {"ok": False, "error": "runtime is draining"}
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="runtime_unavailable",
+                    message="runtime is draining",
+                    retryable=True,
+                ),
+            )
 
-        route = self._local_ingress_routes.get(requested_node.strip())
+        route = self._local_ingress_routes.get(request.node_alias)
         if route is None:
-            return {
-                "ok": False,
-                "error": f"Unknown local ingress node '{requested_node}'",
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                correlation_id=request.correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="unknown_node",
+                    message=f"Unknown local ingress node '{request.node_alias}'",
+                ),
+            )
 
-        correlation_id = normalize_correlation_id(request.get("correlation_id"))
+        correlation_id = normalize_correlation_id(request.correlation_id)
         envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
-            payload=cast("object", payload),
+            payload=cast("object", request.payload),
             correlation_id=correlation_id,
             envelope_timestamp=datetime.now(UTC),
             event_type=route.event_type,
@@ -2222,7 +2251,10 @@ class RuntimeHostProcess:
         async with self._pending_lock:
             self._pending_message_count += 1
         try:
-            result = await self._dispatch_engine.dispatch(route.command_topic, envelope)
+            result = await asyncio.wait_for(
+                self._dispatch_engine.dispatch(route.command_topic, envelope),
+                timeout=request.timeout_ms / 1000.0,
+            )
             if (
                 self._local_ingress_dispatch_result_applier is not None
                 and result is not None
@@ -2233,42 +2265,91 @@ class RuntimeHostProcess:
                 )
 
             if result is None:
-                return {
-                    "ok": False,
-                    "error": "dispatch_engine returned no result",
-                    "node_name": requested_node,
-                    "topic": route.command_topic,
-                    "correlation_id": str(correlation_id),
-                }
+                return ModelLocalRuntimeIngressResponse(
+                    ok=False,
+                    node_alias=request.node_alias,
+                    resolved_node_name=route.node_name,
+                    contract_name=route.contract_name,
+                    topic=route.command_topic,
+                    terminal_event=route.terminal_event,
+                    correlation_id=correlation_id,
+                    error=ModelLocalRuntimeIngressError(
+                        code="dispatch_result_missing",
+                        message="dispatch_engine returned no result",
+                    ),
+                )
 
-            return {
-                "ok": result.status != EnumDispatchStatus.NO_DISPATCHER,
-                "node_name": requested_node,
-                "resolved_node_name": route.node_name,
-                "contract_name": route.contract_name,
-                "topic": route.command_topic,
-                "terminal_event": route.terminal_event,
-                "correlation_id": str(correlation_id),
-                "dispatch_result": result.model_dump(mode="json"),
-            }
+            if result.status == EnumDispatchStatus.NO_DISPATCHER:
+                return ModelLocalRuntimeIngressResponse(
+                    ok=False,
+                    node_alias=request.node_alias,
+                    resolved_node_name=route.node_name,
+                    contract_name=route.contract_name,
+                    topic=route.command_topic,
+                    terminal_event=route.terminal_event,
+                    correlation_id=correlation_id,
+                    dispatch_result=result,
+                    error=ModelLocalRuntimeIngressError(
+                        code="dispatch_error",
+                        message=(
+                            result.error_message
+                            or f"No dispatcher registered for topic {route.command_topic}"
+                        ),
+                    ),
+                )
+
+            return ModelLocalRuntimeIngressResponse(
+                ok=True,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                dispatch_result=result,
+            )
+        except TimeoutError:
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="dispatch_timeout",
+                    message=(
+                        f"Local runtime ingress timed out after {request.timeout_ms} ms"
+                    ),
+                    retryable=True,
+                ),
+            )
         except Exception as exc:  # noqa: BLE001
             sanitized_error = sanitize_error_message(exc)
             logger.error(  # noqa: TRY400
                 "Local ingress dispatch failed",
                 extra={
-                    "node_name": requested_node,
+                    "node_alias": request.node_alias,
                     "topic": route.command_topic,
                     "correlation_id": str(correlation_id),
                     "error": sanitized_error,
                 },
             )
-            return {
-                "ok": False,
-                "error": sanitized_error,
-                "node_name": requested_node,
-                "topic": route.command_topic,
-                "correlation_id": str(correlation_id),
-            }
+            return ModelLocalRuntimeIngressResponse(
+                ok=False,
+                node_alias=request.node_alias,
+                resolved_node_name=route.node_name,
+                contract_name=route.contract_name,
+                topic=route.command_topic,
+                terminal_event=route.terminal_event,
+                correlation_id=correlation_id,
+                error=ModelLocalRuntimeIngressError(
+                    code="dispatch_error",
+                    message=sanitized_error,
+                    retryable=True,
+                ),
+            )
         finally:
             async with self._pending_lock:
                 self._pending_message_count -= 1
@@ -4736,6 +4817,13 @@ class RuntimeHostProcess:
             components.append(published_events_map_health.model_dump(mode="json"))
             if published_events_map_health.status == "unhealthy":
                 healthy = False
+        local_ingress_health = self._build_local_ingress_health()
+        local_ingress_component = self._build_local_ingress_component(
+            local_ingress_health
+        )
+        components.append(local_ingress_component.model_dump(mode="json"))
+        if local_ingress_component.status == "unhealthy":
+            healthy = False
 
         return {
             "healthy": healthy,
@@ -4762,8 +4850,43 @@ class RuntimeHostProcess:
             "handler_pools": pool_metrics,
             "no_handlers_registered": no_handlers_registered,
             "config_prefetch_status": self._config_prefetch_status,
+            "local_ingress": local_ingress_health.model_dump(mode="json"),
             "components": components,
         }
+
+    def _build_local_ingress_health(self) -> ModelLocalRuntimeIngressHealth:
+        """Build typed health details for local runtime ingress."""
+        return ModelLocalRuntimeIngressHealth(
+            enabled=self._local_ingress_config.enabled,
+            running=(
+                self._local_ingress_server.is_running
+                if self._local_ingress_server is not None
+                else False
+            ),
+            socket_path=(
+                self._local_ingress_config.socket_path
+                if self._local_ingress_config.enabled
+                else None
+            ),
+            route_count=len(self._local_ingress_routes),
+            active_packages=self._local_ingress_active_packages,
+        )
+
+    def _build_local_ingress_component(
+        self,
+        health: ModelLocalRuntimeIngressHealth,
+    ) -> ModelComponentHealth:
+        """Convert local ingress health to component health."""
+        details = health.model_dump(mode="json")
+        if not health.enabled:
+            return ModelComponentHealth.healthy("local_ingress", details=details)
+        if health.running:
+            return ModelComponentHealth.healthy("local_ingress", details=details)
+        return ModelComponentHealth.unhealthy(
+            "local_ingress",
+            error="Local runtime ingress is enabled but not serving",
+            details=details,
+        )
 
     async def _check_published_events_map(
         self,

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -12,16 +12,21 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.models import (
+    ModelLocalRuntimeIngressRequest,
+    ModelLocalRuntimeIngressResponse,
+)
 from omnibase_infra.runtime.runtime_local_ingress import (
     RuntimeLocalIngressServer,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
 from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
-from tests.helpers.runtime_helpers import make_runtime_config
+from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
 
 
 @pytest.mark.asyncio
@@ -29,21 +34,41 @@ async def test_runtime_local_ingress_server_round_trip(tmp_path: Path) -> None:
     socket_path = Path(f"/tmp/runtime-local-ingress-{uuid4().hex}.sock")  # noqa: S108
     server = RuntimeLocalIngressServer(
         str(socket_path),
-        AsyncMock(return_value={"ok": True, "status": "done"}),
+        AsyncMock(
+            return_value=ModelLocalRuntimeIngressResponse(
+                ok=True,
+                node_alias="test",
+                resolved_node_name="node_test",
+                dispatch_result=ModelDispatchResult(
+                    status=EnumDispatchStatus.SUCCESS,
+                    topic="onex.cmd.test.start.v1",
+                    started_at=datetime.now(UTC),
+                    completed_at=datetime.now(UTC),
+                    correlation_id=uuid4(),
+                ),
+            )
+        ),
     )
 
     await server.start()
     try:
         reader, writer = await asyncio.open_unix_connection(str(socket_path))
-        writer.write(b'{"node_name":"test","payload":{}}\n')
+        writer.write(b'{"node_alias":"test","payload":{}}\n')
         await writer.drain()
         response = await reader.readline()
         writer.close()
         await writer.wait_closed()
 
-        assert json.loads(response.decode("utf-8")) == {"ok": True, "status": "done"}
+        decoded = json.loads(response.decode("utf-8"))
+        assert decoded["ok"] is True
+        assert decoded["node_alias"] == "test"
     finally:
         await server.stop()
+
+
+def test_local_runtime_ingress_request_rejects_blank_node_name() -> None:
+    with pytest.raises(ValidationError, match="node_alias must be a non-empty string"):
+        ModelLocalRuntimeIngressRequest(node_alias="   ")
 
 
 def test_parse_active_runtime_packages_honors_env_override() -> None:
@@ -144,14 +169,89 @@ async def test_runtime_host_process_dispatch_local_ingress_request() -> None:
     process._local_ingress_dispatch_result_applier = SimpleNamespace(apply=AsyncMock())
 
     response = await process._dispatch_local_ingress_request(
-        {
-            "node_name": "session_orchestrator",
-            "payload": {"dry_run": True},
-            "correlation_id": str(uuid4()),
-        }
+        ModelLocalRuntimeIngressRequest(
+            node_alias="session_orchestrator",
+            payload={"dry_run": True},
+            correlation_id=uuid4(),
+        )
     )
 
-    assert response["ok"] is True
-    assert response["topic"] == "onex.cmd.omnimarket.session-orchestrator-start.v1"
+    assert response.ok is True
+    assert response.topic == "onex.cmd.omnimarket.session-orchestrator-start.v1"
     dispatch_engine.dispatch.assert_awaited()
     process._local_ingress_dispatch_result_applier.apply.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_dispatch_local_ingress_request_times_out() -> None:
+    async def _sleepy_dispatch(
+        *_args: object, **_kwargs: object
+    ) -> ModelDispatchResult:
+        await asyncio.sleep(0.05)
+        return ModelDispatchResult(
+            status=EnumDispatchStatus.SUCCESS,
+            topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            correlation_id=uuid4(),
+        )
+
+    dispatch_engine = AsyncMock()
+    dispatch_engine.dispatch = AsyncMock(side_effect=_sleepy_dispatch)
+    process = RuntimeHostProcess(
+        config=make_runtime_config(local_ingress={"enabled": True}),
+        dispatch_engine=dispatch_engine,
+    )
+    process._is_running = True
+    process._local_ingress_routes = {
+        "session_orchestrator": SimpleNamespace(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        )
+    }
+
+    response = await process._dispatch_local_ingress_request(
+        ModelLocalRuntimeIngressRequest(
+            node_alias="session_orchestrator",
+            payload={"dry_run": True},
+            timeout_ms=1,
+        )
+    )
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "dispatch_timeout"
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_includes_local_ingress_details() -> None:
+    process = RuntimeHostProcess(
+        config=make_runtime_config(local_ingress={"enabled": True}),
+        dispatch_engine=AsyncMock(),
+    )
+    seed_mock_handlers(process)
+    process._is_running = True
+    process._local_ingress_active_packages = ("omnibase_infra", "omnimarket")
+    process._local_ingress_routes = {
+        "session_orchestrator": SimpleNamespace(
+            node_name="node_session_orchestrator",
+            contract_name="session_orchestrator",
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            event_type="omnimarket.session-orchestrator-start",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        )
+    }
+
+    health = await process.health_check()
+
+    assert "local_ingress" in health
+    local_ingress = health["local_ingress"]
+    assert local_ingress["enabled"] is True
+    assert local_ingress["route_count"] == 1
+    assert "components" in health
+    assert any(
+        component["name"] == "local_ingress" for component in health["components"]
+    )


### PR DESCRIPTION
## Summary
- add typed local runtime ingress request, response, error, and health models
- validate socket requests before dispatch and enforce request timeout handling
- expose local ingress health in runtime diagnostics and cover the protocol with focused tests

## Verification
- uv run pytest tests/unit/runtime/test_runtime_local_ingress.py -q
- uv run pytest tests/unit/runtime/test_service_health.py -q
- uv run ruff check src/omnibase_infra/runtime/models/__init__.py src/omnibase_infra/runtime/models/model_local_runtime_ingress_error.py src/omnibase_infra/runtime/models/model_local_runtime_ingress_health.py src/omnibase_infra/runtime/models/model_local_runtime_ingress_request.py src/omnibase_infra/runtime/models/model_local_runtime_ingress_response.py src/omnibase_infra/runtime/runtime_local_ingress.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_runtime_local_ingress.py
- git diff --check
