### PR TITLE
fix(OMN-10450): inherit stability runtime image

### DIFF
--- a/contracts/OMN-10450.yaml
+++ b/contracts/OMN-10450.yaml
@@ -46,8 +46,8 @@ dod_evidence:
       - check_type: command
         check_value: 'uv run ruff check tests/integration/infra/test_stability_test_runtime_compose_render.py'
   - id: dod-004
-    description: Runtime deploy smoke validates stability overlay inherits release runtime image after merge
-    source: manual
+    description: Rendered stability overlay inherits release runtime image settings
+    source: generated
     checks:
       - check_type: command
-        check_value: 'deploy stability-test after merge and verify rendered compose has no runtime:stability-test-workspace image override, restart unless-stopped, and release build args'
+        check_value: 'uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_render_contains_isolated_runtime_identity tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_render_inherits_release_build_source -q'

--- a/contracts/OMN-10450.yaml
+++ b/contracts/OMN-10450.yaml
@@ -1,0 +1,52 @@
+# OMN-10450 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for stability overlay image alignment.
+schema_version: '1.0.0'
+ticket_id: OMN-10450
+summary: 'fix(OMN-10450): make stability overlay inherit release runtime image'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Stability-test compose render tests pass
+    command: uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q
+  - kind: manual
+    description: Stability overlay compose config renders successfully
+    command: env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
+  - kind: tests
+    description: Stability-test compose render test passes ruff
+    command: uv run ruff check tests/integration/infra/test_stability_test_runtime_compose_render.py
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Stability-test compose render tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q'
+  - id: dod-002
+    description: Stability overlay compose config renders successfully
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet'
+  - id: dod-003
+    description: Stability-test compose render test passes ruff
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run ruff check tests/integration/infra/test_stability_test_runtime_compose_render.py'
+  - id: dod-004
+    description: Runtime deploy smoke validates stability overlay inherits release runtime image after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'deploy stability-test after merge and verify rendered compose has no runtime:stability-test-workspace image override, restart unless-stopped, and release build args'

--- a/contracts/OMN-10450.yaml
+++ b/contracts/OMN-10450.yaml
@@ -51,3 +51,9 @@ dod_evidence:
     checks:
       - check_type: command
         check_value: 'uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_render_contains_isolated_runtime_identity tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_render_inherits_release_build_source -q'
+  - id: dod-deploy
+    description: Post-deploy stability runtime smoke validates the stability-test lane identity
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'docker exec ${STABILITY_RUNTIME_CONTAINER:-omninode-stability-test-runtime} printenv ONEX_ENVIRONMENT'

--- a/contracts/OMN-10450.yaml
+++ b/contracts/OMN-10450.yaml
@@ -3,6 +3,7 @@
 # contract carries deploy-gate evidence for stability overlay image alignment.
 schema_version: '1.0.0'
 ticket_id: OMN-10450
+title: 'Stability overlay inherits release runtime image'
 summary: 'fix(OMN-10450): make stability overlay inherit release runtime image'
 is_seam_ticket: true
 interface_change: true

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -15,12 +15,6 @@
 #
 # Requires Docker Compose v2.24.4 or later for !override merge semantics.
 name: omnibase-infra-stability-test
-x-stability-runtime-build: &stability-runtime-build
-  context: ..
-  dockerfile: docker/Dockerfile.runtime
-  args:
-    BUILD_SOURCE: workspace
-    EXPECTED_BUILD_SOURCE: workspace
 services:
   postgres:
     container_name: omnibase-infra-stability-test-postgres
@@ -88,18 +82,14 @@ services:
   intelligence-migration:
     container_name: omnibase-infra-stability-test-intelligence-migration
   omninode-runtime:
-    build: *stability-runtime-build
-    image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime
-    restart: "no"
+    restart: unless-stopped
     depends_on:
       intelligence-migration:
         condition: service_completed_successfully
       redpanda-partition-cap:
         condition: service_completed_successfully
     environment:
-      BUILD_SOURCE: workspace
-      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override
@@ -126,13 +116,9 @@ services:
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/main"
       - "com.omninode.runtime.id=stability-test-main"
   runtime-effects:
-    build: *stability-runtime-build
-    image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime-effects
-    restart: "no"
+    restart: unless-stopped
     environment:
-      BUILD_SOURCE: workspace
-      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override
@@ -159,13 +145,9 @@ services:
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/effects"
       - "com.omninode.runtime.id=stability-test-effects"
   runtime-worker:
-    build: *stability-runtime-build
-    image: runtime:stability-test-workspace
     container_name: omninode-stability-test-runtime-worker
-    restart: "no"
+    restart: unless-stopped
     environment:
-      BUILD_SOURCE: workspace
-      EXPECTED_BUILD_SOURCE: workspace
       # Keep PluginMemory inactive in stability lane:
       # - blank legacy flag
       # - blank Memgraph host override

--- a/docs/runbooks/stability-test-runtime-lane.md
+++ b/docs/runbooks/stability-test-runtime-lane.md
@@ -12,9 +12,8 @@ The stability-test lane exists so runtime proof can be prepared without sharing
 production runtime names, state paths, or consumer groups. It is the bridge from
 the two-phase runtime build plan into a concrete runtime lane:
 
-- `BUILD_SOURCE=workspace` is declared in the overlay so selector-aware builds
-  use local workspace contents once OMN-9471 or equivalent selector support is
-  on main.
+- The overlay inherits the release runtime image build from the base compose
+  file instead of declaring a lane-specific workspace image.
 - `ONEX_ENVIRONMENT=stability-test` separates derived node consumer groups from
   the production/local `ONEX_ENVIRONMENT=local` group prefix.
 - Explicit `ONEX_GROUP_ID` values use the `onex-stability-test-` prefix for the
@@ -36,7 +35,7 @@ the two-phase runtime build plan into a concrete runtime lane:
 
 - Compose overlay: `docker/docker-compose.stability-test.yml`
 - Compose project name: `omnibase-infra-stability-test`
-- Runtime image tag: `runtime:stability-test-workspace`
+- Runtime image: inherited from the base runtime build.
 - Runtime containers:
   - `omninode-stability-test-runtime`
   - `omninode-stability-test-runtime-effects`
@@ -62,9 +61,7 @@ the two-phase runtime build plan into a concrete runtime lane:
   - Valkey: `26379`
   - Runtime main: `18085`
   - Runtime effects: `18086`
-- Build args:
-  - `BUILD_SOURCE=workspace`
-  - `EXPECTED_BUILD_SOURCE=workspace`
+- Build args: inherited from the base runtime build.
 - Networks:
   - `omnibase-infra-stability-test-network`
   - `omnibase-infra-stability-test-omnimemory-network`
@@ -109,8 +106,8 @@ uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render
 - It does not install launchd, cron, systemd, or autoheal hooks.
 - It does not prove runtime health, Redpanda membership, or build-loop to
   ticket-pipeline processing.
-- It does not prove workspace image provenance until `BUILD_SOURCE` selector
-  support is available on this branch.
+- It does not prove workspace image provenance; this lane intentionally follows
+  the release runtime build until a separately approved selector change lands.
 
 ## Operator Gate
 

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -205,13 +205,14 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
 
     for service_name in REQUIRED_RUNTIME_SERVICES:
         environment = services[service_name]["environment"]
-        assert environment["BUILD_SOURCE"] == "workspace"
-        assert environment["EXPECTED_BUILD_SOURCE"] == "workspace"
+        assert "BUILD_SOURCE" not in environment
+        assert "EXPECTED_BUILD_SOURCE" not in environment
         assert environment["OMNIMEMORY_ENABLED"] == ""
         assert environment["OMNIMEMORY_MEMGRAPH_HOST"] == ""
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
-        assert services[service_name]["image"] == "runtime:stability-test-workspace"
+        assert "image" not in services[service_name]
+        assert services[service_name]["restart"] == "unless-stopped"
         assert environment["ONEX_RUNTIME_ADDRESS"].startswith(
             "runtime://omninode-pc/stability-test/"
         )
@@ -261,7 +262,7 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
 
 
 @pytest.mark.integration
-def test_stability_lane_render_uses_workspace_build_source() -> None:
+def test_stability_lane_render_inherits_release_build_source() -> None:
     rendered_config = _compose_config_json()
     services = rendered_config["services"]
 
@@ -270,8 +271,8 @@ def test_stability_lane_render_uses_workspace_build_source() -> None:
         assert build["context"] == str(REPO_ROOT)
         assert build["dockerfile"] == "docker/Dockerfile.runtime"
         assert build["args"] == {
-            "BUILD_SOURCE": "workspace",
-            "EXPECTED_BUILD_SOURCE": "workspace",
+            "BUILD_SOURCE": "release",
+            "EXPECTED_BUILD_SOURCE": "release",
         }
 
 

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -114,12 +114,9 @@ def test_stability_lane_runtime_services_do_not_reuse_production_names() -> None
         container_name = service["container_name"]
         assert "stability-test" in container_name
         assert container_name not in PRODUCTION_CONTAINER_NAMES
-        assert service["image"] == "runtime:stability-test-workspace"
-        assert service["restart"] == "no"
-        assert service["build"]["args"] == {
-            "BUILD_SOURCE": "workspace",
-            "EXPECTED_BUILD_SOURCE": "workspace",
-        }
+        assert "image" not in service
+        assert "build" not in service
+        assert service["restart"] == "unless-stopped"
 
 
 @pytest.mark.unit
@@ -129,8 +126,8 @@ def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
 
     for service_name in RUNTIME_SERVICES:
         environment = services[service_name]["environment"]
-        assert environment["BUILD_SOURCE"] == "workspace"
-        assert environment["EXPECTED_BUILD_SOURCE"] == "workspace"
+        assert "BUILD_SOURCE" not in environment
+        assert "EXPECTED_BUILD_SOURCE" not in environment
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
@@ -326,7 +323,7 @@ def test_stability_runbook_is_validation_only() -> None:
     assert "does not render inherited out-of-lane runtime services" in runbook
     assert "config" in runbook
     assert "--profile runtime" in runbook
-    assert "BUILD_SOURCE=workspace" in runbook
+    assert "inherits the release runtime image build" in runbook
     assert "runtime://omninode-pc/stability-test/main" in runbook
     assert "runtime://omninode-pc/stability-test/effects" in runbook
     assert "runtime://omninode-pc/stability-test/worker" in runbook


### PR DESCRIPTION
## Summary
- remove stability-only runtime build/image overrides
- make stability runtime services restart `unless-stopped`
- remove `BUILD_SOURCE=workspace` / `EXPECTED_BUILD_SOURCE=workspace` runtime env overrides
- update render tests to prove release build args, no image override, and restart recovery
- add repo-local OMN-10450 deploy-gate contract

## Verification
- uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q
- uv run ruff check tests/integration/infra/test_stability_test_runtime_compose_render.py
- env POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
- uv run validate-yaml contracts/OMN-10450.yaml
- pre-commit hooks during commit
- pre-push hooks during push

Evidence-Ticket: OMN-10450
Evidence-Source: OCC#624
Central evidence PR: OmniNode-ai/onex_change_control#624

Closes OMN-10450.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deploy-gate contract introducing validation checks for render, lint, and runtime assertions.

* **Chores**
  * Stability-test runtime services now inherit the release runtime image build instead of a workspace-specific image.
  * Runtime service restart policy changed to "unless-stopped".

* **Tests**
  * Updated and renamed tests to assert absent workspace build vars, no explicit images/builds, and the new restart behavior.

* **Documentation**
  * Runbook updated to reflect the runtime image inheritance model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->