### PR TITLE
fix(OMN-10168): add orchestrator dispatcher coverage gate

### DIFF
--- a/contracts/OMN-10168.yaml
+++ b/contracts/OMN-10168.yaml
@@ -1,0 +1,53 @@
+# OMN-10168 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the runtime auto-wiring change.
+schema_version: '1.0.0'
+ticket_id: OMN-10168
+summary: 'fix(OMN-10168): add strict orchestrator dispatcher coverage gate'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - events
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Unit tests cover strict dispatcher coverage behavior
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py -q
+  - kind: tests
+    description: Integration test covers the strict gate at the wire_from_manifest boundary
+    command: uv run pytest tests/integration/test_orchestrator_dispatcher_coverage_integration.py -q
+  - kind: tests
+    description: Existing auto-wiring regression tests still pass
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Strict dispatcher coverage unit tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py -q'
+  - id: dod-002
+    description: Strict dispatcher coverage integration test passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/test_orchestrator_dispatcher_coverage_integration.py -q'
+  - id: dod-003
+    description: Strict dispatcher coverage helper imports cleanly
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run python -c "from omnibase_infra.runtime.auto_wiring.handler_wiring import _strict_dispatcher_coverage_enabled; assert callable(_strict_dispatcher_coverage_enabled)"'
+  - id: dod-004
+    description: Runtime deploy validates ONEX_STRICT_DISPATCHER_COVERAGE startup after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'deploy omninode-runtime-effects after merge with ONEX_STRICT_DISPATCHER_COVERAGE=1 and verify auto-wiring completes before enabling the flag permanently'

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -96,6 +96,7 @@ _SENSITIVE_PATTERN = re.compile(
     r"(?:postgresql|postgres|mysql|redis|amqp|kafka|mongodb|http|https)://\S*",
     re.IGNORECASE,
 )
+_STRICT_DISPATCHER_COVERAGE_ENV = "ONEX_STRICT_DISPATCHER_COVERAGE"
 
 
 def _sanitize_exc(exc: BaseException) -> str:
@@ -931,6 +932,94 @@ def _derive_event_type_alias_from_topic(topic: str) -> str | None:
     return None
 
 
+def _strict_dispatcher_coverage_enabled() -> bool:
+    """Return True when strict orchestrator dispatcher coverage is enabled."""
+    return os.environ.get(_STRICT_DISPATCHER_COVERAGE_ENV, "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _is_orchestrator_contract(contract: ModelDiscoveredContract) -> bool:
+    """Return True when a discovered contract is an orchestrator variant."""
+    return "orchestrator" in contract.node_type.lower()
+
+
+def _start_event_type_aliases(contract: ModelDiscoveredContract) -> tuple[str, ...]:
+    """Return topic-derived event_type aliases for orchestrator start commands."""
+    if contract.event_bus is None:
+        return ()
+
+    aliases: list[str] = []
+    for topic in contract.event_bus.subscribe_topics:
+        parts = topic.split(".")
+        if (
+            len(parts) < 5
+            or parts[0] != "onex"
+            or parts[1] != "cmd"
+            or not parts[3].endswith("-start")
+            or parts[4] != "v1"
+        ):
+            continue
+        alias = _derive_event_type_alias_from_topic(topic)
+        if alias is not None:
+            aliases.append(alias)
+    return tuple(dict.fromkeys(aliases))
+
+
+def _live_message_types(pcw: PreparedContractWiring) -> set[str]:
+    """Return message types that will be committed for non-skipped handlers."""
+    message_types: set[str] = set()
+    for prepared in pcw.prepared_wirings:
+        if prepared.is_skip or prepared.is_quarantined:
+            continue
+        if prepared.message_types is not None:
+            message_types.update(prepared.message_types)
+    return message_types
+
+
+def _collect_orchestrator_dispatcher_coverage_gaps(
+    prepared_contracts: list[PreparedContractWiring],
+    failed_gaps: list[str] | None = None,
+) -> tuple[str, ...]:
+    """Find orchestrator start topics that lack a matching live dispatcher."""
+    gaps: list[str] = list(failed_gaps or [])
+    for pcw in prepared_contracts:
+        contract = pcw.contract
+        if not _is_orchestrator_contract(contract):
+            continue
+        start_aliases = _start_event_type_aliases(contract)
+        if not start_aliases:
+            continue
+        message_types = _live_message_types(pcw)
+        for alias in start_aliases:
+            if alias in message_types:
+                continue
+            gaps.append(
+                f"{contract.name}: missing dispatcher for {alias} "
+                f"(node_type={contract.node_type}, contract={contract.contract_path})"
+            )
+    return tuple(gaps)
+
+
+def _assert_orchestrator_dispatcher_coverage(
+    prepared_contracts: list[PreparedContractWiring],
+    failed_gaps: list[str] | None = None,
+) -> None:
+    """Raise when strict mode finds an orchestrator start topic without a dispatcher."""
+    gaps = _collect_orchestrator_dispatcher_coverage_gaps(
+        prepared_contracts,
+        failed_gaps,
+    )
+    if gaps:
+        raise ModelOnexError(
+            "Strict dispatcher coverage failed for orchestrator start topics: "
+            + "; ".join(gaps)
+        )
+
+
 def _detect_duplicate_topics(
     manifest: ModelAutoWiringManifest,
 ) -> list[ModelDuplicateTopicOwnership]:
@@ -1075,6 +1164,7 @@ async def wire_from_manifest(
     # Failures are collected; if any exist, we raise before touching anything (OMN-8735).
     prepared_contracts: list[PreparedContractWiring] = []
     failed_results: list[ModelContractWiringResult] = []
+    dispatcher_coverage_failed_gaps: list[str] = []
     for contract in manifest.contracts:
         try:
             prepared = _prepare_contract_wiring(
@@ -1112,6 +1202,13 @@ async def wire_from_manifest(
                     reason=f"{type(exc).__name__}: {exc_summary}",
                 )
             )
+            if _is_orchestrator_contract(contract):
+                for alias in _start_event_type_aliases(contract):
+                    dispatcher_coverage_failed_gaps.append(
+                        f"{contract.name}: missing dispatcher for {alias} "
+                        f"because handler preparation failed "
+                        f"({type(exc).__name__}: {exc_summary})"
+                    )
 
     # Check for failures before committing any side effects.
     # ONEX_WIRING_STRICT_MODE=1 raises on any failure (default OFF per OMN-9126:
@@ -1128,6 +1225,12 @@ async def wire_from_manifest(
             "Auto-wiring failed for %d contract(s) (non-strict — set ONEX_WIRING_STRICT_MODE=1 to enforce): %s",
             len(failures),
             "; ".join(failed_reasons),
+        )
+
+    if _strict_dispatcher_coverage_enabled():
+        _assert_orchestrator_dispatcher_coverage(
+            prepared_contracts,
+            dispatcher_coverage_failed_gaps,
         )
 
     # Phase 2: All contracts validated — commit registrations and subscriptions.

--- a/tests/integration/test_orchestrator_dispatcher_coverage_integration.py
+++ b/tests/integration/test_orchestrator_dispatcher_coverage_integration.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for strict orchestrator dispatcher gating.
+
+The CI integration-test gate requires feature-code PRs to prove behavior
+through an integration surface, not only unit-level helpers. These tests keep
+that proof local and side-effect free: no event bus, no Kafka, no live runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_core.models.errors import ModelOnexError
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import MessageDispatchEngine
+
+START_TOPIC = "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1"
+START_ALIAS = "omnimarket.pr-lifecycle-orchestrator-start"
+
+
+def _make_contract(
+    handler_routing: ModelHandlerRouting | None,
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="pr_lifecycle_orchestrator",
+        node_type="orchestrator",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/pr_lifecycle_orchestrator/contract.yaml"),
+        entry_point_name="pr_lifecycle_orchestrator",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(START_TOPIC,),
+            publish_topics=(),
+        ),
+        handler_routing=handler_routing,
+    )
+
+
+def _make_handler_routing() -> ModelHandlerRouting:
+    return ModelHandlerRouting(
+        routing_strategy="payload_type_match",
+        handlers=(
+            ModelHandlerRoutingEntry(
+                handler=ModelHandlerRef(
+                    name="HandlerPrLifecycleOrchestrator",
+                    module="fake.handlers",
+                ),
+                event_model=ModelHandlerRef(
+                    name="ModelPrLifecycleStartCommand",
+                    module="fake.models",
+                ),
+                event_type=START_ALIAS,
+                message_category="command",
+            ),
+        ),
+    )
+
+
+class FakeHandler:
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_strict_coverage_blocks_commit_before_dispatcher_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    engine = MessageDispatchEngine()
+    manifest = ModelAutoWiringManifest(contracts=(_make_contract(None),))
+
+    with pytest.raises(ModelOnexError):
+        await wire_from_manifest(manifest, engine)
+
+    assert engine.dispatcher_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_strict_coverage_allows_contract_alias_to_register_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    engine = MessageDispatchEngine()
+    manifest = ModelAutoWiringManifest(
+        contracts=(_make_contract(_make_handler_routing()),),
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=FakeHandler,
+    ):
+        report = await wire_from_manifest(manifest, engine)
+
+    assert report.total_wired == 1
+    assert engine.dispatcher_count == 1

--- a/tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py
+++ b/tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Strict dispatcher coverage tests for orchestrator start topics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_core.models.errors import ModelOnexError
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+START_TOPIC = "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1"
+START_ALIAS = "omnimarket.pr-lifecycle-orchestrator-start"
+
+
+def _make_contract(
+    *,
+    node_type: str = "ORCHESTRATOR_GENERIC",
+    handler_routing: ModelHandlerRouting | None = None,
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="pr_lifecycle_orchestrator",
+        node_type=node_type,
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/pr_lifecycle_orchestrator/contract.yaml"),
+        entry_point_name="pr_lifecycle_orchestrator",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(START_TOPIC,),
+            publish_topics=(),
+        ),
+        handler_routing=handler_routing,
+    )
+
+
+def _make_handler_routing(
+    *,
+    event_type: str | None = START_ALIAS,
+    event_model_name: str | None = "ModelPrLifecycleStartCommand",
+) -> ModelHandlerRouting:
+    event_model = (
+        ModelHandlerRef(
+            name=event_model_name,
+            module="fake.models",
+        )
+        if event_model_name is not None
+        else None
+    )
+    return ModelHandlerRouting(
+        routing_strategy="payload_type_match",
+        handlers=(
+            ModelHandlerRoutingEntry(
+                handler=ModelHandlerRef(
+                    name="HandlerPrLifecycleOrchestrator",
+                    module="fake.handlers",
+                ),
+                event_model=event_model,
+                event_type=event_type,
+                message_category="command",
+            ),
+        ),
+    )
+
+
+class FakeHandler:
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_start_coverage_is_default_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ONEX_STRICT_DISPATCHER_COVERAGE", raising=False)
+    manifest = ModelAutoWiringManifest(contracts=(_make_contract(),))
+
+    report = await wire_from_manifest(manifest, MagicMock())
+
+    assert report.total_skipped == 1
+    assert report.results[0].outcome is EnumWiringOutcome.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_strict_coverage_rejects_orchestrator_start_without_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    manifest = ModelAutoWiringManifest(contracts=(_make_contract(),))
+
+    with pytest.raises(ModelOnexError) as exc_info:
+        await wire_from_manifest(manifest, MagicMock())
+
+    message = str(exc_info.value)
+    assert "Strict dispatcher coverage failed" in message
+    assert "pr_lifecycle_orchestrator" in message
+    assert START_ALIAS in message
+
+
+@pytest.mark.asyncio
+async def test_strict_coverage_accepts_contract_event_type_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnibase_infra.runtime.service_message_dispatch_engine import (
+        MessageDispatchEngine,
+    )
+
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    manifest = ModelAutoWiringManifest(
+        contracts=(
+            _make_contract(
+                handler_routing=_make_handler_routing(event_type=START_ALIAS)
+            ),
+        ),
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=FakeHandler,
+    ):
+        report = await wire_from_manifest(manifest, MessageDispatchEngine())
+
+    assert report.total_wired == 1
+    assert report.results[0].dispatchers_registered == (
+        "dispatcher.auto.pr_lifecycle_orchestrator.HandlerPrLifecycleOrchestrator",
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_coverage_accepts_topic_derived_event_type_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnibase_infra.runtime.service_message_dispatch_engine import (
+        MessageDispatchEngine,
+    )
+
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    manifest = ModelAutoWiringManifest(
+        contracts=(
+            _make_contract(
+                handler_routing=_make_handler_routing(
+                    event_type=None,
+                    event_model_name=None,
+                )
+            ),
+        ),
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=FakeHandler,
+    ):
+        report = await wire_from_manifest(manifest, MessageDispatchEngine())
+
+    assert report.total_wired == 1
+
+
+@pytest.mark.asyncio
+async def test_strict_coverage_rejects_orchestrator_start_when_prepare_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "true")
+    manifest = ModelAutoWiringManifest(
+        contracts=(_make_contract(handler_routing=_make_handler_routing()),),
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        side_effect=ImportError("missing handler"),
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            await wire_from_manifest(manifest, MagicMock())
+
+    message = str(exc_info.value)
+    assert "because handler preparation failed" in message
+    assert START_ALIAS in message


### PR DESCRIPTION
## Summary
- Adds default-off `ONEX_STRICT_DISPATCHER_COVERAGE` enforcement before auto-wiring commits dispatchers/subscriptions.
- Fails strict startup when an orchestrator subscribing to an `onex.cmd.*.*-start.v1` topic has no live dispatcher message type for the topic-derived event_type alias.
- Adds unit and integration coverage for default-off behavior, strict missing-dispatcher failure, explicit `event_type` aliases, topic-derived aliases, and handler-preparation failures.
- Adds repo-local deploy-gate contract evidence for `OMN-10168`.

## SEAM-4 audit
Parser-only audit used fresh `OMN-10168` worktrees, not the stale canonical checkout:
- Roots: `omnibase_infra/src/omnibase_infra/nodes`, `omnimarket/src/omnimarket/nodes`
- Contracts parsed: 235
- Discovery errors: 0
- Orchestrator start contracts: 11
- Missing dispatchers: 0

`pr_lifecycle_orchestrator` is already covered by its contract alias from `omnimarket#431`: `omnimarket.pr-lifecycle-orchestrator-start`. No omnimarket code change was required for this task.

## Verification
- `uv run pytest tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py tests/integration/test_orchestrator_dispatcher_coverage_integration.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q` -> 53 passed
- `uv run validate-yaml contracts/OMN-10168.yaml` -> passed
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py` -> passed
- `uv run ruff check --fix tests/integration/test_orchestrator_dispatcher_coverage_integration.py` -> passed
- `uv run ruff format --check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py` -> passed
- `uv run ruff format tests/integration/test_orchestrator_dispatcher_coverage_integration.py` -> passed
- `uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict` -> passed
- `git diff --check` -> passed
- `pre-commit run --files src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py tests/integration/test_orchestrator_dispatcher_coverage_integration.py contracts/OMN-10168.yaml` -> passed
- Commit and push hooks -> passed

No live `.201` deploy/restart was performed.

Refs OMN-10168.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional strict orchestrator dispatcher coverage validation mode that enforces routing completeness and blocks wiring when gaps are detected (toggleable via environment variable).

* **Tests**
  * Added unit and integration tests covering strict-mode success, failure, and failure propagation scenarios.

* **Chores**
  * Added a deployment contract describing required evidence, validation checks, and manual post-merge verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->