### PR TITLE
feat(OMN-10238): add shared local runtime skill client

### DIFF
--- a/contracts/OMN-10238.yaml
+++ b/contracts/OMN-10238.yaml
@@ -1,0 +1,41 @@
+# OMN-10238 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the concrete local transport client.
+schema_version: "1.0.0"
+ticket_id: "OMN-10238"
+summary: "feat(OMN-10238): add shared local runtime skill client"
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+  - public_api
+evidence_requirements:
+  - kind: "tests"
+    description: "Local runtime skill client unit tests pass"
+    command: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10238/omnibase_core/src uv run pytest tests/unit/clients/test_runtime_skill_client.py -q"
+  - kind: "ci"
+    description: "omnibase_infra PR checks pass for the shared runtime skill client"
+    command: "gh pr checks 1445 --repo OmniNode-ai/omnibase_infra --watch"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Concrete host-local transport client unit tests pass"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10238/omnibase_core/src uv run pytest tests/unit/clients/test_runtime_skill_client.py -q"
+  - id: "dod-002"
+    description: "Concrete transport imports shared runtime skill models from omnibase_core"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "rg -n \"from omnibase_core.models.runtime\" src/omnibase_infra/clients/runtime_skill_client.py"
+  - id: "dod-003"
+    description: "Runtime deploy validates local socket client against merged runtime ingress after merge"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omninode-runtime after merge and verify LocalRuntimeSkillClient reaches the runtime socket ingress"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,10 +167,9 @@ override-dependencies = [
 [tool.uv.sources]
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
-# Pinned to core main post-OMN-9637 (delegation models — ModelRemoteTaskState et al.).
-# OMN-10204 depends on the Pattern B broker client/models added in OMN-10203.
-# Switch back to the mainline core pin after PR #954 merges.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }
+# OMN-10238 depends on the shared runtime skill contract models/protocol added in core.
+# Switch back to the mainline core pin after the OMN-10238 core PR merges.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "f5ac07cb269ad12c6f5084fbc3f230c235b5c486" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,9 @@ override-dependencies = [
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
 # Pinned to core main post-OMN-9637 (delegation models — ModelRemoteTaskState et al.).
-# PyPI release v0.39.0 (2026-04-06) predates PR 912 — switch back after v0.40.0 ships.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "6a65f885303e29b4ddc36a66a0cb860537f47316" }
+# OMN-10204 depends on the Pattern B broker client/models added in OMN-10203.
+# Switch back to the mainline core pin after PR #954 merges.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/src/omnibase_infra/clients/__init__.py
+++ b/src/omnibase_infra/clients/__init__.py
@@ -1,2 +1,9 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
+from omnibase_infra.clients.runtime_skill_client import (
+    LocalRuntimeSkillClient,
+    default_runtime_socket_path,
+)
+
+__all__ = ["LocalRuntimeSkillClient", "default_runtime_socket_path"]

--- a/src/omnibase_infra/clients/runtime_skill_client.py
+++ b/src/omnibase_infra/clients/runtime_skill_client.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Shared host-local runtime skill client implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Literal
+
+from omnibase_core.models.runtime import (
+    ModelRuntimeSkillError,
+    ModelRuntimeSkillRequest,
+    ModelRuntimeSkillResponse,
+)
+from omnibase_core.protocols.runtime import ProtocolRuntimeSkillClient
+
+_DEFAULT_RUNTIME_SOCKET_PATH = "/tmp/onex-runtime.sock"  # noqa: S108
+
+
+def default_runtime_socket_path() -> str:
+    """Resolve the local runtime ingress socket path."""
+
+    return os.environ.get(
+        "ONEX_LOCAL_RUNTIME_SOCKET_PATH", _DEFAULT_RUNTIME_SOCKET_PATH
+    )
+
+
+class LocalRuntimeSkillClient(ProtocolRuntimeSkillClient):
+    """Unix-socket client for the canonical host-local runtime skill path."""
+
+    def __init__(
+        self,
+        *,
+        socket_path: str | None = None,
+        connect_timeout_seconds: float = 5.0,
+    ) -> None:
+        self._socket_path = socket_path or default_runtime_socket_path()
+        self._connect_timeout_seconds = connect_timeout_seconds
+
+    async def dispatch_async(
+        self,
+        request: ModelRuntimeSkillRequest,
+    ) -> ModelRuntimeSkillResponse:
+        writer: asyncio.StreamWriter | None = None
+        try:
+            reader, connected_writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(self._socket_path),
+                timeout=self._connect_timeout_seconds,
+            )
+            writer = connected_writer
+            writer.write(
+                request.model_dump_json(exclude_none=True).encode("utf-8") + b"\n"
+            )
+            await writer.drain()
+            raw_response = await asyncio.wait_for(
+                reader.readline(),
+                timeout=request.timeout_ms / 1000.0,
+            )
+            if not raw_response:
+                return _transport_error_response(
+                    request=request,
+                    code="dispatch_error",
+                    message="Runtime local ingress closed the socket without a response.",
+                )
+            payload = json.loads(raw_response.decode("utf-8"))
+            return ModelRuntimeSkillResponse.model_validate(payload)
+        except TimeoutError:
+            return _transport_error_response(
+                request=request,
+                code="dispatch_timeout",
+                message=f"Local runtime transport timed out after {request.timeout_ms} ms.",
+                retryable=True,
+            )
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            return _transport_error_response(
+                request=request,
+                code="runtime_unavailable"
+                if isinstance(exc, OSError)
+                else "dispatch_error",
+                message=str(exc),
+                retryable=isinstance(exc, OSError),
+            )
+        finally:
+            if writer is not None:
+                writer.close()
+                await writer.wait_closed()
+
+    def dispatch_sync(
+        self,
+        request: ModelRuntimeSkillRequest,
+    ) -> ModelRuntimeSkillResponse:
+        return asyncio.run(self.dispatch_async(request))
+
+
+def _transport_error_response(
+    *,
+    request: ModelRuntimeSkillRequest,
+    code: Literal[
+        "validation_error",
+        "unknown_command",
+        "runtime_unavailable",
+        "dispatch_timeout",
+        "dispatch_error",
+    ],
+    message: str,
+    retryable: bool = False,
+) -> ModelRuntimeSkillResponse:
+    return ModelRuntimeSkillResponse(
+        ok=False,
+        command_name=request.command_name,
+        correlation_id=request.correlation_id,
+        error=ModelRuntimeSkillError(
+            code=code,
+            message=message,
+            retryable=retryable,
+        ),
+    )
+
+
+__all__ = ["LocalRuntimeSkillClient", "default_runtime_socket_path"]

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -53,6 +53,7 @@ class EnumOmnibaseInfraTopic(str, Enum):
     EVT_LLM_COMPLETION_COMPLETED_V1 = "onex.evt.omnibase-infra.llm-completion-completed.v1"  # onex.evt.omnibase-infra.llm-completion-completed.v1
     EVT_ONBOARDING_COMPLETED_V1 = "onex.evt.omnibase-infra.onboarding-completed.v1"  # onex.evt.omnibase-infra.onboarding-completed.v1
     EVT_ONBOARDING_STEP_VERIFIED_V1 = "onex.evt.omnibase-infra.onboarding-step-verified.v1"  # onex.evt.omnibase-infra.onboarding-step-verified.v1
+    EVT_PATTERN_B_DISPATCH_COMPLETED_V1 = "onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1"  # onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1
     EVT_QUALITY_GATE_RESULT_V1 = "onex.evt.omnibase-infra.quality-gate-result.v1"  # onex.evt.omnibase-infra.quality-gate-result.v1
     EVT_ROUTING_DECISION_V1 = "onex.evt.omnibase-infra.routing-decision.v1"  # onex.evt.omnibase-infra.routing-decision.v1
     EVT_ROW_COUNT_DIAGNOSTIC_V1 = "onex.evt.omnibase-infra.row-count-diagnostic.v1"  # onex.evt.omnibase-infra.row-count-diagnostic.v1

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -30,6 +30,7 @@ class EnumOmnibaseInfraTopic(str, Enum):
     CMD_LLM_EMBEDDING_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-embedding-request.v1"  # onex.cmd.omnibase-infra.llm-embedding-request.v1
     CMD_LLM_INFERENCE_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-inference-request.v1"  # onex.cmd.omnibase-infra.llm-inference-request.v1
     CMD_ONBOARDING_START_V1 = "onex.cmd.omnibase-infra.onboarding-start.v1"  # onex.cmd.omnibase-infra.onboarding-start.v1
+    CMD_PATTERN_B_DISPATCH_V1 = "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"  # onex.cmd.omnibase-infra.pattern-b-dispatch.v1
     CMD_REMOTE_AGENT_INVOKE_V1 = "onex.cmd.omnibase-infra.remote-agent-invoke.v1"  # onex.cmd.omnibase-infra.remote-agent-invoke.v1
     CMD_VECTOR_STORE_REQUEST_V1 = "onex.cmd.omnibase-infra.vector-store-request.v1"  # onex.cmd.omnibase-infra.vector-store-request.v1
     EVT_AGENT_TASK_LIFECYCLE_V1 = "onex.evt.omnibase-infra.agent-task-lifecycle.v1"  # onex.evt.omnibase-infra.agent-task-lifecycle.v1

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -527,6 +527,11 @@ TOPIC_PATTERN_B_DISPATCH_COMMAND: Final[str] = (
 )
 """Command topic for runtime-owned Pattern B skill dispatch requests."""
 
+TOPIC_PATTERN_B_DISPATCH_COMPLETED: Final[str] = (
+    "onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1"
+)
+"""Terminal event topic for runtime-owned Pattern B skill dispatch results."""
+
 __all__ = [
     "TOPIC_DELEGATION_COMPLETED",
     "TOPIC_DELEGATION_FAILED",
@@ -540,6 +545,7 @@ __all__ = [
     "TOPIC_DELEGATION_ROUTING_DECISION",
     "TOPIC_EVAL_COMPLETED",
     "TOPIC_PATTERN_B_DISPATCH_COMMAND",
+    "TOPIC_PATTERN_B_DISPATCH_COMPLETED",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",
     "DLQ_DOMAIN",

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -517,6 +517,16 @@ TOPIC_DELEGATION_BASELINE_COMPARISON: Final[str] = (
 )
 """Command topic for baseline comparison compute from the delegation orchestrator."""
 
+
+# ---------------------------------------------------------------------------
+# Pattern B Broker Topics (OMN-10204)
+# ---------------------------------------------------------------------------
+
+TOPIC_PATTERN_B_DISPATCH_COMMAND: Final[str] = (
+    "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+)
+"""Command topic for runtime-owned Pattern B skill dispatch requests."""
+
 __all__ = [
     "TOPIC_DELEGATION_COMPLETED",
     "TOPIC_DELEGATION_FAILED",
@@ -529,6 +539,7 @@ __all__ = [
     "TOPIC_DELEGATION_REQUEST",
     "TOPIC_DELEGATION_ROUTING_DECISION",
     "TOPIC_EVAL_COMPLETED",
+    "TOPIC_PATTERN_B_DISPATCH_COMMAND",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",
     "DLQ_DOMAIN",

--- a/src/omnibase_infra/protocols/protocol_pattern_b_broker_transport.py
+++ b/src/omnibase_infra/protocols/protocol_pattern_b_broker_transport.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Transport protocol for the Pattern B broker service."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+from omnibase_infra.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_infra.event_bus.models.model_event_headers import ModelEventHeaders
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.models import ModelNodeIdentity
+
+
+@runtime_checkable
+class ProtocolPatternBBrokerTransport(Protocol):
+    """Minimal publish/subscribe surface required by ServicePatternBBroker."""
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: ModelEventHeaders | None = None,
+    ) -> None: ...
+
+    async def subscribe(
+        self,
+        topic: str,
+        node_identity: ModelNodeIdentity | None = None,
+        on_message: Callable[[ModelEventMessage], Awaitable[None]] | None = None,
+        *,
+        group_id: str | None = None,
+        purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+        required_for_readiness: bool = False,
+    ) -> Callable[[], Awaitable[None]]: ...
+
+
+__all__ = ["ProtocolPatternBBrokerTransport"]

--- a/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
+++ b/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pattern B broker runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_infra.event_bus.topic_constants import TOPIC_PATTERN_B_DISPATCH_COMMAND
+
+
+class ModelPatternBBrokerConfig(BaseModel):
+    """Configuration for the runtime-owned Pattern B broker service."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    enabled: bool = Field(
+        default=False,
+        description="Whether the runtime should start the Pattern B broker service.",
+    )
+    command_topic: str = Field(
+        default=TOPIC_PATTERN_B_DISPATCH_COMMAND,
+        min_length=1,
+        description="Command topic consumed by the Pattern B broker.",
+    )
+    package_names: tuple[str, ...] = Field(
+        default=("omnibase_infra",),
+        description="Package roots scanned for broker-addressable node contracts.",
+    )
+
+    @field_validator("command_topic")
+    @classmethod
+    def _validate_command_topic(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("command_topic must be a non-empty string")
+        return normalized
+
+    @field_validator("package_names", mode="before")
+    @classmethod
+    def _coerce_package_names(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("package_names")
+    @classmethod
+    def _validate_package_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(part.strip() for part in value if part.strip())
+        if not normalized:
+            raise ValueError("package_names must contain at least one package name")
+        return normalized
+
+
+__all__ = ["ModelPatternBBrokerConfig"]

--- a/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
+++ b/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from omnibase_infra.event_bus.topic_constants import TOPIC_PATTERN_B_DISPATCH_COMMAND
+from omnibase_infra.enums.generated.enum_omnibase_infra_topic import (
+    EnumOmnibaseInfraTopic,
+)
 
 
 class ModelPatternBBrokerConfig(BaseModel):
@@ -24,7 +26,7 @@ class ModelPatternBBrokerConfig(BaseModel):
         description="Whether the runtime should start the Pattern B broker service.",
     )
     command_topic: str = Field(
-        default=TOPIC_PATTERN_B_DISPATCH_COMMAND,
+        default=EnumOmnibaseInfraTopic.CMD_PATTERN_B_DISPATCH_V1.value,
         min_length=1,
         description="Command topic consumed by the Pattern B broker.",
     )

--- a/src/omnibase_infra/runtime/models/model_runtime_config.py
+++ b/src/omnibase_infra/runtime/models/model_runtime_config.py
@@ -62,6 +62,9 @@ from omnibase_infra.runtime.models.model_local_runtime_ingress_config import (
     ModelLocalRuntimeIngressConfig,
 )
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
+from omnibase_infra.runtime.models.model_pattern_b_broker_config import (
+    ModelPatternBBrokerConfig,
+)
 from omnibase_infra.runtime.models.model_shutdown_config import ModelShutdownConfig
 
 
@@ -85,6 +88,7 @@ class ModelRuntimeConfig(BaseModel):
         contract_registry: Contract registry configuration [ACTIVE]
         gateway: Gateway configuration for envelope signing and realm enforcement [RESERVED]
         local_ingress: Local Unix-socket command ingress configuration [ACTIVE]
+        pattern_b_broker: Pattern B broker configuration [ACTIVE]
 
     Field Status Legend:
         [ACTIVE]   - Currently used by kernel.py
@@ -169,6 +173,10 @@ class ModelRuntimeConfig(BaseModel):
     local_ingress: ModelLocalRuntimeIngressConfig = Field(
         default_factory=ModelLocalRuntimeIngressConfig,
         description="Configuration for the runtime-owned local command ingress.",
+    )
+    pattern_b_broker: ModelPatternBBrokerConfig = Field(
+        default_factory=ModelPatternBBrokerConfig,
+        description="Configuration for the runtime-owned Pattern B broker.",
     )
 
 

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pattern B broker process for contract-driven command to terminal-result flow."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
+    ProtocolPatternBBrokerTransport,
+)
+from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+
+
+def _broker_group_id(command_topic: str) -> str:
+    normalized = command_topic.replace(".", "-")
+    return f"pattern-b-broker-{normalized}"
+
+
+def _terminal_group_id(correlation_id: UUID) -> str:
+    return f"pattern-b-broker-terminal-{correlation_id}"
+
+
+def _error_result(
+    correlation_id: UUID,
+    *,
+    status: str,
+    error_message: str,
+) -> ModelDispatchBusTerminalResult:
+    return ModelDispatchBusTerminalResult(
+        correlation_id=correlation_id,
+        status=status,
+        error_message=error_message,
+        completed_at=datetime.now(UTC),
+    )
+
+
+class RuntimePatternBBroker:
+    """Long-lived broker that normalizes worker terminal events for external CLIs."""
+
+    def __init__(
+        self,
+        event_bus: ProtocolPatternBBrokerTransport,
+        *,
+        command_topic: str,
+        routes: Mapping[str, RuntimeLocalIngressRoute],
+    ) -> None:
+        self._event_bus = event_bus
+        self._command_topic = command_topic
+        self._routes = dict(routes)
+        self._unsubscribe: Callable[[], Awaitable[None]] | None = None
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def is_running(self) -> bool:
+        return self._unsubscribe is not None
+
+    async def start(self) -> None:
+        if self._unsubscribe is not None:
+            return
+
+        async def on_command(message: ModelEventMessage) -> None:
+            task = asyncio.create_task(self._handle_command_message(message))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+
+        self._unsubscribe = await self._event_bus.subscribe(
+            self._command_topic,
+            group_id=_broker_group_id(self._command_topic),
+            on_message=on_command,
+        )
+
+    async def stop(self) -> None:
+        if self._unsubscribe is not None:
+            await self._unsubscribe()
+            self._unsubscribe = None
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
+
+    async def _handle_command_message(self, message: ModelEventMessage) -> None:
+        command_envelope = ModelEventEnvelope[
+            ModelDispatchBusCommand
+        ].model_validate_json(message.value)
+        command = command_envelope.payload
+        correlation_id = command.correlation_id
+
+        route = self._routes.get(command.command_name)
+        if route is None:
+            await self._publish_terminal_result(
+                command.response_topic,
+                _error_result(
+                    correlation_id,
+                    status="failed",
+                    error_message=f"Unknown Pattern B route '{command.command_name}'",
+                ),
+            )
+            return
+
+        if route.terminal_event is None:
+            await self._publish_terminal_result(
+                command.response_topic,
+                _error_result(
+                    correlation_id,
+                    status="failed",
+                    error_message=(
+                        f"Route '{command.command_name}' does not declare a terminal_event"
+                    ),
+                ),
+            )
+            return
+
+        terminal_queue: asyncio.Queue[object] = asyncio.Queue(maxsize=1)
+
+        async def on_terminal(message: ModelEventMessage) -> None:
+            terminal_envelope = ModelEventEnvelope[object].model_validate_json(
+                message.value
+            )
+            if terminal_envelope.correlation_id != correlation_id:
+                return
+            if terminal_queue.empty():
+                await terminal_queue.put(terminal_envelope.payload)
+
+        unsubscribe_terminal = await self._event_bus.subscribe(
+            route.terminal_event,
+            group_id=_terminal_group_id(correlation_id),
+            on_message=on_terminal,
+        )
+        try:
+            worker_envelope = ModelEventEnvelope[object](
+                payload=command.payload,
+                correlation_id=correlation_id,
+                envelope_timestamp=datetime.now(UTC),
+                event_type=route.event_type,
+                source_tool="pattern-b-broker",
+                target_tool=route.contract_name,
+            )
+            await self._event_bus.publish(
+                route.command_topic,
+                None,
+                worker_envelope.model_dump_json().encode("utf-8"),
+                None,
+            )
+            try:
+                terminal_payload = await asyncio.wait_for(
+                    terminal_queue.get(),
+                    timeout=command.timeout_seconds,
+                )
+            except TimeoutError:
+                await self._publish_terminal_result(
+                    command.response_topic,
+                    _error_result(
+                        correlation_id,
+                        status="timeout",
+                        error_message=(
+                            "Timed out waiting for Pattern B broker terminal event."
+                        ),
+                    ),
+                )
+                return
+
+            await self._publish_terminal_result(
+                command.response_topic,
+                ModelDispatchBusTerminalResult(
+                    correlation_id=correlation_id,
+                    status="completed",
+                    payload=terminal_payload,
+                    completed_at=datetime.now(UTC),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            await self._publish_terminal_result(
+                command.response_topic,
+                _error_result(
+                    correlation_id,
+                    status="failed",
+                    error_message=str(exc),
+                ),
+            )
+        finally:
+            await unsubscribe_terminal()
+
+    async def _publish_terminal_result(
+        self,
+        response_topic: str,
+        result: ModelDispatchBusTerminalResult,
+    ) -> None:
+        envelope = ModelEventEnvelope[ModelDispatchBusTerminalResult](
+            payload=result,
+            correlation_id=result.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=response_topic,
+            source_tool="pattern-b-broker",
+            target_tool="pattern-b-client",
+            payload_type=ModelDispatchBusTerminalResult.__name__,
+        )
+        await self._event_bus.publish(
+            response_topic,
+            None,
+            envelope.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+
+__all__ = ["RuntimePatternBBroker"]

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -125,6 +125,9 @@ from omnibase_infra.runtime.models.model_component_health import (
 from omnibase_infra.runtime.models.model_materialized_resources import (
     ModelMaterializedResources,
 )
+from omnibase_infra.runtime.models.model_pattern_b_broker_config import (
+    ModelPatternBBrokerConfig,
+)
 from omnibase_infra.runtime.protocol_lifecycle_executor import (
     DEFAULT_HANDLER_SHUTDOWN_TIMEOUT,
     ProtocolLifecycleExecutor,
@@ -138,6 +141,7 @@ from omnibase_infra.runtime.runtime_local_ingress import (
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
+from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
 from omnibase_infra.runtime.util_mcp_auth import inject_mcp_api_keys
 from omnibase_infra.runtime.util_wiring import wire_default_handlers
 from omnibase_infra.utils.util_consumer_group import compute_consumer_group_id
@@ -893,6 +897,12 @@ class RuntimeHostProcess:
         self._local_ingress_config = ModelLocalRuntimeIngressConfig.model_validate(
             local_ingress_config_raw
         )
+        pattern_b_broker_config_raw = config.get("pattern_b_broker", {})
+        if not isinstance(pattern_b_broker_config_raw, dict):
+            raise ValueError("config.pattern_b_broker must be a mapping when provided")
+        self._pattern_b_broker_config = ModelPatternBBrokerConfig.model_validate(
+            pattern_b_broker_config_raw
+        )
 
         # Topic configuration (config overrides constructor args)
         self._input_topic: str = str(config.get("input_topic", input_topic))
@@ -1221,6 +1231,7 @@ class RuntimeHostProcess:
         self._local_ingress_server: RuntimeLocalIngressServer | None = None
         self._local_ingress_dispatch_result_applier: DispatchResultApplier | None = None
         self._local_ingress_active_packages: tuple[str, ...] = ()
+        self._pattern_b_broker: RuntimePatternBBroker | None = None
 
         # Message dispatch engine for routing received messages (OMN-2050)
         # When set, contract-declared topics are routed through
@@ -1870,6 +1881,7 @@ class RuntimeHostProcess:
 
         # Step 5.75: Start local runtime ingress once dispatch routing is ready.
         await self._start_local_ingress()
+        await self._start_pattern_b_broker()
 
         self._is_running = True
 
@@ -1967,6 +1979,9 @@ class RuntimeHostProcess:
         if self._local_ingress_server is not None:
             await self._local_ingress_server.stop()
             self._local_ingress_server = None
+        if self._pattern_b_broker is not None:
+            await self._pattern_b_broker.stop()
+            self._pattern_b_broker = None
 
         # Step 1: Unsubscribe from topics (stop receiving new messages)
         if self._subscription is not None:
@@ -2189,6 +2204,23 @@ class RuntimeHostProcess:
             max_payload_bytes=self._local_ingress_config.max_payload_bytes,
         )
         await self._local_ingress_server.start()
+
+    async def _start_pattern_b_broker(self) -> None:
+        """Start the runtime-owned Pattern B broker when enabled."""
+        if not self._pattern_b_broker_config.enabled:
+            self._pattern_b_broker = None
+            return
+
+        package_names = parse_active_runtime_packages(
+            self._pattern_b_broker_config.package_names
+        )
+        routes = discover_runtime_local_ingress_routes(package_names)
+        self._pattern_b_broker = RuntimePatternBBroker(
+            self._event_bus,
+            command_topic=self._pattern_b_broker_config.command_topic,
+            routes=routes,
+        )
+        await self._pattern_b_broker.start()
 
     async def _dispatch_local_ingress_request(
         self,

--- a/tests/integration/runtime/test_pattern_b_broker_omnimarket.py
+++ b/tests/integration/runtime/test_pattern_b_broker_omnimarket.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pattern B broker integration against a real omnimarket handler."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from omnimarket.nodes.node_aislop_sweep.handlers.handler_aislop_sweep import (
+    AislopSweepRequest,
+    NodeAislopSweep,
+)
+
+from omnibase_core.dispatch.dispatch_bus_client import DispatchBusClient
+from omnibase_core.models.dispatch.model_dispatch_bus_route import (
+    ModelDispatchBusRoute,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.event_bus.topic_constants import TOPIC_PATTERN_B_DISPATCH_COMMAND
+from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
+
+pytestmark = pytest.mark.integration
+
+
+def _route() -> RuntimeLocalIngressRoute:
+    package = importlib.import_module("omnimarket")
+    node_dir = Path(package.__file__).resolve().parent
+    contract_path = node_dir / "nodes" / "node_aislop_sweep" / "contract.yaml"
+    return RuntimeLocalIngressRoute(
+        node_name="node_aislop_sweep",
+        contract_name="aislop_sweep",
+        command_topic="onex.cmd.omnimarket.aislop-sweep-start.v1",
+        event_type="omnimarket.aislop-sweep-start",
+        terminal_event="onex.evt.omnimarket.aislop-sweep-completed.v1",
+        contract_path=str(contract_path),
+        package_name="omnimarket",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pattern_b_broker_dispatches_real_aislop_handler(tmp_path: Path) -> None:
+    route = _route()
+    repo_dir = tmp_path / "demo_repo"
+    src_dir = repo_dir / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "demo.py").write_text(
+        'ONEX_EVENT_BUS_TYPE = "inmemory"\n',
+        encoding="utf-8",
+    )
+
+    bus = EventBusInmemory(environment="test", group="pattern-b-omnimarket")
+    await bus.start()
+
+    broker = RuntimePatternBBroker(
+        bus,
+        command_topic=TOPIC_PATTERN_B_DISPATCH_COMMAND,
+        routes={"aislop_sweep": route},
+    )
+    await broker.start()
+
+    handler = NodeAislopSweep()
+
+    async def worker(message: ModelEventMessage) -> None:
+        envelope = ModelEventEnvelope[object].model_validate_json(message.value)
+        request = AislopSweepRequest.model_validate(envelope.payload)
+        result = handler.handle(request)
+        terminal_envelope = ModelEventEnvelope[object](
+            payload=result.model_dump(mode="json"),
+            correlation_id=envelope.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=route.terminal_event or "unknown",
+            source_tool="aislop_sweep",
+        )
+        await bus.publish(
+            route.terminal_event or "unknown",
+            None,
+            terminal_envelope.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+    await bus.subscribe(
+        route.command_topic, group_id="aislop-worker", on_message=worker
+    )
+
+    client = DispatchBusClient(bus, source="pytest")
+    broker_route = ModelDispatchBusRoute(
+        contract_path=Path(route.contract_path),
+        command_topic=TOPIC_PATTERN_B_DISPATCH_COMMAND,
+        terminal_topic="onex.evt.omnibase-infra.pattern-b-dispatch-test-completed.v1",
+    )
+
+    try:
+        result = await client.request(
+            broker_route,
+            command_name="aislop_sweep",
+            payload={"target_dirs": [str(repo_dir)], "dry_run": True},
+            timeout_seconds=10,
+        )
+    finally:
+        await broker.stop()
+        await bus.close()
+
+    assert result.status == "completed"
+    assert isinstance(result.payload, dict)
+    findings = result.payload.get("findings")
+    assert isinstance(findings, list)
+    assert findings
+    first = findings[0]
+    assert isinstance(first, dict)
+    assert first["check"] == "prohibited-patterns"
+    assert first["repo"] == "demo_repo"

--- a/tests/unit/clients/test_runtime_skill_client.py
+++ b/tests/unit/clients/test_runtime_skill_client.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_core.models.runtime import (
+    ModelRuntimeSkillRequest,
+    ModelRuntimeSkillResponse,
+)
+from omnibase_infra.clients.runtime_skill_client import (
+    LocalRuntimeSkillClient,
+    default_runtime_socket_path,
+)
+
+
+@pytest.mark.unit
+def test_default_runtime_socket_path_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    socket_path = tmp_path / "test-runtime.sock"
+    monkeypatch.setenv("ONEX_LOCAL_RUNTIME_SOCKET_PATH", str(socket_path))
+    assert default_runtime_socket_path() == str(socket_path)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_async_round_trip(tmp_path: Path) -> None:
+    socket_path = Path(f"/tmp/runtime-skill-client-{uuid4().hex}.sock")  # noqa: S108
+
+    async def handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        request = json.loads((await reader.readline()).decode("utf-8"))
+        correlation_id = UUID(request["correlation_id"])
+        response = ModelRuntimeSkillResponse(
+            ok=True,
+            command_name=request["command_name"],
+            contract_name=request["command_name"],
+            command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+            terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+            correlation_id=correlation_id,
+            dispatch_result=ModelDispatchBusTerminalResult(
+                correlation_id=correlation_id,
+                status="completed",
+                payload={"status": "complete"},
+            ),
+            output_payloads=[{"status": "complete"}],
+        )
+        writer.write(
+            response.model_dump_json(exclude_none=True).encode("utf-8") + b"\n"
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+    client = LocalRuntimeSkillClient(socket_path=str(socket_path))
+    request = ModelRuntimeSkillRequest(
+        command_name="session_orchestrator",
+        payload={"dry_run": True},
+        correlation_id=uuid4(),
+    )
+
+    try:
+        response = await client.dispatch_async(request)
+    finally:
+        server.close()
+        await server.wait_closed()
+        socket_path.unlink(missing_ok=True)
+
+    assert response.ok is True
+    assert response.command_name == "session_orchestrator"
+    assert response.output_payloads == [{"status": "complete"}]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_async_returns_runtime_unavailable_for_missing_socket() -> None:
+    client = LocalRuntimeSkillClient(socket_path="/tmp/does-not-exist.sock")  # noqa: S108
+    response = await client.dispatch_async(
+        ModelRuntimeSkillRequest(command_name="session_orchestrator")
+    )
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "runtime_unavailable"

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -112,6 +112,7 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolDomainPlugin": "runtime/protocol_domain_plugin.py",
     "ProtocolHandlerPluginLoader": "runtime/protocol_handler_plugin_loader.py",
     "ProtocolHandlerDiscovery": "runtime/protocol_handler_discovery.py",
+    "ProtocolPatternBBrokerTransport": "protocols/protocol_pattern_b_broker_transport.py",  # [RUNTIME] OMN-10238 narrow broker transport DI boundary
     "ProtocolPolicy": "runtime/protocol_policy.py",
     "ProtocolProjectionEffect": "runtime/protocol_projection_effect.py",
     "ProtocolContractEventCallbacks": "runtime/kafka_contract_source.py",

--- a/tests/unit/models/test_model_serialization_roundtrip.py
+++ b/tests/unit/models/test_model_serialization_roundtrip.py
@@ -75,6 +75,9 @@ from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
 )
 from omnibase_infra.runtime.models.model_logging_config import ModelLoggingConfig
 from omnibase_infra.runtime.models.model_optional_string import ModelOptionalString
+from omnibase_infra.runtime.models.model_pattern_b_broker_config import (
+    ModelPatternBBrokerConfig,
+)
 from omnibase_infra.runtime.models.model_retry_policy import ModelRetryPolicy
 from omnibase_infra.runtime.models.model_runtime_scheduler_config import (
     ModelRuntimeSchedulerConfig,
@@ -393,6 +396,14 @@ def _make_local_runtime_ingress_response() -> ModelLocalRuntimeIngressResponse:
     )
 
 
+def _make_pattern_b_broker_config() -> ModelPatternBBrokerConfig:
+    return ModelPatternBBrokerConfig(
+        enabled=True,
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        package_names=("omnibase_infra", "omnimarket"),
+    )
+
+
 # ============================================================================
 # Factory registry: maps model class -> factory callable
 # ============================================================================
@@ -418,6 +429,7 @@ MODEL_FACTORIES: dict[type[BaseModel], Any] = {
     ModelLocalRuntimeIngressRequest: _make_local_runtime_ingress_request,
     ModelLocalRuntimeIngressResponse: _make_local_runtime_ingress_response,
     ModelOptionalString: _make_optional_string,
+    ModelPatternBBrokerConfig: _make_pattern_b_broker_config,
     ModelRetryPolicy: _make_retry_policy,
     ModelRuntimeSchedulerConfig: _make_runtime_scheduler_config,
     ModelRuntimeTick: _make_runtime_tick,

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+
+pytestmark = pytest.mark.unit
+
+
+def _route() -> RuntimeLocalIngressRoute:
+    return RuntimeLocalIngressRoute(
+        node_name="node_session_orchestrator",
+        contract_name="session_orchestrator",
+        command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
+        event_type="omnimarket.session-orchestrator-start",
+        terminal_event="onex.evt.omnimarket.session-orchestrator-completed.v1",
+        contract_path="/tmp/node_session_orchestrator/contract.yaml",  # noqa: S108
+        package_name="omnimarket",
+    )
+
+
+async def _collect_terminal_result(
+    bus: EventBusInmemory,
+    response_topic: str,
+) -> asyncio.Queue[ModelDispatchBusTerminalResult]:
+    queue: asyncio.Queue[ModelDispatchBusTerminalResult] = asyncio.Queue(maxsize=1)
+
+    async def on_message(message: ModelEventMessage) -> None:
+        envelope = ModelEventEnvelope[
+            ModelDispatchBusTerminalResult
+        ].model_validate_json(message.value)
+        if queue.empty():
+            await queue.put(envelope.payload)
+
+    await bus.subscribe(
+        response_topic,
+        group_id=f"collector-{uuid4()}",
+        on_message=on_message,
+    )
+    return queue
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_round_trips_terminal_event() -> None:
+    bus = EventBusInmemory(environment="test", group="pattern-b")
+    await bus.start()
+
+    route = _route()
+    broker = RuntimePatternBBroker(
+        bus,
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+    await broker.start()
+
+    async def worker(message: ModelEventMessage) -> None:
+        envelope = ModelEventEnvelope[object].model_validate_json(message.value)
+        terminal_envelope = ModelEventEnvelope[object](
+            payload={"status": "complete", "dispatch_count": 5},
+            correlation_id=envelope.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=route.terminal_event,
+            source_tool="session_orchestrator",
+        )
+        await bus.publish(
+            route.terminal_event or "unknown",
+            None,
+            terminal_envelope.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+    await bus.subscribe(route.command_topic, group_id="worker", on_message=worker)
+
+    response_topic = "onex.evt.pattern-b.dispatch-completed.v1"
+    results = await _collect_terminal_result(bus, response_topic)
+
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic=response_topic,
+        timeout_seconds=1,
+    )
+    envelope = ModelEventEnvelope[ModelDispatchBusCommand](
+        payload=command,
+        correlation_id=command.correlation_id,
+        envelope_timestamp=datetime.now(UTC),
+        event_type="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        source_tool="codex",
+    )
+    await bus.publish(
+        "onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        None,
+        envelope.model_dump_json().encode("utf-8"),
+        None,
+    )
+
+    result = await asyncio.wait_for(results.get(), timeout=2)
+
+    assert result.status == "completed"
+    assert result.payload == {"status": "complete", "dispatch_count": 5}
+
+    await broker.stop()
+    await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_publishes_timeout_result() -> None:
+    bus = EventBusInmemory(environment="test", group="pattern-b")
+    await bus.start()
+
+    route = _route()
+    broker = RuntimePatternBBroker(
+        bus,
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+    await broker.start()
+
+    response_topic = "onex.evt.pattern-b.dispatch-completed.v1"
+    results = await _collect_terminal_result(bus, response_topic)
+
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic=response_topic,
+        timeout_seconds=1,
+    )
+    envelope = ModelEventEnvelope[ModelDispatchBusCommand](
+        payload=command,
+        correlation_id=command.correlation_id,
+        envelope_timestamp=datetime.now(UTC),
+        event_type="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        source_tool="codex",
+    )
+    await bus.publish(
+        "onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        None,
+        envelope.model_dump_json().encode("utf-8"),
+        None,
+    )
+
+    result = await asyncio.wait_for(results.get(), timeout=2)
+
+    assert result.status == "timeout"
+    assert result.error_message is not None
+
+    await broker.stop()
+    await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_publishes_failed_result_for_unknown_route() -> (
+    None
+):
+    bus = EventBusInmemory(environment="test", group="pattern-b")
+    await bus.start()
+
+    broker = RuntimePatternBBroker(
+        bus,
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={},
+    )
+    await broker.start()
+
+    response_topic = "onex.evt.pattern-b.dispatch-completed.v1"
+    results = await _collect_terminal_result(bus, response_topic)
+
+    command = ModelDispatchBusCommand(
+        command_name="missing_route",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic=response_topic,
+        timeout_seconds=1,
+    )
+    envelope = ModelEventEnvelope[ModelDispatchBusCommand](
+        payload=command,
+        correlation_id=command.correlation_id,
+        envelope_timestamp=datetime.now(UTC),
+        event_type="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        source_tool="codex",
+    )
+    await bus.publish(
+        "onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        None,
+        envelope.model_dump_json().encode("utf-8"),
+        None,
+    )
+
+    result = await asyncio.wait_for(results.get(), timeout=1)
+
+    assert result.status == "failed"
+    assert result.error_message is not None
+    assert "Unknown Pattern B route" in result.error_message
+
+    await broker.stop()
+    await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_starts_pattern_b_broker_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    captured: dict[str, object] = {}
+
+    class FakeBroker:
+        def __init__(
+            self,
+            event_bus: object,
+            *,
+            command_topic: str,
+            routes: object,
+        ) -> None:
+            captured["event_bus"] = event_bus
+            captured["command_topic"] = command_topic
+            captured["routes"] = routes
+            self.start = AsyncMock()
+            self.stop = AsyncMock()
+            captured["start_mock"] = self.start
+
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.discover_runtime_local_ingress_routes",
+        lambda _packages: {"session_orchestrator": route},
+    )
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.RuntimePatternBBroker",
+        FakeBroker,
+    )
+
+    process = RuntimeHostProcess(
+        event_bus=EventBusInmemory(environment="test", group="pattern-b"),
+        config={
+            "service_name": "test-service",
+            "node_name": "test-node",
+            "env": "test",
+            "version": "v1",
+            "pattern_b_broker": {
+                "enabled": True,
+                "command_topic": "onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+                "package_names": ["omnibase_infra", "omnimarket"],
+            },
+        },
+        dispatch_engine=AsyncMock(),
+    )
+
+    await process._start_pattern_b_broker()
+
+    assert process._pattern_b_broker is not None
+    assert captured["command_topic"] == "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+    assert captured["routes"] == {"session_orchestrator": route}
+    start_mock = captured["start_mock"]
+    assert isinstance(start_mock, AsyncMock)
+    start_mock.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" }]
+overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.40.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316#6a65f885303e29b4ddc36a66a0cb860537f47316" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5#0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2036,7 +2036,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.4,<0.4.0" },
+    { name = "a2a-sdk", specifier = ">=0.3.4,<1.1.0" },
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiokafka", specifier = ">=0.11.0,<0.14.0" },
@@ -2044,7 +2044,7 @@ requires-dist = [
     { name = "circuitbreaker", specifier = ">=2.0.0,<3.0.0" },
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "confluent-kafka", specifier = ">=2.12.0,<3.0.0" },
-    { name = "cryptography", specifier = ">=46.0.3,<47.0.0" },
+    { name = "cryptography", specifier = ">=46.0.3,<48.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.1,<5.0.0" },
     { name = "fastapi", specifier = ">=0.120.1,<0.137.0" },
     { name = "grpcio", specifier = ">=1.62.0,<2.0.0" },
@@ -2054,7 +2054,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6a65f885303e29b4ddc36a66a0cb860537f47316" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" },
     { name = "omnibase-spi", specifier = ">=0.20.5" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }]
+overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f5ac07cb269ad12c6f5084fbc3f230c235b5c486" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.40.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5#0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f5ac07cb269ad12c6f5084fbc3f230c235b5c486#f5ac07cb269ad12c6f5084fbc3f230c235b5c486" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2054,7 +2054,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=0e4939cbb6af9a65d7703ec2bbedfebfc5b9f2c5" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f5ac07cb269ad12c6f5084fbc3f230c235b5c486" },
     { name = "omnibase-spi", specifier = ">=0.20.5" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- add the shared local runtime skill client in `omnibase_infra`
- repin the infra branch to the new `omnibase_core` shared runtime skill contract commit
- add focused unit coverage for Unix-socket request/response behavior

## Depends On
- https://github.com/OmniNode-ai/omnibase_core/pull/957

## Verification
- `env -u PYTHONPATH uv run ruff check src/omnibase_infra/clients/__init__.py src/omnibase_infra/clients/runtime_skill_client.py tests/unit/clients/test_runtime_skill_client.py`
- `env -u PYTHONPATH uv run pytest tests/unit/clients/test_runtime_skill_client.py -q`
- commit/push hooks were run with `PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10238/omnibase_core/src` so the local hook environment resolved the new core contract surface during verification and push
