### PR TITLE
feat(OMN-8738): recover compose catalog manifests

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -117,3 +117,34 @@ tracing:
   inject_env:
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix:6006"
     OTEL_TRACES_EXPORTER: "otlp"
+omnimemory:
+  description: "OmniMemory data layer — Qdrant, Memgraph, Valkey, Kreuzberg (OMN-8738)"
+  services:
+    - omnimemory-qdrant
+    - omnimemory-memgraph
+    - omnimemory-valkey
+    - omnimemory-kreuzberg
+  includes: []
+  inject_env: {}
+  inject_required_env: []
+omnimarket-projections:
+  description: "OmniMarket Kafka-to-DB projection consumers (OMN-7610 / OMN-8738)"
+  services:
+    - omnimarket-projection-session-outcome
+    - omnimarket-projection-llm-cost
+    - omnimarket-projection-savings
+    - omnimarket-projection-delegation
+    - omnimarket-projection-baselines
+    - omnimarket-projection-registration
+  includes:
+    - core
+  inject_required_env:
+    - OMNIDASH_ANALYTICS_DB_URL
+omnidash:
+  description: "OmniDash Next.js analytics dashboard (OMN-8738)"
+  services:
+    - omnidash
+  includes:
+    - core
+  inject_required_env:
+    - OMNIDASH_ANALYTICS_DB_URL

--- a/docker/catalog/services/omnidash.yaml
+++ b/docker/catalog/services/omnidash.yaml
@@ -1,0 +1,32 @@
+name: omnidash
+description: OmniDash Next.js analytics dashboard
+image: omnidash:latest
+layer: runtime
+container_name: omnidash
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env: {}
+operational_defaults:
+  NODE_ENV: production
+ports:
+  external: 3000
+  internal: 3000
+healthcheck:
+  test: curl -f http://localhost:3000/api/registry/health
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 20
+volumes: []
+depends_on:
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "1.0"
+  memory: 512M
+  cpus_reservation: "0.25"
+  memory_reservation: 128M
+labels:
+  com.omninode.service: omnidash
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-baselines.yaml
+++ b/docker/catalog/services/omnimarket-projection-baselines.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-baselines
+description: Kafka-to-DB projection consumer for baseline events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-baselines
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_baselines.handlers.handler_baselines
+labels:
+  com.omninode.service: omnimarket-projection-baselines
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-delegation.yaml
+++ b/docker/catalog/services/omnimarket-projection-delegation.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-delegation
+description: Kafka-to-DB projection consumer for delegation events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-delegation
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_delegation.handlers.handler_delegation
+labels:
+  com.omninode.service: omnimarket-projection-delegation
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-llm-cost.yaml
+++ b/docker/catalog/services/omnimarket-projection-llm-cost.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-llm-cost
+description: Kafka-to-DB projection consumer for LLM cost events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-llm-cost
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_llm_cost.handlers.handler_llm_cost
+labels:
+  com.omninode.service: omnimarket-projection-llm-cost
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-registration.yaml
+++ b/docker/catalog/services/omnimarket-projection-registration.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-registration
+description: Kafka-to-DB projection consumer for registration events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-registration
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_registration.handlers.handler_registration
+labels:
+  com.omninode.service: omnimarket-projection-registration
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-savings.yaml
+++ b/docker/catalog/services/omnimarket-projection-savings.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-savings
+description: Kafka-to-DB projection consumer for savings events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-savings
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_savings.handlers.handler_savings
+labels:
+  com.omninode.service: omnimarket-projection-savings
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimarket-projection-session-outcome.yaml
+++ b/docker/catalog/services/omnimarket-projection-session-outcome.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-session-outcome
+description: Kafka-to-DB projection consumer for session outcome events (OMN-7610)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-session-outcome
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_session_outcome.handlers.handler_session_outcome
+labels:
+  com.omninode.service: omnimarket-projection-session-outcome
+  com.omninode.layer: runtime

--- a/docker/catalog/services/omnimemory-kreuzberg.yaml
+++ b/docker/catalog/services/omnimemory-kreuzberg.yaml
@@ -1,0 +1,27 @@
+name: omnimemory-kreuzberg
+description: Kreuzberg document parser for OmniMemory text extraction
+image: ghcr.io/kreuzberg-dev/kreuzberg:core
+layer: infrastructure
+container_name: omnimemory-kreuzberg-parser
+required_env: []
+hardcoded_env: {}
+operational_defaults:
+  KREUZBERG_PORT: "8090"
+ports:
+  external: 8090
+  internal: 8000
+healthcheck:
+  test: curl -f http://localhost:8000/health
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 30
+volumes: []
+depends_on: []
+restart: unless-stopped
+resources: null
+extra_networks:
+  - omnimemory-network
+labels:
+  com.omninode.service: omnimemory-kreuzberg
+  com.omninode.layer: infrastructure

--- a/docker/catalog/services/omnimemory-memgraph.yaml
+++ b/docker/catalog/services/omnimemory-memgraph.yaml
@@ -1,0 +1,42 @@
+name: omnimemory-memgraph
+description: Memgraph graph database for OmniMemory relationship queries
+image: memgraph/memgraph:${MEMGRAPH_VERSION:-2.18.1}
+layer: infrastructure
+container_name: omnimemory-memgraph
+required_env: []
+hardcoded_env: {}
+operational_defaults:
+  MEMGRAPH_BOLT_PORT: "7687"
+  MEMGRAPH_HTTP_PORT: "7444"
+  MEMGRAPH_MEMORY_LIMIT: "4096"
+ports:
+  external: 7687
+  internal: 7687
+healthcheck:
+  test:
+    - bash
+    - -c
+    - echo 'RETURN 1;' | mgconsole --host localhost --port 7687 || exit 1
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 30
+volumes:
+  - omnimemory-memgraph-data:/var/lib/memgraph
+depends_on: []
+restart: unless-stopped
+resources:
+  cpus: "2.0"
+  memory: 4G
+  cpus_reservation: "0.25"
+  memory_reservation: 512M
+command:
+  - --storage-snapshot-retention-count=2
+  - --storage-wal-enabled=true
+  - --storage-snapshot-interval-sec=3600
+  - --bolt-port=7687
+extra_networks:
+  - omnimemory-network
+labels:
+  com.omninode.service: omnimemory-memgraph
+  com.omninode.layer: infrastructure

--- a/docker/catalog/services/omnimemory-qdrant.yaml
+++ b/docker/catalog/services/omnimemory-qdrant.yaml
@@ -1,0 +1,39 @@
+name: omnimemory-qdrant
+description: Qdrant vector database for OmniMemory semantic storage
+image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.3}
+layer: infrastructure
+container_name: omnimemory-qdrant
+required_env: []
+hardcoded_env:
+  QDRANT__SERVICE__HOST: 0.0.0.0
+  QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
+  QDRANT__STORAGE__ON_DISK_PAYLOAD: "true"
+  QDRANT__LOG_LEVEL: INFO
+operational_defaults:
+  QDRANT__SERVICE__HTTP_PORT: "6333"
+  QDRANT__SERVICE__GRPC_PORT: "6334"
+  QDRANT__SERVICE__API_KEY: ""
+ports:
+  external: 6333
+  internal: 6333
+healthcheck:
+  test: "bash -c 'exec 3<>/dev/tcp/localhost/6333 && echo -e \"GET /readyz HTTP/1.1\\r\\nHost: localhost:6333\\r\\n\\r\\n\" >&3 && timeout 2 cat <&3 | grep -q ready'"
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 30
+volumes:
+  - omnimemory-qdrant-data:/qdrant/storage
+  - omnimemory-qdrant-snapshots:/qdrant/snapshots
+depends_on: []
+restart: unless-stopped
+resources:
+  cpus: "2.0"
+  memory: 2G
+  cpus_reservation: "0.25"
+  memory_reservation: 512M
+extra_networks:
+  - omnimemory-network
+labels:
+  com.omninode.service: omnimemory-qdrant
+  com.omninode.layer: infrastructure

--- a/docker/catalog/services/omnimemory-valkey.yaml
+++ b/docker/catalog/services/omnimemory-valkey.yaml
@@ -1,0 +1,33 @@
+name: omnimemory-valkey
+description: Valkey in-memory cache for OmniMemory session and embedding state
+image: valkey/valkey:${VALKEY_VERSION:-8}
+layer: infrastructure
+container_name: omnimemory-valkey
+required_env: []
+hardcoded_env: {}
+operational_defaults:
+  VALKEY_PORT: "6379"
+ports:
+  external: 6380
+  internal: 6379
+healthcheck:
+  test: sh -c 'REDISCLI_AUTH=${VALKEY_PASSWORD:-} valkey-cli -p 6379 ping'
+  interval_s: 30
+  timeout_s: 10
+  retries: 3
+  start_period_s: 10
+volumes:
+  - omnimemory-valkey-data:/data
+depends_on: []
+restart: unless-stopped
+resources:
+  cpus: "1.0"
+  memory: 1G
+  cpus_reservation: "0.1"
+  memory_reservation: 128M
+command: sh -c 'valkey-server --port 6379 --appendonly yes ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}'
+extra_networks:
+  - omnimemory-network
+labels:
+  com.omninode.service: omnimemory-valkey
+  com.omninode.layer: infrastructure

--- a/tests/unit/infra/test_omn8738_compose_migration_manifests.py
+++ b/tests/unit/infra/test_omn8738_compose_migration_manifests.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-8738: Validator tests for compose-migrated service manifests.
+
+Each test asserts that the new manifest YAML parses into a valid CatalogManifest
+and resolves cleanly through CatalogResolver. Tests are written TDD-first and
+must fail until the corresponding manifest files are added.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.docker.catalog.resolver import CatalogResolver, _load_manifest
+
+CATALOG_DIR = Path(__file__).resolve().parents[3] / "docker" / "catalog"
+SERVICES_DIR = CATALOG_DIR / "services"
+
+# ── Expected manifests from OMN-8738 migration ──────────────────────────────
+
+OMNIMEMORY_MANIFESTS = [
+    "omnimemory-qdrant",
+    "omnimemory-memgraph",
+    "omnimemory-valkey",
+    "omnimemory-kreuzberg",
+]
+
+OMNIMARKET_PROJECTION_MANIFESTS = [
+    "omnimarket-projection-session-outcome",
+    "omnimarket-projection-llm-cost",
+    "omnimarket-projection-savings",
+    "omnimarket-projection-delegation",
+    "omnimarket-projection-baselines",
+    "omnimarket-projection-registration",
+]
+
+OMNIDASH_MANIFESTS = [
+    "omnidash",
+]
+
+ALL_NEW_MANIFESTS = (
+    OMNIMEMORY_MANIFESTS + OMNIMARKET_PROJECTION_MANIFESTS + OMNIDASH_MANIFESTS
+)
+
+
+# ── Parse tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("manifest_name", ALL_NEW_MANIFESTS)
+def test_new_manifest_file_exists(manifest_name: str) -> None:
+    """Each OMN-8738 manifest YAML file must exist in catalog/services/."""
+    manifest_path = SERVICES_DIR / f"{manifest_name}.yaml"
+    assert manifest_path.exists(), (
+        f"OMN-8738: manifest file missing: {manifest_path}. "
+        "Create it from the source compose definition."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("manifest_name", ALL_NEW_MANIFESTS)
+def test_new_manifest_parses_as_catalog_manifest(manifest_name: str) -> None:
+    """Each OMN-8738 manifest must parse into a valid CatalogManifest (no loose dicts)."""
+    manifest_path = SERVICES_DIR / f"{manifest_name}.yaml"
+    if not manifest_path.exists():
+        pytest.skip(f"Manifest not yet created: {manifest_name}")
+    manifest = _load_manifest(manifest_path)
+    assert manifest.name == manifest_name, (
+        f"Manifest 'name' field must equal '{manifest_name}', got '{manifest.name}'"
+    )
+    assert manifest.description, f"{manifest_name}: description must be non-empty"
+    assert manifest.image, f"{manifest_name}: image must be non-empty"
+    assert manifest.layer is not None, f"{manifest_name}: layer must be set"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("manifest_name", ALL_NEW_MANIFESTS)
+def test_new_manifest_yaml_loads_cleanly(manifest_name: str) -> None:
+    """Each OMN-8738 manifest YAML must be valid YAML with required top-level keys."""
+    manifest_path = SERVICES_DIR / f"{manifest_name}.yaml"
+    if not manifest_path.exists():
+        pytest.skip(f"Manifest not yet created: {manifest_name}")
+    with open(manifest_path) as f:
+        raw = yaml.safe_load(f)
+    required_keys = {"name", "description", "image", "layer"}
+    missing = required_keys - set(raw.keys())
+    assert not missing, f"{manifest_name}: missing required keys: {missing}"
+
+
+# ── Bundle integration tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_omnimemory_bundle_resolves_all_four_services() -> None:
+    """The omnimemory bundle must resolve all 4 migrated services."""
+    resolver = CatalogResolver(catalog_dir=str(CATALOG_DIR))
+    resolved = resolver.resolve(bundles=["omnimemory"])
+    for svc in OMNIMEMORY_MANIFESTS:
+        assert svc in resolved.service_names, (
+            f"omnimemory bundle missing service '{svc}'"
+        )
+
+
+@pytest.mark.unit
+def test_omnimarket_projections_bundle_resolves_all_six_consumers() -> None:
+    """The omnimarket-projections bundle must resolve all 6 projection consumers."""
+    resolver = CatalogResolver(catalog_dir=str(CATALOG_DIR))
+    resolved = resolver.resolve(bundles=["omnimarket-projections"])
+    for svc in OMNIMARKET_PROJECTION_MANIFESTS:
+        assert svc in resolved.service_names, (
+            f"omnimarket-projections bundle missing service '{svc}'"
+        )
+
+
+@pytest.mark.unit
+def test_omnidash_bundle_resolves() -> None:
+    """The omnidash bundle must resolve the omnidash service."""
+    resolver = CatalogResolver(catalog_dir=str(CATALOG_DIR))
+    resolved = resolver.resolve(bundles=["omnidash"])
+    assert "omnidash" in resolved.service_names


### PR DESCRIPTION
## Summary

- recovers the still-applicable compose catalog manifest subset from the 2026-04-29 salvage sweep
- adds catalog service manifests for omnidash, omnimarket projection consumers, and omnimemory backing services
- registers the recovered services in `docker/catalog/bundles.yaml`
- adds a focused catalog-manifest test for the recovered OMN-8738 migration subset

## Scope note

This intentionally does not replay older project-tracker hunks from the archived patch because current `omnibase_infra` main has moved/removed those paths. This PR is the useful catalog-manifest portion of the recovered work, not the full OMN-8738 epic closure.

## Verification

- `PYTHONPATH=src uv run pytest tests/unit/infra/test_omn8738_compose_migration_manifests.py -q` — 36 passed
- pre-commit hooks on commit — passed
- pre-push hooks — passed

## Recovery context

Recovered from `/Users/jonah/Code/omni_home/omni_worktrees/RECOVERY-2026-04-29` after Linear confirmed OMN-8738 is still Backlog.
