### PR TITLE
feat(OMN-10338): add gpu usage evidence to llm metrics

### DIFF
--- a/contracts/OMN-10338.yaml
+++ b/contracts/OMN-10338.yaml
@@ -1,0 +1,34 @@
+# OMN-10338 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for GPU usage evidence on LLM metrics.
+schema_version: "1.0.0"
+ticket_id: "OMN-10338"
+title: "Add GPU usage evidence to LLM metrics"
+summary: "Emit GPU type, count, measured seconds, and compute usage source for local-model LLM calls."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused migration, pricing, handler, publisher, writer, and integration proofs pass locally."
+    command: "uv run pytest tests/integration/test_llm_gpu_usage_evidence_integration.py tests/unit/db/test_migration_073.py tests/unit/models/pricing/test_model_pricing_table.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py -q"
+  - kind: "manual"
+    description: "Post-merge runtime validation is required before claiming live runtime GPU metric emission."
+    command: "deploy: query llm-call-completed events for gpu_seconds, gpu_type, gpu_count, and compute_usage_source after runtime rollout"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused GPU usage evidence test suite passes locally."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/test_llm_gpu_usage_evidence_integration.py tests/unit/db/test_migration_073.py tests/unit/models/pricing/test_model_pricing_table.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py -q"
+  - id: "dod-deploy"
+    description: "deploy gate evidence: pre-merge live deploy is not claimed; runtime validation remains post-merge."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: query llm-call-completed events for gpu_seconds, gpu_type, gpu_count, and compute_usage_source after runtime rollout"

--- a/docker/migrations/forward/073_add_llm_call_metrics_gpu_fields.sql
+++ b/docker/migrations/forward/073_add_llm_call_metrics_gpu_fields.sql
@@ -1,0 +1,43 @@
+-- Migration: 073_add_llm_call_metrics_gpu_fields
+-- Predecessor: 072_add_llm_call_metrics_attribution
+-- Description: Add GPU usage evidence and aggregate compute cost columns (OMN-10338)
+-- Created: 2026-04-29
+--
+-- Purpose:
+--   Local-model calls have zero token/API cost but consume GPU time. These
+--   nullable evidence columns preserve historical compatibility while allowing
+--   projections to compute compute_cost_usd from the pricing manifest.
+--
+-- Rollback: See rollback/rollback_073_add_llm_call_metrics_gpu_fields.sql
+
+ALTER TABLE llm_call_metrics
+    ADD COLUMN IF NOT EXISTS gpu_seconds NUMERIC(10, 3),
+    ADD COLUMN IF NOT EXISTS gpu_type VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS gpu_count SMALLINT,
+    ADD COLUMN IF NOT EXISTS compute_usage_source usage_source_type;
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_gpu_type
+    ON llm_call_metrics (gpu_type)
+    WHERE gpu_type IS NOT NULL;
+
+ALTER TABLE llm_cost_aggregates
+    ADD COLUMN IF NOT EXISTS compute_cost_usd NUMERIC(14, 6) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN llm_call_metrics.gpu_seconds IS
+    'Measured or estimated GPU wall-clock seconds for local-model inference (OMN-10338).';
+
+COMMENT ON COLUMN llm_call_metrics.gpu_type IS
+    'Configured GPU type used for local-model inference, e.g. rtx_5090 (OMN-10338).';
+
+COMMENT ON COLUMN llm_call_metrics.gpu_count IS
+    'Configured GPU count used for local-model inference (OMN-10338).';
+
+COMMENT ON COLUMN llm_call_metrics.compute_usage_source IS
+    'Provenance for GPU usage evidence using usage_source_type enum (OMN-10338).';
+
+COMMENT ON COLUMN llm_cost_aggregates.compute_cost_usd IS
+    'Projected GPU compute cost in USD, computed from gpu_seconds and pricing_manifest compute_cost rates (OMN-10338).';
+
+UPDATE public.db_metadata
+SET schema_version = '073', updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/rollback/rollback_073_add_llm_call_metrics_gpu_fields.sql
+++ b/docker/migrations/rollback/rollback_073_add_llm_call_metrics_gpu_fields.sql
@@ -1,0 +1,18 @@
+-- Rollback: forward/073_add_llm_call_metrics_gpu_fields.sql
+-- Description: Remove LLM call metric GPU evidence and aggregate compute cost (OMN-10338)
+-- Created: 2026-04-29
+
+DROP INDEX IF EXISTS idx_llm_call_metrics_gpu_type;
+
+ALTER TABLE llm_cost_aggregates
+    DROP COLUMN IF EXISTS compute_cost_usd;
+
+ALTER TABLE llm_call_metrics
+    DROP COLUMN IF EXISTS compute_usage_source,
+    DROP COLUMN IF EXISTS gpu_count,
+    DROP COLUMN IF EXISTS gpu_type,
+    DROP COLUMN IF EXISTS gpu_seconds;
+
+UPDATE public.db_metadata
+SET schema_version = '072', updated_at = NOW()
+WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:e0dba762c7d57f4d982cc21b2baa42127464f8ed5119b2a2fc6a29f13ef4234a
-generated_at: 2026-04-29T22:31:52Z
-migration_file_count: 58
+sha256:08a99b956a38de53e9eabb5a5ac908ffecb1c59bbad1b95d0fe8c28ab9ac201b
+generated_at: 2026-04-30T08:06:29Z
+migration_file_count: 59

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -20,6 +20,19 @@
 #
 # Schema version for compatibility checking.
 schema_version: "1.0.0"
+compute_cost:
+  rtx_5090:
+    electricity_per_hour: 0.12
+    amortization_per_hour: 0.28
+    note: "Local RTX 5090 GPU compute cost policy"
+  rtx_4090:
+    electricity_per_hour: 0.09
+    amortization_per_hour: 0.18
+    note: "Local RTX 4090 GPU compute cost policy"
+  m2_ultra:
+    electricity_per_hour: 0.04
+    amortization_per_hour: 0.12
+    note: "Local M2 Ultra compute cost policy"
 models:
   # --- Anthropic Claude models ---
   claude-opus-4-6:

--- a/src/omnibase_infra/models/pricing/__init__.py
+++ b/src/omnibase_infra/models/pricing/__init__.py
@@ -11,12 +11,14 @@ Related Tickets:
     - OMN-2239: E1-T3 Model pricing table and cost estimation
 """
 
+from omnibase_infra.models.pricing.model_compute_cost_entry import ModelComputeCostEntry
 from omnibase_infra.models.pricing.model_cost_estimate import ModelCostEstimate
 from omnibase_infra.models.pricing.model_pricing_entry import ModelPricingEntry
 from omnibase_infra.models.pricing.model_pricing_table import ModelPricingTable
 
 __all__: list[str] = [
     "ModelCostEstimate",
+    "ModelComputeCostEntry",
     "ModelPricingEntry",
     "ModelPricingTable",
 ]

--- a/src/omnibase_infra/models/pricing/model_compute_cost_entry.py
+++ b/src/omnibase_infra/models/pricing/model_compute_cost_entry.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Per-GPU compute cost entry from the pricing manifest."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelComputeCostEntry(BaseModel):
+    """Hourly compute cost policy for a GPU type.
+
+    Events carry measured usage evidence. This manifest entry carries pricing
+    policy applied by projections at read/projection time.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    electricity_per_hour: float = Field(
+        ...,
+        ge=0.0,
+        description="Electricity cost in USD per GPU hour.",
+    )
+    amortization_per_hour: float = Field(
+        ...,
+        ge=0.0,
+        description="Hardware amortization cost in USD per GPU hour.",
+    )
+    note: str = Field(
+        default="",
+        max_length=512,
+        description="Optional human-readable note about this compute rate.",
+    )
+
+    @property
+    def total_per_hour(self) -> float:
+        """Combined hourly rate in USD."""
+        return self.electricity_per_hour + self.amortization_per_hour
+
+
+__all__: list[str] = ["ModelComputeCostEntry"]

--- a/src/omnibase_infra/models/pricing/model_pricing_table.py
+++ b/src/omnibase_infra/models/pricing/model_pricing_table.py
@@ -38,6 +38,9 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_infra.models.pricing.model_compute_cost_entry import (
+    ModelComputeCostEntry,
+)
 from omnibase_infra.models.pricing.model_cost_estimate import ModelCostEstimate
 from omnibase_infra.models.pricing.model_pricing_entry import ModelPricingEntry
 
@@ -80,6 +83,10 @@ class ModelPricingTable(BaseModel):
     models: dict[str, ModelPricingEntry] = Field(
         default_factory=dict,
         description="Mapping from model identifier to pricing entry.",
+    )
+    compute_cost: dict[str, ModelComputeCostEntry] = Field(
+        default_factory=dict,
+        description="Mapping from GPU type to hourly compute cost policy.",
     )
 
     @model_validator(mode="after")
@@ -171,6 +178,40 @@ class ModelPricingTable(BaseModel):
         """
         return self.models.get(model_id)
 
+    def estimate_compute_cost(
+        self,
+        gpu_type: str,
+        gpu_seconds: float,
+        gpu_count: int,
+    ) -> float | None:
+        """Estimate compute cost from GPU usage evidence.
+
+        Args:
+            gpu_type: Manifest compute-cost key, e.g. ``"rtx_5090"``.
+            gpu_seconds: GPU wall-clock seconds.
+            gpu_count: Number of GPUs used.
+
+        Returns:
+            Rounded USD compute cost, or ``None`` when the GPU type is not
+            present in the manifest.
+        """
+        if gpu_seconds < 0:
+            raise ValueError("gpu_seconds must be non-negative")
+        if gpu_count < 0:
+            raise ValueError("gpu_count must be non-negative")
+
+        entry = self.compute_cost.get(gpu_type)
+        if entry is None:
+            logger.debug(
+                "GPU type %r not found in pricing manifest compute_cost; "
+                "returning null compute cost.",
+                gpu_type,
+            )
+            return None
+
+        cost = (gpu_seconds / 3600.0) * entry.total_per_hour * gpu_count
+        return round(cost, 10)
+
     @staticmethod
     def from_yaml(path: Path | str | None = None) -> ModelPricingTable:
         """Load a pricing table from a YAML manifest file.
@@ -240,7 +281,7 @@ class ModelPricingTable(BaseModel):
                 "Pricing manifest missing required field: 'schema_version'"
             )
 
-        allowed_keys = {"schema_version", "models"}
+        allowed_keys = {"schema_version", "models", "compute_cost"}
         extra_keys = set(data.keys()) - allowed_keys
         if extra_keys:
             raise ValueError(
@@ -263,9 +304,26 @@ class ModelPricingTable(BaseModel):
                 )
             entries[model_id] = ModelPricingEntry(**entry_data)
 
+        raw_compute_cost = data.get("compute_cost", {})
+        if not isinstance(raw_compute_cost, dict):
+            raise ValueError(
+                f"Pricing manifest 'compute_cost' must be a mapping, "
+                f"got: {type(raw_compute_cost).__name__}"
+            )
+
+        compute_entries: dict[str, ModelComputeCostEntry] = {}
+        for gpu_type, entry_data in raw_compute_cost.items():
+            if not isinstance(entry_data, dict):
+                raise ValueError(
+                    f"Compute cost entry for GPU {gpu_type!r} must be a mapping, "
+                    f"got: {type(entry_data).__name__}"
+                )
+            compute_entries[str(gpu_type)] = ModelComputeCostEntry(**entry_data)
+
         return ModelPricingTable(
             schema_version=str(schema_version),
             models=entries,
+            compute_cost=compute_entries,
         )
 
 

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -16,7 +16,7 @@ contract_name: "node_llm_inference_effect"
 node_name: "node_llm_inference_effect"
 contract_version:
   major: 1
-  minor: 1
+  minor: 2
   patch: 0
 node_version:
   major: 0
@@ -26,7 +26,7 @@ node_version:
 node_type: "EFFECT_GENERIC"
 # Description
 description: >
-  LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, and structured response parsing.
+  LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence for local-model compute attribution.
 
 # Strongly typed I/O models
 # Note: These models live in the shared omnibase_infra.models.llm package.
@@ -135,10 +135,10 @@ consumed_events:
 published_events:
   - topic: "onex.evt.omniintelligence.llm-call-completed.v1"
     event_type: "LlmCallCompletedEvent"
-    description: "Per-call metrics emitted after each inference call"
+    description: "Per-call metrics emitted after each inference call; may include gpu_seconds, gpu_type, gpu_count, and compute_usage_source when the request declares GPU configuration"
   - topic: "onex.evt.omnibase-infra.llm-call-completed.v1"
     event_type: "LlmCallCompletedInfraEvent"
-    description: "Lightweight per-call metrics for infra-owned consumers"
+    description: "Lightweight per-call metrics for infra-owned consumers; mirrors optional GPU usage evidence fields for infra projections"
 # Dependencies
 dependencies:
   - name: "protocol_llm_http_transport"
@@ -156,6 +156,8 @@ capabilities:
     description: "Function/tool calling with structured arguments"
   - name: "circuit_breaker_protection"
     description: "Per-backend circuit breaker for provider fault isolation"
+  - name: "gpu_usage_evidence"
+    description: "When gpu_type and gpu_count are provided together, emits measured gpu_seconds and compute_usage_source on both LLM metric events"
 # Golden path: llm_cost chain (llm-call-completed -> llm_cost_aggregates table)
 golden_path:
   - "Complete LLM inference via provider-specific handler"
@@ -166,11 +168,11 @@ golden_path:
   - "Golden chain test: omnimarket/tests/test_golden_chain_projection_llm_cost.py"
 # Metadata
 metadata:
-  description: "LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, and structured response parsing."
+  description: "LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence."
   author: "OmniNode Team"
   license: "MIT"
   created: "2026-02-13"
-  updated: "2026-02-14"
+  updated: "2026-04-30"
   tags:
     - effect
     - llm

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -380,6 +380,22 @@ class HandlerLlmOpenaiCompatible:
             # Compute input hash for reproducibility tracking.
             input_hash = _compute_input_hash(request)
 
+            extensions: dict[str, JsonType] = {}
+            if request.gpu_type is not None and request.gpu_count is not None:
+                compute_usage_source = request.compute_usage_source or (
+                    "API"
+                    if normalized.source is ContractEnumUsageSource.API
+                    else "ESTIMATED"
+                )
+                extensions.update(
+                    {
+                        "gpu_seconds": round(latency_ms / 1000.0, 3),
+                        "gpu_type": request.gpu_type,
+                        "gpu_count": request.gpu_count,
+                        "compute_usage_source": compute_usage_source,
+                    }
+                )
+
             # Build the metrics contract.
             metrics = ContractLlmCallMetrics(
                 model_id=request.model,
@@ -393,6 +409,7 @@ class HandlerLlmOpenaiCompatible:
                 input_hash=input_hash,
                 timestamp_iso=datetime.now(UTC).isoformat(),
                 reporting_source="handler-llm-openai-compatible",
+                extensions=extensions,
             )
 
             logger.debug(

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
@@ -149,6 +149,22 @@ class ModelLlmInferenceRequest(BaseModel):
         le=600.0,
         description="HTTP request timeout in seconds.",
     )
+    gpu_type: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        description="Configured GPU type for local-model compute evidence.",
+    )
+    gpu_count: int | None = Field(
+        default=None,
+        ge=1,
+        le=32767,
+        description="Configured GPU count for local-model compute evidence.",
+    )
+    compute_usage_source: str | None = Field(
+        default=None,
+        description="Optional compute usage provenance: API, ESTIMATED, or MISSING.",
+    )
 
     @field_validator("base_url")
     @classmethod
@@ -198,6 +214,22 @@ class ModelLlmInferenceRequest(BaseModel):
             and self.prompt is None
         ):
             raise ValueError("COMPLETION requires a non-None prompt")
+        if (self.gpu_type is None) != (self.gpu_count is None):
+            raise ValueError("gpu_type and gpu_count must be provided together")
+        if self.compute_usage_source is not None and (
+            self.gpu_type is None or self.gpu_count is None
+        ):
+            raise ValueError(
+                "compute_usage_source requires gpu_type and gpu_count to be provided"
+            )
+        if self.compute_usage_source is not None and self.compute_usage_source not in {
+            "API",
+            "ESTIMATED",
+            "MISSING",
+        }:
+            raise ValueError(
+                "compute_usage_source must be one of API, ESTIMATED, or MISSING"
+            )
         return self
 
 

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/services/service_llm_metrics_publisher.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/services/service_llm_metrics_publisher.py
@@ -257,6 +257,16 @@ class ServiceLlmMetricsPublisher:
 
         try:
             payload = json.loads(metrics.model_dump_json())
+            extensions = payload.get("extensions")
+            if isinstance(extensions, dict):
+                for key in (
+                    "gpu_seconds",
+                    "gpu_type",
+                    "gpu_count",
+                    "compute_usage_source",
+                ):
+                    if key in extensions:
+                        payload[key] = extensions[key]
             await self._publisher(
                 self._topic_llm_call,
                 payload,
@@ -292,6 +302,16 @@ class ServiceLlmMetricsPublisher:
                 "success": True,
                 "timestamp": datetime.now(UTC).isoformat(),
             }
+            metric_extensions = metrics.extensions
+            if isinstance(metric_extensions, dict):
+                for key in (
+                    "gpu_seconds",
+                    "gpu_type",
+                    "gpu_count",
+                    "compute_usage_source",
+                ):
+                    if key in metric_extensions:
+                        infra_payload[key] = metric_extensions[key]
             await self._publisher(
                 self._topic_llm_call_infra,
                 infra_payload,

--- a/tests/integration/test_llm_gpu_usage_evidence_integration.py
+++ b/tests/integration/test_llm_gpu_usage_evidence_integration.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration checks for LLM GPU usage evidence wiring (OMN-10338)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from omnibase_infra.enums import EnumLlmOperationType
+from omnibase_infra.mixins.mixin_llm_http_transport import MixinLlmHttpTransport
+from omnibase_infra.models.pricing.model_pricing_table import ModelPricingTable
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_openai_compatible import (
+    HandlerLlmOpenaiCompatible,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.models.model_llm_inference_request import (
+    ModelLlmInferenceRequest,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.services.service_llm_metrics_publisher import (
+    ServiceLlmMetricsPublisher,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_CORRELATION_ID = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PRICING_MANIFEST = (
+    _REPO_ROOT / "src" / "omnibase_infra" / "configs" / "pricing_manifest.yaml"
+)
+
+
+def _make_transport() -> MagicMock:
+    transport = MagicMock(spec=MixinLlmHttpTransport)
+    transport._execute_llm_http_call = AsyncMock(
+        return_value={
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+        }
+    )
+    transport._http_client = None
+    transport._owns_http_client = True
+    return transport
+
+
+def _make_request(**overrides: Any) -> ModelLlmInferenceRequest:
+    defaults: dict[str, Any] = {
+        "base_url": "http://localhost:8000",
+        "model": "qwen3-coder-30b-a3b",
+        "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
+        "messages": ({"role": "user", "content": "Hello"},),
+        "gpu_type": "rtx_5090",
+        "gpu_count": 1,
+    }
+    defaults.update(overrides)
+    return ModelLlmInferenceRequest(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_gpu_usage_evidence_reaches_both_metric_events() -> None:
+    """Measured GPU evidence is preserved from handler metrics into both events."""
+    publisher = AsyncMock(return_value=True)
+    handler = HandlerLlmOpenaiCompatible(_make_transport())
+    service = ServiceLlmMetricsPublisher(handler=handler, publisher=publisher)
+
+    with patch(
+        "omnibase_infra.nodes.node_llm_inference_effect.handlers."
+        "handler_llm_openai_compatible.time.perf_counter",
+        side_effect=[10.0, 12.34567],
+    ):
+        await service.handle(_make_request(), correlation_id=_CORRELATION_ID)
+    await asyncio.sleep(0)
+
+    assert publisher.await_count == 2
+    omni_payload = publisher.call_args_list[0].args[1]
+    infra_payload = publisher.call_args_list[1].args[1]
+    for payload in (omni_payload, infra_payload):
+        assert payload["gpu_seconds"] == 2.346
+        assert payload["gpu_type"] == "rtx_5090"
+        assert payload["gpu_count"] == 1
+        assert payload["compute_usage_source"] == "API"
+
+
+def test_pricing_manifest_rates_gpu_usage_evidence() -> None:
+    """Bundled pricing manifest can rate the GPU usage evidence emitted by runtime."""
+    pricing = ModelPricingTable.from_yaml(_PRICING_MANIFEST)
+
+    assert (
+        pricing.estimate_compute_cost(
+            gpu_type="rtx_5090",
+            gpu_seconds=2.346,
+            gpu_count=1,
+        )
+        is not None
+    )

--- a/tests/unit/db/test_migration_073.py
+++ b/tests/unit/db/test_migration_073.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for migration 073: add GPU time fields (OMN-10338)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+MIGRATION_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "073_add_llm_call_metrics_gpu_fields.sql"
+)
+ROLLBACK_FILE = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "rollback"
+    / "rollback_073_add_llm_call_metrics_gpu_fields.sql"
+)
+
+
+def _strip_comments(sql: str) -> str:
+    sql = re.sub(r"--[^\n]*", "", sql)
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    return sql
+
+
+@pytest.mark.unit
+class TestMigration073Files:
+    def test_migration_file_exists(self) -> None:
+        assert MIGRATION_FILE.exists()
+
+    def test_rollback_file_exists(self) -> None:
+        assert ROLLBACK_FILE.exists()
+
+
+@pytest.mark.unit
+class TestMigration073Schema:
+    def test_adds_gpu_metric_columns(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        expected_patterns = {
+            "gpu_seconds": r"gpu_seconds\s+NUMERIC\(10,\s*3\)",
+            "gpu_type": r"gpu_type\s+VARCHAR\(64\)",
+            "gpu_count": r"gpu_count\s+SMALLINT",
+            "compute_usage_source": r"compute_usage_source\s+usage_source_type",
+        }
+        for column, pattern in expected_patterns.items():
+            assert re.search(
+                rf"\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+{pattern}",
+                sql,
+                re.IGNORECASE,
+            ), f"Migration must add {column}"
+
+    def test_adds_compute_cost_to_aggregates(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bALTER\s+TABLE\s+llm_cost_aggregates\b.*"
+            r"\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+compute_cost_usd\s+"
+            r"NUMERIC\(14,\s*6\)\s+NOT\s+NULL\s+DEFAULT\s+0",
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+    def test_gpu_type_partial_index_present(self) -> None:
+        sql = _strip_comments(MIGRATION_FILE.read_text())
+        assert re.search(
+            r"\bCREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+"
+            r"idx_llm_call_metrics_gpu_type\b.*"
+            r"\bON\s+llm_call_metrics\s*\(\s*gpu_type\s*\).*"
+            r"\bWHERE\s+gpu_type\s+IS\s+NOT\s+NULL\b",
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+
+@pytest.mark.unit
+class TestMigration073Rollback:
+    def test_rollback_drops_index_and_columns(self) -> None:
+        sql = _strip_comments(ROLLBACK_FILE.read_text())
+        assert re.search(
+            r"\bDROP\s+INDEX\s+IF\s+EXISTS\s+idx_llm_call_metrics_gpu_type\b",
+            sql,
+            re.IGNORECASE,
+        )
+        for column in (
+            "compute_usage_source",
+            "gpu_count",
+            "gpu_type",
+            "gpu_seconds",
+        ):
+            assert re.search(
+                rf"\bDROP\s+COLUMN\s+IF\s+EXISTS\s+{column}\b",
+                sql,
+                re.IGNORECASE,
+            ), f"Rollback must drop {column}"
+        assert re.search(
+            r"\bALTER\s+TABLE\s+llm_cost_aggregates\b.*"
+            r"\bDROP\s+COLUMN\s+IF\s+EXISTS\s+compute_cost_usd\b",
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )

--- a/tests/unit/models/pricing/test_model_pricing_table.py
+++ b/tests/unit/models/pricing/test_model_pricing_table.py
@@ -72,6 +72,7 @@ class TestModelPricingTableFromDict:
         assert "claude-opus-4-6" in table.models
         assert "gpt-4o" in table.models
         assert "qwen2.5-coder-14b" in table.models
+        assert table.compute_cost == {}
 
     def test_from_dict_missing_schema_version(self) -> None:
         """Missing schema_version should raise ValueError."""
@@ -87,6 +88,33 @@ class TestModelPricingTableFromDict:
             }
         )
         assert len(table.models) == 0
+
+    def test_from_dict_accepts_compute_cost_section(
+        self, sample_manifest_data: dict
+    ) -> None:
+        """Compute cost entries are parsed as manifest policy."""
+        sample_manifest_data["compute_cost"] = {
+            "rtx_5090": {
+                "electricity_per_hour": 0.12,
+                "amortization_per_hour": 0.28,
+            },
+        }
+
+        table = ModelPricingTable.from_dict(sample_manifest_data)
+
+        assert table.compute_cost["rtx_5090"].total_per_hour == 0.40
+        assert table.estimate_compute_cost("rtx_5090", 7200, 1) == 0.8
+
+    def test_from_dict_rejects_invalid_compute_cost_section(self) -> None:
+        """Non-mapping compute cost section is rejected."""
+        with pytest.raises(ValueError, match=r"compute_cost.*mapping"):
+            ModelPricingTable.from_dict(
+                {
+                    "schema_version": "1.0.0",
+                    "models": {},
+                    "compute_cost": ["rtx_5090"],
+                }
+            )
 
     def test_from_dict_no_models_key(self) -> None:
         """Missing models key defaults to empty dict."""

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""GPU usage evidence tests for node_llm_inference_effect (OMN-10338)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from omnibase_infra.enums import EnumLlmOperationType
+from omnibase_infra.mixins.mixin_llm_http_transport import MixinLlmHttpTransport
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_openai_compatible import (
+    HandlerLlmOpenaiCompatible,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.models.model_llm_inference_request import (
+    ModelLlmInferenceRequest,
+)
+
+_CORRELATION_ID = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+
+def _make_transport() -> MagicMock:
+    transport = MagicMock(spec=MixinLlmHttpTransport)
+    transport._execute_llm_http_call = AsyncMock(
+        return_value={
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+        }
+    )
+    transport._http_client = None
+    transport._owns_http_client = True
+    return transport
+
+
+def _make_request(**overrides: Any) -> ModelLlmInferenceRequest:
+    defaults: dict[str, Any] = {
+        "base_url": "http://localhost:8000",
+        "model": "qwen3-coder-30b-a3b",
+        "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
+        "messages": ({"role": "user", "content": "Hello"},),
+        "gpu_type": "rtx_5090",
+        "gpu_count": 1,
+    }
+    defaults.update(overrides)
+    return ModelLlmInferenceRequest(**defaults)
+
+
+@pytest.mark.unit
+class TestGpuMeasurement:
+    @pytest.mark.asyncio
+    async def test_gpu_seconds_and_config_are_added_to_metrics_extensions(
+        self,
+    ) -> None:
+        """GPU seconds come from call wall-clock; GPU type/count from config."""
+        handler = HandlerLlmOpenaiCompatible(_make_transport())
+        with patch(
+            "omnibase_infra.nodes.node_llm_inference_effect.handlers."
+            "handler_llm_openai_compatible.time.perf_counter",
+            side_effect=[10.0, 12.34567],
+        ):
+            await handler.handle(_make_request(), correlation_id=_CORRELATION_ID)
+
+        metrics = handler.last_call_metrics
+        assert metrics is not None
+        assert metrics.extensions["gpu_seconds"] == 2.346
+        assert metrics.extensions["gpu_type"] == "rtx_5090"
+        assert metrics.extensions["gpu_count"] == 1
+        assert metrics.extensions["compute_usage_source"] == "API"
+
+    @pytest.mark.asyncio
+    async def test_compute_usage_source_estimated_when_usage_is_estimated(
+        self,
+    ) -> None:
+        """Without API usage, compute usage provenance degrades to ESTIMATED."""
+        transport = _make_transport()
+        transport._execute_llm_http_call.return_value = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "estimated"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        handler = HandlerLlmOpenaiCompatible(transport)
+
+        await handler.handle(_make_request(), correlation_id=_CORRELATION_ID)
+
+        metrics = handler.last_call_metrics
+        assert metrics is not None
+        assert metrics.extensions["compute_usage_source"] == "ESTIMATED"
+
+    def test_gpu_type_and_count_must_be_configured_together(self) -> None:
+        with pytest.raises(ValueError, match="gpu_type and gpu_count"):
+            _make_request(gpu_type="rtx_5090", gpu_count=None)
+
+    def test_gpu_count_must_be_positive_smallint(self) -> None:
+        with pytest.raises(ValueError):
+            _make_request(gpu_type="rtx_5090", gpu_count=0)
+        with pytest.raises(ValueError):
+            _make_request(gpu_type="rtx_5090", gpu_count=32768)
+
+    def test_compute_usage_source_requires_gpu_configuration(self) -> None:
+        with pytest.raises(ValueError, match="compute_usage_source requires"):
+            _make_request(
+                gpu_type=None,
+                gpu_count=None,
+                compute_usage_source="API",
+            )

--- a/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
+++ b/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
@@ -279,6 +279,25 @@ class TestMetricsEmission:
         UUID(second_corr_id)
         assert first_corr_id == second_corr_id
 
+    @pytest.mark.asyncio
+    async def test_gpu_evidence_is_flattened_into_published_payload(self) -> None:
+        """Published LLM event carries GPU evidence as top-level fields."""
+        transport = _make_transport()
+        transport._execute_llm_http_call.return_value = _make_response_with_usage()
+        service, _, publisher = _make_service(transport=transport)
+
+        await service.handle(
+            _make_chat_request(gpu_type="rtx_5090", gpu_count=1),
+            correlation_id=_CORRELATION_ID,
+        )
+        await asyncio.sleep(0)
+
+        payload = publisher.call_args_list[0][0][1]
+        assert payload["gpu_seconds"] >= 0
+        assert payload["gpu_type"] == "rtx_5090"
+        assert payload["gpu_count"] == 1
+        assert payload["compute_usage_source"] == "API"
+
 
 # ---------------------------------------------------------------------------
 # Infra-namespace topic emission tests


### PR DESCRIPTION
## Summary
- Adds migration 073 for llm_call_metrics GPU fields and aggregate compute_cost_usd
- Adds compute_cost pricing manifest support
- Wires GPU usage evidence through local inference metrics and publisher payloads

Linear: OMN-10338

## Verification
- uv run pytest <Task 7 targeted omnibase_infra tests> -q (58 passed)
- ruff format/check passed
- commit and pre-push hooks passed

## Runtime note
- Read-only schema fingerprint verify attempted but could not reach configured .201 DB (No route to host). No fingerprint stamp was run because that would mutate live runtime state and requires explicit approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU usage evidence added to per-call metrics (gpu_seconds, gpu_type, gpu_count, compute_usage_source)
  * Compute-cost configuration and per-call cost estimation for supported GPU types

* **Chores**
  * Database schema extended to store GPU evidence, a compute cost field, and a partial index
  * Contract bumped and manifest updated to document optional GPU evidence and compute pricing

* **Tests**
  * Unit and integration tests added for GPU measurement, publishing, pricing, and migrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->