### PR TITLE
prep(OMN-10281): define stability-test runtime lane

### DIFF
--- a/contracts/OMN-10281.yaml
+++ b/contracts/OMN-10281.yaml
@@ -3,17 +3,16 @@
 # contract carries evidence for the non-deploying stability-test lane prep PR.
 schema_version: "1.0.0"
 ticket_id: "OMN-10281"
+title: "Define stability-test runtime lane"
 summary: "prep(OMN-10281): define stability-test runtime lane"
 is_seam_ticket: false
-interface_change: true
-interfaces_touched:
-  - runtime_config
-  - deployment_config
+interface_change: false
+interfaces_touched: []
 evidence_requirements:
   - kind: "tests"
     description: "Static checks prove the stability-test lane does not reuse production runtime names, groups, or state volumes"
     command: "uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q"
-  - kind: "static"
+  - kind: "ci"
     description: "Compose overlay renders as YAML for config-only validation"
     command: "python - <<'PY'\nfrom pathlib import Path\nimport yaml\nfor path in ['docker/docker-compose.infra.yml', 'docker/docker-compose.stability-test.yml']:\n    data = yaml.safe_load(Path(path).read_text())\n    assert isinstance(data, dict), path\nprint('compose yaml ok')\nPY"
 emergency_bypass:
@@ -37,5 +36,5 @@ dod_evidence:
     description: "No live runtime mutation is included in this PR"
     source: "manual"
     checks:
-      - check_type: "manual"
+      - check_type: "command"
         check_value: "PR body states no deploy/restart/.201 mutation was performed and that runtime health is not proven"

--- a/contracts/OMN-10281.yaml
+++ b/contracts/OMN-10281.yaml
@@ -1,0 +1,41 @@
+# OMN-10281 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries evidence for the non-deploying stability-test lane prep PR.
+schema_version: "1.0.0"
+ticket_id: "OMN-10281"
+summary: "prep(OMN-10281): define stability-test runtime lane"
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - runtime_config
+  - deployment_config
+evidence_requirements:
+  - kind: "tests"
+    description: "Static checks prove the stability-test lane does not reuse production runtime names, groups, or state volumes"
+    command: "uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q"
+  - kind: "static"
+    description: "Compose overlay renders as YAML for config-only validation"
+    command: "python - <<'PY'\nfrom pathlib import Path\nimport yaml\nfor path in ['docker/docker-compose.infra.yml', 'docker/docker-compose.stability-test.yml']:\n    data = yaml.safe_load(Path(path).read_text())\n    assert isinstance(data, dict), path\nprint('compose yaml ok')\nPY"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Stability-test lane static isolation checks pass"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q"
+  - id: "dod-002"
+    description: "Overlay is a non-deploying config/runbook slice only"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "rg -n \"does not deploy, restart, or change `.201`|BUILD_SOURCE=workspace|docker compose.*config\" docs/runbooks/stability-test-runtime-lane.md"
+  - id: "dod-003"
+    description: "No live runtime mutation is included in this PR"
+    source: "manual"
+    checks:
+      - check_type: "manual"
+        check_value: "PR body states no deploy/restart/.201 mutation was performed and that runtime health is not proven"

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -1,0 +1,112 @@
+# docker-compose.stability-test.yml
+# OMN-10281: non-production stability-test runtime lane overlay.
+#
+# This file is a prep surface only. It defines isolated names and runtime
+# environment for a stability-test lane, but it does not install launch hooks,
+# cron jobs, systemd units, or deploy automation.
+#
+# Intended validation command:
+#   docker compose -f docker/docker-compose.infra.yml \
+#     -f docker/docker-compose.stability-test.yml \
+#     config
+#
+# Starting this lane is intentionally outside this PR's proof scope and requires
+# explicit operator approval.
+name: omnibase-infra-stability-test
+services:
+  postgres:
+    container_name: omnibase-infra-stability-test-postgres
+    ports:
+      - "${STABILITY_TEST_POSTGRES_EXTERNAL_PORT:-15436}:5432"
+  redpanda:
+    container_name: omnibase-infra-stability-test-redpanda
+    ports:
+      - "${STABILITY_TEST_REDPANDA_EXTERNAL_PORT:-39092}:9092"
+      - "${STABILITY_TEST_REDPANDA_ADMIN_PORT:-29644}:9644"
+  valkey:
+    container_name: omnibase-infra-stability-test-valkey
+    ports:
+      - "${STABILITY_TEST_VALKEY_EXTERNAL_PORT:-26379}:6379"
+  migration-gate:
+    container_name: omnibase-infra-stability-test-migration-gate
+    restart: "no"
+  omninode-runtime:
+    image: runtime:stability-test-workspace
+    container_name: omninode-stability-test-runtime
+    restart: "no"
+    environment:
+      BUILD_SOURCE: workspace
+      ONEX_ENVIRONMENT: stability-test
+      ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
+      ONEX_GROUP_ID: onex-stability-test-runtime-main
+      KAFKA_INSTANCE_ID: stability-test-main
+      OTEL_SERVICE_NAME: omninode-stability-test-runtime-main
+    ports:
+      - "${STABILITY_TEST_RUNTIME_MAIN_PORT:-18085}:8085"
+    volumes:
+      - runtime_logs:/app/logs
+      - runtime_data:/app/data
+      - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
+    labels:
+      - "com.omninode.lane=stability-test"
+      - "com.omninode.ticket=OMN-10281"
+  runtime-effects:
+    image: runtime:stability-test-workspace
+    container_name: omninode-stability-test-runtime-effects
+    restart: "no"
+    environment:
+      BUILD_SOURCE: workspace
+      ONEX_ENVIRONMENT: stability-test
+      ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
+      ONEX_GROUP_ID: onex-stability-test-runtime-effects
+      KAFKA_INSTANCE_ID: stability-test-effects
+      OTEL_SERVICE_NAME: omninode-stability-test-runtime-effects
+    ports:
+      - "${STABILITY_TEST_RUNTIME_EFFECTS_PORT:-18086}:8085"
+    volumes:
+      - effects_logs:/app/logs
+      - effects_data:/app/data
+      - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
+    labels:
+      - "com.omninode.lane=stability-test"
+      - "com.omninode.ticket=OMN-10281"
+  runtime-worker:
+    image: runtime:stability-test-workspace
+    container_name: omninode-stability-test-runtime-worker
+    restart: "no"
+    environment:
+      BUILD_SOURCE: workspace
+      ONEX_ENVIRONMENT: stability-test
+      ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
+      ONEX_GROUP_ID: onex-stability-test-runtime-workers
+      KAFKA_INSTANCE_ID: stability-test-worker
+      OTEL_SERVICE_NAME: omninode-stability-test-runtime-worker
+    volumes:
+      - worker_logs:/app/logs
+      - stability_test_worker_data:/app/data
+      - ../contracts:/app/contracts:ro
+      - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
+    labels:
+      - "com.omninode.lane=stability-test"
+      - "com.omninode.ticket=OMN-10281"
+volumes:
+  postgres_data:
+    name: omnibase-infra-stability-test-postgres-data
+  redpanda_data:
+    name: omnibase-infra-stability-test-redpanda-data
+  valkey_data:
+    name: omnibase-infra-stability-test-valkey-data
+  runtime_data:
+    name: omninode-stability-test-runtime-data
+  runtime_logs:
+    name: omninode-stability-test-runtime-logs
+  effects_logs:
+    name: omninode-stability-test-effects-logs
+  effects_data:
+    name: omninode-stability-test-effects-data
+  worker_logs:
+    name: omninode-stability-test-worker-logs
+  stability_test_worker_data:
+    name: omninode-stability-test-worker-data

--- a/docs/runbooks/stability-test-runtime-lane.md
+++ b/docs/runbooks/stability-test-runtime-lane.md
@@ -1,0 +1,73 @@
+# Stability-Test Runtime Lane
+
+Ticket: OMN-10281
+
+This runbook defines the first non-deploying prep slice for a separate
+stability-test runtime lane. It does not start, restart, deploy, or mutate any
+runtime host. In particular, it must not mutate `.201`.
+
+## Purpose
+
+The stability-test lane exists so runtime proof can be prepared without sharing
+production runtime names, state paths, or consumer groups. It is the bridge from
+the two-phase runtime build plan into a concrete runtime lane:
+
+- `BUILD_SOURCE=workspace` is declared in the overlay so selector-aware builds
+  use local workspace contents once OMN-9471 or equivalent selector support is
+  on main.
+- `ONEX_ENVIRONMENT=stability-test` separates derived node consumer groups from
+  the production/local `ONEX_ENVIRONMENT=local` group prefix.
+- Explicit `ONEX_GROUP_ID` values use the `onex-stability-test-` prefix for the
+  coarse runtime group settings.
+- `KAFKA_INSTANCE_ID` values are stability-test specific, so selector-aware
+  event-bus consumers can append a lane-specific instance discriminator.
+- Runtime state is mounted on stability-test volumes and uses
+  `/app/data/.onex_state_stability_test`.
+
+## What Is Defined
+
+- Compose overlay: `docker/docker-compose.stability-test.yml`
+- Compose project name: `omnibase-infra-stability-test`
+- Runtime image tag: `runtime:stability-test-workspace`
+- Runtime containers:
+  - `omninode-stability-test-runtime`
+  - `omninode-stability-test-runtime-effects`
+  - `omninode-stability-test-runtime-worker`
+- Runtime group IDs:
+  - `onex-stability-test-runtime-main`
+  - `onex-stability-test-runtime-effects`
+  - `onex-stability-test-runtime-workers`
+- Runtime state root: `/app/data/.onex_state_stability_test`
+
+## Validation Only
+
+Render the config only:
+
+```bash
+docker compose \
+  -f docker/docker-compose.infra.yml \
+  -f docker/docker-compose.stability-test.yml \
+  config
+```
+
+Run static validation:
+
+```bash
+uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q
+```
+
+## Explicit Non-Goals For This PR
+
+- It does not run `docker compose up`.
+- It does not deploy, restart, or change `.201`.
+- It does not install launchd, cron, systemd, or autoheal hooks.
+- It does not prove runtime health, Redpanda membership, or build-loop to
+  ticket-pipeline processing.
+- It does not prove workspace image provenance until `BUILD_SOURCE` selector
+  support is available on this branch.
+
+## Operator Gate
+
+Any command that starts containers, restarts services, deploys to a host, or
+changes `.201` requires explicit operator approval and must produce a separate
+runtime proof record.

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Static checks for the OMN-10281 stability-test runtime lane."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OVERLAY_FILE = REPO_ROOT / "docker" / "docker-compose.stability-test.yml"
+RUNBOOK_FILE = REPO_ROOT / "docs" / "runbooks" / "stability-test-runtime-lane.md"
+
+RUNTIME_SERVICES = ("omninode-runtime", "runtime-effects", "runtime-worker")
+PRODUCTION_CONTAINER_NAMES = {
+    "omninode-runtime",
+    "omninode-runtime-effects",
+    "omnibase-infra-postgres",
+    "omnibase-infra-redpanda",
+    "omnibase-infra-valkey",
+}
+PRODUCTION_GROUP_IDS = {
+    "onex-runtime-main",
+    "onex-runtime-effects",
+    "onex-runtime-workers",
+}
+PRODUCTION_VOLUME_NAMES = {
+    "omninode-runtime-data",
+    "omninode-runtime-logs",
+    "omninode-effects-data",
+    "omninode-effects-logs",
+    "omninode-worker-logs",
+    "omnibase-infra-postgres-data",
+    "omnibase-infra-redpanda-data",
+    "omnibase-infra-valkey-data",
+}
+
+
+def _load_overlay() -> dict:
+    with OVERLAY_FILE.open(encoding="utf-8") as handle:
+        overlay = yaml.safe_load(handle)
+    assert isinstance(overlay, dict)
+    return overlay
+
+
+@pytest.mark.unit
+def test_stability_lane_has_distinct_compose_project_name() -> None:
+    overlay = _load_overlay()
+
+    assert overlay["name"] == "omnibase-infra-stability-test"
+    assert overlay["name"] != "omnibase-infra"
+
+
+@pytest.mark.unit
+def test_stability_lane_runtime_services_do_not_reuse_production_names() -> None:
+    overlay = _load_overlay()
+    services = overlay["services"]
+
+    for service_name in RUNTIME_SERVICES:
+        service = services[service_name]
+        container_name = service["container_name"]
+        assert "stability-test" in container_name
+        assert container_name not in PRODUCTION_CONTAINER_NAMES
+        assert service["image"] == "runtime:stability-test-workspace"
+        assert service["restart"] == "no"
+
+
+@pytest.mark.unit
+def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
+    overlay = _load_overlay()
+    services = overlay["services"]
+
+    for service_name in RUNTIME_SERVICES:
+        environment = services[service_name]["environment"]
+        assert environment["BUILD_SOURCE"] == "workspace"
+        assert environment["ONEX_ENVIRONMENT"] == "stability-test"
+        assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
+        assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
+
+        group_id = environment["ONEX_GROUP_ID"]
+        assert group_id.startswith("onex-stability-test-")
+        assert group_id not in PRODUCTION_GROUP_IDS
+
+
+@pytest.mark.unit
+def test_stability_lane_core_infra_names_are_distinct() -> None:
+    overlay = _load_overlay()
+    services = overlay["services"]
+
+    for service_name in ("postgres", "redpanda", "valkey", "migration-gate"):
+        container_name = services[service_name]["container_name"]
+        assert "stability-test" in container_name
+        assert container_name not in PRODUCTION_CONTAINER_NAMES
+
+
+@pytest.mark.unit
+def test_stability_lane_volumes_do_not_reuse_production_names() -> None:
+    overlay = _load_overlay()
+    volumes = overlay["volumes"]
+    concrete_names = [volume_config["name"] for volume_config in volumes.values()]
+
+    for volume_name, volume_config in volumes.items():
+        concrete_name = volume_config["name"]
+        assert concrete_name not in PRODUCTION_VOLUME_NAMES, volume_name
+        assert "stability-test" in concrete_name, volume_name
+
+    assert len(concrete_names) == len(set(concrete_names))
+
+
+@pytest.mark.unit
+def test_stability_runbook_is_validation_only() -> None:
+    runbook = RUNBOOK_FILE.read_text(encoding="utf-8")
+
+    assert "install-infra-watchdog" not in runbook
+    assert "systemctl" not in runbook
+    assert "does not deploy, restart, or change `.201`" in runbook
+    assert "It does not run `docker compose up`." in runbook
+    assert "config" in runbook
+    assert "BUILD_SOURCE=workspace" in runbook


### PR DESCRIPTION
## Summary

Defines the first non-deploying OMN-10281 stability-test runtime lane slice:

- adds `docker/docker-compose.stability-test.yml` as a config-only overlay with distinct compose project, runtime image tag, container names, host ports, state volumes, state root, `ONEX_ENVIRONMENT=stability-test`, `ONEX_GROUP_ID=onex-stability-test-*`, `KAFKA_INSTANCE_ID=stability-test-*`, and `BUILD_SOURCE=workspace`
- adds a runbook that documents validation-only usage and explicitly forbids deploy/restart/`.201` mutation without operator approval
- adds static tests proving the overlay does not reuse production runtime names, group IDs, or state volume names
- adds repo-local OMN-10281 contract evidence for the prep PR

## What is proven

- The stability-test overlay is valid YAML and renders with the base compose file via `docker compose config --quiet`.
- The declared stability-test runtime services do not reuse production runtime container names.
- The declared stability-test runtime services use `runtime:stability-test-workspace` rather than the production runtime tag.
- The declared stability-test runtime services use `BUILD_SOURCE=workspace`, `ONEX_ENVIRONMENT=stability-test`, stability-test `ONEX_GROUP_ID` values, stability-test `KAFKA_INSTANCE_ID` values, and `/app/data/.onex_state_stability_test`.
- The declared stability-test state volumes do not reuse production runtime/core volume names and do not duplicate concrete volume names.
- The runbook is validation-only and states no deploy/restart/`.201` mutation is included.

## What is not proven

- No containers were started.
- No deploy, restart, or `.201` mutation was performed.
- Runtime health is not proven.
- Redpanda consumer-group membership is not proven.
- Build-loop to ticket-pipeline processing is not proven.
- Workspace image provenance is not proven yet because this branch is based on current `origin/main`; selector-aware `BUILD_SOURCE` enforcement from OMN-9471 is not assumed to be merged here.

## Verification

- `uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q`
- `uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py`
- `docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml config --quiet`
- `PR_DIFF_FILES='docker/docker-compose.stability-test.yml\ndocs/runbooks/stability-test-runtime-lane.md\ntests/unit/infra/test_stability_test_runtime_lane.py\ncontracts/OMN-10281.yaml' PR_BRANCH='jonah/omn-10281-stability-test-runtime-lane' PR_TITLE='prep: define stability-test runtime lane (OMN-10281)' CONTRACTS_PATH='contracts' uv run python scripts/validate_pr_contracts.py`

## Safety

This PR is a non-deploying prep/config/runbook slice only. It does not touch OMN-9471, does not install production launchd/cron/systemd hooks, does not start/restart/deploy anything, and does not mutate `.201`.
