### PR TITLE
feat: add Keycloak healthcheck to docker-compose.infra.yml [OMN-10089]

### DIFF
--- a/contracts/OMN-10089.yaml
+++ b/contracts/OMN-10089.yaml
@@ -1,0 +1,40 @@
+# OMN-10089 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-10089"
+summary: "feat(OMN-10089): add Keycloak OIDC discovery healthcheck to docker-compose"
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "public_api"
+evidence_requirements:
+  - kind: "tests"
+    description: "Compose YAML assertion proves the Keycloak healthcheck shape"
+    command: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); hc=data[\"services\"][\"keycloak\"][\"healthcheck\"]; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"realms/omninode/.well-known/openid-configuration\" in \" \".join(hc[\"test\"]); print(\"keycloak healthcheck validated\")'"
+  - kind: "ci"
+    description: "CI pipeline green on PR"
+    command: "gh pr checks 1433 --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Contract artifact file present in repo"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "test -f contracts/OMN-10089.yaml"
+  - id: "dod-002"
+    description: "Local compose YAML assertion validates the Keycloak healthcheck shape"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); hc=data[\"services\"][\"keycloak\"][\"healthcheck\"]; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"realms/omninode/.well-known/openid-configuration\" in \" \".join(hc[\"test\"]); print(\"keycloak healthcheck validated\")'"
+  - id: "dod-003"
+    description: "Runtime deploy validates Keycloak health after merge"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omnibase_infra after merge, then verify docker compose keycloak reaches healthy via the OIDC discovery healthcheck"

--- a/contracts/OMN-10089.yaml
+++ b/contracts/OMN-10089.yaml
@@ -3,7 +3,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: "OMN-10089"
-summary: "feat(OMN-10089): add Keycloak OIDC discovery healthcheck to docker-compose"
+summary: "feat(OMN-10089): add Keycloak readiness healthcheck to docker-compose"
 is_seam_ticket: true
 interface_change: true
 interfaces_touched:
@@ -11,7 +11,7 @@ interfaces_touched:
 evidence_requirements:
   - kind: "tests"
     description: "Compose YAML assertion proves the Keycloak healthcheck shape"
-    command: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); hc=data[\"services\"][\"keycloak\"][\"healthcheck\"]; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"realms/omninode/.well-known/openid-configuration\" in \" \".join(hc[\"test\"]); print(\"keycloak healthcheck validated\")'"
+    command: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); svc=data[\"services\"][\"keycloak\"]; hc=svc[\"healthcheck\"]; test=\" \".join(hc[\"test\"]); assert svc[\"environment\"][\"KC_HEALTH_ENABLED\"] == \"true\"; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"bash -ec\" in test; assert \"health/ready\" in test; assert \"localhost/9000\" in test; assert \"curl\" not in test; print(\"keycloak healthcheck validated\")'"
   - kind: "ci"
     description: "CI pipeline green on PR"
     command: "gh pr checks 1433 --repo OmniNode-ai/omnibase_infra"
@@ -31,10 +31,10 @@ dod_evidence:
     source: "generated"
     checks:
       - check_type: "command"
-        check_value: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); hc=data[\"services\"][\"keycloak\"][\"healthcheck\"]; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"realms/omninode/.well-known/openid-configuration\" in \" \".join(hc[\"test\"]); print(\"keycloak healthcheck validated\")'"
+        check_value: "uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(\"docker/docker-compose.infra.yml\").read_text()); svc=data[\"services\"][\"keycloak\"]; hc=svc[\"healthcheck\"]; test=\" \".join(hc[\"test\"]); assert svc[\"environment\"][\"KC_HEALTH_ENABLED\"] == \"true\"; assert hc[\"interval\"] == \"15s\"; assert hc[\"start_period\"] == \"60s\"; assert hc[\"retries\"] == 10; assert \"bash -ec\" in test; assert \"health/ready\" in test; assert \"localhost/9000\" in test; assert \"curl\" not in test; print(\"keycloak healthcheck validated\")'"
   - id: "dod-003"
     description: "Runtime deploy validates Keycloak health after merge"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "deploy omnibase_infra after merge, then verify docker compose keycloak reaches healthy via the OIDC discovery healthcheck"
+        check_value: "deploy omnibase_infra after merge, then verify docker compose keycloak reaches healthy via the management-port readiness healthcheck"

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -484,6 +484,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -m 3 http://localhost:8080/realms/omninode/.well-known/openid-configuration > /dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
     logging: *logging-defaults
     restart: unless-stopped
     labels:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -456,7 +456,7 @@ services:
   #
   # Realm JSON is imported at startup via --import-realm (start-dev command).
   # onex-service and onex-admin clients are created dynamically by provision-keycloak.py.
-  # No compose healthcheck — provision-keycloak.py handles readiness polling.
+  # Compose healthcheck uses Keycloak's management readiness endpoint.
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.3
     container_name: omnibase-infra-keycloak
@@ -471,6 +471,7 @@ services:
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-keycloak-dev-password}
       KC_HTTP_ENABLED: "true"
       KC_HTTP_PORT: "8080"
+      KC_HEALTH_ENABLED: "true"
       KC_HOSTNAME_STRICT: "false"
       # KC_HOSTNAME_STRICT_HTTPS removed: not supported in Keycloak 26+
       KC_LOG_LEVEL: INFO
@@ -485,7 +486,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -m 3 http://localhost:8080/realms/omninode/.well-known/openid-configuration > /dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "bash -ec \"{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000\""]
       interval: 15s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

Add an OIDC discovery healthcheck to the Keycloak service in `docker-compose.infra.yml` (15s interval, 60s start_period, 10 retries). Lets the new `make seed-keycloak` target (in the umbrella `omnibase` repo) wait reliably for Keycloak readiness before invoking the reconciler.

This is the omnibase_infra side of OMN-10089 (Task 3 of the billing stack reconciliation plan). The umbrella Makefile change is in a separate PR against the omnibase repo.

**Replaces** PR #1426 (closed — branch contained OMN-10087's commits + 3 OMN-955x duplicates mingled with this change). Clean cherry-pick of the single T3 commit onto a fresh branch off origin/main.

## Files
- Modify: `docker/docker-compose.infra.yml` — add healthcheck to keycloak service

## Test plan
- [ ] `docker compose -f docker/docker-compose.infra.yml config` validates
- [ ] `docker compose -f docker/docker-compose.infra.yml --profile auth up -d keycloak` reaches `healthy` state within ~60s

Linear: OMN-10089 (under epic OMN-9480)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Keycloak service now includes automated health monitoring that performs periodic OIDC discovery endpoint validation to ensure continuous service readiness, with configurable health check intervals, initial delay periods, and automatic retry behavior for enhanced reliability.
  * Deployment contract specifications have been formalized with comprehensive evidence requirements including health verification checks, infrastructure validation assertions, and post-deployment runtime verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->