### PR TITLE
docs(OMN-10348): define ONEX (OmniNode eXecution) on first use in omnibase_infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # omnibase_infra
 
-Production infrastructure runtime for ONEX.
+Production infrastructure runtime for ONEX (OmniNode eXecution).
 
 [![CI](https://github.com/OmniNode-ai/omnibase_infra/actions/workflows/test.yml/badge.svg)](https://github.com/OmniNode-ai/omnibase_infra/actions/workflows/test.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)

--- a/contracts/OMN-10348.yaml
+++ b/contracts/OMN-10348.yaml
@@ -1,0 +1,34 @@
+schema_version: "1.0.0"
+ticket_id: OMN-10348
+title: "Define ONEX (OmniNode eXecution) on first use across all canonical repo docs"
+summary: "Add canonical ONEX expansion on first use in primary doc entrypoints; correct stale/wrong expansion in secondary docs"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: ci
+    description: "omnibase_infra PR 1475 checks pass"
+    command: "gh pr checks 1475 --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "README.md updated with ONEX (OmniNode eXecution) on first use"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "gh pr diff 1475 --repo OmniNode-ai/omnibase_infra | grep -q 'OmniNode eXecution'"
+  - id: dod-002
+    description: "docs/architecture/overview.md corrected from wrong expansion to canonical form"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "gh pr diff 1475 --repo OmniNode-ai/omnibase_infra | grep -q 'OmniNode eXecution'"
+  - id: dod-003
+    description: "Deploy-gate evidence: docs-only change, no Docker image or runtime service deploy required"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "echo 'deploy-gate: OMN-10348 changes only markdown documentation; no Docker image, runtime process, broker topic, or service deploy is required'"

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 # ONEX Architecture Overview
 
-This document provides a high-level overview of the ONEX (OmniNode Execution) architecture used in `omnibase_infra`.
+This document provides a high-level overview of the ONEX (OmniNode eXecution) architecture used in `omnibase_infra`.
 
 ## Design Philosophy
 


### PR DESCRIPTION
## Summary

Defines `ONEX (OmniNode eXecution)` on first use in `README.md` per OMN-10348, and corrects a stale expansion in architecture docs.

## DoD evidence

**Ticket:** OMN-10348

| File | Before | After |
|---|---|---|
| `README.md:3` | `Production infrastructure runtime for ONEX.` | `Production infrastructure runtime for ONEX (OmniNode eXecution).` |
| `docs/architecture/overview.md:5` | `ONEX (OmniNode Execution)` | `ONEX (OmniNode eXecution)` |

## Notes

- `docs/architecture/overview.md` had "OmniNode Execution" (missing capitalized X) — corrected to canonical form