### PR TITLE
feat(OMN-10334): add cost API routes

### DIFF
--- a/contracts/OMN-10334.yaml
+++ b/contracts/OMN-10334.yaml
@@ -1,0 +1,34 @@
+# OMN-10334 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the cost API route PR.
+schema_version: "1.0.0"
+ticket_id: "OMN-10334"
+title: "Add cost API routes"
+summary: "Expose cost summary, trend, token usage, and breakdown routes backed by LLM metric aggregate tables."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused route, migration, writer, and protocol ownership proofs pass locally."
+    command: "uv run pytest tests/integration/api/test_cost_api_routes.py tests/unit/db/test_migration_072.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py tests/unit/contracts/test_protocol_ownership.py -q"
+  - kind: "manual"
+    description: "Post-merge runtime validation is required before claiming live cost API route availability."
+    command: "deploy: curl the registry API cost routes against the target runtime after rollout"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused cost API route and protocol ownership test suite passes locally."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/api/test_cost_api_routes.py tests/unit/db/test_migration_072.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py tests/unit/contracts/test_protocol_ownership.py -q"
+  - id: "dod-deploy"
+    description: "deploy gate evidence: pre-merge live deploy is not claimed; runtime validation remains post-merge."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: curl the registry API cost routes against the target runtime after rollout"

--- a/src/omnibase_infra/services/cost_api/__init__.py
+++ b/src/omnibase_infra/services/cost_api/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost API routes for LLM cost and token usage projections."""
+
+from omnibase_infra.services.cost_api.router import router
+
+__all__ = ["router"]

--- a/src/omnibase_infra/services/cost_api/handlers.py
+++ b/src/omnibase_infra/services/cost_api/handlers.py
@@ -63,7 +63,7 @@ async def fetch_cost_summary(
     *,
     window: AggregationWindow,
 ) -> ModelCostSummary:
-    """Fetch totals from canonical session/composite-session aggregate rows."""
+    """Fetch totals from canonical session aggregate rows."""
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
@@ -81,6 +81,7 @@ async def fetch_cost_summary(
             FROM llm_cost_aggregates
             WHERE "window" = $1::cost_aggregation_window
               AND aggregation_key LIKE 'session:%'
+              AND aggregation_key NOT LIKE 'session:%;%'
             """,
             window,
         )
@@ -233,7 +234,7 @@ async def fetch_token_usage(
     *,
     window: AggregationWindow,
 ) -> ModelTokenUsage:
-    """Fetch token totals from canonical session/composite-session aggregate rows."""
+    """Fetch token totals from canonical session aggregate rows."""
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
@@ -250,6 +251,7 @@ async def fetch_token_usage(
             FROM llm_cost_aggregates
             WHERE "window" = $1::cost_aggregation_window
               AND aggregation_key LIKE 'session:%'
+              AND aggregation_key NOT LIKE 'session:%;%'
             """,
             window,
         )

--- a/src/omnibase_infra/services/cost_api/handlers.py
+++ b/src/omnibase_infra/services/cost_api/handlers.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Database handlers for LLM cost API routes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol
+
+from omnibase_infra.services.cost_api.models import (
+    AggregationWindow,
+    ModelCostBreakdown,
+    ModelCostBreakdownItem,
+    ModelCostSummary,
+    ModelCostTrend,
+    ModelCostTrendPoint,
+    ModelTokenUsage,
+    TrendBucket,
+)
+
+if TYPE_CHECKING:
+    import asyncpg
+
+
+class RowLookup(Protocol):
+    """Minimal row interface shared by asyncpg.Record and test rows."""
+
+    def __getitem__(self, key: str) -> object:
+        """Return the row value for a string key."""
+        raise NotImplementedError
+
+
+def _decimal(value: object, default: str = "0.000000") -> Decimal:
+    if value is None:
+        return Decimal(default)
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str | bytes | bytearray):
+        return int(value)
+    return int(value)  # type: ignore[call-overload]
+
+
+def _row_get(row: RowLookup | None, key: str, default: object = None) -> object:
+    if row is None:
+        return default
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return default
+
+
+async def fetch_cost_summary(
+    pool: asyncpg.Pool,
+    *,
+    window: AggregationWindow,
+) -> ModelCostSummary:
+    """Fetch totals from canonical session/composite-session aggregate rows."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COALESCE(SUM(total_cost_usd), 0)::numeric(14, 6) AS total_cost_usd,
+                COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens,
+                COALESCE(SUM(call_count), 0)::bigint AS call_count,
+                CASE
+                    WHEN COALESCE(SUM(call_count), 0) = 0 THEN NULL
+                    ELSE (
+                        SUM(COALESCE(estimated_coverage_pct, 0) * call_count)
+                        / NULLIF(SUM(call_count), 0)
+                    )::numeric(5, 2)
+                END AS estimated_coverage_pct
+            FROM llm_cost_aggregates
+            WHERE "window" = $1::cost_aggregation_window
+              AND aggregation_key LIKE 'session:%'
+            """,
+            window,
+        )
+    return ModelCostSummary(
+        window=window,
+        total_cost_usd=_decimal(_row_get(row, "total_cost_usd")),
+        total_tokens=_int(_row_get(row, "total_tokens")),
+        call_count=_int(_row_get(row, "call_count")),
+        estimated_coverage_pct=(
+            None
+            if _row_get(row, "estimated_coverage_pct") is None
+            else _decimal(_row_get(row, "estimated_coverage_pct"), "0.00")
+        ),
+    )
+
+
+async def fetch_cost_trend(
+    pool: asyncpg.Pool,
+    *,
+    bucket: TrendBucket,
+    days: int,
+) -> ModelCostTrend:
+    """Fetch event-time trend buckets from raw LLM call metrics.
+
+    ``llm_cost_aggregates`` stores rolling aggregate windows, so it is not a
+    reliable source for time series buckets. Raw ``created_at`` timestamps are
+    used here to avoid presenting rolling-window updates as historical events.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT
+                date_trunc($1, created_at) AS bucket_start,
+                COALESCE(SUM(estimated_cost_usd), 0)::numeric(14, 6) AS total_cost_usd,
+                COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens,
+                COUNT(*)::bigint AS call_count
+            FROM llm_call_metrics
+            WHERE created_at >= NOW() - ($2::int * INTERVAL '1 day')
+            GROUP BY bucket_start
+            ORDER BY bucket_start ASC
+            """,
+            bucket,
+            days,
+        )
+    return ModelCostTrend(
+        bucket=bucket,
+        days=days,
+        points=[
+            ModelCostTrendPoint(
+                bucket_start=str(_row_get(row, "bucket_start")),
+                total_cost_usd=_decimal(_row_get(row, "total_cost_usd")),
+                total_tokens=_int(_row_get(row, "total_tokens")),
+                call_count=_int(_row_get(row, "call_count")),
+            )
+            for row in rows
+        ],
+    )
+
+
+async def fetch_cost_by_model(
+    pool: asyncpg.Pool,
+    *,
+    window: AggregationWindow,
+) -> ModelCostBreakdown:
+    """Fetch model cost groups from composite session keys or legacy model keys."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            WITH composite AS (
+                SELECT
+                    split_part(split_part(aggregation_key, ';model:', 2), ';', 1) AS name,
+                    SUM(total_cost_usd)::numeric(14, 6) AS total_cost_usd,
+                    SUM(total_tokens)::bigint AS total_tokens,
+                    SUM(call_count)::bigint AS call_count
+                FROM llm_cost_aggregates
+                WHERE "window" = $1::cost_aggregation_window
+                  AND aggregation_key LIKE 'session:%'
+                  AND aggregation_key LIKE '%;model:%'
+                GROUP BY name
+            ),
+            legacy AS (
+                SELECT
+                    substring(aggregation_key FROM '^model:(.*)$') AS name,
+                    SUM(total_cost_usd)::numeric(14, 6) AS total_cost_usd,
+                    SUM(total_tokens)::bigint AS total_tokens,
+                    SUM(call_count)::bigint AS call_count
+                FROM llm_cost_aggregates
+                WHERE "window" = $1::cost_aggregation_window
+                  AND aggregation_key LIKE 'model:%'
+                  AND NOT EXISTS (SELECT 1 FROM composite)
+                GROUP BY name
+            )
+            SELECT * FROM composite
+            UNION ALL
+            SELECT * FROM legacy
+            WHERE name IS NOT NULL
+            ORDER BY total_cost_usd DESC, name ASC
+            """,
+            window,
+        )
+    return _breakdown_from_rows(window=window, rows=rows)
+
+
+async def fetch_cost_by_repo(
+    pool: asyncpg.Pool,
+    *,
+    window: AggregationWindow,
+) -> ModelCostBreakdown:
+    """Fetch repo cost groups from composite session keys or legacy repo keys."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            WITH composite AS (
+                SELECT
+                    split_part(split_part(aggregation_key, ';repo:', 2), ';', 1) AS name,
+                    SUM(total_cost_usd)::numeric(14, 6) AS total_cost_usd,
+                    SUM(total_tokens)::bigint AS total_tokens,
+                    SUM(call_count)::bigint AS call_count
+                FROM llm_cost_aggregates
+                WHERE "window" = $1::cost_aggregation_window
+                  AND aggregation_key LIKE 'session:%'
+                  AND aggregation_key LIKE '%;repo:%'
+                GROUP BY name
+            ),
+            legacy AS (
+                SELECT
+                    substring(aggregation_key FROM '^repo:(.*)$') AS name,
+                    SUM(total_cost_usd)::numeric(14, 6) AS total_cost_usd,
+                    SUM(total_tokens)::bigint AS total_tokens,
+                    SUM(call_count)::bigint AS call_count
+                FROM llm_cost_aggregates
+                WHERE "window" = $1::cost_aggregation_window
+                  AND aggregation_key LIKE 'repo:%'
+                  AND NOT EXISTS (SELECT 1 FROM composite)
+                GROUP BY name
+            )
+            SELECT * FROM composite
+            UNION ALL
+            SELECT * FROM legacy
+            WHERE name IS NOT NULL
+            ORDER BY total_cost_usd DESC, name ASC
+            """,
+            window,
+        )
+    return _breakdown_from_rows(window=window, rows=rows)
+
+
+async def fetch_token_usage(
+    pool: asyncpg.Pool,
+    *,
+    window: AggregationWindow,
+) -> ModelTokenUsage:
+    """Fetch token totals from canonical session/composite-session aggregate rows."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens,
+                COALESCE(SUM(call_count), 0)::bigint AS call_count,
+                CASE
+                    WHEN COALESCE(SUM(call_count), 0) = 0 THEN 0
+                    ELSE (
+                        COALESCE(SUM(total_tokens), 0)::numeric
+                        / NULLIF(SUM(call_count), 0)
+                    )
+                END::numeric(14, 6) AS average_tokens_per_call
+            FROM llm_cost_aggregates
+            WHERE "window" = $1::cost_aggregation_window
+              AND aggregation_key LIKE 'session:%'
+            """,
+            window,
+        )
+    return ModelTokenUsage(
+        window=window,
+        total_tokens=_int(_row_get(row, "total_tokens")),
+        call_count=_int(_row_get(row, "call_count")),
+        average_tokens_per_call=_decimal(_row_get(row, "average_tokens_per_call")),
+    )
+
+
+def _breakdown_from_rows(
+    *,
+    window: AggregationWindow,
+    rows: Sequence[RowLookup],
+) -> ModelCostBreakdown:
+    return ModelCostBreakdown(
+        window=window,
+        items=[
+            ModelCostBreakdownItem(
+                name=str(_row_get(row, "name", "unknown")),
+                total_cost_usd=_decimal(_row_get(row, "total_cost_usd")),
+                total_tokens=_int(_row_get(row, "total_tokens")),
+                call_count=_int(_row_get(row, "call_count")),
+            )
+            for row in rows
+        ],
+    )

--- a/src/omnibase_infra/services/cost_api/model_cost_api_base.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_api_base.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared base model for LLM cost API responses."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_serializer
+
+
+class ModelCostApiBase(BaseModel):
+    """Base model with strict, immutable API contracts."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+    )
+
+    @field_serializer(
+        "total_cost_usd",
+        "estimated_coverage_pct",
+        "average_tokens_per_call",
+        check_fields=False,
+    )
+    def serialize_decimal(self, value: Decimal | None) -> str | None:
+        """Serialize Decimal values as strings to avoid JSON float drift."""
+        if value is None:
+            return None
+        return str(value)

--- a/src/omnibase_infra/services/cost_api/model_cost_breakdown.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_breakdown.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost breakdown response model."""
+
+from __future__ import annotations
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+from omnibase_infra.services.cost_api.model_cost_breakdown_item import (
+    ModelCostBreakdownItem,
+)
+from omnibase_infra.services.cost_api.model_types import AggregationWindow
+
+
+class ModelCostBreakdown(ModelCostApiBase):
+    """Collection of cost groups for a single aggregate window."""
+
+    window: AggregationWindow
+    items: list[ModelCostBreakdownItem]

--- a/src/omnibase_infra/services/cost_api/model_cost_breakdown_item.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_breakdown_item.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost breakdown item response model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import Field
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+
+
+class ModelCostBreakdownItem(ModelCostApiBase):
+    """Cost grouped by a stable aggregate dimension."""
+
+    name: str
+    total_cost_usd: Decimal = Field(default=Decimal("0.000000"))
+    total_tokens: int = 0
+    call_count: int = 0

--- a/src/omnibase_infra/services/cost_api/model_cost_summary.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_summary.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost summary response model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import Field
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+from omnibase_infra.services.cost_api.model_types import AggregationWindow
+
+
+class ModelCostSummary(ModelCostApiBase):
+    """Top-level LLM cost summary for canonical session aggregate rows."""
+
+    window: AggregationWindow
+    total_cost_usd: Decimal = Field(default=Decimal("0.000000"))
+    total_tokens: int = 0
+    call_count: int = 0
+    estimated_coverage_pct: Decimal | None = None

--- a/src/omnibase_infra/services/cost_api/model_cost_trend.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_trend.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost trend response model."""
+
+from __future__ import annotations
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+from omnibase_infra.services.cost_api.model_cost_trend_point import ModelCostTrendPoint
+from omnibase_infra.services.cost_api.model_types import TrendBucket
+
+
+class ModelCostTrend(ModelCostApiBase):
+    """Time series derived from raw call metric timestamps."""
+
+    bucket: TrendBucket
+    days: int
+    points: list[ModelCostTrendPoint]

--- a/src/omnibase_infra/services/cost_api/model_cost_trend_point.py
+++ b/src/omnibase_infra/services/cost_api/model_cost_trend_point.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cost trend point response model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import Field
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+
+
+class ModelCostTrendPoint(ModelCostApiBase):
+    """Cost and usage for a real event-time bucket."""
+
+    bucket_start: str
+    total_cost_usd: Decimal = Field(default=Decimal("0.000000"))
+    total_tokens: int = 0
+    call_count: int = 0

--- a/src/omnibase_infra/services/cost_api/model_savings_unavailable.py
+++ b/src/omnibase_infra/services/cost_api/model_savings_unavailable.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Savings unavailable response model."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+
+
+class ModelSavingsUnavailable(ModelCostApiBase):
+    """Stable unavailable response for future savings estimation routes."""
+
+    status: Literal["unavailable"] = "unavailable"
+    code: Literal["savings_summary_not_implemented"] = "savings_summary_not_implemented"
+    message: str

--- a/src/omnibase_infra/services/cost_api/model_token_usage.py
+++ b/src/omnibase_infra/services/cost_api/model_token_usage.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Token usage response model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import Field
+
+from omnibase_infra.services.cost_api.model_cost_api_base import ModelCostApiBase
+from omnibase_infra.services.cost_api.model_types import AggregationWindow
+
+
+class ModelTokenUsage(ModelCostApiBase):
+    """Token usage totals from canonical session aggregate rows."""
+
+    window: AggregationWindow
+    total_tokens: int = 0
+    call_count: int = 0
+    average_tokens_per_call: Decimal = Field(default=Decimal("0.000000"))

--- a/src/omnibase_infra/services/cost_api/model_types.py
+++ b/src/omnibase_infra/services/cost_api/model_types.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared type aliases for LLM cost API models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+AggregationWindow = Literal["24h", "7d", "30d"]
+TrendBucket = Literal["hour", "day"]

--- a/src/omnibase_infra/services/cost_api/models.py
+++ b/src/omnibase_infra/services/cost_api/models.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Public response model imports for LLM cost API routes."""
+
+from __future__ import annotations
+
+from omnibase_infra.services.cost_api.model_cost_breakdown import ModelCostBreakdown
+from omnibase_infra.services.cost_api.model_cost_breakdown_item import (
+    ModelCostBreakdownItem,
+)
+from omnibase_infra.services.cost_api.model_cost_summary import ModelCostSummary
+from omnibase_infra.services.cost_api.model_cost_trend import ModelCostTrend
+from omnibase_infra.services.cost_api.model_cost_trend_point import (
+    ModelCostTrendPoint,
+)
+from omnibase_infra.services.cost_api.model_savings_unavailable import (
+    ModelSavingsUnavailable,
+)
+from omnibase_infra.services.cost_api.model_token_usage import ModelTokenUsage
+from omnibase_infra.services.cost_api.model_types import AggregationWindow, TrendBucket
+
+__all__ = [
+    "AggregationWindow",
+    "ModelCostBreakdown",
+    "ModelCostBreakdownItem",
+    "ModelCostSummary",
+    "ModelCostTrend",
+    "ModelCostTrendPoint",
+    "ModelSavingsUnavailable",
+    "ModelTokenUsage",
+    "TrendBucket",
+]

--- a/src/omnibase_infra/services/cost_api/router.py
+++ b/src/omnibase_infra/services/cost_api/router.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""FastAPI routes for LLM cost and savings summaries."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.errors import ModelInfraErrorContext
+from omnibase_infra.services.cost_api.handlers import (
+    fetch_cost_by_model,
+    fetch_cost_by_repo,
+    fetch_cost_summary,
+    fetch_cost_trend,
+    fetch_token_usage,
+)
+from omnibase_infra.services.cost_api.models import (
+    AggregationWindow,
+    ModelCostBreakdown,
+    ModelCostSummary,
+    ModelCostTrend,
+    ModelSavingsUnavailable,
+    ModelTokenUsage,
+    TrendBucket,
+)
+
+router = APIRouter(tags=["costs"])
+
+
+def _request_correlation_id(request: Request) -> UUID:
+    raw_correlation = request.headers.get("X-Correlation-ID")
+    if raw_correlation:
+        try:
+            return UUID(raw_correlation)
+        except ValueError:
+            pass
+    return uuid4()
+
+
+def get_cost_api_pool(request: Request) -> object:
+    """Return the asyncpg pool configured by the registry app factory."""
+    pool = getattr(request.app.state, "cost_api_pool", None)
+    if pool is None:
+        context = ModelInfraErrorContext.with_correlation(
+            correlation_id=_request_correlation_id(request),
+            transport_type=EnumInfraTransportType.DATABASE,
+            operation="cost_api_pool_lookup",
+            target_name="registry_api.cost_api_pool",
+            suggested_resolution="Configure cost_api_pool on the registry API app state.",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "message": "Cost API database pool not configured",
+                "context": context.model_dump(mode="json"),
+            },
+        )
+    return pool
+
+
+@router.get(
+    "/api/costs/summary",
+    response_model=ModelCostSummary,
+    summary="LLM Cost Summary",
+)
+async def get_cost_summary(
+    pool: Annotated[object, Depends(get_cost_api_pool)],
+    window: Annotated[
+        AggregationWindow,
+        Query(description="Rolling aggregate window to read."),
+    ] = "24h",
+) -> ModelCostSummary:
+    return await fetch_cost_summary(pool, window=window)  # type: ignore[arg-type]
+
+
+@router.get(
+    "/api/costs/trend",
+    response_model=ModelCostTrend,
+    summary="LLM Cost Trend",
+)
+async def get_cost_trend(
+    pool: Annotated[object, Depends(get_cost_api_pool)],
+    bucket: Annotated[
+        TrendBucket,
+        Query(description="Event-time bucket size for raw call metrics."),
+    ] = "day",
+    days: Annotated[
+        int,
+        Query(ge=1, le=365, description="Number of trailing days to include."),
+    ] = 30,
+) -> ModelCostTrend:
+    return await fetch_cost_trend(pool, bucket=bucket, days=days)  # type: ignore[arg-type]
+
+
+@router.get(
+    "/api/costs/by-model",
+    response_model=ModelCostBreakdown,
+    summary="LLM Cost By Model",
+)
+async def get_cost_by_model(
+    pool: Annotated[object, Depends(get_cost_api_pool)],
+    window: Annotated[
+        AggregationWindow,
+        Query(description="Rolling aggregate window to read."),
+    ] = "24h",
+) -> ModelCostBreakdown:
+    return await fetch_cost_by_model(pool, window=window)  # type: ignore[arg-type]
+
+
+@router.get(
+    "/api/costs/by-repo",
+    response_model=ModelCostBreakdown,
+    summary="LLM Cost By Repo",
+)
+async def get_cost_by_repo(
+    pool: Annotated[object, Depends(get_cost_api_pool)],
+    window: Annotated[
+        AggregationWindow,
+        Query(description="Rolling aggregate window to read."),
+    ] = "24h",
+) -> ModelCostBreakdown:
+    return await fetch_cost_by_repo(pool, window=window)  # type: ignore[arg-type]
+
+
+@router.get(
+    "/api/costs/token-usage",
+    response_model=ModelTokenUsage,
+    summary="LLM Token Usage",
+)
+async def get_token_usage(
+    pool: Annotated[object, Depends(get_cost_api_pool)],
+    window: Annotated[
+        AggregationWindow,
+        Query(description="Rolling aggregate window to read."),
+    ] = "24h",
+) -> ModelTokenUsage:
+    return await fetch_token_usage(pool, window=window)  # type: ignore[arg-type]
+
+
+@router.get(
+    "/api/savings/summary",
+    response_model=ModelSavingsUnavailable,
+    summary="Savings Summary",
+    responses={503: {"model": ModelSavingsUnavailable}},
+)
+async def get_savings_summary() -> JSONResponse:
+    body = ModelSavingsUnavailable(
+        message="Savings summary is not implemented yet for OMN-10334."
+    )
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content=body.model_dump(mode="json"),
+    )

--- a/src/omnibase_infra/services/registry_api/main.py
+++ b/src/omnibase_infra/services/registry_api/main.py
@@ -42,10 +42,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from omnibase_core.container import ModelONEXContainer
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import ModelInfraErrorContext, ProtocolConfigurationError
+from omnibase_infra.services.cost_api import router as cost_api_router
 from omnibase_infra.services.registry_api.routes import router
 from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
 
 if TYPE_CHECKING:
+    import asyncpg
+
     from omnibase_infra.projectors import ProjectionReaderRegistration
 
 logger = logging.getLogger(__name__)
@@ -112,6 +115,7 @@ def create_app(
     projection_reader: ProjectionReaderRegistration | None = None,
     widget_mapping_path: Path | None = None,
     cors_origins: list[str] | None = None,
+    cost_api_pool: asyncpg.Pool | None = None,
 ) -> FastAPI:
     """Create and configure the Registry API FastAPI application.
 
@@ -127,6 +131,7 @@ def create_app(
         cors_origins: Optional list of allowed CORS origins.
             If not provided, reads from CORS_ORIGINS environment variable.
             Raises ProtocolConfigurationError if neither is configured (fail-fast).
+        cost_api_pool: Optional asyncpg pool for LLM cost API routes.
 
     Returns:
         Configured FastAPI application.
@@ -194,9 +199,11 @@ def create_app(
         widget_mapping_path=widget_mapping_path,
     )
     app.state.registry_service = service
+    app.state.cost_api_pool = cost_api_pool
 
     # Include routes
     app.include_router(router)
+    app.include_router(cost_api_router)
 
     # Root endpoint
     @app.get("/", include_in_schema=False)

--- a/src/omnibase_infra/services/registry_api/routes.py
+++ b/src/omnibase_infra/services/registry_api/routes.py
@@ -24,7 +24,7 @@ Related Tickets:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
@@ -45,9 +45,7 @@ from omnibase_infra.services.registry_api.models import (
     ModelTopicView,
     ModelWidgetMapping,
 )
-
-if TYPE_CHECKING:
-    from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
+from omnibase_infra.services.registry_api.service import ServiceRegistryDiscovery
 
 
 def get_correlation_id(

--- a/tests/integration/api/test_cost_api_routes.py
+++ b/tests/integration/api/test_cost_api_routes.py
@@ -130,7 +130,10 @@ async def get_json(app: Any, path: str) -> dict[str, Any]:
     return response.json()
 
 
-async def test_cost_summary_uses_canonical_session_totals(app: Any) -> None:
+async def test_cost_summary_uses_canonical_session_totals(
+    app: Any,
+    fake_conn: FakeConnection,
+) -> None:
     body = await get_json(app, "/api/costs/summary")
 
     assert body == {
@@ -140,6 +143,10 @@ async def test_cost_summary_uses_canonical_session_totals(app: Any) -> None:
         "call_count": 3,
         "estimated_coverage_pct": "33.33",
     }
+    sql, args = fake_conn.queries[-1]
+    assert "aggregation_key LIKE 'session:%'" in sql
+    assert "aggregation_key NOT LIKE 'session:%;%'" in sql
+    assert args == ("24h",)
 
 
 async def test_cost_trend_uses_raw_call_metric_timestamps(
@@ -232,7 +239,7 @@ async def test_cost_by_repo_groups_composite_and_legacy_fallback(
     assert args == ("24h",)
 
 
-async def test_token_usage_response(app: Any) -> None:
+async def test_token_usage_response(app: Any, fake_conn: FakeConnection) -> None:
     body = await get_json(app, "/api/costs/token-usage")
 
     assert body == {
@@ -241,6 +248,10 @@ async def test_token_usage_response(app: Any) -> None:
         "call_count": 3,
         "average_tokens_per_call": "2000.000000",
     }
+    sql, args = fake_conn.queries[-1]
+    assert "aggregation_key LIKE 'session:%'" in sql
+    assert "aggregation_key NOT LIKE 'session:%;%'" in sql
+    assert args == ("24h",)
 
 
 async def test_savings_summary_returns_stable_503_body(app: Any) -> None:

--- a/tests/integration/api/test_cost_api_routes.py
+++ b/tests/integration/api/test_cost_api_routes.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ASGI coverage for OMN-10334 cost API routes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from omnibase_core.container import ModelONEXContainer
+from omnibase_infra.services.registry_api.main import create_app
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+class FakeAcquire:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._conn
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self._conn)
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchrow(self, sql: str, *args: object) -> Mapping[str, object]:
+        self.queries.append((sql, args))
+        if "average_tokens_per_call" in sql:
+            return {
+                "total_tokens": 6000,
+                "call_count": 3,
+                "average_tokens_per_call": Decimal("2000.000000"),
+            }
+        return {
+            "total_cost_usd": Decimal("1.234567"),
+            "total_tokens": 6000,
+            "call_count": 3,
+            "estimated_coverage_pct": Decimal("33.33"),
+        }
+
+    async def fetch(self, sql: str, *args: object) -> list[Mapping[str, object]]:
+        self.queries.append((sql, args))
+        if "llm_call_metrics" in sql:
+            return [
+                {
+                    "bucket_start": "2026-04-28 00:00:00+00:00",
+                    "total_cost_usd": Decimal("0.750000"),
+                    "total_tokens": 3000,
+                    "call_count": 2,
+                },
+                {
+                    "bucket_start": "2026-04-29 00:00:00+00:00",
+                    "total_cost_usd": Decimal("0.484567"),
+                    "total_tokens": 3000,
+                    "call_count": 1,
+                },
+            ]
+        if ";model:" in sql:
+            return [
+                {
+                    "name": "gpt-4.1",
+                    "total_cost_usd": Decimal("1.000000"),
+                    "total_tokens": 4000,
+                    "call_count": 2,
+                },
+                {
+                    "name": "gpt-4.1-mini",
+                    "total_cost_usd": Decimal("0.234567"),
+                    "total_tokens": 2000,
+                    "call_count": 1,
+                },
+            ]
+        if ";repo:" in sql:
+            return [
+                {
+                    "name": "omnibase_infra",
+                    "total_cost_usd": Decimal("1.111111"),
+                    "total_tokens": 5000,
+                    "call_count": 2,
+                },
+                {
+                    "name": "omnibase_core",
+                    "total_cost_usd": Decimal("0.123456"),
+                    "total_tokens": 1000,
+                    "call_count": 1,
+                },
+            ]
+        raise AssertionError(f"unexpected fetch SQL: {sql}")
+
+
+@pytest.fixture
+def fake_conn() -> FakeConnection:
+    return FakeConnection()
+
+
+@pytest.fixture
+def app(fake_conn: FakeConnection) -> Any:
+    return create_app(
+        container=ModelONEXContainer(),
+        cors_origins=["http://testserver"],
+        cost_api_pool=FakePool(fake_conn),
+    )
+
+
+async def get_json(app: Any, path: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get(path)
+    assert response.status_code == 200
+    return response.json()
+
+
+async def test_cost_summary_uses_canonical_session_totals(app: Any) -> None:
+    body = await get_json(app, "/api/costs/summary")
+
+    assert body == {
+        "window": "24h",
+        "total_cost_usd": "1.234567",
+        "total_tokens": 6000,
+        "call_count": 3,
+        "estimated_coverage_pct": "33.33",
+    }
+
+
+async def test_cost_trend_uses_raw_call_metric_timestamps(
+    app: Any,
+    fake_conn: FakeConnection,
+) -> None:
+    body = await get_json(app, "/api/costs/trend?bucket=day&days=7")
+
+    assert body == {
+        "bucket": "day",
+        "days": 7,
+        "points": [
+            {
+                "bucket_start": "2026-04-28 00:00:00+00:00",
+                "total_cost_usd": "0.750000",
+                "total_tokens": 3000,
+                "call_count": 2,
+            },
+            {
+                "bucket_start": "2026-04-29 00:00:00+00:00",
+                "total_cost_usd": "0.484567",
+                "total_tokens": 3000,
+                "call_count": 1,
+            },
+        ],
+    }
+    trend_sql, trend_args = fake_conn.queries[-1]
+    assert "FROM llm_call_metrics" in trend_sql
+    assert "created_at" in trend_sql
+    assert trend_args == ("day", 7)
+
+
+async def test_cost_by_model_groups_composite_and_legacy_fallback(
+    app: Any,
+    fake_conn: FakeConnection,
+) -> None:
+    body = await get_json(app, "/api/costs/by-model")
+
+    assert body == {
+        "window": "24h",
+        "items": [
+            {
+                "name": "gpt-4.1",
+                "total_cost_usd": "1.000000",
+                "total_tokens": 4000,
+                "call_count": 2,
+            },
+            {
+                "name": "gpt-4.1-mini",
+                "total_cost_usd": "0.234567",
+                "total_tokens": 2000,
+                "call_count": 1,
+            },
+        ],
+    }
+    sql, args = fake_conn.queries[-1]
+    assert "aggregation_key LIKE 'session:%'" in sql
+    assert "aggregation_key LIKE 'model:%'" in sql
+    assert "NOT EXISTS (SELECT 1 FROM composite)" in sql
+    assert args == ("24h",)
+
+
+async def test_cost_by_repo_groups_composite_and_legacy_fallback(
+    app: Any,
+    fake_conn: FakeConnection,
+) -> None:
+    body = await get_json(app, "/api/costs/by-repo")
+
+    assert body == {
+        "window": "24h",
+        "items": [
+            {
+                "name": "omnibase_infra",
+                "total_cost_usd": "1.111111",
+                "total_tokens": 5000,
+                "call_count": 2,
+            },
+            {
+                "name": "omnibase_core",
+                "total_cost_usd": "0.123456",
+                "total_tokens": 1000,
+                "call_count": 1,
+            },
+        ],
+    }
+    sql, args = fake_conn.queries[-1]
+    assert "aggregation_key LIKE 'session:%'" in sql
+    assert "aggregation_key LIKE 'repo:%'" in sql
+    assert "NOT EXISTS (SELECT 1 FROM composite)" in sql
+    assert args == ("24h",)
+
+
+async def test_token_usage_response(app: Any) -> None:
+    body = await get_json(app, "/api/costs/token-usage")
+
+    assert body == {
+        "window": "24h",
+        "total_tokens": 6000,
+        "call_count": 3,
+        "average_tokens_per_call": "2000.000000",
+    }
+
+
+async def test_savings_summary_returns_stable_503_body(app: Any) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/savings/summary")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "status": "unavailable",
+        "code": "savings_summary_not_implemented",
+        "message": "Savings summary is not implemented yet for OMN-10334.",
+    }
+
+
+async def test_cost_pool_unavailable_response_carries_correlation_context() -> None:
+    app = create_app(
+        container=ModelONEXContainer(),
+        cors_origins=["http://testserver"],
+        cost_api_pool=None,
+    )
+    correlation_id = uuid4()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get(
+            "/api/costs/summary",
+            headers={"X-Correlation-ID": str(correlation_id)},
+        )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["message"] == "Cost API database pool not configured"
+    context = detail["context"]
+    assert UUID(context["correlation_id"]) == correlation_id
+    assert context["operation"] == "cost_api_pool_lookup"
+    assert context["transport_type"] == "db"
+
+
+async def test_openapi_registers_cost_and_savings_paths(app: Any) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/openapi.json")
+
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert "/api/costs/summary" in paths
+    assert "/api/costs/trend" in paths
+    assert "/api/costs/by-model" in paths
+    assert "/api/costs/by-repo" in paths
+    assert "/api/costs/token-usage" in paths
+    assert "/api/savings/summary" in paths

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -83,6 +83,7 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolTopicCatalogService": "services/protocol_topic_catalog_service.py",
     "ProtocolManifestPersistence": "services/corpus_capture.py",
     "ProtocolSessionAggregator": "services/session/protocol_session_aggregator.py",
+    "RowLookup": "services/cost_api/handlers.py",  # [DI] OMN-10334 narrow row adapter for asyncpg.Record/test rows
     # [DI] Publisher callable boundary for HandlerBaselinesBatchCompute (OMN-3039)
     "ProtocolPublisher": "nodes/node_baselines_batch_compute/handlers/handler_baselines_batch_compute.py",
     # === [MIXIN] Mixin host contracts ===


### PR DESCRIPTION
## Summary
- OMN-10334: add LLM cost API routes for summary, trend, by-model, by-repo, and token usage.
- Add stable 503 savings summary stub.
- Wire the cost router into the registry API app factory with an optional asyncpg pool.
- Add ASGI integration tests with fake asyncpg-style pool coverage for all paths and OpenAPI registration.

## Verification
- `uv run pytest tests/integration/api/test_cost_api_routes.py tests/unit/db/test_migration_072.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py tests/unit/contracts/test_protocol_ownership.py -q`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cost API endpoints for summary, trend, by-model, by-repo, token-usage, and a savings-summary placeholder (503).

* **Models**
  * New immutable response schemas for summaries, trends, trend points, breakdowns, breakdown items, token usage, and savings-unavailable. Decimal fields serialized as strings; shared type aliases added.

* **Tests**
  * Integration tests covering all cost/savings routes and OpenAPI; protocol allowlist updated.

* **Chores**
  * App factory accepts an optional cost DB pool and registers the cost routes; package entrypoint exported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->