### PR TITLE
feat(OMN-10339): replace seed pricing with measured metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,13 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [pre-commit]
+      - id: lint-pricing-manifest
+        name: Lint pricing manifest seed keys
+        entry: uv run --frozen python scripts/lint_pricing_manifest.py
+        language: system
+        files: ^src/omnibase_infra/configs/pricing_manifest\.yaml$
+        pass_filenames: true
+        stages: [pre-commit]
   # ONEX Validation Hooks (infrastructure-specific)
   - repo: local
     hooks:

--- a/scripts/lint_pricing_manifest.py
+++ b/scripts/lint_pricing_manifest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Reject seed-prefixed pricing manifest keys."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_SEED_KEY_RE = re.compile(r"^\s*seed_[A-Za-z0-9_-]*\s*:", re.MULTILINE)
+
+
+def lint_pricing_manifest(path: Path) -> list[str]:
+    """Return lint errors for seed-prefixed manifest keys."""
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for match in _SEED_KEY_RE.finditer(text):
+        line_no = text.count("\n", 0, match.start()) + 1
+        key = match.group(0).strip().removesuffix(":")
+        errors.append(f"{path}:{line_no}: seed pricing key is forbidden: {key}")
+    return errors
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path("src/omnibase_infra/configs/pricing_manifest.yaml")],
+        help="Pricing manifest paths to lint.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    errors: list[str] = []
+    for path in args.paths:
+        errors.extend(lint_pricing_manifest(path))
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_pricing_manifest.py
+++ b/scripts/lint_pricing_manifest.py
@@ -10,7 +10,10 @@ import re
 import sys
 from pathlib import Path
 
-_SEED_KEY_RE = re.compile(r"^\s*seed_[A-Za-z0-9_-]*\s*:", re.MULTILINE)
+_SEED_KEY_RE = re.compile(
+    r"""^\s*(?P<quote>["']?)seed_[A-Za-z0-9_-]*(?P=quote)\s*:""",
+    re.MULTILINE,
+)
 
 
 def lint_pricing_manifest(path: Path) -> list[str]:

--- a/scripts/recompute_measured_pricing.py
+++ b/scripts/recompute_measured_pricing.py
@@ -18,6 +18,7 @@ from typing import Protocol, cast
 import yaml
 
 DEFAULT_MANIFEST = Path("src/omnibase_infra/configs/pricing_manifest.yaml")
+DEFAULT_ENV_FILE = Path.home() / ".omnibase" / ".env"
 LOW_CONFIDENCE = "LOW_CONFIDENCE"
 MEASURED = "MEASURED"
 MEASURED_SOURCE = "API_REPORTED_COST_ROLLING_7D"
@@ -263,7 +264,27 @@ def _fallback_source(entry: dict[str, object]) -> str:
     return FALLBACK_SOURCE
 
 
+def load_dotenv(path: Path = DEFAULT_ENV_FILE) -> None:
+    """Load KEY=VALUE pairs from a dotenv file without overriding the environment."""
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key or key in os.environ:
+            continue
+        value = raw_value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        os.environ[key] = value
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--output", type=Path)

--- a/scripts/recompute_measured_pricing.py
+++ b/scripts/recompute_measured_pricing.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Recompute pricing manifest token rates from API-reported cost evidence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, cast
+
+import yaml
+
+DEFAULT_MANIFEST = Path("src/omnibase_infra/configs/pricing_manifest.yaml")
+LOW_CONFIDENCE = "LOW_CONFIDENCE"
+MEASURED = "MEASURED"
+MEASURED_SOURCE = "API_REPORTED_COST_ROLLING_7D"
+FALLBACK_SOURCE = "FALLBACK_PROVIDER_DOCUMENTATION"
+LOCAL_SOURCE = "LOCAL_ZERO_API_COST_POLICY"
+MANIFEST_HEADER = (
+    "# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.\n# SPDX-License-Identifier: MIT\n"
+)
+
+
+@dataclass(frozen=True)
+class PricingSample:
+    """One API-reported cost sample from llm_call_metrics."""
+
+    model_id: str
+    prompt_tokens: int
+    completion_tokens: int
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class ComputedPricing:
+    """Computed pricing result for one model."""
+
+    input_cost_per_1k: float
+    output_cost_per_1k: float
+    sample_count: int
+    confidence: str
+
+
+class DbConnection(Protocol):
+    """Minimal asyncpg connection protocol used by this script."""
+
+    async def fetch(self, query: str) -> list[object]:
+        """Fetch query rows."""
+
+    async def close(self) -> None:
+        """Close the connection."""
+
+
+def _as_mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("Expected YAML mapping")
+    return value
+
+
+def _sample_from_mapping(data: dict[str, object]) -> PricingSample | None:
+    model_id = data.get("model_id")
+    cost = data.get("estimated_cost_usd", data.get("cost_usd"))
+    prompt_tokens = data.get("prompt_tokens", data.get("input_tokens", 0))
+    completion_tokens = data.get(
+        "completion_tokens",
+        data.get("output_tokens", 0),
+    )
+    usage_source = data.get("usage_source", "API")
+
+    if not isinstance(model_id, str) or usage_source != "API" or cost is None:
+        return None
+
+    prompt = int(cast("int | float | str", prompt_tokens or 0))
+    completion = int(cast("int | float | str", completion_tokens or 0))
+    if prompt < 0 or completion < 0 or (prompt == 0 and completion == 0):
+        return None
+
+    return PricingSample(
+        model_id=model_id,
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cost_usd=float(cast("int | float | str", cost)),
+    )
+
+
+def load_fixture_samples(path: Path) -> list[PricingSample]:
+    """Load deterministic pricing samples from JSONL fixture rows."""
+    samples: list[PricingSample] = []
+    for line_no, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        line = raw_line.strip()
+        if not line:
+            continue
+        decoded = json.loads(line)
+        sample = _sample_from_mapping(_as_mapping(decoded))
+        if sample is not None:
+            samples.append(sample)
+        elif decoded:
+            continue
+        else:
+            raise ValueError(f"{path}:{line_no}: fixture row must be a JSON object")
+    return samples
+
+
+async def fetch_db_samples(database_url: str) -> list[PricingSample]:
+    """Fetch the last 7 days of API-reported llm_call_metrics rows."""
+    import asyncpg
+
+    query = """
+        SELECT
+            model_id,
+            COALESCE(prompt_tokens, 0) AS prompt_tokens,
+            COALESCE(completion_tokens, 0) AS completion_tokens,
+            estimated_cost_usd
+        FROM llm_call_metrics
+        WHERE created_at >= NOW() - INTERVAL '7 days'
+          AND usage_source = 'API'
+          AND estimated_cost_usd IS NOT NULL
+          AND COALESCE(prompt_tokens, 0) + COALESCE(completion_tokens, 0) > 0
+        ORDER BY model_id, created_at
+    """
+    connection = cast("DbConnection", await asyncpg.connect(database_url))
+    try:
+        rows = await connection.fetch(query)
+    finally:
+        await connection.close()
+
+    samples: list[PricingSample] = []
+    for row in rows:
+        sample = _sample_from_mapping(dict(cast("object", row)))
+        if sample is not None:
+            samples.append(sample)
+    return samples
+
+
+def compute_pricing_by_model(
+    samples: list[PricingSample],
+    *,
+    min_samples: int,
+) -> dict[str, ComputedPricing]:
+    """Compute per-1k input/output rates per model via least squares."""
+    grouped: dict[str, list[PricingSample]] = defaultdict(list)
+    for sample in samples:
+        grouped[sample.model_id].append(sample)
+
+    results: dict[str, ComputedPricing] = {}
+    for model_id, model_samples in grouped.items():
+        sample_count = len(model_samples)
+        input_rate, output_rate = _solve_token_rates(model_samples)
+        results[model_id] = ComputedPricing(
+            input_cost_per_1k=input_rate,
+            output_cost_per_1k=output_rate,
+            sample_count=sample_count,
+            confidence=MEASURED if sample_count >= min_samples else LOW_CONFIDENCE,
+        )
+    return results
+
+
+def _solve_token_rates(samples: list[PricingSample]) -> tuple[float, float]:
+    prompt_units = [sample.prompt_tokens / 1000.0 for sample in samples]
+    completion_units = [sample.completion_tokens / 1000.0 for sample in samples]
+    costs = [sample.cost_usd for sample in samples]
+
+    sum_prompt_sq = sum(value * value for value in prompt_units)
+    sum_cross = sum(
+        prompt * completion
+        for prompt, completion in zip(prompt_units, completion_units, strict=True)
+    )
+    sum_completion_sq = sum(value * value for value in completion_units)
+    sum_prompt_cost = sum(
+        prompt * cost for prompt, cost in zip(prompt_units, costs, strict=True)
+    )
+    sum_completion_cost = sum(
+        completion * cost
+        for completion, cost in zip(completion_units, costs, strict=True)
+    )
+
+    determinant = sum_prompt_sq * sum_completion_sq - sum_cross * sum_cross
+    if abs(determinant) > 1e-12:
+        input_rate = (
+            sum_prompt_cost * sum_completion_sq - sum_cross * sum_completion_cost
+        ) / determinant
+        output_rate = (
+            sum_prompt_sq * sum_completion_cost - sum_cross * sum_prompt_cost
+        ) / determinant
+        return round(max(input_rate, 0.0), 10), round(max(output_rate, 0.0), 10)
+
+    prompt_total = sum(prompt_units)
+    completion_total = sum(completion_units)
+    cost_total = sum(costs)
+    if prompt_total > 0 and completion_total == 0:
+        return round(max(cost_total / prompt_total, 0.0), 10), 0.0
+    if completion_total > 0 and prompt_total == 0:
+        return 0.0, round(max(cost_total / completion_total, 0.0), 10)
+    if cost_total == 0:
+        return 0.0, 0.0
+    blended = cost_total / max(prompt_total + completion_total, 1e-12)
+    return round(max(blended, 0.0), 10), round(max(blended, 0.0), 10)
+
+
+def update_manifest(
+    manifest_path: Path,
+    output_path: Path,
+    computed: dict[str, ComputedPricing],
+    *,
+    min_samples: int,
+    generated_at: str,
+) -> None:
+    """Write updated pricing metadata to a manifest."""
+    manifest = _as_mapping(yaml.safe_load(manifest_path.read_text(encoding="utf-8")))
+    models = _as_mapping(manifest.get("models", {}))
+
+    for model_id, raw_entry in models.items():
+        entry = _as_mapping(raw_entry)
+        result = computed.get(str(model_id))
+        if result is not None:
+            entry["input_cost_per_1k"] = result.input_cost_per_1k
+            entry["output_cost_per_1k"] = result.output_cost_per_1k
+            entry["confidence"] = result.confidence
+            entry["source"] = (
+                MEASURED_SOURCE
+                if result.confidence == MEASURED
+                else _fallback_source(entry)
+            )
+            entry["sample_count"] = result.sample_count
+        else:
+            entry.setdefault("confidence", LOW_CONFIDENCE)
+            entry.setdefault("source", _fallback_source(entry))
+            entry.setdefault("sample_count", 0)
+
+        entry["evidence"] = {
+            "generated_at": generated_at,
+            "sample_window_days": 7,
+            "sample_count": int(entry["sample_count"]),
+            "min_samples": min_samples,
+            "query": "llm_call_metrics usage_source=API created_at>=now-7d",
+            "authoritative": entry["confidence"] == MEASURED,
+        }
+
+    rendered = yaml.safe_dump(
+        manifest,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    output_path.write_text(f"{MANIFEST_HEADER}{rendered}", encoding="utf-8")
+
+
+def _fallback_source(entry: dict[str, object]) -> str:
+    note = str(entry.get("note", "")).lower()
+    if "local" in note:
+        return LOCAL_SOURCE
+    source = entry.get("source")
+    if isinstance(source, str) and source != MEASURED_SOURCE:
+        return source
+    return FALLBACK_SOURCE
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--database-url", default=os.getenv("DATABASE_URL"))
+    parser.add_argument("--fixture-jsonl", type=Path)
+    parser.add_argument("--min-samples", type=int, default=20)
+    parser.add_argument("--generated-at")
+    return parser.parse_args(argv)
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output_path = args.output or args.manifest
+    generated_at = args.generated_at or dt.datetime.now(dt.UTC).isoformat()
+
+    if args.fixture_jsonl is not None:
+        samples = load_fixture_samples(args.fixture_jsonl)
+    elif args.database_url:
+        samples = await fetch_db_samples(str(args.database_url))
+    else:
+        raise SystemExit("--database-url or --fixture-jsonl is required")
+
+    computed = compute_pricing_by_model(samples, min_samples=int(args.min_samples))
+    update_manifest(
+        args.manifest,
+        output_path,
+        computed,
+        min_samples=int(args.min_samples),
+        generated_at=str(generated_at),
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(async_main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -1,144 +1,351 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2026 OmniNode Team
-#
-# LLM Model Pricing Manifest
-#
-# Canonical pricing data for all supported LLM models. Used by
-# ModelPricingTable to compute estimated_cost_usd per LLM call.
-#
-# Update cadence: Manual update via PR. CI validates manifest schema.
-# No auto-fetch from provider APIs.
-#
-# Cost convention:
-#   - Costs are in USD per 1,000 tokens.
-#   - Local models have explicit 0.0 costs (not omitted).
-#   - Unknown models (not listed here) return null cost, NOT 0.
-#
-# Related Tickets:
-#   - OMN-2239: E1-T3 Model pricing table and cost estimation
-#
-# Schema version for compatibility checking.
-schema_version: "1.0.0"
+schema_version: 1.0.0
 compute_cost:
   rtx_5090:
     electricity_per_hour: 0.12
     amortization_per_hour: 0.28
-    note: "Local RTX 5090 GPU compute cost policy"
+    note: Local RTX 5090 GPU compute cost policy
   rtx_4090:
     electricity_per_hour: 0.09
     amortization_per_hour: 0.18
-    note: "Local RTX 4090 GPU compute cost policy"
+    note: Local RTX 4090 GPU compute cost policy
   m2_ultra:
     electricity_per_hour: 0.04
     amortization_per_hour: 0.12
-    note: "Local M2 Ultra compute cost policy"
+    note: Local M2 Ultra compute cost policy
 models:
-  # --- Anthropic Claude models ---
   claude-opus-4-6:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.075
-    effective_date: "2026-02-01"
+    effective_date: '2026-02-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   claude-sonnet-4-20250514:
     input_cost_per_1k: 0.003
     output_cost_per_1k: 0.015
-    effective_date: "2025-05-22"
+    effective_date: '2025-05-22'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   claude-haiku-3-5:
     input_cost_per_1k: 0.0008
     output_cost_per_1k: 0.004
-    effective_date: "2025-06-01"
-  # --- OpenAI GPT models ---
+    effective_date: '2025-06-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gpt-4o:
     input_cost_per_1k: 0.0025
     output_cost_per_1k: 0.01
-    effective_date: "2025-11-01"
+    effective_date: '2025-11-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gpt-4o-mini:
     input_cost_per_1k: 0.00015
     output_cost_per_1k: 0.0006
-    effective_date: "2025-07-01"
+    effective_date: '2025-07-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gpt-4-turbo:
     input_cost_per_1k: 0.01
     output_cost_per_1k: 0.03
-    effective_date: "2025-04-01"
+    effective_date: '2025-04-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   o1:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.06
-    effective_date: "2025-12-01"
+    effective_date: '2025-12-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   o1-mini:
     input_cost_per_1k: 0.003
     output_cost_per_1k: 0.012
-    effective_date: "2025-09-01"
+    effective_date: '2025-09-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   o3-mini:
     input_cost_per_1k: 0.0011
     output_cost_per_1k: 0.0044
-    effective_date: "2026-01-01"
-  # --- Google Gemini models ---
+    effective_date: '2026-01-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gemini-2.0-flash:
     input_cost_per_1k: 0.0001
     output_cost_per_1k: 0.0004
-    effective_date: "2026-02-01"
+    effective_date: '2026-02-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gemini-1.5-pro:
     input_cost_per_1k: 0.00125
     output_cost_per_1k: 0.005
-    effective_date: "2025-05-01"
-  # --- Local models (zero API cost) ---
+    effective_date: '2025-05-01'
+    confidence: LOW_CONFIDENCE
+    source: FALLBACK_PROVIDER_DOCUMENTATION
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen2.5-coder-14b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on RTX 5090 - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on RTX 5090 - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen2.5-72b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on Mac Studio M2 Ultra - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on Mac Studio M2 Ultra - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen2.5-14b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on Mac Mini M2 Pro - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on Mac Mini M2 Pro - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen2.5-7b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on RTX 4090 (hot-swap) - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on RTX 4090 (hot-swap) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   gte-qwen2-1.5b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local embedding model on RTX 4090 - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local embedding model on RTX 4090 - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   deepseek-v2-lite:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on RTX 4090 (hot-swap) - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on RTX 4090 (hot-swap) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   deepseek-r1-distill:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local model on Mac Studio M2 Ultra (hot-swap) - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local model on Mac Studio M2 Ultra (hot-swap) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen2-vl:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-02-01"
-    note: "Local vision model on Mac Studio M2 Ultra - zero API cost"
+    effective_date: '2026-02-01'
+    note: Local vision model on Mac Studio M2 Ultra - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen3-coder-30b-a3b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-03-19"
-    note: "Local model on RTX 5090 (port 8000) - zero API cost"
+    effective_date: '2026-03-19'
+    note: Local model on RTX 5090 (port 8000) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen3-14b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-03-19"
-    note: "Local model on RTX 4090 (port 8001) - zero API cost"
+    effective_date: '2026-03-19'
+    note: Local model on RTX 4090 (port 8001) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   qwen3-embedding-8b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-03-19"
-    note: "Local embedding model on M2 Ultra (port 8100) - zero API cost"
+    effective_date: '2026-03-19'
+    note: Local embedding model on M2 Ultra (port 8100) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
   deepseek-r1-distill-qwen-32b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: "2026-03-19"
-    note: "Local model on RTX 4090 .201 (port 8001) - zero API cost"
+    effective_date: '2026-03-19'
+    note: Local model on RTX 4090 .201 (port 8001) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-04-29T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false

--- a/src/omnibase_infra/models/pricing/model_pricing_entry.py
+++ b/src/omnibase_infra/models/pricing/model_pricing_entry.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 
 import datetime
 import re
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+PricingConfidence = Literal["MEASURED", "LOW_CONFIDENCE"]
 
 
 class ModelPricingEntry(BaseModel):
@@ -80,6 +83,25 @@ class ModelPricingEntry(BaseModel):
         max_length=512,
         description="Optional human-readable note about this model's pricing.",
     )
+    confidence: PricingConfidence = Field(
+        default="LOW_CONFIDENCE",
+        description="Confidence level for the token pricing entry.",
+    )
+    source: str = Field(
+        default="FALLBACK_PROVIDER_DOCUMENTATION",
+        min_length=1,
+        max_length=128,
+        description="Pricing source; fallback sources are not authoritative.",
+    )
+    evidence: dict[str, object] = Field(
+        default_factory=dict,
+        description="Structured evidence for the pricing source.",
+    )
+    sample_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of API-reported rows used to compute the rate.",
+    )
 
     @field_validator("effective_date")
     @classmethod
@@ -106,4 +128,4 @@ class ModelPricingEntry(BaseModel):
         return v
 
 
-__all__: list[str] = ["ModelPricingEntry"]
+__all__: list[str] = ["ModelPricingEntry", "PricingConfidence"]

--- a/tests/integration/scripts/test_recompute_measured_pricing.py
+++ b/tests/integration/scripts/test_recompute_measured_pricing.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for measured pricing recomputation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "recompute_measured_pricing.py"
+
+
+def _load_recompute_module() -> object:
+    spec = importlib.util.spec_from_file_location("recompute_measured_pricing", _SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["recompute_measured_pricing"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "1.0.0",
+                "models": {
+                    "measured-model": {
+                        "input_cost_per_1k": 0.0,
+                        "output_cost_per_1k": 0.0,
+                        "effective_date": "2026-04-29",
+                        "confidence": "LOW_CONFIDENCE",
+                        "source": "FALLBACK_PROVIDER_DOCUMENTATION",
+                        "sample_count": 0,
+                        "evidence": {"authoritative": False},
+                    },
+                    "thin-model": {
+                        "input_cost_per_1k": 0.0,
+                        "output_cost_per_1k": 0.0,
+                        "effective_date": "2026-04-29",
+                        "confidence": "LOW_CONFIDENCE",
+                        "source": "FALLBACK_PROVIDER_DOCUMENTATION",
+                        "sample_count": 0,
+                        "evidence": {"authoritative": False},
+                    },
+                    "fallback-model": {
+                        "input_cost_per_1k": 0.001,
+                        "output_cost_per_1k": 0.002,
+                        "effective_date": "2026-04-29",
+                        "confidence": "LOW_CONFIDENCE",
+                        "source": "FALLBACK_PROVIDER_DOCUMENTATION",
+                        "sample_count": 0,
+                        "evidence": {"authoritative": False},
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_fixture(path: Path) -> None:
+    rows: list[dict[str, object]] = []
+    for _ in range(10):
+        rows.append(
+            {
+                "model_id": "measured-model",
+                "prompt_tokens": 1000,
+                "completion_tokens": 0,
+                "estimated_cost_usd": 0.003,
+                "usage_source": "API",
+            }
+        )
+        rows.append(
+            {
+                "model_id": "measured-model",
+                "prompt_tokens": 0,
+                "completion_tokens": 1000,
+                "estimated_cost_usd": 0.015,
+                "usage_source": "API",
+            }
+        )
+    for _ in range(19):
+        rows.append(
+            {
+                "model_id": "thin-model",
+                "prompt_tokens": 1000,
+                "completion_tokens": 0,
+                "estimated_cost_usd": 0.004,
+                "usage_source": "API",
+            }
+        )
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.integration
+def test_recompute_measured_pricing_updates_manifest_from_fixture(
+    tmp_path: Path,
+) -> None:
+    module = _load_recompute_module()
+    manifest = tmp_path / "pricing_manifest.yaml"
+    output = tmp_path / "pricing_manifest.updated.yaml"
+    fixture = tmp_path / "llm_call_metrics.jsonl"
+    _write_manifest(manifest)
+    _write_fixture(fixture)
+
+    assert (
+        module.main(
+            [
+                "--manifest",
+                str(manifest),
+                "--output",
+                str(output),
+                "--fixture-jsonl",
+                str(fixture),
+                "--generated-at",
+                "2026-04-29T00:00:00+00:00",
+            ]
+        )
+        == 0
+    )
+
+    data = yaml.safe_load(output.read_text(encoding="utf-8"))
+    measured = data["models"]["measured-model"]
+    thin = data["models"]["thin-model"]
+    fallback = data["models"]["fallback-model"]
+
+    assert measured["input_cost_per_1k"] == 0.003
+    assert measured["output_cost_per_1k"] == 0.015
+    assert measured["sample_count"] == 20
+    assert measured["confidence"] == "MEASURED"
+    assert measured["source"] == "API_REPORTED_COST_ROLLING_7D"
+    assert measured["evidence"]["authoritative"] is True
+
+    assert thin["input_cost_per_1k"] == 0.004
+    assert thin["sample_count"] == 19
+    assert thin["confidence"] == "LOW_CONFIDENCE"
+    assert thin["source"] == "FALLBACK_PROVIDER_DOCUMENTATION"
+    assert thin["evidence"]["authoritative"] is False
+
+    assert fallback["input_cost_per_1k"] == 0.001
+    assert fallback["output_cost_per_1k"] == 0.002
+    assert fallback["source"] == "FALLBACK_PROVIDER_DOCUMENTATION"
+    assert fallback["evidence"]["authoritative"] is False

--- a/tests/integration/scripts/test_recompute_measured_pricing.py
+++ b/tests/integration/scripts/test_recompute_measured_pricing.py
@@ -153,3 +153,23 @@ def test_recompute_measured_pricing_updates_manifest_from_fixture(
     assert fallback["output_cost_per_1k"] == 0.002
     assert fallback["source"] == "FALLBACK_PROVIDER_DOCUMENTATION"
     assert fallback["evidence"]["authoritative"] is False
+
+
+@pytest.mark.integration
+def test_load_dotenv_sets_database_url_without_overriding_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_recompute_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        'DATABASE_URL="postgresql://from-file"\nOTHER_VALUE=from-file\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("OTHER_VALUE", "from-env")
+
+    module.load_dotenv(env_file)
+
+    assert module.os.environ["DATABASE_URL"] == "postgresql://from-file"
+    assert module.os.environ["OTHER_VALUE"] == "from-env"

--- a/tests/unit/configs/test_pricing_manifest_schema.py
+++ b/tests/unit/configs/test_pricing_manifest_schema.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Task 8 pricing manifest schema checks."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.models.pricing.model_pricing_table import _DEFAULT_MANIFEST_PATH
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LINT_SCRIPT = _REPO_ROOT / "scripts" / "lint_pricing_manifest.py"
+
+
+def _load_lint_module() -> object:
+    spec = importlib.util.spec_from_file_location("lint_pricing_manifest", _LINT_SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lint_pricing_manifest"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _walk_seed_keys(value: object, path: str = "$") -> list[str]:
+    violations: list[str] = []
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            key = str(raw_key)
+            child_path = f"{path}.{key}"
+            if key.startswith("seed_"):
+                violations.append(child_path)
+            violations.extend(_walk_seed_keys(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            violations.extend(_walk_seed_keys(child, f"{path}[{index}]"))
+    return violations
+
+
+@pytest.mark.unit
+def test_pricing_manifest_has_no_seed_keys() -> None:
+    data = yaml.safe_load(_DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert _walk_seed_keys(data) == []
+
+
+@pytest.mark.unit
+def test_fallback_pricing_has_source_and_non_authoritative_evidence() -> None:
+    data = yaml.safe_load(_DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    for model_id, entry in data["models"].items():
+        assert entry["source"], f"{model_id} missing pricing source"
+        assert entry["evidence"], f"{model_id} missing pricing evidence"
+        if entry["confidence"] == "LOW_CONFIDENCE":
+            assert entry["evidence"]["authoritative"] is False
+
+
+@pytest.mark.unit
+def test_low_sample_manifest_models_are_low_confidence() -> None:
+    data = yaml.safe_load(_DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    for model_id, entry in data["models"].items():
+        if entry["sample_count"] < 20:
+            assert entry["confidence"] == "LOW_CONFIDENCE", model_id
+
+
+@pytest.mark.unit
+def test_lint_pricing_manifest_blocks_seed_keys(tmp_path: Path) -> None:
+    module = _load_lint_module()
+    manifest = tmp_path / "pricing_manifest.yaml"
+    manifest.write_text(
+        "schema_version: '1.0.0'\nmodels:\n  bad:\n    seed_price: 1\n",
+        encoding="utf-8",
+    )
+
+    errors = module.lint_pricing_manifest(manifest)
+
+    assert errors
+    assert "seed_price" in errors[0]
+
+
+@pytest.mark.unit
+def test_lint_pricing_manifest_allows_non_seed_manifest(tmp_path: Path) -> None:
+    module = _load_lint_module()
+    manifest = tmp_path / "pricing_manifest.yaml"
+    manifest.write_text(
+        "schema_version: '1.0.0'\nmodels:\n  ok:\n    source: fallback\n",
+        encoding="utf-8",
+    )
+
+    assert module.lint_pricing_manifest(manifest) == []

--- a/tests/unit/configs/test_pricing_manifest_schema.py
+++ b/tests/unit/configs/test_pricing_manifest_schema.py
@@ -85,6 +85,26 @@ def test_lint_pricing_manifest_blocks_seed_keys(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_lint_pricing_manifest_blocks_quoted_seed_keys(tmp_path: Path) -> None:
+    module = _load_lint_module()
+    manifest = tmp_path / "pricing_manifest.yaml"
+    manifest.write_text(
+        "schema_version: '1.0.0'\n"
+        "models:\n"
+        "  bad:\n"
+        "    'seed_price': 1\n"
+        '    "seed_source": fallback\n',
+        encoding="utf-8",
+    )
+
+    errors = module.lint_pricing_manifest(manifest)
+
+    assert len(errors) == 2
+    assert "'seed_price'" in errors[0]
+    assert '"seed_source"' in errors[1]
+
+
+@pytest.mark.unit
 def test_lint_pricing_manifest_allows_non_seed_manifest(tmp_path: Path) -> None:
     module = _load_lint_module()
     manifest = tmp_path / "pricing_manifest.yaml"


### PR DESCRIPTION
## Summary
- replaces seed pricing fields with confidence/source/evidence metadata in the pricing manifest
- adds deterministic measured-pricing recomputation from API-reported llm_call_metrics rows
- adds a manifest lint hook that blocks future seed_ pricing keys

## Verification
- uv run pytest tests/unit/configs/test_pricing_manifest_schema.py tests/integration/scripts/test_recompute_measured_pricing.py tests/ci/test_pricing_manifest_schema.py tests/unit/models/pricing/test_model_pricing_entry.py tests/unit/models/pricing/test_model_pricing_table.py -q
- uv run ruff format .pre-commit-config.yaml src/omnibase_infra/configs/pricing_manifest.yaml src/omnibase_infra/models/pricing/model_pricing_entry.py scripts/recompute_measured_pricing.py scripts/lint_pricing_manifest.py tests/unit/configs/test_pricing_manifest_schema.py tests/integration/scripts/test_recompute_measured_pricing.py
- uv run ruff check .pre-commit-config.yaml src/omnibase_infra/configs/pricing_manifest.yaml src/omnibase_infra/models/pricing/model_pricing_entry.py scripts/recompute_measured_pricing.py scripts/lint_pricing_manifest.py tests/unit/configs/test_pricing_manifest_schema.py tests/integration/scripts/test_recompute_measured_pricing.py
- uv run python scripts/lint_pricing_manifest.py src/omnibase_infra/configs/pricing_manifest.yaml
- ! grep -E "^\s*seed_" src/omnibase_infra/configs/pricing_manifest.yaml
- uv run pre-commit run lint-pricing-manifest --all-files
- uv run pre-commit run --files .pre-commit-config.yaml src/omnibase_infra/configs/pricing_manifest.yaml src/omnibase_infra/models/pricing/model_pricing_entry.py scripts/recompute_measured_pricing.py scripts/lint_pricing_manifest.py tests/unit/configs/test_pricing_manifest_schema.py tests/integration/scripts/test_recompute_measured_pricing.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing data now includes confidence indicators and source attribution to distinguish measured rates from documentation-based estimates
  * Added automatic computation of model pricing rates from measured usage data

* **Chores**
  * Added pricing manifest validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->