### PR TITLE
feat(OMN-9471): add runtime build source selector

### DIFF
--- a/contracts/OMN-9471.yaml
+++ b/contracts/OMN-9471.yaml
@@ -3,13 +3,13 @@
 # contract carries deploy-gate evidence for runtime build-source selector work.
 schema_version: "1.0.0"
 ticket_id: "OMN-9471"
+title: "Define the canonical runtime build-source selector"
 summary: "feat(OMN-9471): add runtime BUILD_SOURCE selector contract"
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
-  - deploy-agent-command
-  - docker-compose-runtime-build
-  - runtime-image-provenance
+  - events
+  - public_api
 evidence_requirements:
   - kind: tests
     description: Deploy-agent validates and forwards the runtime build-source selector

--- a/contracts/OMN-9471.yaml
+++ b/contracts/OMN-9471.yaml
@@ -1,0 +1,45 @@
+# OMN-9471 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for runtime build-source selector work.
+schema_version: "1.0.0"
+ticket_id: "OMN-9471"
+summary: "feat(OMN-9471): add runtime BUILD_SOURCE selector contract"
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - deploy-agent-command
+  - docker-compose-runtime-build
+  - runtime-image-provenance
+evidence_requirements:
+  - kind: tests
+    description: Deploy-agent validates and forwards the runtime build-source selector
+    command: uv run --project scripts/deploy-agent pytest scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py -q
+  - kind: ci
+    description: Deploy-agent build-source files pass ruff
+    command: uv run --project scripts/deploy-agent ruff check scripts/deploy-agent/deploy_agent/events.py scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/deploy_agent/agent.py scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py
+  - kind: manual
+    description: Post-merge deploy validation confirms runtime containers expose BUILD_SOURCE
+    command: deploy omninode-runtime and runtime-effects after merge, then verify docker inspect environment contains BUILD_SOURCE=release or BUILD_SOURCE=workspace as requested
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: Deploy-agent selector validation and forwarding tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "uv run --project scripts/deploy-agent pytest scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py -q"
+  - id: dod-002
+    description: Deploy-agent build-source files pass ruff
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "uv run --project scripts/deploy-agent ruff check scripts/deploy-agent/deploy_agent/events.py scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/deploy_agent/agent.py scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py"
+  - id: dod-003
+    description: Runtime image build-source selector is deploy-validated after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy omninode-runtime and runtime-effects after merge; docker inspect omninode-runtime omninode-runtime-effects and verify BUILD_SOURCE matches the requested mode"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -89,6 +89,24 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-bin
 # ============================================================================
 FROM python:${PYTHON_VERSION}-slim AS builder
 
+ARG BUILD_SOURCE=release
+ARG EXPECTED_BUILD_SOURCE=release
+ARG OMNI_HOME=""
+
+RUN set -eu; \
+    case "${BUILD_SOURCE}" in \
+      workspace|release) ;; \
+      *) echo "Invalid BUILD_SOURCE='${BUILD_SOURCE}'; expected workspace or release" >&2; exit 64 ;; \
+    esac; \
+    if [ "${BUILD_SOURCE}" != "${EXPECTED_BUILD_SOURCE}" ]; then \
+      echo "BUILD_SOURCE selector mismatch: BUILD_SOURCE='${BUILD_SOURCE}' EXPECTED_BUILD_SOURCE='${EXPECTED_BUILD_SOURCE}'" >&2; \
+      exit 64; \
+    fi; \
+    if [ "${BUILD_SOURCE}" = "workspace" ] && [ -z "${OMNI_HOME}" ]; then \
+      echo "BUILD_SOURCE=workspace requires OMNI_HOME" >&2; \
+      exit 64; \
+    fi
+
 # Build-time environment configuration
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -276,12 +294,29 @@ FROM python:${PYTHON_VERSION}-slim AS runtime
 ARG RUNTIME_VERSION=0.1.0
 ARG BUILD_DATE
 ARG VCS_REF
+ARG BUILD_SOURCE=release
+ARG EXPECTED_BUILD_SOURCE=release
+ARG OMNI_HOME=""
 # Source hash from the repo being deployed (short git SHA from the build context).
 # Default "unknown" ensures manual `docker compose up` without the arg still works.
 ARG RUNTIME_SOURCE_HASH=unknown
 # Docker Compose project name used for this deployment.
 # Lets operators confirm the container belongs to the expected compose stack.
 ARG COMPOSE_PROJECT=unknown
+
+RUN set -eu; \
+    case "${BUILD_SOURCE}" in \
+      workspace|release) ;; \
+      *) echo "Invalid BUILD_SOURCE='${BUILD_SOURCE}'; expected workspace or release" >&2; exit 64 ;; \
+    esac; \
+    if [ "${BUILD_SOURCE}" != "${EXPECTED_BUILD_SOURCE}" ]; then \
+      echo "BUILD_SOURCE selector mismatch: BUILD_SOURCE='${BUILD_SOURCE}' EXPECTED_BUILD_SOURCE='${EXPECTED_BUILD_SOURCE}'" >&2; \
+      exit 64; \
+    fi; \
+    if [ "${BUILD_SOURCE}" = "workspace" ] && [ -z "${OMNI_HOME}" ]; then \
+      echo "BUILD_SOURCE=workspace requires OMNI_HOME" >&2; \
+      exit 64; \
+    fi
 
 # OCI Image Labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
 LABEL org.opencontainers.image.title="OmniBase Infra Runtime" \
@@ -292,7 +327,8 @@ LABEL org.opencontainers.image.title="OmniBase Infra Runtime" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.version="${RUNTIME_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
-      org.opencontainers.image.revision="${VCS_REF}"
+      org.opencontainers.image.revision="${VCS_REF}" \
+      com.omninode.build_source="${BUILD_SOURCE}"
 
 # Runtime environment configuration
 ENV PYTHONUNBUFFERED=1 \
@@ -317,7 +353,8 @@ ENV PYTHONUNBUFFERED=1 \
 # Read by entrypoint-runtime.sh to emit the startup banner.
 # Operators can verify which code is running via: docker logs <container> | head -10
 ENV RUNTIME_SOURCE_HASH=${RUNTIME_SOURCE_HASH} \
-    COMPOSE_PROJECT=${COMPOSE_PROJECT}
+    COMPOSE_PROJECT=${COMPOSE_PROJECT} \
+    BUILD_SOURCE=${BUILD_SOURCE}
 
 # Install minimal runtime dependencies only
 # No build tools needed - all Python packages are pre-compiled in builder stage.

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -110,6 +110,10 @@ x-runtime-base: &runtime-base
   build:
     context: ..
     dockerfile: docker/Dockerfile.runtime
+    args:
+      BUILD_SOURCE: "${BUILD_SOURCE:-release}"
+      EXPECTED_BUILD_SOURCE: "${EXPECTED_BUILD_SOURCE:-${BUILD_SOURCE:-release}}"
+      OMNI_HOME: "${OMNI_HOME:-}"
   networks:
     - omnibase-infra-network
   logging: *logging-defaults

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -112,8 +112,7 @@ x-runtime-base: &runtime-base
     dockerfile: docker/Dockerfile.runtime
     args:
       BUILD_SOURCE: "${BUILD_SOURCE:-release}"
-      EXPECTED_BUILD_SOURCE: "${EXPECTED_BUILD_SOURCE:-${BUILD_SOURCE:-release}}"
-      OMNI_HOME: "${OMNI_HOME:-}"
+      EXPECTED_BUILD_SOURCE: "${EXPECTED_BUILD_SOURCE:-release}"
   networks:
     - omnibase-infra-network
   logging: *logging-defaults

--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -197,6 +197,7 @@ class DeployAgent:
                 cmd.services,
                 on_phase_update=on_phase_update,
                 git_sha=self._current_git_sha,
+                build_source=cmd.build_source,
                 skip_self_update=self._skip_self_update,
             )
 

--- a/scripts/deploy-agent/deploy_agent/events.py
+++ b/scripts/deploy-agent/deploy_agent/events.py
@@ -26,6 +26,11 @@ class Scope(StrEnum):
     CORE = "core"
 
 
+class BuildSource(StrEnum):
+    WORKSPACE = "workspace"
+    RELEASE = "release"
+
+
 class Phase(StrEnum):
     PREFLIGHT = "preflight"
     GIT = "git"
@@ -82,6 +87,7 @@ class ModelRebuildRequested(BaseModel):
     correlation_id: UUID
     requested_by: str
     scope: Scope
+    build_source: BuildSource = BuildSource.RELEASE
     services: list[str] = Field(default_factory=list)
     git_ref: str = "origin/main"
 

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -10,10 +10,11 @@ import os
 import subprocess
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 from deploy_agent.events import (
+    BuildSource,
     ModelHealthCheck,
     Phase,
     PhaseStatus,
@@ -52,6 +53,8 @@ RUNTIME_HEALTH_TARGETS: tuple[tuple[str, int], ...] = (
     ("runtime-effects", 8086),
 )
 
+_BUILD_SOURCE_ALLOWED = ", ".join(source.value for source in BuildSource)
+
 
 def _requested_services_for_up(scope: Scope, services: list[str]) -> list[str]:
     """Return the explicit service list compose should recreate for this scope.
@@ -74,6 +77,49 @@ def _requested_services_for_up(scope: Scope, services: list[str]) -> list[str]:
     if scope == Scope.RUNTIME:
         return services_for_scope(scope)
     return []
+
+
+def _coerce_build_source(value: BuildSource | str, *, layer: str) -> BuildSource:
+    try:
+        return BuildSource(value)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Invalid {layer} BUILD_SOURCE={value!r}; expected one of: {_BUILD_SOURCE_ALLOWED}"
+        ) from exc
+
+
+def _build_source_build_args(
+    build_source: BuildSource | str,
+    *,
+    expected_build_source: BuildSource | str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return validated immutable build-source args for docker compose build."""
+    selected = _coerce_build_source(build_source, layer="deploy-agent")
+    expected = _coerce_build_source(
+        selected if expected_build_source is None else expected_build_source,
+        layer="expected",
+    )
+    if selected != expected:
+        raise RuntimeError(
+            "BUILD_SOURCE selector disagreement: "
+            f"deploy-agent selected {selected.value!r}, "
+            f"Dockerfile expected {expected.value!r}"
+        )
+
+    source_env = os.environ if env is None else env
+    omni_home = source_env.get("OMNI_HOME", "").strip()
+    if selected == BuildSource.WORKSPACE and not omni_home:
+        raise RuntimeError("BUILD_SOURCE=workspace requires OMNI_HOME before build")
+
+    return [
+        "--build-arg",
+        f"BUILD_SOURCE={selected.value}",
+        "--build-arg",
+        f"EXPECTED_BUILD_SOURCE={expected.value}",
+        "--build-arg",
+        f"OMNI_HOME={omni_home}",
+    ]
 
 
 def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
@@ -481,6 +527,7 @@ class DeployExecutor:
         on_phase_update: PhaseCallback,
         *,
         git_sha: str = "",
+        build_source: BuildSource | str = BuildSource.RELEASE,
         skip_self_update: bool = False,
     ) -> list[str]:
         self.self_update(skip=skip_self_update)
@@ -489,13 +536,17 @@ class DeployExecutor:
             # Build images first (both scopes), then bring them up.
             # _compose_build passes --build-arg GIT_SHA so Docker invalidates
             # the COPY src/ layer even when the file-system mtime is cached.
-            self._compose_build(Scope.CORE, git_sha, on_phase_update)
-            self._compose_build(Scope.RUNTIME, git_sha, on_phase_update)
+            self._compose_build(
+                Scope.CORE, git_sha, on_phase_update, build_source=build_source
+            )
+            self._compose_build(
+                Scope.RUNTIME, git_sha, on_phase_update, build_source=build_source
+            )
             self._compose_up(Phase.CORE, Scope.CORE, [], on_phase_update)
             self._compose_up(Phase.RUNTIME, Scope.RUNTIME, [], on_phase_update)
             return services_for_scope(Scope.FULL)
 
-        self._compose_build(scope, git_sha, on_phase_update)
+        self._compose_build(scope, git_sha, on_phase_update, build_source=build_source)
         self._compose_up(phase, scope, services, on_phase_update)
         return services if services else services_for_scope(scope)
 
@@ -504,6 +555,9 @@ class DeployExecutor:
         scope: Scope,
         git_sha: str,
         on_phase_update: PhaseCallback,
+        *,
+        build_source: BuildSource | str = BuildSource.RELEASE,
+        expected_build_source: BuildSource | str | None = None,
     ) -> None:
         """Build images with --build-arg GIT_SHA to bust the COPY src/ layer cache.
 
@@ -527,6 +581,12 @@ class DeployExecutor:
             "--build-arg",
             f"GIT_SHA={git_sha}",
         ]
+        cmd.extend(
+            _build_source_build_args(
+                build_source,
+                expected_build_source=expected_build_source,
+            )
+        )
         result = _run(cmd, timeout=timeout)
         if result.returncode != 0:
             raise RuntimeError(f"Docker compose build failed: {result.stderr}")

--- a/scripts/deploy-agent/tests/unit/test_executor_build_source.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_build_source.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""BUILD_SOURCE selector contract tests for deploy-agent builds."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import yaml
+from deploy_agent.events import (
+    BuildSource,
+    ModelRebuildRequested,
+    Phase,
+    PhaseStatus,
+    Scope,
+)
+from deploy_agent.executor import DeployExecutor
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
+    pass
+
+
+def _ok() -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def test_rebuild_request_accepts_canonical_build_source() -> None:
+    cmd = ModelRebuildRequested(
+        correlation_id=uuid4(),
+        requested_by="test",
+        scope=Scope.RUNTIME,
+        build_source="workspace",
+    )
+
+    assert cmd.build_source == BuildSource.WORKSPACE
+
+
+def test_rebuild_request_rejects_unknown_build_source() -> None:
+    with pytest.raises(ValidationError, match="build_source"):
+        ModelRebuildRequested(
+            correlation_id=uuid4(),
+            requested_by="test",
+            scope=Scope.RUNTIME,
+            build_source="local",  # type: ignore[arg-type]
+        )
+
+
+def test_compose_build_passes_build_source_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMNI_HOME", "/data/omninode/omni_home")
+    executor = DeployExecutor()
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        captured_cmds.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+
+    executor._compose_build(
+        Scope.RUNTIME,
+        "abc1234",
+        _noop_phase_update,
+        build_source=BuildSource.WORKSPACE,
+    )
+
+    build_cmd = captured_cmds[0]
+    assert "--build-arg" in build_cmd
+    assert "BUILD_SOURCE=workspace" in build_cmd
+    assert "EXPECTED_BUILD_SOURCE=workspace" in build_cmd
+    assert "OMNI_HOME=/data/omninode/omni_home" in build_cmd
+
+
+def test_unknown_build_source_fails_before_compose_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = DeployExecutor()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Invalid deploy-agent BUILD_SOURCE"):
+        executor._compose_build(
+            Scope.RUNTIME,
+            "abc1234",
+            _noop_phase_update,
+            build_source="local",
+        )
+
+    assert calls == []
+
+
+def test_selector_disagreement_fails_before_compose_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = DeployExecutor()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+
+    with pytest.raises(RuntimeError, match="selector disagreement"):
+        executor._compose_build(
+            Scope.RUNTIME,
+            "abc1234",
+            _noop_phase_update,
+            build_source=BuildSource.WORKSPACE,
+            expected_build_source=BuildSource.RELEASE,
+        )
+
+    assert calls == []
+
+
+def test_workspace_build_requires_omni_home_before_compose_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OMNI_HOME", raising=False)
+    executor = DeployExecutor()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+
+    with pytest.raises(RuntimeError, match="BUILD_SOURCE=workspace requires OMNI_HOME"):
+        executor._compose_build(
+            Scope.RUNTIME,
+            "abc1234",
+            _noop_phase_update,
+            build_source=BuildSource.WORKSPACE,
+        )
+
+    assert calls == []
+
+
+def test_runtime_compose_passes_build_source_args() -> None:
+    compose_path = REPO_ROOT / "docker/docker-compose.infra.yml"
+    compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    build_args = compose["x-runtime-base"]["build"]["args"]
+
+    assert build_args["BUILD_SOURCE"] == "${BUILD_SOURCE:-release}"
+    assert (
+        build_args["EXPECTED_BUILD_SOURCE"]
+        == "${EXPECTED_BUILD_SOURCE:-${BUILD_SOURCE:-release}}"
+    )
+    assert build_args["OMNI_HOME"] == "${OMNI_HOME:-}"
+
+
+def test_runtime_dockerfile_validates_and_stamps_build_source() -> None:
+    dockerfile = (REPO_ROOT / "docker/Dockerfile.runtime").read_text(encoding="utf-8")
+
+    assert "ARG BUILD_SOURCE=release" in dockerfile
+    assert "ARG EXPECTED_BUILD_SOURCE=release" in dockerfile
+    assert "Invalid BUILD_SOURCE=" in dockerfile
+    assert "BUILD_SOURCE selector mismatch" in dockerfile
+    assert "BUILD_SOURCE=workspace requires OMNI_HOME" in dockerfile
+    assert 'com.omninode.build_source="${BUILD_SOURCE}"' in dockerfile
+    assert "BUILD_SOURCE=${BUILD_SOURCE}" in dockerfile

--- a/scripts/deploy-agent/tests/unit/test_executor_build_source.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_build_source.py
@@ -21,6 +21,7 @@ from deploy_agent.executor import DeployExecutor
 from pydantic import ValidationError
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
+pytestmark = pytest.mark.unit
 
 
 def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
@@ -156,11 +157,8 @@ def test_runtime_compose_passes_build_source_args() -> None:
     build_args = compose["x-runtime-base"]["build"]["args"]
 
     assert build_args["BUILD_SOURCE"] == "${BUILD_SOURCE:-release}"
-    assert (
-        build_args["EXPECTED_BUILD_SOURCE"]
-        == "${EXPECTED_BUILD_SOURCE:-${BUILD_SOURCE:-release}}"
-    )
-    assert build_args["OMNI_HOME"] == "${OMNI_HOME:-}"
+    assert build_args["EXPECTED_BUILD_SOURCE"] == "${EXPECTED_BUILD_SOURCE:-release}"
+    assert "OMNI_HOME" not in build_args
 
 
 def test_runtime_dockerfile_validates_and_stamps_build_source() -> None:

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -61,7 +61,7 @@ class TestCacheBust:
         git_sha = "abc1234def56"
         call_order: list[str] = []
 
-        def fake_build(scope: Scope, sha: str, cb) -> None:
+        def fake_build(scope: Scope, sha: str, cb, **kwargs) -> None:
             call_order.append("build")
 
         def fake_up(phase: Phase, scope: Scope, services: list[str], cb) -> None:
@@ -72,9 +72,10 @@ class TestCacheBust:
 
         executor.rebuild_scope(Scope.RUNTIME, [], _noop_phase_update, git_sha=git_sha)
 
-        assert call_order == ["build", "up"], (
-            f"_compose_build must precede _compose_up, got order: {call_order}"
-        )
+        assert call_order == [
+            "build",
+            "up",
+        ], f"_compose_build must precede _compose_up, got order: {call_order}"
 
     def test_compose_build_called_for_full_scope(self) -> None:
         """Full scope rebuild must call _compose_build for both core and runtime."""
@@ -82,7 +83,7 @@ class TestCacheBust:
         git_sha = "abc1234def56"
         build_scopes: list[Scope] = []
 
-        def fake_build(scope: Scope, sha: str, cb) -> None:
+        def fake_build(scope: Scope, sha: str, cb, **kwargs) -> None:
             build_scopes.append(scope)
 
         def fake_up(phase: Phase, scope: Scope, services: list[str], cb) -> None:
@@ -101,7 +102,7 @@ class TestCacheBust:
         executor = DeployExecutor()
         git_sha_seen_in_build: list[str] = []
 
-        def fake_build(scope: Scope, sha: str, cb) -> None:
+        def fake_build(scope: Scope, sha: str, cb, **kwargs) -> None:
             git_sha_seen_in_build.append(sha)
 
         def fake_up(phase: Phase, scope: Scope, services: list[str], cb) -> None:

--- a/scripts/deploy-agent/tests/unit/test_executor_self_update.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_self_update.py
@@ -175,7 +175,7 @@ class TestSelfUpdateWiredIntoRebuildScope:
         def fake_self_update(*, skip: bool = False) -> None:
             call_order.append("self_update")
 
-        def fake_build(scope: Scope, sha: str, cb) -> None:
+        def fake_build(scope: Scope, sha: str, cb, **kwargs) -> None:
             call_order.append("build")
 
         def fake_up(phase: Phase, scope: Scope, services: list[str], cb) -> None:
@@ -200,7 +200,7 @@ class TestSelfUpdateWiredIntoRebuildScope:
         def fake_self_update(*, skip: bool = False) -> None:
             received_skip.append(skip)
 
-        def fake_build(scope, sha, cb) -> None:
+        def fake_build(scope, sha, cb, **kwargs) -> None:
             pass
 
         def fake_up(phase, scope, services, cb) -> None:


### PR DESCRIPTION
## Summary
- Adds a typed deploy-agent `BuildSource` selector with canonical `workspace` and `release` values.
- Forwards `build_source` from rebuild commands into compose builds and fails closed on invalid selector, selector mismatch, or workspace mode without `OMNI_HOME`.
- Passes `BUILD_SOURCE`, `EXPECTED_BUILD_SOURCE`, and `OMNI_HOME` into the runtime image build and stamps `BUILD_SOURCE` into runtime labels/env for post-build provenance checks.
- Adds repo-local `contracts/OMN-9471.yaml` for deploy-gate evidence.

## Verification
- `uv run --project scripts/deploy-agent pytest scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py -q` -> 23 passed
- `uv run ruff format --check scripts/deploy-agent/deploy_agent/events.py scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/deploy_agent/agent.py scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py` -> passed
- `uv run ruff check scripts/deploy-agent/deploy_agent/events.py scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/deploy_agent/agent.py scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_self_update.py` -> passed
- `ruby -e 'require "yaml"; YAML.load_file("contracts/OMN-9471.yaml"); puts "yaml ok"'` -> yaml ok
- `git diff --cached --check` before commit -> passed
- Commit hooks -> passed

## Notes
- `docker build --check ...` could not be run locally because the `docker` command is not installed on this machine.
- No deploy, restart, or `.201` mutation was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deploy-gate contract for build-source validation and required evidence for merge.
  * Enforced build-source selection (workspace vs release) with OMNI_HOME required for workspace; compose defaults applied.
  * Runtime images now surface build-source via OCI label and runtime env; deploy flow forwards build-source end-to-end.

* **Tests**
  * Added unit tests covering build-source selection, validation/error paths, compose/Dockerfile build-arg behavior; updated test doubles to accept extra kwargs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->