### PR TITLE
feat(OMN-10342): emit cost projection snapshots

### DIFF
--- a/contracts/OMN-10342.yaml
+++ b/contracts/OMN-10342.yaml
@@ -1,0 +1,46 @@
+# OMN-10342 contract file for omnibase_infra deploy-gate (OMN-8912).
+# Canonical OCC evidence lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the cost snapshot emitter surface.
+schema_version: "1.0.0"
+ticket_id: "OMN-10342"
+title: "Add cost projection snapshot emitters"
+summary: "Emit cost summary, by-repo, and token-usage projection snapshots and let cost API routes prefer fresh snapshots."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "events"
+  - "public_api"
+  - "runtime"
+evidence_requirements:
+  - kind: "tests"
+    description: "Cost snapshot replay emitters and API snapshot fallback tests pass"
+    command: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:$PYTHONPATH uv run pytest tests/integration/nodes/test_node_projection_cost_snapshots.py tests/integration/api/test_cost_api_routes.py -q"
+  - kind: "tests"
+    description: "Touched cost snapshot paths pass ruff"
+    command: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:$PYTHONPATH uv run ruff check src/omnibase_infra/nodes/node_projection_cost_summary src/omnibase_infra/nodes/node_projection_cost_by_repo src/omnibase_infra/nodes/node_projection_cost_token_usage src/omnibase_infra/services/cost_api/handlers.py src/omnibase_infra/services/cost_api/snapshot_cache.py tests/integration/nodes/test_node_projection_cost_snapshots.py tests/integration/api/test_cost_api_routes.py"
+  - kind: "manual"
+    description: "Post-merge deploy smoke confirms cost snapshot handlers import in the deployed runtime container"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.nodes.node_projection_cost_summary.handlers.handler_projection_cost_summary import HandlerProjectionCostSummary; from omnibase_infra.nodes.node_projection_cost_by_repo.handlers.handler_projection_cost_by_repo import HandlerProjectionCostByRepo; from omnibase_infra.nodes.node_projection_cost_token_usage.handlers.handler_projection_cost_token_usage import HandlerProjectionCostTokenUsage; print('deploy smoke ok', HandlerProjectionCostSummary.__name__, HandlerProjectionCostByRepo.__name__, HandlerProjectionCostTokenUsage.__name__)\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Cost snapshot replay emitters and API snapshot fallback tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:$PYTHONPATH uv run pytest tests/integration/nodes/test_node_projection_cost_snapshots.py tests/integration/api/test_cost_api_routes.py -q"
+  - id: "dod-002"
+    description: "Touched cost snapshot paths pass ruff"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:$PYTHONPATH uv run ruff check src/omnibase_infra/nodes/node_projection_cost_summary src/omnibase_infra/nodes/node_projection_cost_by_repo src/omnibase_infra/nodes/node_projection_cost_token_usage src/omnibase_infra/services/cost_api/handlers.py src/omnibase_infra/services/cost_api/snapshot_cache.py tests/integration/nodes/test_node_projection_cost_snapshots.py tests/integration/api/test_cost_api_routes.py"
+  - id: "dod-003"
+    description: "Post-merge deploy smoke plan for cost snapshot handlers"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.nodes.node_projection_cost_summary.handlers.handler_projection_cost_summary import HandlerProjectionCostSummary; from omnibase_infra.nodes.node_projection_cost_by_repo.handlers.handler_projection_cost_by_repo import HandlerProjectionCostByRepo; from omnibase_infra.nodes.node_projection_cost_token_usage.handlers.handler_projection_cost_token_usage import HandlerProjectionCostTokenUsage; print('deploy smoke ok', HandlerProjectionCostSummary.__name__, HandlerProjectionCostByRepo.__name__, HandlerProjectionCostTokenUsage.__name__)\""

--- a/scripts/validation/lint_topic_names.py
+++ b/scripts/validation/lint_topic_names.py
@@ -10,8 +10,9 @@
 # files follow the canonical ONEX naming convention:
 #
 #   onex.{kind}.{producer}.{event-slug}.v{n}
+#   onex.snapshot.{producer}.{snapshot.slug}.v{n}
 #
-#   kind:     evt | cmd | dlq | intent
+#   kind:     evt | cmd | dlq | intent | snapshot
 #   producer: lowercase, hyphens allowed, no underscores
 #   event:    kebab-case slug  [a-z0-9._-]+
 #   version:  v followed by one or more digits (no leading zeros after 'v')
@@ -57,7 +58,7 @@ import yaml
 # Constants — must stay in sync with ContractTopicExtractor
 # ---------------------------------------------------------------------------
 
-_VALID_KINDS: frozenset[str] = frozenset({"evt", "cmd", "dlq", "intent"})
+_VALID_KINDS: frozenset[str] = frozenset({"evt", "cmd", "dlq", "intent", "snapshot"})
 _VALID_SEGMENT_PATTERN = re.compile(r"^[a-z0-9._-]+$")
 _VALID_PRODUCER_PATTERN = re.compile(r"^[a-z0-9-]+$")
 _VALID_VERSION_PATTERN = re.compile(r"^v[1-9]\d*$|^v1$")
@@ -77,6 +78,7 @@ _KNOWN_PRODUCERS: frozenset[str] = frozenset(
         "platform",
     }
 )
+_KNOWN_SNAPSHOT_PRODUCERS: frozenset[str] = frozenset({"platform", "projection"})
 
 # Regex to detect strings that look like complete ONEX topic names (for Python
 # scanning).  We require the string to start with 'onex.' AND end with a version
@@ -128,15 +130,29 @@ def lint_topic(raw: str) -> LintResult:
     violations: list[str] = []
     parts = raw.split(".")
 
-    if len(parts) != 5:
+    if len(parts) < 5:
         violations.append(
-            f"expected 5 dot-separated segments "
+            f"expected at least 5 dot-separated segments "
             f"(onex.{{kind}}.{{producer}}.{{event}}.{{version}}), "
             f"got {len(parts)}: {raw!r}"
         )
         return LintResult(topic=raw, violations=violations)
 
-    prefix, kind, producer, event_name, version = parts
+    prefix, kind = parts[0], parts[1]
+
+    if kind == "snapshot":
+        producer = parts[2]
+        event_name = ".".join(parts[3:-1])
+        version = parts[-1]
+    else:
+        if len(parts) != 5:
+            violations.append(
+                f"expected 5 dot-separated segments "
+                f"(onex.{{kind}}.{{producer}}.{{event}}.{{version}}), "
+                f"got {len(parts)}: {raw!r}"
+            )
+            return LintResult(topic=raw, violations=violations)
+        producer, event_name, version = parts[2], parts[3], parts[4]
 
     if prefix != "onex":
         violations.append(
@@ -149,15 +165,18 @@ def lint_topic(raw: str) -> LintResult:
             f"must be one of {sorted(_VALID_KINDS)}"
         )
 
+    known_producers = (
+        _KNOWN_SNAPSHOT_PRODUCERS if kind == "snapshot" else _KNOWN_PRODUCERS
+    )
     if not _VALID_PRODUCER_PATTERN.match(producer):
         violations.append(
             f"invalid producer {producer!r} in topic {raw!r}; "
             f"must match ^[a-z0-9-]+$ (no underscores)"
         )
-    elif producer not in _KNOWN_PRODUCERS:
+    elif producer not in known_producers:
         violations.append(
             f"unknown producer {producer!r} in topic {raw!r}; "
-            f"must be one of {sorted(_KNOWN_PRODUCERS)}. "
+            f"must be one of {sorted(known_producers)}. "
             f"Did you mean the repo name (e.g. 'omnimarket' not {producer!r})?"
         )
 

--- a/src/omnibase_infra/nodes/node_projection_cost_by_repo/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_by_repo/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_by_repo.node import (
+    NodeProjectionCostByRepo,
+)
+
+__all__ = ["NodeProjectionCostByRepo"]

--- a/src/omnibase_infra/nodes/node_projection_cost_by_repo/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_by_repo/handlers/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_by_repo.handlers.handler_projection_cost_by_repo import (
+    HandlerProjectionCostByRepo,
+)
+
+__all__ = ["HandlerProjectionCostByRepo"]

--- a/src/omnibase_infra/nodes/node_projection_cost_by_repo/handlers/handler_projection_cost_by_repo.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_by_repo/handlers/handler_projection_cost_by_repo.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Handler for repeatable cost-by-repo snapshot emission."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+
+from omniintelligence.models.events import (
+    ModelCostByRepoSnapshot,
+    ModelCostByRepoSnapshotRow,
+)
+
+from omnibase_infra.services.cost_api.snapshot_cache import (
+    TOPIC_COST_BY_REPO,
+    store_latest_snapshot,
+)
+
+
+class SnapshotPublisher(Protocol):
+    async def publish(self, topic: str, payload: dict[str, object]) -> object: ...
+
+
+def _decimal(value: object) -> Decimal:
+    if value is None:
+        return Decimal("0.000000")
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, Decimal | float):
+        return int(value)
+    return int(str(value))
+
+
+def _row_get(row: Mapping[str, object], key: str) -> object:
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return None
+
+
+class HandlerProjectionCostByRepo:
+    """Compute and publish repository cost snapshots from raw projection data."""
+
+    async def emit_snapshot(
+        self,
+        pool: object,
+        publisher: SnapshotPublisher | None = None,
+        *,
+        window: str = "24h",
+        snapshot_timestamp: datetime | None = None,
+    ) -> ModelCostByRepoSnapshot:
+        """Compute one by-repo snapshot and optionally publish it."""
+        timestamp = snapshot_timestamp or datetime.now(tz=UTC)
+        async with pool.acquire() as conn:  # type: ignore[attr-defined]
+            rows = await conn.fetch(
+                """
+                SELECT
+                    COALESCE(repo_name, 'unknown') AS repo_name,
+                    COALESCE(SUM(estimated_cost_usd), 0)::numeric(14, 6) AS cost_usd,
+                    COUNT(*)::bigint AS call_count
+                FROM llm_call_metrics
+                WHERE created_at >= $1::timestamptz - (
+                    CASE $2
+                        WHEN '24h' THEN INTERVAL '24 hours'
+                        WHEN '7d' THEN INTERVAL '7 days'
+                        WHEN '30d' THEN INTERVAL '30 days'
+                    END
+                )
+                  AND created_at <= $1::timestamptz
+                GROUP BY COALESCE(repo_name, 'unknown')
+                ORDER BY cost_usd DESC, repo_name ASC
+                """,
+                timestamp,
+                window,
+            )
+        snapshot = ModelCostByRepoSnapshot(
+            window=window,  # type: ignore[arg-type]
+            rows=[
+                ModelCostByRepoSnapshotRow(
+                    repo_name=str(_row_get(row, "repo_name")),
+                    cost_usd=_decimal(_row_get(row, "cost_usd")),
+                    call_count=_int(_row_get(row, "call_count")),
+                )
+                for row in rows
+            ],
+            snapshot_timestamp=timestamp,
+        )
+        payload = snapshot.model_dump(mode="json")
+        store_latest_snapshot(TOPIC_COST_BY_REPO, window, payload)
+        if publisher is not None:
+            await publisher.publish(TOPIC_COST_BY_REPO, payload)
+        return snapshot
+
+
+__all__ = ["HandlerProjectionCostByRepo", "SnapshotPublisher"]

--- a/src/omnibase_infra/nodes/node_projection_cost_by_repo/node.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_by_repo/node.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Declarative reducer shell for cost-by-repo snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.nodes.node_reducer import NodeReducer
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class NodeProjectionCostByRepo(NodeReducer):
+    """Reducer node for ``cost.by_repo.v1`` snapshot emission."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        super().__init__(container)
+
+
+__all__ = ["NodeProjectionCostByRepo"]

--- a/src/omnibase_infra/nodes/node_projection_cost_summary/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_summary/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_summary.node import (
+    NodeProjectionCostSummary,
+)
+
+__all__ = ["NodeProjectionCostSummary"]

--- a/src/omnibase_infra/nodes/node_projection_cost_summary/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_summary/handlers/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_summary.handlers.handler_projection_cost_summary import (
+    HandlerProjectionCostSummary,
+)
+
+__all__ = ["HandlerProjectionCostSummary"]

--- a/src/omnibase_infra/nodes/node_projection_cost_summary/handlers/handler_projection_cost_summary.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_summary/handlers/handler_projection_cost_summary.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Handler for repeatable cost summary snapshot emission."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+
+from omniintelligence.models.events import ModelCostSummarySnapshot
+
+from omnibase_infra.services.cost_api.snapshot_cache import (
+    TOPIC_COST_SUMMARY,
+    store_latest_snapshot,
+)
+
+WINDOWS: tuple[str, ...] = ("24h", "7d", "30d")
+
+
+class SnapshotPublisher(Protocol):
+    async def publish(self, topic: str, payload: dict[str, object]) -> object: ...
+
+
+def _decimal(value: object) -> Decimal:
+    if value is None:
+        return Decimal("0.000000")
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, Decimal | float):
+        return int(value)
+    return int(str(value))
+
+
+def _row_get(row: Mapping[str, object] | None, key: str) -> object:
+    if row is None:
+        return None
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return None
+
+
+class HandlerProjectionCostSummary:
+    """Compute and publish cost summary snapshots from projection tables."""
+
+    async def emit_snapshot(
+        self,
+        pool: object,
+        publisher: SnapshotPublisher | None = None,
+        *,
+        window: str = "24h",
+        snapshot_timestamp: datetime | None = None,
+    ) -> ModelCostSummarySnapshot:
+        """Compute one summary snapshot and optionally publish it."""
+        timestamp = snapshot_timestamp or datetime.now(tz=UTC)
+        async with pool.acquire() as conn:  # type: ignore[attr-defined]
+            cost_row = await conn.fetchrow(
+                """
+                SELECT
+                    COALESCE(SUM(total_cost_usd), 0)::numeric(14, 6) AS total_cost_usd,
+                    COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens,
+                    COALESCE(SUM(call_count), 0)::bigint AS call_count
+                FROM llm_cost_aggregates
+                WHERE "window" = $1::cost_aggregation_window
+                  AND aggregation_key LIKE 'session:%'
+                """,
+                window,
+            )
+            savings_row = await conn.fetchrow(
+                """
+                SELECT COALESCE(SUM(savings_usd), 0)::numeric(14, 6) AS total_savings_usd
+                FROM savings_estimates
+                WHERE event_timestamp >= $1::timestamptz - (
+                    CASE $2
+                        WHEN '24h' THEN INTERVAL '24 hours'
+                        WHEN '7d' THEN INTERVAL '7 days'
+                        WHEN '30d' THEN INTERVAL '30 days'
+                    END
+                )
+                  AND event_timestamp <= $1::timestamptz
+                """,
+                timestamp,
+                window,
+            )
+
+        snapshot = ModelCostSummarySnapshot(
+            window=window,  # type: ignore[arg-type]
+            total_cost_usd=_decimal(_row_get(cost_row, "total_cost_usd")),
+            total_savings_usd=_decimal(_row_get(savings_row, "total_savings_usd")),
+            total_tokens=_int(_row_get(cost_row, "total_tokens")),
+            session_count=_int(_row_get(cost_row, "call_count")),
+            snapshot_timestamp=timestamp,
+        )
+        payload = snapshot.model_dump(mode="json")
+        store_latest_snapshot(TOPIC_COST_SUMMARY, window, payload)
+        if publisher is not None:
+            await publisher.publish(TOPIC_COST_SUMMARY, payload)
+        return snapshot
+
+
+__all__ = ["HandlerProjectionCostSummary", "SnapshotPublisher", "WINDOWS"]

--- a/src/omnibase_infra/nodes/node_projection_cost_summary/node.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_summary/node.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Declarative reducer shell for cost summary snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.nodes.node_reducer import NodeReducer
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class NodeProjectionCostSummary(NodeReducer):
+    """Reducer node for ``cost.summary.v1`` snapshot emission."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        super().__init__(container)
+
+
+__all__ = ["NodeProjectionCostSummary"]

--- a/src/omnibase_infra/nodes/node_projection_cost_token_usage/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_token_usage/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_token_usage.node import (
+    NodeProjectionCostTokenUsage,
+)
+
+__all__ = ["NodeProjectionCostTokenUsage"]

--- a/src/omnibase_infra/nodes/node_projection_cost_token_usage/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_token_usage/handlers/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_infra.nodes.node_projection_cost_token_usage.handlers.handler_projection_cost_token_usage import (
+    HandlerProjectionCostTokenUsage,
+)
+
+__all__ = ["HandlerProjectionCostTokenUsage"]

--- a/src/omnibase_infra/nodes/node_projection_cost_token_usage/handlers/handler_projection_cost_token_usage.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_token_usage/handlers/handler_projection_cost_token_usage.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Handler for repeatable token usage snapshot emission."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Protocol
+
+from omniintelligence.models.events import (
+    ModelCostTokenUsageSnapshot,
+    ModelCostTokenUsageSnapshotRow,
+)
+
+from omnibase_infra.services.cost_api.snapshot_cache import (
+    TOPIC_COST_TOKEN_USAGE,
+    store_latest_snapshot,
+)
+
+
+class SnapshotPublisher(Protocol):
+    async def publish(self, topic: str, payload: dict[str, object]) -> object: ...
+
+
+def _int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return int(str(value))
+
+
+def _row_get(row: Mapping[str, object], key: str) -> object:
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return None
+
+
+def _datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+    parsed = datetime.fromisoformat(str(value))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+class HandlerProjectionCostTokenUsage:
+    """Compute and publish model/time-bucket token snapshots."""
+
+    async def emit_snapshot(
+        self,
+        pool: object,
+        publisher: SnapshotPublisher | None = None,
+        *,
+        window: str = "24h",
+        snapshot_timestamp: datetime | None = None,
+    ) -> ModelCostTokenUsageSnapshot:
+        """Compute one token usage snapshot and optionally publish it."""
+        timestamp = snapshot_timestamp or datetime.now(tz=UTC)
+        bucket = "hour" if window == "24h" else "day"
+        async with pool.acquire() as conn:  # type: ignore[attr-defined]
+            rows = await conn.fetch(
+                """
+                SELECT
+                    date_trunc($3, created_at) AS bucket_timestamp,
+                    model_id,
+                    COALESCE(SUM(prompt_tokens), 0)::bigint AS prompt_tokens,
+                    COALESCE(SUM(completion_tokens), 0)::bigint AS completion_tokens,
+                    COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens
+                FROM llm_call_metrics
+                WHERE created_at >= $1::timestamptz - (
+                    CASE $2
+                        WHEN '24h' THEN INTERVAL '24 hours'
+                        WHEN '7d' THEN INTERVAL '7 days'
+                        WHEN '30d' THEN INTERVAL '30 days'
+                    END
+                )
+                  AND created_at <= $1::timestamptz
+                GROUP BY bucket_timestamp, model_id
+                ORDER BY bucket_timestamp ASC, model_id ASC
+                """,
+                timestamp,
+                window,
+                bucket,
+            )
+        snapshot = ModelCostTokenUsageSnapshot(
+            window=window,  # type: ignore[arg-type]
+            rows=[
+                ModelCostTokenUsageSnapshotRow(
+                    bucket_timestamp=_datetime(_row_get(row, "bucket_timestamp")),
+                    model_id=str(_row_get(row, "model_id")),
+                    prompt_tokens=_int(_row_get(row, "prompt_tokens")),
+                    completion_tokens=_int(_row_get(row, "completion_tokens")),
+                    total_tokens=_int(_row_get(row, "total_tokens")),
+                )
+                for row in rows
+            ],
+            snapshot_timestamp=timestamp,
+        )
+        payload = snapshot.model_dump(mode="json")
+        store_latest_snapshot(TOPIC_COST_TOKEN_USAGE, window, payload)
+        if publisher is not None:
+            await publisher.publish(TOPIC_COST_TOKEN_USAGE, payload)
+        return snapshot
+
+
+__all__ = ["HandlerProjectionCostTokenUsage", "SnapshotPublisher"]

--- a/src/omnibase_infra/nodes/node_projection_cost_token_usage/node.py
+++ b/src/omnibase_infra/nodes/node_projection_cost_token_usage/node.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Declarative reducer shell for token-usage snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.nodes.node_reducer import NodeReducer
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class NodeProjectionCostTokenUsage(NodeReducer):
+    """Reducer node for ``cost.token_usage.v1`` snapshot emission."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        super().__init__(container)
+
+
+__all__ = ["NodeProjectionCostTokenUsage"]

--- a/src/omnibase_infra/services/cost_api/handlers.py
+++ b/src/omnibase_infra/services/cost_api/handlers.py
@@ -20,6 +20,12 @@ from omnibase_infra.services.cost_api.models import (
     ModelTokenUsage,
     TrendBucket,
 )
+from omnibase_infra.services.cost_api.snapshot_cache import (
+    TOPIC_COST_BY_REPO,
+    TOPIC_COST_SUMMARY,
+    TOPIC_COST_TOKEN_USAGE,
+    get_latest_snapshot,
+)
 
 if TYPE_CHECKING:
     import asyncpg
@@ -64,6 +70,16 @@ async def fetch_cost_summary(
     window: AggregationWindow,
 ) -> ModelCostSummary:
     """Fetch totals from canonical session/composite-session aggregate rows."""
+    snapshot = get_latest_snapshot(TOPIC_COST_SUMMARY, window)
+    if snapshot is not None:
+        return ModelCostSummary(
+            window=window,
+            total_cost_usd=_decimal(snapshot.get("total_cost_usd")),
+            total_tokens=_int(snapshot.get("total_tokens")),
+            call_count=_int(snapshot.get("session_count")),
+            estimated_coverage_pct=None,
+        )
+
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
@@ -190,6 +206,24 @@ async def fetch_cost_by_repo(
     window: AggregationWindow,
 ) -> ModelCostBreakdown:
     """Fetch repo cost groups from composite session keys or legacy repo keys."""
+    snapshot = get_latest_snapshot(TOPIC_COST_BY_REPO, window)
+    if snapshot is not None:
+        raw_rows = snapshot.get("rows")
+        rows = raw_rows if isinstance(raw_rows, list) else []
+        return ModelCostBreakdown(
+            window=window,
+            items=[
+                ModelCostBreakdownItem(
+                    name=str(row.get("repo_name") or "unknown"),
+                    total_cost_usd=_decimal(row.get("cost_usd")),
+                    total_tokens=0,
+                    call_count=_int(row.get("call_count")),
+                )
+                for row in rows
+                if isinstance(row, dict)
+            ],
+        )
+
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             """
@@ -234,6 +268,26 @@ async def fetch_token_usage(
     window: AggregationWindow,
 ) -> ModelTokenUsage:
     """Fetch token totals from canonical session/composite-session aggregate rows."""
+    snapshot = get_latest_snapshot(TOPIC_COST_TOKEN_USAGE, window)
+    if snapshot is not None:
+        raw_rows = snapshot.get("rows")
+        rows = raw_rows if isinstance(raw_rows, list) else []
+        total_tokens = sum(
+            _int(row.get("total_tokens")) for row in rows if isinstance(row, dict)
+        )
+        call_count = len([row for row in rows if isinstance(row, dict)])
+        average = (
+            Decimal(total_tokens) / Decimal(call_count)
+            if call_count
+            else Decimal("0.000000")
+        )
+        return ModelTokenUsage(
+            window=window,
+            total_tokens=total_tokens,
+            call_count=call_count,
+            average_tokens_per_call=average.quantize(Decimal("0.000001")),
+        )
+
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """

--- a/src/omnibase_infra/services/cost_api/snapshot_cache.py
+++ b/src/omnibase_infra/services/cost_api/snapshot_cache.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Process-local cache for latest cost projection snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final
+
+SnapshotPayload = Mapping[str, object]
+
+TOPIC_COST_SUMMARY: Final[str] = "onex.snapshot.projection.cost.summary.v1"  # noqa: RUF100  # noqa: topic-naming-lint
+TOPIC_COST_BY_REPO: Final[str] = "onex.snapshot.projection.cost.by_repo.v1"  # noqa: RUF100  # noqa: topic-naming-lint
+TOPIC_COST_TOKEN_USAGE: Final[str] = "onex.snapshot.projection.cost.token_usage.v1"  # noqa: RUF100  # noqa: topic-naming-lint
+
+_LATEST: dict[tuple[str, str], dict[str, object]] = {}
+
+
+def store_latest_snapshot(topic: str, window: str, payload: SnapshotPayload) -> None:
+    """Store the latest snapshot for an API route fallback boundary."""
+    _LATEST[(topic, window)] = dict(payload)
+
+
+def get_latest_snapshot(topic: str, window: str) -> dict[str, object] | None:
+    """Return a copy of the latest snapshot payload for a topic/window."""
+    payload = _LATEST.get((topic, window))
+    if payload is None:
+        return None
+    return dict(payload)
+
+
+def clear_latest_snapshots() -> None:
+    """Clear cached snapshots; intended for tests."""
+    _LATEST.clear()
+
+
+__all__ = [
+    "TOPIC_COST_BY_REPO",
+    "TOPIC_COST_SUMMARY",
+    "TOPIC_COST_TOKEN_USAGE",
+    "clear_latest_snapshots",
+    "get_latest_snapshot",
+    "store_latest_snapshot",
+]

--- a/tests/fixtures/cost_observability/task-11-by-repo.fixtures.jsonl
+++ b/tests/fixtures/cost_observability/task-11-by-repo.fixtures.jsonl
@@ -1,0 +1,4 @@
+{"kind":"llm_call","created_at":"2026-04-29T10:00:00+00:00","session_id":"sess-001","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.500000","prompt_tokens":100,"completion_tokens":50,"total_tokens":150}
+{"kind":"llm_call","created_at":"2026-04-29T10:30:00+00:00","session_id":"sess-002","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.250000","prompt_tokens":80,"completion_tokens":20,"total_tokens":100}
+{"kind":"llm_call","created_at":"2026-04-29T11:00:00+00:00","session_id":"sess-003","model_id":"gpt-4.1-mini","repo_name":"omnibase_core","estimated_cost_usd":"0.750000","prompt_tokens":200,"completion_tokens":100,"total_tokens":300}
+{"kind":"llm_call","created_at":"2026-04-29T09:00:00+00:00","session_id":"sess-004","model_id":"gpt-4.1","repo_name":null,"estimated_cost_usd":"0.100000","prompt_tokens":30,"completion_tokens":20,"total_tokens":50}

--- a/tests/fixtures/cost_observability/task-11-by-repo.golden.json
+++ b/tests/fixtures/cost_observability/task-11-by-repo.golden.json
@@ -1,0 +1,21 @@
+{
+  "window": "24h",
+  "rows": [
+    {
+      "repo_name": "omnibase_core",
+      "cost_usd": "0.750000",
+      "call_count": 1
+    },
+    {
+      "repo_name": "omnibase_infra",
+      "cost_usd": "0.750000",
+      "call_count": 2
+    },
+    {
+      "repo_name": "unknown",
+      "cost_usd": "0.100000",
+      "call_count": 1
+    }
+  ],
+  "snapshot_timestamp": "2026-04-29T12:00:00Z"
+}

--- a/tests/fixtures/cost_observability/task-11-summary.fixtures.jsonl
+++ b/tests/fixtures/cost_observability/task-11-summary.fixtures.jsonl
@@ -1,0 +1,6 @@
+{"kind":"llm_call","created_at":"2026-04-29T10:00:00+00:00","session_id":"sess-001","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.500000","prompt_tokens":100,"completion_tokens":50,"total_tokens":150}
+{"kind":"llm_call","created_at":"2026-04-29T10:30:00+00:00","session_id":"sess-002","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.250000","prompt_tokens":80,"completion_tokens":20,"total_tokens":100}
+{"kind":"llm_call","created_at":"2026-04-29T11:00:00+00:00","session_id":"sess-003","model_id":"gpt-4.1-mini","repo_name":"omnibase_core","estimated_cost_usd":"0.750000","prompt_tokens":200,"completion_tokens":100,"total_tokens":300}
+{"kind":"llm_call","created_at":"2026-04-29T09:00:00+00:00","session_id":"sess-004","model_id":"gpt-4.1","repo_name":null,"estimated_cost_usd":"0.100000","prompt_tokens":30,"completion_tokens":20,"total_tokens":50}
+{"kind":"savings","event_timestamp":"2026-04-29T09:15:00+00:00","session_id":"sess-001","savings_usd":"2.500000"}
+{"kind":"savings","event_timestamp":"2026-04-29T11:15:00+00:00","session_id":"sess-003","savings_usd":"1.000000"}

--- a/tests/fixtures/cost_observability/task-11-summary.golden.json
+++ b/tests/fixtures/cost_observability/task-11-summary.golden.json
@@ -1,0 +1,8 @@
+{
+  "window": "24h",
+  "total_cost_usd": "1.600000",
+  "total_savings_usd": "3.500000",
+  "total_tokens": 600,
+  "session_count": 4,
+  "snapshot_timestamp": "2026-04-29T12:00:00Z"
+}

--- a/tests/fixtures/cost_observability/task-11-token-usage.fixtures.jsonl
+++ b/tests/fixtures/cost_observability/task-11-token-usage.fixtures.jsonl
@@ -1,0 +1,4 @@
+{"kind":"llm_call","created_at":"2026-04-29T10:00:00+00:00","session_id":"sess-001","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.500000","prompt_tokens":100,"completion_tokens":50,"total_tokens":150}
+{"kind":"llm_call","created_at":"2026-04-29T10:30:00+00:00","session_id":"sess-002","model_id":"gpt-4.1","repo_name":"omnibase_infra","estimated_cost_usd":"0.250000","prompt_tokens":80,"completion_tokens":20,"total_tokens":100}
+{"kind":"llm_call","created_at":"2026-04-29T11:00:00+00:00","session_id":"sess-003","model_id":"gpt-4.1-mini","repo_name":"omnibase_core","estimated_cost_usd":"0.750000","prompt_tokens":200,"completion_tokens":100,"total_tokens":300}
+{"kind":"llm_call","created_at":"2026-04-29T09:00:00+00:00","session_id":"sess-004","model_id":"gpt-4.1","repo_name":null,"estimated_cost_usd":"0.100000","prompt_tokens":30,"completion_tokens":20,"total_tokens":50}

--- a/tests/fixtures/cost_observability/task-11-token-usage.golden.json
+++ b/tests/fixtures/cost_observability/task-11-token-usage.golden.json
@@ -1,0 +1,27 @@
+{
+  "window": "24h",
+  "rows": [
+    {
+      "bucket_timestamp": "2026-04-29T09:00:00Z",
+      "model_id": "gpt-4.1",
+      "prompt_tokens": 30,
+      "completion_tokens": 20,
+      "total_tokens": 50
+    },
+    {
+      "bucket_timestamp": "2026-04-29T10:00:00Z",
+      "model_id": "gpt-4.1",
+      "prompt_tokens": 180,
+      "completion_tokens": 70,
+      "total_tokens": 250
+    },
+    {
+      "bucket_timestamp": "2026-04-29T11:00:00Z",
+      "model_id": "gpt-4.1-mini",
+      "prompt_tokens": 200,
+      "completion_tokens": 100,
+      "total_tokens": 300
+    }
+  ],
+  "snapshot_timestamp": "2026-04-29T12:00:00Z"
+}

--- a/tests/integration/api/test_cost_api_routes.py
+++ b/tests/integration/api/test_cost_api_routes.py
@@ -12,6 +12,13 @@ import httpx
 import pytest
 
 from omnibase_core.container import ModelONEXContainer
+from omnibase_infra.services.cost_api.snapshot_cache import (
+    TOPIC_COST_BY_REPO,
+    TOPIC_COST_SUMMARY,
+    TOPIC_COST_TOKEN_USAGE,
+    clear_latest_snapshots,
+    store_latest_snapshot,
+)
 from omnibase_infra.services.registry_api.main import create_app
 
 pytestmark = pytest.mark.asyncio
@@ -124,6 +131,7 @@ class FakeConnection:
 
 @pytest.fixture
 def fake_conn() -> FakeConnection:
+    clear_latest_snapshots()
     return FakeConnection()
 
 
@@ -256,6 +264,110 @@ async def test_token_usage_response(app: Any) -> None:
         "total_tokens": 6000,
         "call_count": 3,
         "average_tokens_per_call": "2000.000000",
+    }
+
+
+async def test_cost_summary_prefers_latest_projection_snapshot(app: Any) -> None:
+    store_latest_snapshot(
+        TOPIC_COST_SUMMARY,
+        "24h",
+        {
+            "window": "24h",
+            "total_cost_usd": "9.000000",
+            "total_savings_usd": "3.500000",
+            "total_tokens": 9000,
+            "session_count": 4,
+            "snapshot_timestamp": "2026-04-29T12:00:00Z",
+        },
+    )
+
+    body = await get_json(app, "/api/costs/summary")
+
+    assert body == {
+        "window": "24h",
+        "total_cost_usd": "9.000000",
+        "total_tokens": 9000,
+        "call_count": 4,
+        "estimated_coverage_pct": None,
+    }
+
+
+async def test_cost_by_repo_prefers_latest_projection_snapshot(app: Any) -> None:
+    store_latest_snapshot(
+        TOPIC_COST_BY_REPO,
+        "24h",
+        {
+            "window": "24h",
+            "rows": [
+                {
+                    "repo_name": "omnibase_core",
+                    "cost_usd": "0.750000",
+                    "call_count": 1,
+                },
+                {
+                    "repo_name": "unknown",
+                    "cost_usd": "0.100000",
+                    "call_count": 1,
+                },
+            ],
+            "snapshot_timestamp": "2026-04-29T12:00:00Z",
+        },
+    )
+
+    body = await get_json(app, "/api/costs/by-repo")
+
+    assert body == {
+        "window": "24h",
+        "items": [
+            {
+                "name": "omnibase_core",
+                "total_cost_usd": "0.750000",
+                "total_tokens": 0,
+                "call_count": 1,
+            },
+            {
+                "name": "unknown",
+                "total_cost_usd": "0.100000",
+                "total_tokens": 0,
+                "call_count": 1,
+            },
+        ],
+    }
+
+
+async def test_token_usage_prefers_latest_projection_snapshot(app: Any) -> None:
+    store_latest_snapshot(
+        TOPIC_COST_TOKEN_USAGE,
+        "24h",
+        {
+            "window": "24h",
+            "rows": [
+                {
+                    "bucket_timestamp": "2026-04-29T10:00:00Z",
+                    "model_id": "gpt-4.1",
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                },
+                {
+                    "bucket_timestamp": "2026-04-29T11:00:00Z",
+                    "model_id": "gpt-4.1-mini",
+                    "prompt_tokens": 200,
+                    "completion_tokens": 100,
+                    "total_tokens": 300,
+                },
+            ],
+            "snapshot_timestamp": "2026-04-29T12:00:00Z",
+        },
+    )
+
+    body = await get_json(app, "/api/costs/token-usage")
+
+    assert body == {
+        "window": "24h",
+        "total_tokens": 450,
+        "call_count": 2,
+        "average_tokens_per_call": "225.000000",
     }
 
 

--- a/tests/integration/nodes/test_node_projection_cost_snapshots.py
+++ b/tests/integration/nodes/test_node_projection_cost_snapshots.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Replay tests for Task 11 cost projection snapshot emitters."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.nodes.node_projection_cost_by_repo.handlers.handler_projection_cost_by_repo import (
+    HandlerProjectionCostByRepo,
+)
+from omnibase_infra.nodes.node_projection_cost_summary.handlers.handler_projection_cost_summary import (
+    HandlerProjectionCostSummary,
+)
+from omnibase_infra.nodes.node_projection_cost_token_usage.handlers.handler_projection_cost_token_usage import (
+    HandlerProjectionCostTokenUsage,
+)
+from omnibase_infra.services.cost_api.snapshot_cache import clear_latest_snapshots
+
+pytestmark = pytest.mark.asyncio
+
+SNAPSHOT_TS = datetime(2026, 4, 29, 12, 0, tzinfo=UTC)
+FIXTURE_DIR = Path("tests/fixtures/cost_observability")
+
+
+class FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, object]]] = []
+
+    async def publish(self, topic: str, payload: dict[str, object]) -> None:
+        self.published.append((topic, payload))
+
+
+class FakeAcquire:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._conn
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self._conn)
+
+
+class FakeConnection:
+    def __init__(self, records: list[dict[str, object]]) -> None:
+        self.llm_calls = [record for record in records if record["kind"] == "llm_call"]
+        self.savings = [record for record in records if record["kind"] == "savings"]
+
+    async def fetchrow(self, sql: str, *args: object) -> Mapping[str, object]:
+        timestamp = (
+            _as_datetime(args[0])
+            if args and isinstance(args[0], datetime)
+            else SNAPSHOT_TS
+        )
+        window = str(args[1]) if len(args) > 1 else str(args[0])
+        if "FROM savings_estimates" in sql:
+            rows = [
+                row
+                for row in self.savings
+                if _within_window(
+                    _as_datetime(row["event_timestamp"]), timestamp, window
+                )
+            ]
+            return {
+                "total_savings_usd": sum(
+                    (_decimal(row["savings_usd"]) for row in rows),
+                    Decimal("0.000000"),
+                )
+            }
+        rows = list(self.llm_calls)
+        return {
+            "total_cost_usd": sum(
+                (_decimal(row["estimated_cost_usd"]) for row in rows),
+                Decimal("0.000000"),
+            ),
+            "total_tokens": sum(int(row["total_tokens"]) for row in rows),
+            "call_count": len(rows),
+        }
+
+    async def fetch(self, sql: str, *args: object) -> list[Mapping[str, object]]:
+        timestamp = _as_datetime(args[0])
+        window = str(args[1])
+        rows = [
+            row
+            for row in self.llm_calls
+            if _within_window(_as_datetime(row["created_at"]), timestamp, window)
+        ]
+        if "COALESCE(repo_name, 'unknown')" in sql:
+            grouped: dict[str, dict[str, object]] = {}
+            for row in rows:
+                repo = str(row["repo_name"] or "unknown")
+                bucket = grouped.setdefault(
+                    repo,
+                    {
+                        "repo_name": repo,
+                        "cost_usd": Decimal("0.000000"),
+                        "call_count": 0,
+                    },
+                )
+                bucket["cost_usd"] = _decimal(bucket["cost_usd"]) + _decimal(
+                    row["estimated_cost_usd"]
+                )
+                bucket["call_count"] = int(bucket["call_count"]) + 1
+            return sorted(
+                grouped.values(),
+                key=lambda row: (-_decimal(row["cost_usd"]), str(row["repo_name"])),
+            )
+
+        bucket_size = str(args[2])
+        grouped_tokens: dict[tuple[datetime, str], dict[str, object]] = {}
+        for row in rows:
+            bucket_ts = _truncate_bucket(_as_datetime(row["created_at"]), bucket_size)
+            key = (bucket_ts, str(row["model_id"]))
+            bucket = grouped_tokens.setdefault(
+                key,
+                {
+                    "bucket_timestamp": bucket_ts,
+                    "model_id": str(row["model_id"]),
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            )
+            bucket["prompt_tokens"] = int(bucket["prompt_tokens"]) + int(
+                row["prompt_tokens"]
+            )
+            bucket["completion_tokens"] = int(bucket["completion_tokens"]) + int(
+                row["completion_tokens"]
+            )
+            bucket["total_tokens"] = int(bucket["total_tokens"]) + int(
+                row["total_tokens"]
+            )
+        return sorted(
+            grouped_tokens.values(),
+            key=lambda row: (row["bucket_timestamp"], str(row["model_id"])),
+        )
+
+
+def _load_fixture(name: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in (FIXTURE_DIR / name).read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _load_golden(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _as_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _within_window(value: datetime, timestamp: datetime, window: str) -> bool:
+    widths = {
+        "24h": timedelta(hours=24),
+        "7d": timedelta(days=7),
+        "30d": timedelta(days=30),
+    }
+    return timestamp - widths[window] <= value <= timestamp
+
+
+def _truncate_bucket(value: datetime, bucket: str) -> datetime:
+    if bucket == "hour":
+        return value.replace(minute=0, second=0, microsecond=0)
+    return value.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+async def test_cost_summary_replay_matches_golden_field_by_field() -> None:
+    clear_latest_snapshots()
+    pool = FakePool(FakeConnection(_load_fixture("task-11-summary.fixtures.jsonl")))
+    publisher = FakePublisher()
+
+    snapshot = await HandlerProjectionCostSummary().emit_snapshot(
+        pool,
+        publisher,
+        window="24h",
+        snapshot_timestamp=SNAPSHOT_TS,
+    )
+    payload = snapshot.model_dump(mode="json")
+
+    assert payload == _load_golden("task-11-summary.golden.json")
+    assert snapshot.total_cost_usd == Decimal("1.600000")
+    assert snapshot.total_savings_usd == Decimal("3.500000")
+    assert snapshot.total_tokens == 600
+    assert snapshot.session_count == 4
+    assert publisher.published == [
+        ("onex.snapshot.projection.cost.summary.v1", payload)
+    ]
+
+
+async def test_cost_by_repo_replay_matches_golden_field_by_field() -> None:
+    clear_latest_snapshots()
+    pool = FakePool(FakeConnection(_load_fixture("task-11-by-repo.fixtures.jsonl")))
+    publisher = FakePublisher()
+
+    snapshot = await HandlerProjectionCostByRepo().emit_snapshot(
+        pool,
+        publisher,
+        window="24h",
+        snapshot_timestamp=SNAPSHOT_TS,
+    )
+    payload = snapshot.model_dump(mode="json")
+
+    assert payload == _load_golden("task-11-by-repo.golden.json")
+    assert [row.repo_name for row in snapshot.rows] == [
+        "omnibase_core",
+        "omnibase_infra",
+        "unknown",
+    ]
+    assert [row.cost_usd for row in snapshot.rows] == [
+        Decimal("0.750000"),
+        Decimal("0.750000"),
+        Decimal("0.100000"),
+    ]
+    assert [row.call_count for row in snapshot.rows] == [1, 2, 1]
+    assert publisher.published == [
+        ("onex.snapshot.projection.cost.by_repo.v1", payload)
+    ]
+
+
+async def test_cost_token_usage_replay_matches_golden_field_by_field() -> None:
+    clear_latest_snapshots()
+    pool = FakePool(FakeConnection(_load_fixture("task-11-token-usage.fixtures.jsonl")))
+    publisher = FakePublisher()
+
+    snapshot = await HandlerProjectionCostTokenUsage().emit_snapshot(
+        pool,
+        publisher,
+        window="24h",
+        snapshot_timestamp=SNAPSHOT_TS,
+    )
+    payload = snapshot.model_dump(mode="json")
+
+    assert payload == _load_golden("task-11-token-usage.golden.json")
+    assert [row.model_id for row in snapshot.rows] == [
+        "gpt-4.1",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+    ]
+    assert [row.prompt_tokens for row in snapshot.rows] == [30, 180, 200]
+    assert [row.completion_tokens for row in snapshot.rows] == [20, 70, 100]
+    assert [row.total_tokens for row in snapshot.rows] == [50, 250, 300]
+    assert publisher.published == [
+        ("onex.snapshot.projection.cost.token_usage.v1", payload)
+    ]

--- a/tests/unit/scripts/validation/test_lint_topic_names.py
+++ b/tests/unit/scripts/validation/test_lint_topic_names.py
@@ -54,6 +54,35 @@ def test_valid_topic_passes() -> None:
 
 
 @pytest.mark.unit
+def test_valid_projection_snapshot_topic_passes() -> None:
+    """Projection snapshot topics may use a dotted snapshot name."""
+    result = lint_topic("onex.snapshot.projection.cost.token_usage.v1")
+    assert result.violations == []
+    assert result.is_valid is True
+
+
+@pytest.mark.unit
+def test_scan_contracts_accepts_projection_snapshot_publish_topic(
+    tmp_path: Path,
+) -> None:
+    """Contract scanning accepts projection snapshot publish topics."""
+    contracts_dir = tmp_path / "nodes"
+    contracts_dir.mkdir()
+    node_dir = contracts_dir / "snapshot-node"
+    node_dir.mkdir()
+    contract = {
+        "name": "snapshot-node",
+        "event_bus": {
+            "publish_topics": ["onex.snapshot.projection.cost.by_repo.v1"],
+        },
+    }
+    (node_dir / "contract.yaml").write_text(yaml.dump(contract), encoding="utf-8")
+
+    violations = scan_contracts(contracts_dir)
+    assert violations == []
+
+
+@pytest.mark.unit
 def test_invalid_kind_caught() -> None:
     """A topic with an invalid kind segment returns a violation."""
     result = lint_topic("onex.badkind.platform.foo.v1")


### PR DESCRIPTION
Refs OMN-10342\nDepends on OMN-10340 and OMN-10341.\n\n## Summary\n- add cost summary, by-repo, and token usage snapshot emitter nodes\n- wire cost API handlers to prefer latest projection snapshots while preserving existing response shape\n- add replay fixtures/goldens and field-by-field integration tests for all three snapshot outputs\n\n## Verification\n- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:/Users/jonah/Code/omni_home/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_infra/src uv run pytest tests/unit/scripts/validation/test_lint_topic_names.py tests/integration/nodes/test_node_projection_cost_snapshots.py tests/integration/api/test_cost_api_routes.py -q\n- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omniintelligence/src:/Users/jonah/Code/omni_home/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_infra/src uv run mypy src/omnibase_infra/nodes/node_projection_cost_summary/handlers/handler_projection_cost_summary.py src/omnibase_infra/nodes/node_projection_cost_by_repo/handlers/handler_projection_cost_by_repo.py src/omnibase_infra/nodes/node_projection_cost_token_usage/handlers/handler_projection_cost_token_usage.py\n- pre-push hooks passed