### PR TITLE
fix(OMN-9727): check exact runtime consumer groups

### DIFF
--- a/contracts/OMN-9727.yaml
+++ b/contracts/OMN-9727.yaml
@@ -1,22 +1,53 @@
-version: 1
+# OMN-9727 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for runtime verification hardening.
+schema_version: '1.0.0'
 ticket_id: OMN-9727
-title: "Market node deployment runbook and runtime verification hardening"
-repo: omnibase_infra
-change_type: runtime_verification
-summary: >
-  Tighten runtime health consumer coverage so discovered auto-wired contracts are checked against the exact EventBusKafka consumer group IDs they should create, not broad topic substring matches.
-
-runtime_impact:
-  deploy_required: true
-  restart_required: true
-  services:
-    - omninode-runtime
-    - runtime-effects
-validation:
-  local:
-    - "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py -q"
-    - "uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py"
-post_merge:
-  - "Deploy runtime after merge."
-  - "Confirm runtime-health-check events report topic_coverage using exact expected consumer group coverage."
-  - "Diff rpk group list against at least one expected omnimarket auto-wired group ending in .__t.<topic>."
+summary: 'fix(OMN-9727): check exact runtime consumer groups'
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - events
+  - topics
+evidence_requirements:
+  - kind: tests
+    description: Unit tests cover exact runtime consumer group matching
+    command: uv run pytest tests/unit/services/test_service_runtime_health_monitor.py -q
+  - kind: tests
+    description: Integration test proves exact group coverage through run_once
+    command: uv run pytest tests/integration/test_runtime_health_monitor_exact_groups.py -q
+  - kind: ci
+    description: Runtime health monitor code passes ruff
+    command: uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py
+  - kind: manual
+    description: Post-merge deploy validates runtime health monitor output on .201
+    command: deploy omninode-runtime and runtime-effects, then verify runtime-health-check topic_coverage uses exact .__t.<topic> consumer groups
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Exact consumer group unit tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/services/test_service_runtime_health_monitor.py -q'
+  - id: dod-002
+    description: Exact consumer group integration test passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/test_runtime_health_monitor_exact_groups.py -q'
+  - id: dod-003
+    description: Runtime health monitor lint passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py'
+  - id: dod-004
+    description: Runtime deploy verifies exact consumer group topic coverage
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'deploy omninode-runtime and runtime-effects after merge; docker exec omnibase-infra-redpanda rpk group list; verify expected group IDs end with .__t.<topic>'

--- a/contracts/OMN-9727.yaml
+++ b/contracts/OMN-9727.yaml
@@ -1,0 +1,22 @@
+version: 1
+ticket_id: OMN-9727
+title: "Market node deployment runbook and runtime verification hardening"
+repo: omnibase_infra
+change_type: runtime_verification
+summary: >
+  Tighten runtime health consumer coverage so discovered auto-wired contracts are checked against the exact EventBusKafka consumer group IDs they should create, not broad topic substring matches.
+
+runtime_impact:
+  deploy_required: true
+  restart_required: true
+  services:
+    - omninode-runtime
+    - runtime-effects
+validation:
+  local:
+    - "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py -q"
+    - "uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py"
+post_merge:
+  - "Deploy runtime after merge."
+  - "Confirm runtime-health-check events report topic_coverage using exact expected consumer group coverage."
+  - "Diff rpk group list against at least one expected omnimarket auto-wired group ending in .__t.<topic>."

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -30,8 +30,10 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumConsumerGroupPurpose
 from omnibase_infra.enums.enum_infra_transport_type import EnumInfraTransportType
 from omnibase_infra.errors import InfraConnectionError, ModelInfraErrorContext
+from omnibase_infra.models import ModelNodeIdentity
 from omnibase_infra.models.health.model_runtime_health_check_event import (
     ModelRuntimeHealthCheckEvent,
 )
@@ -43,6 +45,10 @@ from omnibase_infra.protocols.protocol_auto_wiring_manifest_like import (
     ProtocolAutoWiringManifestLike,
 )
 from omnibase_infra.topics import topic_keys
+from omnibase_infra.utils import (
+    apply_instance_discriminator,
+    compute_consumer_group_id,
+)
 from omnibase_infra.utils.correlation import generate_correlation_id
 
 if TYPE_CHECKING:
@@ -68,6 +74,15 @@ class ConsumerGroupSnapshot(NamedTuple):
 
     group_id: str
     state: str
+
+
+class ExpectedConsumerGroup(NamedTuple):
+    """Expected per-topic consumer group derived from discovered contracts."""
+
+    topic: str
+    group_id: str
+    node_name: str
+    package_name: str
 
 
 def _consumer_group_state_name(state: object) -> str:
@@ -124,6 +139,63 @@ def _list_consumer_group_snapshots(
             )
         )
     return snapshots
+
+
+def _expected_consumer_groups_from_manifest(
+    manifest: ProtocolAutoWiringManifestLike, instance_id: str | None = None
+) -> list[ExpectedConsumerGroup]:
+    """Derive the exact Kafka group IDs runtime wiring should create.
+
+    Runtime auto-wiring subscribes each contract topic with a node identity based
+    group and ``EventBusKafka`` appends the per-topic ``.__t.<topic>`` suffix.
+    The health monitor must compare against that exact shape; topic substring
+    matching lets unrelated groups mask missing runtime consumers.
+    """
+    expected: list[ExpectedConsumerGroup] = []
+    contracts = getattr(manifest, "contracts", ())
+    for contract in contracts:
+        event_bus = getattr(contract, "event_bus", None)
+        if event_bus is None:
+            continue
+        topics = tuple(getattr(event_bus, "subscribe_topics", ()) or ())
+        if not topics:
+            continue
+
+        node_name = str(getattr(contract, "name", "unknown"))
+        package_name = str(getattr(contract, "package_name", "unknown"))
+        version = str(getattr(contract, "contract_version", "0.0.0"))
+        identity = ModelNodeIdentity(
+            env=os.environ.get("ONEX_ENVIRONMENT", "local"),
+            service=package_name,
+            node_name=node_name,
+            version=version,
+        )
+        base_group_id = compute_consumer_group_id(
+            identity, EnumConsumerGroupPurpose.CONSUME
+        )
+        discriminated_group_id = apply_instance_discriminator(
+            base_group_id, instance_id
+        )
+        for topic in topics:
+            topic_str = str(topic)
+            expected.append(
+                ExpectedConsumerGroup(
+                    topic=topic_str,
+                    group_id=f"{discriminated_group_id}.__t.{topic_str}",
+                    node_name=node_name,
+                    package_name=package_name,
+                )
+            )
+    return expected
+
+
+def _topic_is_covered_by_legacy_group(topic: str, group_id: str) -> bool:
+    """Best-effort coverage check for manifests without contract records."""
+    return (
+        f".__t.{topic}" in group_id
+        or f"-{topic}-" in group_id
+        or group_id.endswith(f"-{topic}")
+    )
 
 
 _HealthStatus = Literal["HEALTHY", "DEGRADED", "CRITICAL"]
@@ -249,11 +321,15 @@ class ServiceRuntimeHealthMonitor:
         contract_count = 0
         discovery_error_count = 0
         subscribe_topics: set[str] = set()
+        expected_groups: list[ExpectedConsumerGroup] = []
         try:
             manifest = _discover_contracts()
             contract_count = manifest.total_discovered
             discovery_error_count = manifest.total_errors
             subscribe_topics = set(manifest.all_subscribe_topics())
+            expected_groups = _expected_consumer_groups_from_manifest(
+                manifest, os.environ.get("KAFKA_INSTANCE_ID")
+            )
 
             if discovery_error_count > 0:
                 dimensions.append(
@@ -307,21 +383,32 @@ class ServiceRuntimeHealthMonitor:
                 empty_consumer_group_count = len(empty_groups)
 
                 # Check which subscribe topics have a matching non-empty group.
-                # ONEX consumer group IDs embed the full topic name surrounded by
-                # "-" delimiters or at end-of-string (e.g. "onex-consumer-<topic>").
-                # A raw substring check would false-positive on prefix collisions
-                # like "orders.v1" matching "orders.v10-extra". We require the
-                # topic to appear as a complete token bounded by "-" or string end.
                 non_empty_groups = set(all_group_ids) - empty_groups
-                uncovered: list[str] = []
-                for topic in sorted(subscribe_topics):
-                    covered = any(
-                        f"-{topic}-" in grp or grp.endswith(f"-{topic}")
-                        for grp in non_empty_groups
-                    )
-                    if not covered:
-                        uncovered.append(topic)
-                uncovered_topic_count = len(uncovered)
+                if expected_groups:
+                    missing_expected = [
+                        expected
+                        for expected in expected_groups
+                        if expected.group_id not in non_empty_groups
+                    ]
+                    uncovered_topic_count = len(missing_expected)
+                    uncovered_details = [
+                        f"{expected.topic} ({expected.node_name}: {expected.group_id})"
+                        for expected in missing_expected
+                    ]
+                else:
+                    # Test doubles and older manifest protocols may only expose
+                    # topic names. Keep a bounded fallback, but production
+                    # manifests use exact expected group IDs above.
+                    uncovered_topics: list[str] = []
+                    for topic in sorted(subscribe_topics):
+                        covered = any(
+                            _topic_is_covered_by_legacy_group(topic, group_id)
+                            for group_id in non_empty_groups
+                        )
+                        if not covered:
+                            uncovered_topics.append(topic)
+                    uncovered_topic_count = len(uncovered_topics)
+                    uncovered_details = uncovered_topics
 
                 if empty_consumer_group_count > 0:
                     dimensions.append(
@@ -344,9 +431,9 @@ class ServiceRuntimeHealthMonitor:
                     )
 
                 if uncovered_topic_count > 0:
-                    detail_topics = ", ".join(uncovered[:5])
-                    if len(uncovered) > 5:
-                        detail_topics += f" … +{len(uncovered) - 5} more"
+                    detail_topics = ", ".join(uncovered_details[:5])
+                    if len(uncovered_details) > 5:
+                        detail_topics += f" … +{len(uncovered_details) - 5} more"
                     dimensions.append(
                         ModelRuntimeHealthDimension(
                             name="topic_coverage",
@@ -360,11 +447,19 @@ class ServiceRuntimeHealthMonitor:
                         )
                     )
                 else:
+                    coverage_target_count = (
+                        len(expected_groups)
+                        if expected_groups
+                        else len(subscribe_topics)
+                    )
                     dimensions.append(
                         ModelRuntimeHealthDimension(
                             name="topic_coverage",
                             status="HEALTHY",
-                            detail=f"All {len(subscribe_topics)} subscribe topics covered",
+                            detail=(
+                                f"All {coverage_target_count} expected "
+                                "consumer group(s) covered"
+                            ),
                         )
                     )
 

--- a/tests/integration/test_runtime_health_monitor_exact_groups.py
+++ b/tests/integration/test_runtime_health_monitor_exact_groups.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime health exact consumer group matching."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+)
+from omnibase_infra.services.service_runtime_health_monitor import (
+    ConsumerGroupSnapshot,
+    ServiceRuntimeHealthMonitor,
+    _expected_consumer_groups_from_manifest,
+)
+
+
+def _contract() -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="node_session_orchestrator",
+        node_type="ORCHESTRATOR",
+        contract_version=ModelContractVersion(major=1, minor=2, patch=3),
+        contract_path=__file__,
+        entry_point_name="node_session_orchestrator",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=("onex.cmd.omnimarket.session-orchestrator-start.v1",),
+            publish_topics=(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_requires_exact_event_bus_consumer_group() -> None:
+    """Topic-shaped but wrong groups must not satisfy runtime coverage."""
+    manifest = ModelAutoWiringManifest(contracts=(_contract(),), errors=())
+    expected = _expected_consumer_groups_from_manifest(manifest)[0]
+    wrong_topic_shaped_group = f"wrong-prefix.__t.{expected.topic}"
+    monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="redpanda:9092")
+
+    with (
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ),
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+            return_value=[
+                ConsumerGroupSnapshot(
+                    group_id=wrong_topic_shaped_group,
+                    state="STABLE",
+                ),
+            ],
+        ),
+    ):
+        event = await monitor.run_once()
+
+    assert event.uncovered_topic_count == 1
+    assert event.status == "DEGRADED"
+    topic_coverage = next(d for d in event.dimensions if d.name == "topic_coverage")
+    assert expected.group_id in topic_coverage.detail
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_accepts_exact_event_bus_consumer_group() -> None:
+    """The exact EventBusKafka group ID satisfies runtime topic coverage."""
+    manifest = ModelAutoWiringManifest(contracts=(_contract(),), errors=())
+    expected = _expected_consumer_groups_from_manifest(manifest)[0]
+    monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="redpanda:9092")
+
+    with (
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ),
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+            return_value=[
+                ConsumerGroupSnapshot(group_id=expected.group_id, state="STABLE"),
+            ],
+        ),
+    ):
+        event = await monitor.run_once()
+
+    assert event.uncovered_topic_count == 0
+    assert event.status == "HEALTHY"

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -29,9 +29,16 @@ from omnibase_infra.models.health.model_runtime_health_check_event import (
 from omnibase_infra.models.health.model_runtime_health_dimension import (
     ModelRuntimeHealthDimension,
 )
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+)
 from omnibase_infra.services.service_runtime_health_monitor import (
     ConsumerGroupSnapshot,
     ServiceRuntimeHealthMonitor,
+    _expected_consumer_groups_from_manifest,
     _worst,
 )
 from omnibase_infra.topics import topic_keys
@@ -49,6 +56,23 @@ def _make_manifest(contracts=5, errors=0, subscribe_topics=()):
     m.total_errors = errors
     m.all_subscribe_topics.return_value = subscribe_topics
     return m
+
+
+def _make_discovered_contract(
+    *,
+    name: str = "node_contract_sweep",
+    package_name: str = "omnimarket",
+    topic: str = "onex.cmd.omnimarket.contract-sweep-start.v1",
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR",
+        contract_version=ModelContractVersion(major=1, minor=2, patch=3),
+        contract_path=__file__,
+        entry_point_name=name,
+        package_name=package_name,
+        event_bus=ModelEventBusWiring(subscribe_topics=(topic,), publish_topics=()),
+    )
 
 
 # =============================================================================
@@ -267,6 +291,65 @@ class TestRunOnceWithKafka:
         assert event.status == "DEGRADED"
         degraded_dims = [d for d in event.dimensions if d.status == "DEGRADED"]
         assert any(d.name == "consumer_coverage" for d in degraded_dims)
+
+    @pytest.mark.asyncio
+    async def test_exact_expected_group_id_required_for_discovered_contracts(self):
+        contract = _make_discovered_contract()
+        manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+        expected = _expected_consumer_groups_from_manifest(manifest)[0]
+        snapshots = self._mock_admin(
+            [
+                # Contains the topic, but is not the group ID EventBusKafka
+                # actually creates for auto-wired runtime subscriptions.
+                f"wrong-prefix.__t.{contract.event_bus.subscribe_topics[0]}",
+                expected.group_id,
+            ],
+            empty_groups=set(),
+        )
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="localhost:9092")
+
+        with (
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+                return_value=snapshots,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.uncovered_topic_count == 0
+        assert event.status == "HEALTHY"
+
+    @pytest.mark.asyncio
+    async def test_missing_exact_expected_group_reports_node_and_group(self):
+        contract = _make_discovered_contract(name="node_session_orchestrator")
+        manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+        topic = contract.event_bus.subscribe_topics[0]
+        snapshots = self._mock_admin([f"wrong-prefix.__t.{topic}"], empty_groups=set())
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="localhost:9092")
+
+        with (
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+                return_value=snapshots,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.uncovered_topic_count == 1
+        degraded_dims = [d for d in event.dimensions if d.name == "topic_coverage"]
+        assert degraded_dims
+        assert "node_session_orchestrator" in degraded_dims[0].detail
+        assert "local.omnimarket.node_session_orchestrator.consume.1.2.3" in (
+            degraded_dims[0].detail
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- derive exact expected EventBusKafka consumer group IDs from discovered runtime contracts
- require runtime health topic coverage to match those exact groups instead of topic substring matches
- retain a fallback for older/test manifests that expose topics only
- add regression tests for exact expected group matching and diagnostic missing-group detail

## Verification
- uv run pytest tests/unit/services/test_service_runtime_health_monitor.py -q
- uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py

## Change control
- Central OCC evidence: OmniNode-ai/onex_change_control#510
- Repo-local deploy contract: contracts/OMN-9727.yaml

## Runtime note
No live deploy, restart, or .201 mutation was performed. Post-merge validation should deploy runtime and compare runtime-health-check topic_coverage against rpk group list entries ending in .__t.<topic>.
