### PR TITLE
fix(OMN-10345): override stability core infra ports

### DIFF
--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -16,7 +16,7 @@ name: omnibase-infra-stability-test
 services:
   postgres:
     container_name: omnibase-infra-stability-test-postgres
-    ports:
+    ports: !override
       - "${STABILITY_TEST_POSTGRES_EXTERNAL_PORT:-15436}:5432"
   redpanda:
     container_name: omnibase-infra-stability-test-redpanda
@@ -52,7 +52,7 @@ services:
       - "${STABILITY_TEST_REDPANDA_ADMIN_PORT:-29644}:9644"
   valkey:
     container_name: omnibase-infra-stability-test-valkey
-    ports:
+    ports: !override
       - "${STABILITY_TEST_VALKEY_EXTERNAL_PORT:-26379}:6379"
   migration-gate:
     container_name: omnibase-infra-stability-test-migration-gate

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -36,6 +36,8 @@ COMPOSE_RENDER_ENV = {
     "ONEX_SERVICE_CLIENT_SECRET": "render-only-client-secret",
     "POSTGRES_PASSWORD": "postgres",
     "REDPANDA_ADVERTISE_HOST": "localhost",
+    "STABILITY_TEST_POSTGRES_EXTERNAL_PORT": "15436",
+    "STABILITY_TEST_VALKEY_EXTERNAL_PORT": "26379",
     "STABILITY_TEST_REDPANDA_ADMIN_PORT": "29644",
     "STABILITY_TEST_REDPANDA_EXTERNAL_PORT": "39092",
     "STABILITY_TEST_REDPANDA_PANDAPROXY_PORT": "28082",
@@ -96,7 +98,9 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
     rendered_config = result.stdout
     rendered = yaml.safe_load(rendered_config)
     services = rendered["services"]
+    postgres_ports = services["postgres"]["ports"]
     redpanda_ports = services["redpanda"]["ports"]
+    valkey_ports = services["valkey"]["ports"]
     main_ports = services["omninode-runtime"]["ports"]
     effects_ports = services["runtime-effects"]["ports"]
     networks = rendered["networks"]
@@ -144,8 +148,14 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
     assert "com.omninode.runtime.id: stability-test-effects" in rendered_config
     assert "com.omninode.runtime.id: stability-test-worker" in rendered_config
     assert "image: runtime:stability-test-workspace" in rendered_config
+    assert {port["published"] for port in postgres_ports} == {"15436"}
+    assert {port["target"] for port in postgres_ports} == {5432}
     assert {port["published"] for port in redpanda_ports} == {"39092", "29644"}
     assert {port["target"] for port in redpanda_ports} == {19092, 9644}
+    assert {port["published"] for port in valkey_ports} == {"26379"}
+    assert {port["target"] for port in valkey_ports} == {6379}
+    assert 'published: "5436"' not in rendered_config
+    assert 'published: "16379"' not in rendered_config
     assert 'published: "19092"' not in rendered_config
     assert 'published: "9644"' not in rendered_config
     assert 'published: "18082"' not in rendered_config

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -136,9 +136,15 @@ def test_stability_lane_runtime_ports_override_production_bindings() -> None:
     overlay = _load_overlay()
     services = overlay["services"]
 
+    assert services["postgres"]["ports"] == [
+        "${STABILITY_TEST_POSTGRES_EXTERNAL_PORT:-15436}:5432"
+    ]
     assert services["redpanda"]["ports"] == [
         "${STABILITY_TEST_REDPANDA_EXTERNAL_PORT:-39092}:19092",
         "${STABILITY_TEST_REDPANDA_ADMIN_PORT:-29644}:9644",
+    ]
+    assert services["valkey"]["ports"] == [
+        "${STABILITY_TEST_VALKEY_EXTERNAL_PORT:-26379}:6379"
     ]
     assert services["omninode-runtime"]["ports"] == [
         "${STABILITY_TEST_RUNTIME_MAIN_PORT:-18085}:8085"


### PR DESCRIPTION
Ticket: OMN-10345

## Summary
- Override stability-test Postgres and Valkey ports instead of appending production bindings.
- Extend unit/render assertions so production core infra ports 5436 and 16379 are not published by the stability lane.
- Completes the core infra port isolation found during .201 stability-test activation.

## Verification
- uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q
- uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- git diff --check

## Runtime note
Found during .201 stability-test activation after omnibase_infra#1470 merged. No production runtime restart was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose stability test configuration to use port override directives for database and cache services.

* **Tests**
  * Enhanced stability test validation to verify port binding overrides for database and cache infrastructure services with configurable external port mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->