### PR TITLE
fix(OMN-10449): align runtime compose env

### DIFF
--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -44,6 +44,13 @@ jobs:
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout omnibase_compat (sibling)
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnibase_compat
+          path: omnibase_compat
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Python and uv
         uses: ./omnibase_infra/.github/actions/setup-python-uv
         with:
@@ -68,7 +75,9 @@ jobs:
           echo "================================================================"
           INFRA_VERSION=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
           echo "omnibase-infra==${INFRA_VERSION}" > /tmp/sibling-overrides.txt
+          echo "omnibase-compat @ file://$(pwd)/../omnibase_compat" >> /tmp/sibling-overrides.txt
           echo "Override: omnibase-infra==${INFRA_VERSION}"
+          echo "Override: omnibase-compat @ file://$(pwd)/../omnibase_compat"
           echo ""
           echo "Dry-run install of siblings with full transitive deps..."
           uv pip install --overrides /tmp/sibling-overrides.txt \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,13 @@ jobs:
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout omnibase_compat (sibling)
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnibase_compat
+          path: omnibase_compat
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Python and uv
         uses: ./omnibase_infra/.github/actions/setup-python-uv
         with:
@@ -461,6 +468,7 @@ jobs:
         run: |
           INFRA_VERSION=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
           echo "omnibase-infra==${INFRA_VERSION}" > /tmp/sibling-overrides.txt
+          echo "omnibase-compat @ file://$(pwd)/../omnibase_compat" >> /tmp/sibling-overrides.txt
           uv pip install --overrides /tmp/sibling-overrides.txt -e ../omniintelligence
 
       - name: Run schema handshake validation (changed-only)
@@ -1033,6 +1041,13 @@ jobs:
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout omnibase_compat (sibling)
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnibase_compat
+          path: omnibase_compat
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Python and uv
         uses: ./omnibase_infra/.github/actions/setup-python-uv
         with:
@@ -1055,6 +1070,7 @@ jobs:
         run: |
           INFRA_VERSION=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
           echo "omnibase-infra==${INFRA_VERSION}" > /tmp/sibling-overrides.txt
+          echo "omnibase-compat @ file://$(pwd)/../omnibase_compat" >> /tmp/sibling-overrides.txt
           uv pip install --overrides /tmp/sibling-overrides.txt -e ../omniintelligence
 
       - name: Run Kafka boundary compatibility tests

--- a/contracts/OMN-10449.yaml
+++ b/contracts/OMN-10449.yaml
@@ -1,0 +1,61 @@
+# OMN-10449 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for compose runtime alignment.
+schema_version: '1.0.0'
+ticket_id: OMN-10449
+summary: 'fix(OMN-10449): align runtime compose env with production'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Runtime env anchor and compose env parity tests pass
+    command: OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q
+  - kind: manual
+    description: Base compose config renders successfully
+    command: env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml --profile runtime config --quiet
+  - kind: manual
+    description: Stability overlay compose config renders successfully
+    command: env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
+  - kind: tests
+    description: Runtime compose env and health values match OMN-10449
+    command: uv run python -c "from pathlib import Path; import yaml; raw=yaml.safe_load(Path('docker/docker-compose.infra.yml').read_text()); env=raw['x-runtime-env']; assert env['ONEX_STATE_ROOT'] == '/app/data/.onex_state'; assert env['ONEX_ACTIVE_RUNTIME_PACKAGES'] == '${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}'; assert env['ONEX_MARKETPLACE_SKILLS_ROOT'] == '${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}'; assert 'OMNICLAUDE_CONTRACTS_ROOT' not in env; assert 'OMNICLAUDE_SKILLS_ROOT' not in env; runtime_base=raw['x-runtime-base']['deploy']['resources']; assert runtime_base['limits']['memory'] == '1536M'; assert runtime_base['reservations']['memory'] == '256M'; assert raw['services']['omninode-runtime']['healthcheck']['start_period'] == '1800s'; assert raw['services']['runtime-effects']['healthcheck']['start_period'] == '1800s'; assert raw['services']['autoheal']['environment']['AUTOHEAL_START_PERIOD'] == 2400"
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Runtime env anchor and compose env parity tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q'
+  - id: dod-002
+    description: Base compose config renders successfully
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml --profile runtime config --quiet'
+  - id: dod-003
+    description: Stability overlay compose config renders successfully
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet'
+  - id: dod-004
+    description: Runtime compose env and health values match OMN-10449
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run python -c "from pathlib import Path; import yaml; raw=yaml.safe_load(Path(''docker/docker-compose.infra.yml'').read_text()); env=raw[''x-runtime-env'']; assert env[''ONEX_STATE_ROOT''] == ''/app/data/.onex_state''; assert env[''ONEX_ACTIVE_RUNTIME_PACKAGES''] == ''${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}''; assert env[''ONEX_MARKETPLACE_SKILLS_ROOT''] == ''${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}''; assert ''OMNICLAUDE_CONTRACTS_ROOT'' not in env; assert ''OMNICLAUDE_SKILLS_ROOT'' not in env; runtime_base=raw[''x-runtime-base''][''deploy''][''resources'']; assert runtime_base[''limits''][''memory''] == ''1536M''; assert runtime_base[''reservations''][''memory''] == ''256M''; assert raw[''services''][''omninode-runtime''][''healthcheck''][''start_period''] == ''1800s''; assert raw[''services''][''runtime-effects''][''healthcheck''][''start_period''] == ''1800s''; assert raw[''services''][''autoheal''][''environment''][''AUTOHEAL_START_PERIOD''] == 2400"'
+  - id: dod-005
+    description: Runtime deploy smoke validates compose alignment after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'deploy omninode-runtime-effects after merge and verify docker compose config includes ONEX_MARKETPLACE_SKILLS_ROOT with no OMNICLAUDE_* runtime env roots'

--- a/contracts/OMN-10449.yaml
+++ b/contracts/OMN-10449.yaml
@@ -12,7 +12,7 @@ interfaces_touched:
 evidence_requirements:
   - kind: tests
     description: Runtime env anchor and compose env parity tests pass
-    command: OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q
+    command: OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q
   - kind: manual
     description: Base compose config renders successfully
     command: env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml --profile runtime config --quiet
@@ -21,7 +21,8 @@ evidence_requirements:
     command: env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
   - kind: tests
     description: Runtime compose env and health values match OMN-10449
-    command: uv run python -c "from pathlib import Path; import yaml; raw=yaml.safe_load(Path('docker/docker-compose.infra.yml').read_text()); env=raw['x-runtime-env']; assert env['ONEX_STATE_ROOT'] == '/app/data/.onex_state'; assert env['ONEX_ACTIVE_RUNTIME_PACKAGES'] == '${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}'; assert env['ONEX_MARKETPLACE_SKILLS_ROOT'] == '${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}'; assert 'OMNICLAUDE_CONTRACTS_ROOT' not in env; assert 'OMNICLAUDE_SKILLS_ROOT' not in env; runtime_base=raw['x-runtime-base']['deploy']['resources']; assert runtime_base['limits']['memory'] == '1536M'; assert runtime_base['reservations']['memory'] == '256M'; assert raw['services']['omninode-runtime']['healthcheck']['start_period'] == '1800s'; assert raw['services']['runtime-effects']['healthcheck']['start_period'] == '1800s'; assert raw['services']['autoheal']['environment']['AUTOHEAL_START_PERIOD'] == 2400"
+    command: >-
+      uv run python -c 'from pathlib import Path; import yaml; raw=yaml.safe_load(Path("docker/docker-compose.infra.yml").read_text()); env=raw["x-runtime-env"]; assert env["ONEX_STATE_ROOT"] == "/app/data/.onex_state"; assert env["ONEX_ACTIVE_RUNTIME_PACKAGES"] == "${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}"; assert env["ONEX_MARKETPLACE_SKILLS_ROOT"] == "${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}"; assert "OMNICLAUDE_CONTRACTS_ROOT" not in env; assert "OMNICLAUDE_SKILLS_ROOT" not in env; runtime_base=raw["x-runtime-base"]["deploy"]["resources"]; assert runtime_base["limits"]["memory"] == "1536M"; assert runtime_base["reservations"]["memory"] == "256M"; assert raw["services"]["omninode-runtime"]["healthcheck"]["start_period"] == "1800s"; assert raw["services"]["runtime-effects"]["healthcheck"]["start_period"] == "1800s"; assert raw["services"]["autoheal"]["environment"]["AUTOHEAL_START_PERIOD"] == 2400'
   - kind: ci
     description: CI pipeline green on PR
     command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
@@ -35,7 +36,7 @@ dod_evidence:
     source: generated
     checks:
       - check_type: command
-        check_value: 'OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q'
+        check_value: 'OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q'
   - id: dod-002
     description: Base compose config renders successfully
     source: generated
@@ -53,7 +54,8 @@ dod_evidence:
     source: generated
     checks:
       - check_type: command
-        check_value: 'uv run python -c "from pathlib import Path; import yaml; raw=yaml.safe_load(Path(''docker/docker-compose.infra.yml'').read_text()); env=raw[''x-runtime-env'']; assert env[''ONEX_STATE_ROOT''] == ''/app/data/.onex_state''; assert env[''ONEX_ACTIVE_RUNTIME_PACKAGES''] == ''${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}''; assert env[''ONEX_MARKETPLACE_SKILLS_ROOT''] == ''${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}''; assert ''OMNICLAUDE_CONTRACTS_ROOT'' not in env; assert ''OMNICLAUDE_SKILLS_ROOT'' not in env; runtime_base=raw[''x-runtime-base''][''deploy''][''resources'']; assert runtime_base[''limits''][''memory''] == ''1536M''; assert runtime_base[''reservations''][''memory''] == ''256M''; assert raw[''services''][''omninode-runtime''][''healthcheck''][''start_period''] == ''1800s''; assert raw[''services''][''runtime-effects''][''healthcheck''][''start_period''] == ''1800s''; assert raw[''services''][''autoheal''][''environment''][''AUTOHEAL_START_PERIOD''] == 2400"'
+        check_value: >-
+          uv run python -c 'from pathlib import Path; import yaml; raw=yaml.safe_load(Path("docker/docker-compose.infra.yml").read_text()); env=raw["x-runtime-env"]; assert env["ONEX_STATE_ROOT"] == "/app/data/.onex_state"; assert env["ONEX_ACTIVE_RUNTIME_PACKAGES"] == "${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}"; assert env["ONEX_MARKETPLACE_SKILLS_ROOT"] == "${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}"; assert "OMNICLAUDE_CONTRACTS_ROOT" not in env; assert "OMNICLAUDE_SKILLS_ROOT" not in env; runtime_base=raw["x-runtime-base"]["deploy"]["resources"]; assert runtime_base["limits"]["memory"] == "1536M"; assert runtime_base["reservations"]["memory"] == "256M"; assert raw["services"]["omninode-runtime"]["healthcheck"]["start_period"] == "1800s"; assert raw["services"]["runtime-effects"]["healthcheck"]["start_period"] == "1800s"; assert raw["services"]["autoheal"]["environment"]["AUTOHEAL_START_PERIOD"] == 2400'
   - id: dod-005
     description: Runtime deploy smoke validates compose alignment after merge
     source: manual

--- a/contracts/OMN-10449.yaml
+++ b/contracts/OMN-10449.yaml
@@ -3,6 +3,7 @@
 # contract carries deploy-gate evidence for compose runtime alignment.
 schema_version: '1.0.0'
 ticket_id: OMN-10449
+title: 'Runtime compose environment alignment'
 summary: 'fix(OMN-10449): align runtime compose env with production'
 is_seam_ticket: true
 interface_change: true

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -210,7 +210,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # required dependency but we use --no-deps for the source install, so it must
 # be present first. The GitHub archive source avoids recursive submodule
 # checkout from the repository while PyPI publishing is automated.
-ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/refs/heads/main.tar.gz"
+ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/ba32d12efdf2671846c2267b570763d4fab18672.tar.gz"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "${OMNIBASE_COMPAT_SOURCE}"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -207,11 +207,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "omninode-intelligence>=0.15.0,<2.0.0"
 
 # Install omnibase_compat before omnimarket — omnimarket declares it as a
-# required dependency but we use --no-deps for the git install, so it must
-# be present first. Pinned to git main until PyPI publishing is automated.
+# required dependency but we use --no-deps for the source install, so it must
+# be present first. The GitHub archive source avoids recursive submodule
+# checkout from the repository while PyPI publishing is automated.
+ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/refs/heads/main.tar.gz"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "git+https://github.com/OmniNode-ai/omnibase_compat.git@main#egg=omnibase-compat"
+    "${OMNIBASE_COMPAT_SOURCE}"
 
 # Install onex_change_control before omnimarket — omnimarket's node_overseer_verifier
 # imports it at module level but omnimarket is installed --no-deps, so it must

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -144,6 +144,7 @@ x-runtime-env: &runtime-env
   BUS_ID: "local"
   ONEX_CONTRACTS_DIR: /app/contracts
   ONEX_STATE_ROOT: /app/data/.onex_state
+  # Restrict the runtime surface to first-party infra + marketplace packages.
   ONEX_ACTIVE_RUNTIME_PACKAGES: ${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}
   # OMN-6440: Runtime contract YAMLs from omnibase_core (env var override for Docker)
   ONEX_RUNTIME_CONTRACTS_DIR: /app/contracts/runtime
@@ -176,14 +177,9 @@ x-runtime-env: &runtime-env
   QDRANT_HOST: ${QDRANT_HOST:-}
   QDRANT_PORT: ${QDRANT_PORT:-6333}
   QDRANT_API_KEY: ${QDRANT_API_KEY:-}
-  # OmniClaude domain plugin (OMN-3182): required by PluginClaude.wire_dispatchers()
-  # Hardcoded to venv path — host OMNICLAUDE_CONTRACTS_ROOT points at /Volumes/...
-  # which doesn't exist inside the container. The pip-installed package has its
-  # nodes at the site-packages path below.
-  OMNICLAUDE_CONTRACTS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/nodes
-  # OMN-4622: Skills root for topic provisioning (flat-list topics.yaml manifests)
-  # Overrideable for remote deployments where skills are mounted from host (e.g. OMNICLAUDE_SKILLS_ROOT=/app/skills)
-  OMNICLAUDE_SKILLS_ROOT: ${OMNICLAUDE_SKILLS_ROOT:-/app/.venv/lib/python3.12/site-packages/omniclaude/plugins/onex/skills}
+  # Marketplace skill-manifest root for topic provisioning (flat-list topics.yaml manifests).
+  # This is the single runtime ingress for marketplace-packaged skills.
+  ONEX_MARKETPLACE_SKILLS_ROOT: ${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}
   # --- Infisical config store ---
   INFISICAL_ADDR: ${INFISICAL_ADDR:-}
   INFISICAL_CLIENT_ID: ${INFISICAL_CLIENT_ID:-}

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -190,8 +190,8 @@ DEFAULT_RUNTIME_CONFIG = "runtime/runtime_config.yaml"
 
 # Environment variable name for contracts directory
 ENV_CONTRACTS_DIR = "ONEX_CONTRACTS_DIR"
-# Environment variable for omniclaude skills root (cross-repo topic discovery)
-ENV_OMNICLAUDE_SKILLS_ROOT = "OMNICLAUDE_SKILLS_ROOT"
+# Environment variable for marketplace skill roots (cross-repo topic discovery)
+ENV_MARKETPLACE_SKILLS_ROOT = "ONEX_MARKETPLACE_SKILLS_ROOT"
 DEFAULT_INPUT_TOPIC = "requests"  # onex-topic-allow: pending contract auto-wiring
 DEFAULT_OUTPUT_TOPIC = "responses"  # onex-topic-allow: pending contract auto-wiring
 DEFAULT_GROUP_ID = "onex-runtime"
@@ -1044,21 +1044,21 @@ async def bootstrap() -> int:
                 )
 
                 # Resolve optional cross-repo skill-manifest root for topic discovery.
-                # OMNICLAUDE_SKILLS_ROOT: path to omniclaude plugins/onex/skills/
+                # ONEX_MARKETPLACE_SKILLS_ROOT: path to marketplace-packaged skills.
                 _skills_root_env = os.environ.get(
-                    ENV_OMNICLAUDE_SKILLS_ROOT, ""
+                    ENV_MARKETPLACE_SKILLS_ROOT, ""
                 ).strip()
                 _skill_manifests_root: Path | None = None
                 if not _skills_root_env:
                     logger.info(
                         "Topic provisioning: skill-manifest discovery disabled"
-                        " (OMNICLAUDE_SKILLS_ROOT not set)"
+                        " (ONEX_MARKETPLACE_SKILLS_ROOT not set)"
                     )
                 else:
                     _skill_manifests_path = Path(_skills_root_env)
                     if not _skill_manifests_path.exists():
                         logger.warning(
-                            "Topic provisioning: OMNICLAUDE_SKILLS_ROOT=%s not found,"
+                            "Topic provisioning: ONEX_MARKETPLACE_SKILLS_ROOT=%s not found,"
                             " skill topics will not be provisioned",
                             _skills_root_env,
                         )
@@ -3787,7 +3787,7 @@ if __name__ == "__main__":
 
 __all__: list[str] = [
     "ENV_CONTRACTS_DIR",
-    "ENV_OMNICLAUDE_SKILLS_ROOT",
+    "ENV_MARKETPLACE_SKILLS_ROOT",
     "bootstrap",
     "load_runtime_config",
     "main",

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -110,6 +110,10 @@ LOCAL_ONLY_KEYS: frozenset[str] = frozenset(
         "OMNIBASE_INFRA_DIR",
         # OmniMemory crawl path — local server path, has no k8s equivalent
         "OMNIMEMORY_CRAWL_PATH_PREFIXES",
+        # Local runtime surface and marketplace skill roots are Docker-runtime
+        # ingress controls; k8s derives package/skill mounts separately.
+        "ONEX_ACTIVE_RUNTIME_PACKAGES",
+        "ONEX_MARKETPLACE_SKILLS_ROOT",
         # LLM endpoints — lab-local GPU servers (192.168.86.*); k8s onex-dev
         # routes to cluster-internal or public model endpoints via a different
         # mechanism (tracked: OMN-7979). In local docker these activate PluginLlm.
@@ -141,14 +145,8 @@ CONFIGMAP_DEBT_KEYS: frozenset[str] = frozenset(
         # Qdrant vector store connection — not yet in k8s ConfigMap (tracked: OMN-4307)
         "QDRANT_HOST",
         "QDRANT_PORT",
-        "OMNICLAUDE_CONTRACTS_ROOT",  # container-internal path (OMN-5382: re-added for PluginClaude.wire_dispatchers)
-        "OMNICLAUDE_SKILLS_ROOT",  # container-internal path — same as CONTRACTS_ROOT
         "ONEX_REGISTRATION_AUTO_ACK",
         "USE_EVENT_ROUTING",
-        # Runtime package activation selector. k8s ConfigMap parity is tracked
-        # with the OMN-10445 release/deploy follow-up because this PR cannot
-        # update the sibling omninode_infra checkout used by the parity job.
-        "ONEX_ACTIVE_RUNTIME_PACKAGES",
         # OpenTelemetry — opt-in observability (empty = disabled)
         "OTEL_EXPORTER_OTLP_ENDPOINT",
         "OTEL_SERVICE_NAME",

--- a/tests/ci/test_runtime_env_anchor.py
+++ b/tests/ci/test_runtime_env_anchor.py
@@ -41,6 +41,8 @@ REQUIRED_RUNTIME_KEYS: frozenset[str] = frozenset(
         "INFISICAL_CLIENT_SECRET",
         "INFISICAL_PROJECT_ID",
         "ONEX_CONTRACTS_DIR",
+        "ONEX_ACTIVE_RUNTIME_PACKAGES",
+        "ONEX_MARKETPLACE_SKILLS_ROOT",
         "ONEX_LOG_LEVEL",
         "ONEX_ENVIRONMENT",
         "USE_EVENT_ROUTING",
@@ -129,6 +131,17 @@ class TestRuntimeEnvAnchorSyntaxValid:
             f"x-runtime-env has {len(null_keys)} key(s) with null values: {null_keys}. "
             "Use KEY: ${{KEY:-}} for optional vars or KEY: ${{KEY:?error}} for required vars."
         )
+
+    @pytest.mark.unit
+    def test_anchor_uses_onex_marketplace_skill_roots(self) -> None:
+        """Assert legacy OmniClaude runtime roots are not exposed to runtime containers."""
+        data = _load_compose()
+        runtime_env_keys = _get_runtime_env_keys(data)
+
+        assert "ONEX_ACTIVE_RUNTIME_PACKAGES" in runtime_env_keys
+        assert "ONEX_MARKETPLACE_SKILLS_ROOT" in runtime_env_keys
+        assert "OMNICLAUDE_CONTRACTS_ROOT" not in runtime_env_keys
+        assert "OMNICLAUDE_SKILLS_ROOT" not in runtime_env_keys
 
 
 class TestRuntimeEnvPassthroughNotBypassed:

--- a/tests/integration/test_omn_10449_marketplace_skills_env.py
+++ b/tests/integration/test_omn_10449_marketplace_skills_env.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.integration
 
 def test_runtime_compose_env_matches_kernel_marketplace_skills_env() -> None:
     """Compose and kernel agree on the marketplace skill-manifest env name."""
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = Path(__file__).parent.parent.parent
     compose_path = repo_root / "docker" / "docker-compose.infra.yml"
     compose = yaml.safe_load(compose_path.read_text())
 

--- a/tests/integration/test_omn_10449_marketplace_skills_env.py
+++ b/tests/integration/test_omn_10449_marketplace_skills_env.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime marketplace skill-manifest env wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.runtime.service_kernel import ENV_MARKETPLACE_SKILLS_ROOT
+
+pytestmark = pytest.mark.integration
+
+
+def test_runtime_compose_env_matches_kernel_marketplace_skills_env() -> None:
+    """Compose and kernel agree on the marketplace skill-manifest env name."""
+    repo_root = Path(__file__).resolve().parents[2]
+    compose_path = repo_root / "docker" / "docker-compose.infra.yml"
+    compose = yaml.safe_load(compose_path.read_text())
+
+    runtime_env = compose["services"]["omninode-runtime"]["environment"]
+
+    assert ENV_MARKETPLACE_SKILLS_ROOT == "ONEX_MARKETPLACE_SKILLS_ROOT"
+    assert ENV_MARKETPLACE_SKILLS_ROOT in runtime_env
+    assert "OMNICLAUDE_SKILLS_ROOT" not in runtime_env


### PR DESCRIPTION
## Summary
- add `ONEX_ACTIVE_RUNTIME_PACKAGES` and `ONEX_MARKETPLACE_SKILLS_ROOT` to `x-runtime-env`
- remove legacy `OMNICLAUDE_CONTRACTS_ROOT` and `OMNICLAUDE_SKILLS_ROOT` from the runtime env anchor
- add CI guards for ONEX marketplace/runtime env ownership
- add repo-local OMN-10449 deploy-gate contract

## Verification
- OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q
- uv run ruff check tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py
- env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml --profile runtime config --quiet
- env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
- uv run validate-yaml contracts/OMN-10449.yaml
- pre-commit hooks during commit
- pre-push hooks during push

Evidence-Ticket: OMN-10449
Evidence-Source: OCC#623
Central evidence PR: OmniNode-ai/onex_change_control#623

Closes OMN-10449.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Runtime env updated to use a marketplace skills root and removed legacy OmniClaude runtime roots.
  * Added a deploy-gate contract (OMN-10449) to verify runtime/compose environment alignment and required evidence.
  * CI and build updated to include an additional sibling repository for compatibility checks and to install it from a controlled source.

* **Tests**
  * New and adjusted unit/integration tests to validate runtime env anchors, env-parity allowlists, and compose/runtime parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->