### PR TITLE
test(OMN-10180): harden dispatcher coverage checks

### DIFF
--- a/tests/integration/test_orchestrator_dispatcher_coverage_integration.py
+++ b/tests/integration/test_orchestrator_dispatcher_coverage_integration.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import pytest
 
 from omnibase_core.models.errors import ModelOnexError
+from omnibase_infra.runtime.auto_wiring import discover_contracts_from_paths
 from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
@@ -26,9 +27,26 @@ from omnibase_infra.runtime.auto_wiring.models import (
     ModelHandlerRoutingEntry,
 )
 from omnibase_infra.runtime.service_message_dispatch_engine import MessageDispatchEngine
+from tests.helpers.path_utils import find_project_root
 
 START_TOPIC = "onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1"
 START_ALIAS = "omnimarket.pr-lifecycle-orchestrator-start"
+
+
+def _project_root() -> Path:
+    return find_project_root(Path(__file__).resolve().parent)
+
+
+def _omnimarket_worktree_root() -> Path | None:
+    """Locate the sibling omnimarket repo-local worktree for this ticket."""
+    project_root = _project_root()
+    if project_root.parent.name.startswith("OMN-"):
+        ticket = project_root.parent.name
+        omni_home = project_root.parents[3]
+        candidate = omni_home / "omnimarket" / "omni_worktrees" / ticket / "omnimarket"
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _make_contract(
@@ -106,5 +124,50 @@ async def test_strict_coverage_allows_contract_alias_to_register_dispatcher(
     ):
         report = await wire_from_manifest(manifest, engine)
 
+    assert report.total_wired == 1
+    assert engine.dispatcher_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_real_omnimarket_contract_wires_under_strict_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OMN-10194: prove the real cross-repo contract and handler wire cleanly.
+
+    This covers the production path the synthetic manifest tests do not:
+    1. load the actual omnimarket contract.yaml from the ticket-matched worktree
+    2. import the real handler module from that sibling repo
+    3. run wire_from_manifest with strict dispatcher coverage enabled
+
+    The test skips cleanly when the sibling repo-local worktree is absent so
+    generic CI or single-repo environments remain safe.
+    """
+    omnimarket_root = _omnimarket_worktree_root()
+    if omnimarket_root is None:
+        pytest.skip(
+            "OMN-10194 proof requires sibling omnimarket worktree for this ticket"
+        )
+
+    contract_path = (
+        omnimarket_root
+        / "src/omnimarket/nodes/node_pr_lifecycle_orchestrator/contract.yaml"
+    )
+    assert contract_path.exists(), f"missing real omnimarket contract: {contract_path}"
+
+    monkeypatch.setenv("ONEX_STRICT_DISPATCHER_COVERAGE", "1")
+    monkeypatch.syspath_prepend(str(omnimarket_root / "src"))
+
+    manifest = discover_contracts_from_paths([contract_path])
+    assert manifest.total_errors == 0, f"contract parse errors: {manifest.errors!r}"
+    assert manifest.total_discovered == 1
+    assert manifest.all_subscribe_topics() == frozenset({START_TOPIC})
+
+    engine = MessageDispatchEngine()
+    report = await wire_from_manifest(manifest, engine)
+
+    assert report.total_failed == 0, (
+        f"wiring failures: {[r for r in report.results if r.outcome != 'wired']!r}"
+    )
     assert report.total_wired == 1
     assert engine.dispatcher_count == 1


### PR DESCRIPTION
## Summary
- add strict dispatcher coverage integration around real cross-repo contracts
- prove the current orchestrator wiring surface is covered by the gate

## Verification
- uv run pytest tests/integration/test_orchestrator_dispatcher_coverage_integration.py -v