### PR TITLE
fix(OMN-9728): verify deploy-agent runtime health ports

### DIFF
--- a/contracts/OMN-9728.yaml
+++ b/contracts/OMN-9728.yaml
@@ -1,0 +1,26 @@
+# OMN-9728 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-9728"
+summary: "fix(deploy-agent): verify runtime health on canonical 8085/8086 endpoints"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Deploy-agent verification probes runtime health ports instead of LLM ports"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run --extra dev pytest scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py -q"
+  - id: "dod-002"
+    description: "Runtime deploy verification rejects degraded config prefetch after merge"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omninode-runtime after merge, then verify http://localhost:8085/health and http://localhost:8086/health both report status=healthy, details.is_running=true, and details.config_prefetch_status=ok"

--- a/docs/runbooks/market-node-deployment.md
+++ b/docs/runbooks/market-node-deployment.md
@@ -158,13 +158,12 @@ healthcheck:
   start_period_s: 90
 ```
 
-**GAP — deploy-agent verification checks wrong ports:**
-`executor.py::verify()` checks `http://localhost:8000/health` (LLM port),
-`http://localhost:8001/health` (LLM port), and `http://localhost:8002/health`.
-The real runtime health endpoints are `8085` (omninode-runtime) and
-`8086` (runtime-effects). This is a documented gap from the E3 addendum in the
-platform plan. The verification phase may report "pass" while the actual runtime
-is unhealthy.
+**Deploy-agent verification:** `executor.py::verify()` checks the real runtime
+health endpoints: `8085` (omninode-runtime) and `8086` (runtime-effects). It
+requires `status=healthy`, `details.is_running=true`, and
+`details.config_prefetch_status=ok`. This closes the former E3 gap where
+verification probed LLM ports and could report "pass" while the actual runtime
+was unhealthy.
 
 ---
 
@@ -244,7 +243,7 @@ consuming correctly. The deploy-agent's `verify()` phase checks:
 1. No unhealthy Docker containers
 2. No restarting Docker containers
 3. `handler_registry` row count > 0 in Postgres
-4. HTTP health on ports 8000, 8001, 8002 (wrong ports — see Step 4 gap)
+4. HTTP health on ports 8085 and 8086, including `config_prefetch_status=ok`
 
 None of these checks send a synthetic event and await a node-specific response.
 
@@ -265,7 +264,7 @@ but it is not yet implemented.
 |---|-----|----------|----------|-----------------|
 | 1 | Deploy-agent consuming from wrong Kafka bus (localhost vs cloud) | HIGH | OMN-9713; executor.py hardcodes `localhost:19092`; trigger publishes to cloud SASL endpoint | Fix deploy-agent Kafka config to match trigger bus; add preflight broker-reachability check |
 | 2 | No per-node round-trip verification after deploy | HIGH | executor.py verify() checks only count>0 and wrong ports; OMN-9695 undetected 6 days | Implement F4 canary: synthetic event → expected response per node |
-| 3 | Deploy-agent health check probes wrong ports (8000/8001/8002 vs 8085/8086) | HIGH | executor.py:636-654 hardcodes LLM ports; runtime health is on 8085/8086 | Fix executor.py verify() to probe 8085 and 8086; check `details.config_prefetch_status=ok` |
+| 3 | Deploy-agent health check probes wrong ports (8000/8001/8002 vs 8085/8086) | DONE | OMN-9728 updates `executor.py::verify()` to probe 8085/8086 and require `details.config_prefetch_status=ok` | Keep regression tests in `scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py` green |
 | 4 | No expected consumer group registry | HIGH | No `expected_consumer_groups.yaml` exists; rpk group list diff is manual | Create registry from F0 matrix; wire into E1a baseline check |
 | 5 | No feedback loop from deploy-agent to PR/CI | MED | trigger_rebuild_on_merge.py exits after publish; no status returned | Publish `rebuild-completed` event back; add GHA job that polls for completion |
 | 6 | handler_registry count check is not node-specific | MED | executor.py verify() only checks count>0; a single registered node passes | Query expected set from contract.yaml discovery; diff against actual registry |
@@ -275,22 +274,17 @@ but it is not yet implemented.
 
 ## Highest-leverage gap (proposed for immediate closure)
 
-**Gap #3 — Deploy-agent health check probes wrong ports** is the most actionable
-immediate fix because it is a single-file code change with high impact: it makes
-the deploy-agent's `verify()` phase actually test the real runtime health surface
-instead of the LLM inference ports. This closes the scenario where a deploy
-completes with a green verify result while `omninode-runtime` is actually down or
-in `config_prefetch_status=degraded_error`.
+**Gap #3 — Deploy-agent health check probes wrong ports** is closed by OMN-9728.
+The deploy-agent's `verify()` phase now tests the real runtime health surface
+instead of the LLM inference ports and fails when either runtime endpoint is not
+healthy, not running, or reports `config_prefetch_status` other than `ok`.
 
-**Proposed fix scope:**
-- `scripts/deploy-agent/deploy_agent/executor.py`: change the health check loop at
-  lines 636-654 to probe `http://localhost:8085/health` and `http://localhost:8086/health`
-  instead of ports 8000/8001/8002
-- Add a check that the health response body contains `config_prefetch_status` equal
-  to `ok` (not just HTTP 200), matching the E3b spec in the platform plan
-- Add a test in `scripts/deploy-agent/tests/` that mocks the health endpoints and
-  asserts the verifier correctly distinguishes `config_prefetch_status=ok` from
-  `config_prefetch_status=degraded_error`
+**Regression scope:**
+- `scripts/deploy-agent/deploy_agent/executor.py`: probes
+  `http://localhost:8085/health` and `http://localhost:8086/health`
+- `scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py`: asserts
+  the verifier avoids LLM ports and distinguishes `config_prefetch_status=ok`
+  from `config_prefetch_status=degraded_error`
 
 **Why not Gap #1 (bus mismatch)?** Gap #1 (OMN-9713) is already tracked by the
 runtime team and gated on their deliverable. It cannot be fixed here without

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -46,6 +47,11 @@ PHASE_TIMEOUTS = {
 
 PhaseCallback = Callable[[Phase, PhaseStatus], None]
 
+RUNTIME_HEALTH_TARGETS: tuple[tuple[str, int], ...] = (
+    ("omninode-runtime", 8085),
+    ("runtime-effects", 8086),
+)
+
 
 def _requested_services_for_up(scope: Scope, services: list[str]) -> list[str]:
     """Return the explicit service list compose should recreate for this scope.
@@ -78,6 +84,26 @@ def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
         text=True,
         check=False,
         **kwargs,
+    )
+
+
+def _runtime_health_passed(result: subprocess.CompletedProcess) -> bool:
+    """Return whether a runtime /health response proves deploy readiness."""
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    details = payload.get("details")
+    if not isinstance(details, dict):
+        return False
+    return (
+        payload.get("status") == "healthy"
+        and details.get("is_running") is True
+        and details.get("config_prefetch_status") == "ok"
     )
 
 
@@ -676,15 +702,21 @@ class DeployExecutor:
                 )
             )
 
-        # Health endpoint checks
-        for service, port in [
-            ("runtime", 8000),
-            ("intelligence-api", 8001),
-            ("contract-resolver", 8002),
-        ]:
+        # Runtime health endpoint checks.
+        #
+        # OMN-9728: deployment readiness is owned by the runtime health servers
+        # on 8085/8086. Ports 8000/8001/8002 are LLM endpoints and cannot prove
+        # that the runtime or runtime-effects processes are healthy.
+        for service, port in RUNTIME_HEALTH_TARGETS:
             start = time.monotonic()
             result = _run(
-                ["curl", "-sf", f"http://localhost:{port}/health"],
+                [
+                    "curl",
+                    "-sS",
+                    "--max-time",
+                    "10",
+                    f"http://localhost:{port}/health",
+                ],
                 timeout=10,
             )
             latency = int((time.monotonic() - start) * 1000)
@@ -692,7 +724,7 @@ class DeployExecutor:
                 ModelHealthCheck(
                     service=service,
                     endpoint=f"http://localhost:{port}/health",
-                    status="pass" if result.returncode == 0 else "fail",
+                    status="pass" if _runtime_health_passed(result) else "fail",
                     latency_ms=latency,
                 )
             )

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Deploy-agent verification must probe runtime health, not LLM ports."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from deploy_agent.events import Phase, PhaseStatus
+from deploy_agent.executor import DeployExecutor
+
+
+def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
+    return None
+
+
+def _completed(
+    cmd: list[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=cmd,
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _health_payload(
+    *,
+    status: str = "healthy",
+    is_running: bool = True,
+    config_prefetch_status: str = "ok",
+) -> str:
+    return json.dumps(
+        {
+            "status": status,
+            "details": {
+                "is_running": is_running,
+                "config_prefetch_status": config_prefetch_status,
+            },
+        }
+    )
+
+
+def test_verify_probes_runtime_health_ports_only() -> None:
+    executor = DeployExecutor()
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str], timeout: int, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        captured_cmds.append(cmd)
+        if cmd[:2] == ["docker", "ps"]:
+            return _completed(cmd)
+        if "handler_registry count" in cmd:
+            return _completed(cmd, stdout="4\n")
+        if "http://localhost:8085/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        if "http://localhost:8086/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        return _completed(cmd, returncode=1, stderr=f"unexpected command: {cmd}")
+
+    with patch("deploy_agent.executor._run", side_effect=fake_run):
+        checks = executor.verify(on_phase_update=_noop_phase_update)
+
+    endpoints = [check.endpoint for check in checks]
+    assert "http://localhost:8085/health" in endpoints
+    assert "http://localhost:8086/health" in endpoints
+    assert not any(":8000/health" in endpoint for endpoint in endpoints)
+    assert not any(":8001/health" in endpoint for endpoint in endpoints)
+    assert not any(":8002/health" in endpoint for endpoint in endpoints)
+    assert not any(
+        "localhost:8000" in " ".join(cmd)
+        or "localhost:8001" in " ".join(cmd)
+        or "localhost:8002" in " ".join(cmd)
+        for cmd in captured_cmds
+    )
+    runtime_checks = {
+        check.service: check.status
+        for check in checks
+        if check.service in {"omninode-runtime", "runtime-effects"}
+    }
+    assert runtime_checks == {
+        "omninode-runtime": "pass",
+        "runtime-effects": "pass",
+    }
+
+
+def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:
+    executor = DeployExecutor()
+
+    def fake_run(
+        cmd: list[str], timeout: int, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        if cmd[:2] == ["docker", "ps"]:
+            return _completed(cmd)
+        if "handler_registry count" in cmd:
+            return _completed(cmd, stdout="4\n")
+        if "http://localhost:8085/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        if "http://localhost:8086/health" in cmd:
+            return _completed(
+                cmd,
+                stdout=_health_payload(config_prefetch_status="degraded_error"),
+            )
+        return _completed(cmd, returncode=1, stderr=f"unexpected command: {cmd}")
+
+    with patch("deploy_agent.executor._run", side_effect=fake_run):
+        checks = executor.verify(on_phase_update=_noop_phase_update)
+
+    status_by_service = {check.service: check.status for check in checks}
+    assert status_by_service["omninode-runtime"] == "pass"
+    assert status_by_service["runtime-effects"] == "fail"
+
+
+def test_verify_fails_runtime_health_when_process_not_running() -> None:
+    executor = DeployExecutor()
+
+    def fake_run(
+        cmd: list[str], timeout: int, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        if cmd[:2] == ["docker", "ps"]:
+            return _completed(cmd)
+        if "handler_registry count" in cmd:
+            return _completed(cmd, stdout="4\n")
+        if "http://localhost:8085/health" in cmd:
+            return _completed(cmd, stdout=_health_payload(is_running=False))
+        if "http://localhost:8086/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        return _completed(cmd, returncode=1, stderr=f"unexpected command: {cmd}")
+
+    with patch("deploy_agent.executor._run", side_effect=fake_run):
+        checks = executor.verify(on_phase_update=_noop_phase_update)
+
+    status_by_service = {check.service: check.status for check in checks}
+    assert status_by_service["omninode-runtime"] == "fail"
+    assert status_by_service["runtime-effects"] == "pass"


### PR DESCRIPTION
## Summary
- Replace deploy-agent verify() health probes on LLM ports 8000/8001/8002 with canonical runtime health endpoints 8085/8086
- Require runtime health payloads to report status=healthy, details.is_running=true, and details.config_prefetch_status=ok
- Add regression tests for wrong-port avoidance, degraded config prefetch, and not-running runtime health
- Update the market-node deployment runbook and add repo-local deploy evidence contract

## Verification
- cd scripts/deploy-agent && uv run --extra dev pytest tests/unit/test_executor_runtime_health_verify.py -q
- cd scripts/deploy-agent && uv run --extra dev pytest tests/unit -q
- cd scripts/deploy-agent && uv run ruff check deploy_agent/executor.py tests/unit/test_executor_runtime_health_verify.py

## Change control
- Central OCC evidence PR: OmniNode-ai/onex_change_control#508

No live deploy or runtime restart performed.