### PR TITLE
fix(OMN-10447): key handler wiring by operation

### DIFF
--- a/contracts/OMN-10447.yaml
+++ b/contracts/OMN-10447.yaml
@@ -3,6 +3,7 @@
 # contract carries deploy-gate evidence for the handler auto-wiring change.
 schema_version: '1.0.0'
 ticket_id: OMN-10447
+title: 'Handler auto-wiring entry keys by operation'
 summary: 'fix(OMN-10447): key handler auto-wiring by operation'
 is_seam_ticket: true
 interface_change: true

--- a/contracts/OMN-10447.yaml
+++ b/contracts/OMN-10447.yaml
@@ -1,0 +1,53 @@
+# OMN-10447 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the handler auto-wiring change.
+schema_version: '1.0.0'
+ticket_id: OMN-10447
+summary: 'fix(OMN-10447): key handler auto-wiring by operation'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+  - topics
+evidence_requirements:
+  - kind: tests
+    description: Focused handler entry-key and sync container skip tests pass
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py -q
+  - kind: tests
+    description: Adjacent auto-wiring regression tests pass
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_async_container_resolution.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_wiring.py -q
+  - kind: tests
+    description: Handler wiring source and tests pass ruff
+    command: uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py tests/unit/runtime/auto_wiring/test_wiring.py
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Focused handler entry-key and sync container skip tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py -q'
+  - id: dod-002
+    description: Adjacent auto-wiring regression tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_async_container_resolution.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_wiring.py -q'
+  - id: dod-003
+    description: Handler wiring source and tests pass ruff
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py tests/unit/runtime/auto_wiring/test_wiring.py'
+  - id: dod-004
+    description: Runtime effects deploy smoke validates auto-wiring helper availability after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'docker exec omninode-runtime-effects python -c "from omnibase_infra.runtime.auto_wiring.handler_wiring import _derive_handler_entry_key, _should_skip_sync_container_resolution; assert callable(_derive_handler_entry_key); assert callable(_should_skip_sync_container_resolution)"'

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -838,11 +838,10 @@ def _dispatch_freeze_wait_timeout_seconds() -> float:
 
 def _derive_route_id(
     contract_name: str,
-    handler_name: str,
+    handler_key: str,
     topic: str,
-    operation: str | None = None,
 ) -> str:
-    """Derive a route ID from contract name, handler name, full topic path, and optional operation.
+    """Derive a route ID from contract name, handler entry key, and full topic path.
 
     Uses the full topic path (sanitized) to guarantee uniqueness across topics
     that share a common segment (OMN-8735).
@@ -850,40 +849,70 @@ def _derive_route_id(
     When two routing entries reference the same handler class for different
     operations (e.g. ``HandlerLlmCliSubprocess`` for both ``inference.gemini_cli``
     and ``inference.codex_cli``) and subscribe to the same topic, the
-    ``handler_name + topic`` pair alone produces a collision.  Including the
-    sanitized ``operation`` suffix guarantees each entry gets a distinct route
-    ID (OMN-9461).
+    ``handler + topic`` pair alone produces a collision.  The handler entry key
+    includes the sanitized operation suffix when present, guaranteeing each
+    entry gets a distinct route ID (OMN-9461 / OMN-10447).
     """
     safe_topic = re.sub(r"[.\-]", "_", topic)
-    if operation:
-        normalized = re.sub(r"[^A-Za-z0-9_]+", "_", operation.strip()).strip("_")
-        digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
-        safe_op = f"{normalized}_{digest}" if normalized else digest
-        return f"route.auto.{contract_name}.{handler_name}.{safe_op}.{safe_topic}"
-    return f"route.auto.{contract_name}.{handler_name}.{safe_topic}"
+    return f"route.auto.{contract_name}.{handler_key}.{safe_topic}"
 
 
-def _derive_dispatcher_id(
-    contract_name: str, handler_name: str, operation: str | None = None
-) -> str:
-    """Derive a dispatcher ID from contract name, handler name, and optional operation.
+def _derive_dispatcher_id(contract_name: str, handler_key: str) -> str:
+    """Derive a dispatcher ID from contract name and handler entry key.
 
     When two routing entries in the same contract reference the same handler
     class (e.g. ``HandlerLlmCliSubprocess`` wired for both ``inference.gemini_cli``
-    and ``inference.codex_cli``), the plain ``handler_name`` alone produces a
-    collision.  Including the sanitized ``operation`` suffix guarantees each
-    entry gets a distinct dispatcher ID (OMN-9461).
-
-    When ``operation`` is absent the ID degrades to the original two-segment
-    form so existing contracts without repeated handler references are
-    unaffected.
+    and ``inference.codex_cli``), the plain handler name alone produces a
+    collision.  The entry key includes the sanitized operation suffix and keeps
+    dispatcher IDs distinct (OMN-9461 / OMN-10447).
     """
+    return f"dispatcher.auto.{contract_name}.{handler_key}"
+
+
+def _derive_handler_entry_key(entry: ModelHandlerRoutingEntry) -> str:
+    """Return the stable per-entry handler key used for pre-resolution and IDs.
+
+    The key preserves the legacy plain handler name when ``operation`` is
+    absent. When operation is present, it appends a sanitized operation label
+    plus a short digest, preventing collisions when a contract uses the same
+    handler class for multiple operations.
+    """
+    handler_name = entry.handler.name
+    operation = entry.operation
     if operation:
         normalized = re.sub(r"[^A-Za-z0-9_]+", "_", operation.strip()).strip("_")
         digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
         safe_op = f"{normalized}_{digest}" if normalized else digest
-        return f"dispatcher.auto.{contract_name}.{handler_name}.{safe_op}"
-    return f"dispatcher.auto.{contract_name}.{handler_name}"
+        return f"{handler_name}.{safe_op}"
+    return handler_name
+
+
+def _required_handler_init_params(handler_cls: type) -> frozenset[str]:
+    """Return required constructor parameter names for a handler class."""
+    sig = inspect.signature(handler_cls)
+    return frozenset(
+        name
+        for name, param in sig.parameters.items()
+        if name != "self"
+        and param.kind
+        in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+        and param.default is inspect.Parameter.empty
+    )
+
+
+def _should_skip_sync_container_resolution(handler_cls: type) -> bool:
+    """Return True when sync container resolution is unnecessary for handler_cls.
+
+    Zero-arg handlers can be constructed directly by the resolver, and handlers
+    that require only ``event_bus`` can be constructed from the event-bus path.
+    In both cases, calling a sync container from runtime-managed async boot is
+    unnecessary and can trip ``asyncio.run()`` crashes.
+    """
+    required_params = _required_handler_init_params(handler_cls)
+    return not required_params or required_params == frozenset({"event_bus"})
 
 
 def _derive_topic_pattern_from_topic(topic: str) -> str:
@@ -1141,7 +1170,8 @@ async def wire_from_manifest(
                 continue
             for entry in contract.handler_routing.handlers:
                 handler_name = entry.handler.name
-                if handler_name in pre_resolved_handlers:
+                handler_key = _derive_handler_entry_key(entry)
+                if handler_key in pre_resolved_handlers:
                     continue
                 try:
                     handler_cls = _import_handler_class(
@@ -1151,11 +1181,12 @@ async def wire_from_manifest(
                         container, handler_cls
                     )
                     if instance is not None:
-                        pre_resolved_handlers[handler_name] = instance
+                        pre_resolved_handlers[handler_key] = instance
                         logger.debug(
-                            "Auto-wiring: pre-resolved %s.%s via container (async)",
+                            "Auto-wiring: pre-resolved %s.%s key=%s via container (async)",
                             entry.handler.module,
                             handler_name,
+                            handler_key,
                         )
                 except Exception:  # noqa: BLE001 — import errors are caught per-contract in Phase 1
                     pass
@@ -1749,6 +1780,7 @@ def _prepare_handler_wiring(
     from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
 
     handler_ref = entry.handler
+    handler_key = _derive_handler_entry_key(entry)
 
     # Determine category/message types before importing or constructing the
     # handler. Some domain-owned contracts use auto-wiring for subscriptions
@@ -1806,24 +1838,11 @@ def _prepare_handler_wiring(
     # Fast path: if Phase 0 pre-resolved this handler via get_service_async,
     # skip the sync resolver's container Step 3 entirely (OMN-9410).
     pre_resolved_instance = (
-        pre_resolved_handlers.get(handler_ref.name) if pre_resolved_handlers else None
+        pre_resolved_handlers.get(handler_key) if pre_resolved_handlers else None
     )
-    sig = inspect.signature(handler_cls)
-    required_ctor_params = {
-        k
-        for k, v in sig.parameters.items()
-        if k != "self"
-        and v.kind
-        in {
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        }
-        and v.default is inspect.Parameter.empty
-    }
-    can_construct_without_container = (
-        not required_ctor_params or required_ctor_params == {"event_bus"}
-    )
-    if pre_resolved_handlers is not None and can_construct_without_container:
+    if pre_resolved_handlers is not None and _should_skip_sync_container_resolution(
+        handler_cls
+    ):
         _effective_container = None
     else:
         _effective_container = container or (
@@ -1872,9 +1891,10 @@ def _prepare_handler_wiring(
             handler_instance=pre_resolved_instance,
         )
         logger.debug(
-            "Auto-wiring: using pre-resolved instance for %s.%s",
+            "Auto-wiring: using pre-resolved instance for %s.%s key=%s",
             handler_ref.module,
             handler_ref.name,
+            handler_key,
         )
     else:
         # node_name=contract.name: established ONEX naming convention — see
@@ -1947,18 +1967,14 @@ def _prepare_handler_wiring(
         )
     else:
         callback = _make_dispatch_callback(handler_instance, entry.event_model)
-    dispatcher_id = _derive_dispatcher_id(
-        contract.name, handler_ref.name, entry.operation
-    )
+    dispatcher_id = _derive_dispatcher_id(contract.name, handler_key)
 
     # Pre-compute routes (no engine calls yet)
     route_ids: list[str] = []
     routes: list[ModelDispatchRoute] = []
     if contract.event_bus:
         for topic in contract.event_bus.subscribe_topics:
-            route_id = _derive_route_id(
-                contract.name, handler_ref.name, topic, entry.operation
-            )
+            route_id = _derive_route_id(contract.name, handler_key, topic)
             topic_pattern = _derive_topic_pattern_from_topic(topic)
 
             route = ModelDispatchRoute(

--- a/tests/integration/runtime/test_handler_wiring_entry_keys_integration.py
+++ b/tests/integration/runtime/test_handler_wiring_entry_keys_integration.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration guard for operation-keyed handler auto-wiring IDs."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _derive_dispatcher_id,
+    _derive_handler_entry_key,
+    _derive_route_id,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelHandlerRef,
+    ModelHandlerRoutingEntry,
+)
+
+
+def _routing_entry(operation: str) -> ModelHandlerRoutingEntry:
+    return ModelHandlerRoutingEntry(
+        handler=ModelHandlerRef(
+            name="HandlerShared",
+            module="omnimarket.handlers.model_router",
+        ),
+        operation=operation,
+    )
+
+
+@pytest.mark.integration
+def test_operation_keyed_wiring_keeps_shared_handler_routes_distinct() -> None:
+    topic = "onex.cmd.omnimarket.model-route.v1"
+    gemini_key = _derive_handler_entry_key(_routing_entry("inference.gemini-cli"))
+    codex_key = _derive_handler_entry_key(_routing_entry("inference.codex-cli"))
+
+    assert gemini_key != codex_key
+    assert _derive_dispatcher_id("node_model_router", gemini_key) != (
+        _derive_dispatcher_id("node_model_router", codex_key)
+    )
+    assert _derive_route_id("node_model_router", gemini_key, topic) != (
+        _derive_route_id("node_model_router", codex_key, topic)
+    )

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Handler entry key guards for auto-wiring runtime stability."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _derive_dispatcher_id,
+    _derive_handler_entry_key,
+    _derive_route_id,
+    _required_handler_init_params,
+    _should_skip_sync_container_resolution,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelHandlerRef,
+    ModelHandlerRoutingEntry,
+)
+
+
+def _entry(operation: str | None = None) -> ModelHandlerRoutingEntry:
+    return ModelHandlerRoutingEntry(
+        handler=ModelHandlerRef(name="HandlerShared", module="fake.handlers"),
+        operation=operation,
+    )
+
+
+class TestHandlerEntryKeyDerivation:
+    @pytest.mark.unit
+    def test_key_without_operation_preserves_handler_name(self) -> None:
+        assert _derive_handler_entry_key(_entry()) == "HandlerShared"
+
+    @pytest.mark.unit
+    def test_key_with_operation_includes_sanitized_operation_and_digest(self) -> None:
+        operation = "inference.gemini-cli"
+        digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
+
+        assert (
+            _derive_handler_entry_key(_entry(operation))
+            == f"HandlerShared.inference_gemini_cli_{digest}"
+        )
+
+    @pytest.mark.unit
+    def test_key_with_symbol_only_operation_falls_back_to_digest(self) -> None:
+        operation = "!!!"
+        digest = hashlib.sha1(operation.encode()).hexdigest()[:8]
+
+        assert _derive_handler_entry_key(_entry(operation)) == f"HandlerShared.{digest}"
+
+    @pytest.mark.unit
+    def test_dispatcher_id_uses_handler_entry_key(self) -> None:
+        handler_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+
+        assert (
+            _derive_dispatcher_id("node_model_router", handler_key)
+            == f"dispatcher.auto.node_model_router.{handler_key}"
+        )
+
+    @pytest.mark.unit
+    def test_dispatcher_ids_are_distinct_for_same_handler_different_operations(
+        self,
+    ) -> None:
+        gemini_key = _derive_handler_entry_key(_entry("inference.gemini-cli"))
+        codex_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+
+        assert _derive_dispatcher_id("node_model_router", gemini_key) != (
+            _derive_dispatcher_id("node_model_router", codex_key)
+        )
+
+    @pytest.mark.unit
+    def test_route_ids_are_distinct_for_same_handler_same_topic_different_operations(
+        self,
+    ) -> None:
+        topic = "onex.cmd.omnimarket.model-route.v1"
+        gemini_key = _derive_handler_entry_key(_entry("inference.gemini-cli"))
+        codex_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+
+        assert _derive_route_id("node_model_router", gemini_key, topic) != (
+            _derive_route_id("node_model_router", codex_key, topic)
+        )
+
+
+class TestRequiredHandlerInitParams:
+    @pytest.mark.unit
+    def test_required_params_empty_for_zero_arg_handler(self) -> None:
+        class HandlerZeroArg:
+            pass
+
+        assert _required_handler_init_params(HandlerZeroArg) == frozenset()
+
+    @pytest.mark.unit
+    def test_required_params_include_required_positional_dependency(self) -> None:
+        class HandlerWithDependency:
+            def __init__(self, service: object) -> None:
+                self.service = service
+
+        assert _required_handler_init_params(HandlerWithDependency) == frozenset(
+            {"service"}
+        )
+
+    @pytest.mark.unit
+    def test_required_params_include_required_keyword_only_dependency(self) -> None:
+        class HandlerWithKeywordDependency:
+            def __init__(self, *, service: object) -> None:
+                self.service = service
+
+        assert _required_handler_init_params(HandlerWithKeywordDependency) == (
+            frozenset({"service"})
+        )
+
+    @pytest.mark.unit
+    def test_required_params_ignore_optional_dependencies(self) -> None:
+        class HandlerWithOptionalDependency:
+            def __init__(self, service: object | None = None) -> None:
+                self.service = service
+
+        assert _required_handler_init_params(HandlerWithOptionalDependency) == (
+            frozenset()
+        )
+
+
+class TestSyncContainerResolutionSkip:
+    @pytest.mark.unit
+    def test_skip_sync_container_resolution_for_zero_arg_handler(self) -> None:
+        class HandlerZeroArg:
+            pass
+
+        assert _should_skip_sync_container_resolution(HandlerZeroArg) is True
+
+    @pytest.mark.unit
+    def test_skip_sync_container_resolution_for_event_bus_only_handler(self) -> None:
+        class HandlerEventBusOnly:
+            def __init__(self, event_bus: object) -> None:
+                self.event_bus = event_bus
+
+        assert _should_skip_sync_container_resolution(HandlerEventBusOnly) is True
+
+    @pytest.mark.unit
+    def test_do_not_skip_sync_container_resolution_for_complex_handler(self) -> None:
+        class HandlerWithDependency:
+            def __init__(self, service: object) -> None:
+                self.service = service
+
+        assert _should_skip_sync_container_resolution(HandlerWithDependency) is False

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _derive_dispatcher_id,
+    _derive_handler_entry_key,
     _derive_message_category,
     _derive_route_id,
     _derive_topic_pattern_from_topic,
@@ -132,6 +133,15 @@ class TestDeriveMessageCategory:
 
 
 class TestDeriveIds:
+    @staticmethod
+    def _entry(
+        handler_name: str, operation: str | None = None
+    ) -> ModelHandlerRoutingEntry:
+        return ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name=handler_name, module="test.handlers"),
+            operation=operation,
+        )
+
     def test_route_id(self) -> None:
         assert (
             _derive_route_id("my_node", "my_handler", "onex.evt.platform.my-topic.v1")
@@ -140,12 +150,15 @@ class TestDeriveIds:
 
     def test_route_id_with_operation(self) -> None:
         """OMN-9461: operation suffix disambiguates repeated handler references."""
+        handler_key = _derive_handler_entry_key(
+            self._entry("HandlerLlmCliSubprocess", "inference.gemini_cli")
+        )
+
         assert (
             _derive_route_id(
                 "my_node",
-                "HandlerLlmCliSubprocess",
+                handler_key,
                 "onex.cmd.omnibase-infra.llm-inference-request.v1",
-                "inference.gemini_cli",
             )
             == "route.auto.my_node.HandlerLlmCliSubprocess.inference_gemini_cli_fb462661.onex_cmd_omnibase_infra_llm_inference_request_v1"
         )
@@ -157,7 +170,6 @@ class TestDeriveIds:
                 "my_node",
                 "my_handler",
                 "onex.evt.platform.my-topic.v1",
-                None,
             )
             == "route.auto.my_node.my_handler.onex_evt_platform_my_topic_v1"
         )
@@ -170,25 +182,30 @@ class TestDeriveIds:
 
     def test_dispatcher_id_with_operation(self) -> None:
         """OMN-9461: operation suffix disambiguates repeated handler references."""
+        handler_key = _derive_handler_entry_key(
+            self._entry("HandlerLlmCliSubprocess", "inference.gemini_cli")
+        )
+
         assert (
             _derive_dispatcher_id(
                 "node_llm_inference_effect",
-                "HandlerLlmCliSubprocess",
-                "inference.gemini_cli",
+                handler_key,
             )
             == "dispatcher.auto.node_llm_inference_effect.HandlerLlmCliSubprocess.inference_gemini_cli_fb462661"
         )
 
     def test_dispatcher_id_collision_safe(self) -> None:
         """OMN-9461: operations that normalize identically still produce distinct IDs."""
-        id_a = _derive_dispatcher_id("n", "H", "inference.a-b")
-        id_b = _derive_dispatcher_id("n", "H", "inference.a/b")
+        key_a = _derive_handler_entry_key(self._entry("H", "inference.a-b"))
+        key_b = _derive_handler_entry_key(self._entry("H", "inference.a/b"))
+        id_a = _derive_dispatcher_id("n", key_a)
+        id_b = _derive_dispatcher_id("n", key_b)
         assert id_a != id_b
 
     def test_dispatcher_id_without_operation_unchanged(self) -> None:
         """OMN-9461: absence of operation keeps original ID form."""
         assert (
-            _derive_dispatcher_id("my_node", "my_handler", None)
+            _derive_dispatcher_id("my_node", "my_handler")
             == "dispatcher.auto.my_node.my_handler"
         )
 


### PR DESCRIPTION
## Summary
- derive a stable handler entry key from handler + operation for route/dispatcher IDs
- key async pre-resolution by entry key so repeated handler classes do not collide
- extract constructor dependency checks and skip sync container resolution for zero-arg/event_bus-only handlers
- add repo-local OMN-10447 deploy-gate contract

## Verification
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py -q
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_async_container_resolution.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_wiring.py -q
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py tests/unit/runtime/auto_wiring/test_handler_wiring_async_container_resolution.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_wiring.py -q
- uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py tests/unit/runtime/auto_wiring/test_wiring.py
- uv run validate-yaml contracts/OMN-10447.yaml
- pre-commit hooks during commit
- pre-push hooks during push

Evidence-Ticket: OMN-10447
Evidence-Source: OCC#619
Central evidence PR: OmniNode-ai/onex_change_control#619

Closes OMN-10447.
