### PR TITLE
test(OMN-10281): prove stability runtime compose render

### DIFF
--- a/docs/runbooks/stability-test-runtime-lane.md
+++ b/docs/runbooks/stability-test-runtime-lane.md
@@ -47,13 +47,26 @@ Render the config only:
 docker compose \
   -f docker/docker-compose.infra.yml \
   -f docker/docker-compose.stability-test.yml \
+  --profile runtime \
   config
+```
+
+List the rendered services and confirm the stability-test runtime services are
+present:
+
+```bash
+docker compose \
+  -f docker/docker-compose.infra.yml \
+  -f docker/docker-compose.stability-test.yml \
+  --profile runtime \
+  config --services
 ```
 
 Run static validation:
 
 ```bash
 uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q
+uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q
 ```
 
 ## Explicit Non-Goals For This PR

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -19,6 +20,20 @@ REQUIRED_RUNTIME_SERVICES = {
     "omninode-runtime",
     "runtime-effects",
     "runtime-worker",
+}
+COMPOSE_RENDER_ENV = {
+    "INFISICAL_AUTH_SECRET": "render-only-infisical-auth-secret",
+    "INFISICAL_DB_CONNECTION_URI": "postgresql://postgres:postgres@postgres:5432/infisical",
+    "INFISICAL_ENCRYPTION_KEY": "render-only-infisical-encryption-key-32",
+    "INFISICAL_REDIS_URL": "redis://valkey:6379",
+    "LINEAR_API_KEY": "render-only-linear-api-key",
+    "LLM_CODER_FAST_URL": "http://llm-coder-fast.invalid",
+    "LLM_CODER_URL": "http://llm-coder.invalid",
+    "LLM_DEEPSEEK_R1_URL": "http://llm-deepseek.invalid",
+    "LLM_EMBEDDING_URL": "http://llm-embedding.invalid",
+    "ONEX_REGISTRATION_AUTO_ACK": "false",
+    "ONEX_SERVICE_CLIENT_SECRET": "render-only-client-secret",
+    "POSTGRES_PASSWORD": "postgres",
 }
 
 
@@ -36,6 +51,10 @@ def _docker_compose_command(*args: str) -> list[str]:
     ]
 
 
+def _compose_render_env() -> dict[str, str]:
+    return {**os.environ, **COMPOSE_RENDER_ENV}
+
+
 pytestmark = pytest.mark.skipif(
     shutil.which("docker") is None,
     reason="docker is required for non-mutating compose render validation",
@@ -49,6 +68,7 @@ def test_stability_lane_runtime_services_render_with_runtime_profile() -> None:
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
+        env=_compose_render_env(),
         text=True,
     )
 
@@ -64,6 +84,7 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
+        env=_compose_render_env(),
         text=True,
     )
 

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Non-mutating compose render checks for the OMN-10281 stability-test lane."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_FILES = (
+    "docker/docker-compose.infra.yml",
+    "docker/docker-compose.stability-test.yml",
+)
+REQUIRED_RUNTIME_SERVICES = {
+    "omninode-runtime",
+    "runtime-effects",
+    "runtime-worker",
+}
+
+
+def _docker_compose_command(*args: str) -> list[str]:
+    return [
+        "docker",
+        "compose",
+        "-f",
+        COMPOSE_FILES[0],
+        "-f",
+        COMPOSE_FILES[1],
+        "--profile",
+        "runtime",
+        *args,
+    ]
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker is required for non-mutating compose render validation",
+)
+
+
+@pytest.mark.integration
+def test_stability_lane_runtime_services_render_with_runtime_profile() -> None:
+    result = subprocess.run(
+        _docker_compose_command("config", "--services"),
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    rendered_services = set(result.stdout.splitlines())
+
+    assert rendered_services >= REQUIRED_RUNTIME_SERVICES
+
+
+@pytest.mark.integration
+def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
+    result = subprocess.run(
+        _docker_compose_command("config"),
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    rendered_config = result.stdout
+
+    assert "container_name: omninode-stability-test-runtime" in rendered_config
+    assert "container_name: omninode-stability-test-runtime-effects" in rendered_config
+    assert "container_name: omninode-stability-test-runtime-worker" in rendered_config
+    assert "ONEX_ENVIRONMENT: stability-test" in rendered_config
+    assert "ONEX_GROUP_ID: onex-stability-test-runtime-main" in rendered_config
+    assert "KAFKA_INSTANCE_ID: stability-test-main" in rendered_config
+    assert "image: runtime:stability-test-workspace" in rendered_config

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -118,4 +118,5 @@ def test_stability_runbook_is_validation_only() -> None:
     assert "does not deploy, restart, or change `.201`" in runbook
     assert "It does not run `docker compose up`." in runbook
     assert "config" in runbook
+    assert "--profile runtime" in runbook
     assert "BUILD_SOURCE=workspace" in runbook


### PR DESCRIPTION
## Summary

Turns the OMN-10281 stability-test runtime lane from static overlay-only proof into non-mutating compose-render proof:

- updates the runbook validation commands to include `--profile runtime`, which is required for the runtime services to render from the base compose file
- adds an integration test that runs `docker compose ... --profile runtime config --services` and asserts the runtime services render
- adds an integration test that checks the rendered config includes stability-test container names, env, group IDs, Kafka instance IDs, and workspace image tag
- keeps this as validation-only: no `docker compose up`, no deploy, no restart, no .201 mutation

## Verification

- `uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q` -> 8 passed
- `docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet`
- `docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --services`
- `uv run validate-yaml contracts/OMN-10281.yaml`
- Commit hooks passed.

## Runtime boundary

This PR still does not start containers or mutate the runtime host. It only proves the stability-test runtime services render when the required runtime profile is selected.
