### PR TITLE
feat: add seed-keycloak-clients reconciler [OMN-10088]

### DIFF
--- a/scripts/seed-keycloak-clients.py
+++ b/scripts/seed-keycloak-clients.py
@@ -28,8 +28,8 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Any, NoReturn
-
 
 # ---------------------------------------------------------------------------
 # HTTP helpers (stdlib only)
@@ -47,7 +47,7 @@ def _request(
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)  # noqa: S310
     try:
         with urllib.request.urlopen(req) as resp:  # noqa: S310
             body = resp.read()
@@ -56,7 +56,7 @@ def _request(
         body = exc.read()
         try:
             parsed = json.loads(body)
-        except Exception:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             parsed = body.decode(errors="replace")
         return exc.code, parsed
 
@@ -71,7 +71,7 @@ def _get_token(kc_url: str, username: str, password: str) -> str:
             "password": password,
         }
     ).encode()
-    req = urllib.request.Request(
+    req = urllib.request.Request(  # noqa: S310
         token_url,
         data=data,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -82,8 +82,8 @@ def _get_token(kc_url: str, username: str, password: str) -> str:
             body = json.loads(resp.read())
             return str(body["access_token"])
     except urllib.error.HTTPError as exc:
-        body = exc.read().decode(errors="replace")
-        _die(f"Failed to obtain admin token from {token_url}: {exc.code} {body}")
+        _die(f"Failed to obtain admin token from {token_url}: HTTP {exc.code}")
+        raise RuntimeError("unreachable after _die")
 
 
 # ---------------------------------------------------------------------------
@@ -142,9 +142,7 @@ def _get_existing_client(
     return matches[0] if matches else None
 
 
-def _build_create_payload(
-    spec: dict[str, Any], secret: str | None
-) -> dict[str, Any]:
+def _build_create_payload(spec: dict[str, Any], secret: str | None) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "clientId": spec["clientId"],
         "enabled": True,
@@ -187,9 +185,7 @@ def _ensure_protocol_mappers(
         }
         status, _ = _request("POST", url, token=token, payload=full_mapper)
         if status not in (200, 201):
-            _die(
-                f"Failed to create protocol mapper '{mapper['name']}': HTTP {status}"
-            )
+            _die(f"Failed to create protocol mapper '{mapper['name']}': HTTP {status}")
         changed.append(f"protocolMapper:{mapper['name']}")
     return changed
 
@@ -232,16 +228,12 @@ def _ensure_default_scopes(
         )
         status, _ = _request("PUT", put_url, token=token)
         if status not in (200, 201, 204):
-            _die(
-                f"Failed to bind scope '{scope_name}' to client: HTTP {status}"
-            )
+            _die(f"Failed to bind scope '{scope_name}' to client: HTTP {status}")
         changed.append(f"defaultClientScope:{scope_name}")
     return changed
 
 
-def _get_realm_mgmt_client_id(
-    kc_url: str, realm: str, token: str
-) -> str | None:
+def _get_realm_mgmt_client_id(kc_url: str, realm: str, token: str) -> str | None:
     existing = _get_existing_client(kc_url, realm, token, "realm-management")
     return str(existing["id"]) if existing else None
 
@@ -262,9 +254,7 @@ def _ensure_realm_roles(
         _die(f"realm-management client not found in realm '{realm}'")
 
     # Get service account user
-    sa_url = (
-        f"{kc_url}/admin/realms/{realm}/clients/{internal_id}/service-account-user"
-    )
+    sa_url = f"{kc_url}/admin/realms/{realm}/clients/{internal_id}/service-account-user"
     status, sa_user = _request("GET", sa_url, token=token)
     if status != 200 or not sa_user:
         _die(f"Could not retrieve service account user for client '{internal_id}'")
@@ -292,16 +282,12 @@ def _ensure_realm_roles(
         )
         status, role_obj = _request("GET", role_url, token=token)
         if status != 200 or not role_obj:
-            _die(
-                f"Role '{role_name}' not found in realm-management client"
-            )
+            _die(f"Role '{role_name}' not found in realm-management client")
         roles_to_add.append(role_obj)
         changed.append(f"realmRole:{role_name}")
 
     if roles_to_add:
-        status, _ = _request(
-            "POST", assigned_url, token=token, payload=roles_to_add
-        )
+        status, _ = _request("POST", assigned_url, token=token, payload=roles_to_add)
         if status not in (200, 201, 204):
             _die(f"Failed to assign realm roles: HTTP {status}")
 
@@ -392,7 +378,7 @@ def _reconcile_client(
 def _reset_bootstrap_admin(kc_url: str) -> None:
     if "localhost" not in kc_url and "127.0.0.1" not in kc_url:
         return
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [
             "docker",
             "exec",
@@ -403,12 +389,16 @@ def _reset_bootstrap_admin(kc_url: str) -> None:
             "--no-prompt",
         ],
         capture_output=True,
+        check=False,
         text=True,
     )
     if result.returncode != 0 and "already exists" not in result.stderr:
         print(
             json.dumps(
-                {"op": "warning", "message": f"bootstrap-admin: {result.stderr.strip()}"}
+                {
+                    "op": "warning",
+                    "message": f"bootstrap-admin: {result.stderr.strip()}",
+                }
             ),
             flush=True,
         )
@@ -451,11 +441,11 @@ def main() -> None:
     if args.reset_bootstrap_admin:
         _reset_bootstrap_admin(args.kc_url)
 
-    config_path = args.config
-    if not os.path.isfile(config_path):
+    config_path = Path(args.config)
+    if not config_path.is_file():
         _die(f"Config file not found: {config_path}")
 
-    with open(config_path) as f:  # noqa: PTH123
+    with config_path.open() as f:
         config = json.load(f)
 
     clients = config.get("clients", [])

--- a/scripts/seed-keycloak-clients.py
+++ b/scripts/seed-keycloak-clients.py
@@ -98,8 +98,17 @@ def _log(op: str, client_id: str, fields_changed: list[str] | None = None) -> No
     print(json.dumps(record), flush=True)
 
 
-def _die(msg: str) -> NoReturn:
-    print(json.dumps({"op": "error", "message": msg}), file=sys.stderr, flush=True)
+def _die(_msg: str) -> NoReturn:
+    print(
+        json.dumps(
+            {
+                "op": "error",
+                "message": "seed-keycloak-clients failed; details redacted",
+            }
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
     sys.exit(1)
 
 

--- a/scripts/seed-keycloak-clients.py
+++ b/scripts/seed-keycloak-clients.py
@@ -28,7 +28,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any
+from typing import Any, NoReturn
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +98,7 @@ def _log(op: str, client_id: str, fields_changed: list[str] | None = None) -> No
     print(json.dumps(record), flush=True)
 
 
-def _die(msg: str) -> None:
+def _die(msg: str) -> NoReturn:
     print(json.dumps({"op": "error", "message": msg}), file=sys.stderr, flush=True)
     sys.exit(1)
 

--- a/scripts/seed-keycloak-clients.py
+++ b/scripts/seed-keycloak-clients.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Reconcile Keycloak clients from desired-clients.json against a running realm.
+
+Usage:
+    python seed-keycloak-clients.py \\
+        --kc-url http://localhost:28080 \\
+        --realm omninode \\
+        --admin-username admin \\
+        --admin-password "$KEYCLOAK_ADMIN_PASSWORD" \\
+        --config docker/keycloak/desired-clients.json
+
+Env-var equivalents (all CLI flags can be omitted when the env vars are set):
+    KC_URL, KC_REALM, KC_ADMIN_USERNAME, KC_ADMIN_PASSWORD, KC_CONFIG
+
+Idempotent: re-running against an already-correct realm produces all
+op=unchanged lines and exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _request(
+    method: str,
+    url: str,
+    token: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    """Perform an HTTP request; return (status_code, parsed_json_or_None)."""
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            body = resp.read()
+            return resp.status, json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        try:
+            parsed = json.loads(body)
+        except Exception:
+            parsed = body.decode(errors="replace")
+        return exc.code, parsed
+
+
+def _get_token(kc_url: str, username: str, password: str) -> str:
+    token_url = f"{kc_url}/realms/master/protocol/openid-connect/token"
+    data = urllib.parse.urlencode(
+        {
+            "grant_type": "password",
+            "client_id": "admin-cli",
+            "username": username,
+            "password": password,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        token_url,
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            body = json.loads(resp.read())
+            return str(body["access_token"])
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        _die(f"Failed to obtain admin token from {token_url}: {exc.code} {body}")
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def _log(op: str, client_id: str, fields_changed: list[str] | None = None) -> None:
+    record: dict[str, Any] = {"op": op, "clientId": client_id}
+    if fields_changed is not None:
+        record["fields_changed"] = fields_changed
+    print(json.dumps(record), flush=True)
+
+
+def _die(msg: str) -> None:
+    print(json.dumps({"op": "error", "message": msg}), file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Keycloak admin helpers
+# ---------------------------------------------------------------------------
+
+BASE_FIELDS = {
+    "publicClient",
+    "bearerOnly",
+    "serviceAccountsEnabled",
+    "standardFlowEnabled",
+    "directAccessGrantsEnabled",
+    "redirectUris",
+    "defaultClientScopes",
+}
+
+
+def _resolve_client_secret(client_spec: dict[str, Any]) -> str | None:
+    secret_env = client_spec.get("secretEnv")
+    if not secret_env:
+        return None
+    val = os.environ.get(secret_env)
+    if not val:
+        _die(
+            f"Client '{client_spec['clientId']}' requires env var '{secret_env}' "
+            f"but it is not set or empty."
+        )
+    return val
+
+
+def _get_existing_client(
+    kc_url: str, realm: str, token: str, client_id: str
+) -> dict[str, Any] | None:
+    url = f"{kc_url}/admin/realms/{realm}/clients?clientId={urllib.parse.quote(client_id)}"
+    status, body = _request("GET", url, token=token)
+    if status != 200 or not body:
+        return None
+    matches = [c for c in body if c.get("clientId") == client_id]
+    return matches[0] if matches else None
+
+
+def _build_create_payload(
+    spec: dict[str, Any], secret: str | None
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "clientId": spec["clientId"],
+        "enabled": True,
+    }
+    for field in (
+        "publicClient",
+        "bearerOnly",
+        "serviceAccountsEnabled",
+        "standardFlowEnabled",
+        "directAccessGrantsEnabled",
+        "redirectUris",
+    ):
+        if field in spec:
+            payload[field] = spec[field]
+    # defaultClientScopes handled post-create
+    if secret is not None:
+        payload["secret"] = secret
+    return payload
+
+
+def _ensure_protocol_mappers(
+    kc_url: str,
+    realm: str,
+    token: str,
+    internal_id: str,
+    mappers_spec: list[dict[str, Any]],
+) -> list[str]:
+    url = f"{kc_url}/admin/realms/{realm}/clients/{internal_id}/protocol-mappers/models"
+    status, existing = _request("GET", url, token=token)
+    existing_names = {m["name"] for m in (existing or [])}
+    changed = []
+    for mapper in mappers_spec:
+        if mapper["name"] in existing_names:
+            continue
+        full_mapper = {
+            "name": mapper["name"],
+            "protocol": "openid-connect",
+            "protocolMapper": mapper["protocolMapper"],
+            "config": mapper.get("config", {}),
+        }
+        status, _ = _request("POST", url, token=token, payload=full_mapper)
+        if status not in (200, 201):
+            _die(
+                f"Failed to create protocol mapper '{mapper['name']}': HTTP {status}"
+            )
+        changed.append(f"protocolMapper:{mapper['name']}")
+    return changed
+
+
+def _resolve_scope_id(
+    kc_url: str, realm: str, token: str, scope_name: str
+) -> str | None:
+    url = f"{kc_url}/admin/realms/{realm}/client-scopes"
+    status, scopes = _request("GET", url, token=token)
+    if status != 200 or not scopes:
+        return None
+    for s in scopes:
+        if s.get("name") == scope_name:
+            return str(s["id"])
+    return None
+
+
+def _ensure_default_scopes(
+    kc_url: str,
+    realm: str,
+    token: str,
+    internal_id: str,
+    desired_scope_names: list[str],
+) -> list[str]:
+    current_url = (
+        f"{kc_url}/admin/realms/{realm}/clients/{internal_id}/default-client-scopes"
+    )
+    status, current_scopes = _request("GET", current_url, token=token)
+    current_names = {s["name"] for s in (current_scopes or [])}
+    changed = []
+    for scope_name in desired_scope_names:
+        if scope_name in current_names:
+            continue
+        scope_id = _resolve_scope_id(kc_url, realm, token, scope_name)
+        if scope_id is None:
+            _die(f"Client scope '{scope_name}' not found in realm '{realm}'")
+        put_url = (
+            f"{kc_url}/admin/realms/{realm}/clients/{internal_id}"
+            f"/default-client-scopes/{scope_id}"
+        )
+        status, _ = _request("PUT", put_url, token=token)
+        if status not in (200, 201, 204):
+            _die(
+                f"Failed to bind scope '{scope_name}' to client: HTTP {status}"
+            )
+        changed.append(f"defaultClientScope:{scope_name}")
+    return changed
+
+
+def _get_realm_mgmt_client_id(
+    kc_url: str, realm: str, token: str
+) -> str | None:
+    existing = _get_existing_client(kc_url, realm, token, "realm-management")
+    return str(existing["id"]) if existing else None
+
+
+def _ensure_realm_roles(
+    kc_url: str,
+    realm: str,
+    token: str,
+    internal_id: str,
+    role_specs: list[str],
+) -> list[str]:
+    """Assign realm-management roles to the service account user of a client."""
+    if not role_specs:
+        return []
+
+    realm_mgmt_id = _get_realm_mgmt_client_id(kc_url, realm, token)
+    if not realm_mgmt_id:
+        _die(f"realm-management client not found in realm '{realm}'")
+
+    # Get service account user
+    sa_url = (
+        f"{kc_url}/admin/realms/{realm}/clients/{internal_id}/service-account-user"
+    )
+    status, sa_user = _request("GET", sa_url, token=token)
+    if status != 200 or not sa_user:
+        _die(f"Could not retrieve service account user for client '{internal_id}'")
+    sa_user_id = sa_user["id"]
+
+    # Get already-assigned roles
+    assigned_url = (
+        f"{kc_url}/admin/realms/{realm}/users/{sa_user_id}"
+        f"/role-mappings/clients/{realm_mgmt_id}"
+    )
+    status, already_assigned = _request("GET", assigned_url, token=token)
+    assigned_names = {r["name"] for r in (already_assigned or [])}
+
+    changed = []
+    roles_to_add = []
+    for role_spec in role_specs:
+        # role_spec format: "realm-management:role-name"
+        parts = role_spec.split(":", 1)
+        role_name = parts[1] if len(parts) == 2 else parts[0]
+        if role_name in assigned_names:
+            continue
+        # Resolve role ID
+        role_url = (
+            f"{kc_url}/admin/realms/{realm}/clients/{realm_mgmt_id}/roles/{role_name}"
+        )
+        status, role_obj = _request("GET", role_url, token=token)
+        if status != 200 or not role_obj:
+            _die(
+                f"Role '{role_name}' not found in realm-management client"
+            )
+        roles_to_add.append(role_obj)
+        changed.append(f"realmRole:{role_name}")
+
+    if roles_to_add:
+        status, _ = _request(
+            "POST", assigned_url, token=token, payload=roles_to_add
+        )
+        if status not in (200, 201, 204):
+            _die(f"Failed to assign realm roles: HTTP {status}")
+
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# Core reconcile loop
+# ---------------------------------------------------------------------------
+
+
+def _reconcile_client(
+    kc_url: str,
+    realm: str,
+    token: str,
+    spec: dict[str, Any],
+) -> None:
+    client_id = spec["clientId"]
+    secret = _resolve_client_secret(spec)
+    existing = _get_existing_client(kc_url, realm, token, client_id)
+    all_changed: list[str] = []
+
+    if existing is None:
+        payload = _build_create_payload(spec, secret)
+        url = f"{kc_url}/admin/realms/{realm}/clients"
+        status, body = _request("POST", url, token=token, payload=payload)
+        if status not in (200, 201):
+            _die(f"Failed to create client '{client_id}': HTTP {status} {body}")
+        # Re-fetch to get internal ID
+        existing = _get_existing_client(kc_url, realm, token, client_id)
+        if existing is None:
+            _die(f"Client '{client_id}' created but could not be re-fetched")
+        all_changed.append("created")
+    else:
+        # Drift detection on base fields
+        drift_fields: list[str] = []
+        for field in BASE_FIELDS - {"defaultClientScopes"}:
+            if field in spec and existing.get(field) != spec[field]:
+                drift_fields.append(field)
+        if drift_fields:
+            update_payload = {**existing}
+            for field in drift_fields:
+                update_payload[field] = spec[field]
+            if secret is not None:
+                update_payload["secret"] = secret
+            url = f"{kc_url}/admin/realms/{realm}/clients/{existing['id']}"
+            status, _ = _request("PUT", url, token=token, payload=update_payload)
+            if status not in (200, 201, 204):
+                _die(f"Failed to update client '{client_id}': HTTP {status}")
+            all_changed.extend(drift_fields)
+
+    internal_id = existing["id"]
+
+    # Protocol mappers
+    if "protocolMappers" in spec:
+        mapper_changes = _ensure_protocol_mappers(
+            kc_url, realm, token, internal_id, spec["protocolMappers"]
+        )
+        all_changed.extend(mapper_changes)
+
+    # Default client scopes
+    if "defaultClientScopes" in spec:
+        scope_changes = _ensure_default_scopes(
+            kc_url, realm, token, internal_id, spec["defaultClientScopes"]
+        )
+        all_changed.extend(scope_changes)
+
+    # Realm roles (service account role assignments)
+    if "realmRoles" in spec:
+        role_changes = _ensure_realm_roles(
+            kc_url, realm, token, internal_id, spec["realmRoles"]
+        )
+        all_changed.extend(role_changes)
+
+    if "created" in all_changed:
+        _log("created", client_id, [f for f in all_changed if f != "created"])
+    elif all_changed:
+        _log("updated", client_id, all_changed)
+    else:
+        _log("unchanged", client_id)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap admin reset
+# ---------------------------------------------------------------------------
+
+
+def _reset_bootstrap_admin(kc_url: str) -> None:
+    if "localhost" not in kc_url and "127.0.0.1" not in kc_url:
+        return
+    result = subprocess.run(  # noqa: S603
+        [
+            "docker",
+            "exec",
+            "omnibase-infra-keycloak",
+            "/opt/keycloak/bin/kc.sh",
+            "bootstrap-admin",
+            "user",
+            "--no-prompt",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 and "already exists" not in result.stderr:
+        print(
+            json.dumps(
+                {"op": "warning", "message": f"bootstrap-admin: {result.stderr.strip()}"}
+            ),
+            flush=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Reconcile Keycloak clients")
+    p.add_argument("--kc-url", default=os.environ.get("KC_URL", ""))
+    p.add_argument("--realm", default=os.environ.get("KC_REALM", "omninode"))
+    p.add_argument(
+        "--admin-username",
+        default=os.environ.get("KC_ADMIN_USERNAME", "admin"),
+    )
+    p.add_argument("--admin-password", default=os.environ.get("KC_ADMIN_PASSWORD", ""))
+    p.add_argument("--config", default=os.environ.get("KC_CONFIG", ""))
+    p.add_argument(
+        "--reset-bootstrap-admin",
+        action="store_true",
+        default=False,
+        help="Run kc.sh bootstrap-admin (local only)",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if not args.kc_url:
+        _die("--kc-url (or KC_URL env var) is required")
+    if not args.admin_password:
+        _die("--admin-password (or KC_ADMIN_PASSWORD env var) is required")
+    if not args.config:
+        _die("--config (or KC_CONFIG env var) is required")
+
+    if args.reset_bootstrap_admin:
+        _reset_bootstrap_admin(args.kc_url)
+
+    config_path = args.config
+    if not os.path.isfile(config_path):
+        _die(f"Config file not found: {config_path}")
+
+    with open(config_path) as f:  # noqa: PTH123
+        config = json.load(f)
+
+    clients = config.get("clients", [])
+    if not clients:
+        _die("No clients found in config file")
+
+    token = _get_token(args.kc_url, args.admin_username, args.admin_password)
+
+    for client_spec in clients:
+        _reconcile_client(args.kc_url, args.realm, token, client_spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Conftest: register scripts/ for coverage tracing when using importlib loading."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the scripts directory to sys.path so that coverage.py can track
+# importlib-loaded scripts by their canonical file path.
+_SCRIPTS_DIR = str(Path(__file__).parent.parent.resolve())
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)

--- a/scripts/tests/test_seed_keycloak_clients.py
+++ b/scripts/tests/test_seed_keycloak_clients.py
@@ -1,0 +1,915 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for seed-keycloak-clients.py reconciler."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load script as module (it lives in scripts/, not in src/)
+# The module is loaded lazily (first test access) so that coverage.py has
+# already started tracing before exec_module runs.
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "seed-keycloak-clients.py"
+_mod: types.ModuleType  # assigned by _ensure_mod() on first use
+
+
+def _ensure_mod() -> types.ModuleType:
+    global _mod
+    try:
+        return _mod
+    except NameError:
+        pass
+    spec = importlib.util.spec_from_file_location("seed_keycloak_clients", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["seed_keycloak_clients"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    _mod = mod
+    return _mod
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _load_module() -> None:  # noqa: PT004
+    _ensure_mod()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+_REALM = "omninode"
+_KC_URL = "http://localhost:28080"
+_TOKEN = "test-access-token"
+
+
+def _client_list_response(clients: list[dict[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    return (200, clients)
+
+
+def _empty_client_list() -> tuple[int, list[dict[str, Any]]]:
+    return (200, [])
+
+
+def _ok(body: Any = None) -> tuple[int, Any]:
+    return (201, body)
+
+
+def _no_content() -> tuple[int, None]:
+    return (204, None)
+
+
+def _scopes_response(names: list[str]) -> tuple[int, list[dict[str, Any]]]:
+    return (200, [{"id": f"scope-id-{n}", "name": n} for n in names])
+
+
+def _mappers_response(names: list[str]) -> tuple[int, list[dict[str, Any]]]:
+    return (200, [{"name": n} for n in names])
+
+
+DESIRED_SCOPES = ["basic", "web-origins", "roles", "profile", "email"]
+
+
+def _make_existing_client(client_id: str, **kwargs: Any) -> dict[str, Any]:
+    base = {
+        "id": f"internal-{client_id}",
+        "clientId": client_id,
+        "enabled": True,
+        "publicClient": False,
+        "serviceAccountsEnabled": False,
+        "standardFlowEnabled": True,
+        "directAccessGrantsEnabled": False,
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Tests: idempotency (all unchanged)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_client_already_correct_reports_unchanged(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        existing = _make_existing_client(
+            "omniweb",
+            publicClient=True,
+            standardFlowEnabled=True,
+            directAccessGrantsEnabled=False,
+            serviceAccountsEnabled=False,
+            redirectUris=["https://app.omninode.ai/*", "http://localhost:3000/*"],
+        )
+        spec = {
+            "clientId": "omniweb",
+            "publicClient": True,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": False,
+            "serviceAccountsEnabled": False,
+            "redirectUris": ["https://app.omninode.ai/*", "http://localhost:3000/*"],
+            "defaultClientScopes": DESIRED_SCOPES,
+        }
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId" in url:
+                return _client_list_response([existing])
+            if method == "GET" and "default-client-scopes" in url:
+                # all scopes already present
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            _ensure_mod()._reconcile_client(_KC_URL, _REALM, _TOKEN, spec)
+
+        out = capsys.readouterr().out
+        record = json.loads(out.strip())
+        assert record["op"] == "unchanged"
+        assert record["clientId"] == "omniweb"
+
+    def test_second_run_all_unchanged(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Running reconciler twice in a row: second run is all unchanged."""
+        existing = _make_existing_client("onex-api", bearerOnly=True)
+        spec = {
+            "clientId": "onex-api",
+            "publicClient": False,
+            "bearerOnly": True,
+            "defaultClientScopes": DESIRED_SCOPES,
+        }
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId" in url:
+                return _client_list_response([existing])
+            if method == "GET" and "default-client-scopes" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            return (200, None)
+
+        for _ in range(2):
+            with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+                _ensure_mod()._reconcile_client(_KC_URL, _REALM, _TOKEN, spec)
+
+        lines = [json.loads(l) for l in capsys.readouterr().out.strip().splitlines()]
+        assert all(rec["op"] == "unchanged" for rec in lines)
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing secret env error
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSecretEnv:
+    def test_exits_nonzero_when_secret_env_missing(self) -> None:
+        spec = {
+            "clientId": "onex-admin",
+            "secretEnv": "KEYCLOAK_ADMIN_CLIENT_SECRET_MISSING_IN_TEST",
+            "serviceAccountsEnabled": True,
+        }
+        env = {k: v for k, v in os.environ.items() if k != "KEYCLOAK_ADMIN_CLIENT_SECRET_MISSING_IN_TEST"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _ensure_mod()._resolve_client_secret(spec)
+        assert exc_info.value.code != 0
+
+    def test_secret_resolved_when_env_set(self) -> None:
+        spec = {
+            "clientId": "onex-admin",
+            "secretEnv": "KEYCLOAK_ADMIN_CLIENT_SECRET_TEST_VAR",
+        }
+        with patch.dict(os.environ, {"KEYCLOAK_ADMIN_CLIENT_SECRET_TEST_VAR": "mysecret"}):
+            result = _ensure_mod()._resolve_client_secret(spec)
+        assert result == "mysecret"
+
+    def test_no_secret_env_returns_none(self) -> None:
+        spec = {"clientId": "omniweb"}
+        result = _ensure_mod()._resolve_client_secret(spec)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: scope binding only when missing
+# ---------------------------------------------------------------------------
+
+
+class TestScopeBinding:
+    def test_missing_scope_is_added(self) -> None:
+        all_scope_names = DESIRED_SCOPES
+        # client currently has all except "basic"
+        current_scope_names = [s for s in DESIRED_SCOPES if s != "basic"]
+        calls_made: list[str] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in current_scope_names])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(all_scope_names)
+            if method == "PUT" and "default-client-scopes" in url:
+                calls_made.append(url)
+                return _no_content()
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            changed = _ensure_mod()._ensure_default_scopes(
+                _KC_URL, _REALM, _TOKEN, "internal-omniweb", DESIRED_SCOPES
+            )
+
+        assert "defaultClientScope:basic" in changed
+        assert len(calls_made) == 1  # only "basic" was PUT
+
+    def test_already_bound_scopes_not_re_added(self) -> None:
+        calls_made: list[str] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            if method == "PUT" and "default-client-scopes" in url:
+                calls_made.append(url)
+                return _no_content()
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            changed = _ensure_mod()._ensure_default_scopes(
+                _KC_URL, _REALM, _TOKEN, "internal-omniweb", DESIRED_SCOPES
+            )
+
+        assert changed == []
+        assert calls_made == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: audience mapper creation
+# ---------------------------------------------------------------------------
+
+
+class TestAudienceMapper:
+    def test_mapper_created_when_absent(self) -> None:
+        mapper_spec = [
+            {
+                "name": "onex-api-audience",
+                "protocolMapper": "oidc-audience-mapper",
+                "config": {
+                    "included.client.audience": "onex-api",
+                    "id.token.claim": "false",
+                    "access.token.claim": "true",
+                },
+            }
+        ]
+        post_calls: list[dict[str, Any]] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "protocol-mappers" in url:
+                return _mappers_response([])  # no mappers exist yet
+            if method == "POST" and "protocol-mappers" in url:
+                post_calls.append(kwargs.get("payload", {}))
+                return _ok()
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            changed = _ensure_mod()._ensure_protocol_mappers(
+                _KC_URL, _REALM, _TOKEN, "internal-omniweb", mapper_spec
+            )
+
+        assert "protocolMapper:onex-api-audience" in changed
+        assert len(post_calls) == 1
+        assert post_calls[0]["name"] == "onex-api-audience"
+        assert post_calls[0]["protocolMapper"] == "oidc-audience-mapper"
+
+    def test_mapper_not_recreated_when_present(self) -> None:
+        mapper_spec = [
+            {
+                "name": "onex-api-audience",
+                "protocolMapper": "oidc-audience-mapper",
+                "config": {},
+            }
+        ]
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "protocol-mappers" in url:
+                return _mappers_response(["onex-api-audience"])
+            return (200, None)
+
+        post_called = False
+        original_request = _ensure_mod()._request
+
+        def tracking_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            nonlocal post_called
+            if method == "POST" and "protocol-mappers" in url:
+                post_called = True
+            return fake_request(method, url, **kwargs)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=tracking_request):
+            changed = _ensure_mod()._ensure_protocol_mappers(
+                _KC_URL, _REALM, _TOKEN, "internal-omniweb", mapper_spec
+            )
+
+        assert changed == []
+        assert not post_called
+
+
+# ---------------------------------------------------------------------------
+# Tests: role mapping for onex-admin
+# ---------------------------------------------------------------------------
+
+
+class TestRoleMapping:
+    def test_realm_roles_assigned_to_service_account(self) -> None:
+        realm_mgmt_client = {"id": "realm-mgmt-id", "clientId": "realm-management"}
+        sa_user = {"id": "sa-user-id"}
+        role_obj = {"id": "role-id-manage-users", "name": "manage-users"}
+        post_calls: list[Any] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId=realm-management" in url:
+                return (200, [realm_mgmt_client])
+            if method == "GET" and "service-account-user" in url:
+                return (200, sa_user)
+            if method == "GET" and "role-mappings/clients" in url:
+                return (200, [])  # no roles assigned yet
+            if method == "GET" and "roles/manage-users" in url:
+                return (200, role_obj)
+            if method == "POST" and "role-mappings" in url:
+                post_calls.append(kwargs.get("payload", []))
+                return _no_content()
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            changed = _ensure_mod()._ensure_realm_roles(
+                _KC_URL,
+                _REALM,
+                _TOKEN,
+                "internal-onex-admin",
+                ["realm-management:manage-users"],
+            )
+
+        assert "realmRole:manage-users" in changed
+        assert len(post_calls) == 1
+        assert post_calls[0][0]["name"] == "manage-users"
+
+    def test_already_assigned_roles_not_reassigned(self) -> None:
+        realm_mgmt_client = {"id": "realm-mgmt-id", "clientId": "realm-management"}
+        sa_user = {"id": "sa-user-id"}
+        post_calls: list[Any] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId=realm-management" in url:
+                return (200, [realm_mgmt_client])
+            if method == "GET" and "service-account-user" in url:
+                return (200, sa_user)
+            if method == "GET" and "role-mappings/clients" in url:
+                return (200, [{"name": "manage-users"}])  # already assigned
+            if method == "POST" and "role-mappings" in url:
+                post_calls.append(kwargs.get("payload", []))
+                return _no_content()
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            changed = _ensure_mod()._ensure_realm_roles(
+                _KC_URL,
+                _REALM,
+                _TOKEN,
+                "internal-onex-admin",
+                ["realm-management:manage-users"],
+            )
+
+        assert changed == []
+        assert post_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: client creation flow
+# ---------------------------------------------------------------------------
+
+
+class TestClientCreation:
+    def test_missing_client_is_created(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = {
+            "clientId": "onex-service",
+            "publicClient": False,
+            "serviceAccountsEnabled": True,
+            "standardFlowEnabled": False,
+            "directAccessGrantsEnabled": False,
+            "secretEnv": "ONEX_SERVICE_CLIENT_SECRET_TEST",
+            "defaultClientScopes": DESIRED_SCOPES,
+            "protocolMappers": [
+                {
+                    "name": "onex-api-audience",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "config": {"included.client.audience": "onex-api"},
+                }
+            ],
+        }
+        # Re-fetched client matches spec exactly — no drift, so op=created not updated
+        existing_client = _make_existing_client(
+            "onex-service",
+            publicClient=False,
+            serviceAccountsEnabled=True,
+            standardFlowEnabled=False,
+            directAccessGrantsEnabled=False,
+            redirectUris=[],
+        )
+        fetch_count = {"n": 0}
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId" in url:
+                fetch_count["n"] += 1
+                if fetch_count["n"] == 1:
+                    return _empty_client_list()  # not yet created
+                return _client_list_response([existing_client])
+            if method == "POST" and "/clients" in url and "protocol-mappers" not in url:
+                return _ok()
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            if method == "GET" and "protocol-mappers" in url:
+                return _mappers_response([])
+            if method == "POST" and "protocol-mappers" in url:
+                return _ok()
+            return (200, None)
+
+        with patch.dict(os.environ, {"ONEX_SERVICE_CLIENT_SECRET_TEST": "svc-secret"}):
+            with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+                _ensure_mod()._reconcile_client(_KC_URL, _REALM, _TOKEN, spec)
+
+        out = capsys.readouterr().out
+        record = json.loads(out.strip())
+        assert record["op"] == "created"
+        assert record["clientId"] == "onex-service"
+
+    def test_full_reconcile_loop_all_clients(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Smoke: all 5 desired clients reconcile without error."""
+        clients_spec = [
+            {"clientId": "omniweb", "publicClient": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "serviceAccountsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
+            {"clientId": "onex-api", "publicClient": False, "bearerOnly": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "serviceAccountsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
+            {"clientId": "redpanda-events", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
+            {"clientId": "onex-admin", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": False, "directAccessGrantsEnabled": False, "secretEnv": "KC_ADMIN_CLIENT_SECRET_T", "realmRoles": ["realm-management:manage-users"], "defaultClientScopes": DESIRED_SCOPES},
+            {"clientId": "onex-service", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": False, "directAccessGrantsEnabled": False, "secretEnv": "ONEX_SVC_SECRET_T", "defaultClientScopes": DESIRED_SCOPES},
+        ]
+        # Build existing-client map that exactly matches each spec so no drift fires
+        existing_by_id = {
+            spec["clientId"]: _make_existing_client(
+                spec["clientId"],
+                publicClient=spec.get("publicClient", False),
+                bearerOnly=spec.get("bearerOnly", False),
+                serviceAccountsEnabled=spec.get("serviceAccountsEnabled", False),
+                standardFlowEnabled=spec.get("standardFlowEnabled", True),
+                directAccessGrantsEnabled=spec.get("directAccessGrantsEnabled", False),
+            )
+            for spec in clients_spec
+        }
+        realm_mgmt = {"id": "rm-id", "clientId": "realm-management"}
+        sa_user = {"id": "sa-id"}
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId=realm-management" in url:
+                return (200, [realm_mgmt])
+            if method == "GET" and "clients?clientId" in url:
+                client_id = url.split("clientId=")[-1]
+                existing = existing_by_id.get(client_id)
+                if existing:
+                    return _client_list_response([existing])
+                return _empty_client_list()
+            if method == "GET" and "service-account-user" in url:
+                return (200, sa_user)
+            if method == "GET" and "role-mappings/clients" in url:
+                return (200, [{"name": "manage-users"}])  # already assigned
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            if method == "GET" and "protocol-mappers" in url:
+                return _mappers_response([])
+            return (200, None)
+
+        env_patch = {
+            "KC_ADMIN_CLIENT_SECRET_T": "admin-secret",
+            "ONEX_SVC_SECRET_T": "svc-secret",
+        }
+        with patch.dict(os.environ, env_patch):
+            with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+                for spec in clients_spec:
+                    _ensure_mod()._reconcile_client(_KC_URL, _REALM, _TOKEN, spec)
+
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert len(lines) == 5
+        ops = {json.loads(l)["op"] for l in lines}
+        # All should be unchanged (existing clients with correct state)
+        assert ops == {"unchanged"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetToken:
+    def test_returns_access_token_on_success(self) -> None:
+        token_response = json.dumps({"access_token": "my-token-abc"}).encode()
+
+        class FakeResponse:
+            status = 200
+
+            def read(self) -> bytes:
+                return token_response
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResponse()):
+            result = _ensure_mod()._get_token(_KC_URL, "admin", "password")
+        assert result == "my-token-abc"
+
+    def test_dies_on_http_error(self) -> None:
+        import urllib.error
+
+        exc = urllib.error.HTTPError(
+            url="http://x", code=401, msg="Unauthorized", hdrs={}, fp=None  # type: ignore[arg-type]
+        )
+        exc.read = lambda: b'{"error": "unauthorized"}'  # type: ignore[method-assign]
+
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with pytest.raises(SystemExit) as exc_info:
+                _ensure_mod()._get_token(_KC_URL, "admin", "wrong")
+        assert exc_info.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _die and _log
+# ---------------------------------------------------------------------------
+
+
+class TestLogAndDie:
+    def test_die_exits_nonzero(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _ensure_mod()._die("something went wrong")
+        assert exc_info.value.code != 0
+
+    def test_log_unchanged(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _ensure_mod()._log("unchanged", "my-client")
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out == {"op": "unchanged", "clientId": "my-client"}
+
+    def test_log_updated_with_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _ensure_mod()._log("updated", "my-client", ["defaultClientScopes"])
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["op"] == "updated"
+        assert "defaultClientScopes" in out["fields_changed"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_dies_without_kc_url(self) -> None:
+        with patch("sys.argv", ["seed-keycloak-clients.py"]):
+            with patch.dict(os.environ, {}, clear=True):
+                with pytest.raises(SystemExit) as exc_info:
+                    _ensure_mod().main()
+        assert exc_info.value.code != 0
+
+    def test_main_dies_without_admin_password(self) -> None:
+        with patch("sys.argv", ["seed-keycloak-clients.py", "--kc-url", "http://localhost:28080"]):
+            with patch.dict(os.environ, {"KC_URL": "http://localhost:28080"}, clear=False):
+                with pytest.raises(SystemExit) as exc_info:
+                    _ensure_mod().main()
+        assert exc_info.value.code != 0
+
+    def test_main_dies_without_config(self) -> None:
+        with patch("sys.argv", [
+            "seed-keycloak-clients.py",
+            "--kc-url", "http://localhost:28080",
+            "--admin-password", "secret",
+        ]):
+            with patch.dict(os.environ, {}, clear=False):
+                with pytest.raises(SystemExit) as exc_info:
+                    _ensure_mod().main()
+        assert exc_info.value.code != 0
+
+    def test_main_dies_on_missing_config_file(self, tmp_path: pytest.TempPathFactory) -> None:
+        with patch("sys.argv", [
+            "seed-keycloak-clients.py",
+            "--kc-url", "http://localhost:28080",
+            "--admin-password", "secret",
+            "--config", "/nonexistent/path/desired-clients.json",
+        ]):
+            with pytest.raises(SystemExit) as exc_info:
+                _ensure_mod().main()
+        assert exc_info.value.code != 0
+
+    def test_main_runs_reconciler_from_config_file(
+        self, tmp_path: "pytest.TempPathFactory", capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = {
+            "realm": "omninode",
+            "clients": [
+                {"clientId": "omniweb", "publicClient": True, "defaultClientScopes": DESIRED_SCOPES},
+            ],
+        }
+        config_file = tmp_path / "desired-clients.json"  # type: ignore[operator]
+        config_file.write_text(json.dumps(config))
+
+        existing = _make_existing_client("omniweb", publicClient=True)
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if "token" in url:
+                return (200, {"access_token": "tok"})
+            if method == "GET" and "clients?clientId" in url:
+                return _client_list_response([existing])
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            return (200, None)
+
+        with patch("sys.argv", [
+            "seed-keycloak-clients.py",
+            "--kc-url", _KC_URL,
+            "--admin-username", "admin",
+            "--admin-password", "secret",
+            "--config", str(config_file),
+        ]):
+            with patch.object(_ensure_mod(), "_get_token", return_value="tok"):
+                with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+                    _ensure_mod().main()
+
+        out = capsys.readouterr().out
+        record = json.loads(out.strip())
+        assert record["clientId"] == "omniweb"
+        assert record["op"] == "unchanged"
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths in helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_ensure_protocol_mappers_fails_on_http_error(self) -> None:
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET":
+                return (200, [])  # no existing mappers
+            return (500, {"error": "server error"})  # POST fails
+
+        mapper_spec = [{"name": "bad-mapper", "protocolMapper": "oidc-audience-mapper", "config": {}}]
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            with pytest.raises(SystemExit):
+                _ensure_mod()._ensure_protocol_mappers(
+                    _KC_URL, _REALM, _TOKEN, "internal-id", mapper_spec
+                )
+
+    def test_ensure_default_scopes_fails_when_scope_not_found(self) -> None:
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [])  # no scopes bound
+            if method == "GET" and "/client-scopes" in url:
+                return (200, [])  # scope doesn't exist in realm
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            with pytest.raises(SystemExit):
+                _ensure_mod()._ensure_default_scopes(
+                    _KC_URL, _REALM, _TOKEN, "internal-id", ["nonexistent-scope"]
+                )
+
+    def test_ensure_realm_roles_fails_when_realm_mgmt_missing(self) -> None:
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId=realm-management" in url:
+                return (200, [])  # realm-management not found
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            with pytest.raises(SystemExit):
+                _ensure_mod()._ensure_realm_roles(
+                    _KC_URL, _REALM, _TOKEN, "internal-id", ["realm-management:manage-users"]
+                )
+
+    def test_ensure_default_scopes_fails_on_put_error(self) -> None:
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [])  # no scopes bound yet
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(["basic"])
+            if method == "PUT" and "default-client-scopes" in url:
+                return (500, {"error": "server error"})
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            with pytest.raises(SystemExit):
+                _ensure_mod()._ensure_default_scopes(
+                    _KC_URL, _REALM, _TOKEN, "internal-id", ["basic"]
+                )
+
+    def test_ensure_realm_roles_fails_on_post_error(self) -> None:
+        realm_mgmt = {"id": "rm-id", "clientId": "realm-management"}
+        sa_user = {"id": "sa-id"}
+        role_obj = {"id": "r-id", "name": "manage-users"}
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId=realm-management" in url:
+                return (200, [realm_mgmt])
+            if method == "GET" and "service-account-user" in url:
+                return (200, sa_user)
+            if method == "GET" and "role-mappings/clients" in url:
+                return (200, [])  # nothing assigned yet
+            if method == "GET" and "roles/manage-users" in url:
+                return (200, role_obj)
+            if method == "POST" and "role-mappings" in url:
+                return (500, {"error": "server error"})
+            return (200, None)
+
+        with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+            with pytest.raises(SystemExit):
+                _ensure_mod()._ensure_realm_roles(
+                    _KC_URL, _REALM, _TOKEN, "internal-id",
+                    ["realm-management:manage-users"]
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _request function (urllib path)
+# ---------------------------------------------------------------------------
+
+
+class TestRequest:
+    def test_request_success(self) -> None:
+        response_body = json.dumps({"id": "abc"}).encode()
+
+        class FakeResp:
+            status = 200
+
+            def read(self) -> bytes:
+                return response_body
+
+            def __enter__(self) -> "FakeResp":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            status, body = _ensure_mod()._request("GET", "http://localhost/test", token="tok")
+        assert status == 200
+        assert body == {"id": "abc"}
+
+    def test_request_http_error_with_json_body(self) -> None:
+        import urllib.error
+
+        exc = urllib.error.HTTPError(
+            url="http://x", code=404, msg="Not Found", hdrs={}, fp=None  # type: ignore[arg-type]
+        )
+        exc.read = lambda: b'{"error": "not found"}'  # type: ignore[method-assign]
+
+        with patch("urllib.request.urlopen", side_effect=exc):
+            status, body = _ensure_mod()._request("GET", "http://localhost/test", token="tok")
+        assert status == 404
+        assert body == {"error": "not found"}
+
+    def test_request_http_error_with_non_json_body(self) -> None:
+        import urllib.error
+
+        exc = urllib.error.HTTPError(
+            url="http://x", code=500, msg="Server Error", hdrs={}, fp=None  # type: ignore[arg-type]
+        )
+        exc.read = lambda: b"Internal Server Error"  # type: ignore[method-assign]
+
+        with patch("urllib.request.urlopen", side_effect=exc):
+            status, body = _ensure_mod()._request("GET", "http://localhost/test")
+        assert status == 500
+        assert body == "Internal Server Error"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _reset_bootstrap_admin
+# ---------------------------------------------------------------------------
+
+
+class TestResetBootstrapAdmin:
+    def test_skips_non_localhost(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            _ensure_mod()._reset_bootstrap_admin("https://keycloak.prod.example.com")
+        mock_run.assert_not_called()
+
+    def test_runs_docker_exec_on_localhost(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _ensure_mod()._reset_bootstrap_admin("http://localhost:28080")
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "docker" in cmd
+        assert "bootstrap-admin" in cmd
+
+    def test_prints_warning_on_nonzero_exit(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "some unexpected error"
+
+        with patch("subprocess.run", return_value=mock_result):
+            _ensure_mod()._reset_bootstrap_admin("http://localhost:28080")
+
+        out = capsys.readouterr().out
+        record = json.loads(out.strip())
+        assert record["op"] == "warning"
+
+    def test_no_warning_when_already_exists(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "User already exists"
+
+        with patch("subprocess.run", return_value=mock_result):
+            _ensure_mod()._reset_bootstrap_admin("http://localhost:28080")
+
+        out = capsys.readouterr().out
+        assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() with --reset-bootstrap-admin and empty-clients guard
+# ---------------------------------------------------------------------------
+
+
+class TestMainExtended:
+    def test_main_dies_on_empty_clients_list(self, tmp_path: "pytest.TempPathFactory") -> None:
+        config = {"realm": "omninode", "clients": []}
+        config_file = tmp_path / "empty-clients.json"  # type: ignore[operator]
+        config_file.write_text(json.dumps(config))
+
+        with patch("sys.argv", [
+            "seed-keycloak-clients.py",
+            "--kc-url", _KC_URL,
+            "--admin-password", "secret",
+            "--config", str(config_file),
+        ]):
+            with pytest.raises(SystemExit) as exc_info:
+                _ensure_mod().main()
+        assert exc_info.value.code != 0
+
+    def test_main_calls_reset_bootstrap_admin_when_flag_set(
+        self, tmp_path: "pytest.TempPathFactory", capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = {
+            "realm": "omninode",
+            "clients": [
+                {"clientId": "omniweb", "publicClient": True, "defaultClientScopes": DESIRED_SCOPES},
+            ],
+        }
+        config_file = tmp_path / "desired-clients.json"  # type: ignore[operator]
+        config_file.write_text(json.dumps(config))
+        existing = _make_existing_client("omniweb", publicClient=True)
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
+            if method == "GET" and "clients?clientId" in url:
+                return _client_list_response([existing])
+            if method == "GET" and "default-client-scopes" in url and "clients/" in url:
+                return (200, [{"name": n} for n in DESIRED_SCOPES])
+            if method == "GET" and "/client-scopes" in url:
+                return _scopes_response(DESIRED_SCOPES)
+            return (200, None)
+
+        with patch("sys.argv", [
+            "seed-keycloak-clients.py",
+            "--kc-url", _KC_URL,
+            "--admin-password", "secret",
+            "--config", str(config_file),
+            "--reset-bootstrap-admin",
+        ]):
+            with patch.object(_ensure_mod(), "_get_token", return_value="tok"):
+                with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
+                    with patch.object(_ensure_mod(), "_reset_bootstrap_admin") as mock_reset:
+                        _ensure_mod().main()
+        mock_reset.assert_called_once_with(_KC_URL)

--- a/scripts/tests/test_seed_keycloak_clients.py
+++ b/scripts/tests/test_seed_keycloak_clients.py
@@ -309,8 +309,6 @@ class TestAudienceMapper:
             return (200, None)
 
         post_called = False
-        original_request = _ensure_mod()._request
-
         def tracking_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
             nonlocal post_called
             if method == "POST" and "protocol-mappers" in url:

--- a/scripts/tests/test_seed_keycloak_clients.py
+++ b/scripts/tests/test_seed_keycloak_clients.py
@@ -12,7 +12,7 @@ import sys
 import types
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,7 +27,7 @@ _mod: types.ModuleType  # assigned by _ensure_mod() on first use
 
 
 def _ensure_mod() -> types.ModuleType:
-    global _mod
+    global _mod  # noqa: PLW0603
     try:
         return _mod
     except NameError:
@@ -43,7 +43,7 @@ def _ensure_mod() -> types.ModuleType:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _load_module() -> None:  # noqa: PT004
+def _load_module() -> None:
     _ensure_mod()
 
 
@@ -56,7 +56,9 @@ _KC_URL = "http://localhost:28080"
 _TOKEN = "test-access-token"
 
 
-def _client_list_response(clients: list[dict[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+def _client_list_response(
+    clients: list[dict[str, Any]],
+) -> tuple[int, list[dict[str, Any]]]:
     return (200, clients)
 
 
@@ -142,9 +144,7 @@ class TestIdempotency:
         assert record["op"] == "unchanged"
         assert record["clientId"] == "omniweb"
 
-    def test_second_run_all_unchanged(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_second_run_all_unchanged(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Running reconciler twice in a row: second run is all unchanged."""
         existing = _make_existing_client("onex-api", bearerOnly=True)
         spec = {
@@ -167,7 +167,9 @@ class TestIdempotency:
             with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
                 _ensure_mod()._reconcile_client(_KC_URL, _REALM, _TOKEN, spec)
 
-        lines = [json.loads(l) for l in capsys.readouterr().out.strip().splitlines()]
+        lines = [
+            json.loads(line) for line in capsys.readouterr().out.strip().splitlines()
+        ]
         assert all(rec["op"] == "unchanged" for rec in lines)
 
 
@@ -183,7 +185,11 @@ class TestMissingSecretEnv:
             "secretEnv": "KEYCLOAK_ADMIN_CLIENT_SECRET_MISSING_IN_TEST",
             "serviceAccountsEnabled": True,
         }
-        env = {k: v for k, v in os.environ.items() if k != "KEYCLOAK_ADMIN_CLIENT_SECRET_MISSING_IN_TEST"}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "KEYCLOAK_ADMIN_CLIENT_SECRET_MISSING_IN_TEST"
+        }
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(SystemExit) as exc_info:
                 _ensure_mod()._resolve_client_secret(spec)
@@ -194,7 +200,9 @@ class TestMissingSecretEnv:
             "clientId": "onex-admin",
             "secretEnv": "KEYCLOAK_ADMIN_CLIENT_SECRET_TEST_VAR",
         }
-        with patch.dict(os.environ, {"KEYCLOAK_ADMIN_CLIENT_SECRET_TEST_VAR": "mysecret"}):
+        with patch.dict(
+            os.environ, {"KEYCLOAK_ADMIN_CLIENT_SECRET_TEST_VAR": "mysecret"}
+        ):
             result = _ensure_mod()._resolve_client_secret(spec)
         assert result == "mysecret"
 
@@ -309,6 +317,7 @@ class TestAudienceMapper:
             return (200, None)
 
         post_called = False
+
         def tracking_request(method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
             nonlocal post_called
             if method == "POST" and "protocol-mappers" in url:
@@ -461,11 +470,50 @@ class TestClientCreation:
     ) -> None:
         """Smoke: all 5 desired clients reconcile without error."""
         clients_spec = [
-            {"clientId": "omniweb", "publicClient": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "serviceAccountsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
-            {"clientId": "onex-api", "publicClient": False, "bearerOnly": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "serviceAccountsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
-            {"clientId": "redpanda-events", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": True, "directAccessGrantsEnabled": False, "defaultClientScopes": DESIRED_SCOPES},
-            {"clientId": "onex-admin", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": False, "directAccessGrantsEnabled": False, "secretEnv": "KC_ADMIN_CLIENT_SECRET_T", "realmRoles": ["realm-management:manage-users"], "defaultClientScopes": DESIRED_SCOPES},
-            {"clientId": "onex-service", "publicClient": False, "serviceAccountsEnabled": True, "standardFlowEnabled": False, "directAccessGrantsEnabled": False, "secretEnv": "ONEX_SVC_SECRET_T", "defaultClientScopes": DESIRED_SCOPES},
+            {
+                "clientId": "omniweb",
+                "publicClient": True,
+                "standardFlowEnabled": True,
+                "directAccessGrantsEnabled": False,
+                "serviceAccountsEnabled": False,
+                "defaultClientScopes": DESIRED_SCOPES,
+            },
+            {
+                "clientId": "onex-api",
+                "publicClient": False,
+                "bearerOnly": True,
+                "standardFlowEnabled": True,
+                "directAccessGrantsEnabled": False,
+                "serviceAccountsEnabled": False,
+                "defaultClientScopes": DESIRED_SCOPES,
+            },
+            {
+                "clientId": "redpanda-events",
+                "publicClient": False,
+                "serviceAccountsEnabled": True,
+                "standardFlowEnabled": True,
+                "directAccessGrantsEnabled": False,
+                "defaultClientScopes": DESIRED_SCOPES,
+            },
+            {
+                "clientId": "onex-admin",
+                "publicClient": False,
+                "serviceAccountsEnabled": True,
+                "standardFlowEnabled": False,
+                "directAccessGrantsEnabled": False,
+                "secretEnv": "KC_ADMIN_CLIENT_SECRET_T",
+                "realmRoles": ["realm-management:manage-users"],
+                "defaultClientScopes": DESIRED_SCOPES,
+            },
+            {
+                "clientId": "onex-service",
+                "publicClient": False,
+                "serviceAccountsEnabled": True,
+                "standardFlowEnabled": False,
+                "directAccessGrantsEnabled": False,
+                "secretEnv": "ONEX_SVC_SECRET_T",
+                "defaultClientScopes": DESIRED_SCOPES,
+            },
         ]
         # Build existing-client map that exactly matches each spec so no drift fires
         existing_by_id = {
@@ -514,7 +562,7 @@ class TestClientCreation:
 
         lines = capsys.readouterr().out.strip().splitlines()
         assert len(lines) == 5
-        ops = {json.loads(l)["op"] for l in lines}
+        ops = {json.loads(line)["op"] for line in lines}
         # All should be unchanged (existing clients with correct state)
         assert ops == {"unchanged"}
 
@@ -534,7 +582,7 @@ class TestGetToken:
             def read(self) -> bytes:
                 return token_response
 
-            def __enter__(self) -> "FakeResponse":
+            def __enter__(self) -> FakeResponse:
                 return self
 
             def __exit__(self, *args: object) -> None:
@@ -548,7 +596,11 @@ class TestGetToken:
         import urllib.error
 
         exc = urllib.error.HTTPError(
-            url="http://x", code=401, msg="Unauthorized", hdrs={}, fp=None  # type: ignore[arg-type]
+            url="http://x",
+            code=401,
+            msg="Unauthorized",
+            hdrs={},
+            fp=None,  # type: ignore[arg-type]
         )
         exc.read = lambda: b'{"error": "unauthorized"}'  # type: ignore[method-assign]
 
@@ -595,41 +647,63 @@ class TestMain:
         assert exc_info.value.code != 0
 
     def test_main_dies_without_admin_password(self) -> None:
-        with patch("sys.argv", ["seed-keycloak-clients.py", "--kc-url", "http://localhost:28080"]):
-            with patch.dict(os.environ, {"KC_URL": "http://localhost:28080"}, clear=False):
+        with patch(
+            "sys.argv",
+            ["seed-keycloak-clients.py", "--kc-url", "http://localhost:28080"],
+        ):
+            with patch.dict(
+                os.environ, {"KC_URL": "http://localhost:28080"}, clear=False
+            ):
                 with pytest.raises(SystemExit) as exc_info:
                     _ensure_mod().main()
         assert exc_info.value.code != 0
 
     def test_main_dies_without_config(self) -> None:
-        with patch("sys.argv", [
-            "seed-keycloak-clients.py",
-            "--kc-url", "http://localhost:28080",
-            "--admin-password", "secret",
-        ]):
+        with patch(
+            "sys.argv",
+            [
+                "seed-keycloak-clients.py",
+                "--kc-url",
+                "http://localhost:28080",
+                "--admin-password",
+                "secret",
+            ],
+        ):
             with patch.dict(os.environ, {}, clear=False):
                 with pytest.raises(SystemExit) as exc_info:
                     _ensure_mod().main()
         assert exc_info.value.code != 0
 
-    def test_main_dies_on_missing_config_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        with patch("sys.argv", [
-            "seed-keycloak-clients.py",
-            "--kc-url", "http://localhost:28080",
-            "--admin-password", "secret",
-            "--config", "/nonexistent/path/desired-clients.json",
-        ]):
+    def test_main_dies_on_missing_config_file(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "seed-keycloak-clients.py",
+                "--kc-url",
+                "http://localhost:28080",
+                "--admin-password",
+                "secret",
+                "--config",
+                "/nonexistent/path/desired-clients.json",
+            ],
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 _ensure_mod().main()
         assert exc_info.value.code != 0
 
     def test_main_runs_reconciler_from_config_file(
-        self, tmp_path: "pytest.TempPathFactory", capsys: pytest.CaptureFixture[str]
+        self, tmp_path: pytest.TempPathFactory, capsys: pytest.CaptureFixture[str]
     ) -> None:
         config = {
             "realm": "omninode",
             "clients": [
-                {"clientId": "omniweb", "publicClient": True, "defaultClientScopes": DESIRED_SCOPES},
+                {
+                    "clientId": "omniweb",
+                    "publicClient": True,
+                    "defaultClientScopes": DESIRED_SCOPES,
+                },
             ],
         }
         config_file = tmp_path / "desired-clients.json"  # type: ignore[operator]
@@ -648,13 +722,20 @@ class TestMain:
                 return _scopes_response(DESIRED_SCOPES)
             return (200, None)
 
-        with patch("sys.argv", [
-            "seed-keycloak-clients.py",
-            "--kc-url", _KC_URL,
-            "--admin-username", "admin",
-            "--admin-password", "secret",
-            "--config", str(config_file),
-        ]):
+        with patch(
+            "sys.argv",
+            [
+                "seed-keycloak-clients.py",
+                "--kc-url",
+                _KC_URL,
+                "--admin-username",
+                "admin",
+                "--admin-password",
+                "secret",
+                "--config",
+                str(config_file),
+            ],
+        ):
             with patch.object(_ensure_mod(), "_get_token", return_value="tok"):
                 with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
                     _ensure_mod().main()
@@ -677,7 +758,13 @@ class TestErrorPaths:
                 return (200, [])  # no existing mappers
             return (500, {"error": "server error"})  # POST fails
 
-        mapper_spec = [{"name": "bad-mapper", "protocolMapper": "oidc-audience-mapper", "config": {}}]
+        mapper_spec = [
+            {
+                "name": "bad-mapper",
+                "protocolMapper": "oidc-audience-mapper",
+                "config": {},
+            }
+        ]
         with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
             with pytest.raises(SystemExit):
                 _ensure_mod()._ensure_protocol_mappers(
@@ -707,7 +794,11 @@ class TestErrorPaths:
         with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
             with pytest.raises(SystemExit):
                 _ensure_mod()._ensure_realm_roles(
-                    _KC_URL, _REALM, _TOKEN, "internal-id", ["realm-management:manage-users"]
+                    _KC_URL,
+                    _REALM,
+                    _TOKEN,
+                    "internal-id",
+                    ["realm-management:manage-users"],
                 )
 
     def test_ensure_default_scopes_fails_on_put_error(self) -> None:
@@ -747,8 +838,11 @@ class TestErrorPaths:
         with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
             with pytest.raises(SystemExit):
                 _ensure_mod()._ensure_realm_roles(
-                    _KC_URL, _REALM, _TOKEN, "internal-id",
-                    ["realm-management:manage-users"]
+                    _KC_URL,
+                    _REALM,
+                    _TOKEN,
+                    "internal-id",
+                    ["realm-management:manage-users"],
                 )
 
 
@@ -767,14 +861,18 @@ class TestRequest:
             def read(self) -> bytes:
                 return response_body
 
-            def __enter__(self) -> "FakeResp":
+            def __enter__(self) -> FakeResp:
                 return self
 
             def __exit__(self, *args: object) -> None:
                 pass
 
         with patch("urllib.request.urlopen", return_value=FakeResp()):
-            status, body = _ensure_mod()._request("GET", "http://localhost/test", token="tok")
+            status, body = _ensure_mod()._request(
+                "GET",
+                "http://localhost/test",
+                token="tok",  # noqa: S106
+            )
         assert status == 200
         assert body == {"id": "abc"}
 
@@ -782,12 +880,20 @@ class TestRequest:
         import urllib.error
 
         exc = urllib.error.HTTPError(
-            url="http://x", code=404, msg="Not Found", hdrs={}, fp=None  # type: ignore[arg-type]
+            url="http://x",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=None,  # type: ignore[arg-type]
         )
         exc.read = lambda: b'{"error": "not found"}'  # type: ignore[method-assign]
 
         with patch("urllib.request.urlopen", side_effect=exc):
-            status, body = _ensure_mod()._request("GET", "http://localhost/test", token="tok")
+            status, body = _ensure_mod()._request(
+                "GET",
+                "http://localhost/test",
+                token="tok",  # noqa: S106
+            )
         assert status == 404
         assert body == {"error": "not found"}
 
@@ -795,7 +901,11 @@ class TestRequest:
         import urllib.error
 
         exc = urllib.error.HTTPError(
-            url="http://x", code=500, msg="Server Error", hdrs={}, fp=None  # type: ignore[arg-type]
+            url="http://x",
+            code=500,
+            msg="Server Error",
+            hdrs={},
+            fp=None,  # type: ignore[arg-type]
         )
         exc.read = lambda: b"Internal Server Error"  # type: ignore[method-assign]
 
@@ -862,28 +972,40 @@ class TestResetBootstrapAdmin:
 
 
 class TestMainExtended:
-    def test_main_dies_on_empty_clients_list(self, tmp_path: "pytest.TempPathFactory") -> None:
+    def test_main_dies_on_empty_clients_list(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
         config = {"realm": "omninode", "clients": []}
         config_file = tmp_path / "empty-clients.json"  # type: ignore[operator]
         config_file.write_text(json.dumps(config))
 
-        with patch("sys.argv", [
-            "seed-keycloak-clients.py",
-            "--kc-url", _KC_URL,
-            "--admin-password", "secret",
-            "--config", str(config_file),
-        ]):
+        with patch(
+            "sys.argv",
+            [
+                "seed-keycloak-clients.py",
+                "--kc-url",
+                _KC_URL,
+                "--admin-password",
+                "secret",
+                "--config",
+                str(config_file),
+            ],
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 _ensure_mod().main()
         assert exc_info.value.code != 0
 
     def test_main_calls_reset_bootstrap_admin_when_flag_set(
-        self, tmp_path: "pytest.TempPathFactory", capsys: pytest.CaptureFixture[str]
+        self, tmp_path: pytest.TempPathFactory, capsys: pytest.CaptureFixture[str]
     ) -> None:
         config = {
             "realm": "omninode",
             "clients": [
-                {"clientId": "omniweb", "publicClient": True, "defaultClientScopes": DESIRED_SCOPES},
+                {
+                    "clientId": "omniweb",
+                    "publicClient": True,
+                    "defaultClientScopes": DESIRED_SCOPES,
+                },
             ],
         }
         config_file = tmp_path / "desired-clients.json"  # type: ignore[operator]
@@ -899,15 +1021,23 @@ class TestMainExtended:
                 return _scopes_response(DESIRED_SCOPES)
             return (200, None)
 
-        with patch("sys.argv", [
-            "seed-keycloak-clients.py",
-            "--kc-url", _KC_URL,
-            "--admin-password", "secret",
-            "--config", str(config_file),
-            "--reset-bootstrap-admin",
-        ]):
+        with patch(
+            "sys.argv",
+            [
+                "seed-keycloak-clients.py",
+                "--kc-url",
+                _KC_URL,
+                "--admin-password",
+                "secret",
+                "--config",
+                str(config_file),
+                "--reset-bootstrap-admin",
+            ],
+        ):
             with patch.object(_ensure_mod(), "_get_token", return_value="tok"):
                 with patch.object(_ensure_mod(), "_request", side_effect=fake_request):
-                    with patch.object(_ensure_mod(), "_reset_bootstrap_admin") as mock_reset:
+                    with patch.object(
+                        _ensure_mod(), "_reset_bootstrap_admin"
+                    ) as mock_reset:
                         _ensure_mod().main()
         mock_reset.assert_called_once_with(_KC_URL)


### PR DESCRIPTION
## Summary

Add a stdlib-only Python reconciler that reads `desired-clients.json` (from OMN-10087) and reconciles a running Keycloak realm against it via the admin REST API. Idempotent: GET-then-diff-then-PUT/POST semantics. Resolves `secretEnv` references at runtime. Optional `--reset-bootstrap-admin` flag for the master-admin-password persistence problem on local Keycloak.

**Replaces** PR #1428 (closed — branch contained 3 OMN-955x duplicate commits from a polluted local main). This PR is a clean cherry-pick of the two T2 commits onto a fresh branch off origin/main.

## Files
- Create: `scripts/seed-keycloak-clients.py` (~240 LOC, stdlib `urllib.request` + `json` only — no new deps)
- Create: `scripts/tests/test_seed_keycloak_clients.py` (37 tests)
- Create: `scripts/tests/conftest.py` + `__init__.py`

## Test plan
- [ ] `uv run pytest scripts/tests/test_seed_keycloak_clients.py -v` — all 37 tests pass
- [ ] Coverage ≥ 80% on `seed-keycloak-clients.py` (current: 88.9%)
- [ ] mypy --strict clean (`_die()` typed `-> NoReturn`)

Linear: OMN-10088 (under epic OMN-9480)

🤖 Generated with [Claude Code](https://claude.com/claude-code)