### PR TITLE
fix(OMN-10345): preserve stability runtime image contracts

### DIFF
--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -76,10 +76,9 @@ services:
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-main
     ports: !override
       - "${STABILITY_TEST_RUNTIME_MAIN_PORT:-18085}:8085"
-    volumes:
+    volumes: !override
       - runtime_logs:/app/logs
       - runtime_data:/app/data
-      - ../contracts:/app/contracts:ro
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     labels:
       - "com.omninode.lane=stability-test"
@@ -103,10 +102,9 @@ services:
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-effects
     ports: !override
       - "${STABILITY_TEST_RUNTIME_EFFECTS_PORT:-18086}:8085"
-    volumes:
+    volumes: !override
       - effects_logs:/app/logs
       - effects_data:/app/data
-      - ../contracts:/app/contracts:ro
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     labels:
       - "com.omninode.lane=stability-test"
@@ -128,10 +126,9 @@ services:
       ONEX_GROUP_ID: onex-stability-test-runtime-workers
       KAFKA_INSTANCE_ID: stability-test-worker
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-worker
-    volumes:
+    volumes: !override
       - worker_logs:/app/logs
       - stability_test_worker_data:/app/data
-      - ../contracts:/app/contracts:ro
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
     labels:
       - "com.omninode.lane=stability-test"

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -104,6 +104,12 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
     main_ports = services["omninode-runtime"]["ports"]
     effects_ports = services["runtime-effects"]["ports"]
     networks = rendered["networks"]
+    runtime_service_volumes = {
+        service_name: {
+            volume["target"] for volume in services[service_name].get("volumes", [])
+        }
+        for service_name in REQUIRED_RUNTIME_SERVICES
+    }
 
     assert "container_name: omninode-stability-test-runtime" in rendered_config
     assert "container_name: omninode-stability-test-runtime-effects" in rendered_config
@@ -165,6 +171,9 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
     assert {port["published"] for port in effects_ports} == {"18086"}
     assert 'published: "8085"' not in rendered_config
     assert 'published: "8086"' not in rendered_config
+    for service_name, volume_targets in runtime_service_volumes.items():
+        assert "/app/contracts" not in volume_targets, service_name
+        assert "/app/skills" in volume_targets, service_name
     assert networks["omnibase-infra-network"]["name"] == (
         "omnibase-infra-stability-test-network"
     )

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -155,6 +155,18 @@ def test_stability_lane_runtime_ports_override_production_bindings() -> None:
 
 
 @pytest.mark.unit
+def test_stability_lane_runtime_services_preserve_image_runtime_contracts() -> None:
+    overlay = _load_overlay()
+    services = overlay["services"]
+
+    for service_name in RUNTIME_SERVICES:
+        volumes = services[service_name]["volumes"]
+        assert "../contracts:/app/contracts:ro" not in volumes
+        assert all(":/app/contracts" not in volume for volume in volumes)
+        assert any(volume.endswith(":/app/skills:ro") for volume in volumes)
+
+
+@pytest.mark.unit
 def test_stability_lane_core_infra_names_are_distinct() -> None:
     overlay = _load_overlay()
     services = overlay["services"]


### PR DESCRIPTION
Ticket: OMN-10345

## Summary
- Override stability runtime service volumes so /app/contracts from the image is not shadowed by the host contracts checkout.
- Preserve isolated runtime data/log volumes and skills mounts for the stability lane.
- Add unit/render assertions that stability runtime services do not bind-mount /app/contracts.

## Verification
- uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py -q
- uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q (skipped locally because Docker is unavailable)
- uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- git diff --check

## Runtime note
Found during .201 stability-test activation after omnibase_infra#1471 merged. The isolated lane reached service_kernel config load and failed because /app/contracts/runtime/runtime_orchestrator.yaml was hidden by the host contracts bind mount. Production runtime was not restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify runtime service volume mount isolation, ensuring `/app/skills` is mounted while `/app/contracts` is excluded.
  * Added unit test to validate runtime service volume mappings prevent contract mounting while preserving skills access.

* **Chores**
  * Updated stability-test runtime configuration to remove contracts volume binding from runtime containers while maintaining skills and log/data mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->