### PR TITLE
fix(OMN-9573): resolve topic lint repo path automatically

### DIFF
--- a/scripts/validation/run_topic_lint.sh
+++ b/scripts/validation/run_topic_lint.sh
@@ -5,16 +5,59 @@
 # Copyright (c) 2026 OmniNode Team
 #
 # Wrapper: run topic-naming-lint against both contract YAML files and Python
-# source files. (OMN-3259)
+# source files. (OMN-3259, OMN-9573)
+#
+# Path resolution order for INFRA_ROOT (absolute path to omnibase_infra repo):
+#   1. $OMNIBASE_INFRA_PATH (backward-compatible explicit override)
+#   2. Two levels up from this script's directory (canonical: scripts/validation/)
+#   3. $OMNI_HOME/omnibase_infra (cross-repo fallback)
+#   4. Walk up from cwd looking for a sibling omnibase_infra/ directory
+#   5. Warn and skip gracefully if none resolve
 #
 # Usage: invoked by pre-commit as a system-language hook.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT="$SCRIPT_DIR/lint_topic_names.py"
-RC=0
 
-uv run --frozen python "$LINT" --scan-contracts src/omnibase_infra/nodes || RC=$?
-uv run --frozen python "$LINT" --scan-python src/omnibase_infra || RC=$?
+# --- Resolve INFRA_ROOT ---
+INFRA_ROOT=""
+
+# 1. Backward-compatible explicit override.
+if [[ -n "${OMNIBASE_INFRA_PATH:-}" && -d "$OMNIBASE_INFRA_PATH/src/omnibase_infra" ]]; then
+    INFRA_ROOT="$OMNIBASE_INFRA_PATH"
+fi
+
+# 2. Canonical: this script lives at <infra_root>/scripts/validation/
+_candidate="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [[ -z "$INFRA_ROOT" && -d "$_candidate/src/omnibase_infra" ]]; then
+    INFRA_ROOT="$_candidate"
+fi
+
+# 3. $OMNI_HOME/omnibase_infra
+if [[ -z "$INFRA_ROOT" && -n "${OMNI_HOME:-}" && -d "$OMNI_HOME/omnibase_infra/src/omnibase_infra" ]]; then
+    INFRA_ROOT="$OMNI_HOME/omnibase_infra"
+fi
+
+# 4. Walk up from cwd looking for a sibling omnibase_infra/
+if [[ -z "$INFRA_ROOT" ]]; then
+    _walk="$(pwd)"
+    while [[ "$_walk" != "/" ]]; do
+        if [[ -d "$_walk/omnibase_infra/src/omnibase_infra" ]]; then
+            INFRA_ROOT="$_walk/omnibase_infra"
+            break
+        fi
+        _walk="$(dirname "$_walk")"
+    done
+fi
+
+if [[ -z "$INFRA_ROOT" ]]; then
+    echo "topic-naming-lint: WARNING: could not locate omnibase_infra source tree; skipping scan." >&2
+    exit 0
+fi
+
+RC=0
+uv run --frozen python "$LINT" --scan-contracts "$INFRA_ROOT/src/omnibase_infra/nodes" || RC=$?
+uv run --frozen python "$LINT" --scan-python "$INFRA_ROOT/src/omnibase_infra" || RC=$?
 
 exit "$RC"

--- a/tests/scripts/test_run_topic_lint_path_resolution.py
+++ b/tests/scripts/test_run_topic_lint_path_resolution.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for run_topic_lint.sh path resolution (OMN-9573).
+
+Verifies that the hook resolves the omnibase_infra source tree without
+requiring OMNIBASE_INFRA_PATH to be set, using OMNI_HOME and sibling-walk
+fallbacks.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "run_topic_lint.sh"
+LINT = REPO_ROOT / "scripts" / "validation" / "lint_topic_names.py"
+
+
+def copy_validation_scripts(root: Path) -> Path:
+    """Copy the lint wrapper into a fake repo so script-dir resolution is not canonical."""
+    scripts_dir = root / "scripts" / "validation"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(SCRIPT, scripts_dir / "run_topic_lint.sh")
+    shutil.copy2(LINT, scripts_dir / "lint_topic_names.py")
+    return scripts_dir / "run_topic_lint.sh"
+
+
+@pytest.mark.unit
+def test_script_resolves_via_script_dir_canonical(tmp_path: Path) -> None:
+    """Invoked from unrelated cwd, OMNI_HOME unset — resolves via SCRIPT_DIR."""
+    env = {k: v for k, v in os.environ.items() if k != "OMNIBASE_INFRA_PATH"}
+    env.pop("OMNI_HOME", None)
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        timeout=120,
+    )
+    # Must not exit 2 (runtime error from uv/missing path).
+    # Exit 0 = clean; exit 1 = topic violations found (still a valid resolution).
+    assert result.returncode in (0, 1), (
+        f"Script failed with unexpected exit code {result.returncode}.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # Must not emit the "could not locate" warning — path was found.
+    assert "could not locate omnibase_infra source tree" not in result.stderr
+
+
+@pytest.mark.unit
+def test_script_resolves_via_omnibase_infra_path(tmp_path: Path) -> None:
+    """OMNIBASE_INFRA_PATH remains the explicit compatibility override."""
+    script = copy_validation_scripts(tmp_path / "tooling")
+    fake_infra = tmp_path / "explicit_infra"
+    source_root = fake_infra / "src" / "omnibase_infra"
+    source_root.mkdir(parents=True)
+    (source_root / "nodes").mkdir()
+
+    env = {k: v for k, v in os.environ.items() if k != "OMNI_HOME"}
+    env["OMNIBASE_INFRA_PATH"] = str(fake_infra)
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"Exit {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "could not locate omnibase_infra source tree" not in result.stderr
+
+
+@pytest.mark.unit
+def test_script_resolves_via_omni_home(tmp_path: Path) -> None:
+    """OMNI_HOME set to a fake root containing omnibase_infra/src/omnibase_infra."""
+    script = copy_validation_scripts(tmp_path / "tooling")
+    fake_infra = tmp_path / "omnibase_infra" / "src" / "omnibase_infra"
+    fake_infra.mkdir(parents=True)
+    (fake_infra / "nodes").mkdir()
+
+    env = {k: v for k, v in os.environ.items() if k != "OMNIBASE_INFRA_PATH"}
+    env["OMNI_HOME"] = str(tmp_path)
+
+    # Run from a directory that is NOT the canonical infra root so SCRIPT_DIR
+    # candidate (two levels up from scripts/validation) won't match.
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        timeout=120,
+    )
+    # Empty src tree → scan returns 0 (no topics to check).
+    assert result.returncode == 0, (
+        f"Exit {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "could not locate omnibase_infra source tree" not in result.stderr
+
+
+@pytest.mark.unit
+def test_script_warns_and_exits_zero_when_no_infra_found(tmp_path: Path) -> None:
+    """No canonical path, no OMNI_HOME, no sibling — must warn and exit 0."""
+    script = copy_validation_scripts(tmp_path / "tooling")
+    env = {k: v for k, v in os.environ.items() if k != "OMNIBASE_INFRA_PATH"}
+    env.pop("OMNI_HOME", None)
+
+    isolated = tmp_path / "isolated_repo"
+    isolated.mkdir()
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        cwd=str(isolated),
+        env=env,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Expected graceful exit 0, got {result.returncode}.\nstderr: {result.stderr}"
+    )
+    assert "could not locate omnibase_infra source tree" in result.stderr
+
+
+@pytest.mark.unit
+def test_script_resolves_via_sibling_walk(tmp_path: Path) -> None:
+    """A sibling omnibase_infra/ directory found by walking up from cwd."""
+    script = copy_validation_scripts(tmp_path / "tooling")
+    sibling_infra = tmp_path / "omnibase_infra" / "src" / "omnibase_infra"
+    sibling_infra.mkdir(parents=True)
+    (sibling_infra / "nodes").mkdir()
+
+    child_repo = tmp_path / "omniclaude" / "src"
+    child_repo.mkdir(parents=True)
+
+    env = {k: v for k, v in os.environ.items() if k != "OMNIBASE_INFRA_PATH"}
+    env.pop("OMNI_HOME", None)
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        cwd=str(child_repo),
+        env=env,
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"Exit {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "could not locate omnibase_infra source tree" not in result.stderr


### PR DESCRIPTION
## Summary

- preserves `OMNIBASE_INFRA_PATH` as an explicit compatibility override for `run_topic_lint.sh`
- adds automatic path resolution via script directory, `$OMNI_HOME/omnibase_infra`, and sibling repo walk-up
- skips cleanly with a warning only when no omnibase_infra source tree can be resolved
- adds focused tests for explicit override, canonical script-dir, `$OMNI_HOME`, sibling-walk, and graceful skip behavior

## Verification

- `PYTHONPATH=src uv run pytest tests/scripts/test_run_topic_lint_path_resolution.py -q` — 5 passed
- `bash -n scripts/validation/run_topic_lint.sh` — passed
- pre-commit hooks on commit — passed
- pre-push hooks — passed

## Recovery context

Recovered and completed from `/Users/jonah/Code/omni_home/omni_worktrees/RECOVERY-2026-04-29` after Linear confirmed OMN-9573 is still Backlog.
