### PR TITLE
feat(OMN-10123): block Plugin lifecycle classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Check topic suffix exports (F56)
         run: python scripts/validation/check_topic_suffix_exports.py
 
+      - name: Check Plugin* lifecycle class guard (OMN-10123)
+        run: PYTHONPATH=src uv run python -m omnibase_infra.validators.no_plugin_daemon_classes src/omnibase_infra
+
       - name: Run mypy type checking
         run: uv run mypy src/omnibase_infra
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -190,6 +190,16 @@ repos:
         types: [python]
         pass_filenames: false
         stages: [pre-commit]
+      # OMN-10123: Plugin* classes are deterministic compute plugins only.
+      # Daemon/service/worker lifecycles belong behind ONEX nodes and handlers.
+      - id: no-plugin-daemon-classes
+        name: Block Plugin* daemon/service/worker classes
+        entry: env PYTHONPATH=src uv run --frozen python -m omnibase_infra.validators.no_plugin_daemon_classes src/omnibase_infra
+        language: system
+        types: [python]
+        files: ^src/omnibase_infra/.*\.py$
+        pass_filenames: false
+        stages: [pre-commit]
       # Union usage validation
       # TECH DEBT: Baseline increased to 108 violations (OMN-871)
       # Target: Reduce to 30 incrementally after PR #37 merges

--- a/contracts/OMN-10123.yaml
+++ b/contracts/OMN-10123.yaml
@@ -1,0 +1,49 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10123"
+title: "Document plugin_compute_base scope and forbid new Plugin* daemon classes"
+summary: "Add an AST guard that blocks Plugin* daemon/service/worker lifecycle classes while allowing deterministic PluginComputeBase subclasses."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Unit tests prove the AST guard catches fake PluginXyzDaemon classes and allows PluginComputeBase subclasses."
+    command: "uv run pytest tests/unit/validators/test_no_plugin_daemon_classes.py -q"
+  - kind: "tests"
+    description: "Validator scans current infra source tree without baseline violations."
+    command: "PYTHONPATH=src uv run python -m omnibase_infra.validators.no_plugin_daemon_classes src/omnibase_infra"
+  - kind: "ci"
+    description: "Pre-commit hook blocks Plugin* daemon/service/worker classes."
+    command: "pre-commit run no-plugin-daemon-classes --all-files"
+  - kind: "ci"
+    description: "Required lint job runs the Plugin* lifecycle class guard."
+    command: "gh pr checks {pr} --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "AST validator unit tests pass, including fake PluginXyzDaemon detection."
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/validators/test_no_plugin_daemon_classes.py -q"
+  - id: "dod-002"
+    description: "Current omnibase_infra source tree has no Plugin* lifecycle violations."
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run python -m omnibase_infra.validators.no_plugin_daemon_classes src/omnibase_infra"
+  - id: "dod-003"
+    description: "Pre-commit hook enforces the Plugin* lifecycle class guard."
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "pre-commit run no-plugin-daemon-classes --all-files"
+  - id: "dod-004"
+    description: "CI lint job includes the Plugin* lifecycle class guard as a required check."
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "rg -n \"Check Plugin\\* lifecycle class guard|no_plugin_daemon_classes\" .github/workflows/ci.yml .pre-commit-config.yaml"

--- a/src/omnibase_infra/validators/__init__.py
+++ b/src/omnibase_infra/validators/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Repository-local source validators."""

--- a/src/omnibase_infra/validators/no_plugin_daemon_classes.py
+++ b/src/omnibase_infra/validators/no_plugin_daemon_classes.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Block Plugin* classes from owning daemon, service, or worker lifecycles."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SCAN_ROOT = Path("src/omnibase_infra")
+LIFECYCLE_TERMS = frozenset(
+    (
+        "Daemon",
+        "Service",
+        "Worker",
+        "Runtime",
+        "Consumer",
+        "Publisher",
+        "Controller",
+        "Server",
+        "Client",
+    )
+)
+COMPUTE_PLUGIN_BASE = "PluginComputeBase"
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleClassFinding:
+    """A banned Plugin* lifecycle class found in source."""
+
+    path: Path
+    line: int
+    column: int
+    class_name: str
+    bases: tuple[str, ...]
+    reason: str
+
+    def format(self) -> str:
+        bases = ", ".join(self.bases) if self.bases else "<no bases>"
+        return (
+            f"{self.path}:{self.line}:{self.column + 1}: {self.class_name} "
+            f"uses Plugin* lifecycle ownership ({self.reason}); bases: {bases}"
+        )
+
+
+def validate_paths(paths: Sequence[Path]) -> list[LifecycleClassFinding]:
+    """Validate Python files under the provided paths."""
+    findings: list[LifecycleClassFinding] = []
+    for path in _iter_python_files(paths):
+        findings.extend(validate_file(path))
+    return findings
+
+
+def validate_file(path: Path) -> list[LifecycleClassFinding]:
+    """Validate one Python file for banned Plugin* lifecycle classes."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return [
+            LifecycleClassFinding(
+                path=path,
+                line=1,
+                column=0,
+                class_name="<parse-error>",
+                bases=(),
+                reason=f"could not decode as UTF-8: {exc}",
+            )
+        ]
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [
+            LifecycleClassFinding(
+                path=path,
+                line=exc.lineno or 1,
+                column=exc.offset or 0,
+                class_name="<syntax-error>",
+                bases=(),
+                reason=exc.msg,
+            )
+        ]
+
+    findings: list[LifecycleClassFinding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            finding = _validate_class(path, node)
+            if finding is not None:
+                findings.append(finding)
+    return findings
+
+
+def _validate_class(path: Path, node: ast.ClassDef) -> LifecycleClassFinding | None:
+    if not node.name.startswith("Plugin"):
+        return None
+
+    base_names = tuple(
+        name for base in node.bases if (name := _qualified_expr_name(base)) is not None
+    )
+    if _is_compute_base_definition(path, node):
+        return None
+    if _is_direct_compute_plugin(base_names):
+        return None
+
+    reason = _lifecycle_reason(node.name, base_names)
+    if reason is None:
+        return None
+
+    return LifecycleClassFinding(
+        path=path,
+        line=node.lineno,
+        column=node.col_offset,
+        class_name=node.name,
+        bases=base_names,
+        reason=reason,
+    )
+
+
+def _is_compute_base_definition(path: Path, node: ast.ClassDef) -> bool:
+    return node.name == COMPUTE_PLUGIN_BASE and path.name == "plugin_compute_base.py"
+
+
+def _is_direct_compute_plugin(base_names: Iterable[str]) -> bool:
+    return any(_simple_name(base) == COMPUTE_PLUGIN_BASE for base in base_names)
+
+
+def _lifecycle_reason(class_name: str, base_names: Sequence[str]) -> str | None:
+    class_term = _matching_lifecycle_term(class_name)
+    if class_term is not None:
+        return f"class name contains {class_term}"
+
+    for base in base_names:
+        base_term = _matching_lifecycle_term(base)
+        if base_term is not None:
+            return f"base class {base} contains {base_term}"
+    return None
+
+
+def _matching_lifecycle_term(value: str) -> str | None:
+    value_lower = value.lower()
+    for term in sorted(LIFECYCLE_TERMS):
+        if term.lower() in value_lower:
+            return term
+    return None
+
+
+def _qualified_expr_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _qualified_expr_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Subscript):
+        return _qualified_expr_name(node.value)
+    if isinstance(node, ast.Call):
+        return _qualified_expr_name(node.func)
+    return None
+
+
+def _simple_name(value: str) -> str:
+    return value.rsplit(".", maxsplit=1)[-1]
+
+
+def _iter_python_files(paths: Sequence[Path]) -> Iterator[Path]:
+    scan_paths = paths or (DEFAULT_SCAN_ROOT,)
+    for path in scan_paths:
+        if path.is_file() and path.suffix == ".py":
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob("*.py")
+                if "__pycache__" not in candidate.parts
+            )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Block Plugin* classes from owning daemon, service, worker, runtime, "
+            "consumer, publisher, server, controller, or client lifecycles."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SCAN_ROOT],
+        help="Python file or directory paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_paths(args.paths)
+    if not findings:
+        return 0
+
+    sys.stderr.write("Plugin lifecycle class guard failed:\n")
+    for finding in findings:
+        sys.stderr.write(f"  {finding.format()}\n")
+    sys.stderr.write(
+        "\nPlugin* classes may only represent deterministic compute plugins. "
+        "Put daemon, service, worker, runtime, publisher, consumer, client, "
+        "controller, or server lifecycles behind ONEX nodes/handlers instead.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/omnibase_infra/validators/no_plugin_daemon_classes.py
+++ b/src/omnibase_infra/validators/no_plugin_daemon_classes.py
@@ -125,7 +125,10 @@ def _is_compute_base_definition(path: Path, node: ast.ClassDef) -> bool:
 
 
 def _is_direct_compute_plugin(base_names: Iterable[str]) -> bool:
-    return any(_simple_name(base) == COMPUTE_PLUGIN_BASE for base in base_names)
+    names = tuple(base_names)
+    return bool(names) and all(
+        _simple_name(base) == COMPUTE_PLUGIN_BASE for base in names
+    )
 
 
 def _lifecycle_reason(class_name: str, base_names: Sequence[str]) -> str | None:

--- a/tests/integration/validators/test_no_plugin_daemon_classes_integration.py
+++ b/tests/integration/validators/test_no_plugin_daemon_classes_integration.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the Plugin* lifecycle class validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.validators.no_plugin_daemon_classes import main, validate_paths
+
+
+@pytest.mark.integration
+def test_validator_scans_tree_and_reports_nested_plugin_lifecycle_class(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    package_root = tmp_path / "src" / "omnibase_infra" / "fake_plugins"
+    package_root.mkdir(parents=True)
+    (package_root / "plugin_runtime.py").write_text(
+        """
+class RuntimeBase:
+    pass
+
+
+class PluginRuntimeBridge(RuntimeBase):
+    pass
+""",
+        encoding="utf-8",
+    )
+    (package_root / "plugin_compute.py").write_text(
+        """
+class PluginComputeBase:
+    pass
+
+
+class PluginRuntimeMetrics(PluginComputeBase):
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    findings = validate_paths([tmp_path / "src"])
+    exit_code = main([str(tmp_path / "src")])
+    captured = capsys.readouterr()
+
+    assert [finding.class_name for finding in findings] == ["PluginRuntimeBridge"]
+    assert exit_code == 1
+    assert "PluginRuntimeBridge" in captured.err

--- a/tests/unit/validators/test_no_plugin_daemon_classes.py
+++ b/tests/unit/validators/test_no_plugin_daemon_classes.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the Plugin* lifecycle class guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.validators.no_plugin_daemon_classes import main, validate_paths
+
+
+def test_flags_fake_plugin_daemon_class(tmp_path: Path) -> None:
+    source = tmp_path / "plugin_bad.py"
+    source.write_text(
+        """
+class DaemonBase:
+    pass
+
+
+class PluginXyzDaemon(DaemonBase):
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    findings = validate_paths([source])
+
+    assert len(findings) == 1
+    assert findings[0].class_name == "PluginXyzDaemon"
+    assert findings[0].bases == ("DaemonBase",)
+
+
+def test_allows_direct_plugin_compute_base_subclass(tmp_path: Path) -> None:
+    source = tmp_path / "plugin_compute.py"
+    source.write_text(
+        """
+from omnibase_infra.plugins import PluginComputeBase
+
+
+class PluginDataService(PluginComputeBase):
+    def execute(self, input_data, context):
+        return input_data
+""",
+        encoding="utf-8",
+    )
+
+    assert validate_paths([source]) == []
+
+
+def test_allows_non_plugin_service_classes(tmp_path: Path) -> None:
+    source = tmp_path / "service.py"
+    source.write_text(
+        """
+class ServiceEnvelopeSigner:
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    assert validate_paths([source]) == []
+
+
+def test_cli_returns_nonzero_for_banned_class(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "plugin_worker.py"
+    source.write_text(
+        """
+class WorkerBase:
+    pass
+
+
+class PluginBatchWorker(WorkerBase):
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    exit_code = main([str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "PluginBatchWorker" in captured.err

--- a/tests/unit/validators/test_no_plugin_daemon_classes.py
+++ b/tests/unit/validators/test_no_plugin_daemon_classes.py
@@ -49,6 +49,32 @@ class PluginDataService(PluginComputeBase):
     assert validate_paths([source]) == []
 
 
+def test_flags_compute_plugin_with_lifecycle_base(tmp_path: Path) -> None:
+    source = tmp_path / "plugin_mixed_base.py"
+    source.write_text(
+        """
+from omnibase_infra.plugins import PluginComputeBase
+
+
+class ServiceBase:
+    pass
+
+
+class PluginDataNormalizer(PluginComputeBase, ServiceBase):
+    def execute(self, input_data, context):
+        return input_data
+""",
+        encoding="utf-8",
+    )
+
+    findings = validate_paths([source])
+
+    assert len(findings) == 1
+    assert findings[0].class_name == "PluginDataNormalizer"
+    assert findings[0].bases == ("PluginComputeBase", "ServiceBase")
+    assert findings[0].reason == "base class ServiceBase contains Service"
+
+
 def test_allows_non_plugin_service_classes(tmp_path: Path) -> None:
     source = tmp_path / "service.py"
     source.write_text(


### PR DESCRIPTION
## Summary
- Adds `omnibase_infra.validators.no_plugin_daemon_classes`, an AST guard for banned `Plugin*` daemon/service/worker/runtime lifecycle classes.
- Wires the guard into pre-commit and the required CI lint job.
- Adds repo-local OMN-10123 contract evidence and focused unit tests, including fake `PluginXyzDaemon` detection.

## Verification
- `uv run pytest tests/unit/validators/test_no_plugin_daemon_classes.py -q` -> 4 passed
- `PYTHONPATH=src uv run python -m omnibase_infra.validators.no_plugin_daemon_classes src/omnibase_infra` -> pass
- `pre-commit run no-plugin-daemon-classes --all-files` -> pass
- `uv run validate-yaml contracts/OMN-10123.yaml` -> pass
- `uv run ruff check src/omnibase_infra/validators/no_plugin_daemon_classes.py tests/unit/validators/test_no_plugin_daemon_classes.py` -> pass
- `uv run ruff format --check src/omnibase_infra/validators/no_plugin_daemon_classes.py tests/unit/validators/test_no_plugin_daemon_classes.py` -> pass
- `uv run mypy src/omnibase_infra/validators/no_plugin_daemon_classes.py --show-error-codes --no-error-summary` -> pass
- Commit hook full pre-commit stack -> pass
- Pre-push hooks -> pass

## Evidence
- Companion root docs PR: OmniNode-ai/omni_home#129
- Central OCC evidence PR: OmniNode-ai/onex_change_control#632

## Worktree Cleanup
- Worktree retained while PR is open: `/Users/jonah/Code/omni_home/omni_worktrees/OMN-10123/omnibase_infra`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation guard to prevent Plugin classes from adopting daemon, service, worker, or runtime lifecycle patterns. Direct PluginComputeBase subclasses are exempted.

* **Chores**
  * Integrated the new validation into CI pipeline and pre-commit hooks for continuous enforcement.

* **Tests**
  * Added comprehensive test suite for the new validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->