### PR TITLE
test(OMN-10453): add runtime boot validation

### DIFF
--- a/contracts/OMN-10453.yaml
+++ b/contracts/OMN-10453.yaml
@@ -1,0 +1,52 @@
+# OMN-10453 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for runtime boot validation.
+schema_version: '1.0.0'
+ticket_id: OMN-10453
+summary: 'test(OMN-10453): add main-profile runtime boot auto-wiring gate'
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Main-profile runtime boot auto-wiring validation passes
+    command: uv run pytest tests/integration/runtime/test_runtime_boot_clean.py -q
+  - kind: tests
+    description: Runtime boot validation test passes ruff
+    command: uv run ruff check tests/integration/runtime/test_runtime_boot_clean.py
+  - kind: manual
+    description: Repo-local ticket contract validates
+    command: uv run validate-yaml contracts/OMN-10453.yaml
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks {pr} --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-runtime-boot-tests
+    description: Main-profile runtime boot auto-wiring validation passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/runtime/test_runtime_boot_clean.py -q'
+  - id: dod-lint
+    description: Runtime boot validation test passes ruff
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run ruff check tests/integration/runtime/test_runtime_boot_clean.py'
+  - id: dod-contract-validate
+    description: Repo-local ticket contract validates
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run validate-yaml contracts/OMN-10453.yaml'
+  - id: dod-post-merge-runtime-proof
+    description: Runtime deploy proof validates same main-profile manifest after merge
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'after merge, deploy release candidate and verify omninode-runtime boots with RUNTIME_PROFILE=main without ModelOnexError'

--- a/contracts/OMN-10453.yaml
+++ b/contracts/OMN-10453.yaml
@@ -3,6 +3,7 @@
 # contract carries deploy-gate evidence for runtime boot validation.
 schema_version: '1.0.0'
 ticket_id: OMN-10453
+title: 'Runtime boot auto-wiring validation'
 summary: 'test(OMN-10453): add main-profile runtime boot auto-wiring gate'
 is_seam_ticket: true
 interface_change: true

--- a/tests/integration/runtime/test_runtime_boot_clean.py
+++ b/tests/integration/runtime/test_runtime_boot_clean.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+"""Runtime boot validation for the main auto-wiring profile.
+
+OMN-10453 proves that the real installed contract manifest, filtered to the
+production ``main`` runtime profile, can pass through ``wire_from_manifest``
+without a runtime boot crash. The test uses an in-process dispatch engine and a
+deterministic DI container so the gate validates manifest and routing shape
+without requiring live external services.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring import (
+    ModelAutoWiringManifest,
+    discover_contracts,
+    filter_manifest_for_runtime_profile,
+    wire_from_manifest,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+pytestmark = [pytest.mark.integration]
+
+MAIN_RUNTIME_PROFILE = "main"
+OMNIMARKET_PACKAGE = "omnimarket"
+EXCLUDED_MAIN_PROFILE_NODES = frozenset(
+    {
+        "node_intelligence_orchestrator",
+        "node_intent_event_consumer_effect",
+    }
+)
+
+
+class _BootValidationHandler:
+    """Minimal async handler instance returned by the boot-validation container."""
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _BootValidationContainer:
+    """Deterministic DI container for constructor-free boot validation."""
+
+    async def get_service_async(self, handler_cls: type[object]) -> object:
+        return _BootValidationHandler()
+
+    def get_service(self, handler_cls: type[object]) -> object:
+        return _BootValidationHandler()
+
+
+def _main_profile_manifest() -> ModelAutoWiringManifest:
+    discovered = discover_contracts()
+    ownership = filter_manifest_for_runtime_profile(
+        manifest=discovered,
+        runtime_profile=MAIN_RUNTIME_PROFILE,
+    )
+    return ownership.manifest
+
+
+@pytest.mark.asyncio
+async def test_wire_from_manifest_main_profile_no_crash() -> None:
+    """The real main-profile manifest wires cleanly without ModelOnexError."""
+    manifest = _main_profile_manifest()
+    assert manifest.total_discovered > 0
+
+    engine = MessageDispatchEngine(logger=MagicMock())
+    report = await wire_from_manifest(
+        manifest=manifest,
+        dispatch_engine=engine,
+        event_bus=None,
+        environment="test",
+        container=_BootValidationContainer(),
+        subscribe_immediately=False,
+    )
+
+    assert report.total_failed == 0
+    assert len(report.results) == manifest.total_discovered
+
+
+def test_manifest_includes_omnimarket_contracts() -> None:
+    """The main-profile boot gate is not vacuous: omnimarket is present."""
+    manifest = _main_profile_manifest()
+
+    omnimarket_contracts = {
+        contract.name
+        for contract in manifest.contracts
+        if contract.package_name == OMNIMARKET_PACKAGE
+    }
+
+    assert omnimarket_contracts
+    assert {
+        "build_loop",
+        "merge_sweep",
+        "runtime_sweep",
+    }.issubset(omnimarket_contracts)
+
+
+def test_main_profile_excludes_memory_and_intelligence() -> None:
+    """Known non-main crashers must not be owned by the main runtime profile."""
+    manifest = _main_profile_manifest()
+    main_profile_contract_names = {contract.name for contract in manifest.contracts}
+
+    assert EXCLUDED_MAIN_PROFILE_NODES.isdisjoint(main_profile_contract_names)


### PR DESCRIPTION
## Summary
- Add `tests/integration/runtime/test_runtime_boot_clean.py` for the OMN-10453 main-profile runtime boot gate.
- The test uses the real installed auto-wiring manifest, filters it to `RUNTIME_PROFILE=main`, validates `wire_from_manifest` completes with zero failed wiring results, proves omnimarket contracts are included, and asserts known memory/intelligence crashers are absent from main.
- Add repo-local deploy-gate contract `contracts/OMN-10453.yaml`.

## Evidence
- Evidence-Ticket: OMN-10453
- Evidence-Source: OCC#627
- `uv run pytest tests/integration/runtime/test_runtime_boot_clean.py -q` -> 3 passed
- `uv run ruff check tests/integration/runtime/test_runtime_boot_clean.py` -> passed
- `uv run validate-yaml contracts/OMN-10453.yaml` -> passed
- Commit hooks passed during commit.

## Worktree Cleanup
- Retained while PR is open: `/Users/jonah/Code/omni_home/omni_worktrees/OMN-10453/omnibase_infra`
