### PR TITLE
test(OMN-10281): isolate stability runtime render

### DIFF
--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -12,7 +12,15 @@
 #
 # Starting this lane is intentionally outside this PR's proof scope and requires
 # explicit operator approval.
+#
+# Requires Docker Compose v2.24.4 or later for !override merge semantics.
 name: omnibase-infra-stability-test
+x-stability-runtime-build: &stability-runtime-build
+  context: ..
+  dockerfile: docker/Dockerfile.runtime
+  args:
+    BUILD_SOURCE: workspace
+    EXPECTED_BUILD_SOURCE: workspace
 services:
   postgres:
     container_name: omnibase-infra-stability-test-postgres
@@ -69,22 +77,29 @@ services:
     container_name: omnibase-infra-stability-test-valkey
     ports: !override
       - "${STABILITY_TEST_VALKEY_EXTERNAL_PORT:-26379}:6379"
+  infisical:
+    profiles: !override ["stability-test-disabled"]
+  forward-migration:
+    container_name: omnibase-infra-stability-test-forward-migration
+    restart: "no"
   migration-gate:
     container_name: omnibase-infra-stability-test-migration-gate
     restart: "no"
-  forward-migration:
-    container_name: omnibase-infra-stability-test-forward-migration
   intelligence-migration:
     container_name: omnibase-infra-stability-test-intelligence-migration
   omninode-runtime:
+    build: *stability-runtime-build
     image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime
     restart: "no"
     depends_on:
+      intelligence-migration:
+        condition: service_completed_successfully
       redpanda-partition-cap:
         condition: service_completed_successfully
     environment:
       BUILD_SOURCE: workspace
+      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override
@@ -111,11 +126,13 @@ services:
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/main"
       - "com.omninode.runtime.id=stability-test-main"
   runtime-effects:
+    build: *stability-runtime-build
     image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime-effects
     restart: "no"
     environment:
       BUILD_SOURCE: workspace
+      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override
@@ -142,11 +159,13 @@ services:
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/effects"
       - "com.omninode.runtime.id=stability-test-effects"
   runtime-worker:
+    build: *stability-runtime-build
     image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime-worker
     restart: "no"
     environment:
       BUILD_SOURCE: workspace
+      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override
@@ -170,6 +189,20 @@ services:
       - "com.omninode.ticket=OMN-10281"
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/worker"
       - "com.omninode.runtime.id=stability-test-worker"
+  agent-actions-consumer:
+    profiles: !override ["stability-test-disabled"]
+  skill-lifecycle-consumer:
+    profiles: !override ["stability-test-disabled"]
+  context-audit-consumer:
+    profiles: !override ["stability-test-disabled"]
+  intelligence-api:
+    profiles: !override ["stability-test-disabled"]
+  omninode-contract-resolver:
+    profiles: !override ["stability-test-disabled"]
+  phoenix:
+    profiles: !override ["stability-test-disabled"]
+  autoheal:
+    profiles: !override ["stability-test-disabled"]
 volumes:
   postgres_data:
     name: omnibase-infra-stability-test-postgres-data
@@ -192,6 +225,8 @@ volumes:
 networks:
   omnibase-infra-network:
     name: omnibase-infra-stability-test-network
+    driver: bridge
   omnimemory-network:
     name: omnibase-infra-stability-test-omnimemory-network
+    driver: bridge
     external: false

--- a/docs/runbooks/stability-test-runtime-lane.md
+++ b/docs/runbooks/stability-test-runtime-lane.md
@@ -27,6 +27,10 @@ the two-phase runtime build plan into a concrete runtime lane:
   event-bus consumers can append a lane-specific instance discriminator.
 - Runtime state is mounted on stability-test volumes and uses
   `/app/data/.onex_state_stability_test`.
+- The overlay does not expose inherited production host ports in the rendered
+  stability-test config.
+- The overlay does not render inherited out-of-lane runtime services such as
+  observability consumers, contract resolver, Phoenix, autoheal, or Infisical.
 
 ## What Is Defined
 
@@ -51,6 +55,19 @@ the two-phase runtime build plan into a concrete runtime lane:
   - `onex-stability-test-runtime-effects`
   - `onex-stability-test-runtime-workers`
 - Runtime state root: `/app/data/.onex_state_stability_test`
+- Published host ports:
+  - Postgres: `15436`
+  - Redpanda Kafka: `39092`
+  - Redpanda admin: `29644`
+  - Valkey: `26379`
+  - Runtime main: `18085`
+  - Runtime effects: `18086`
+- Build args:
+  - `BUILD_SOURCE=workspace`
+  - `EXPECTED_BUILD_SOURCE=workspace`
+- Networks:
+  - `omnibase-infra-stability-test-network`
+  - `omnibase-infra-stability-test-omnimemory-network`
 
 ## Validation Only
 
@@ -63,6 +80,9 @@ docker compose \
   --profile runtime \
   config
 ```
+
+The overlay requires Docker Compose v2.24.4 or later because it uses Compose
+`!override` merge semantics to replace inherited port and profile lists.
 
 List the rendered services and confirm the stability-test runtime services are
 present:

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_FILES = (
@@ -21,6 +21,72 @@ REQUIRED_RUNTIME_SERVICES = {
     "omninode-runtime",
     "runtime-effects",
     "runtime-worker",
+}
+EXPECTED_RENDERED_SERVICES = {
+    "postgres",
+    "redpanda",
+    "redpanda-partition-cap",
+    "valkey",
+    "forward-migration",
+    "intelligence-migration",
+    "migration-gate",
+    *REQUIRED_RUNTIME_SERVICES,
+}
+OUT_OF_LANE_SERVICES = {
+    "agent-actions-consumer",
+    "skill-lifecycle-consumer",
+    "context-audit-consumer",
+    "intelligence-api",
+    "omninode-contract-resolver",
+    "phoenix",
+    "autoheal",
+    "infisical",
+}
+EXPECTED_PUBLISHED_PORTS = {
+    "postgres": {"15436"},
+    "redpanda": {"39092", "29644"},
+    "valkey": {"26379"},
+    "omninode-runtime": {"18085"},
+    "runtime-effects": {"18086"},
+    "runtime-worker": set(),
+    "forward-migration": set(),
+    "intelligence-migration": set(),
+    "migration-gate": set(),
+    "redpanda-partition-cap": set(),
+}
+PRODUCTION_PUBLISHED_PORTS = {
+    "5436",
+    "19092",
+    "18082",
+    "18081",
+    "9644",
+    "16379",
+    "8880",
+    "8085",
+    "8086",
+    "8087",
+    "8053",
+    "8091",
+    "8092",
+    "8093",
+    "6006",
+}
+PRODUCTION_CONTAINER_NAMES = {
+    "omninode-runtime",
+    "omninode-runtime-effects",
+    "omnibase-infra-postgres",
+    "omnibase-infra-redpanda",
+    "omnibase-infra-valkey",
+    "omnibase-forward-migration",
+    "omnibase-infra-infisical",
+    "omninode-agent-actions-consumer",
+    "omninode-skill-lifecycle-consumer",
+    "omninode-context-audit-consumer",
+    "omnibase-intelligence-api",
+    "omnibase-intelligence-migration",
+    "omninode-contract-resolver",
+    "omnibase-infra-phoenix",
+    "omnibase-infra-autoheal",
 }
 COMPOSE_RENDER_ENV = {
     "INFISICAL_AUTH_SECRET": "render-only-infisical-auth-secret",
@@ -59,7 +125,44 @@ def _docker_compose_command(*args: str) -> list[str]:
 
 
 def _compose_render_env() -> dict[str, str]:
-    return {**os.environ, **COMPOSE_RENDER_ENV}
+    return {
+        "HOME": os.environ.get("HOME", ""),
+        "PATH": os.environ.get("PATH", ""),
+        "USER": os.environ.get("USER", ""),
+        **COMPOSE_RENDER_ENV,
+    }
+
+
+def _compose_config_json() -> dict:
+    result = subprocess.run(
+        _docker_compose_command("config", "--format", "json"),
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        env=_compose_render_env(),
+        text=True,
+    )
+
+    rendered_config = json.loads(result.stdout)
+    assert isinstance(rendered_config, dict)
+    return rendered_config
+
+
+def _published_ports(service_config: dict) -> set[str]:
+    return {str(port["published"]) for port in service_config.get("ports", [])}
+
+
+def _label_value(service_config: dict, key: str) -> str | None:
+    labels = service_config.get("labels", {})
+    if isinstance(labels, dict):
+        value = labels.get(key)
+        return str(value) if value is not None else None
+    if isinstance(labels, list):
+        prefix = f"{key}="
+        for label in labels:
+            if isinstance(label, str) and label.startswith(prefix):
+                return label.removeprefix(prefix)
+    return None
 
 
 pytestmark = pytest.mark.skipif(
@@ -81,131 +184,144 @@ def test_stability_lane_runtime_services_render_with_runtime_profile() -> None:
 
     rendered_services = set(result.stdout.splitlines())
 
-    assert rendered_services >= REQUIRED_RUNTIME_SERVICES
+    assert rendered_services == EXPECTED_RENDERED_SERVICES
+    assert rendered_services.isdisjoint(OUT_OF_LANE_SERVICES)
 
 
 @pytest.mark.integration
 def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
-    result = subprocess.run(
-        _docker_compose_command("config"),
-        cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        env=_compose_render_env(),
-        text=True,
+    rendered_config = _compose_config_json()
+    services = rendered_config["services"]
+
+    assert services["omninode-runtime"]["container_name"] == (
+        "omninode-stability-test-runtime"
+    )
+    assert services["runtime-effects"]["container_name"] == (
+        "omninode-stability-test-runtime-effects"
+    )
+    assert services["runtime-worker"]["container_name"] == (
+        "omninode-stability-test-runtime-worker"
     )
 
-    rendered_config = result.stdout
-    rendered = yaml.safe_load(rendered_config)
-    services = rendered["services"]
-    main_depends_on = services["omninode-runtime"]["depends_on"]
-    partition_cap_depends_on = services["redpanda-partition-cap"]["depends_on"]
-    postgres_ports = services["postgres"]["ports"]
-    redpanda_ports = services["redpanda"]["ports"]
-    partition_cap_command = "\n".join(services["redpanda-partition-cap"]["command"])
-    valkey_ports = services["valkey"]["ports"]
-    main_ports = services["omninode-runtime"]["ports"]
-    effects_ports = services["runtime-effects"]["ports"]
-    networks = rendered["networks"]
-    runtime_service_volumes = {
-        service_name: {
-            volume["target"] for volume in services[service_name].get("volumes", [])
+    for service_name in REQUIRED_RUNTIME_SERVICES:
+        environment = services[service_name]["environment"]
+        assert environment["BUILD_SOURCE"] == "workspace"
+        assert environment["EXPECTED_BUILD_SOURCE"] == "workspace"
+        assert environment["OMNIMEMORY_ENABLED"] == ""
+        assert environment["OMNIMEMORY_MEMGRAPH_HOST"] == ""
+        assert environment["ONEX_ENVIRONMENT"] == "stability-test"
+        assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
+        assert services[service_name]["image"] == "runtime:stability-test-workspace"
+        assert environment["ONEX_RUNTIME_ADDRESS"].startswith(
+            "runtime://omninode-pc/stability-test/"
+        )
+        assert environment["ONEX_RUNTIME_ID"].startswith("stability-test-")
+        assert (
+            _label_value(
+                services[service_name],
+                "com.omninode.runtime.address",
+            )
+            == environment["ONEX_RUNTIME_ADDRESS"]
+        )
+        assert (
+            _label_value(
+                services[service_name],
+                "com.omninode.runtime.id",
+            )
+            == environment["ONEX_RUNTIME_ID"]
+        )
+
+    assert services["omninode-runtime"]["environment"]["ONEX_GROUP_ID"] == (
+        "onex-stability-test-runtime-main"
+    )
+    assert services["forward-migration"]["container_name"] == (
+        "omnibase-infra-stability-test-forward-migration"
+    )
+    assert services["intelligence-migration"]["container_name"] == (
+        "omnibase-infra-stability-test-intelligence-migration"
+    )
+    assert services["redpanda-partition-cap"]["container_name"] == (
+        "omnibase-infra-stability-test-redpanda-partition-cap"
+    )
+    assert (
+        services["omninode-runtime"]["depends_on"]["intelligence-migration"][
+            "condition"
+        ]
+        == "service_completed_successfully"
+    )
+    assert (
+        services["omninode-runtime"]["depends_on"]["redpanda-partition-cap"][
+            "condition"
+        ]
+        == "service_completed_successfully"
+    )
+    assert services["redpanda-partition-cap"]["depends_on"]["redpanda"][
+        "condition"
+    ] == ("service_healthy")
+
+
+@pytest.mark.integration
+def test_stability_lane_render_uses_workspace_build_source() -> None:
+    rendered_config = _compose_config_json()
+    services = rendered_config["services"]
+
+    for service_name in REQUIRED_RUNTIME_SERVICES:
+        build = services[service_name]["build"]
+        assert build["context"] == str(REPO_ROOT)
+        assert build["dockerfile"] == "docker/Dockerfile.runtime"
+        assert build["args"] == {
+            "BUILD_SOURCE": "workspace",
+            "EXPECTED_BUILD_SOURCE": "workspace",
         }
-        for service_name in REQUIRED_RUNTIME_SERVICES
-    }
 
-    assert "container_name: omninode-stability-test-runtime" in rendered_config
-    assert "container_name: omninode-stability-test-runtime-effects" in rendered_config
-    assert "container_name: omninode-stability-test-runtime-worker" in rendered_config
+
+@pytest.mark.integration
+def test_stability_lane_render_does_not_expose_production_ports_or_services() -> None:
+    rendered_config = _compose_config_json()
+    services = rendered_config["services"]
+
+    assert set(services) == EXPECTED_RENDERED_SERVICES
+    assert set(services).isdisjoint(OUT_OF_LANE_SERVICES)
+    assert rendered_config["networks"]["omnibase-infra-network"]["name"] == (
+        "omnibase-infra-stability-test-network"
+    )
+    assert rendered_config["networks"]["omnibase-infra-network"]["driver"] == "bridge"
+    assert rendered_config["networks"]["omnimemory-network"]["name"] == (
+        "omnibase-infra-stability-test-omnimemory-network"
+    )
+    assert rendered_config["networks"]["omnimemory-network"]["driver"] == "bridge"
     assert (
-        "container_name: omnibase-infra-stability-test-forward-migration"
-        in rendered_config
+        rendered_config["networks"]["omnimemory-network"].get("external", False)
+        is False
     )
-    assert (
-        "container_name: omnibase-infra-stability-test-intelligence-migration"
-        in rendered_config
-    )
-    assert (
-        "container_name: omnibase-infra-stability-test-redpanda-partition-cap"
-        in rendered_config
-    )
-    assert "container_name: omnibase-forward-migration" not in rendered_config
-    assert "container_name: omnibase-intelligence-migration" not in rendered_config
-    assert main_depends_on["intelligence-migration"]["condition"] == (
-        "service_completed_successfully"
-    )
-    assert main_depends_on["redpanda-partition-cap"]["condition"] == (
-        "service_completed_successfully"
-    )
-    assert partition_cap_depends_on["redpanda"]["condition"] == "service_healthy"
-    assert "ONEX_ENVIRONMENT: stability-test" in rendered_config
-    assert "ONEX_BOX_ID: omninode-pc" in rendered_config
-    assert (
-        "ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/main"
-        in rendered_config
-    )
-    assert (
-        "ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/effects"
-        in rendered_config
-    )
-    assert (
-        "ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/worker"
-        in rendered_config
-    )
-    assert "ONEX_RUNTIME_ID: stability-test-main" in rendered_config
-    assert "ONEX_RUNTIME_ID: stability-test-effects" in rendered_config
-    assert "ONEX_RUNTIME_ID: stability-test-worker" in rendered_config
-    assert "ONEX_GROUP_ID: onex-stability-test-runtime-main" in rendered_config
-    assert "KAFKA_INSTANCE_ID: stability-test-main" in rendered_config
-    assert (
-        "com.omninode.runtime.address: runtime://omninode-pc/stability-test/main"
-        in rendered_config
-    )
-    assert (
-        "com.omninode.runtime.address: runtime://omninode-pc/stability-test/effects"
-        in rendered_config
-    )
-    assert (
-        "com.omninode.runtime.address: runtime://omninode-pc/stability-test/worker"
-        in rendered_config
-    )
-    assert "com.omninode.runtime.id: stability-test-main" in rendered_config
-    assert "com.omninode.runtime.id: stability-test-effects" in rendered_config
-    assert "com.omninode.runtime.id: stability-test-worker" in rendered_config
-    assert "image: runtime:stability-test-workspace" in rendered_config
-    assert {port["published"] for port in postgres_ports} == {"15436"}
-    assert {port["target"] for port in postgres_ports} == {5432}
-    assert {port["published"] for port in redpanda_ports} == {"39092", "29644"}
-    assert {port["target"] for port in redpanda_ports} == {19092, 9644}
-    assert {port["published"] for port in valkey_ports} == {"26379"}
-    assert {port["target"] for port in valkey_ports} == {6379}
-    assert 'published: "5436"' not in rendered_config
-    assert 'published: "16379"' not in rendered_config
-    assert 'published: "19092"' not in rendered_config
-    assert 'published: "9644"' not in rendered_config
-    assert 'published: "18082"' not in rendered_config
-    assert 'published: "18081"' not in rendered_config
-    assert "external://localhost:39092" in rendered_config
+
+    rendered_container_names = {
+        service_config["container_name"]
+        for service_config in services.values()
+        if "container_name" in service_config
+    }
+    assert rendered_container_names.isdisjoint(PRODUCTION_CONTAINER_NAMES)
+
+    for service_name, service_config in services.items():
+        published_ports = _published_ports(service_config)
+        assert published_ports == EXPECTED_PUBLISHED_PORTS[service_name]
+        assert published_ports.isdisjoint(PRODUCTION_PUBLISHED_PORTS)
+
+    redpanda_command = " ".join(services["redpanda"]["command"])
+    assert "localhost:39092" in redpanda_command
+    assert "localhost:19092" not in redpanda_command
+
+    partition_cap_command = "\n".join(services["redpanda-partition-cap"]["command"])
     assert "/usr/bin/rpk -X brokers=redpanda:9092" in partition_cap_command
     assert "admin.hosts=redpanda:9644" in partition_cap_command
     assert "topic_partitions_per_shard" in partition_cap_command
     assert "7000" in partition_cap_command
     assert "topic_memory_per_partition" in partition_cap_command
     assert "1048576" in partition_cap_command
+
     for service_name in REQUIRED_RUNTIME_SERVICES:
-        assert services[service_name]["environment"]["OMNIMEMORY_ENABLED"] == ""
-        assert services[service_name]["environment"]["OMNIMEMORY_MEMGRAPH_HOST"] == ""
-    assert {port["published"] for port in main_ports} == {"18085"}
-    assert {port["published"] for port in effects_ports} == {"18086"}
-    assert 'published: "8085"' not in rendered_config
-    assert 'published: "8086"' not in rendered_config
-    for service_name, volume_targets in runtime_service_volumes.items():
+        volume_targets = {
+            volume["target"] for volume in services[service_name].get("volumes", [])
+        }
         assert "/app/contracts" not in volume_targets, service_name
         assert "/app/skills" in volume_targets, service_name
-    assert networks["omnibase-infra-network"]["name"] == (
-        "omnibase-infra-stability-test-network"
-    )
-    assert networks["omnimemory-network"]["name"] == (
-        "omnibase-infra-stability-test-omnimemory-network"
-    )
-    assert networks["omnimemory-network"].get("external", False) is False

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -15,6 +15,16 @@ RUNBOOK_FILE = REPO_ROOT / "docs" / "runbooks" / "stability-test-runtime-lane.md
 
 RUNTIME_SERVICES = ("omninode-runtime", "runtime-effects", "runtime-worker")
 RUNTIME_ADDRESS_PREFIX = "runtime://omninode-pc/stability-test/"
+OUT_OF_LANE_SERVICES = {
+    "agent-actions-consumer",
+    "skill-lifecycle-consumer",
+    "context-audit-consumer",
+    "intelligence-api",
+    "omninode-contract-resolver",
+    "phoenix",
+    "autoheal",
+    "infisical",
+}
 PRODUCTION_CONTAINER_NAMES = {
     "omninode-runtime",
     "omninode-runtime-effects",
@@ -22,7 +32,15 @@ PRODUCTION_CONTAINER_NAMES = {
     "omnibase-infra-redpanda",
     "omnibase-infra-valkey",
     "omnibase-forward-migration",
+    "omnibase-infra-infisical",
+    "omninode-agent-actions-consumer",
+    "omninode-skill-lifecycle-consumer",
+    "omninode-context-audit-consumer",
+    "omnibase-intelligence-api",
     "omnibase-intelligence-migration",
+    "omninode-contract-resolver",
+    "omnibase-infra-phoenix",
+    "omnibase-infra-autoheal",
 }
 PRODUCTION_NETWORK_NAMES = {
     "omnibase-infra-network",
@@ -45,12 +63,27 @@ PRODUCTION_VOLUME_NAMES = {
 }
 
 
+def _construct_compose_value(
+    loader: yaml.SafeLoader,
+    node: yaml.Node,
+) -> object:
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_scalar(node)
+
+
+class _TestSafeLoader(yaml.SafeLoader):
+    """Test-local YAML loader with Docker Compose tag support."""
+
+
+_TestSafeLoader.add_constructor("!override", _construct_compose_value)
+
+
 def _load_overlay() -> dict:
-    overlay_text = OVERLAY_FILE.read_text(encoding="utf-8").replace(
-        ": !override",
-        ":",
-    )
-    overlay = yaml.safe_load(overlay_text)
+    overlay_text = OVERLAY_FILE.read_text(encoding="utf-8")
+    overlay = yaml.load(overlay_text, Loader=_TestSafeLoader)  # noqa: S506
     assert isinstance(overlay, dict)
     return overlay
 
@@ -83,6 +116,10 @@ def test_stability_lane_runtime_services_do_not_reuse_production_names() -> None
         assert container_name not in PRODUCTION_CONTAINER_NAMES
         assert service["image"] == "runtime:stability-test-workspace"
         assert service["restart"] == "no"
+        assert service["build"]["args"] == {
+            "BUILD_SOURCE": "workspace",
+            "EXPECTED_BUILD_SOURCE": "workspace",
+        }
 
 
 @pytest.mark.unit
@@ -93,6 +130,7 @@ def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
     for service_name in RUNTIME_SERVICES:
         environment = services[service_name]["environment"]
         assert environment["BUILD_SOURCE"] == "workspace"
+        assert environment["EXPECTED_BUILD_SOURCE"] == "workspace"
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
@@ -180,6 +218,12 @@ def test_stability_lane_sets_redpanda_partition_capacity_before_runtime() -> Non
         ]
         == "service_completed_successfully"
     )
+    assert (
+        services["omninode-runtime"]["depends_on"]["intelligence-migration"][
+            "condition"
+        ]
+        == "service_completed_successfully"
+    )
 
 
 @pytest.mark.unit
@@ -243,7 +287,17 @@ def test_stability_lane_networks_do_not_reuse_production_names() -> None:
         assert concrete_name not in PRODUCTION_NETWORK_NAMES, network_name
         assert "stability-test" in concrete_name, network_name
 
+    assert networks["omnimemory-network"]["driver"] == "bridge"
     assert networks["omnimemory-network"]["external"] is False
+
+
+@pytest.mark.unit
+def test_stability_lane_disables_out_of_lane_inherited_services() -> None:
+    overlay = _load_overlay()
+    services = overlay["services"]
+
+    for service_name in OUT_OF_LANE_SERVICES:
+        assert services[service_name]["profiles"] == ["stability-test-disabled"]
 
 
 @pytest.mark.unit
@@ -268,6 +322,8 @@ def test_stability_runbook_is_validation_only() -> None:
     assert "systemctl" not in runbook
     assert "does not deploy, restart, or change `.201`" in runbook
     assert "It does not run `docker compose up`." in runbook
+    assert "does not expose inherited production host ports" in runbook
+    assert "does not render inherited out-of-lane runtime services" in runbook
     assert "config" in runbook
     assert "--profile runtime" in runbook
     assert "BUILD_SOURCE=workspace" in runbook


### PR DESCRIPTION
## Summary
- hardens the stability-test runtime compose overlay before any activation
- prevents inherited base/prod ports and out-of-lane runtime services from rendering in the stability lane
- switches stability render to workspace build args and an isolated network

## Verification
- `uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q` -> 11 passed

## Safety
- static/render-only follow-up
- did not run `docker compose up`
- did not deploy, restart services, or mutate `.201`

## Stack
- stacked on #1455 (`codex/omn-10281-stability-runtime-activation`) until that render-only PR lands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated stability test runtime lane documentation with explicit Docker Compose version requirements and port mapping details.

* **Tests**
  * Enhanced stability test validation with improved structured configuration checks and expanded integration test coverage for runtime services, ports, and networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->