### PR TITLE
chore(OMN-10169): pin omnibase-spi >=0.20.5

### DIFF
--- a/contracts/OMN-10169.yaml
+++ b/contracts/OMN-10169.yaml
@@ -1,0 +1,44 @@
+# OMN-10169 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-10169"
+summary: "Pin omnibase_infra to published omnibase-spi 0.20.5 for runtime protocol imports"
+is_seam_ticket: true
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "manual"
+    description: "PyPI publishes omnibase-spi 0.20.5"
+    command: "curl -fsS https://pypi.org/pypi/omnibase-spi/json | jq -e '.releases | has(\"0.20.5\")' >/dev/null"
+  - kind: "manual"
+    description: "omnibase_spi runtime protocol import works from the published wheel"
+    command: "uv run --with \"omnibase-spi==0.20.5\" python -c \"from omnibase_spi.protocols.runtime import protocol_handler_resolver; print('ok')\""
+  - kind: "ci"
+    description: "omnibase_infra PR checks pass, including deploy gate"
+    command: "gh pr checks 1441 --repo OmniNode-ai/omnibase_infra --watch"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "PyPI release 0.20.5 exists"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "curl -fsS https://pypi.org/pypi/omnibase-spi/json | jq -e '.releases | has(\"0.20.5\")' >/dev/null"
+  - id: "dod-002"
+    description: "Published omnibase-spi 0.20.5 exposes protocols.runtime"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run --with \"omnibase-spi==0.20.5\" python -c \"from omnibase_spi.protocols.runtime import protocol_handler_resolver; print('ok')\""
+  - id: "dod-003"
+    description: "Dependency floor is raised and the stale git source override is removed"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "grep -F '\"omnibase-spi>=0.20.5\"' pyproject.toml && ! grep -F 'omnibase-spi = { git =' pyproject.toml"
+      - check_type: "command"
+        check_value: "gh pr checks 1441 --repo OmniNode-ai/omnibase_infra | grep -F 'deploy-gate / deploy-gate'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Remember to switch back to PyPI versions before merging to main.
     #
     "omnibase-core>=0.40.0,<0.41.0",
-    "omnibase-spi>=0.20.4",
+    "omnibase-spi>=0.20.5",
     "omnimarket>=0.1.0",
     # ============================================================================
     # External Dependency Security Guidance
@@ -170,11 +170,6 @@ omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "
 # Pinned to core main post-OMN-9637 (delegation models — ModelRemoteTaskState et al.).
 # PyPI release v0.39.0 (2026-04-06) predates PR 912 — switch back after v0.40.0 ships.
 omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "6a65f885303e29b4ddc36a66a0cb860537f47316" }
-# Pinned to spi main post-OMN-9197 (ProtocolHandlerResolver + ProtocolHandlerOwnershipQuery).
-# PyPI release v0.20.4 (2026-04-03) predates PR 186 — switch back after v0.20.5 ships.
-omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", rev = "a9380008fb4a2f2a784d374389260d896455c3b2" }
-
-
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -180,7 +180,7 @@ _FALLBACK_MATRIX: list[VersionConstraint] = [
     ),
     VersionConstraint(
         package="omnibase_spi",
-        min_version="0.20.4",
+        min_version="0.20.5",
         max_version="0.21.0",
     ),
 ]

--- a/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
+++ b/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration sentinel for the omnibase-spi 0.20.5 runtime protocol floor.
+
+OMN-10169 raises the dependency floor because runtime auto-wiring imports
+``omnibase_spi.protocols.runtime``. The fallback compatibility matrix must
+carry the same floor for installed-package environments where ``pyproject.toml``
+is not present.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from omnibase_infra.runtime.version_compatibility import (
+    _FALLBACK_MATRIX,
+    VERSION_MATRIX,
+    VersionConstraint,
+)
+
+
+def _minimum_for(package: str, matrix: Sequence[VersionConstraint]) -> str:
+    for constraint in matrix:
+        if constraint.package == package:
+            return constraint.min_version
+    raise AssertionError(f"{package} missing from compatibility matrix")
+
+
+@pytest.mark.integration
+def test_omnibase_spi_runtime_protocols_match_0205_floor() -> None:
+    """The declared and fallback SPI floors both expose runtime protocols."""
+    from omnibase_spi.protocols.runtime.protocol_handler_ownership_query import (
+        ProtocolHandlerOwnershipQuery,
+    )
+    from omnibase_spi.protocols.runtime.protocol_handler_resolver import (
+        ProtocolHandlerResolver,
+    )
+
+    assert _minimum_for("omnibase_spi", VERSION_MATRIX) == "0.20.5"
+    assert _minimum_for("omnibase_spi", _FALLBACK_MATRIX) == "0.20.5"
+    assert hasattr(ProtocolHandlerResolver, "__class_getitem__")
+    assert hasattr(ProtocolHandlerOwnershipQuery, "__class_getitem__")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2055,7 +2055,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
     { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=a9380008fb4a2f2a784d374389260d896455c3b2" },
+    { name = "omnibase-spi", specifier = ">=0.20.5" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },
@@ -2109,12 +2109,16 @@ dev = [
 
 [[package]]
 name = "omnibase-spi"
-version = "0.20.4"
-source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=a9380008fb4a2f2a784d374389260d896455c3b2#a9380008fb4a2f2a784d374389260d896455c3b2" }
+version = "0.20.5"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c4/d2198088d22006d197ce75c335ac5b79d7be08e9fd82da1b23a71c56e88a/omnibase_spi-0.20.5.tar.gz", hash = "sha256:6245001d2c263dec93ac12612dbe2c19ce215b28413e8e7f208fae857d0c4747", size = 1143592, upload-time = "2026-04-23T15:49:56.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/f4/bdf41eefebadc983ef36bc44c2b32ac2c1695f5acfe779a103670ba0bc3e/omnibase_spi-0.20.5-py3-none-any.whl", hash = "sha256:57b4be9e53b630062032254fb9e98f98601712e8e372df7fd8bfc6c3ee792cba", size = 790932, upload-time = "2026-04-23T15:49:57.886Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Raise omnibase_infra dependency floor to `omnibase-spi>=0.20.5`.
- Remove the stale `omnibase-spi` git source override now that PyPI 0.20.5 is published.
- Regenerate `uv.lock` against the published 0.20.5 wheel and add repo-local deploy evidence contract `contracts/OMN-10169.yaml`.

## Verification
- `curl -fsS https://pypi.org/pypi/omnibase-spi/json | jq -r '.releases | has("0.20.5")'` -> `true`\n- `uv run --with "omnibase-spi==0.20.5" python -c "from omnibase_spi.protocols.runtime import protocol_handler_resolver; print('ok')"` -> `ok`\n- `uv run validate-yaml contracts/OMN-10169.yaml`\n- `uv lock --check`\n- `git diff --check`\n- `pre-commit run --files pyproject.toml uv.lock contracts/OMN-10169.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped omnibase-spi requirement to >=0.20.5 and removed a git-based source override so the package is resolved from PyPI.
  * Added a per-repo deployment contract describing required verification steps for infrastructure deploy gating.

* **Tests**
  * Added an integration test to verify the runtime protocol compatibility floor matches the new omnibase-spi requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->