### PR TITLE
feat(OMN-10388): project dispatch eval savings

### DIFF
--- a/contracts/OMN-10388.yaml
+++ b/contracts/OMN-10388.yaml
@@ -1,0 +1,63 @@
+# OMN-10388 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-10388"
+title: "Dispatch eval savings projection"
+summary: >-
+  Project dispatch evaluation outcomes into savings evidence with cost provenance and migration coverage.
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - events
+  - topics
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: Dispatch savings projection and migration tests pass
+    command: >-
+      uv run pytest tests/unit/services/observability/savings_estimation/test_consumer.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py -q
+  - kind: ci
+    description: Focused savings consumer type check passes
+    command: >-
+      uv run mypy src/omnibase_infra/services/observability/savings_estimation/consumer.py
+  - kind: ci
+    description: Focused ruff checks pass
+    command: >-
+      uv run ruff check src/omnibase_infra/services/observability/savings_estimation/consumer.py src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py
+  - kind: manual
+    description: Post-merge runtime deploy smoke verifies savings projection consumer
+    command: >-
+      after merge, deploy the runtime release candidate and verify the savings projection consumer can process a dispatch evaluation event without DLQ
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-dispatch-savings-tests
+    description: Dispatch savings projection and migration tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >-
+          uv run pytest tests/unit/services/observability/savings_estimation/test_consumer.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py -q
+  - id: dod-savings-consumer-mypy
+    description: Focused savings consumer type check passes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >-
+          uv run mypy src/omnibase_infra/services/observability/savings_estimation/consumer.py
+  - id: dod-focused-ruff
+    description: Focused ruff checks pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >-
+          uv run ruff check src/omnibase_infra/services/observability/savings_estimation/consumer.py src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py
+  - id: dod-post-merge-deploy-smoke
+    description: Post-merge runtime deploy smoke verifies savings projection consumer
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          after merge, deploy the runtime release candidate and verify the savings projection consumer can process a dispatch evaluation event without DLQ

--- a/docker/migrations/forward/076_add_savings_estimate_provenance.sql
+++ b/docker/migrations/forward/076_add_savings_estimate_provenance.sql
@@ -1,0 +1,55 @@
+-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Migration 076: add provenance columns for dispatch-derived savings estimates (OMN-10388).
+
+ALTER TABLE savings_estimates
+    ADD COLUMN IF NOT EXISTS usage_source TEXT NOT NULL DEFAULT 'UNKNOWN',
+    ADD COLUMN IF NOT EXISTS estimation_method TEXT,
+    ADD COLUMN IF NOT EXISTS source_payload_hash TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_savings_estimates_usage_source'
+    ) THEN
+        ALTER TABLE savings_estimates
+            ADD CONSTRAINT chk_savings_estimates_usage_source
+            CHECK (usage_source IN ('MEASURED', 'ESTIMATED', 'UNKNOWN'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_savings_estimates_estimation_method'
+    ) THEN
+        ALTER TABLE savings_estimates
+            ADD CONSTRAINT chk_savings_estimates_estimation_method
+            CHECK (
+                (usage_source = 'ESTIMATED' AND estimation_method IS NOT NULL)
+                OR usage_source <> 'ESTIMATED'
+            );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_savings_estimates_source_payload_hash'
+    ) THEN
+        ALTER TABLE savings_estimates
+            ADD CONSTRAINT chk_savings_estimates_source_payload_hash
+            CHECK (
+                (usage_source = 'MEASURED' AND source_payload_hash IS NOT NULL)
+                OR usage_source <> 'MEASURED'
+            );
+    END IF;
+END $$;
+
+COMMENT ON COLUMN savings_estimates.usage_source IS
+    'Cost provenance source for dispatch-derived savings estimates. OMN-10388.';
+COMMENT ON COLUMN savings_estimates.estimation_method IS
+    'Estimator identifier when savings are derived from estimated dispatch usage. OMN-10388.';
+COMMENT ON COLUMN savings_estimates.source_payload_hash IS
+    'Stable source payload hash when savings are derived from measured dispatch usage. OMN-10388.';

--- a/docker/migrations/rollback/rollback_076_add_savings_estimate_provenance.sql
+++ b/docker/migrations/rollback/rollback_076_add_savings_estimate_provenance.sql
@@ -1,0 +1,14 @@
+-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Rollback migration 076: remove savings_estimates provenance columns.
+
+ALTER TABLE savings_estimates
+    DROP CONSTRAINT IF EXISTS chk_savings_estimates_source_payload_hash,
+    DROP CONSTRAINT IF EXISTS chk_savings_estimates_estimation_method,
+    DROP CONSTRAINT IF EXISTS chk_savings_estimates_usage_source;
+
+ALTER TABLE savings_estimates
+    DROP COLUMN IF EXISTS source_payload_hash,
+    DROP COLUMN IF EXISTS estimation_method,
+    DROP COLUMN IF EXISTS usage_source;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:16d89127c16624fcae46f8504d72835f3805a24ef380303f924c07e8d9525eb0
-generated_at: 2026-05-01T22:34:11Z
-migration_file_count: 62
+sha256:c573b449b412b6b9d62c875664dd88e8b4c76673faf19c21374084ec041f2699
+generated_at: 2026-05-02T00:36:33Z
+migration_file_count: 63

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py
@@ -55,6 +55,8 @@ class ModelSavingsEstimate(BaseModel):
         heuristic_confidence_avg: Average confidence across heuristic estimates.
         estimation_method: Algorithm identifier.
         treatment_group: A/B test group if applicable.
+        usage_source: Dispatch/cost provenance source when available.
+        source_payload_hash: Stable source payload hash for measured dispatch costs.
         is_measured: Whether savings are directly measured vs estimated.
         completeness_status: Data completeness ('complete', 'partial').
         pricing_manifest_version: Pricing table version used.
@@ -120,6 +122,14 @@ class ModelSavingsEstimate(BaseModel):
         default="tiered_attribution_v1", description="Estimation algorithm"
     )
     treatment_group: str | None = Field(default=None, description="A/B test group")
+    usage_source: str = Field(
+        default="UNKNOWN",
+        description="Cost provenance source: MEASURED, ESTIMATED, or UNKNOWN.",
+    )
+    source_payload_hash: str | None = Field(
+        default=None,
+        description="Stable source payload hash for measured dispatch costs.",
+    )
     is_measured: bool = Field(default=False, description="True if directly measured")
     completeness_status: str = Field(
         default="complete", description="Data completeness"

--- a/src/omnibase_infra/services/observability/savings_estimation/consumer.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/consumer.py
@@ -151,6 +151,24 @@ class ValidatorCatchSignal:
 
 
 @dataclass
+class DispatchEvalSignal:
+    """Raw dispatch evaluation signal for task-level savings projection."""
+
+    task_id: str
+    dispatch_id: str
+    ticket_id: str | None = None
+    verdict: str = ""
+    quality_score: float | None = None
+    token_cost: int = 0
+    dollars_cost: float = 0.0
+    usage_source: str = "UNKNOWN"
+    estimation_method: str | None = None
+    source_payload_hash: str | None = None
+    model_local: str | None = None
+    model_cloud_baseline: str | None = None
+
+
+@dataclass
 class SessionBuffer:
     """Accumulates signals for a single session."""
 
@@ -159,6 +177,7 @@ class SessionBuffer:
     llm_calls: list[LlmCallSignal] = field(default_factory=list)
     injection_signals: list[InjectionSignal] = field(default_factory=list)
     validator_catches: list[ValidatorCatchSignal] = field(default_factory=list)
+    dispatch_evals: list[DispatchEvalSignal] = field(default_factory=list)
     treatment_group: str = "treatment"
     outcome_received: bool = False
     outcome_received_at: float = 0.0
@@ -185,6 +204,66 @@ def _classify_severity(raw: str) -> EnumCatchSeverity:
     if lower in ("major", "warning", "warn"):
         return EnumCatchSeverity.MAJOR
     return EnumCatchSeverity.MINOR
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    """Coerce wire payload numeric values without raising on missing fields."""
+    if value is None:
+        return default
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: object, default: float = 0.0) -> float:
+    """Coerce wire payload numeric values without raising on missing fields."""
+    if value is None:
+        return default
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_optional_str(value: object) -> str | None:
+    """Return a non-empty string or None for absent wire fields."""
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _coerce_quality_score(value: object) -> float | None:
+    """Return a bounded dispatch quality score when present."""
+    if value is None:
+        return None
+    score = _coerce_float(value, default=-1.0)
+    if 0.0 <= score <= 1.0:
+        return score
+    return None
+
+
+def _first_model_call_model(payload: dict[str, object]) -> str | None:
+    """Extract the first model call's model name from a dispatch payload."""
+    model_calls = payload.get("model_calls")
+    if not isinstance(model_calls, list) or not model_calls:
+        return None
+    first_call = model_calls[0]
+    if not isinstance(first_call, dict):
+        return None
+    model = str(first_call.get("model", ""))
+    return model or None
+
+
+def _session_id_for_topic(topic: str, payload: dict[str, object]) -> str:
+    """Resolve the correlation key for session and dispatch feeds."""
+    session_id = _coerce_optional_str(payload.get("session_id"))
+    if session_id:
+        return session_id
+    if "dispatch-outcome-evaluated" in topic:
+        return _coerce_optional_str(payload.get("task_id")) or ""
+    return ""
 
 
 def _compute_validator_catch_savings(
@@ -315,7 +394,66 @@ def _build_effectiveness_entries(
             )
         )
 
+    for dispatch_sig in buf.dispatch_evals:
+        if dispatch_sig.token_cost <= 0 or dispatch_sig.verdict.upper() != "PASS":
+            continue
+        utilization = (
+            dispatch_sig.quality_score
+            if dispatch_sig.quality_score is not None
+            else 0.5
+        )
+        entries.append(
+            ModelEffectivenessEntry(
+                utilization_score=round(utilization, 4),
+                patterns_count=0,
+                tokens_saved=dispatch_sig.token_cost,
+                model_tier=_model_tier_from_id(
+                    dispatch_sig.model_cloud_baseline or "claude-opus-4-6"
+                ),
+                is_output_tokens=False,
+            )
+        )
+
     return tuple(entries)
+
+
+def _ingest_dispatch_eval(buf: SessionBuffer, payload: dict[str, object]) -> None:
+    """Accumulate an idempotent dispatch-eval signal in a session buffer."""
+    task_id = str(payload.get("task_id", ""))
+    dispatch_id = str(payload.get("dispatch_id", ""))
+    if not task_id or not dispatch_id:
+        return
+
+    model_local = _coerce_optional_str(
+        payload.get("model_local")
+    ) or _first_model_call_model(payload)
+    model_cloud_baseline = _coerce_optional_str(payload.get("model_cloud_baseline"))
+    usage_source = str(payload.get("usage_source", "UNKNOWN")).upper()
+    if usage_source not in {"MEASURED", "ESTIMATED", "UNKNOWN"}:
+        usage_source = "UNKNOWN"
+
+    signal = DispatchEvalSignal(
+        task_id=task_id,
+        dispatch_id=dispatch_id,
+        ticket_id=_coerce_optional_str(payload.get("ticket_id")),
+        verdict=str(payload.get("verdict", "")).upper(),
+        quality_score=_coerce_quality_score(payload.get("quality_score")),
+        token_cost=_coerce_int(payload.get("token_cost")),
+        dollars_cost=_coerce_float(payload.get("dollars_cost")),
+        usage_source=usage_source,
+        estimation_method=_coerce_optional_str(payload.get("estimation_method")),
+        source_payload_hash=_coerce_optional_str(payload.get("source_payload_hash")),
+        model_local=model_local,
+        model_cloud_baseline=model_cloud_baseline,
+    )
+    for index, existing in enumerate(buf.dispatch_evals):
+        if existing.task_id == task_id and existing.dispatch_id == dispatch_id:
+            buf.dispatch_evals[index] = signal
+            break
+    else:
+        buf.dispatch_evals.append(signal)
+    buf.outcome_received = True
+    buf.outcome_received_at = time.monotonic()
 
 
 class ServiceSavingsEstimator:
@@ -348,7 +486,7 @@ class ServiceSavingsEstimator:
 
     def ingest_event(self, topic: str, payload: dict[str, object]) -> None:
         """Ingest a consumed event into the correlation buffer."""
-        session_id = str(payload.get("session_id", ""))
+        session_id = _session_id_for_topic(topic, payload)
         if not session_id:
             return
 
@@ -359,6 +497,8 @@ class ServiceSavingsEstimator:
 
         if "llm-call-completed" in topic:
             self._ingest_llm_call(buf, payload)
+        elif "dispatch-outcome-evaluated" in topic:
+            _ingest_dispatch_eval(buf, payload)
         elif "session-outcome" in topic:
             self._ingest_session_outcome(buf, payload)
         elif "hook-context-injected" in topic:
@@ -464,11 +604,16 @@ class ServiceSavingsEstimator:
         actual_total_tokens = sum(
             c.prompt_tokens + c.completion_tokens for c in buf.llm_calls
         )
+        dispatch_total_tokens = sum(sig.token_cost for sig in buf.dispatch_evals)
+        if actual_total_tokens == 0:
+            actual_total_tokens = dispatch_total_tokens
 
         # Determine model ID from LLM calls
         actual_model_id = "claude-opus-4-6"
         if buf.llm_calls:
             actual_model_id = buf.llm_calls[0].model_id
+        elif buf.dispatch_evals and buf.dispatch_evals[0].model_local:
+            actual_model_id = buf.dispatch_evals[0].model_local
 
         # Pass the session's correlation_id through to the estimate so it
         # appears in the Kafka payload.  The omnidash projection handler uses
@@ -495,6 +640,8 @@ class ServiceSavingsEstimator:
 
             # --- Counterfactual model ---
             counterfactual = _resolve_counterfactual(actual_model_id)
+            if buf.dispatch_evals and buf.dispatch_evals[0].model_cloud_baseline:
+                counterfactual = buf.dispatch_evals[0].model_cloud_baseline
             result["counterfactual_model_id"] = counterfactual
 
             # --- Heuristic savings from validator catches (Task 3) ---
@@ -539,6 +686,26 @@ class ServiceSavingsEstimator:
             # savings_estimates table for A/B analysis.
             if buf.treatment_group:
                 result["treatment_group"] = buf.treatment_group
+
+            if buf.dispatch_evals:
+                first_dispatch = buf.dispatch_evals[0]
+                result["task_id"] = first_dispatch.task_id
+                result["dispatch_id"] = first_dispatch.dispatch_id
+                result["ticket_id"] = first_dispatch.ticket_id
+                result["usage_source"] = first_dispatch.usage_source
+                result["estimation_method"] = (
+                    first_dispatch.estimation_method or "dispatch_eval_projection_v1"
+                )
+                result["source_payload_hash"] = first_dispatch.source_payload_hash
+                result["model_local"] = first_dispatch.model_local or actual_model_id
+                result["model_cloud_baseline"] = counterfactual
+                result["local_cost_usd"] = first_dispatch.dollars_cost
+                result["cloud_cost_usd"] = round(
+                    first_dispatch.dollars_cost
+                    + float(result.get("estimated_total_savings_usd", 0.0)),
+                    10,
+                )
+                result["savings_usd"] = result["estimated_total_savings_usd"]
             return result
         except Exception:
             logger.exception(

--- a/tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py
+++ b/tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dispatch-eval projection coverage for savings estimation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.services.observability.savings_estimation.config import (
+    ConfigSavingsEstimation,
+)
+from omnibase_infra.services.observability.savings_estimation.consumer import (
+    ServiceSavingsEstimator,
+)
+
+TOPIC_DISPATCH_OUTCOME = "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"
+
+
+def _service() -> ServiceSavingsEstimator:
+    return ServiceSavingsEstimator(
+        ConfigSavingsEstimation(
+            kafka_bootstrap_servers="localhost:19092",
+            grace_window_seconds=1.0,
+            session_timeout_seconds=3600.0,
+            max_sessions=100,
+            finalized_session_cache_size=1000,
+            schema_version="1.0",
+        )
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dispatch_eval_pass_projects_single_savings_estimate() -> None:
+    service = _service()
+
+    with patch("time.monotonic", return_value=1000.0):
+        service.ingest_event(
+            TOPIC_DISPATCH_OUTCOME,
+            {
+                "task_id": "t1",
+                "dispatch_id": "d1",
+                "ticket_id": "OMN-10388",
+                "verdict": "pass",
+                "quality_score": 0.85,
+                "token_cost": 12_500,
+                "dollars_cost": 0.031,
+                "usage_source": "measured",
+                "estimation_method": None,
+                "source_payload_hash": "a" * 64,
+                "model_local": "claude-sonnet-4",
+                "model_cloud_baseline": "claude-opus-4-6",
+                "model_calls": [
+                    {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4",
+                        "input_tokens": 10_000,
+                        "output_tokens": 2_500,
+                        "latency_ms": 750,
+                        "cost_dollars": 0.031,
+                    }
+                ],
+            },
+        )
+
+    with patch("time.monotonic", return_value=1002.0):
+        results = await service.finalize_ready_sessions()
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["session_id"] == "t1"
+    assert row["task_id"] == "t1"
+    assert row["dispatch_id"] == "d1"
+    assert row["ticket_id"] == "OMN-10388"
+    assert row["model_local"] == "claude-sonnet-4"
+    assert row["model_cloud_baseline"] == "claude-opus-4-6"
+    assert row["usage_source"] == "MEASURED"
+    assert row["source_payload_hash"] == "a" * 64
+    assert row["savings_usd"] > 0
+    assert row["estimated_total_savings_usd"] == row["savings_usd"]
+    assert row["local_cost_usd"] == 0.031
+    assert row["cloud_cost_usd"] == pytest.approx(0.031 + row["savings_usd"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dispatch_eval_replay_finalizes_once_for_dedupe_key() -> None:
+    service = _service()
+    payload = {
+        "task_id": "t1",
+        "dispatch_id": "d1",
+        "verdict": "PASS",
+        "quality_score": 0.85,
+        "token_cost": 12_500,
+        "dollars_cost": 0.031,
+        "usage_source": "MEASURED",
+        "source_payload_hash": "a" * 64,
+    }
+
+    with patch("time.monotonic", return_value=1000.0):
+        service.ingest_event(TOPIC_DISPATCH_OUTCOME, payload)
+        service.ingest_event(TOPIC_DISPATCH_OUTCOME, payload)
+
+    with patch("time.monotonic", return_value=1002.0):
+        results = await service.finalize_ready_sessions()
+
+    assert len(results) == 1
+    assert results[0]["session_id"] == "t1"
+    assert results[0]["direct_tokens_saved"] == 12_500

--- a/tests/unit/db/test_migration_076.py
+++ b/tests/unit/db/test_migration_076.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit checks for migration 076 savings_estimates provenance columns."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FORWARD = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "076_add_savings_estimate_provenance.sql"
+)
+ROLLBACK = (
+    REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "rollback"
+    / "rollback_076_add_savings_estimate_provenance.sql"
+)
+
+
+def test_076_forward_adds_provenance_columns_and_constraints() -> None:
+    sql = FORWARD.read_text(encoding="utf-8").lower()
+
+    assert "alter table savings_estimates" in sql
+    assert (
+        "add column if not exists usage_source text not null default 'unknown'" in sql
+    )
+    assert "add column if not exists estimation_method text" in sql
+    assert "add column if not exists source_payload_hash text" in sql
+    assert "chk_savings_estimates_usage_source" in sql
+    assert "measured" in sql
+    assert "estimated" in sql
+    assert "unknown" in sql
+
+
+def test_076_rollback_removes_provenance_columns_and_constraints() -> None:
+    sql = ROLLBACK.read_text(encoding="utf-8").lower()
+
+    assert "drop constraint if exists chk_savings_estimates_usage_source" in sql
+    assert "drop column if exists usage_source" in sql
+    assert "drop column if exists estimation_method" in sql
+    assert "drop column if exists source_payload_hash" in sql


### PR DESCRIPTION
## Summary
- consume dispatch-outcome-evaluated events in the savings estimator correlation buffer
- project PASS dispatch evals into savings estimates with provenance, model_local, and model_cloud_baseline fields
- add migration 076 for savings_estimates provenance columns plus focused projection and migration tests

## Verification
- uv run ruff check src/omnibase_infra/services/observability/savings_estimation/consumer.py src/omnibase_infra/nodes/node_savings_estimation_compute/models/model_savings_estimate.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py
- uv run mypy src/omnibase_infra/services/observability/savings_estimation/consumer.py
- uv run pytest tests/unit/services/observability/savings_estimation/test_consumer.py tests/integration/observability/test_savings_estimation_dispatch_eval_projection.py tests/unit/db/test_migration_076.py -q
- pre-commit hooks during commit
- pre-push hooks during push

## OCC Evidence
- Central OMN-10388 receipt PR will follow with PASS receipts for this PR and the paired omniintelligence PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced savings estimation with provenance tracking, capturing sources and methods of usage data to improve cost visibility and auditability across operations.
  * Integrated dispatch evaluation results to refine cost estimates, now incorporating actual task execution data for more accurate cost comparisons and model performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->