### PR TITLE
feat(OMN-10387): register savings dispatch outcome subscription

### DIFF
--- a/contracts/OMN-10387.yaml
+++ b/contracts/OMN-10387.yaml
@@ -1,0 +1,36 @@
+# OMN-10387 contract file for omnibase_infra deploy-gate (OMN-8912).
+# Canonical OCC evidence lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for dispatch outcome savings subscription.
+schema_version: "1.0.0"
+ticket_id: "OMN-10387"
+title: "Register dispatch outcome savings subscription"
+summary: "Register the omniintelligence dispatch-outcome-evaluated topic and include it in the savings estimation consumer defaults."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "events"
+  - "topics"
+evidence_requirements:
+  - kind: "tests"
+    description: "Savings estimator config and registry coverage pass for dispatch outcome subscription"
+    command: "uv run pytest tests/integration/observability/test_savings_estimation_e2e.py tests/unit/observability/test_savings_estimation_config.py tests/unit/topics/test_service_topic_registry.py -q"
+  - kind: "manual"
+    description: "Post-merge deploy smoke confirms the savings estimator default subscription resolves in the deployed runtime container"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.services.observability.savings_estimation.config import ConfigSavingsEstimation; from omnibase_infra.topics import topic_keys; from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry; reg=ServiceTopicRegistry.from_defaults(); topic=reg.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED); cfg=ConfigSavingsEstimation(); assert topic in cfg.consumed_topics; print('deploy smoke ok', topic)\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Savings estimator config and registry coverage pass for dispatch outcome subscription"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/observability/test_savings_estimation_e2e.py tests/unit/observability/test_savings_estimation_config.py tests/unit/topics/test_service_topic_registry.py -q"
+  - id: "dod-002"
+    description: "Post-merge deploy smoke plan for dispatch outcome savings subscription"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.services.observability.savings_estimation.config import ConfigSavingsEstimation; from omnibase_infra.topics import topic_keys; from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry; reg=ServiceTopicRegistry.from_defaults(); topic=reg.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED); cfg=ConfigSavingsEstimation(); assert topic in cfg.consumed_topics; print('deploy smoke ok', topic)\""

--- a/src/omnibase_infra/services/observability/savings_estimation/config.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/config.py
@@ -24,6 +24,7 @@ def _default_consumed_topics() -> list[str]:
     reg = ServiceTopicRegistry.from_defaults()
     return [
         reg.resolve(topic_keys.LLM_CALL_COMPLETED),
+        reg.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED),
         reg.resolve(topic_keys.SESSION_OUTCOME_CANONICAL),
         reg.resolve(topic_keys.HOOK_CONTEXT_INJECTED),
         reg.resolve(topic_keys.VALIDATOR_CATCH),

--- a/src/omnibase_infra/services/observability/savings_estimation/consumer.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/consumer.py
@@ -16,6 +16,7 @@ Architecture:
 
 Consumed topics:
     - onex.evt.omniintelligence.llm-call-completed.v1
+    - onex.evt.omniintelligence.dispatch-outcome-evaluated.v1
     - onex.evt.omniclaude.session-outcome.v1
     - onex.evt.omniclaude.hook-context-injected.v1
     - onex.evt.omniclaude.validator-catch.v1

--- a/src/omnibase_infra/topics/service_topic_registry.py
+++ b/src/omnibase_infra/topics/service_topic_registry.py
@@ -93,6 +93,9 @@ class ServiceTopicRegistry:
             topic_keys.LLM_CALL_COMPLETED: (
                 "onex.evt.omniintelligence.llm-call-completed.v1"
             ),
+            topic_keys.DISPATCH_OUTCOME_EVALUATED: (
+                "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"
+            ),
             topic_keys.LLM_CALL_COMPLETED_INFRA: (
                 "onex.evt.omnibase-infra.llm-call-completed.v1"
             ),

--- a/src/omnibase_infra/topics/topic_keys.py
+++ b/src/omnibase_infra/topics/topic_keys.py
@@ -73,6 +73,9 @@ MANIFEST_INJECTION_FAILED: Final[str] = "MANIFEST_INJECTION_FAILED"
 LLM_CALL_COMPLETED: Final[str] = "LLM_CALL_COMPLETED"
 """LLM call completed metrics from omniintelligence."""
 
+DISPATCH_OUTCOME_EVALUATED: Final[str] = "DISPATCH_OUTCOME_EVALUATED"
+"""Dispatch worker outcome evaluations from omniintelligence."""
+
 LLM_CALL_COMPLETED_INFRA: Final[str] = "LLM_CALL_COMPLETED_INFRA"
 """LLM call completed event from omnibase-infra inference effect."""
 
@@ -262,6 +265,7 @@ __all__: list[str] = [
     "CIRCUIT_BREAKER_STATE",
     "CONSUMER_HEALTH",
     "CONSUMER_RESTART_CMD",
+    "DISPATCH_OUTCOME_EVALUATED",
     "EFFECTIVENESS_INVALIDATION",
     "ERROR_TRIAGED",
     "EVAL_COMPLETED",

--- a/tests/integration/observability/test_savings_estimation_e2e.py
+++ b/tests/integration/observability/test_savings_estimation_e2e.py
@@ -34,12 +34,15 @@ from omnibase_infra.services.observability.savings_estimation.consumer import (
     ValidatorCatchSignal,
     _compute_validator_catch_savings,
 )
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
 
 # ---------------------------------------------------------------------------
 # Test fixtures
 # ---------------------------------------------------------------------------
 
 TOPIC_LLM_CALL = "onex.evt.omniintelligence.llm-call-completed.v1"
+TOPIC_DISPATCH_OUTCOME = "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"
 TOPIC_SESSION_OUTCOME = "onex.evt.omniclaude.session-outcome.v1"
 TOPIC_HOOK_INJECTION = "onex.evt.omniclaude.hook-context-injected.v1"
 TOPIC_VALIDATOR_CATCH = "onex.evt.omniclaude.validator-catch.v1"
@@ -107,6 +110,16 @@ REQUIRED_OUTPUT_FIELDS = {
 @pytest.mark.integration
 class TestSavingsEstimationE2E:
     """End-to-end integration tests for the full savings estimation pipeline."""
+
+    def test_default_config_subscribes_to_dispatch_outcome_topic(self) -> None:
+        """Default savings config consumes the omniintelligence dispatch outcome feed."""
+        registry = ServiceTopicRegistry.from_defaults()
+        config = _build_config()
+
+        assert registry.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED) == (
+            TOPIC_DISPATCH_OUTCOME
+        )
+        assert TOPIC_DISPATCH_OUTCOME in config.consumed_topics
 
     async def test_full_pipeline_produces_savings_event(self) -> None:
         """Ingest a realistic session's events and verify the output estimate."""

--- a/tests/unit/observability/test_savings_estimation_config.py
+++ b/tests/unit/observability/test_savings_estimation_config.py
@@ -73,3 +73,23 @@ class TestSavingsEstimationConfig:
 
         with pytest.raises(ValidationError):
             ConfigSavingsEstimation()
+
+    def test_default_topics_include_dispatch_outcome_evaluated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", "broker-specific:9092"
+        )
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+        from omnibase_infra.topics import topic_keys
+        from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
+
+        registry = ServiceTopicRegistry.from_defaults()
+        cfg = ConfigSavingsEstimation()
+
+        assert registry.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED) in (
+            cfg.consumed_topics
+        )


### PR DESCRIPTION
## Summary
- Add a logical `DISPATCH_OUTCOME_EVALUATED` topic key and default registry mapping
- Include the dispatch outcome evaluated topic in savings estimation consumed topics
- Add unit and integration coverage proving the default subscription is registered
- Add OMN-10387 deploy-gate evidence contract for the runtime subscription change
- No projection/ingestion business logic added

## Verification
- `uv run ruff format src/omnibase_infra/topics/topic_keys.py src/omnibase_infra/topics/service_topic_registry.py src/omnibase_infra/services/observability/savings_estimation/config.py src/omnibase_infra/services/observability/savings_estimation/consumer.py tests/unit/observability/test_savings_estimation_config.py tests/integration/observability/test_savings_estimation_e2e.py`
- `uv run ruff check tests/integration/observability/test_savings_estimation_e2e.py tests/unit/observability/test_savings_estimation_config.py src/omnibase_infra/topics/topic_keys.py src/omnibase_infra/topics/service_topic_registry.py src/omnibase_infra/services/observability/savings_estimation/config.py src/omnibase_infra/services/observability/savings_estimation/consumer.py`
- `uv run pytest tests/integration/observability/test_savings_estimation_e2e.py tests/unit/observability/test_savings_estimation_config.py tests/unit/topics/test_service_topic_registry.py -q`
- `python - <<PY ...` parsed `contracts/OMN-10387.yaml` and verified deploy-smoke evidence is present

## Dependency
- Should merge after the linked omniintelligence producer contract for `onex.evt.omniintelligence.dispatch-outcome-evaluated.v1` exists.
