### PR TITLE
feat(OMN-10333): add LLM metric attribution columns

### DIFF
--- a/docker/migrations/forward/072_add_llm_call_metrics_attribution.sql
+++ b/docker/migrations/forward/072_add_llm_call_metrics_attribution.sql
@@ -1,0 +1,29 @@
+-- Migration: 072_add_llm_call_metrics_attribution
+-- Predecessor: 071_add_llm_call_metrics_idempotency_unique
+-- Description: Add repository and machine attribution to LLM call metrics (OMN-10333)
+-- Created: 2026-04-29
+--
+-- Purpose:
+--   Cost and usage projections need durable repo and machine attribution on
+--   raw LLM call metrics. These columns are nullable to preserve compatibility
+--   with historical events and producers that have not yet been upgraded.
+--
+-- Rollback: See rollback/rollback_072_add_llm_call_metrics_attribution.sql
+
+ALTER TABLE llm_call_metrics
+    ADD COLUMN IF NOT EXISTS repo_name VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS machine_id VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_repo_name
+    ON llm_call_metrics (repo_name)
+    WHERE repo_name IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_machine_id
+    ON llm_call_metrics (machine_id)
+    WHERE machine_id IS NOT NULL;
+
+COMMENT ON COLUMN llm_call_metrics.repo_name IS
+    'Repository name attributed by the LLM call producer for cost and usage analysis (OMN-10333).';
+
+COMMENT ON COLUMN llm_call_metrics.machine_id IS
+    'Machine identifier attributed by the LLM call producer for cost and usage analysis (OMN-10333).';

--- a/docker/migrations/rollback/rollback_072_add_llm_call_metrics_attribution.sql
+++ b/docker/migrations/rollback/rollback_072_add_llm_call_metrics_attribution.sql
@@ -1,0 +1,10 @@
+-- Rollback: forward/072_add_llm_call_metrics_attribution.sql
+-- Description: Remove LLM call metric repository and machine attribution (OMN-10333)
+-- Created: 2026-04-29
+
+DROP INDEX IF EXISTS idx_llm_call_metrics_machine_id;
+DROP INDEX IF EXISTS idx_llm_call_metrics_repo_name;
+
+ALTER TABLE llm_call_metrics
+    DROP COLUMN IF EXISTS machine_id,
+    DROP COLUMN IF EXISTS repo_name;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:8d54529acbbad25ead5abc2e9190d69fc11164329eea3f3730e4ae4abcc2fc9d
-generated_at: 2026-04-29T20:30:48Z
-migration_file_count: 57
+sha256:e0dba762c7d57f4d982cc21b2baa42127464f8ed5119b2a2fc6a29f13ef4234a
+generated_at: 2026-04-29T22:31:52Z
+migration_file_count: 58

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-# no-migration: docstring-only AI-slop cleanup
 """PostgreSQL Writer for LLM cost aggregation.
 
 A PostgreSQL writer for persisting LLM cost aggregation
@@ -300,10 +299,11 @@ class WriterLlmCostAggregationPostgres(MixinAsyncCircuitBreaker):
                                         estimated_cost_usd, latency_ms,
                                         usage_source, usage_is_estimated,
                                         usage_raw, input_hash,
-                                        code_version, contract_version, source
+                                        code_version, contract_version,
+                                        repo_name, machine_id, source
                                     ) VALUES (
                                         $1, $2, $3, $4, $5, $6, $7, $8, $9,
-                                        $10, $11, $12, $13, $14, $15, $16
+                                        $10, $11, $12, $13, $14, $15, $16, $17, $18
                                     )
                                     ON CONFLICT DO NOTHING
                                     """,
@@ -324,6 +324,8 @@ class WriterLlmCostAggregationPostgres(MixinAsyncCircuitBreaker):
                                     ),
                                     str(event.get("code_version", ""))[:64] or None,
                                     str(event.get("contract_version", ""))[:64] or None,
+                                    _safe_varchar(event.get("repo_name"), 255),
+                                    _safe_varchar(event.get("machine_id"), 255),
                                     str(event.get("reporting_source", ""))[:255]
                                     or None,
                                 )
@@ -734,15 +736,15 @@ def _build_aggregation_rows(
                 f"{_KEY_PREFIX_MODEL}:{_sanitize_dimension_value(str(model_id))}"
             )
 
-        # Repo dimension (from extensions if available)
+        # Repo dimension (top-level field for new events, extensions fallback for old events)
+        repo = event.get("repo_name")
         extensions = event.get("extensions")
-        if isinstance(extensions, dict):
+        if not repo and isinstance(extensions, dict):
             repo = extensions.get("repo")
-            if repo:
-                keys.append(
-                    f"{_KEY_PREFIX_REPO}:{_sanitize_dimension_value(str(repo))}"
-                )
+        if repo:
+            keys.append(f"{_KEY_PREFIX_REPO}:{_sanitize_dimension_value(str(repo))}")
 
+        if isinstance(extensions, dict):
             # Pattern dimension
             pattern_id = extensions.get("pattern_id")
             if pattern_id:
@@ -991,6 +993,14 @@ def _postgres_inserted_row_count(status: object) -> int:
         return 1
 
     return int(match.group(1))
+
+
+def _safe_varchar(value: object, max_length: int) -> str | None:
+    """Safely convert a value to a bounded VARCHAR parameter."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:max_length] or None
 
 
 def _resolve_usage_source(event: dict[str, object]) -> str:

--- a/tests/integration/test_llm_call_metrics_attribution_integration.py
+++ b/tests/integration/test_llm_call_metrics_attribution_integration.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration checks for LLM call metric attribution wiring (OMN-10333)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.services.observability.llm_cost_aggregation.writer_postgres import (
+    WriterLlmCostAggregationPostgres,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORWARD_MIGRATION = (
+    _REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "072_add_llm_call_metrics_attribution.sql"
+)
+
+
+def _mock_pool() -> MagicMock:
+    pool = MagicMock()
+    conn = AsyncMock()
+    transaction_cm = MagicMock()
+    transaction_cm.__aenter__ = AsyncMock(return_value=None)
+    transaction_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=transaction_cm)
+    conn.execute = AsyncMock(return_value="INSERT 0 1")
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_attribution_migration_and_writer_bind_same_columns() -> None:
+    """Migration columns are populated by the raw metric writer insert."""
+    migration_sql = _FORWARD_MIGRATION.read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS repo_name VARCHAR(255)" in migration_sql
+    assert "ADD COLUMN IF NOT EXISTS machine_id VARCHAR(255)" in migration_sql
+
+    pool = _mock_pool()
+    writer = WriterLlmCostAggregationPostgres(pool=pool)
+    result = await writer.write_call_metrics(
+        [
+            {
+                "model_id": "gpt-4o",
+                "session_id": "session-omni-10333",
+                "input_hash": "sha256-omni-10333-attribution-proof",
+                "repo_name": "omnibase_infra",
+                "machine_id": "devbox-201",
+                "reporting_source": "integration-test",
+            }
+        ]
+    )
+
+    assert result == 1
+    conn = pool.acquire.return_value.__aenter__.return_value
+    insert_call = next(
+        call
+        for call in conn.execute.call_args_list
+        if "INSERT INTO llm_call_metrics" in call.args[0]
+    )
+    assert "repo_name, machine_id, source" in insert_call.args[0]
+    assert insert_call.args[16] == "omnibase_infra"
+    assert insert_call.args[17] == "devbox-201"

--- a/tests/unit/db/test_migration_072.py
+++ b/tests/unit/db/test_migration_072.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for migration 072: add LLM call metric attribution (OMN-10333)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+MIGRATION_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "072_add_llm_call_metrics_attribution.sql"
+)
+ROLLBACK_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "rollback"
+    / "rollback_072_add_llm_call_metrics_attribution.sql"
+)
+
+
+def _strip_comments(sql: str) -> str:
+    sql = re.sub(r"--[^\n]*", "", sql)
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    return sql
+
+
+@pytest.mark.unit
+class TestMigration072Files:
+    """Validate required migration files exist."""
+
+    def test_migration_file_exists(self) -> None:
+        assert MIGRATION_FILE.exists(), f"Migration file not found: {MIGRATION_FILE}"
+
+    def test_rollback_file_exists(self) -> None:
+        assert ROLLBACK_FILE.exists(), f"Rollback file not found: {ROLLBACK_FILE}"
+
+
+@pytest.mark.unit
+class TestMigration072Schema:
+    """Validate LLM call metric attribution schema changes."""
+
+    def test_adds_nullable_attribution_columns(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        for column in ("repo_name", "machine_id"):
+            assert re.search(
+                rf"\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+{column}\s+VARCHAR\(255\)",
+                sql,
+                re.IGNORECASE,
+            ), f"Migration must add nullable VARCHAR(255) column {column}"
+
+    def test_partial_indexes_present(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        expected = {
+            "idx_llm_call_metrics_repo_name": "repo_name",
+            "idx_llm_call_metrics_machine_id": "machine_id",
+        }
+        for index_name, column in expected.items():
+            assert re.search(
+                rf"\bCREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+{index_name}\b"
+                rf".*?\bON\s+llm_call_metrics\s*\(\s*{column}\s*\)"
+                rf".*?\bWHERE\s+{column}\s+IS\s+NOT\s+NULL\b",
+                sql,
+                re.IGNORECASE | re.DOTALL,
+            ), f"Migration must create partial index {index_name}"
+
+
+@pytest.mark.unit
+class TestMigration072Rollback:
+    """Validate rollback SQL."""
+
+    def test_rollback_drops_indexes_and_columns(self) -> None:
+        sql = _strip_comments(ROLLBACK_FILE.read_text())
+        for index_name in (
+            "idx_llm_call_metrics_machine_id",
+            "idx_llm_call_metrics_repo_name",
+        ):
+            assert re.search(
+                rf"\bDROP\s+INDEX\s+IF\s+EXISTS\s+{index_name}\b",
+                sql,
+                re.IGNORECASE,
+            ), f"Rollback must drop index {index_name}"
+
+        for column in ("machine_id", "repo_name"):
+            assert re.search(
+                rf"\bDROP\s+COLUMN\s+IF\s+EXISTS\s+{column}\b",
+                sql,
+                re.IGNORECASE,
+            ), f"Rollback must drop column {column}"

--- a/tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py
+++ b/tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py
@@ -159,6 +159,39 @@ class TestBuildAggregationRows:
         assert keys == {"session", "model"}
 
     @pytest.mark.unit
+    def test_repo_dimension_prefers_top_level_repo_name(self) -> None:
+        """Top-level repo_name is authoritative over legacy extensions.repo."""
+        event = {
+            "model_id": "gpt-4o",
+            "repo_name": "omnibase_core",
+            "extensions": {"repo": "legacy-repo"},
+        }
+        rows = _build_aggregation_rows([event])
+
+        repo_keys = {
+            row["aggregation_key"]
+            for row in rows
+            if str(row["aggregation_key"]).startswith("repo:")
+        }
+        assert repo_keys == {"repo:omnibase_core"}
+
+    @pytest.mark.unit
+    def test_repo_dimension_falls_back_to_extensions_repo(self) -> None:
+        """Legacy events still aggregate by extensions.repo."""
+        event = {
+            "model_id": "gpt-4o",
+            "extensions": {"repo": "legacy-repo"},
+        }
+        rows = _build_aggregation_rows([event])
+
+        repo_keys = {
+            row["aggregation_key"]
+            for row in rows
+            if str(row["aggregation_key"]).startswith("repo:")
+        }
+        assert repo_keys == {"repo:legacy-repo"}
+
+    @pytest.mark.unit
     def test_builds_rows_without_session(self) -> None:
         """Events without session_id produce only model rows."""
         event = {"model_id": "gpt-4o"}
@@ -562,6 +595,35 @@ class TestWriterCallMetrics:
         conn = mock_pool.acquire.return_value.__aenter__.return_value
         # SET LOCAL + 2 INSERT calls
         assert conn.execute.call_count == 3
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_write_call_metrics_persists_attribution_fields(
+        self,
+        writer: WriterLlmCostAggregationPostgres,
+        mock_pool: MagicMock,
+        sample_event: dict[str, object],
+    ) -> None:
+        """Raw metric insert binds top-level repo_name and machine_id."""
+        event = {
+            **sample_event,
+            "repo_name": "omnibase_core",
+            "machine_id": "devbox-201",
+        }
+
+        result = await writer.write_call_metrics([event])
+
+        assert result == 1
+        conn = mock_pool.acquire.return_value.__aenter__.return_value
+        insert_call = next(
+            call
+            for call in conn.execute.call_args_list
+            if "INSERT INTO llm_call_metrics" in call.args[0]
+        )
+        sql = insert_call.args[0]
+        assert "repo_name, machine_id" in sql
+        assert insert_call.args[16] == "omnibase_core"
+        assert insert_call.args[17] == "devbox-201"
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add migration 072 for nullable llm_call_metrics repo_name and machine_id columns plus indexes
- Stamp and verify schema fingerprint after migration 072
- Persist attribution fields in the LLM cost aggregation writer
- Prefer top-level repo_name for repo aggregates while preserving extensions.repo fallback
- Add repeatable migration and writer tests

## Verification
- uv run python scripts/check_schema_fingerprint.py stamp
- uv run python scripts/check_schema_fingerprint.py verify
- uv run pytest tests/unit/db/test_migration_072.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py -q -> 59 passed
- uv run ruff check changed paths
- commit/pre-push hooks passed

Linear: OMN-10333

Stacked on OMN-10332 / PR #1454 for migration 071.