### PR TITLE
fix(OMN-8131): add group_id to savings estimator Kafka subscriptions

### DIFF
--- a/contracts/OMN-8131.yaml
+++ b/contracts/OMN-8131.yaml
@@ -1,5 +1,6 @@
 schema_version: "1.0.0"
 ticket_id: "OMN-8131"
+title: "Fix savings estimator Kafka subscriptions"
 summary: "Fix savings estimator Kafka subscriptions"
 is_seam_ticket: false
 interface_change: false

--- a/contracts/OMN-8131.yaml
+++ b/contracts/OMN-8131.yaml
@@ -1,0 +1,23 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-8131"
+summary: "Fix savings estimator Kafka subscriptions"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Runtime service kernel passes an explicit savings estimator consumer group"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/runtime/test_savings_estimator_subscription_group.py -q"
+  - id: "dod-deploy"
+    description: "Post-merge deploy smoke verifies savings estimator Kafka consumption"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omnibase_infra after merge, then rpk topic produce onex.evt.omniclaude.session-outcome.v1 with a synthetic session and verify onex.evt.omnibase-infra.savings-estimated.v1 receives the savings estimate"

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1450,6 +1450,7 @@ async def bootstrap() -> int:
                             logger.warning(
                                 "Could not subscribe to %s for savings estimation",
                                 _input_topic,
+                                exc_info=True,
                             )
 
                     while True:

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1444,9 +1444,10 @@ async def bootstrap() -> int:
                             await event_bus.subscribe(
                                 _input_topic,
                                 on_message=_savings_on_message,  # type: ignore[arg-type]
+                                group_id=f"savings-estimator.{_input_topic}",
                             )
                         except Exception:  # noqa: BLE001
-                            logger.debug(
+                            logger.warning(
                                 "Could not subscribe to %s for savings estimation",
                                 _input_topic,
                             )

--- a/tests/integration/runtime/test_savings_estimator_subscription_group.py
+++ b/tests/integration/runtime/test_savings_estimator_subscription_group.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration guard for savings estimator runtime subscriptions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SERVICE_KERNEL_PATH = Path("src/omnibase_infra/runtime/service_kernel.py")
+
+
+def _load_service_kernel_ast() -> ast.Module:
+    return ast.parse(SERVICE_KERNEL_PATH.read_text(encoding="utf-8"))
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+@pytest.mark.integration
+def test_savings_estimator_subscribe_calls_include_group_id() -> None:
+    """Savings estimator subscriptions must be consumer-group owned."""
+    tree = _load_service_kernel_ast()
+    subscribe_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _call_name(node.func) == "subscribe"
+    ]
+
+    savings_subscribe_calls = [
+        node
+        for node in subscribe_calls
+        if any(
+            keyword.arg == "group_id"
+            and isinstance(keyword.value, ast.JoinedStr)
+            and any(
+                isinstance(part, ast.Constant) and part.value == "savings-estimator."
+                for part in keyword.value.values
+            )
+            for keyword in node.keywords
+        )
+    ]
+
+    assert len(savings_subscribe_calls) == 1
+
+
+@pytest.mark.integration
+def test_savings_estimator_subscription_failures_are_warning_logged() -> None:
+    """Subscription failures should be visible in runtime logs."""
+    tree = _load_service_kernel_ast()
+    warning_messages = [
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "warning"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ]
+
+    assert "Could not subscribe to %s for savings estimation" in warning_messages


### PR DESCRIPTION
## Summary
- Adds `group_id` parameter to savings estimator `event_bus.subscribe()` calls in `service_kernel.py`
- Elevates subscription failure logging from debug to warning

## Root Cause
`event_bus.subscribe()` requires either `node_identity` or `group_id`. Neither was passed, causing `ValueError` silently swallowed by `except Exception: logger.debug(...)`. Consumer appeared to start but never received messages.

## Test plan
- [x] Unit tests pass (178 passed, 1 skipped)
- [x] Pre-commit clean (all hooks passed)
- [ ] After deploy: re-emit synthetic session-outcome event and verify savings-estimate.v1 is produced within 30s

OMN-8131

Evidence-Source: OCC#671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka subscription configuration in the savings estimator service for enhanced reliability.
  * Enhanced logging visibility for subscription failures.

* **Tests**
  * Added integration tests validating Kafka subscription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Evidence-Ticket: OMN-8131