### PR TITLE
feat(OMN-10392): add kafka replay compute primitive

### DIFF
--- a/contracts/OMN-10392.yaml
+++ b/contracts/OMN-10392.yaml
@@ -1,0 +1,52 @@
+# OMN-10392 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the kafka replay compute primitive.
+schema_version: "1.0.0"
+ticket_id: "OMN-10392"
+title: "Add kafka replay compute primitive"
+summary: "Add node_kafka_replay_compute with typed input/output/progress models, handler, contract registration, and focused replay tests."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused contract and isolated kafka replay tests pass for node_kafka_replay_compute."
+    command: "uv run pytest tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py -q"
+  - kind: "tests"
+    description: "Strict typing passes for kafka replay compute source."
+    command: "uv run mypy --strict src/omnibase_infra/nodes/node_kafka_replay_compute/"
+  - kind: "ci"
+    description: "Lint passes for kafka replay compute source, tests, and pyproject entry point registration."
+    command: "uv run ruff check pyproject.toml src/omnibase_infra/nodes/node_kafka_replay_compute tests/unit/nodes/node_kafka_replay_compute tests/integration/nodes/node_kafka_replay_compute"
+  - kind: "manual"
+    description: "Post-merge deploy validation imports the registered node and re-runs the focused replay suite against the deployed image or release checkout before claiming runtime completion."
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.nodes.node_kafka_replay_compute import NodeKafkaReplayCompute; print('deploy smoke ok', NodeKafkaReplayCompute.__name__)\" && uv run pytest tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused kafka replay contract and isolated replay tests pass locally."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py -q"
+  - id: "dod-002"
+    description: "Strict typing passes for kafka replay compute source."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy --strict src/omnibase_infra/nodes/node_kafka_replay_compute/"
+  - id: "dod-003"
+    description: "Lint passes for kafka replay compute source, tests, and pyproject entry point registration."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff check pyproject.toml src/omnibase_infra/nodes/node_kafka_replay_compute tests/unit/nodes/node_kafka_replay_compute tests/integration/nodes/node_kafka_replay_compute"
+  - id: "dod-deploy"
+    description: "deploy gate evidence: post-merge runtime validation is required before claiming live kafka replay compute availability; no pre-merge live deploy is claimed."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.nodes.node_kafka_replay_compute import NodeKafkaReplayCompute; print('deploy smoke ok', NodeKafkaReplayCompute.__name__)\" && uv run pytest tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py -q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,6 +484,7 @@ node_gmail_archive_cleanup_effect = "omnibase_infra.nodes.node_gmail_archive_cle
 node_gmail_intent_poller_effect = "omnibase_infra.nodes.node_gmail_intent_poller_effect"
 node_impact_analyzer_compute = "omnibase_infra.nodes.node_impact_analyzer_compute"
 node_intent_storage_effect = "omnibase_infra.nodes.node_intent_storage_effect"
+node_kafka_replay_compute = "omnibase_infra.nodes.node_kafka_replay_compute"
 node_ledger_projection_compute = "omnibase_infra.nodes.node_ledger_projection_compute"
 node_ledger_write_effect = "omnibase_infra.nodes.node_ledger_write_effect"
 node_llm_completion_effect = "omnibase_infra.nodes.node_llm_completion_effect"

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/__init__.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka replay compute node."""
+
+from omnibase_infra.nodes.node_kafka_replay_compute.node import NodeKafkaReplayCompute
+
+__all__ = ["NodeKafkaReplayCompute"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/contract.yaml
@@ -38,6 +38,7 @@ handler_routing:
         module: "omnibase_infra.nodes.node_kafka_replay_compute.handlers.handler_replay"
 metadata:
   description: "Typed Kafka replay primitive for deterministic proof workflows"
+  transport_type: "KAFKA"
   author: "OmniNode Team"
   created: "2026-04-30"
   tags:

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/contract.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# ONEX Node Contract - Kafka Replay Compute
+#
+# Ticket: OMN-10392
+name: "node_kafka_replay_compute"
+node_type: "COMPUTE_GENERIC"
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+node_version: "1.0.0"
+description: >
+  Compute node that replays Kafka event-bus envelopes from an explicitly injected target Kafka/Redpanda bootstrap for deterministic projection-equality proofs. The node never reads production bootstrap configuration or mutates runtime .201.
+
+input_model:
+  name: "ModelKafkaReplayInput"
+  module: "omnibase_infra.nodes.node_kafka_replay_compute.models"
+  description: "Typed replay command with injected bootstrap, topics, offset bounds, replay mode, and optional resume sequence info."
+output_model:
+  name: "ModelKafkaReplayOutput"
+  module: "omnibase_infra.nodes.node_kafka_replay_compute.models"
+  description: "Replay result with event count, offset progress, correlation chain, and failed deserialization offsets."
+definitions:
+  progress_model:
+    name: "ModelKafkaReplayProgress"
+    module: "omnibase_infra.nodes.node_kafka_replay_compute.models"
+    description: "Per topic-partition progress emitted during replay."
+event_bus:
+  subscribe_topics: []
+  publish_topics: []
+handler_routing:
+  routing_strategy: "operation_match"
+  handlers:
+    - operation: "kafka.replay"
+      handler:
+        name: "HandlerKafkaReplay"
+        module: "omnibase_infra.nodes.node_kafka_replay_compute.handlers.handler_replay"
+metadata:
+  description: "Typed Kafka replay primitive for deterministic proof workflows"
+  author: "OmniNode Team"
+  created: "2026-04-30"
+  tags:
+    - "compute"
+    - "kafka"
+    - "replay"
+    - "deterministic-replay"

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Handlers for node_kafka_replay_compute."""
+
+from omnibase_infra.nodes.node_kafka_replay_compute.handlers.handler_replay import (
+    HandlerKafkaReplay,
+)
+
+__all__ = ["HandlerKafkaReplay"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from asyncio import gather
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -282,7 +283,7 @@ class HandlerKafkaReplay:
         )
         result = self._progress_callback(progress)
         if inspect.isawaitable(result):
-            await result
+            await gather(result)
 
     @staticmethod
     def _sequence_key(topic: str, partition: int) -> str:

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka replay compute handler."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID
+
+from aiokafka import AIOKafkaConsumer, TopicPartition
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.models.projection import ModelSequenceInfo
+from omnibase_infra.nodes.node_kafka_replay_compute.models import (
+    ModelKafkaReplayInput,
+    ModelKafkaReplayOutput,
+    ModelKafkaReplayProgress,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols import (
+    ConsumerFactory,
+    EnvelopeDeserializer,
+    ProgressCallback,
+    ProtocolKafkaMessage,
+    ProtocolKafkaReplayConsumer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ModelReplayBounds:
+    start_offsets: Mapping[TopicPartition, int]
+    end_offsets: Mapping[TopicPartition, int]
+
+
+def _default_consumer_factory(
+    command: ModelKafkaReplayInput,
+) -> ProtocolKafkaReplayConsumer:
+    """Build an AIOKafkaConsumer from only the injected replay command target."""
+    consumer = AIOKafkaConsumer(
+        bootstrap_servers=command.target_cluster_bootstrap,
+        group_id=command.target_consumer_group,
+        enable_auto_commit=False,
+        auto_offset_reset="earliest",
+    )
+    return cast("ProtocolKafkaReplayConsumer", consumer)
+
+
+def _deserialize_event_envelope(value: bytes) -> ModelEventEnvelope[object]:
+    """Deserialize canonical event-bus envelope bytes."""
+    return ModelEventEnvelope[object].model_validate_json(value)
+
+
+class HandlerKafkaReplay:
+    """Replay Kafka event envelopes from an explicitly injected target cluster."""
+
+    def __init__(
+        self,
+        consumer_factory: ConsumerFactory | None = None,
+        envelope_deserializer: EnvelopeDeserializer = _deserialize_event_envelope,
+        progress_callback: ProgressCallback | None = None,
+    ) -> None:
+        """Initialize the replay handler.
+
+        Args:
+            consumer_factory: Optional test seam for isolated Kafka fixtures.
+            envelope_deserializer: Canonical envelope deserializer.
+            progress_callback: Optional progress sink.
+        """
+        self._consumer_factory = consumer_factory or _default_consumer_factory
+        self._envelope_deserializer = envelope_deserializer
+        self._progress_callback = progress_callback
+
+    @property
+    def handler_type(self) -> EnumHandlerType:
+        return EnumHandlerType.NODE_HANDLER
+
+    @property
+    def handler_category(self) -> EnumHandlerTypeCategory:
+        return EnumHandlerTypeCategory.COMPUTE
+
+    async def handle(self, command: ModelKafkaReplayInput) -> ModelKafkaReplayOutput:
+        """Replay envelopes from the target cluster and return offset evidence."""
+        consumer = self._consumer_factory(command)
+        started_at = datetime.now(UTC)
+        events_replayed = 0
+        correlation_id_chain: list[UUID] = []
+        failed_event_offsets: list[int] = []
+        last_offset_per_topic: dict[str, int] = {}
+        sequence_info_per_topic: dict[str, ModelSequenceInfo] = {}
+
+        await consumer.start()
+        try:
+            partitions = await self._resolve_topic_partitions(consumer, command.topics)
+            bounds = await self._resolve_bounds(consumer, command, partitions)
+            active_partitions = [
+                partition
+                for partition in partitions
+                if bounds.start_offsets[partition] < bounds.end_offsets[partition]
+            ]
+            consumer.assign(active_partitions)
+            for partition in active_partitions:
+                consumer.seek(partition, bounds.start_offsets[partition])
+
+            empty_polls = 0
+            completed_partitions: set[TopicPartition] = set()
+
+            while len(completed_partitions) < len(active_partitions):
+                if (
+                    command.expected_event_count is not None
+                    and events_replayed >= command.expected_event_count
+                ):
+                    break
+
+                records_by_partition = await consumer.getmany(
+                    *active_partitions,
+                    timeout_ms=command.poll_timeout_ms,
+                )
+                if not records_by_partition:
+                    empty_polls += 1
+                    if empty_polls >= command.max_empty_polls:
+                        break
+                    continue
+
+                empty_polls = 0
+                for partition, records in records_by_partition.items():
+                    if partition in completed_partitions:
+                        continue
+                    end_offset = bounds.end_offsets[partition]
+                    for record in records:
+                        if record.offset >= end_offset:
+                            completed_partitions.add(partition)
+                            break
+                        envelope = self._decode_record(record, failed_event_offsets)
+                        if envelope is not None and envelope.correlation_id is not None:
+                            correlation_id_chain.append(envelope.correlation_id)
+
+                        events_replayed += 1
+                        last_offset_per_topic[record.topic] = record.offset
+                        sequence_key = self._sequence_key(
+                            record.topic, record.partition
+                        )
+                        sequence_info_per_topic[sequence_key] = (
+                            ModelSequenceInfo.from_kafka(
+                                partition=record.partition,
+                                offset=record.offset,
+                            )
+                        )
+                        if events_replayed % command.progress_interval_events == 0:
+                            await self._emit_progress(record, events_replayed)
+
+                        if record.offset + 1 >= end_offset:
+                            completed_partitions.add(partition)
+                            break
+
+            if (
+                command.expected_event_count is not None
+                and events_replayed != command.expected_event_count
+            ):
+                raise ValueError(
+                    "Kafka replay event count mismatch: "
+                    f"expected {command.expected_event_count}, got {events_replayed}"
+                )
+
+            completed_at = datetime.now(UTC)
+            logger.info(
+                "Kafka replay complete",
+                extra={
+                    "topics": command.topics,
+                    "events_replayed": events_replayed,
+                    "target_consumer_group": command.target_consumer_group,
+                },
+            )
+            return ModelKafkaReplayOutput(
+                events_replayed=events_replayed,
+                last_offset_per_topic=last_offset_per_topic,
+                sequence_info_per_topic=sequence_info_per_topic,
+                started_at=started_at,
+                completed_at=completed_at,
+                correlation_id_chain=correlation_id_chain,
+                failed_event_offsets=failed_event_offsets,
+            )
+        finally:
+            await consumer.stop()
+
+    async def _resolve_topic_partitions(
+        self, consumer: ProtocolKafkaReplayConsumer, topics: Sequence[str]
+    ) -> list[TopicPartition]:
+        partitions: list[TopicPartition] = []
+        for topic in topics:
+            topic_partitions = await consumer.partitions_for_topic(topic)
+            if topic_partitions is None:
+                raise ValueError(f"Kafka topic not found for replay: {topic}")
+            for partition in sorted(topic_partitions):
+                partitions.append(TopicPartition(topic, partition))
+        return partitions
+
+    async def _resolve_bounds(
+        self,
+        consumer: ProtocolKafkaReplayConsumer,
+        command: ModelKafkaReplayInput,
+        partitions: Sequence[TopicPartition],
+    ) -> ModelReplayBounds:
+        beginning_offsets = await consumer.beginning_offsets(partitions)
+        end_offsets = await consumer.end_offsets(partitions)
+
+        resolved_start: dict[TopicPartition, int] = {}
+        for partition in partitions:
+            sequence_key = self._sequence_key(partition.topic, partition.partition)
+            resume_info = command.resume_from.get(sequence_key)
+            if resume_info is not None and resume_info.offset is not None:
+                candidate = resume_info.offset + 1
+            elif command.from_offset == "earliest":
+                candidate = beginning_offsets[partition]
+            else:
+                candidate = int(command.from_offset)
+            resolved_start[partition] = max(candidate, beginning_offsets[partition])
+
+        resolved_end: dict[TopicPartition, int]
+        if command.to_offset == "latest":
+            resolved_end = dict(end_offsets)
+        elif not command.to_offset.isdecimal():
+            timestamp_ms = int(
+                datetime.fromisoformat(command.to_offset).timestamp() * 1000
+            )
+            offsets_for_times = await consumer.offsets_for_times(
+                dict.fromkeys(partitions, timestamp_ms)
+            )
+            resolved_end = {}
+            for partition in partitions:
+                offset_for_time = offsets_for_times[partition]
+                resolved_end[partition] = (
+                    offset_for_time.offset
+                    if offset_for_time is not None
+                    else end_offsets[partition]
+                )
+        else:
+            end = int(command.to_offset)
+            resolved_end = {
+                partition: min(end, end_offsets[partition]) for partition in partitions
+            }
+
+        return ModelReplayBounds(start_offsets=resolved_start, end_offsets=resolved_end)
+
+    def _decode_record(
+        self, record: ProtocolKafkaMessage, failed_event_offsets: list[int]
+    ) -> ModelEventEnvelope[object] | None:
+        if record.value is None:
+            failed_event_offsets.append(record.offset)
+            return None
+        try:
+            return self._envelope_deserializer(bytes(record.value))
+        except Exception:
+            failed_event_offsets.append(record.offset)
+            logger.exception(
+                "Failed to deserialize replay event envelope",
+                extra={
+                    "topic": record.topic,
+                    "partition": record.partition,
+                    "offset": record.offset,
+                },
+            )
+            return None
+
+    async def _emit_progress(
+        self, record: ProtocolKafkaMessage, events_replayed: int
+    ) -> None:
+        if self._progress_callback is None:
+            return
+        progress = ModelKafkaReplayProgress(
+            topic=record.topic,
+            partition=record.partition,
+            current_offset=record.offset,
+            events_replayed_so_far=events_replayed,
+            eta_seconds=None,
+        )
+        result = self._progress_callback(progress)
+        if inspect.isawaitable(result):
+            await result
+
+    @staticmethod
+    def _sequence_key(topic: str, partition: int) -> str:
+        return f"{topic}:{partition}"
+
+
+__all__ = ["HandlerKafkaReplay"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/models/__init__.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/models/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Models for node_kafka_replay_compute."""
+
+from omnibase_infra.nodes.node_kafka_replay_compute.models.model_kafka_replay_input import (
+    ModelKafkaReplayInput,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.models.model_kafka_replay_output import (
+    ModelKafkaReplayOutput,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.models.model_kafka_replay_progress import (
+    ModelKafkaReplayProgress,
+)
+
+__all__ = [
+    "ModelKafkaReplayInput",
+    "ModelKafkaReplayOutput",
+    "ModelKafkaReplayProgress",
+]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_input.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_input.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Input model for Kafka replay compute."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.replay.enum_replay_mode import EnumReplayMode
+from omnibase_infra.models.projection import ModelSequenceInfo
+
+
+class ModelKafkaReplayInput(BaseModel):
+    """Typed command for replaying Kafka event envelopes from an injected cluster."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    topics: list[str] = Field(
+        ..., min_length=1, description="Kafka topics to replay from the target cluster."
+    )
+    from_offset: str = Field(
+        default="earliest",
+        description="Starting offset. Use 'earliest' or a non-negative numeric offset.",
+    )
+    to_offset: str = Field(
+        default="latest",
+        description=(
+            "Exclusive ending offset. Use 'latest', a non-negative numeric offset, "
+            "or an ISO-8601 wall-clock timestamp."
+        ),
+    )
+    target_cluster_bootstrap: str = Field(
+        ...,
+        min_length=1,
+        description="Injected Kafka/Redpanda bootstrap servers for the isolated target.",
+    )
+    target_consumer_group: str = Field(
+        ..., min_length=1, description="Consumer group used for this replay run."
+    )
+    mode: EnumReplayMode = Field(
+        default=EnumReplayMode.REPLAYING,
+        description="Replay mode from omnibase_core deterministic replay contracts.",
+    )
+    expected_event_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="Optional exact event count assertion for the replay run.",
+    )
+    resume_from: dict[str, ModelSequenceInfo] = Field(
+        default_factory=dict,
+        description=(
+            "Optional per topic-partition resume offsets. Keys use '<topic>:<partition>'."
+        ),
+    )
+    poll_timeout_ms: int = Field(
+        default=1000,
+        gt=0,
+        description="Kafka poll timeout in milliseconds.",
+    )
+    max_empty_polls: int = Field(
+        default=3,
+        gt=0,
+        description="Consecutive empty polls allowed before the replay run stops.",
+    )
+    progress_interval_events: int = Field(
+        default=100,
+        gt=0,
+        description="Emit progress after this many replayed events.",
+    )
+
+    @field_validator("topics")
+    @classmethod
+    def _topics_must_be_non_empty_strings(cls, topics: list[str]) -> list[str]:
+        cleaned = [topic.strip() for topic in topics]
+        if any(not topic for topic in cleaned):
+            raise ValueError("topics must not contain empty topic names")
+        return cleaned
+
+    @field_validator("from_offset", mode="before")
+    @classmethod
+    def _from_offset_must_be_earliest_or_numeric(cls, value: object) -> str:
+        normalized = str(value).strip()
+        if normalized == "earliest" or normalized.isdecimal():
+            return normalized
+        raise ValueError("from_offset must be 'earliest' or a non-negative integer")
+
+    @field_validator("to_offset", mode="before")
+    @classmethod
+    def _to_offset_must_be_latest_numeric_or_timestamp(cls, value: object) -> str:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        normalized = str(value).strip()
+        if normalized == "latest" or normalized.isdecimal():
+            return normalized
+        try:
+            datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(
+                "to_offset must be 'latest', a non-negative integer, "
+                "or an ISO-8601 timestamp"
+            ) from exc
+        return normalized
+
+    @field_validator("target_cluster_bootstrap")
+    @classmethod
+    def _bootstrap_must_be_explicit_target(cls, bootstrap: str) -> str:
+        cleaned = bootstrap.strip()
+        if not cleaned:
+            raise ValueError("target_cluster_bootstrap must not be empty")
+        if ".201:" in cleaned or cleaned.endswith(".201"):
+            raise ValueError(
+                "target_cluster_bootstrap points at protected .201 runtime; "
+                "use an isolated target cluster"
+            )
+        return cleaned
+
+    @field_validator("target_consumer_group")
+    @classmethod
+    def _consumer_group_must_be_explicit(cls, group: str) -> str:
+        cleaned = group.strip()
+        if not cleaned:
+            raise ValueError("target_consumer_group must not be empty")
+        return cleaned
+
+
+__all__ = ["ModelKafkaReplayInput"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_output.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_output.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Output model for Kafka replay compute."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.projection import ModelSequenceInfo
+
+
+class ModelKafkaReplayOutput(BaseModel):
+    """Replay result and offset proof surface."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    events_replayed: int = Field(..., ge=0, description="Total replayed events.")
+    last_offset_per_topic: dict[str, int] = Field(
+        default_factory=dict,
+        description="Last replayed offset by topic name across all partitions.",
+    )
+    sequence_info_per_topic: dict[str, ModelSequenceInfo] = Field(
+        default_factory=dict,
+        description="ModelSequenceInfo-compatible offset progress per topic-partition.",
+    )
+    started_at: datetime = Field(..., description="Replay start timestamp.")
+    completed_at: datetime = Field(..., description="Replay completion timestamp.")
+    correlation_id_chain: list[UUID] = Field(
+        default_factory=list,
+        description="Correlation IDs recovered from replayed envelopes.",
+    )
+    failed_event_offsets: list[int] = Field(
+        default_factory=list,
+        description="Offsets that failed canonical envelope deserialization.",
+    )
+
+
+__all__ = ["ModelKafkaReplayOutput"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_progress.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/models/model_kafka_replay_progress.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Progress model for Kafka replay compute."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelKafkaReplayProgress(BaseModel):
+    """Replay progress for one topic partition."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    topic: str = Field(..., min_length=1, description="Kafka topic being replayed.")
+    partition: int = Field(..., ge=0, description="Kafka partition being replayed.")
+    current_offset: int = Field(..., ge=0, description="Current Kafka offset.")
+    events_replayed_so_far: int = Field(
+        ..., ge=0, description="Number of events replayed by this run."
+    )
+    eta_seconds: float | None = Field(
+        default=None,
+        ge=0,
+        description="Optional estimated seconds remaining for the run.",
+    )
+
+
+__all__ = ["ModelKafkaReplayProgress"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/node.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/node.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka replay compute node shell.
+
+All behavior is defined in contract.yaml and implemented by HandlerKafkaReplay.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.nodes.node_compute import NodeCompute
+
+if TYPE_CHECKING:
+    from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class NodeKafkaReplayCompute(NodeCompute):
+    """Declarative compute node for deterministic Kafka replay proofs."""
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        """Initialize with container dependency injection."""
+        super().__init__(container)
+
+
+__all__ = ["NodeKafkaReplayCompute"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/__init__.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/__init__.py
@@ -11,6 +11,9 @@ from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_rep
 from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_offset_and_timestamp import (
     ProtocolOffsetAndTimestamp,
 )
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_topic_partition import (
+    ProtocolTopicPartition,
+)
 from omnibase_infra.nodes.node_kafka_replay_compute.protocols.types_kafka_replay import (
     ConsumerFactory,
     EnvelopeDeserializer,
@@ -24,4 +27,5 @@ __all__ = [
     "ProtocolKafkaMessage",
     "ProtocolKafkaReplayConsumer",
     "ProtocolOffsetAndTimestamp",
+    "ProtocolTopicPartition",
 ]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/__init__.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Protocols for node_kafka_replay_compute."""
+
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_message import (
+    ProtocolKafkaMessage,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_replay_consumer import (
+    ProtocolKafkaReplayConsumer,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_offset_and_timestamp import (
+    ProtocolOffsetAndTimestamp,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.types_kafka_replay import (
+    ConsumerFactory,
+    EnvelopeDeserializer,
+    ProgressCallback,
+)
+
+__all__ = [
+    "ConsumerFactory",
+    "EnvelopeDeserializer",
+    "ProgressCallback",
+    "ProtocolKafkaMessage",
+    "ProtocolKafkaReplayConsumer",
+    "ProtocolOffsetAndTimestamp",
+]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_message.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_message.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka message protocol for replay compute."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ProtocolKafkaMessage(Protocol):
+    """Kafka message fields consumed by the replay handler."""
+
+    topic: str
+    partition: int
+    offset: int
+    value: bytes | None
+
+
+__all__ = ["ProtocolKafkaMessage"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
@@ -21,31 +21,40 @@ from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_topic_par
 class ProtocolKafkaReplayConsumer(Protocol):
     """Subset of AIOKafkaConsumer used by replay compute."""
 
-    async def start(self) -> None: ...
+    async def start(self) -> None:
+        raise NotImplementedError
 
-    async def stop(self) -> None: ...
+    async def stop(self) -> None:
+        raise NotImplementedError
 
-    async def partitions_for_topic(self, topic: str) -> set[int] | None: ...
+    async def partitions_for_topic(self, topic: str) -> set[int] | None:
+        raise NotImplementedError
 
     async def beginning_offsets(
         self, partitions: Iterable[ProtocolTopicPartition]
-    ) -> Mapping[ProtocolTopicPartition, int]: ...
+    ) -> Mapping[ProtocolTopicPartition, int]:
+        raise NotImplementedError
 
     async def end_offsets(
         self, partitions: Iterable[ProtocolTopicPartition]
-    ) -> Mapping[ProtocolTopicPartition, int]: ...
+    ) -> Mapping[ProtocolTopicPartition, int]:
+        raise NotImplementedError
 
     async def offsets_for_times(
         self, timestamps: Mapping[ProtocolTopicPartition, int]
-    ) -> Mapping[ProtocolTopicPartition, ProtocolOffsetAndTimestamp | None]: ...
+    ) -> Mapping[ProtocolTopicPartition, ProtocolOffsetAndTimestamp | None]:
+        raise NotImplementedError
 
-    def assign(self, partitions: Iterable[ProtocolTopicPartition]) -> None: ...
+    def assign(self, partitions: Iterable[ProtocolTopicPartition]) -> None:
+        raise NotImplementedError
 
-    def seek(self, partition: ProtocolTopicPartition, offset: int) -> None: ...
+    def seek(self, partition: ProtocolTopicPartition, offset: int) -> None:
+        raise NotImplementedError
 
     async def getmany(
         self, *partitions: ProtocolTopicPartition, timeout_ms: int
-    ) -> Mapping[ProtocolTopicPartition, Sequence[ProtocolKafkaMessage]]: ...
+    ) -> Mapping[ProtocolTopicPartition, Sequence[ProtocolKafkaMessage]]:
+        raise NotImplementedError
 
 
 __all__ = ["ProtocolKafkaReplayConsumer"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka replay consumer protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Protocol
+
+from aiokafka import TopicPartition
+
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_message import (
+    ProtocolKafkaMessage,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_offset_and_timestamp import (
+    ProtocolOffsetAndTimestamp,
+)
+
+
+class ProtocolKafkaReplayConsumer(Protocol):
+    """Subset of AIOKafkaConsumer used by replay compute."""
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    async def partitions_for_topic(self, topic: str) -> set[int] | None: ...
+
+    async def beginning_offsets(
+        self, partitions: Iterable[TopicPartition]
+    ) -> Mapping[TopicPartition, int]: ...
+
+    async def end_offsets(
+        self, partitions: Iterable[TopicPartition]
+    ) -> Mapping[TopicPartition, int]: ...
+
+    async def offsets_for_times(
+        self, timestamps: Mapping[TopicPartition, int]
+    ) -> Mapping[TopicPartition, ProtocolOffsetAndTimestamp | None]: ...
+
+    def assign(self, partitions: Iterable[TopicPartition]) -> None: ...
+
+    def seek(self, partition: TopicPartition, offset: int) -> None: ...
+
+    async def getmany(
+        self, *partitions: TopicPartition, timeout_ms: int
+    ) -> Mapping[TopicPartition, Sequence[ProtocolKafkaMessage]]: ...
+
+
+__all__ = ["ProtocolKafkaReplayConsumer"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Protocol
 
-from aiokafka import TopicPartition
-
 from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_message import (
     ProtocolKafkaMessage,
 )
 from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_offset_and_timestamp import (
     ProtocolOffsetAndTimestamp,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_topic_partition import (
+    ProtocolTopicPartition,
 )
 
 
@@ -27,24 +28,24 @@ class ProtocolKafkaReplayConsumer(Protocol):
     async def partitions_for_topic(self, topic: str) -> set[int] | None: ...
 
     async def beginning_offsets(
-        self, partitions: Iterable[TopicPartition]
-    ) -> Mapping[TopicPartition, int]: ...
+        self, partitions: Iterable[ProtocolTopicPartition]
+    ) -> Mapping[ProtocolTopicPartition, int]: ...
 
     async def end_offsets(
-        self, partitions: Iterable[TopicPartition]
-    ) -> Mapping[TopicPartition, int]: ...
+        self, partitions: Iterable[ProtocolTopicPartition]
+    ) -> Mapping[ProtocolTopicPartition, int]: ...
 
     async def offsets_for_times(
-        self, timestamps: Mapping[TopicPartition, int]
-    ) -> Mapping[TopicPartition, ProtocolOffsetAndTimestamp | None]: ...
+        self, timestamps: Mapping[ProtocolTopicPartition, int]
+    ) -> Mapping[ProtocolTopicPartition, ProtocolOffsetAndTimestamp | None]: ...
 
-    def assign(self, partitions: Iterable[TopicPartition]) -> None: ...
+    def assign(self, partitions: Iterable[ProtocolTopicPartition]) -> None: ...
 
-    def seek(self, partition: TopicPartition, offset: int) -> None: ...
+    def seek(self, partition: ProtocolTopicPartition, offset: int) -> None: ...
 
     async def getmany(
-        self, *partitions: TopicPartition, timeout_ms: int
-    ) -> Mapping[TopicPartition, Sequence[ProtocolKafkaMessage]]: ...
+        self, *partitions: ProtocolTopicPartition, timeout_ms: int
+    ) -> Mapping[ProtocolTopicPartition, Sequence[ProtocolKafkaMessage]]: ...
 
 
 __all__ = ["ProtocolKafkaReplayConsumer"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka offset timestamp protocol for replay compute."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ProtocolOffsetAndTimestamp(Protocol):
+    """Kafka offset lookup result for wall-clock replay bounds."""
+
+    offset: int
+
+
+__all__ = ["ProtocolOffsetAndTimestamp"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka topic-partition protocol for replay compute."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ProtocolTopicPartition(Protocol):
+    """Structural topic-partition key used by Kafka replay consumers."""
+
+    topic: str
+    partition: int
+
+
+__all__ = ["ProtocolTopicPartition"]

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/types_kafka_replay.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/protocols/types_kafka_replay.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Type aliases for Kafka replay compute."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.nodes.node_kafka_replay_compute.models import (
+    ModelKafkaReplayInput,
+    ModelKafkaReplayProgress,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.protocols.protocol_kafka_replay_consumer import (
+    ProtocolKafkaReplayConsumer,
+)
+
+ConsumerFactory = Callable[[ModelKafkaReplayInput], ProtocolKafkaReplayConsumer]
+ProgressCallback = Callable[[ModelKafkaReplayProgress], Awaitable[None] | None]
+EnvelopeDeserializer = Callable[[bytes], ModelEventEnvelope[object]]
+
+
+__all__ = ["ConsumerFactory", "EnvelopeDeserializer", "ProgressCallback"]

--- a/tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py
+++ b/tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for Kafka replay compute using an isolated fixture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from aiokafka import TopicPartition
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.models.projection import ModelSequenceInfo
+from omnibase_infra.nodes.node_kafka_replay_compute.handlers.handler_replay import (
+    HandlerKafkaReplay,
+)
+from omnibase_infra.nodes.node_kafka_replay_compute.models import ModelKafkaReplayInput
+
+
+@dataclass(frozen=True)
+class _FixtureRecord:
+    topic: str
+    partition: int
+    offset: int
+    value: bytes
+
+
+class _IsolatedKafkaConsumer:
+    def __init__(self, records_by_topic: dict[str, list[bytes]]) -> None:
+        self._records_by_topic = records_by_topic
+        self._positions: dict[TopicPartition, int] = {}
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def partitions_for_topic(self, topic: str) -> set[int] | None:
+        if topic not in self._records_by_topic:
+            return None
+        return {0}
+
+    async def beginning_offsets(
+        self, partitions: list[TopicPartition]
+    ) -> dict[TopicPartition, int]:
+        return dict.fromkeys(partitions, 0)
+
+    async def end_offsets(
+        self, partitions: list[TopicPartition]
+    ) -> dict[TopicPartition, int]:
+        return {
+            partition: len(self._records_by_topic[partition.topic])
+            for partition in partitions
+        }
+
+    async def offsets_for_times(
+        self, timestamps: dict[TopicPartition, int]
+    ) -> dict[TopicPartition, None]:
+        return dict.fromkeys(timestamps)
+
+    def assign(self, partitions: list[TopicPartition]) -> None:
+        for partition in partitions:
+            self._positions.setdefault(partition, 0)
+
+    def seek(self, partition: TopicPartition, offset: int) -> None:
+        self._positions[partition] = offset
+
+    async def getmany(
+        self, *partitions: TopicPartition, timeout_ms: int
+    ) -> dict[TopicPartition, list[_FixtureRecord]]:
+        del timeout_ms
+        batch: dict[TopicPartition, list[_FixtureRecord]] = {}
+        for partition in partitions:
+            position = self._positions.get(partition, 0)
+            values = self._records_by_topic[partition.topic]
+            if position >= len(values):
+                continue
+            value = values[position]
+            batch[partition] = [
+                _FixtureRecord(
+                    topic=partition.topic,
+                    partition=partition.partition,
+                    offset=position,
+                    value=value,
+                )
+            ]
+            self._positions[partition] = position + 1
+        return batch
+
+
+def _envelope_bytes(event_type: str, ordinal: int) -> bytes:
+    envelope = ModelEventEnvelope[dict[str, object]](
+        payload={"ordinal": ordinal},
+        correlation_id=uuid4(),
+        event_type=event_type,
+    )
+    return envelope.model_dump_json().encode("utf-8")
+
+
+@pytest.fixture
+def isolated_kafka_records() -> dict[str, list[bytes]]:
+    return {
+        "dispatch_worker-completed.v1": [
+            _envelope_bytes("dispatch_worker-completed.v1", i) for i in range(10)
+        ],
+        "dispatch-outcome-evaluated.v1": [
+            _envelope_bytes("dispatch-outcome-evaluated.v1", i) for i in range(5)
+        ],
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_replay_against_isolated_cluster(
+    isolated_kafka_records: dict[str, list[bytes]],
+) -> None:
+    handler = HandlerKafkaReplay(
+        consumer_factory=lambda _: _IsolatedKafkaConsumer(isolated_kafka_records)
+    )
+
+    result = await handler.handle(
+        ModelKafkaReplayInput(
+            topics=[
+                "dispatch_worker-completed.v1",
+                "dispatch-outcome-evaluated.v1",
+            ],
+            target_cluster_bootstrap="isolated-redpanda:9092",
+            target_consumer_group="omn-10392-isolated-replay",
+            expected_event_count=15,
+            progress_interval_events=5,
+        )
+    )
+
+    assert result.events_replayed == 15
+    assert result.last_offset_per_topic == {
+        "dispatch_worker-completed.v1": 9,
+        "dispatch-outcome-evaluated.v1": 4,
+    }
+    assert result.sequence_info_per_topic[
+        "dispatch_worker-completed.v1:0"
+    ] == ModelSequenceInfo.from_kafka(partition=0, offset=9)
+    assert len(result.correlation_id_chain) == 15
+    assert result.failed_event_offsets == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_replay_resumes_from_sequence_info(
+    isolated_kafka_records: dict[str, list[bytes]],
+) -> None:
+    handler = HandlerKafkaReplay(
+        consumer_factory=lambda _: _IsolatedKafkaConsumer(isolated_kafka_records)
+    )
+
+    result = await handler.handle(
+        ModelKafkaReplayInput(
+            topics=["dispatch_worker-completed.v1"],
+            target_cluster_bootstrap="isolated-redpanda:9092",
+            target_consumer_group="omn-10392-isolated-replay-resume",
+            expected_event_count=6,
+            resume_from={
+                "dispatch_worker-completed.v1:0": ModelSequenceInfo.from_kafka(
+                    partition=0,
+                    offset=3,
+                )
+            },
+        )
+    )
+
+    assert result.events_replayed == 6
+    assert result.last_offset_per_topic == {"dispatch_worker-completed.v1": 9}

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -147,6 +147,12 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     # [NODE] DI boundary for lifecycle event emission — lets the remote-agent effect
     # test lifecycle publication without coupling the handler to EventBusKafka (OMN-9637).
     "ProtocolLifecycleEventSink": "nodes/node_remote_agent_invoke_effect/services/lifecycle_event_sink.py",
+    # [NODE] OMN-10392 replay compute narrows the AIOKafkaConsumer surface and
+    # Kafka record/key shapes for isolated replay handler tests.
+    "ProtocolKafkaMessage": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_message.py",
+    "ProtocolKafkaReplayConsumer": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py",
+    "ProtocolOffsetAndTimestamp": "nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py",
+    "ProtocolTopicPartition": "nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py",
 }
 
 # Duplicate protocol names that appear in multiple files (node-internal

--- a/tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py
+++ b/tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py
@@ -37,6 +37,7 @@ def test_contract_loads_with_compute_shape() -> None:
     assert contract["name"] == "node_kafka_replay_compute"
     assert contract["node_type"] == "COMPUTE_GENERIC"
     assert contract["event_bus"] == {"subscribe_topics": [], "publish_topics": []}
+    assert contract["metadata"]["transport_type"] == "KAFKA"
 
     input_model = contract["input_model"]
     output_model = contract["output_model"]

--- a/tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py
+++ b/tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Contract tests for node_kafka_replay_compute."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.replay.enum_replay_mode import EnumReplayMode
+from omnibase_infra.nodes.node_kafka_replay_compute.models import ModelKafkaReplayInput
+
+_CONTRACT_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "omnibase_infra"
+    / "nodes"
+    / "node_kafka_replay_compute"
+    / "contract.yaml"
+)
+
+
+def _load_contract() -> dict[str, object]:
+    with _CONTRACT_PATH.open() as f:
+        loaded = yaml.safe_load(f)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+@pytest.mark.unit
+def test_contract_loads_with_compute_shape() -> None:
+    contract = _load_contract()
+
+    assert contract["name"] == "node_kafka_replay_compute"
+    assert contract["node_type"] == "COMPUTE_GENERIC"
+    assert contract["event_bus"] == {"subscribe_topics": [], "publish_topics": []}
+
+    input_model = contract["input_model"]
+    output_model = contract["output_model"]
+    definitions = contract["definitions"]
+    assert isinstance(definitions, dict)
+    progress_model = definitions["progress_model"]
+    assert isinstance(input_model, dict)
+    assert isinstance(output_model, dict)
+    assert isinstance(progress_model, dict)
+    assert input_model["name"] == "ModelKafkaReplayInput"
+    assert output_model["name"] == "ModelKafkaReplayOutput"
+    assert progress_model["name"] == "ModelKafkaReplayProgress"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_section", "class_name"),
+    [
+        ("input_model", "ModelKafkaReplayInput"),
+        ("output_model", "ModelKafkaReplayOutput"),
+        ("definitions.progress_model", "ModelKafkaReplayProgress"),
+    ],
+)
+def test_contract_model_imports(model_section: str, class_name: str) -> None:
+    contract = _load_contract()
+    section: object = contract
+    for part in model_section.split("."):
+        assert isinstance(section, dict)
+        section = section[part]
+    assert isinstance(section, dict)
+
+    module = importlib.import_module(str(section["module"]))
+    assert getattr(module, class_name).__name__ == class_name
+
+
+@pytest.mark.unit
+def test_input_reuses_core_replay_mode_and_rejects_protected_runtime() -> None:
+    command = ModelKafkaReplayInput(
+        topics=["dispatch_worker-completed.v1"],
+        target_cluster_bootstrap="localhost:19092",
+        target_consumer_group="omn-10392-replay",
+        mode=EnumReplayMode.REPLAYING,
+    )
+
+    assert command.mode is EnumReplayMode.REPLAYING
+
+    with pytest.raises(ValueError, match=r"protected \.201 runtime"):
+        ModelKafkaReplayInput(
+            topics=["dispatch_worker-completed.v1"],
+            target_cluster_bootstrap="10.0.0.201:9092",
+            target_consumer_group="omn-10392-replay",
+        )


### PR DESCRIPTION
## Summary
- Add `node_kafka_replay_compute` contract, node shell, typed input/output/progress models, and handler.
- Replay consumes canonical `ModelEventEnvelope` bytes from an injected target bootstrap only, records offset/correlation evidence, and supports `ModelSequenceInfo` resume offsets.
- Register the node in `onex.nodes` and add focused contract plus isolated fixture replay tests.

## Verification
- `uv run ruff format pyproject.toml src/omnibase_infra/nodes/node_kafka_replay_compute tests/unit/nodes/node_kafka_replay_compute tests/integration/nodes/node_kafka_replay_compute`
- `uv run ruff check pyproject.toml src/omnibase_infra/nodes/node_kafka_replay_compute tests/unit/nodes/node_kafka_replay_compute tests/integration/nodes/node_kafka_replay_compute`
- `uv run mypy --strict src/omnibase_infra/nodes/node_kafka_replay_compute/`
- `uv run pytest tests/unit/nodes/node_kafka_replay_compute/test_contract_loads.py tests/integration/nodes/node_kafka_replay_compute/test_replay_against_isolated_cluster.py -q`
- `PYTHONPATH=src uv run python - <<'PY' ... ContractLinter(check_imports=True) ... PY` => valid, 0 errors, 0 warnings
- pre-commit on commit: full local hook suite passed
- pre-push: mypy + architecture layer validation passed

## Notes
- No production `.201` bootstrap fallback or mutation.
- The integration test uses an isolated in-process Kafka consumer fixture because this repo did not expose a reusable per-test Redpanda fixture for this node path.

Linear: OMN-10392
