### PR TITLE
feat(OMN-9869): propagate LLM adapter timeout into infra inference requests

### DIFF
--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -733,6 +733,11 @@ class AdapterLlmProviderOpenai:
         Bridges the structural mismatch between ProtocolLLMRequest.prompt
         (single string) and ModelLlmInferenceRequest's messages tuple.
 
+        ``request.timeout_seconds`` is propagated directly into the infra
+        request so that contract-owned endpoint timeouts (e.g. long-running
+        local model calls) reach the HTTP transport instead of falling back
+        to the inference request's 30-second default.
+
         Args:
             request: SPI-level request.
 
@@ -747,6 +752,7 @@ class AdapterLlmProviderOpenai:
             max_tokens=request.max_tokens,
             temperature=request.temperature,
             api_key=self._api_key,
+            timeout_seconds=request.timeout_seconds,
         )
 
 

--- a/src/omnibase_infra/adapters/llm/model_llm_adapter_request.py
+++ b/src/omnibase_infra/adapters/llm/model_llm_adapter_request.py
@@ -32,6 +32,11 @@ class ModelLlmAdapterRequest(BaseModel):
         parameters: Generation parameters as a JSON-compatible dictionary.
         max_tokens: Maximum tokens to generate, or None for default.
         temperature: Sampling temperature, or None for default.
+        timeout_seconds: HTTP request timeout in seconds applied to the
+            downstream inference call. Mirrors the bounds enforced on
+            ``ModelLlmInferenceRequest.timeout_seconds`` (1.0-600.0
+            inclusive, default 30.0). Owned by the calling node contract /
+            endpoint config -- never read from environment variables here.
 
     Warning:
         Dict fields (``parameters``) are shallowly mutable despite
@@ -76,6 +81,16 @@ class ModelLlmAdapterRequest(BaseModel):
         ge=0.0,
         le=2.0,
         description="Temperature for generation.",
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        le=600.0,
+        description=(
+            "HTTP request timeout in seconds applied to the downstream "
+            "inference call. Bounds match ModelLlmInferenceRequest "
+            "(1.0-600.0). Contract-owned; do not source from env vars."
+        ),
     )
 
 

--- a/tests/integration/adapters/llm/test_adapter_llm_provider_openai_timeout_propagation.py
+++ b/tests/integration/adapters/llm/test_adapter_llm_provider_openai_timeout_propagation.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""End-to-end integration test for OMN-9869 LLM adapter timeout propagation.
+
+Exercises the full adapter -> handler -> transport call chain with a
+recording transport substitute, asserting that the contract-owned
+``ModelLlmAdapterRequest.timeout_seconds`` value reaches the HTTP
+transport layer's ``_execute_llm_http_call`` (the boundary where
+``httpx.Client.post`` would issue the network call).
+
+This is the integration counterpart to the unit translation test in
+``tests/unit/adapters/llm/test_adapter_llm_provider_openai.py``: the unit
+test verifies the field hand-off in ``_translate_request``; this test
+verifies the same value survives the handler delegation path that runs
+on every real generation call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from omnibase_core.types import JsonType
+from omnibase_infra.adapters.llm.adapter_llm_provider_openai import (
+    AdapterLlmProviderOpenai,
+    TransportHolderLlmHttp,
+)
+from omnibase_infra.adapters.llm.model_llm_adapter_request import (
+    ModelLlmAdapterRequest,
+)
+
+
+class _RecordingTransport(TransportHolderLlmHttp):
+    """Transport double that records ``timeout_seconds`` on each call.
+
+    Bypasses real HTTP, allowlist, and HMAC checks so the test stays
+    hermetic and observes the exact value the handler forwards from the
+    inference request.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            target_name="omn-9869-recorder",
+            max_timeout_seconds=600.0,
+        )
+        self.calls: list[dict[str, Any]] = []
+
+    async def _execute_llm_http_call(
+        self,
+        url: str,
+        payload: dict[str, JsonType],
+        correlation_id: UUID,
+        max_retries: int = 3,
+        timeout_seconds: float = 30.0,
+    ) -> dict[str, JsonType]:
+        self.calls.append(
+            {
+                "url": url,
+                "timeout_seconds": timeout_seconds,
+                "model": payload.get("model"),
+            }
+        )
+        # Minimal OpenAI-shape chat completion response so the handler can
+        # finish parsing without raising.
+        return {
+            "id": "chatcmpl-omn-9869",
+            "object": "chat.completion",
+            "model": payload.get("model", "qwen2.5-coder-14b"),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+
+
+@pytest.mark.asyncio
+async def test_explicit_timeout_reaches_http_transport_layer() -> None:
+    """Caller-provided ``timeout_seconds`` propagates to ``_execute_llm_http_call``.
+
+    Regression guard for OMN-9869: prior to the fix the adapter dropped
+    the contract-owned timeout, so the inference layer always used its
+    30-second default and long-running local-model calls failed before
+    the node-contract timeout window.
+    """
+    adapter = AdapterLlmProviderOpenai(
+        base_url="http://localhost:8000",
+        default_model="qwen2.5-coder-14b",
+    )
+    recorder = _RecordingTransport()
+    adapter._transport = recorder
+    # Re-bind the handler so it uses the recording transport instead of the
+    # one created during ``AdapterLlmProviderOpenai.__init__``.
+    adapter._handler._transport = recorder
+
+    try:
+        await adapter.generate_async(
+            ModelLlmAdapterRequest(
+                prompt="Long-running prompt",
+                model_name="qwen2.5-coder-14b",
+                timeout_seconds=240.0,
+            )
+        )
+    finally:
+        await recorder.close()
+
+    assert recorder.calls, "expected at least one HTTP call"
+    assert recorder.calls[0]["timeout_seconds"] == 240.0
+
+
+@pytest.mark.asyncio
+async def test_default_timeout_reaches_http_transport_layer() -> None:
+    """Omitting ``timeout_seconds`` propagates the 30.0 default end-to-end."""
+    adapter = AdapterLlmProviderOpenai(
+        base_url="http://localhost:8000",
+        default_model="qwen2.5-coder-14b",
+    )
+    recorder = _RecordingTransport()
+    adapter._transport = recorder
+    adapter._handler._transport = recorder
+
+    try:
+        await adapter.generate_async(
+            ModelLlmAdapterRequest(
+                prompt="Hello",
+                model_name="qwen2.5-coder-14b",
+            )
+        )
+    finally:
+        await recorder.close()
+
+    assert recorder.calls, "expected at least one HTTP call"
+    assert recorder.calls[0]["timeout_seconds"] == 30.0

--- a/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
@@ -222,6 +222,39 @@ class TestAdapterLlmProviderOpenaiTranslation:
                 model_name="",
             )
 
+    def test_translate_request_propagates_explicit_timeout(self) -> None:
+        """Caller-supplied timeout_seconds reaches the infra request.
+
+        Regression guard for OMN-9869: prior behavior dropped the contract
+        timeout and inferred a 30s default at the inference layer, causing
+        long-running local-model calls to fail before the node-contract
+        timeout window.
+        """
+        adapter = AdapterLlmProviderOpenai(
+            base_url="http://localhost:8000",
+            default_model="qwen2.5-coder-14b",
+        )
+        spi_request = ModelLlmAdapterRequest(
+            prompt="Long-running prompt",
+            model_name="qwen2.5-coder-14b",
+            timeout_seconds=240.0,
+        )
+        infra_request = adapter._translate_request(spi_request)
+        assert infra_request.timeout_seconds == 240.0
+
+    def test_translate_request_uses_default_timeout(self) -> None:
+        """Omitting timeout_seconds yields the model default on the infra request."""
+        adapter = AdapterLlmProviderOpenai(
+            base_url="http://localhost:8000",
+            default_model="qwen2.5-coder-14b",
+        )
+        spi_request = ModelLlmAdapterRequest(
+            prompt="Hello",
+            model_name="qwen2.5-coder-14b",
+        )
+        infra_request = adapter._translate_request(spi_request)
+        assert infra_request.timeout_seconds == 30.0
+
 
 class TestAdapterLlmProviderOpenaiModelDiscovery:
     """Tests for model discovery behavior."""

--- a/tests/unit/adapters/llm/test_model_llm_adapter_request.py
+++ b/tests/unit/adapters/llm/test_model_llm_adapter_request.py
@@ -104,3 +104,55 @@ class TestModelLlmAdapterRequest:
         assert isinstance(req.prompt, str)
         assert isinstance(req.model_name, str)
         assert isinstance(req.parameters, dict)
+
+    def test_default_timeout_seconds(self) -> None:
+        """timeout_seconds defaults to 30.0 when not provided.
+
+        Mirrors ModelLlmInferenceRequest.timeout_seconds default so that
+        the adapter does not silently shorten or lengthen the contract
+        timeout for callers that omit the field.
+        """
+        req = ModelLlmAdapterRequest(prompt="Hello", model_name="test")
+        assert req.timeout_seconds == 30.0
+
+    def test_explicit_timeout_seconds_preserved(self) -> None:
+        """Caller-provided timeout_seconds is preserved verbatim."""
+        req = ModelLlmAdapterRequest(
+            prompt="Hello",
+            model_name="test",
+            timeout_seconds=120.0,
+        )
+        assert req.timeout_seconds == 120.0
+
+    def test_timeout_seconds_lower_bound(self) -> None:
+        """timeout_seconds below 1.0 is rejected."""
+        with pytest.raises(ValidationError):
+            ModelLlmAdapterRequest(
+                prompt="Hello",
+                model_name="test",
+                timeout_seconds=0.5,
+            )
+
+    def test_timeout_seconds_upper_bound(self) -> None:
+        """timeout_seconds above 600.0 is rejected."""
+        with pytest.raises(ValidationError):
+            ModelLlmAdapterRequest(
+                prompt="Hello",
+                model_name="test",
+                timeout_seconds=600.1,
+            )
+
+    def test_timeout_seconds_boundary_values_accepted(self) -> None:
+        """Exact bounds 1.0 and 600.0 are accepted."""
+        req_min = ModelLlmAdapterRequest(
+            prompt="Hello",
+            model_name="test",
+            timeout_seconds=1.0,
+        )
+        req_max = ModelLlmAdapterRequest(
+            prompt="Hello",
+            model_name="test",
+            timeout_seconds=600.0,
+        )
+        assert req_min.timeout_seconds == 1.0
+        assert req_max.timeout_seconds == 600.0


### PR DESCRIPTION
## Summary
- Adds `timeout_seconds: float` field to `ModelLlmAdapterRequest` (default 30.0, bounds 1.0-600.0 mirroring `ModelLlmInferenceRequest`).
- Passes `request.timeout_seconds` through `AdapterLlmProviderOpenai._translate_request()` into the infra inference request so contract-owned endpoint timeouts reach the HTTP transport.
- No env-var fallback introduced; timeout configuration stays contract-owned by callers/endpoints.

## Why
Merge-sweep runtime effects routed through `AdapterLlmProviderOpenai` were dropping the contract-owned endpoint timeout and silently using the inference layer's 30s default, causing long-running local-model calls to fail before the node-contract timeout window.

Resolves [OMN-9869](https://linear.app/omninode/issue/OMN-9869). Unblocks [OMN-9870](https://linear.app/omninode/issue/OMN-9870).

## Test plan
- [x] `pytest tests/unit/adapters/llm/test_model_llm_adapter_request.py tests/unit/adapters/llm/test_adapter_llm_provider_openai.py` -> 33 passed
- [x] `pytest tests/unit/adapters/llm/ tests/unit/nodes/node_llm_inference_effect/` -> 809 passed (no regressions)
- [x] `mypy --strict` on both modified source files -> clean
- [x] All 32 pre-commit hooks passed
- [x] TDD evidence: 4 added tests fail without the implementation (`AttributeError: no attribute 'timeout_seconds'` and `extra_forbidden` ValidationError) and pass with it

## Acceptance criteria coverage
- ✅ Runtime callers can set request timeout from typed node contract endpoint config (new `timeout_seconds` field).
- ✅ No env-var fallback required for local model endpoint timeout behavior.
- ✅ Unit tests prove the timeout reaches the inference request (`test_translate_request_propagates_explicit_timeout`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout support for LLM inference requests, allowing users to specify custom timeouts (1–600 seconds) with a 30-second default. Timeouts are now properly propagated to the HTTP transport layer.

* **Tests**
  * Added integration and unit test coverage for timeout propagation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->