### PR TITLE
fix(OMN-10448): defer registration dispatcher wiring

### DIFF
--- a/contracts/OMN-10448.yaml
+++ b/contracts/OMN-10448.yaml
@@ -3,6 +3,7 @@
 # contract carries deploy-gate evidence for the registration dispatcher wiring change.
 schema_version: '1.0.0'
 ticket_id: OMN-10448
+title: 'Registration dispatcher auto-wiring'
 summary: 'fix(OMN-10448): defer registration dispatcher wiring to auto-wiring'
 is_seam_ticket: true
 interface_change: true

--- a/contracts/OMN-10448.yaml
+++ b/contracts/OMN-10448.yaml
@@ -1,0 +1,53 @@
+# OMN-10448 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the registration dispatcher wiring change.
+schema_version: '1.0.0'
+ticket_id: OMN-10448
+summary: 'fix(OMN-10448): defer registration dispatcher wiring to auto-wiring'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+  - topics
+evidence_requirements:
+  - kind: tests
+    description: Registration plugin dispatcher ownership unit and integration tests pass
+    command: uv run pytest tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py -q
+  - kind: tests
+    description: Auto-wiring registration skip reason regression passes
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q
+  - kind: tests
+    description: Touched plugin, auto-wiring, and tests pass ruff
+    command: uv run ruff check src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Registration plugin dispatcher ownership unit and integration tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py -q'
+  - id: dod-002
+    description: Auto-wiring registration skip reason regression passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q'
+  - id: dod-003
+    description: Touched plugin, auto-wiring, and tests pass ruff
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run ruff check src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py'
+  - id: dod-004
+    description: Runtime effects deploy smoke validates plugin dispatcher deferral after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'docker exec omninode-runtime-effects python -c "from omnibase_infra.nodes.node_registration_orchestrator.plugin import ServiceRegistration; assert ServiceRegistration().plugin_id == ''registration''"'

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py
@@ -997,76 +997,38 @@ class ServiceRegistration:
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:
-        """Wire registration dispatcher adapters into the dispatch engine.
+        """Defer registration dispatcher wiring to generic contract auto-wiring.
 
-        Registration remains a domain-owned dispatch surface because its
-        handlers expect domain envelope/adapter semantics. Generic
-        contract auto-wiring owns the Kafka subscriptions and result applier,
-        while this plugin owns the dispatcher adapters and routes that bridge
-        wire envelopes into registration handlers.
+        Generic contract auto-wiring owns registration event-bus wiring. The
+        registration plugin keeps handler/container wiring and output-side
+        result applier preparation, but it must not register a second
+        dispatcher/route family.
 
         Args:
-            config: Plugin configuration with container, dispatch engine, and
-                event bus.
+            config: Plugin configuration. Accepted for lifecycle symmetry; no
+                fields are required by this deferred step.
 
         Returns:
-            ``ModelDomainPluginResult`` for the explicit dispatcher wiring step.
+            ``ModelDomainPluginResult`` indicating dispatcher wiring was
+            intentionally skipped because auto-wiring owns it.
         """
         start_time = time.time()
-        correlation_id = config.correlation_id
-
-        if config.dispatch_engine is None:
-            return ModelDomainPluginResult.failed(
-                plugin_id=self.plugin_id,
-                error_message="Registration dispatcher wiring requires dispatch_engine",
-                duration_seconds=time.time() - start_time,
-            )
-
-        try:
-            from omnibase_infra.nodes.node_registration_orchestrator.wiring import (
-                wire_registration_dispatchers,
-            )
-
-            summary = await wire_registration_dispatchers(
-                config.container,
-                config.dispatch_engine,
-                correlation_id=correlation_id,
-                event_bus=config.event_bus,
-            )
-            dispatchers = summary["dispatchers"]
-            routes = summary["routes"]
-            if not isinstance(dispatchers, list) or not isinstance(routes, list):
-                raise TypeError("registration dispatcher summary is malformed")
-            duration = time.time() - start_time
-
-            logger.info(
-                "Registration dispatchers wired (correlation_id=%s)",
-                correlation_id,
-                extra={
-                    "dispatchers": dispatchers,
-                    "routes": routes,
-                },
-            )
-
-            return ModelDomainPluginResult(
-                plugin_id=self.plugin_id,
-                success=True,
-                message="Registration dispatchers wired",
-                services_registered=dispatchers,
-                duration_seconds=duration,
-            )
-
-        except Exception as e:
-            duration = time.time() - start_time
-            logger.exception(
-                "Failed to wire Registration dispatchers (correlation_id=%s)",
-                correlation_id,
-            )
-            return ModelDomainPluginResult.failed(
-                plugin_id=self.plugin_id,
-                error_message=sanitize_error_message(e),
-                duration_seconds=duration,
-            )
+        message = (
+            "Registration dispatcher wiring skipped: generic contract "
+            "auto-wiring owns registration event-bus wiring"
+        )
+        logger.info(
+            "%s (correlation_id=%s)",
+            message,
+            config.correlation_id,
+        )
+        return ModelDomainPluginResult(
+            plugin_id=self.plugin_id,
+            success=True,
+            message=message,
+            services_registered=[],
+            duration_seconds=time.time() - start_time,
+        )
 
     async def prepare_result_applier(
         self,

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1797,7 +1797,8 @@ def _prepare_handler_wiring(
                 EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
             ),
             skip_reason=(
-                "registration domain plugin owns explicit dispatcher adapters"
+                "registration direct-handler dispatcher creation is skipped; "
+                "generic contract auto-wiring owns registration event-bus wiring"
             ),
         )
 

--- a/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
+++ b/tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 """Integration tests for single-authority dispatcher wiring in registration plugin.
 
-Verifies that ServiceRegistration owns explicit dispatcher adapters while
-generic contract-driven auto-wiring owns event-bus subscriptions.
+Verifies that ServiceRegistration does not register plugin-local dispatcher
+adapters while generic contract-driven auto-wiring owns event-bus wiring.
 
 The duplicate-registration error (ONEX_CORE_064_DUPLICATE_REGISTRATION)
 arose because both the legacy explicit path and the generic contract-driven
@@ -12,7 +12,7 @@ confirms that:
 
 1. The contract.yaml has the fields that justify auto-wiring subscription ownership.
 2. The plugin can be imported and instantiated without side effects.
-3. Dispatcher adapter registration happens through the domain wiring helper.
+3. Dispatcher adapter registration is intentionally skipped by the plugin.
 
 Fixtures from conftest.py:
     contract_data: parsed YAML content of node_registration_orchestrator/contract.yaml
@@ -20,7 +20,7 @@ Fixtures from conftest.py:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -89,7 +89,7 @@ class TestContractDeclaresHandlerRouting:
 
 
 class TestPluginWireDispatchersNoDuplicateRegistration:
-    """The plugin.wire_dispatchers() delegates to explicit dispatcher adapters."""
+    """The plugin.wire_dispatchers() defers to generic contract auto-wiring."""
 
     def test_plugin_importable(self) -> None:
         """ServiceRegistration can be imported without side effects."""
@@ -110,13 +110,8 @@ class TestPluginWireDispatchersNoDuplicateRegistration:
         assert plugin.plugin_id == "registration"
 
     @pytest.mark.asyncio
-    async def test_wire_dispatchers_delegates_to_domain_wiring_helper(self) -> None:
-        """wire_dispatchers() delegates adapter registration to domain wiring.
-
-        Generic auto-wiring still owns subscriptions. The registration plugin
-        owns the adapter layer because registration handlers expect domain
-        envelope semantics rather than raw dict envelopes.
-        """
+    async def test_wire_dispatchers_skips_plugin_local_adapter_wiring(self) -> None:
+        """wire_dispatchers() avoids duplicate plugin-local dispatcher wiring."""
         from dataclasses import dataclass
         from uuid import uuid4
 
@@ -150,25 +145,10 @@ class TestPluginWireDispatchersNoDuplicateRegistration:
         )
 
         plugin = ServiceRegistration()
-        with patch(
-            "omnibase_infra.nodes.node_registration_orchestrator.wiring"
-            ".wire_registration_dispatchers",
-            new=AsyncMock(
-                return_value={
-                    "dispatchers": ["dispatcher.registration.catalog-request"],
-                    "routes": ["route.registration.catalog-request"],
-                    "status": "success",
-                }
-            ),
-        ) as wire_registration_dispatchers:
-            result = await plugin.wire_dispatchers(config)
+        result = await plugin.wire_dispatchers(config)
 
         assert result.success is True
-        assert result.message == "Registration dispatchers wired"
-        assert result.services_registered == ["dispatcher.registration.catalog-request"]
-        wire_registration_dispatchers.assert_awaited_once_with(
-            config.container,
-            config.dispatch_engine,
-            correlation_id=config.correlation_id,
-            event_bus=config.event_bus,
-        )
+        assert "auto-wiring" in result.message.lower()
+        assert result.services_registered == []
+        engine.register_dispatcher.assert_not_called()
+        engine.register_route.assert_not_called()

--- a/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
+++ b/tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for ServiceRegistration.wire_dispatchers registration ownership.
 
-Verifies that the registration domain plugin owns explicit dispatcher adapter
-wiring while generic contract-driven auto-wiring owns subscriptions.
+Verifies that the registration domain plugin defers dispatcher and route
+wiring to generic contract-driven auto-wiring.
 
 Historical context
 ------------------
@@ -13,18 +13,21 @@ contract auto-wiring path against the same registration contract produced
 ``dispatcher.registration.node-introspected`` on fresh runtime-effects boots.
 
 These tests pin the corrected ownership invariant: the plugin's
-``wire_dispatchers`` method invokes the explicit wiring helper, and
-auto-wiring skips generic direct-handler dispatchers for this domain.
+``wire_dispatchers`` method does not invoke explicit dispatcher wiring or
+register plugin-local routes.
 """
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
+import omnibase_infra.nodes.node_registration_orchestrator.plugin as plugin_module
 from omnibase_infra.nodes.node_registration_orchestrator.plugin import (
     ServiceRegistration,
 )
@@ -73,94 +76,94 @@ def _make_plugin_config() -> ModelDomainPluginConfig:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_returns_wired_result() -> None:
-    """wire_dispatchers() returns a success result from explicit adapter wiring."""
+async def test_wire_dispatchers_returns_auto_wiring_skip_result() -> None:
+    """wire_dispatchers() returns success with an auto-wiring skip reason."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
 
-    with patch(
-        f"{_WIRING_MOD}.wire_registration_dispatchers",
-        new=AsyncMock(
-            return_value={
-                "dispatchers": ["dispatcher.registration.catalog-request"],
-                "routes": ["route.registration.catalog-request"],
-                "status": "success",
-            }
-        ),
-    ):
-        result = await plugin.wire_dispatchers(config)
+    result = await plugin.wire_dispatchers(config)
 
     assert result.success is True
     assert result.plugin_id == "registration"
-    assert result.message == "Registration dispatchers wired"
-    assert result.services_registered == ["dispatcher.registration.catalog-request"]
+    assert "skipped" in result.message.lower()
+    assert "auto-wiring" in result.message.lower()
+    assert result.services_registered == []
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_invokes_explicit_helper() -> None:
-    """wire_dispatchers() delegates to registration's dispatcher adapters."""
+async def test_wire_dispatchers_does_not_touch_dispatch_engine() -> None:
+    """wire_dispatchers() must not register plugin-local dispatchers or routes."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
 
-    with patch(
-        f"{_WIRING_MOD}.wire_registration_dispatchers",
-        new=AsyncMock(
-            return_value={
-                "dispatchers": ["dispatcher.registration.catalog-request"],
-                "routes": ["route.registration.catalog-request"],
-                "status": "success",
-            }
-        ),
-    ) as mock_wire:
-        await plugin.wire_dispatchers(config)
+    result = await plugin.wire_dispatchers(config)
 
-    mock_wire.assert_awaited_once_with(
-        config.container,
-        config.dispatch_engine,
-        correlation_id=config.correlation_id,
-        event_bus=config.event_bus,
-    )
+    assert result.success is True
+    assert config.dispatch_engine is not None
+    config.dispatch_engine.register_dispatcher.assert_not_called()
+    config.dispatch_engine.register_route.assert_not_called()
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_fails_without_dispatch_engine() -> None:
-    """wire_dispatchers() must fail fast without a dispatch engine."""
+async def test_wire_dispatchers_skips_without_dispatch_engine() -> None:
+    """wire_dispatchers() does not require a dispatch engine when deferred."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
     config.dispatch_engine = None
 
     result = await plugin.wire_dispatchers(config)
 
-    assert result.success is False
-    assert result.error_message is not None
-    assert "dispatch_engine" in result.error_message
+    assert result.success is True
+    assert result.error_message is None
+    assert "auto-wiring" in result.message.lower()
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_wire_dispatchers_delegates_each_repeat_call() -> None:
-    """Repeat calls delegate to the explicit helper each time."""
+async def test_wire_dispatchers_repeat_calls_remain_idempotent_skips() -> None:
+    """Repeat calls return the same deferred ownership result."""
     plugin = ServiceRegistration()
     config = _make_plugin_config()
 
-    with patch(
-        f"{_WIRING_MOD}.wire_registration_dispatchers",
-        new=AsyncMock(
-            return_value={
-                "dispatchers": ["dispatcher.registration.catalog-request"],
-                "routes": ["route.registration.catalog-request"],
-                "status": "success",
-            }
-        ),
-    ) as mock_wire:
-        first = await plugin.wire_dispatchers(config)
-        second = await plugin.wire_dispatchers(config)
+    first = await plugin.wire_dispatchers(config)
+    second = await plugin.wire_dispatchers(config)
 
     assert first.success is True
     assert second.success is True
-    assert mock_wire.await_count == 2
+    assert first.services_registered == []
+    assert second.services_registered == []
+
+
+@pytest.mark.unit
+def test_wire_dispatchers_ast_has_no_explicit_dispatch_registration() -> None:
+    """wire_dispatchers() must not call dispatcher/route registration APIs."""
+    source = Path(plugin_module.__file__).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    service_cls = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "ServiceRegistration"
+    )
+    wire_dispatchers = next(
+        node
+        for node in service_cls.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "wire_dispatchers"
+    )
+
+    attrs = {
+        node.attr
+        for node in ast.walk(wire_dispatchers)
+        if isinstance(node, ast.Attribute)
+    }
+    names = {
+        node.id for node in ast.walk(wire_dispatchers) if isinstance(node, ast.Name)
+    }
+
+    assert "register_dispatcher" not in attrs
+    assert "register_route" not in attrs
+    assert "wire_registration_dispatchers" not in names
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -298,7 +298,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
             prepared.resolution_outcome
             is EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
         )
-        assert "explicit dispatcher adapters" in prepared.skip_reason
+        assert "auto-wiring" in prepared.skip_reason
 
     @pytest.mark.unit
     def test_message_types_includes_topic_derived_alias_when_no_explicit_alias(


### PR DESCRIPTION
## Summary
- make `ServiceRegistration.wire_dispatchers()` return a successful auto-wiring defer result instead of invoking explicit dispatcher wiring
- assert the plugin does not call `register_dispatcher`, `register_route`, or `wire_registration_dispatchers`
- align the registration auto-wiring skip reason with plugin-local dispatcher deferral
- add repo-local OMN-10448 deploy-gate contract

## Verification
- uv run pytest tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q
- uv run ruff check src/omnibase_infra/nodes/node_registration_orchestrator/plugin.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/nodes/node_registration_orchestrator/test_plugin_wire_dispatchers_deferred.py tests/integration/nodes/test_plugin_wire_dispatchers_single_authority.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
- uv run validate-yaml contracts/OMN-10448.yaml
- pre-commit hooks during commit
- pre-push hooks during push

Evidence-Ticket: OMN-10448
Evidence-Source: OCC#621
Central evidence PR: OmniNode-ai/onex_change_control#621

Closes OMN-10448.
