### PR TITLE
feat(OMN-10390): add dispatch eval results migration

### DIFF
--- a/docker/migrations/intelligence/023_create_dispatch_eval_results.sql
+++ b/docker/migrations/intelligence/023_create_dispatch_eval_results.sql
@@ -1,0 +1,70 @@
+-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Migration: 023_create_dispatch_eval_results
+-- Description: Create dispatch_eval_results table for dispatch evaluation outcomes.
+-- Ticket: OMN-10390
+--
+-- Idempotency:
+--   All statements use IF NOT EXISTS so re-applying this migration is safe.
+
+CREATE TABLE IF NOT EXISTS dispatch_eval_results (
+    task_id             TEXT        NOT NULL,
+    dispatch_id         TEXT        NOT NULL,
+    ticket_id           TEXT,
+    verdict             TEXT        NOT NULL,
+    quality_score       NUMERIC(4, 3),
+    token_cost          INTEGER     NOT NULL DEFAULT 0,
+    dollars_cost        NUMERIC(10, 4) NOT NULL DEFAULT 0,
+    model_calls         JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    evaluated_at        TIMESTAMPTZ NOT NULL,
+    eval_latency_ms     INTEGER     NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    usage_source        TEXT        NOT NULL,
+    estimation_method   TEXT,
+    source_payload_hash TEXT,
+
+    CONSTRAINT pk_dispatch_eval_results
+        PRIMARY KEY (task_id, dispatch_id),
+    CONSTRAINT uq_dispatch_eval_results_task_dispatch
+        UNIQUE (task_id, dispatch_id),
+    CONSTRAINT chk_dispatch_eval_results_verdict
+        CHECK (verdict IN ('PASS', 'FAIL', 'ERROR', 'SKIPPED')),
+    CONSTRAINT chk_dispatch_eval_results_quality_score
+        CHECK (quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)),
+    CONSTRAINT chk_dispatch_eval_results_token_cost
+        CHECK (token_cost >= 0),
+    CONSTRAINT chk_dispatch_eval_results_dollars_cost
+        CHECK (dollars_cost >= 0),
+    CONSTRAINT chk_dispatch_eval_results_model_calls_array
+        CHECK (jsonb_typeof(model_calls) = 'array'),
+    CONSTRAINT chk_dispatch_eval_results_eval_latency_ms
+        CHECK (eval_latency_ms >= 0),
+    CONSTRAINT chk_dispatch_eval_results_usage_source
+        CHECK (usage_source IN ('MEASURED', 'ESTIMATED', 'UNKNOWN')),
+    CONSTRAINT chk_dispatch_eval_results_estimation_method
+        CHECK (
+            (usage_source = 'ESTIMATED' AND estimation_method IS NOT NULL)
+            OR (usage_source <> 'ESTIMATED' AND estimation_method IS NULL)
+        ),
+    CONSTRAINT chk_dispatch_eval_results_source_payload_hash
+        CHECK (
+            (usage_source = 'MEASURED' AND source_payload_hash IS NOT NULL)
+            OR (usage_source <> 'MEASURED' AND source_payload_hash IS NULL)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_eval_results_ticket_id
+    ON dispatch_eval_results (ticket_id);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_eval_results_evaluated_at_desc
+    ON dispatch_eval_results (evaluated_at DESC);
+
+COMMENT ON TABLE dispatch_eval_results IS
+    'Dispatch evaluation outcomes keyed by task_id and dispatch_id. OMN-10390.';
+
+COMMENT ON COLUMN dispatch_eval_results.evaluated_at IS
+    'Authoritative ordering timestamp for dispatch evaluation projections.';
+
+COMMENT ON COLUMN dispatch_eval_results.created_at IS
+    'Insertion timestamp only; non-authoritative for projection ordering.';

--- a/docker/migrations/intelligence/023_create_dispatch_eval_results.sql
+++ b/docker/migrations/intelligence/023_create_dispatch_eval_results.sql
@@ -26,8 +26,6 @@ CREATE TABLE IF NOT EXISTS dispatch_eval_results (
 
     CONSTRAINT pk_dispatch_eval_results
         PRIMARY KEY (task_id, dispatch_id),
-    CONSTRAINT uq_dispatch_eval_results_task_dispatch
-        UNIQUE (task_id, dispatch_id),
     CONSTRAINT chk_dispatch_eval_results_verdict
         CHECK (verdict IN ('PASS', 'FAIL', 'ERROR', 'SKIPPED')),
     CONSTRAINT chk_dispatch_eval_results_quality_score

--- a/docker/migrations/intelligence/schema_fingerprint.sha256
+++ b/docker/migrations/intelligence/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:c3cdf69eacb2ba4fedf6e18278924bae1321b9425ef46a832f1f0d9e3825db87
-generated_at: 2026-04-30T16:00:41Z
+sha256:713e7d118f7773833076d8d828cc60f0c4ced85dbb25854ff6629343255c5bc8
+generated_at: 2026-04-30T16:23:41Z
 migration_file_count: 25

--- a/docker/migrations/intelligence/schema_fingerprint.sha256
+++ b/docker/migrations/intelligence/schema_fingerprint.sha256
@@ -1,0 +1,6 @@
+# Schema migration fingerprint for omnibase_infra (auto-generated)
+# Regenerate: python scripts/check_schema_fingerprint.py stamp
+# Verify:     python scripts/check_schema_fingerprint.py verify
+sha256:c3cdf69eacb2ba4fedf6e18278924bae1321b9425ef46a832f1f0d9e3825db87
+generated_at: 2026-04-30T16:00:41Z
+migration_file_count: 25

--- a/src/omnibase_infra/models/projection/__init__.py
+++ b/src/omnibase_infra/models/projection/__init__.py
@@ -29,6 +29,9 @@ Related Tickets:
 from omnibase_core.models.projectors.model_projection_intent import (
     ModelProjectionIntent,
 )
+from omnibase_infra.models.projection.enum_projection_ordering_direction import (
+    EnumProjectionOrderingDirection,
+)
 from omnibase_infra.models.projection.model_capability_fields import (
     ModelCapabilityFields,
 )
@@ -37,6 +40,12 @@ from omnibase_infra.models.projection.model_contract_projection import (
 )
 from omnibase_infra.models.projection.model_projected_flag_meta import (
     ModelProjectedFlagMeta,
+)
+from omnibase_infra.models.projection.model_projection_ordering_contract import (
+    DISPATCH_EVAL_RESULTS_ORDERING_CONTRACT,
+    PROJECTION_ORDERING_CONTRACTS,
+    ModelProjectionOrderingContract,
+    get_projection_ordering_contract,
 )
 from omnibase_infra.models.projection.model_registration_projection import (
     ModelRegistrationProjection,
@@ -55,11 +64,16 @@ from omnibase_infra.models.projection.model_topic_projection import (
 __all__ = [
     "ModelCapabilityFields",
     "ModelContractProjection",
+    "DISPATCH_EVAL_RESULTS_ORDERING_CONTRACT",
+    "EnumProjectionOrderingDirection",
     "ModelProjectedFlagMeta",
     "ModelProjectionIntent",
+    "ModelProjectionOrderingContract",
+    "PROJECTION_ORDERING_CONTRACTS",
     "ModelRegistrationProjection",
     "ModelRegistrationSnapshot",
     "ModelSequenceInfo",
     "ModelSnapshotTopicConfig",
     "ModelTopicProjection",
+    "get_projection_ordering_contract",
 ]

--- a/src/omnibase_infra/models/projection/enum_projection_ordering_direction.py
+++ b/src/omnibase_infra/models/projection/enum_projection_ordering_direction.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Projection ordering direction enum."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class EnumProjectionOrderingDirection(str, Enum):
+    """Supported projection ordering directions."""
+
+    ASCENDING = "ASCENDING"
+    DESCENDING = "DESCENDING"
+
+
+__all__ = ["EnumProjectionOrderingDirection"]

--- a/src/omnibase_infra/models/projection/model_projection_ordering_contract.py
+++ b/src/omnibase_infra/models/projection/model_projection_ordering_contract.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Projection ordering contracts for materialized table readers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.models.projection.enum_projection_ordering_direction import (
+    EnumProjectionOrderingDirection,
+)
+
+
+class ModelProjectionOrderingContract(BaseModel):
+    """Declares authoritative ordering fields for a projected table."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    projection_table: str = Field(..., min_length=1)
+    primary_order_field: str = Field(..., min_length=1)
+    tie_breaker_field: str = Field(..., min_length=1)
+    direction: EnumProjectionOrderingDirection
+    non_authoritative_fields: tuple[str, ...] = Field(default_factory=tuple)
+
+
+DISPATCH_EVAL_RESULTS_ORDERING_CONTRACT = ModelProjectionOrderingContract(
+    projection_table="dispatch_eval_results",
+    primary_order_field="evaluated_at",
+    tie_breaker_field="dispatch_id",
+    direction=EnumProjectionOrderingDirection.DESCENDING,
+    non_authoritative_fields=("created_at",),
+)
+
+PROJECTION_ORDERING_CONTRACTS: tuple[ModelProjectionOrderingContract, ...] = (
+    DISPATCH_EVAL_RESULTS_ORDERING_CONTRACT,
+)
+
+
+def get_projection_ordering_contract(
+    projection_table: str,
+) -> ModelProjectionOrderingContract | None:
+    """Return the registered ordering contract for a table, if present."""
+    for contract in PROJECTION_ORDERING_CONTRACTS:
+        if contract.projection_table == projection_table:
+            return contract
+    return None
+
+
+__all__ = [
+    "DISPATCH_EVAL_RESULTS_ORDERING_CONTRACT",
+    "EnumProjectionOrderingDirection",
+    "ModelProjectionOrderingContract",
+    "PROJECTION_ORDERING_CONTRACTS",
+    "get_projection_ordering_contract",
+]

--- a/tests/integration/db/test_dispatch_eval_results_contract_integration.py
+++ b/tests/integration/db/test_dispatch_eval_results_contract_integration.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for dispatch_eval_results migration contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.models.projection import (
+    EnumProjectionOrderingDirection,
+    get_projection_ordering_contract,
+)
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATION = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "intelligence"
+    / "023_create_dispatch_eval_results.sql"
+)
+
+
+def _normalized_sql() -> str:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    return re.sub(r"\s+", " ", sql).lower()
+
+
+def test_dispatch_eval_results_migration_matches_ordering_contract() -> None:
+    sql = _normalized_sql()
+    contract = get_projection_ordering_contract("dispatch_eval_results")
+
+    assert contract is not None
+    assert contract.projection_table == "dispatch_eval_results"
+    assert contract.primary_order_field == "evaluated_at"
+    assert contract.tie_breaker_field == "dispatch_id"
+    assert contract.direction is EnumProjectionOrderingDirection.DESCENDING
+    assert contract.non_authoritative_fields == ("created_at",)
+
+    assert "evaluated_at timestamptz not null" in sql
+    assert "dispatch_id text not null" in sql
+    assert (
+        "create index if not exists idx_dispatch_eval_results_evaluated_at_desc "
+        "on dispatch_eval_results (evaluated_at desc)"
+    ) in sql
+    assert "insertion timestamp only; non-authoritative" in sql

--- a/tests/unit/db/test_dispatch_eval_results_migration.py
+++ b/tests/unit/db/test_dispatch_eval_results_migration.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Static coverage for dispatch_eval_results intelligence migration."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.models.projection import (
+    EnumProjectionOrderingDirection,
+    get_projection_ordering_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATION = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "intelligence"
+    / "023_create_dispatch_eval_results.sql"
+)
+
+
+def _normalized_sql() -> str:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    return re.sub(r"\s+", " ", sql).lower()
+
+
+@pytest.mark.unit
+def test_dispatch_eval_results_migration_declares_table_shape() -> None:
+    sql = _normalized_sql()
+
+    expected_fragments = [
+        "create table if not exists dispatch_eval_results",
+        "task_id text not null",
+        "dispatch_id text not null",
+        "ticket_id text",
+        "verdict text not null",
+        "quality_score numeric(4, 3)",
+        "token_cost integer not null default 0",
+        "dollars_cost numeric(10, 4) not null default 0",
+        "model_calls jsonb not null default '[]'::jsonb",
+        "evaluated_at timestamptz not null",
+        "eval_latency_ms integer not null",
+        "created_at timestamptz not null default now()",
+        "usage_source text not null",
+        "estimation_method text",
+        "source_payload_hash text",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in sql
+
+
+@pytest.mark.unit
+def test_dispatch_eval_results_migration_declares_keys_checks_and_indexes() -> None:
+    sql = _normalized_sql()
+
+    expected_fragments = [
+        "constraint pk_dispatch_eval_results primary key (task_id, dispatch_id)",
+        "constraint uq_dispatch_eval_results_task_dispatch unique (task_id, dispatch_id)",
+        "check (verdict in ('pass', 'fail', 'error', 'skipped'))",
+        "check (usage_source in ('measured', 'estimated', 'unknown'))",
+        "(usage_source = 'estimated' and estimation_method is not null)",
+        "(usage_source <> 'estimated' and estimation_method is null)",
+        "(usage_source = 'measured' and source_payload_hash is not null)",
+        "(usage_source <> 'measured' and source_payload_hash is null)",
+        "create index if not exists idx_dispatch_eval_results_ticket_id on dispatch_eval_results (ticket_id)",
+        "create index if not exists idx_dispatch_eval_results_evaluated_at_desc on dispatch_eval_results (evaluated_at desc)",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in sql
+
+
+@pytest.mark.unit
+def test_dispatch_eval_results_projection_ordering_contract_registered() -> None:
+    contract = get_projection_ordering_contract("dispatch_eval_results")
+
+    assert contract is not None
+    assert contract.projection_table == "dispatch_eval_results"
+    assert contract.primary_order_field == "evaluated_at"
+    assert contract.tie_breaker_field == "dispatch_id"
+    assert contract.direction is EnumProjectionOrderingDirection.DESCENDING
+    assert contract.non_authoritative_fields == ("created_at",)

--- a/tests/unit/db/test_dispatch_eval_results_migration.py
+++ b/tests/unit/db/test_dispatch_eval_results_migration.py
@@ -61,8 +61,12 @@ def test_dispatch_eval_results_migration_declares_keys_checks_and_indexes() -> N
 
     expected_fragments = [
         "constraint pk_dispatch_eval_results primary key (task_id, dispatch_id)",
-        "constraint uq_dispatch_eval_results_task_dispatch unique (task_id, dispatch_id)",
         "check (verdict in ('pass', 'fail', 'error', 'skipped'))",
+        "check (quality_score is null or (quality_score >= 0 and quality_score <= 1))",
+        "check (token_cost >= 0)",
+        "check (dollars_cost >= 0)",
+        "check (jsonb_typeof(model_calls) = 'array')",
+        "check (eval_latency_ms >= 0)",
         "check (usage_source in ('measured', 'estimated', 'unknown'))",
         "(usage_source = 'estimated' and estimation_method is not null)",
         "(usage_source <> 'estimated' and estimation_method is null)",
@@ -74,6 +78,8 @@ def test_dispatch_eval_results_migration_declares_keys_checks_and_indexes() -> N
 
     for fragment in expected_fragments:
         assert fragment in sql
+
+    assert "unique (task_id, dispatch_id)" not in sql
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add intelligence migration for dispatch_eval_results table shape and indexes
- Add intelligence schema fingerprint artifact for the migration directory
- Add projection ordering contract registration for dispatch_eval_results
- Add static unit coverage for table shape, constraints, indexes, and projection ordering

## Verification
- uv run python scripts/check_schema_fingerprint.py verify --migrations-dir docker/migrations/intelligence --artifact docker/migrations/intelligence/schema_fingerprint.sha256
- uv run ruff check src/omnibase_infra/models/projection/enum_projection_ordering_direction.py src/omnibase_infra/models/projection/model_projection_ordering_contract.py src/omnibase_infra/models/projection/__init__.py tests/unit/db/test_dispatch_eval_results_migration.py
- uv run pytest tests/unit/db/test_dispatch_eval_results_migration.py tests/unit/db/test_intelligence_migration_idempotency.py tests/unit/models/projection/test_contract_projection_models.py tests/unit/models/projection/test_model_registration_projection.py -q
- commit hooks passed
- push hooks passed

## Notes
- Per task scope, no runtime .201 connection or mutation was performed; validation is local/static.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to persist dispatch evaluation results with quality scores, cost metrics, and timing information for review and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->