### PR TITLE
fix(OMN-9713): unify deploy-agent kafka control bus

### DIFF
--- a/contracts/OMN-9713.yaml
+++ b/contracts/OMN-9713.yaml
@@ -1,0 +1,32 @@
+# OMN-9713 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-9713"
+summary: "fix(deploy-agent): use one explicit Kafka control bus for consume and publish"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Deploy-agent Kafka config has no localhost fallback and supports SASL_SSL cloud bus"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "cd scripts/deploy-agent && uv run --extra dev pytest tests/unit/test_kafka_config.py tests/unit/test_publisher_kafka_bus.py -q"
+  - id: "dod-002"
+    description: "Deploy-agent consume/publish paths use the same explicit Kafka config"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "cd scripts/deploy-agent && uv run --extra dev pytest tests/unit -q"
+  - id: "dod-003"
+    description: "Post-merge deploy validation confirms .201 deploy-agent is configured with the same KAFKA_BOOTSTRAP_SERVERS as the trigger publisher"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy deploy-agent after merge, then inspect the user service environment and verify KAFKA_BOOTSTRAP_SERVERS matches the runtime-rebuild-trigger publish bus; no live restart performed in PR"

--- a/contracts/OMN-9713.yaml
+++ b/contracts/OMN-9713.yaml
@@ -19,11 +19,11 @@ dod_evidence:
       - check_type: "command"
         check_value: "cd scripts/deploy-agent && uv run --extra dev pytest tests/unit/test_kafka_config.py tests/unit/test_publisher_kafka_bus.py -q"
   - id: "dod-002"
-    description: "Deploy-agent consume/publish paths use the same explicit Kafka config"
+    description: "Deploy-agent consume/publish paths use the same explicit Kafka config and canonical repo source"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "cd scripts/deploy-agent && uv run --extra dev pytest tests/unit -q"
+        check_value: "cd scripts/deploy-agent && uv run --extra dev pytest tests/unit/test_executor_self_update.py tests/unit/test_deploy_agent_service_source.py tests/unit/test_kafka_config.py tests/unit/test_publisher_kafka_bus.py -q"
   - id: "dod-003"
     description: "Post-merge deploy validation confirms .201 deploy-agent is configured with the same KAFKA_BOOTSTRAP_SERVERS as the trigger publisher"
     source: "manual"

--- a/docs/runbooks/market-node-deployment.md
+++ b/docs/runbooks/market-node-deployment.md
@@ -69,15 +69,14 @@ correlation_id, requested_by, scope="runtime", git_ref="origin/main"
 **HMAC signing:** the payload is signed with `DEPLOY_AGENT_HMAC_SECRET` before
 publishing. The deploy-agent verifies the signature on receipt.
 
-**GAP — trigger fires on Kafka cloud bus, not local Docker bus:**
-The trigger script publishes to `KAFKA_BOOTSTRAP_SERVERS` (cloud Confluent endpoint).
-The deploy-agent on .201 must be configured to consume from the same cloud bus
-(or a bridge). There is no evidence in the codebase that the deploy-agent is
-configured to consume from the cloud bus vs the local Docker Redpanda. This is
-a known issue: OMN-9713 tracks "deploy-agent localhost" — the deploy-agent was
-consuming from `localhost:19092` (Docker Redpanda) while the trigger was publishing
-to the cloud bus. Any PR touching `src/omnimarket/**` would silently never reach
-the deploy-agent.
+**Deploy-agent Kafka control bus:** The trigger script publishes to
+`KAFKA_BOOTSTRAP_SERVERS`, and the deploy-agent now requires the same explicit
+Kafka config for command consumption, completion publishing, and rejection
+publishing. There is intentionally no localhost fallback. OMN-9713 fixed the
+code-level split-brain path where the deploy-agent could silently consume or
+publish on a different bus from the trigger publisher. Post-merge validation must
+still verify the `.201` user service environment contains the intended
+`KAFKA_BOOTSTRAP_SERVERS` value before relying on automated rebuilds.
 
 ---
 
@@ -263,7 +262,7 @@ but it is not yet implemented.
 
 | # | Gap | Severity | Evidence | Recommended fix |
 |---|-----|----------|----------|-----------------|
-| 1 | Deploy-agent consuming from wrong Kafka bus (localhost vs cloud) | HIGH | OMN-9713; executor.py hardcodes `localhost:19092`; trigger publishes to cloud SASL endpoint | Fix deploy-agent Kafka config to match trigger bus; add preflight broker-reachability check |
+| 1 | Deploy-agent consuming from wrong Kafka bus (localhost vs cloud) | CODE FIXED | OMN-9713 removes localhost fallback and routes consume/completion/rejection through one explicit Kafka config | Deploy deploy-agent after merge and verify `.201` user service env uses the trigger publisher bus |
 | 2 | No per-node round-trip verification after deploy | HIGH | executor.py verify() checks only count>0 and wrong ports; OMN-9695 undetected 6 days | Implement F4 canary: synthetic event → expected response per node |
 | 3 | Deploy-agent health check probes wrong ports (8000/8001/8002 vs 8085/8086) | HIGH | executor.py:636-654 hardcodes LLM ports; runtime health is on 8085/8086 | Fix executor.py verify() to probe 8085 and 8086; check `details.config_prefetch_status=ok` |
 | 4 | No expected consumer group registry | HIGH | No `expected_consumer_groups.yaml` exists; rpk group list diff is manual | Create registry from F0 matrix; wire into E1a baseline check |
@@ -292,9 +291,10 @@ in `config_prefetch_status=degraded_error`.
   asserts the verifier correctly distinguishes `config_prefetch_status=ok` from
   `config_prefetch_status=degraded_error`
 
-**Why not Gap #1 (bus mismatch)?** Gap #1 (OMN-9713) is already tracked by the
-runtime team and gated on their deliverable. It cannot be fixed here without
-SSH access to .201 and changes to the live deploy-agent configuration.
+**Gap #1 (bus mismatch):** OMN-9713 fixes the code path by requiring explicit
+Kafka config and using it for both consume and publish surfaces. The remaining
+work is post-merge deployment validation on `.201`; this runbook intentionally
+does not imply a PR can mutate the live user service environment.
 
 **Why not Gap #2 (no round-trip canary)?** Gap #2 (F4 canary) is Wave 3 work
 gated on Track B completion. It is the right long-term fix but is not immediately
@@ -304,7 +304,8 @@ actionable from a static code-only PR.
 
 ## Manual deployment path (current fallback)
 
-When the deploy-agent is unreachable (e.g., OMN-9713 bus mismatch), the current
+When the deploy-agent is unreachable (for example, before OMN-9713 is deployed
+and validated on `.201`), the current
 manual path on `.201` is (requires `INFRA_HOST` and `INFRA_USER` from `~/.omnibase/.env`):
 
 ```bash

--- a/scripts/deploy-agent/deploy/deploy-agent.service
+++ b/scripts/deploy-agent/deploy/deploy-agent.service
@@ -20,8 +20,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/data/omninode/deploy-agent
+WorkingDirectory=/data/omninode/omnibase_infra/scripts/deploy-agent
 EnvironmentFile=/home/jonah/.omnibase/.env
+Environment=DEPLOY_AGENT_DIR=/data/omninode/omnibase_infra/scripts/deploy-agent
 Environment=DEPLOY_AGENT_STATE_DIR=/data/omninode/deploy-agent/state/jobs
 Environment=DEPLOY_AGENT_PORT=8099
 ExecStartPre=/bin/sh -c 'fuser -k 8099/tcp || true'

--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -25,6 +25,7 @@ from deploy_agent.events import (
 from deploy_agent.executor import SCOPE_BUNDLES, DeployExecutor
 from deploy_agent.health import create_health_app
 from deploy_agent.job_state import JobStore
+from deploy_agent.kafka_config import load_deploy_agent_kafka_config_from_env
 from deploy_agent.lock import single_flight_lock
 from deploy_agent.publisher import (
     PublishCircuitBreaker,
@@ -37,7 +38,6 @@ logger = logging.getLogger(__name__)
 STATE_DIR = Path(
     os.environ.get("DEPLOY_AGENT_STATE_DIR", "/data/omninode/deploy-agent/state/jobs")
 )
-BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
 HEALTH_PORT = int(os.environ.get("DEPLOY_AGENT_PORT", "8099"))
 PUBLISH_RETRY_INTERVAL = 30
 
@@ -69,6 +69,7 @@ class DeployAgent:
         self._current_git_sha = ""
         self._skip_self_update = skip_self_update
         self._publish_cb = PublishCircuitBreaker()
+        self._kafka_config = load_deploy_agent_kafka_config_from_env()
 
     def _get_state(self) -> str:
         return self._state
@@ -81,7 +82,7 @@ class DeployAgent:
         logger.info(
             "Deploy agent starting (state_dir=%s, kafka=%s)",
             STATE_DIR,
-            BOOTSTRAP_SERVERS,
+            self._kafka_config.bootstrap_servers,
         )
 
         # Step 1: Recover crashed jobs
@@ -116,7 +117,7 @@ class DeployAgent:
 
         # Step 5+6: Main loop
         consumer = DeployConsumer(
-            bootstrap_servers=BOOTSTRAP_SERVERS,
+            kafka_config=self._kafka_config,
             job_store=self.job_store,
         )
 
@@ -220,7 +221,7 @@ class DeployAgent:
             payload = build_completion_payload(
                 job, self._current_git_sha, health_checks
             )
-            if publish_result(payload):
+            if publish_result(payload, self._kafka_config):
                 job.phase_results[Phase.PUBLISH] = PhaseStatus.SUCCESS
                 self.job_store._save(job)
                 self._publish_cb.record_success(str(cid))
@@ -243,7 +244,10 @@ class DeployAgent:
             }
         ).encode()
         try:
-            producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS)
+            producer = KafkaProducer(
+                **self._kafka_config.producer_kwargs(),
+                value_serializer=lambda v: v,
+            )
             producer.send(TOPIC_REBUILD_REJECTED, payload)
             producer.flush(timeout=5)
             producer.close()
@@ -269,7 +273,7 @@ class DeployAgent:
                 continue
 
             payload = build_completion_payload(job, "")
-            if publish_result(payload):
+            if publish_result(payload, self._kafka_config):
                 self.job_store.mark_published(job.correlation_id)
                 self._publish_cb.record_success(cid_str)
                 logger.info("Retried publish for %s: success", cid_str)

--- a/scripts/deploy-agent/deploy_agent/consumer.py
+++ b/scripts/deploy-agent/deploy_agent/consumer.py
@@ -16,15 +16,18 @@ from deploy_agent.events import (
     ModelRebuildRequested,
 )
 from deploy_agent.job_state import JobStore
+from deploy_agent.kafka_config import ModelDeployAgentKafkaConfig
 
 logger = logging.getLogger(__name__)
 
 
 class DeployConsumer:
-    def __init__(self, bootstrap_servers: str, job_store: JobStore):
+    def __init__(
+        self, kafka_config: ModelDeployAgentKafkaConfig, job_store: JobStore
+    ) -> None:
         self.consumer = KafkaConsumer(
             TOPIC_REBUILD_REQUESTED,
-            bootstrap_servers=bootstrap_servers,
+            **kafka_config.consumer_kwargs(),
             group_id="onex-deploy-agent",
             auto_offset_reset="latest",
             enable_auto_commit=False,

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -31,7 +31,7 @@ SCOPE_BUNDLES: dict[Scope, list[str]] = {
 logger = logging.getLogger(__name__)
 
 REPO_DIR = "/data/omninode/omnibase_infra"
-DEPLOY_AGENT_DIR = "/data/omninode/deploy-agent"
+DEPLOY_AGENT_DIR = f"{REPO_DIR}/scripts/deploy-agent"
 COMPOSE_FILE = f"{REPO_DIR}/docker/docker-compose.infra.yml"
 COMPOSE_PROJECT = "omnibase-infra"
 

--- a/scripts/deploy-agent/deploy_agent/kafka_config.py
+++ b/scripts/deploy-agent/deploy_agent/kafka_config.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed Kafka configuration for the deploy-agent control bus."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelDeployAgentKafkaConfig(BaseModel):
+    """Single source of truth for deploy-agent consume and publish bus config."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    bootstrap_servers: str = Field(..., min_length=1)
+    security_protocol: Literal["PLAINTEXT", "SASL_SSL"] = "PLAINTEXT"
+    sasl_mechanism: Literal["PLAIN"] | None = None
+    sasl_username: str | None = None
+    sasl_password: str | None = None
+
+    @model_validator(mode="after")
+    def validate_sasl_pair(self) -> ModelDeployAgentKafkaConfig:
+        if bool(self.sasl_username) != bool(self.sasl_password):
+            raise ValueError(
+                "KAFKA_SASL_USERNAME and KAFKA_SASL_PASSWORD must be set together"
+            )
+        if self.security_protocol == "SASL_SSL":
+            if not self.sasl_username or not self.sasl_password:
+                raise ValueError(
+                    "SASL_SSL deploy-agent Kafka config requires "
+                    "KAFKA_SASL_USERNAME and KAFKA_SASL_PASSWORD"
+                )
+            if self.sasl_mechanism is None:
+                object.__setattr__(self, "sasl_mechanism", "PLAIN")
+        if self.sasl_username and self.security_protocol != "SASL_SSL":
+            raise ValueError(
+                "KAFKA_SECURITY_PROTOCOL must be SASL_SSL when SASL credentials are set"
+            )
+        return self
+
+    def consumer_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "bootstrap_servers": self.bootstrap_servers,
+            "security_protocol": self.security_protocol,
+        }
+        if self.security_protocol == "SASL_SSL":
+            kwargs.update(
+                {
+                    "sasl_mechanism": self.sasl_mechanism or "PLAIN",
+                    "sasl_plain_username": self.sasl_username,
+                    "sasl_plain_password": self.sasl_password,
+                }
+            )
+        return kwargs
+
+    def producer_kwargs(self) -> dict[str, Any]:
+        return self.consumer_kwargs()
+
+
+def load_deploy_agent_kafka_config_from_env() -> ModelDeployAgentKafkaConfig:
+    """Load required deploy-agent Kafka config from environment.
+
+    OMN-9713: there is intentionally no localhost fallback. A missing
+    ``KAFKA_BOOTSTRAP_SERVERS`` must fail startup rather than silently consuming
+    a different bus from the trigger publisher.
+    """
+    bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "").strip()
+    if not bootstrap_servers:
+        raise RuntimeError(
+            "KAFKA_BOOTSTRAP_SERVERS is required for deploy-agent; "
+            "there is no localhost fallback"
+        )
+
+    username = os.environ.get("KAFKA_SASL_USERNAME") or None
+    password = os.environ.get("KAFKA_SASL_PASSWORD") or None
+    default_protocol = "SASL_SSL" if username or password else "PLAINTEXT"
+    security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", default_protocol)
+
+    return ModelDeployAgentKafkaConfig(
+        bootstrap_servers=bootstrap_servers,
+        security_protocol=security_protocol,
+        sasl_mechanism=os.environ.get("KAFKA_SASL_MECHANISM") or None,
+        sasl_username=username,
+        sasl_password=password,
+    )

--- a/scripts/deploy-agent/deploy_agent/publisher.py
+++ b/scripts/deploy-agent/deploy_agent/publisher.py
@@ -6,16 +6,18 @@ from __future__ import annotations
 
 import json
 import logging
-import subprocess
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+
+from kafka import KafkaProducer
 
 from deploy_agent.events import (
     TOPIC_REBUILD_COMPLETED,
     ModelHealthCheck,
 )
 from deploy_agent.job_state import JobState
+from deploy_agent.kafka_config import ModelDeployAgentKafkaConfig
 
 logger = logging.getLogger(__name__)
 
@@ -90,42 +92,36 @@ def build_completion_payload(
     }
 
 
-def publish_result(payload: dict) -> bool:
-    """Publish completion event via rpk inside the redpanda container. Returns True on success."""
+def publish_result(payload: dict, kafka_config: ModelDeployAgentKafkaConfig) -> bool:
+    """Publish completion event to the same control bus consumed by deploy-agent."""
     try:
-        data = json.dumps(payload) + "\n"
-        result = subprocess.run(
-            [
-                "docker",
-                "exec",
-                "-i",
-                "omnibase-infra-redpanda",
-                "rpk",
-                "topic",
-                "produce",
-                TOPIC_REBUILD_COMPLETED,
-            ],
-            input=data,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
+        producer = KafkaProducer(
+            **kafka_config.producer_kwargs(),
+            value_serializer=lambda v: json.dumps(v, default=str).encode("utf-8"),
+            key_serializer=lambda v: str(v).encode("utf-8"),
         )
-        if result.returncode == 0:
-            logger.info("Published result for %s", payload.get("correlation_id"))
-            return True
-        logger.warning("rpk produce failed: %s", result.stderr)
-        return False
+        correlation_id = payload.get("correlation_id", "")
+        producer.send(
+            TOPIC_REBUILD_COMPLETED,
+            key=f"deploy-result/{correlation_id}",
+            value=payload,
+        )
+        producer.flush(timeout=30)
+        producer.close()
+        logger.info("Published result for %s", correlation_id)
+        return True
     except Exception as e:  # noqa: BLE001
         logger.warning("Publish failed: %s", e)
         return False
 
 
-def publish_with_retry(payload: dict) -> bool:
+def publish_with_retry(
+    payload: dict, kafka_config: ModelDeployAgentKafkaConfig
+) -> bool:
     """Attempt to publish with exponential backoff."""
     total_waited = 0
     for delay in RETRY_DELAYS:
-        if publish_result(payload):
+        if publish_result(payload, kafka_config):
             return True
         if total_waited + delay > MAX_RETRY_TOTAL_SECONDS:
             logger.error(
@@ -137,4 +133,4 @@ def publish_with_retry(payload: dict) -> bool:
         time.sleep(delay)
         total_waited += delay
 
-    return publish_result(payload)
+    return publish_result(payload, kafka_config)

--- a/scripts/deploy-agent/tests/unit/test_deploy_agent_service_source.py
+++ b/scripts/deploy-agent/tests/unit/test_deploy_agent_service_source.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Systemd unit must execute deploy-agent code from the canonical repo copy."""
+
+from pathlib import Path
+
+
+def test_service_uses_canonical_repo_source() -> None:
+    service = Path(__file__).resolve().parents[2] / "deploy" / "deploy-agent.service"
+    text = service.read_text()
+
+    assert "WorkingDirectory=/data/omninode/omnibase_infra/scripts/deploy-agent" in text
+    assert (
+        "Environment=DEPLOY_AGENT_DIR=/data/omninode/omnibase_infra/scripts/deploy-agent"
+        in text
+    )
+    assert "WorkingDirectory=/data/omninode/deploy-agent" not in text

--- a/scripts/deploy-agent/tests/unit/test_executor_self_update.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_self_update.py
@@ -14,7 +14,7 @@ import sys
 from unittest.mock import call, patch
 
 import pytest
-from deploy_agent.executor import DeployExecutor
+from deploy_agent.executor import DEPLOY_AGENT_DIR, DeployExecutor
 
 SHA_LOCAL = "aaaaaaaabbbbbbbb"
 SHA_REMOTE = "ccccccccdddddddd"
@@ -54,6 +54,9 @@ def _make_git_responses(
 
 
 class TestSelfUpdateSkip:
+    def test_default_update_source_is_canonical_repo_copy(self) -> None:
+        assert DEPLOY_AGENT_DIR == "/data/omninode/omnibase_infra/scripts/deploy-agent"
+
     def test_skip_flag_bypasses_all_git_calls(self) -> None:
         executor = DeployExecutor()
         with patch("deploy_agent.executor._run") as mock_run:

--- a/scripts/deploy-agent/tests/unit/test_kafka_config.py
+++ b/scripts/deploy-agent/tests/unit/test_kafka_config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Deploy-agent Kafka config must use one explicit control bus."""
+
+from __future__ import annotations
+
+import pytest
+from deploy_agent.kafka_config import (
+    ModelDeployAgentKafkaConfig,
+    load_deploy_agent_kafka_config_from_env,
+)
+from pydantic import ValidationError
+
+_TEST_PASSWORD = "test-sasl-secret"
+
+
+def test_missing_bootstrap_servers_fails_without_localhost_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+    with pytest.raises(RuntimeError, match="no localhost fallback"):
+        load_deploy_agent_kafka_config_from_env()
+
+
+def test_plaintext_config_uses_explicit_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda.example:9092")
+    monkeypatch.delenv("KAFKA_SASL_USERNAME", raising=False)
+    monkeypatch.delenv("KAFKA_SASL_PASSWORD", raising=False)
+
+    config = load_deploy_agent_kafka_config_from_env()
+
+    assert config.bootstrap_servers == "redpanda.example:9092"
+    assert config.security_protocol == "PLAINTEXT"
+    assert config.consumer_kwargs() == {
+        "bootstrap_servers": "redpanda.example:9092",
+        "security_protocol": "PLAINTEXT",
+    }
+
+
+def test_sasl_config_uses_kafka_python_cloud_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "pkc.example.confluent.cloud:9092")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "key")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", _TEST_PASSWORD)
+
+    config = load_deploy_agent_kafka_config_from_env()
+
+    assert config.security_protocol == "SASL_SSL"
+    assert config.consumer_kwargs() == {
+        "bootstrap_servers": "pkc.example.confluent.cloud:9092",
+        "security_protocol": "SASL_SSL",
+        "sasl_mechanism": "PLAIN",
+        "sasl_plain_username": "key",
+        "sasl_plain_password": _TEST_PASSWORD,
+    }
+    assert config.producer_kwargs() == config.consumer_kwargs()
+
+
+def test_sasl_credentials_require_sasl_ssl() -> None:
+    with pytest.raises(ValidationError, match="KAFKA_SECURITY_PROTOCOL"):
+        ModelDeployAgentKafkaConfig(
+            bootstrap_servers="pkc.example.confluent.cloud:9092",
+            security_protocol="PLAINTEXT",
+            sasl_username="key",
+            sasl_password=_TEST_PASSWORD,
+        )

--- a/scripts/deploy-agent/tests/unit/test_llm_endpoint_env_contract_guard.py
+++ b/scripts/deploy-agent/tests/unit/test_llm_endpoint_env_contract_guard.py
@@ -145,11 +145,12 @@ async def test_runtime_deploy_validates_llm_env_before_rebuild(
     store.accept(cmd.correlation_id, cmd.model_dump(mode="json"))
 
     fake_executor = _FakeExecutor()
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
     monkeypatch.setattr(agent_mod, "STATE_DIR", tmp_path / "agent-state")
     agent = DeployAgent(skip_self_update=True)
     agent.job_store = store
     agent.executor = fake_executor  # type: ignore[assignment]
-    monkeypatch.setattr(agent_mod, "publish_result", lambda payload: False)
+    monkeypatch.setattr(agent_mod, "publish_result", lambda payload, config: False)
 
     await agent._run_deploy(cmd)
 
@@ -176,11 +177,12 @@ async def test_core_deploy_does_not_validate_runtime_llm_env(
     store.accept(cmd.correlation_id, cmd.model_dump(mode="json"))
 
     fake_executor = _FakeExecutor()
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
     monkeypatch.setattr(agent_mod, "STATE_DIR", tmp_path / "agent-state")
     agent = DeployAgent(skip_self_update=True)
     agent.job_store = store
     agent.executor = fake_executor  # type: ignore[assignment]
-    monkeypatch.setattr(agent_mod, "publish_result", lambda payload: False)
+    monkeypatch.setattr(agent_mod, "publish_result", lambda payload, config: False)
 
     await agent._run_deploy(cmd)
 
@@ -202,11 +204,12 @@ async def test_full_deploy_validates_llm_env_before_rebuild(
     store.accept(cmd.correlation_id, cmd.model_dump(mode="json"))
 
     fake_executor = _FakeExecutor()
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
     monkeypatch.setattr(agent_mod, "STATE_DIR", tmp_path / "agent-state")
     agent = DeployAgent(skip_self_update=True)
     agent.job_store = store
     agent.executor = fake_executor  # type: ignore[assignment]
-    monkeypatch.setattr(agent_mod, "publish_result", lambda payload: False)
+    monkeypatch.setattr(agent_mod, "publish_result", lambda payload, config: False)
 
     await agent._run_deploy(cmd)
 

--- a/scripts/deploy-agent/tests/unit/test_publisher_kafka_bus.py
+++ b/scripts/deploy-agent/tests/unit/test_publisher_kafka_bus.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Completion publishing must use the configured deploy-agent Kafka bus."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from deploy_agent.events import TOPIC_REBUILD_COMPLETED
+from deploy_agent.kafka_config import ModelDeployAgentKafkaConfig
+from deploy_agent.publisher import publish_result
+
+_TEST_PASSWORD = "test-sasl-secret"
+
+
+def test_publish_result_uses_configured_kafka_bus() -> None:
+    config = ModelDeployAgentKafkaConfig(
+        bootstrap_servers="pkc.example.confluent.cloud:9092",
+        security_protocol="SASL_SSL",
+        sasl_username="key",
+        sasl_password=_TEST_PASSWORD,
+    )
+    producer = MagicMock()
+
+    with patch("deploy_agent.publisher.KafkaProducer", return_value=producer) as ctor:
+        ok = publish_result({"correlation_id": "abc-123"}, config)
+
+    assert ok is True
+    ctor.assert_called_once()
+    kwargs = ctor.call_args.kwargs
+    assert kwargs["bootstrap_servers"] == "pkc.example.confluent.cloud:9092"
+    assert kwargs["security_protocol"] == "SASL_SSL"
+    assert kwargs["sasl_plain_username"] == "key"
+    assert kwargs["sasl_plain_password"] == _TEST_PASSWORD
+    producer.send.assert_called_once_with(
+        TOPIC_REBUILD_COMPLETED,
+        key="deploy-result/abc-123",
+        value={"correlation_id": "abc-123"},
+    )
+    producer.flush.assert_called_once_with(timeout=30)
+    producer.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add one typed deploy-agent Kafka config loaded from KAFKA_* env with no localhost fallback
- run deploy-agent code from the canonical repo copy instead of the stale standalone source directory
- route deploy command consumption, completion publishing, and rejected-message publishing through the same configured bus
- replace local Docker Redpanda/rpk completion publishing with kafka-python producer support for PLAINTEXT and SASL_SSL
- document the code fix and remaining post-merge .201 service env validation

## Verification
- cd scripts/deploy-agent && uv run --extra dev pytest tests/unit -q
- cd scripts/deploy-agent && uv run --extra dev pytest tests/unit/test_executor_self_update.py tests/unit/test_deploy_agent_service_source.py tests/unit/test_kafka_config.py tests/unit/test_publisher_kafka_bus.py -q
- cd scripts/deploy-agent && uv run ruff check deploy_agent/agent.py deploy_agent/consumer.py deploy_agent/publisher.py deploy_agent/kafka_config.py deploy_agent/executor.py tests/unit/test_kafka_config.py tests/unit/test_publisher_kafka_bus.py tests/unit/test_llm_endpoint_env_contract_guard.py tests/unit/test_executor_self_update.py tests/unit/test_deploy_agent_service_source.py
- git diff --check

## Change control
- Central OCC evidence: OmniNode-ai/onex_change_control#509
- Repo-local deploy contract: contracts/OMN-9713.yaml

## Runtime note
No live deploy, restart, or .201 mutation was performed. Post-merge validation should install/restart the deploy-agent service from scripts/deploy-agent/deploy/deploy-agent.service, confirm it runs with WorkingDirectory=/data/omninode/omnibase_infra/scripts/deploy-agent, and confirm logs use configured KAFKA_BOOTSTRAP_SERVERS rather than localhost:9092.
