### PR TITLE
feat(OMN-10382): migrate infra usage source vocabulary

### DIFF
--- a/contracts/OMN-10382.yaml
+++ b/contracts/OMN-10382.yaml
@@ -1,0 +1,45 @@
+# OMN-10382 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the usage_source enum migration.
+schema_version: "1.0.0"
+ticket_id: "OMN-10382"
+title: "Migrate LLM usage_source vocabulary to EnumUsageSource"
+summary: "Migrate infra LLM compute usage evidence from legacy API/ESTIMATED/MISSING literals to the shared EnumUsageSource vocabulary."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "events"
+  - "public_api"
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused migration, GPU measurement, metrics publisher, writer, and recompute pricing tests pass."
+    command: "uv run pytest tests/integration/test_llm_gpu_usage_evidence_integration.py tests/integration/scripts/test_recompute_measured_pricing.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py -q"
+  - kind: "ci"
+    description: "Touched infra usage source paths pass ruff."
+    command: "uv run ruff check scripts/recompute_measured_pricing.py src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py tests/integration/scripts/test_recompute_measured_pricing.py tests/integration/test_llm_gpu_usage_evidence_integration.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py"
+  - kind: "manual"
+    description: "Post-merge runtime validation confirms emitted LLM metric events and aggregate rows use shared EnumUsageSource values."
+    command: "deploy: query llm-call-completed events and llm_cost_aggregates rows for MEASURED, ESTIMATED, and MISSING usage_source values after runtime rollout"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused migration, GPU measurement, metrics publisher, writer, and recompute pricing tests pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/test_llm_gpu_usage_evidence_integration.py tests/integration/scripts/test_recompute_measured_pricing.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py -q"
+  - id: "dod-002"
+    description: "Touched infra usage source paths pass ruff."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff check scripts/recompute_measured_pricing.py src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py tests/integration/scripts/test_recompute_measured_pricing.py tests/integration/test_llm_gpu_usage_evidence_integration.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py"
+  - id: "dod-deploy"
+    description: "deploy gate evidence: pre-merge live deploy is not claimed; runtime validation remains post-merge."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: query llm-call-completed events and llm_cost_aggregates rows for MEASURED, ESTIMATED, and MISSING usage_source values after runtime rollout"

--- a/contracts/OMN-10382.yaml
+++ b/contracts/OMN-10382.yaml
@@ -19,7 +19,7 @@ evidence_requirements:
     command: "uv run ruff check scripts/recompute_measured_pricing.py src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py tests/integration/scripts/test_recompute_measured_pricing.py tests/integration/test_llm_gpu_usage_evidence_integration.py tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py"
   - kind: "manual"
     description: "Post-merge runtime validation confirms emitted LLM metric events and aggregate rows use shared EnumUsageSource values."
-    command: "deploy: query llm-call-completed events and llm_cost_aggregates rows for MEASURED, ESTIMATED, and MISSING usage_source values after runtime rollout"
+    command: "deploy: query llm-call-completed events and llm_cost_aggregates rows for measured, estimated, and unknown usage_source values after runtime rollout"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -42,4 +42,4 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "deploy: query llm-call-completed events and llm_cost_aggregates rows for MEASURED, ESTIMATED, and MISSING usage_source values after runtime rollout"
+        check_value: "deploy: query llm-call-completed events and llm_cost_aggregates rows for measured, estimated, and unknown usage_source values after runtime rollout"

--- a/docker/migrations/forward/077_migrate_usage_source_vocab.sql
+++ b/docker/migrations/forward/077_migrate_usage_source_vocab.sql
@@ -1,0 +1,53 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+
+-- OMN-10382: migrate LLM usage_source values to EnumUsageSource vocabulary.
+
+BEGIN;
+
+CREATE TYPE usage_source_type_v2 AS ENUM ('measured', 'estimated', 'unknown');
+
+ALTER TABLE llm_call_metrics
+    ALTER COLUMN usage_source DROP DEFAULT;
+
+ALTER TABLE llm_call_metrics
+    ALTER COLUMN usage_source TYPE usage_source_type_v2
+    USING CASE usage_source::text
+        WHEN 'API' THEN 'measured'
+        WHEN 'ESTIMATED' THEN 'estimated'
+        WHEN 'MISSING' THEN 'unknown'
+        WHEN 'measured' THEN 'measured'
+        WHEN 'estimated' THEN 'estimated'
+        WHEN 'unknown' THEN 'unknown'
+        ELSE 'unknown'
+    END::usage_source_type_v2;
+
+ALTER TABLE llm_call_metrics
+    ALTER COLUMN usage_source SET DEFAULT 'unknown';
+
+ALTER TABLE llm_call_metrics
+    ALTER COLUMN compute_usage_source TYPE usage_source_type_v2
+    USING CASE compute_usage_source::text
+        WHEN 'API' THEN 'measured'
+        WHEN 'ESTIMATED' THEN 'estimated'
+        WHEN 'MISSING' THEN 'unknown'
+        WHEN 'measured' THEN 'measured'
+        WHEN 'estimated' THEN 'estimated'
+        WHEN 'unknown' THEN 'unknown'
+        ELSE NULL
+    END::usage_source_type_v2;
+
+DROP TYPE usage_source_type;
+
+ALTER TYPE usage_source_type_v2 RENAME TO usage_source_type;
+
+COMMENT ON TYPE usage_source_type IS
+    'Shared usage-source vocabulary: measured, estimated, unknown.';
+
+COMMENT ON COLUMN llm_call_metrics.usage_source IS
+    'Usage provenance using the shared EnumUsageSource vocabulary.';
+
+COMMENT ON COLUMN llm_call_metrics.compute_usage_source IS
+    'GPU usage provenance using the shared EnumUsageSource vocabulary.';
+
+COMMIT;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -2,5 +2,5 @@
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
 sha256:16d89127c16624fcae46f8504d72835f3805a24ef380303f924c07e8d9525eb0
-generated_at: 2026-05-01T22:33:57Z
+generated_at: 2026-05-01T22:34:11Z
 migration_file_count: 62

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:4cf5e57cd08e7f88da9a9fd849128fe6b67ca7e5ff27fce005c3189486bb7fa5
-generated_at: 2026-04-30T08:36:39Z
-migration_file_count: 61
+sha256:16d89127c16624fcae46f8504d72835f3805a24ef380303f924c07e8d9525eb0
+generated_at: 2026-05-01T22:33:57Z
+migration_file_count: 62

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,9 +167,9 @@ override-dependencies = [
 [tool.uv.sources]
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
-# OMN-10238 depends on the shared runtime skill contract models/protocol added in core.
-# Pinned to f5508002 (jonah/omn-10238-shared-runtime-skill-client) — switch back to mainline after core #957 merges.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "f550800252d6bfc990309aa0074ca020cc6003a6" }
+# OMN-10382 depends on the shared usage-source enum added in core.
+# Pinned to the core #993 merge commit until the next PyPI release includes it.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "6ddf546834ca8aa3affeedbc170845062351e4f7" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/scripts/recompute_measured_pricing.py
+++ b/scripts/recompute_measured_pricing.py
@@ -248,7 +248,7 @@ def update_manifest(
             "sample_window_days": 7,
             "sample_count": int(entry["sample_count"]),
             "min_samples": min_samples,
-            "query": "llm_call_metrics usage_source=measured created_at>=now-7d",
+            "query": "llm_call_metrics usage_source in (measured, API) created_at>=now-7d",
             "authoritative": entry["confidence"] == MEASURED,
         }
 

--- a/scripts/recompute_measured_pricing.py
+++ b/scripts/recompute_measured_pricing.py
@@ -22,6 +22,8 @@ DEFAULT_ENV_FILE = Path.home() / ".omnibase" / ".env"
 LOW_CONFIDENCE = "LOW_CONFIDENCE"
 MEASURED = "MEASURED"
 MEASURED_SOURCE = "API_REPORTED_COST_ROLLING_7D"
+MEASURED_USAGE_SOURCE = "measured"
+LEGACY_API_USAGE_SOURCE = "API"
 FALLBACK_SOURCE = "FALLBACK_PROVIDER_DOCUMENTATION"
 LOCAL_SOURCE = "LOCAL_ZERO_API_COST_POLICY"
 MANIFEST_HEADER = (
@@ -73,9 +75,13 @@ def _sample_from_mapping(data: dict[str, object]) -> PricingSample | None:
         "completion_tokens",
         data.get("output_tokens", 0),
     )
-    usage_source = data.get("usage_source", "API")
+    usage_source = data.get("usage_source", LEGACY_API_USAGE_SOURCE)
 
-    if not isinstance(model_id, str) or usage_source != "API" or cost is None:
+    if (
+        not isinstance(model_id, str)
+        or usage_source not in {MEASURED_USAGE_SOURCE, LEGACY_API_USAGE_SOURCE}
+        or cost is None
+    ):
         return None
 
     prompt = int(cast("int | float | str", prompt_tokens or 0))
@@ -123,7 +129,7 @@ async def fetch_db_samples(database_url: str) -> list[PricingSample]:
             estimated_cost_usd
         FROM llm_call_metrics
         WHERE created_at >= NOW() - INTERVAL '7 days'
-          AND usage_source = 'API'
+          AND usage_source::text IN ('measured', 'API')
           AND estimated_cost_usd IS NOT NULL
           AND COALESCE(prompt_tokens, 0) + COALESCE(completion_tokens, 0) > 0
         ORDER BY model_id, created_at
@@ -242,7 +248,7 @@ def update_manifest(
             "sample_window_days": 7,
             "sample_count": int(entry["sample_count"]),
             "min_samples": min_samples,
-            "query": "llm_call_metrics usage_source=API created_at>=now-7d",
+            "query": "llm_call_metrics usage_source=measured created_at>=now-7d",
             "authoritative": entry["confidence"] == MEASURED,
         }
 

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -16,7 +16,7 @@ contract_name: "node_llm_inference_effect"
 node_name: "node_llm_inference_effect"
 contract_version:
   major: 1
-  minor: 2
+  minor: 3
   patch: 0
 node_version:
   major: 0
@@ -26,7 +26,7 @@ node_version:
 node_type: "EFFECT_GENERIC"
 # Description
 description: >
-  LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence for local-model compute attribution.
+  LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence for local-model compute attribution using the shared EnumUsageSource vocabulary.
 
 # Strongly typed I/O models
 # Note: These models live in the shared omnibase_infra.models.llm package.
@@ -36,7 +36,7 @@ description: >
 input_model:
   name: "ModelLlmInferenceRequest"
   module: "omnibase_infra.models.llm"
-  description: "Input model containing LLM inference parameters and routing configuration."
+  description: "Input model containing LLM inference parameters, routing configuration, and optional EnumUsageSource-backed compute usage provenance."
 output_model:
   name: "ModelLlmInferenceResponse"
   module: "omnibase_infra.models.llm"
@@ -135,7 +135,7 @@ consumed_events:
 published_events:
   - topic: "onex.evt.omniintelligence.llm-call-completed.v1"
     event_type: "LlmCallCompletedEvent"
-    description: "Per-call metrics emitted after each inference call; may include gpu_seconds, gpu_type, gpu_count, and compute_usage_source when the request declares GPU configuration"
+    description: "Per-call metrics emitted after each inference call; may include gpu_seconds, gpu_type, gpu_count, and EnumUsageSource-backed compute_usage_source when the request declares GPU configuration"
   - topic: "onex.evt.omnibase-infra.llm-call-completed.v1"
     event_type: "LlmCallCompletedInfraEvent"
     description: "Lightweight per-call metrics for infra-owned consumers; mirrors optional GPU usage evidence fields for infra projections"
@@ -157,7 +157,7 @@ capabilities:
   - name: "circuit_breaker_protection"
     description: "Per-backend circuit breaker for provider fault isolation"
   - name: "gpu_usage_evidence"
-    description: "When gpu_type and gpu_count are provided together, emits measured gpu_seconds and compute_usage_source on both LLM metric events"
+    description: "When gpu_type and gpu_count are provided together, emits measured gpu_seconds and shared EnumUsageSource compute_usage_source values on both LLM metric events"
 # Golden path: llm_cost chain (llm-call-completed -> llm_cost_aggregates table)
 golden_path:
   - "Complete LLM inference via provider-specific handler"
@@ -168,7 +168,7 @@ golden_path:
   - "Golden chain test: omnimarket/tests/test_golden_chain_projection_llm_cost.py"
 # Metadata
 metadata:
-  description: "LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence."
+  description: "LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional EnumUsageSource-backed GPU usage evidence."
   author: "OmniNode Team"
   license: "MIT"
   created: "2026-02-13"

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -72,6 +72,7 @@ from uuid import UUID, uuid4
 
 import httpx
 
+from omnibase_core.enums.cost import EnumUsageSource
 from omnibase_core.types import JsonType
 from omnibase_infra.enums import (
     EnumHandlerType,
@@ -382,11 +383,12 @@ class HandlerLlmOpenaiCompatible:
 
             extensions: dict[str, JsonType] = {}
             if request.gpu_type is not None and request.gpu_count is not None:
-                compute_usage_source = request.compute_usage_source or (
-                    "API"
-                    if normalized.source is ContractEnumUsageSource.API
-                    else "ESTIMATED"
-                )
+                if request.compute_usage_source is not None:
+                    compute_usage_source = request.compute_usage_source.value
+                elif normalized.source is ContractEnumUsageSource.API:
+                    compute_usage_source = EnumUsageSource.MEASURED.value
+                else:
+                    compute_usage_source = EnumUsageSource.ESTIMATED.value
                 extensions.update(
                     {
                         "gpu_seconds": round(latency_ms / 1000.0, 3),

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from omnibase_core.enums.cost import EnumUsageSource
 from omnibase_infra.enums import EnumLlmOperationType
 from omnibase_infra.models.llm.model_llm_tool_choice import (
     ModelLlmToolChoice,
@@ -161,9 +162,9 @@ class ModelLlmInferenceRequest(BaseModel):
         le=32767,
         description="Configured GPU count for local-model compute evidence.",
     )
-    compute_usage_source: str | None = Field(
+    compute_usage_source: EnumUsageSource | None = Field(
         default=None,
-        description="Optional compute usage provenance: API, ESTIMATED, or MISSING.",
+        description="Optional compute usage provenance.",
     )
 
     @field_validator("base_url")
@@ -221,14 +222,6 @@ class ModelLlmInferenceRequest(BaseModel):
         ):
             raise ValueError(
                 "compute_usage_source requires gpu_type and gpu_count to be provided"
-            )
-        if self.compute_usage_source is not None and self.compute_usage_source not in {
-            "API",
-            "ESTIMATED",
-            "MISSING",
-        }:
-            raise ValueError(
-                "compute_usage_source must be one of API, ESTIMATED, or MISSING"
             )
         return self
 

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
@@ -38,6 +38,7 @@ from uuid import UUID, uuid4
 
 import asyncpg
 
+from omnibase_core.enums.cost import EnumUsageSource
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import ModelInfraErrorContext, ProtocolConfigurationError
 from omnibase_infra.mixins import MixinAsyncCircuitBreaker
@@ -1006,36 +1007,33 @@ def _safe_varchar(value: object, max_length: int) -> str | None:
 def _resolve_usage_source(event: dict[str, object]) -> str:
     """Resolve the usage_source enum value from an event.
 
-    The PostgreSQL enum ``usage_source_type`` has values: API, ESTIMATED, MISSING.
-    The ContractLlmCallMetrics uses ``usage_normalized.source`` with values:
-    api, estimated, missing (lowercase). We normalize to uppercase for the DB enum.
+    The PostgreSQL enum ``usage_source_type`` uses the shared usage-source
+    vocabulary.
 
     Args:
         event: Event dictionary.
 
     Returns:
-        One of 'API', 'ESTIMATED', or 'MISSING'.
+        A shared usage-source enum value.
     """
     # Check usage_normalized.source first
     normalized = event.get("usage_normalized")
     if isinstance(normalized, dict):
         source = normalized.get("source", "")
-        if isinstance(source, str) and source.upper() in (
-            "API",
-            "ESTIMATED",
-            "MISSING",
-        ):
-            return source.upper()
+        try:
+            return EnumUsageSource(source).value
+        except ValueError:
+            pass
 
     # Fall back to usage_is_estimated flag
     if event.get("usage_is_estimated"):
-        return "ESTIMATED"
+        return EnumUsageSource.ESTIMATED.value
 
     # Check if any token data is present
     if event.get("total_tokens") or event.get("prompt_tokens"):
-        return "API"
+        return EnumUsageSource.MEASURED.value
 
-    return "MISSING"
+    return EnumUsageSource.UNKNOWN.value
 
 
 __all__ = [

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py
@@ -1020,6 +1020,9 @@ def _resolve_usage_source(event: dict[str, object]) -> str:
     normalized = event.get("usage_normalized")
     if isinstance(normalized, dict):
         source = normalized.get("source", "")
+        # no-migration: legacy API value maps to the existing measured enum.
+        if source == "api":
+            return EnumUsageSource.MEASURED.value
         try:
             return EnumUsageSource(source).value
         except ValueError:

--- a/tests/integration/scripts/test_recompute_measured_pricing.py
+++ b/tests/integration/scripts/test_recompute_measured_pricing.py
@@ -76,7 +76,7 @@ def _write_fixture(path: Path) -> None:
                 "prompt_tokens": 1000,
                 "completion_tokens": 0,
                 "estimated_cost_usd": 0.003,
-                "usage_source": "API",
+                "usage_source": "measured",
             }
         )
         rows.append(
@@ -85,7 +85,7 @@ def _write_fixture(path: Path) -> None:
                 "prompt_tokens": 0,
                 "completion_tokens": 1000,
                 "estimated_cost_usd": 0.015,
-                "usage_source": "API",
+                "usage_source": "measured",
             }
         )
     for _ in range(19):
@@ -95,7 +95,7 @@ def _write_fixture(path: Path) -> None:
                 "prompt_tokens": 1000,
                 "completion_tokens": 0,
                 "estimated_cost_usd": 0.004,
-                "usage_source": "API",
+                "usage_source": "measured",
             }
         )
     path.write_text(

--- a/tests/integration/test_llm_gpu_usage_evidence_integration.py
+++ b/tests/integration/test_llm_gpu_usage_evidence_integration.py
@@ -87,7 +87,7 @@ async def test_gpu_usage_evidence_reaches_both_metric_events() -> None:
         assert payload["gpu_seconds"] == 2.346
         assert payload["gpu_type"] == "rtx_5090"
         assert payload["gpu_count"] == 1
-        assert payload["compute_usage_source"] == "API"
+        assert payload["compute_usage_source"] == "measured"
 
 
 def test_pricing_manifest_rates_gpu_usage_evidence() -> None:

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
@@ -73,7 +73,7 @@ class TestGpuMeasurement:
         assert metrics.extensions["gpu_seconds"] == 2.346
         assert metrics.extensions["gpu_type"] == "rtx_5090"
         assert metrics.extensions["gpu_count"] == 1
-        assert metrics.extensions["compute_usage_source"] == "API"
+        assert metrics.extensions["compute_usage_source"] == "measured"
 
     @pytest.mark.asyncio
     async def test_compute_usage_source_estimated_when_usage_is_estimated(
@@ -95,7 +95,7 @@ class TestGpuMeasurement:
 
         metrics = handler.last_call_metrics
         assert metrics is not None
-        assert metrics.extensions["compute_usage_source"] == "ESTIMATED"
+        assert metrics.extensions["compute_usage_source"] == "estimated"
 
     def test_gpu_type_and_count_must_be_configured_together(self) -> None:
         with pytest.raises(ValueError, match="gpu_type and gpu_count"):
@@ -112,5 +112,5 @@ class TestGpuMeasurement:
             _make_request(
                 gpu_type=None,
                 gpu_count=None,
-                compute_usage_source="API",
+                compute_usage_source="measured",
             )

--- a/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
+++ b/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
@@ -296,7 +296,7 @@ class TestMetricsEmission:
         assert payload["gpu_seconds"] >= 0
         assert payload["gpu_type"] == "rtx_5090"
         assert payload["gpu_count"] == 1
-        assert payload["compute_usage_source"] == "API"
+        assert payload["compute_usage_source"] == "measured"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py
+++ b/tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py
@@ -352,38 +352,38 @@ class TestResolveUsageSource:
 
     @pytest.mark.unit
     def test_api_source_from_normalized(self) -> None:
-        """Resolves 'API' from usage_normalized.source."""
+        """Resolves measured source from usage_normalized.source."""
         event = {"usage_normalized": {"source": "api"}}
-        assert _resolve_usage_source(event) == "API"
+        assert _resolve_usage_source(event) == "measured"
 
     @pytest.mark.unit
     def test_estimated_source_from_normalized(self) -> None:
-        """Resolves 'ESTIMATED' from usage_normalized.source."""
+        """Resolves estimated source from usage_normalized.source."""
         event = {"usage_normalized": {"source": "estimated"}}
-        assert _resolve_usage_source(event) == "ESTIMATED"
+        assert _resolve_usage_source(event) == "estimated"
 
     @pytest.mark.unit
     def test_missing_source_from_normalized(self) -> None:
-        """Resolves 'MISSING' from usage_normalized.source."""
+        """Resolves unknown source from usage_normalized.source."""
         event = {"usage_normalized": {"source": "missing"}}
-        assert _resolve_usage_source(event) == "MISSING"
+        assert _resolve_usage_source(event) == "unknown"
 
     @pytest.mark.unit
     def test_estimated_from_flag(self) -> None:
         """Falls back to usage_is_estimated flag."""
         event = {"usage_is_estimated": True}
-        assert _resolve_usage_source(event) == "ESTIMATED"
+        assert _resolve_usage_source(event) == "estimated"
 
     @pytest.mark.unit
     def test_api_from_token_presence(self) -> None:
-        """Falls back to token presence for API detection."""
+        """Falls back to token presence for measured usage detection."""
         event = {"total_tokens": 100, "usage_is_estimated": False}
-        assert _resolve_usage_source(event) == "API"
+        assert _resolve_usage_source(event) == "measured"
 
     @pytest.mark.unit
     def test_missing_default(self) -> None:
-        """Returns MISSING when no data available."""
-        assert _resolve_usage_source({}) == "MISSING"
+        """Returns unknown when no data available."""
+        assert _resolve_usage_source({}) == "unknown"
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f550800252d6bfc990309aa0074ca020cc6003a6" }]
+overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.40.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f550800252d6bfc990309aa0074ca020cc6003a6#f550800252d6bfc990309aa0074ca020cc6003a6" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7#6ddf546834ca8aa3affeedbc170845062351e4f7" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2054,7 +2054,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f550800252d6bfc990309aa0074ca020cc6003a6" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7" },
     { name = "omnibase-spi", specifier = ">=0.20.5" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- Resolve LLM cost aggregation writer values through omnibase_core EnumUsageSource.
- Type compute_usage_source request input with EnumUsageSource and emit shared values for GPU evidence.
- Add forward migration 077 to move usage_source_type values from API/ESTIMATED/MISSING to measured/estimated/unknown and regenerate schema fingerprint.

## Dependency
- Depends on omnibase_core #992 plus the stacked OMN-10382 core alias PR #993. CI may fail until EnumUsageSource is available from omnibase_core in the install environment.

## Verification
- `PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10382/omnibase_core/src:src uv run pytest tests/unit/services/observability/llm_cost_aggregation/test_writer_postgres.py::TestResolveUsageSource tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py::TestMetricsEmission::test_gpu_evidence_is_flattened_into_published_payload -q`
- `PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10382/omnibase_core/src:src uv run mypy src/omnibase_infra/services/observability/llm_cost_aggregation/writer_postgres.py src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py`
- `uv run python scripts/check_schema_fingerprint.py stamp && uv run python scripts/check_schema_fingerprint.py verify`
- Push hooks: migration sequence, writer-migration coupling, mypy, architecture checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized LLM usage source vocabulary across metrics and database records with a shared enumeration.

* **Chores**
  * Added database migration to update usage source values and enum definitions.
  * Updated dependency versions.
  * Refreshed contract versions and documentation to reflect vocabulary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->