### PR TITLE
fix(OMN-10445): standardize runner fleet health config

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Set to "true" to skip the uv sync step (useful for multi-repo setups that install manually)'
     required: false
     default: 'false'
+  cache-enabled:
+    description: 'Set to "false" to skip uv cache restore/save for short timeout-sensitive jobs'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -46,6 +50,7 @@ runs:
       with:
         version: ${{ inputs.uv-version }}
     - name: Load cached uv
+      if: inputs.cache-enabled != 'false'
       uses: actions/cache@v4
       with:
         path: ~/.cache/uv

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -53,6 +53,7 @@ jobs:
           pip install --quiet confluent-kafka pydantic click
 
       - name: Publish PR webhook event
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         # All potentially attacker-controlled inputs (head_ref, actor) are passed
         # through environment variables, not interpolated directly into the run
         # command, to prevent shell injection.

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -24,7 +24,13 @@ on:
 jobs:
   publish-pr-webhook:
     name: Publish PR Webhook Event
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,7 +36,13 @@ permissions:
 jobs:
   auto-merge:
     name: Enable Auto-Merge
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Resolve PR and author
         id: resolve

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,7 +40,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,7 +40,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -3,19 +3,11 @@
 #
 # baselines-scheduler.yml — Daily Baselines & ROI computation
 #
-# Invokes NodeBaselinesBatchCompute once per day. Runs on the self-hosted
-# runner when USE_SELF_HOSTED_RUNNERS=true (has local PostgreSQL + Kafka).
-# Falls back to ubuntu-latest when no self-hosted runner is available,
-# connecting to cloud PostgreSQL via the OMNIBASE_INFRA_DB_URL secret
-# (Kafka emission is skipped on ubuntu-latest; DB computation still runs).
+# Invokes NodeBaselinesBatchCompute once per day on the trusted runner selector.
 #
 # Requirements (self-hosted runner environment):
 #   OMNIBASE_INFRA_DB_URL  — set in ~/.omnibase/.env (runner picks up via env)
 #   KAFKA_BOOTSTRAP_SERVERS — defaults to localhost:19092 in the script
-#
-# Requirements (ubuntu-latest fallback):
-#   OMNIBASE_INFRA_DB_URL  — GitHub secret pointing to cloud PostgreSQL
-#   KAFKA_BOOTSTRAP_SERVERS — set to empty (no Kafka on ubuntu-latest)
 #
 # Ticket: OMN-3335
 
@@ -39,19 +31,14 @@ env:
 jobs:
   baselines-compute:
     name: Baselines Batch Compute
-    # Self-hosted runner required: needs PostgreSQL and Kafka access.
-    # When USE_SELF_HOSTED_RUNNERS is false, skip entirely — ubuntu-latest
-    # has no PostgreSQL and the OMNIBASE_INFRA_DB_URL secret is not configured.
-    if: vars.USE_SELF_HOSTED_RUNNERS == 'true'
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # Trusted runner required: needs PostgreSQL and Kafka access.
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -76,16 +63,13 @@ jobs:
 
       - name: Run baselines batch compute
         env:
-          # Self-hosted runner: OMNIBASE_INFRA_DB_URL comes from ~/.omnibase/.env
-          # ubuntu-latest fallback: OMNIBASE_INFRA_DB_URL comes from the GitHub secret
-          # The secret value takes precedence only when ~/.omnibase/.env is absent.
+          # Trusted runner: OMNIBASE_INFRA_DB_URL comes from ~/.omnibase/.env.
           OMNIBASE_INFRA_DB_URL: ${{ secrets.OMNIBASE_INFRA_DB_URL }}
-          # Self-hosted: Kafka on localhost:19092. ubuntu-latest: no Kafka, skip emission.
           KAFKA_BOOTSTRAP_SERVERS: >-
             ${{
               github.event.inputs.dry_run == 'true'
               && ''
-              || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'localhost:19092' || '')
+              || 'localhost:19092'
             }}
         run: |
           # On self-hosted runner, shell env from ~/.omnibase/.env overrides the secret.

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -30,7 +30,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -30,7 +30,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -26,7 +26,13 @@ on:
 jobs:
   audit:
     name: Audit Branch Protection
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 15
 
     permissions:

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -44,7 +44,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -44,7 +44,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -40,7 +40,13 @@ env:
 jobs:
   build-and-push:
     name: Build and push migration image
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -53,7 +53,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Timeout breakdown (cold cache worst case):

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -53,7 +53,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Timeout breakdown (cold cache worst case):

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -48,12 +48,13 @@ env:
 jobs:
   build-and-push:
     name: Build and push runtime image
-    # OMNINODE_SELF_HOSTED_DOCKER_V1 — always self-hosted when enabled; kill-switch fallback to ubuntu-latest
+    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker jobs default to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true')
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Timeout breakdown (cold cache worst case):
     #   Docker build:        ~30 min (protobuf upgrade + cold cache adds ~16 min vs baseline)

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -16,7 +16,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -11,15 +11,13 @@ on:
 jobs:
   check-handshake:
     name: Check architecture handshake
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -16,7 +16,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -25,7 +25,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10

--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -25,7 +25,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10

--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -21,7 +21,13 @@ env:
 jobs:
   sibling-compat:
     name: Sibling Compat Check (OMN-4315)
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -91,7 +91,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -162,7 +162,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -193,7 +193,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -225,7 +225,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -248,7 +248,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -280,7 +280,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -323,7 +323,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -394,7 +394,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -475,7 +475,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
@@ -506,7 +506,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -537,7 +537,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -568,7 +568,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -613,7 +613,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
@@ -646,7 +646,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
@@ -711,7 +711,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -772,7 +772,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -833,7 +833,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: test-parallel
@@ -861,7 +861,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     continue-on-error: true
@@ -878,7 +878,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
@@ -918,7 +918,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, migration-integration, migration-required-check, version-pin-check, compliance, contract-sync-gate]
@@ -1007,7 +1007,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -1082,7 +1082,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -1109,7 +1109,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -1177,7 +1177,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   lint:
     name: Lint
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -86,7 +86,7 @@ jobs:
   # ONEX validation - Infrastructure-specific validators
   onex-validation:
     name: ONEX Validators
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -157,7 +157,7 @@ jobs:
   # Prevents stale fingerprint artifacts from being merged (OMN-2149)
   fingerprint-check:
     name: Fingerprint Check
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -188,7 +188,7 @@ jobs:
   # Runs in CI mode (skips live infra checks) as pre-deploy validation
   demo-loop-gate:
     name: Demo Loop Gate
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -220,7 +220,7 @@ jobs:
   # Part of DB-per-repo refactor (OMN-2055), tracking: OMN-2071
   migration-freeze:
     name: Migration Freeze Check
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -243,7 +243,7 @@ jobs:
   # Ensures generated enum files stay in sync with contract.yaml definitions
   topic-enum-drift:
     name: Topic Enum Drift Check
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -275,7 +275,7 @@ jobs:
   # Validates onex.{kind}.{producer}.{event}.v{n} format in all contract.yaml files
   topic-naming-lint:
     name: Topic Naming Lint
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -318,7 +318,7 @@ jobs:
   # Cross-repo scanning (OMN-5258): checks out sibling repos to resolve topic references.
   topic-drift-check:
     name: Topic Drift Check
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -389,7 +389,7 @@ jobs:
   # Requires sibling repos omniintelligence + omnimemory to be checked out.
   schema-handshake:
     name: Kafka Schema Handshake (OMN-3411)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -470,7 +470,7 @@ jobs:
   # topic definition files. Pre-existing violations are suppressed via baseline.
   arch-invariants:
     name: Arch Invariants (OMN-3343)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -501,7 +501,7 @@ jobs:
 
   plugin-env-service-completeness:
     name: "Plugin ENV->Service Completeness (OMN-4313)"
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -532,7 +532,7 @@ jobs:
 
   compose-required-env-coverage:
     name: "Compose Required-Env Coverage (OMN-5439)"
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -641,7 +641,7 @@ jobs:
   test-parallel:
     name: Tests (Split ${{ matrix.split }}/15)
     needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, plugin-env-service-completeness, compose-required-env-coverage, contract-path-preflight, contract-compliance, contract-sync-gate]
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -706,7 +706,7 @@ jobs:
   # Depends on OMN-4803 (check_version_pins.py must exist in omni_home main).
   version-pin-check:
     name: Version Pin Compliance
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -767,7 +767,7 @@ jobs:
   # ============================================================================
   compliance:
     name: Contract Compliance
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -828,7 +828,7 @@ jobs:
   # ============================================================================
   tests-gate:
     name: CI Tests Gate
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -913,7 +913,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -1002,7 +1002,7 @@ jobs:
   # upstream fix (e.g. OMN-3248) lands, at which point xfail is removed.
   kafka-boundary-compat:
     name: Kafka Boundary Compat (OMN-3256)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -1172,7 +1172,7 @@ jobs:
 
   ai-slop-check:
     name: AI-Slop Pattern Check (strict, PR diff)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
         (github.event_name == 'pull_request' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check ruff formatting
         run: uv run ruff format --check src/ tests/
@@ -106,6 +107,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Run architecture layer check
         run: |
@@ -209,6 +211,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Run demo loop assertion gate
         run: |
@@ -264,6 +267,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check topic enum drift
         run: |
@@ -365,6 +369,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           cache-key-prefix: uv-topic-drift
           lock-file-path: 'omnibase_infra/**/uv.lock'
           skip-install: 'true'
@@ -437,6 +442,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           cache-key-prefix: uv-handshake
           lock-file-path: 'omnibase_infra/**/uv.lock'
           skip-install: 'true'
@@ -494,6 +500,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check for raw topic literals in production code
         run: |
@@ -525,6 +532,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Plugin ENV->Service Completeness Check
         run: |
@@ -556,6 +564,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check compose :? env var fixture coverage
         run: |
@@ -671,6 +680,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Run test split ${{ matrix.split }}/15
         run: |
@@ -742,6 +752,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check version pin compliance
         run: |
@@ -791,6 +802,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Install dependencies
         run: uv sync
@@ -1107,6 +1119,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
       - name: Check writer-migration coupling
@@ -1147,6 +1160,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
       - name: Verify Python Postgres client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,18 +1145,59 @@ jobs:
           cache-version: ${{ env.CACHE_VERSION }}
           install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
+      - name: Resolve Postgres service host
+        id: postgres_host
+        env:
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          import socket
+
+          port = int(os.environ["POSTGRES_PORT"])
+
+          def can_connect(host: str) -> bool:
+              try:
+                  with socket.create_connection((host, port), timeout=1.0):
+                      return True
+              except OSError:
+                  return False
+
+          if can_connect("127.0.0.1"):
+              print("host=127.0.0.1")
+              raise SystemExit(0)
+
+          with open("/proc/net/route", encoding="utf-8") as routes:
+              for line in routes.readlines()[1:]:
+                  fields = line.split()
+                  if len(fields) >= 3 and fields[1] == "00000000":
+                      gateway_hex = fields[2]
+                      gateway = ".".join(
+                          str(int(gateway_hex[i : i + 2], 16))
+                          for i in (6, 4, 2, 0)
+                      )
+                      if can_connect(gateway):
+                          print(f"host={gateway}")
+                          raise SystemExit(0)
+
+          raise SystemExit(
+              f"could not reach Postgres service on localhost or default gateway port {port}"
+          )
+          PY
+
       - name: Apply all migrations
         env:
-          OMNIBASE_INFRA_DB_URL: postgresql://postgres:test_password@localhost:${{ job.services.postgres.ports[5432] }}/omnibase_infra
+          OMNIBASE_INFRA_DB_URL: postgresql://postgres:test_password@${{ steps.postgres_host.outputs.host }}:${{ job.services.postgres.ports['5432'] }}/omnibase_infra
         run: |
           uv run python scripts/run-migrations.py
 
       - name: Assert manifest tables exist
         env:
+          POSTGRES_HOST: ${{ steps.postgres_host.outputs.host }}
           PGPASSWORD: test_password
-          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          psql -h localhost -p "$POSTGRES_PORT" -U postgres -d omnibase_infra -c "
+          psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U postgres -d omnibase_infra -c "
             SELECT table_name
             FROM information_schema.tables
             WHERE table_schema = 'public'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1068,6 +1068,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           cache-key-prefix: uv-boundary
           lock-file-path: 'omnibase_infra/**/uv.lock'
           skip-install: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -91,12 +89,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -164,12 +160,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -197,12 +191,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -231,12 +223,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -256,12 +246,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -290,12 +278,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -335,12 +321,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -408,12 +392,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -491,12 +473,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -524,12 +504,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -557,12 +535,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -588,7 +564,13 @@ jobs:
   # Contract path pre-flight: verify all referenced module paths exist before expensive test splits (F8/OMN-6478)
   contract-path-preflight:
     name: Contract Path Pre-Flight
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - uses: actions/checkout@v6
 
@@ -627,7 +609,13 @@ jobs:
 
   contract-sync-gate:
     name: Contract Sync Gate (Wave C) [OMN-8915]
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v6
@@ -656,12 +644,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
     strategy:
@@ -723,12 +709,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -786,12 +770,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -849,12 +831,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: test-parallel
     if: always()
@@ -877,7 +857,13 @@ jobs:
 
   migration-conflict-check:
     name: Cross-Repo Migration Conflicts
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     continue-on-error: true
     steps:
       - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@main
@@ -888,7 +874,13 @@ jobs:
 
   contract-compliance:
     name: Contract Compliance Check
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
@@ -924,12 +916,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, migration-integration, migration-required-check, version-pin-check, compliance, contract-sync-gate]
     if: always()
@@ -1015,12 +1005,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -1090,7 +1078,13 @@ jobs:
   # or handler_*_postgres.py includes a migration file or explicit bypass comment (OMN-3530)
   migration-required-check:
     name: Writer-Migration Coupling Check
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1111,7 +1105,13 @@ jobs:
   # and asserts every manifest table exists (OMN-3529)
   migration-integration:
     name: Migration Integration Test
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 10
     services:
       postgres:
@@ -1175,12 +1175,10 @@ jobs:
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Check schema fingerprint (CI twin for B2)
         run: uv run python scripts/check_schema_fingerprint.py verify
@@ -295,6 +296,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Lint topic names
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,9 +867,16 @@ jobs:
     continue-on-error: true
     steps:
       - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@main
+        id: migration_conflicts
+        continue-on-error: true
         with:
           checks: "migration-conflicts"
           warn-only: "true"
+
+      - name: Report non-blocking boundary validator startup failure
+        if: steps.migration_conflicts.outcome == 'failure'
+        run: |
+          echo "::warning::Cross-repo migration conflict validation could not complete. This job is warn-only; see the validate-boundaries action logs for the upstream packaging/setup failure."
 
 
   contract-compliance:
@@ -1120,7 +1127,7 @@ jobs:
           POSTGRES_PASSWORD: test_password
           POSTGRES_DB: omnibase_infra
         ports:
-          - 5436:5432
+          - 5432/tcp
         options: >-
           --health-cmd pg_isready
           --health-interval 5s
@@ -1140,15 +1147,16 @@ jobs:
 
       - name: Apply all migrations
         env:
-          OMNIBASE_INFRA_DB_URL: postgresql://postgres:test_password@localhost:5436/omnibase_infra
+          OMNIBASE_INFRA_DB_URL: postgresql://postgres:test_password@localhost:${{ job.services.postgres.ports[5432] }}/omnibase_infra
         run: |
           uv run python scripts/run-migrations.py
 
       - name: Assert manifest tables exist
         env:
           PGPASSWORD: test_password
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
         run: |
-          psql -h localhost -p 5436 -U postgres -d omnibase_infra -c "
+          psql -h localhost -p "$POSTGRES_PORT" -U postgres -d omnibase_infra -c "
             SELECT table_name
             FROM information_schema.tables
             WHERE table_schema = 'public'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,9 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 5
+    # The drift scan is short, but self-hosted post-job cache/archive cleanup
+    # has exceeded 5 minutes under runner pressure.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout omnibase_infra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1147,22 +1147,14 @@ jobs:
           cache-version: ${{ env.CACHE_VERSION }}
           install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
-      - name: Install Postgres client
+      - name: Verify Python Postgres client
         run: |
           set -euo pipefail
-          if command -v psql >/dev/null 2>&1; then
-            psql --version
-            exit 0
-          fi
+          uv run python - <<'PY'
+          import asyncpg
 
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends postgresql-client
-          else
-            apt-get update
-            apt-get install -y --no-install-recommends postgresql-client
-          fi
-          psql --version
+          print(f"asyncpg {asyncpg.__version__}")
+          PY
 
       - name: Resolve Postgres service host
         id: postgres_host
@@ -1213,29 +1205,76 @@ jobs:
       - name: Assert manifest tables exist
         env:
           POSTGRES_HOST: ${{ steps.postgres_host.outputs.host }}
-          PGPASSWORD: test_password
           POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U postgres -d omnibase_infra -c "
-            SELECT table_name
-            FROM information_schema.tables
-            WHERE table_schema = 'public'
-            ORDER BY table_name;
-          " | tee /tmp/tables.txt
+          uv run python - <<'PY'
+          import asyncio
+          import os
 
-          for table in agent_actions agent_detection_failures agent_execution_logs \
-              agent_routing_decisions agent_status_events agent_transformation_events \
-              baselines_breakdown baselines_comparisons baselines_trend \
-              contracts db_error_tickets db_metadata gmail_intent_evaluations \
-              injection_effectiveness latency_breakdowns llm_call_metrics \
-              llm_cost_aggregates manifest_injection_lifecycle pattern_hit_rates \
-              registration_projections router_performance_metrics skill_executions topics \
-              schema_migrations; do
-            if ! grep -q "$table" /tmp/tables.txt; then
-              echo "FAIL: expected table '$table' not found in database"
-              exit 1
-            fi
-          done
+          import asyncpg
+
+          EXPECTED_TABLES = {
+              "agent_actions",
+              "agent_detection_failures",
+              "agent_execution_logs",
+              "agent_routing_decisions",
+              "agent_status_events",
+              "agent_transformation_events",
+              "baselines_breakdown",
+              "baselines_comparisons",
+              "baselines_trend",
+              "contracts",
+              "db_error_tickets",
+              "db_metadata",
+              "gmail_intent_evaluations",
+              "injection_effectiveness",
+              "latency_breakdowns",
+              "llm_call_metrics",
+              "llm_cost_aggregates",
+              "manifest_injection_lifecycle",
+              "pattern_hit_rates",
+              "registration_projections",
+              "router_performance_metrics",
+              "skill_executions",
+              "topics",
+              "schema_migrations",
+          }
+
+
+          async def main() -> None:
+              conn = await asyncpg.connect(
+                  host=os.environ["POSTGRES_HOST"],
+                  port=int(os.environ["POSTGRES_PORT"]),
+                  user="postgres",
+                  password="test_password",
+                  database="omnibase_infra",
+              )
+              try:
+                  rows = await conn.fetch(
+                      """
+                      SELECT table_name
+                      FROM information_schema.tables
+                      WHERE table_schema = 'public'
+                      ORDER BY table_name
+                      """
+                  )
+              finally:
+                  await conn.close()
+
+              tables = {row["table_name"] for row in rows}
+              for table in sorted(tables):
+                  print(table)
+
+              missing = sorted(EXPECTED_TABLES - tables)
+              if missing:
+                  raise SystemExit(
+                      "FAIL: expected table(s) not found in database: "
+                      + ", ".join(missing)
+                  )
+
+
+          asyncio.run(main())
+          PY
           echo "All 24 tables present."
 
   ai-slop-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -91,7 +91,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -162,7 +162,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -193,7 +193,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -225,7 +225,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -248,7 +248,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -280,7 +280,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -323,7 +323,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -394,7 +394,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -475,7 +475,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
@@ -506,7 +506,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -537,7 +537,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -568,7 +568,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -613,7 +613,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
@@ -646,7 +646,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
@@ -711,7 +711,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -772,7 +772,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -833,7 +833,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: test-parallel
@@ -861,7 +861,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     continue-on-error: true
@@ -878,7 +878,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
@@ -918,7 +918,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [tests-gate, lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, migration-integration, migration-required-check, version-pin-check, compliance, contract-sync-gate]
@@ -1007,7 +1007,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -1082,7 +1082,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -1109,7 +1109,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
@@ -1177,7 +1177,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,6 +1145,12 @@ jobs:
           cache-version: ${{ env.CACHE_VERSION }}
           install-args: '--reinstall-package omnibase-core --reinstall-package omnibase-spi --frozen'
 
+      - name: Install Postgres client
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends postgresql-client
+
       - name: Resolve Postgres service host
         id: postgres_host
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,8 +1148,19 @@ jobs:
       - name: Install Postgres client
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends postgresql-client
+          if command -v psql >/dev/null 2>&1; then
+            psql --version
+            exit 0
+          fi
+
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends postgresql-client
+          else
+            apt-get update
+            apt-get install -y --no-install-recommends postgresql-client
+          fi
+          psql --version
 
       - name: Resolve Postgres service host
         id: postgres_host

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -39,15 +39,13 @@ concurrency:
 jobs:
   contract-validation:
     name: contract-validation
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -44,7 +44,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -44,7 +44,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -27,7 +27,13 @@ on:
 jobs:
   gate:
     name: CodeRabbit Thread Check
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Checkout omniclaude scripts
         uses: actions/checkout@v6

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -31,7 +31,7 @@ jobs:
       ${{
         (github.event.pull_request &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -29,9 +29,9 @@ jobs:
     name: CodeRabbit Thread Check
     runs-on: >-
       ${{
-        (github.event_name == 'pull_request' &&
+        (github.event.pull_request &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -57,7 +57,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     outputs:
@@ -96,7 +96,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     strategy:

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -57,7 +57,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     outputs:
@@ -96,7 +96,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     strategy:

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -52,15 +52,13 @@ permissions:
 jobs:
   compute-matrix:
     name: Compute Downstream Matrix
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     outputs:
       repos: ${{ steps.matrix.outputs.repos }}
@@ -93,15 +91,13 @@ jobs:
   open-bump-pr:
     name: Bump ${{ matrix.repo }}
     needs: compute-matrix
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,6 +38,7 @@ concurrency:
 env:
   UV_VERSION: "0.6.14"
   PYTHON_VERSION: "3.12"
+  DOCKER_COMPOSE_VERSION: "v2.40.3"
   REGISTRY: ghcr.io
   IMAGE_NAME: omnibase-infra-runtime
 
@@ -246,6 +247,21 @@ jobs:
           if [[ "${DRIVER}" != "docker" ]]; then
             echo "::warning::Expected Buildx driver 'docker', got '${DRIVER}'"
           fi
+
+      - name: Install Docker Compose plugin
+        run: |
+          if docker compose version >/dev/null 2>&1; then
+            docker compose version
+            exit 0
+          fi
+
+          plugin_dir="${HOME}/.docker/cli-plugins"
+          mkdir -p "${plugin_dir}"
+          curl -fsSL \
+            "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+            -o "${plugin_dir}/docker-compose"
+          chmod +x "${plugin_dir}/docker-compose"
+          docker compose version
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -274,7 +274,8 @@ jobs:
           version: ${{ env.UV_VERSION }}
 
       - name: Load cached uv
-        uses: actions/cache@v5
+        if: ${{ false }}
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}-docker

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -78,7 +78,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     permissions:
@@ -212,7 +212,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -297,7 +297,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -355,7 +355,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -404,7 +404,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [docker-build, docker-integration-tests]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -274,9 +274,10 @@ jobs:
         env:
           DOCKER_BUILDKIT: "1"
           ONEX_EVENT_BUS_TYPE: inmemory
+          OMNI_DOCKER_BUILD_TIMEOUT_SECONDS: "1200"
         run: |
           uv run pytest tests/integration/docker/ \
-            --timeout=600 \
+            --timeout="${OMNI_DOCKER_BUILD_TIMEOUT_SECONDS}" \
             --timeout-method=thread \
             --tb=short \
             --junitxml=docker-tests.xml \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
@@ -78,7 +78,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     permissions:
@@ -212,7 +212,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -297,7 +297,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -355,7 +355,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
@@ -404,7 +404,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [docker-build, docker-integration-tests]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,13 @@ jobs:
   # See: scripts/check_dockerfile_pins.py
   dockerfile-pin-check:
     name: Validate Dockerfile Plugin Pins
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 5
 
     steps:
@@ -67,12 +73,13 @@ jobs:
   docker-build:
     name: Build Runtime Image
     needs: dockerfile-pin-check
-    # OMNINODE_SELF_HOSTED_DOCKER_V1 — always self-hosted when enabled; kill-switch fallback to ubuntu-latest
+    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker jobs default to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true')
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     permissions:
       contents: read
@@ -200,12 +207,13 @@ jobs:
   # Run Docker integration tests
   docker-integration-tests:
     name: Docker Integration Tests
-    # OMNINODE_SELF_HOSTED_DOCKER_V1 — always self-hosted when enabled; kill-switch fallback to ubuntu-latest
+    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker jobs default to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true')
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: docker-build
     timeout-minutes: 30
@@ -285,7 +293,13 @@ jobs:
   # Security scanning
   security-scan:
     name: Security Scan (Trivy)
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     needs: docker-build
     if: github.ref == 'refs/heads/main'
     timeout-minutes: 15
@@ -337,7 +351,13 @@ jobs:
   # Warning-only for initial rollout — does not block builds.
   image-analysis:
     name: Image Size Analysis
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     needs: docker-build
     if: github.ref == 'refs/heads/main'
     timeout-minutes: 10
@@ -380,7 +400,13 @@ jobs:
   # Build summary
   build-summary:
     name: Build Summary
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     needs: [docker-build, docker-integration-tests]
     if: always()
 

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -33,7 +33,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -36,7 +36,9 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 5
+    # The parity test itself is short, but self-hosted post-job cache/archive
+    # cleanup has exceeded 5 minutes under runner pressure.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout omnibase_infra

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -33,7 +33,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -28,15 +28,13 @@ env:
 jobs:
   env-parity:
     name: Env Parity (docker-compose vs k8s ConfigMap)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -61,6 +61,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
           working-directory: omnibase_infra
 
       - name: Run env parity test

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -35,7 +35,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -116,7 +116,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -35,7 +35,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -116,7 +116,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -31,7 +31,13 @@ env:
 jobs:
   check-integration-tests:
     name: Integration Test Coverage
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -106,7 +112,13 @@ jobs:
 
   check-test-removal:
     name: Integration Test Removal Gate
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/merge-queue-bypass-audit.yml
+++ b/.github/workflows/merge-queue-bypass-audit.yml
@@ -30,7 +30,13 @@ on:
 jobs:
   audit:
     name: Audit Merge Queue Bypass
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 15
 
     permissions:

--- a/.github/workflows/merge-queue-bypass-audit.yml
+++ b/.github/workflows/merge-queue-bypass-audit.yml
@@ -34,7 +34,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/merge-queue-bypass-audit.yml
+++ b/.github/workflows/merge-queue-bypass-audit.yml
@@ -34,7 +34,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -61,7 +61,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -91,7 +91,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60
@@ -170,7 +170,11 @@ jobs:
     name: Failure Alert
     needs: [guard-live-host, integration-tests]
     if: failure()
-    runs-on: ubuntu-latest
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci.
+    runs-on: >-
+      ${{
+        fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
 
     steps:
       - name: Post Slack alert

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -57,7 +57,13 @@ env:
 jobs:
   guard-live-host:
     name: Assert not targeting live .201
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Reject if ANY host variable targets .201
         # Broadened guard (per CR review): check all host vars the runtime
@@ -80,15 +86,13 @@ jobs:
   integration-tests:
     name: Integration Test Suite (e2e stack)
     needs: guard-live-host
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60
 
@@ -166,7 +170,13 @@ jobs:
     name: Failure Alert
     needs: [guard-live-host, integration-tests]
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
 
     steps:
       - name: Post Slack alert

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -61,7 +61,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -91,7 +91,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60
@@ -170,13 +170,7 @@ jobs:
     name: Failure Alert
     needs: [guard-live-host, integration-tests]
     if: failure()
-    runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Post Slack alert

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,15 +38,13 @@ env:
 jobs:
   slow-tests:
     name: Slow & Chaos Tests
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60  # Extended timeout for slow tests
 
@@ -101,15 +99,13 @@ jobs:
   # Summary job to report overall status
   nightly-summary:
     name: Nightly Summary
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [slow-tests]
     if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -43,7 +43,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60  # Extended timeout for slow tests
@@ -104,7 +104,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [slow-tests]

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -43,7 +43,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 60  # Extended timeout for slow tests
@@ -104,7 +104,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [slow-tests]

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -24,7 +24,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Pre-existing mypy violations on main. Non-blocking until resolved (OMN-5132).
@@ -61,7 +61,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -90,7 +90,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -127,7 +127,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs:
@@ -165,7 +165,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -19,15 +19,13 @@ env:
 jobs:
   type-safety:
     name: Type Safety Validation
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Pre-existing mypy violations on main. Non-blocking until resolved (OMN-5132).
     continue-on-error: true
@@ -58,15 +56,13 @@ jobs:
 
   type-union-check:
     name: PEP 604 Type Union Check (UP007)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - name: Checkout code
@@ -90,7 +86,13 @@ jobs:
 
   handler-contract-compliance:
     name: Handler Contract Compliance
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -116,15 +118,13 @@ jobs:
 
   omni-standards-gate:
     name: Omni Standards Gate
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs:
       - type-safety
@@ -157,7 +157,13 @@ jobs:
 
   ci-naming-convention:
     name: CI Naming Convention
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -108,10 +108,14 @@ jobs:
           version: ${{ env.UV_VERSION }}
 
       - name: Install onex_change_control (pinned)
-        run: uv pip install --system "onex_change_control @ git+https://github.com/OmniNode-ai/onex_change_control.git@08a5194c6e587e8b2256c1f1edde236ad34cd397"
+        run: |
+          uv venv .venv --python "${pythonLocation}/bin/python"
+          . .venv/bin/activate
+          uv pip install "onex_change_control @ git+https://github.com/OmniNode-ai/onex_change_control.git@08a5194c6e587e8b2256c1f1edde236ad34cd397"
 
       - name: Run handler contract compliance check
         run: |
+          . .venv/bin/activate
           python -m onex_change_control.validators.arch_handler_contract_compliance \
             --repo-root . \
             --allowlist-path arch-handler-contract-compliance-allowlist.yaml

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -24,7 +24,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # Pre-existing mypy violations on main. Non-blocking until resolved (OMN-5132).
@@ -61,7 +61,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -90,7 +90,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
@@ -127,7 +127,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs:
@@ -165,7 +165,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -32,15 +32,13 @@ permissions:
 jobs:
   update-dockerfile-pins:
     name: Update Dockerfile.runtime pins for ${{ github.event.client_payload.package || inputs.package }}
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - name: Resolve inputs

--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -33,7 +33,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -33,7 +33,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -29,7 +29,13 @@ jobs:
   publish-pr-merged-event:
     name: Publish PR Merged Event
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release-python-dry-run.yml
+++ b/.github/workflows/release-python-dry-run.yml
@@ -17,12 +17,7 @@ on:
 jobs:
   dry-run:
     runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-python-dry-run.yml
+++ b/.github/workflows/release-python-dry-run.yml
@@ -16,7 +16,13 @@ on:
 
 jobs:
   dry-run:
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:

--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -24,7 +24,13 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,13 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     outputs:
       version: ${{ steps.tag.outputs.tag }}
     steps:
@@ -109,7 +115,13 @@ jobs:
     name: Post-Release Checks
     needs: release
     if: always() && needs.release.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -147,7 +159,13 @@ jobs:
     name: Trigger Runtime Image Rebuild
     needs: release
     if: ${{ !contains(needs.release.outputs.version, 'rc') }}
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     steps:
       - name: Check CROSS_REPO_PAT is configured
         id: token_check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,7 @@ concurrency:
 jobs:
   release:
     runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
     outputs:
       version: ${{ steps.tag.outputs.tag }}
     steps:
@@ -116,12 +111,7 @@ jobs:
     needs: release
     if: always() && needs.release.result == 'success'
     runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -160,12 +150,7 @@ jobs:
     needs: release
     if: ${{ !contains(needs.release.outputs.version, 'rc') }}
     runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
     steps:
       - name: Check CROSS_REPO_PAT is configured
         id: token_check

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -65,15 +65,13 @@ on:
 jobs:
   boot:
     name: runtime-boot (mode=${{ inputs.mode }})
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 20
     env:

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -70,7 +70,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 20

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -70,7 +70,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 20

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -34,7 +34,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -34,7 +34,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -30,7 +30,13 @@ jobs:
   trigger-rebuild:
     name: Trigger Deploy Agent Rebuild
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -26,9 +26,10 @@ jobs:
     name: Stale TODO Gate
     runs-on: >-
       ${{
-        vars.USE_SELF_HOSTED_RUNNERS == 'true'
-        && 'self-hosted, omnibase-ci'
-        || 'ubuntu-latest'
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
 
     steps:

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
 

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -28,7 +28,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
 

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON('["ubuntu-latest"]')
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
 

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -33,7 +33,13 @@ jobs:
   todo-audit:
     name: TODO Audit
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -37,7 +37,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        && fromJSON('["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
 

--- a/config/runner_fleet.yaml
+++ b/config/runner_fleet.yaml
@@ -7,4 +7,4 @@ github_org: OmniNode-ai
 runner_host: 192.168.86.201
 runner_group: omnibase-ci
 runner_name_prefix: omninode-runner
-expected_count: 12
+expected_count: 20

--- a/config/runner_fleet.yaml
+++ b/config/runner_fleet.yaml
@@ -1,0 +1,10 @@
+# Authoritative GitHub Actions runner fleet config.
+#
+# This file is the source of truth for deploy-runners.sh, runner-monitor.sh,
+# and the runner health CLI. Do not duplicate these values in scripts.
+version: "1.0"
+github_org: OmniNode-ai
+runner_host: 192.168.86.201
+runner_group: omnibase-ci
+runner_name_prefix: omninode-runner
+expected_count: 12

--- a/config/runner_fleet.yaml
+++ b/config/runner_fleet.yaml
@@ -7,4 +7,5 @@ github_org: OmniNode-ai
 runner_host: 192.168.86.201
 runner_group: omnibase-ci
 runner_name_prefix: omninode-runner
-expected_count: 20
+expected_count: 12
+burst_count: 20

--- a/config/runner_fleet.yaml
+++ b/config/runner_fleet.yaml
@@ -7,5 +7,5 @@ github_org: OmniNode-ai
 runner_host: 192.168.86.201
 runner_group: omnibase-ci
 runner_name_prefix: omninode-runner
-expected_count: 12
+expected_count: 14
 burst_count: 20

--- a/contracts/OMN-10445.yaml
+++ b/contracts/OMN-10445.yaml
@@ -1,41 +1,40 @@
 schema_version: "1.0.0"
 ticket_id: "OMN-10445"
-title: "Runtime Stability Reconciliation -- runtime package activation"
-summary: "Pin active runtime package activation for omnibase_infra and omnimarket in the infra compose runtime environment."
-is_seam_ticket: true
-interface_change: true
-interfaces_touched:
-  - "public_api"
+title: "Standardize self-hosted runner fleet health config"
+summary: "Make the .201 GitHub Actions runner fleet config-driven, with 14 steady runners, 20 burst-capable runners, 6g memory, 12g swap, and 2 CPU each."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
 evidence_requirements:
   - kind: "tests"
-    description: "Runtime package activation, env completeness, parity, and auto-wiring tests pass"
-    command: "uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q"
+    description: "Runner fleet config, deploy propagation, health collection, and resource-limit tests pass."
+    command: "PYTHONPATH=src uv run pytest tests/unit/observability/runner_health/test_cli_runner_health.py tests/unit/observability/runner_health/test_runner_fleet_config.py tests/unit/observability/runner_health/test_collector_runner_health.py tests/integration/observability/test_runner_fleet_config_contract.py -q"
   - kind: "manual"
-    description: "Sibling omninode_infra env parity checks pass with explicit OMNINODE_INFRA_DIR"
-    command: "OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
+    description: "Runner compose renders the 20-runner fleet with 6g memory, 12g swap, and 2 CPU limits."
+    command: "RUNNER_TOKEN=dummy docker compose -f docker/docker-compose.runners.yml config"
   - kind: "manual"
-    description: "Post-merge deploy/readiness smoke command recorded; live deploy requires explicit approval"
-    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} printenv ONEX_ACTIVE_RUNTIME_PACKAGES"
+    description: "Live .201 read-only proof shows 14 running containers and effective 6g memory / 12g swap / 2 CPU limits."
+    command: "ssh jonah@192.168.86.201 'docker ps --filter name=omninode-runner --format \"{{.Names}}\" | wc -l; docker inspect omninode-runner-1 --format \"Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}} NanoCpus={{.HostConfig.NanoCpus}} PidsLimit={{.HostConfig.PidsLimit}}\"'"
 emergency_bypass:
   enabled: false
   justification: ""
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-001"
-    description: "Runtime package activation, env completeness, parity, and auto-wiring tests pass"
-    source: "generated"
-    checks:
-      - check_type: "command"
-        check_value: "uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q"
-  - id: "dod-002"
-    description: "Sibling omninode_infra env parity checks pass with explicit OMNINODE_INFRA_DIR"
-    source: "generated"
-    checks:
-      - check_type: "command"
-        check_value: "OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
-  - id: "dod-deploy"
-    description: "Post-merge deploy/readiness smoke plan only; this PR has not deployed, restarted runtime, or mutated .201"
+    description: "Runner fleet config, deploy propagation, health collection, and resource-limit tests pass."
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} printenv ONEX_ACTIVE_RUNTIME_PACKAGES"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/observability/runner_health/test_cli_runner_health.py tests/unit/observability/runner_health/test_runner_fleet_config.py tests/unit/observability/runner_health/test_collector_runner_health.py tests/integration/observability/test_runner_fleet_config_contract.py -q"
+  - id: "dod-002"
+    description: "Runner compose renders the 20-runner fleet with 6g memory, 12g swap, and 2 CPU limits."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "RUNNER_TOKEN=dummy docker compose -f docker/docker-compose.runners.yml config"
+  - id: "dod-live-readonly"
+    description: "Live .201 read-only proof shows 14 running containers and effective 6g memory / 12g swap / 2 CPU limits."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "ssh jonah@192.168.86.201 'docker ps --filter name=omninode-runner --format \"{{.Names}}\" | wc -l; docker inspect omninode-runner-1 --format \"Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}} NanoCpus={{.HostConfig.NanoCpus}} PidsLimit={{.HostConfig.PidsLimit}}\"'"

--- a/contracts/OMN-10445.yaml
+++ b/contracts/OMN-10445.yaml
@@ -15,6 +15,9 @@ evidence_requirements:
   - kind: "manual"
     description: "Live .201 read-only proof shows 14 running containers and effective 6g memory / 12g swap / 2 CPU limits."
     command: "ssh jonah@192.168.86.201 'docker ps --filter name=omninode-runner --format \"{{.Names}}\" | wc -l; docker inspect omninode-runner-1 --format \"Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}} NanoCpus={{.HostConfig.NanoCpus}} PidsLimit={{.HostConfig.PidsLimit}}\"'"
+  - kind: "manual"
+    description: "Deploy validation is read-only for this PR; no live runner restart is claimed."
+    command: "deploy validation: compare docker/docker-compose.runners.yml with /home/jonah/.omnibase/runners/docker/docker-compose.runners.yml on .201 and inspect runner limits before any approved restart"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -38,3 +41,9 @@ dod_evidence:
     checks:
       - check_type: "command"
         check_value: "ssh jonah@192.168.86.201 'docker ps --filter name=omninode-runner --format \"{{.Names}}\" | wc -l; docker inspect omninode-runner-1 --format \"Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}} NanoCpus={{.HostConfig.NanoCpus}} PidsLimit={{.HostConfig.PidsLimit}}\"'"
+  - id: "dod-deploy-readonly"
+    description: "Deploy validation is read-only for this PR; no live runner restart is claimed."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy validation: compare docker/docker-compose.runners.yml with /home/jonah/.omnibase/runners/docker/docker-compose.runners.yml on .201 and inspect runner limits before any approved restart"

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -34,8 +34,8 @@
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
 # Resource allocation per runner (RTX 5090 host with ample RAM):
-#   mem_limit: 6g     — 72 GB total across 12 configured runners
-#   cpus: "4.0"       — 4 vCPUs per runner (40 total; host has 48+ cores)
+#   mem_limit: 4g     — 80 GB total across 20 configured runners
+#   cpus: "2.0"       — 2 vCPUs per runner (40 total; host has 32 threads)
 #   pids_limit: 4096  — prevents fork bombs from runaway test processes
 #
 # NOTE: mem_limit/cpus/pids_limit are Compose v2 top-level resource keys.
@@ -43,8 +43,8 @@
 x-runner-base: &runner-base
   image: omninode-runner:latest
   restart: unless-stopped
-  mem_limit: 6g
-  cpus: "4.0"
+  mem_limit: 4g
+  cpus: "2.0"
   pids_limit: 4096
   environment: &runner-env
     RUNNER_LABELS: self-hosted,omnibase-ci,linux,x64
@@ -175,6 +175,78 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-12-creds:/home/runner/.runner-creds
+  omninode-runner-13:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-13
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-13
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-13-creds:/home/runner/.runner-creds
+  omninode-runner-14:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-14
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-14
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-14-creds:/home/runner/.runner-creds
+  omninode-runner-15:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-15
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-15
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-15-creds:/home/runner/.runner-creds
+  omninode-runner-16:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-16
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-16
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-16-creds:/home/runner/.runner-creds
+  omninode-runner-17:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-17
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-17
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-17-creds:/home/runner/.runner-creds
+  omninode-runner-18:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-18
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-18
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-18-creds:/home/runner/.runner-creds
+  omninode-runner-19:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-19
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-19
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-19-creds:/home/runner/.runner-creds
+  omninode-runner-20:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-20
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-20
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-20-creds:/home/runner/.runner-creds
 volumes:
   runner-1-creds:
     name: omninode-runner-1-creds
@@ -200,3 +272,19 @@ volumes:
     name: omninode-runner-11-creds
   runner-12-creds:
     name: omninode-runner-12-creds
+  runner-13-creds:
+    name: omninode-runner-13-creds
+  runner-14-creds:
+    name: omninode-runner-14-creds
+  runner-15-creds:
+    name: omninode-runner-15-creds
+  runner-16-creds:
+    name: omninode-runner-16-creds
+  runner-17-creds:
+    name: omninode-runner-17-creds
+  runner-18-creds:
+    name: omninode-runner-18-creds
+  runner-19-creds:
+    name: omninode-runner-19-creds
+  runner-20-creds:
+    name: omninode-runner-20-creds

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -51,6 +51,7 @@ x-runner-base: &runner-base
     GITHUB_ORG_URL: https://github.com/OmniNode-ai
     RUNNER_TOKEN: ${RUNNER_TOKEN}
     RUNNER_GROUP: omnibase-ci
+    ACTIONS_RUNNER_HOOK_JOB_STARTED: /usr/local/bin/runner-job-started.sh
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
   group_add:

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -2,7 +2,8 @@
 # OmniNode self-hosted GitHub Actions runners
 # Ticket: OMN-3276 / Epic: OMN-3273 | Scaled: OMN-3714
 #
-# Runs 10 identical runner containers (omninode-runner-1 through omninode-runner-10).
+# Runs the configured stateful runner fleet.
+# The expected count is owned by config/runner_fleet.yaml.
 # Each runner registers with GitHub org OmniNode-ai in the 'omnibase-ci' runner group.
 #
 # Prerequisites:
@@ -32,8 +33,8 @@
 #
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
-# Resource allocation per runner (10 runners on RTX 5090 host with ample RAM):
-#   mem_limit: 6g     — 60 GB total across 10 runners
+# Resource allocation per runner (RTX 5090 host with ample RAM):
+#   mem_limit: 6g     — 72 GB total across 12 configured runners
 #   cpus: "4.0"       — 4 vCPUs per runner (40 total; host has 48+ cores)
 #   pids_limit: 4096  — prevents fork bombs from runaway test processes
 #
@@ -156,6 +157,24 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner-10-creds:/home/runner/.runner-creds
+  omninode-runner-11:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-11
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-11
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-11-creds:/home/runner/.runner-creds
+  omninode-runner-12:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-12
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-12
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner-12-creds:/home/runner/.runner-creds
 volumes:
   runner-1-creds:
     name: omninode-runner-1-creds
@@ -177,3 +196,7 @@ volumes:
     name: omninode-runner-9-creds
   runner-10-creds:
     name: omninode-runner-10-creds
+  runner-11-creds:
+    name: omninode-runner-11-creds
+  runner-12-creds:
+    name: omninode-runner-12-creds

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -54,6 +54,7 @@ x-runner-base: &runner-base
     ACTIONS_RUNNER_HOOK_JOB_STARTED: /usr/local/bin/runner-job-started.sh
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
   group_add:
     - "984" # Match host Docker socket GID for DinD access
   healthcheck:
@@ -76,6 +77,7 @@ services:
       RUNNER_NAME: omninode-runner-1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-1-creds:/home/runner/.runner-creds
   omninode-runner-2:
     !!merge <<: *runner-base
@@ -85,6 +87,7 @@ services:
       RUNNER_NAME: omninode-runner-2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-2-creds:/home/runner/.runner-creds
   omninode-runner-3:
     !!merge <<: *runner-base
@@ -94,6 +97,7 @@ services:
       RUNNER_NAME: omninode-runner-3
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-3-creds:/home/runner/.runner-creds
   omninode-runner-4:
     !!merge <<: *runner-base
@@ -103,6 +107,7 @@ services:
       RUNNER_NAME: omninode-runner-4
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-4-creds:/home/runner/.runner-creds
   omninode-runner-5:
     !!merge <<: *runner-base
@@ -112,6 +117,7 @@ services:
       RUNNER_NAME: omninode-runner-5
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-5-creds:/home/runner/.runner-creds
   omninode-runner-6:
     !!merge <<: *runner-base
@@ -121,6 +127,7 @@ services:
       RUNNER_NAME: omninode-runner-6
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-6-creds:/home/runner/.runner-creds
   omninode-runner-7:
     !!merge <<: *runner-base
@@ -130,6 +137,7 @@ services:
       RUNNER_NAME: omninode-runner-7
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-7-creds:/home/runner/.runner-creds
   omninode-runner-8:
     !!merge <<: *runner-base
@@ -139,6 +147,7 @@ services:
       RUNNER_NAME: omninode-runner-8
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-8-creds:/home/runner/.runner-creds
   omninode-runner-9:
     !!merge <<: *runner-base
@@ -148,6 +157,7 @@ services:
       RUNNER_NAME: omninode-runner-9
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-9-creds:/home/runner/.runner-creds
   omninode-runner-10:
     !!merge <<: *runner-base
@@ -157,6 +167,7 @@ services:
       RUNNER_NAME: omninode-runner-10
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-10-creds:/home/runner/.runner-creds
   omninode-runner-11:
     !!merge <<: *runner-base
@@ -166,6 +177,7 @@ services:
       RUNNER_NAME: omninode-runner-11
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-11-creds:/home/runner/.runner-creds
   omninode-runner-12:
     !!merge <<: *runner-base
@@ -175,6 +187,7 @@ services:
       RUNNER_NAME: omninode-runner-12
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-12-creds:/home/runner/.runner-creds
   omninode-runner-13:
     !!merge <<: *runner-base
@@ -184,6 +197,7 @@ services:
       RUNNER_NAME: omninode-runner-13
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-13-creds:/home/runner/.runner-creds
   omninode-runner-14:
     !!merge <<: *runner-base
@@ -193,6 +207,7 @@ services:
       RUNNER_NAME: omninode-runner-14
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-14-creds:/home/runner/.runner-creds
   omninode-runner-15:
     !!merge <<: *runner-base
@@ -202,6 +217,7 @@ services:
       RUNNER_NAME: omninode-runner-15
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-15-creds:/home/runner/.runner-creds
   omninode-runner-16:
     !!merge <<: *runner-base
@@ -211,6 +227,7 @@ services:
       RUNNER_NAME: omninode-runner-16
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-16-creds:/home/runner/.runner-creds
   omninode-runner-17:
     !!merge <<: *runner-base
@@ -220,6 +237,7 @@ services:
       RUNNER_NAME: omninode-runner-17
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-17-creds:/home/runner/.runner-creds
   omninode-runner-18:
     !!merge <<: *runner-base
@@ -229,6 +247,7 @@ services:
       RUNNER_NAME: omninode-runner-18
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-18-creds:/home/runner/.runner-creds
   omninode-runner-19:
     !!merge <<: *runner-base
@@ -238,6 +257,7 @@ services:
       RUNNER_NAME: omninode-runner-19
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-19-creds:/home/runner/.runner-creds
   omninode-runner-20:
     !!merge <<: *runner-base
@@ -247,6 +267,7 @@ services:
       RUNNER_NAME: omninode-runner-20
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-20-creds:/home/runner/.runner-creds
 volumes:
   runner-1-creds:

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -2,8 +2,8 @@
 # OmniNode self-hosted GitHub Actions runners
 # Ticket: OMN-3276 / Epic: OMN-3273 | Scaled: OMN-3714
 #
-# Runs the configured stateful runner fleet.
-# The expected count is owned by config/runner_fleet.yaml.
+# Runs the configured steady-state runner fleet; burst runners are profile-gated.
+# The steady-state and burst counts are owned by config/runner_fleet.yaml.
 # Each runner registers with GitHub org OmniNode-ai in the 'omnibase-ci' runner group.
 #
 # Prerequisites:
@@ -34,8 +34,8 @@
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
 # Resource allocation per runner (RTX 5090 host with ample RAM):
-#   mem_limit: 4g     — 80 GB total across 20 configured runners
-#   cpus: "2.0"       — 2 vCPUs per runner (40 total; host has 32 threads)
+#   mem_limit: 4g     - 48 GB steady across 12 runners; 80 GB only with the burst profile
+#   cpus: "2.0"       — 24 vCPUs steady; 40 vCPUs only with the burst profile
 #   pids_limit: 4096  — prevents fork bombs from runaway test processes
 #
 # NOTE: mem_limit/cpus/pids_limit are Compose v2 top-level resource keys.
@@ -204,6 +204,7 @@ services:
       - runner-12-creds:/home/runner/.runner-creds
   omninode-runner-13:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-13
     environment:
       !!merge <<: *runner-env
@@ -215,6 +216,7 @@ services:
       - runner-13-creds:/home/runner/.runner-creds
   omninode-runner-14:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-14
     environment:
       !!merge <<: *runner-env
@@ -226,6 +228,7 @@ services:
       - runner-14-creds:/home/runner/.runner-creds
   omninode-runner-15:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-15
     environment:
       !!merge <<: *runner-env
@@ -237,6 +240,7 @@ services:
       - runner-15-creds:/home/runner/.runner-creds
   omninode-runner-16:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-16
     environment:
       !!merge <<: *runner-env
@@ -248,6 +252,7 @@ services:
       - runner-16-creds:/home/runner/.runner-creds
   omninode-runner-17:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-17
     environment:
       !!merge <<: *runner-env
@@ -259,6 +264,7 @@ services:
       - runner-17-creds:/home/runner/.runner-creds
   omninode-runner-18:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-18
     environment:
       !!merge <<: *runner-env
@@ -270,6 +276,7 @@ services:
       - runner-18-creds:/home/runner/.runner-creds
   omninode-runner-19:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-19
     environment:
       !!merge <<: *runner-env
@@ -281,6 +288,7 @@ services:
       - runner-19-creds:/home/runner/.runner-creds
   omninode-runner-20:
     !!merge <<: *runner-base
+    profiles: ["burst"]
     container_name: omninode-runner-20
     environment:
       !!merge <<: *runner-env

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -54,6 +54,7 @@ x-runner-base: &runner-base
     ACTIONS_RUNNER_HOOK_JOB_STARTED: /usr/local/bin/runner-job-started.sh
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
     - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
   group_add:
     - "984" # Match host Docker socket GID for DinD access
@@ -77,6 +78,7 @@ services:
       RUNNER_NAME: omninode-runner-1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-1-creds:/home/runner/.runner-creds
   omninode-runner-2:
@@ -87,6 +89,7 @@ services:
       RUNNER_NAME: omninode-runner-2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-2-creds:/home/runner/.runner-creds
   omninode-runner-3:
@@ -97,6 +100,7 @@ services:
       RUNNER_NAME: omninode-runner-3
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-3-creds:/home/runner/.runner-creds
   omninode-runner-4:
@@ -107,6 +111,7 @@ services:
       RUNNER_NAME: omninode-runner-4
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-4-creds:/home/runner/.runner-creds
   omninode-runner-5:
@@ -117,6 +122,7 @@ services:
       RUNNER_NAME: omninode-runner-5
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-5-creds:/home/runner/.runner-creds
   omninode-runner-6:
@@ -127,6 +133,7 @@ services:
       RUNNER_NAME: omninode-runner-6
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-6-creds:/home/runner/.runner-creds
   omninode-runner-7:
@@ -137,6 +144,7 @@ services:
       RUNNER_NAME: omninode-runner-7
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-7-creds:/home/runner/.runner-creds
   omninode-runner-8:
@@ -147,6 +155,7 @@ services:
       RUNNER_NAME: omninode-runner-8
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-8-creds:/home/runner/.runner-creds
   omninode-runner-9:
@@ -157,6 +166,7 @@ services:
       RUNNER_NAME: omninode-runner-9
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-9-creds:/home/runner/.runner-creds
   omninode-runner-10:
@@ -167,6 +177,7 @@ services:
       RUNNER_NAME: omninode-runner-10
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-10-creds:/home/runner/.runner-creds
   omninode-runner-11:
@@ -177,6 +188,7 @@ services:
       RUNNER_NAME: omninode-runner-11
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-11-creds:/home/runner/.runner-creds
   omninode-runner-12:
@@ -187,6 +199,7 @@ services:
       RUNNER_NAME: omninode-runner-12
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-12-creds:/home/runner/.runner-creds
   omninode-runner-13:
@@ -197,6 +210,7 @@ services:
       RUNNER_NAME: omninode-runner-13
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-13-creds:/home/runner/.runner-creds
   omninode-runner-14:
@@ -207,6 +221,7 @@ services:
       RUNNER_NAME: omninode-runner-14
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-14-creds:/home/runner/.runner-creds
   omninode-runner-15:
@@ -217,6 +232,7 @@ services:
       RUNNER_NAME: omninode-runner-15
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-15-creds:/home/runner/.runner-creds
   omninode-runner-16:
@@ -227,6 +243,7 @@ services:
       RUNNER_NAME: omninode-runner-16
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-16-creds:/home/runner/.runner-creds
   omninode-runner-17:
@@ -237,6 +254,7 @@ services:
       RUNNER_NAME: omninode-runner-17
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-17-creds:/home/runner/.runner-creds
   omninode-runner-18:
@@ -247,6 +265,7 @@ services:
       RUNNER_NAME: omninode-runner-18
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-18-creds:/home/runner/.runner-creds
   omninode-runner-19:
@@ -257,6 +276,7 @@ services:
       RUNNER_NAME: omninode-runner-19
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-19-creds:/home/runner/.runner-creds
   omninode-runner-20:
@@ -267,6 +287,7 @@ services:
       RUNNER_NAME: omninode-runner-20
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - runner-20-creds:/home/runner/.runner-creds
 volumes:

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -34,7 +34,8 @@
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
 # Resource allocation per runner (RTX 5090 host with ample RAM):
-#   mem_limit: 4g     - 56 GB steady across 14 runners; 80 GB only with the burst profile
+#   mem_limit: 6g     - 84 GB steady across 14 runners; 120 GB only with the burst profile
+#   memswap_limit: 12g - bounded swap headroom for large CI spikes
 #   cpus: "2.0"       — 28 vCPUs steady; 40 vCPUs only with the burst profile
 #   pids_limit: 4096  — prevents fork bombs from runaway test processes
 #
@@ -43,7 +44,8 @@
 x-runner-base: &runner-base
   image: omninode-runner:latest
   restart: unless-stopped
-  mem_limit: 4g
+  mem_limit: 6g
+  memswap_limit: 12g
   cpus: "2.0"
   pids_limit: 4096
   environment: &runner-env

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -34,8 +34,8 @@
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
 # Resource allocation per runner (RTX 5090 host with ample RAM):
-#   mem_limit: 4g     - 48 GB steady across 12 runners; 80 GB only with the burst profile
-#   cpus: "2.0"       — 24 vCPUs steady; 40 vCPUs only with the burst profile
+#   mem_limit: 4g     - 56 GB steady across 14 runners; 80 GB only with the burst profile
+#   cpus: "2.0"       — 28 vCPUs steady; 40 vCPUs only with the burst profile
 #   pids_limit: 4096  — prevents fork bombs from runaway test processes
 #
 # NOTE: mem_limit/cpus/pids_limit are Compose v2 top-level resource keys.
@@ -204,7 +204,6 @@ services:
       - runner-12-creds:/home/runner/.runner-creds
   omninode-runner-13:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-13
     environment:
       !!merge <<: *runner-env
@@ -216,7 +215,6 @@ services:
       - runner-13-creds:/home/runner/.runner-creds
   omninode-runner-14:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-14
     environment:
       !!merge <<: *runner-env

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -106,7 +106,8 @@ RUN mkdir -p "${RUNNER_HOME}" \
 RUN mkdir -p /home/runner/.runner-creds && chown runner:runner /home/runner/.runner-creds
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY runner-job-started.sh /usr/local/bin/runner-job-started.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/runner-job-started.sh
 
 # Install gosu for privilege de-escalation in entrypoint.
 # The entrypoint starts as root to fix Docker socket GID, then drops to runner.

--- a/docker/runners/entrypoint.sh
+++ b/docker/runners/entrypoint.sh
@@ -91,6 +91,7 @@ _restore_cached_creds() {
         for f in .runner .credentials .credentials_rsaparams; do
             if [[ -f "${cache_file}/${f}" ]]; then
                 cp "${cache_file}/${f}" "${RUNNER_HOME}/${f}"
+                chown runner:runner "${RUNNER_HOME}/${f}"
                 restored=$((restored + 1))
             fi
         done
@@ -111,6 +112,7 @@ _save_creds() {
     for f in .runner .credentials .credentials_rsaparams; do
         if [[ -f "${RUNNER_HOME}/${f}" ]]; then
             cp "${RUNNER_HOME}/${f}" "${cache_file}/${f}"
+            chown runner:runner "${cache_file}/${f}"
         fi
     done
     echo "[entrypoint] Runner credentials cached (key=${key:0:12}...)"

--- a/docker/runners/entrypoint.sh
+++ b/docker/runners/entrypoint.sh
@@ -95,10 +95,14 @@ _restore_cached_creds() {
                 restored=$((restored + 1))
             fi
         done
-        if [[ "${restored}" -gt 0 ]]; then
+        if [[ -f "${RUNNER_HOME}/.runner" && -f "${RUNNER_HOME}/.credentials" ]]; then
             return 0
         fi
-        echo "[entrypoint] Credential cache exists but contains no runner credential files."
+        rm -f -- \
+            "${RUNNER_HOME}/.runner" \
+            "${RUNNER_HOME}/.credentials" \
+            "${RUNNER_HOME}/.credentials_rsaparams"
+        echo "[entrypoint] Credential cache is incomplete; falling back to registration."
     fi
     return 1
 }
@@ -137,7 +141,6 @@ _clear_cached_creds() {
 _is_registration_error() {
     local log_content="${1}"
     local known_patterns=(
-        "Runner.Listener"
         "not registered"
         "HTTP 401"
         "Failed to get session"

--- a/docker/runners/entrypoint.sh
+++ b/docker/runners/entrypoint.sh
@@ -87,8 +87,17 @@ _restore_cached_creds() {
     local cache_file="${CRED_CACHE_DIR}/${key}"
     if [[ -d "${cache_file}" ]]; then
         echo "[entrypoint] Restoring cached runner credentials (key=${key:0:12}...)"
-        cp -r "${cache_file}/"* "${RUNNER_HOME}/" 2>/dev/null || true
-        return 0
+        local restored=0
+        for f in .runner .credentials .credentials_rsaparams; do
+            if [[ -f "${cache_file}/${f}" ]]; then
+                cp "${cache_file}/${f}" "${RUNNER_HOME}/${f}"
+                restored=$((restored + 1))
+            fi
+        done
+        if [[ "${restored}" -gt 0 ]]; then
+            return 0
+        fi
+        echo "[entrypoint] Credential cache exists but contains no runner credential files."
     fi
     return 1
 }

--- a/docker/runners/runner-job-started.sh
+++ b/docker/runners/runner-job-started.sh
@@ -23,19 +23,22 @@ if [[ -z "${workspace}" ]]; then
     exit 0
 fi
 
-case "${workspace}" in
-    "${WORK_ROOT}/"*/*) ;;
+canonical_work_root="$(realpath -m -- "${WORK_ROOT}")"
+canonical_workspace="$(realpath -m -- "${workspace}")"
+
+case "${canonical_workspace}" in
+    "${canonical_work_root}/"*/*) ;;
     *)
-        echo "[runner-job-started] Refusing to clean workspace outside ${WORK_ROOT}: ${workspace}" >&2
+        echo "[runner-job-started] Refusing to clean workspace outside ${canonical_work_root}: ${canonical_workspace}" >&2
         exit 1
         ;;
 esac
 
-if [[ "${workspace}" == "/" || "${workspace}" == "${WORK_ROOT}" ]]; then
-    echo "[runner-job-started] Refusing unsafe workspace path: ${workspace}" >&2
+if [[ "${canonical_workspace}" == "/" || "${canonical_workspace}" == "${canonical_work_root}" ]]; then
+    echo "[runner-job-started] Refusing unsafe workspace path: ${canonical_workspace}" >&2
     exit 1
 fi
 
-echo "[runner-job-started] Resetting workspace: ${workspace}"
-rm -rf -- "${workspace}"
-mkdir -p -- "${workspace}"
+echo "[runner-job-started] Resetting workspace: ${canonical_workspace}"
+rm -rf -- "${canonical_workspace}"
+mkdir -p -- "${canonical_workspace}"

--- a/docker/runners/runner-job-started.sh
+++ b/docker/runners/runner-job-started.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reset the current repository workspace before each self-hosted runner job.
+#
+# Stateful self-hosted runners can inherit sparse-checkout and partial worktree
+# state from earlier jobs on the same runner. GitHub-hosted runners avoid this
+# by starting each job on a fresh VM; this hook gives the Docker runner fleet
+# the same repository-workspace invariant before actions/checkout runs.
+
+set -euo pipefail
+
+RUNNER_HOME="${RUNNER_HOME:-/home/runner/actions-runner}"
+RUNNER_WORK_DIR="${RUNNER_WORK_DIR:-_work}"
+WORK_ROOT="${RUNNER_HOME}/${RUNNER_WORK_DIR}"
+
+workspace="${GITHUB_WORKSPACE:-}"
+if [[ -z "${workspace}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+    repo_name="${GITHUB_REPOSITORY##*/}"
+    workspace="${WORK_ROOT}/${repo_name}/${repo_name}"
+fi
+
+if [[ -z "${workspace}" ]]; then
+    echo "[runner-job-started] GITHUB_WORKSPACE is unset; no workspace cleanup performed."
+    exit 0
+fi
+
+case "${workspace}" in
+    "${WORK_ROOT}/"*/*) ;;
+    *)
+        echo "[runner-job-started] Refusing to clean workspace outside ${WORK_ROOT}: ${workspace}" >&2
+        exit 1
+        ;;
+esac
+
+if [[ "${workspace}" == "/" || "${workspace}" == "${WORK_ROOT}" ]]; then
+    echo "[runner-job-started] Refusing unsafe workspace path: ${workspace}" >&2
+    exit 1
+fi
+
+echo "[runner-job-started] Resetting workspace: ${workspace}"
+rm -rf -- "${workspace}"
+mkdir -p -- "${workspace}"

--- a/docker/runners/runner-monitor.sh
+++ b/docker/runners/runner-monitor.sh
@@ -86,6 +86,7 @@ declare -A github_status
 total_found=0
 healthy=0
 unhealthy_list=()
+github_api_failed=false
 
 while IFS=$'\t' read -r name status; do
     [[ -z "${name}" ]] && continue
@@ -98,16 +99,17 @@ github_json=$(curl -fsS \
     "https://api.github.com/orgs/${RUNNER_ORG}/actions/runners?per_page=100" 2>/dev/null || true)
 
 if [[ -z "${github_json}" ]]; then
+    github_api_failed=true
     unhealthy_list+=("GITHUB_API: failed to fetch org runner status")
 else
-    while IFS=$'\t' read -r name status busy; do
+    while IFS=$'\t' read -r name status; do
         [[ -z "${name}" ]] && continue
         github_status["$name"]="$status"
     done < <(jq -r --arg prefix "${RUNNER_NAME_PREFIX}" --arg group "${RUNNER_GROUP}" '
         .runners[]
         | select(.name | startswith($prefix))
         | select(any(.labels[]; .name == $group))
-        | [.name, .status, (.busy | tostring)]
+        | [.name, .status]
         | @tsv
     ' <<< "${github_json}")
 fi
@@ -119,7 +121,6 @@ for i in $(seq 1 "$EXPECTED_RUNNERS"); do
     name="${RUNNER_NAME_PREFIX}-${i}"
     total_found=$((total_found + 1))
     docker_state="${current_status[$name]:-MISSING (no container)}"
-    gh_state="${github_status[$name]:-missing}"
 
     if [[ "${docker_state}" == "MISSING (no container)" ]]; then
         unhealthy_list+=("${name}: MISSING (no container)")
@@ -131,6 +132,12 @@ for i in $(seq 1 "$EXPECTED_RUNNERS"); do
         continue
     fi
 
+    if [[ "${github_api_failed}" == true ]]; then
+        healthy=$((healthy + 1))
+        continue
+    fi
+
+    gh_state="${github_status[$name]:-missing}"
     if [[ "${gh_state}" != "online" ]]; then
         unhealthy_list+=("${name}: GitHub ${gh_state} while Docker ${docker_state}")
         continue
@@ -165,15 +172,17 @@ for name in "${!current_status[@]}"; do
     fi
 done
 
-for name in "${!github_status[@]}"; do
-    if [[ ! "${name}" =~ ^${RUNNER_NAME_PREFIX}-[0-9]+$ ]]; then
-        continue
-    fi
-    index="${name##*-}"
-    if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
-        unhealthy_list+=("${name}: EXTRA GitHub registration beyond configured count ${EXPECTED_RUNNERS}")
-    fi
-done
+if [[ "${github_api_failed}" != true ]]; then
+    for name in "${!github_status[@]}"; do
+        if [[ ! "${name}" =~ ^${RUNNER_NAME_PREFIX}-[0-9]+$ ]]; then
+            continue
+        fi
+        index="${name##*-}"
+        if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
+            unhealthy_list+=("${name}: EXTRA GitHub registration beyond configured count ${EXPECTED_RUNNERS}")
+        fi
+    done
+fi
 
 # ---------------------------------------------------------------------------
 # Compare with previous state and alert on transitions

--- a/docker/runners/runner-monitor.sh
+++ b/docker/runners/runner-monitor.sh
@@ -3,23 +3,50 @@
 # Deployed to: 192.168.86.201:~/.omnibase/runners/runner-monitor.sh
 # Cron: */3 * * * * (every 3 minutes)
 #
-# Checks all omninode-runner-* containers. Fires a Slack alert on state
-# transitions (healthy → unhealthy/down). Resolves silently when all recover.
-# Uses a state file to prevent alert spam.
+# Checks configured omninode-runner-* containers and their GitHub Actions
+# registrations. Fires a Slack alert on state transitions. Resolves silently
+# when all recover. Uses a state file to prevent alert spam.
 
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
-EXPECTED_RUNNERS=10
 STATE_FILE="/tmp/runner-monitor-state.json"
 COMPOSE_DIR="$HOME/.omnibase/runners/docker"
-COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.runners.yml"
+RUNNER_FLEET_CONFIG_PATH="${RUNNER_FLEET_CONFIG_PATH:-$HOME/.omnibase/runners/config/runner_fleet.yaml}"
+
+config_field() {
+    local field="${1}"
+    [[ -f "${RUNNER_FLEET_CONFIG_PATH}" ]] || {
+        echo "[runner-monitor] ERROR: runner fleet config not found: ${RUNNER_FLEET_CONFIG_PATH}" >&2
+        exit 1
+    }
+    local value
+    value=$(awk -F':[[:space:]]*' -v key="${field}" '
+        $1 == key {
+            gsub(/^[[:space:]"]+|[[:space:]"]+$/, "", $2)
+            print $2
+            found=1
+        }
+        END { if (!found) exit 1 }
+    ' "${RUNNER_FLEET_CONFIG_PATH}") || {
+        echo "[runner-monitor] ERROR: missing ${field} in ${RUNNER_FLEET_CONFIG_PATH}" >&2
+        exit 1
+    }
+    echo "${value}"
+}
+
+RUNNER_ORG="$(config_field github_org)"
+RUNNER_GROUP="$(config_field runner_group)"
+RUNNER_NAME_PREFIX="$(config_field runner_name_prefix)"
+EXPECTED_RUNNERS="$(config_field expected_count)"
+RUNNER_HOST="$(config_field runner_host)"
 
 # Slack config — passed via environment (cron sources ~/.omnibase/.env)
 : "${SLACK_BOT_TOKEN:?SLACK_BOT_TOKEN must be set}"
 : "${SLACK_CHANNEL_ID:?SLACK_CHANNEL_ID must be set}"
+: "${RUNNER_GITHUB_TOKEN:?RUNNER_GITHUB_TOKEN must be set}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -37,12 +64,13 @@ slack_post() {
             --arg fallback "$text" \
             --arg color "$color" \
             --arg text "$text" \
+            --arg footer "runner-monitor | ${RUNNER_HOST}" \
             '{
                 channel: $channel,
                 attachments: [{
                     color: $color,
                     text: $text,
-                    footer: "runner-monitor | 192.168.86.201",
+                    footer: $footer,
                     ts: (now | floor)
                 }]
             }'
@@ -53,29 +81,62 @@ slack_post() {
 # Collect current state
 # ---------------------------------------------------------------------------
 declare -A current_status
+declare -A github_status
 
 total_found=0
 healthy=0
 unhealthy_list=()
 
 while IFS=$'\t' read -r name status; do
-    total_found=$((total_found + 1))
+    [[ -z "${name}" ]] && continue
     current_status["$name"]="$status"
+done < <(docker ps -a --filter "name=${RUNNER_NAME_PREFIX}" --format "{{.Names}}\t{{.Status}}" 2>/dev/null || true)
 
-    if [[ "$status" == *"(healthy)"* ]] && [[ "$status" == Up* ]]; then
-        healthy=$((healthy + 1))
-    else
-        unhealthy_list+=("${name}: ${status}")
-    fi
-done < <(docker ps -a --filter "name=omninode-runner" --format "{{.Names}}\t{{.Status}}" 2>/dev/null || true)
+github_json=$(curl -fsS \
+    -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/orgs/${RUNNER_ORG}/actions/runners?per_page=100" 2>/dev/null || true)
 
-# Check for missing runners (expected but not even in docker ps)
-for i in $(seq 1 $EXPECTED_RUNNERS); do
-    name="omninode-runner-${i}"
-    if [[ -z "${current_status[$name]+x}" ]]; then
+if [[ -z "${github_json}" ]]; then
+    unhealthy_list+=("GITHUB_API: failed to fetch org runner status")
+else
+    while IFS=$'\t' read -r name status busy; do
+        [[ -z "${name}" ]] && continue
+        github_status["$name"]="$status"
+    done < <(jq -r --arg prefix "${RUNNER_NAME_PREFIX}" --arg group "${RUNNER_GROUP}" '
+        .runners[]
+        | select(.name | startswith($prefix))
+        | select(any(.labels[]; .name == $group))
+        | [.name, .status, (.busy | tostring)]
+        | @tsv
+    ' <<< "${github_json}")
+fi
+
+# Check configured runners against both Docker and GitHub. Docker healthy while
+# GitHub says offline is degraded; that is exactly the state container-only
+# health checks miss.
+for i in $(seq 1 "$EXPECTED_RUNNERS"); do
+    name="${RUNNER_NAME_PREFIX}-${i}"
+    total_found=$((total_found + 1))
+    docker_state="${current_status[$name]:-MISSING (no container)}"
+    gh_state="${github_status[$name]:-missing}"
+
+    if [[ "${docker_state}" == "MISSING (no container)" ]]; then
         unhealthy_list+=("${name}: MISSING (no container)")
-        total_found=$((total_found + 1))  # count as expected
+        continue
     fi
+
+    if [[ "${docker_state}" != *"(healthy)"* ]] || [[ "${docker_state}" != Up* ]]; then
+        unhealthy_list+=("${name}: Docker ${docker_state}")
+        continue
+    fi
+
+    if [[ "${gh_state}" != "online" ]]; then
+        unhealthy_list+=("${name}: GitHub ${gh_state} while Docker ${docker_state}")
+        continue
+    fi
+
+    healthy=$((healthy + 1))
 done
 
 # Also check Docker socket accessibility from a healthy runner
@@ -93,6 +154,26 @@ if [[ $healthy -gt 0 ]]; then
         fi
     done
 fi
+
+for name in "${!current_status[@]}"; do
+    if [[ ! "${name}" =~ ^${RUNNER_NAME_PREFIX}-[0-9]+$ ]]; then
+        continue
+    fi
+    index="${name##*-}"
+    if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
+        unhealthy_list+=("${name}: EXTRA Docker container beyond configured count ${EXPECTED_RUNNERS}")
+    fi
+done
+
+for name in "${!github_status[@]}"; do
+    if [[ ! "${name}" =~ ^${RUNNER_NAME_PREFIX}-[0-9]+$ ]]; then
+        continue
+    fi
+    index="${name##*-}"
+    if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
+        unhealthy_list+=("${name}: EXTRA GitHub registration beyond configured count ${EXPECTED_RUNNERS}")
+    fi
+done
 
 # ---------------------------------------------------------------------------
 # Compare with previous state and alert on transitions
@@ -136,7 +217,7 @@ ${detail}
 
 Healthy: ${healthy}/${EXPECTED_RUNNERS}
 Docker socket: $([ "$docker_ok" = true ] && echo 'OK' || echo 'FAILED')
-Host: 192.168.86.201" "danger"
+Host: ${RUNNER_HOST}" "danger"
     log "ALERT: ${current_unhealthy_count} runners unhealthy (was 0). Slack notified."
 
 elif [[ $current_unhealthy_count -gt 0 ]] && [[ $prev_unhealthy_count -gt 0 ]] && [[ $current_unhealthy_count -ne $prev_unhealthy_count ]]; then
@@ -156,7 +237,7 @@ elif [[ $current_unhealthy_count -eq 0 ]] && [[ $prev_unhealthy_count -gt 0 ]]; 
     slack_post "*[RUNNER RECOVERED]* All ${EXPECTED_RUNNERS} runners healthy
 
 Docker socket: $([ "$docker_ok" = true ] && echo 'OK' || echo 'FAILED')
-Host: 192.168.86.201" "good"
+Host: ${RUNNER_HOST}" "good"
     log "RECOVERED: All ${EXPECTED_RUNNERS} runners healthy. Slack notified."
 
 else

--- a/docker/runners/runner-monitor.sh
+++ b/docker/runners/runner-monitor.sh
@@ -41,6 +41,7 @@ RUNNER_ORG="$(config_field github_org)"
 RUNNER_GROUP="$(config_field runner_group)"
 RUNNER_NAME_PREFIX="$(config_field runner_name_prefix)"
 EXPECTED_RUNNERS="$(config_field expected_count)"
+BURST_RUNNERS="$(config_field burst_count 2>/dev/null || echo "${EXPECTED_RUNNERS}")"
 RUNNER_HOST="$(config_field runner_host)"
 
 # Slack config — passed via environment (cron sources ~/.omnibase/.env)
@@ -178,8 +179,8 @@ for name in "${!current_status[@]}"; do
         continue
     fi
     index="${name##*-}"
-    if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
-        unhealthy_list+=("${name}: EXTRA Docker container beyond configured count ${EXPECTED_RUNNERS}")
+    if [[ "${index}" -gt "${BURST_RUNNERS}" ]]; then
+        unhealthy_list+=("${name}: EXTRA Docker container beyond configured burst count ${BURST_RUNNERS}")
     fi
 done
 
@@ -189,8 +190,8 @@ if [[ "${github_api_failed}" != true ]]; then
             continue
         fi
         index="${name##*-}"
-        if [[ "${index}" -gt "${EXPECTED_RUNNERS}" ]]; then
-            unhealthy_list+=("${name}: EXTRA GitHub registration beyond configured count ${EXPECTED_RUNNERS}")
+        if [[ "${index}" -gt "${BURST_RUNNERS}" ]]; then
+            unhealthy_list+=("${name}: EXTRA GitHub registration beyond configured burst count ${BURST_RUNNERS}")
         fi
     done
 fi

--- a/docker/runners/runner-monitor.sh
+++ b/docker/runners/runner-monitor.sh
@@ -81,6 +81,7 @@ slack_post() {
 # Collect current state
 # ---------------------------------------------------------------------------
 declare -A current_status
+declare -A docker_oom_killed
 declare -A github_status
 
 total_found=0
@@ -92,6 +93,11 @@ while IFS=$'\t' read -r name status; do
     [[ -z "${name}" ]] && continue
     current_status["$name"]="$status"
 done < <(docker ps -a --filter "name=${RUNNER_NAME_PREFIX}" --format "{{.Names}}\t{{.Status}}" 2>/dev/null || true)
+
+for name in "${!current_status[@]}"; do
+    oom_killed="$(docker inspect --format '{{.State.OOMKilled}}' "$name" 2>/dev/null || echo "unknown")"
+    docker_oom_killed["$name"]="$oom_killed"
+done
 
 github_json=$(curl -fsS \
     -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
@@ -124,6 +130,11 @@ for i in $(seq 1 "$EXPECTED_RUNNERS"); do
 
     if [[ "${docker_state}" == "MISSING (no container)" ]]; then
         unhealthy_list+=("${name}: MISSING (no container)")
+        continue
+    fi
+
+    if [[ "${docker_oom_killed[$name]:-false}" == "true" ]]; then
+        unhealthy_list+=("${name}: Docker OOMKilled=true while ${docker_state}")
         continue
     fi
 

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -345,12 +345,15 @@ poll_runners_online() {
     local elapsed=0
     while true; do
         local online
-        online=$(gh api "/orgs/${RUNNER_ORG}/actions/runners" --jq "
-          [.runners[] |
-           select(.name | startswith(\"${RUNNER_NAME_PREFIX}\")) |
-           select(.status == \"online\") |
-           select(any(.labels[]; .name == \"${RUNNER_GROUP}\"))] | length
-        ")
+        online=$(
+            gh api --paginate "/orgs/${RUNNER_ORG}/actions/runners?per_page=100" |
+                jq -s --arg prefix "${RUNNER_NAME_PREFIX}" --arg group "${RUNNER_GROUP}" '
+                  [.[].runners[] |
+                   select(.name | startswith($prefix)) |
+                   select(.status == "online") |
+                   select(any(.labels[]; .name == $group))] | length
+                '
+        )
 
         log "Online runners validated: ${online}/${RUNNER_COUNT} (${elapsed}s elapsed)"
 
@@ -459,12 +462,15 @@ print_stale_runner_report() {
 
     # Get all offline runners matching our prefix
     local offline_runners
-    offline_runners=$(gh api "/orgs/${RUNNER_ORG}/actions/runners" --jq "
-      [.runners[] |
-       select(.name | startswith(\"${RUNNER_NAME_PREFIX}\")) |
-       select(.status == \"offline\")] |
-      .[] | {id: .id, name: .name, status: .status}
-    " 2>/dev/null || echo "")
+    offline_runners=$(
+        gh api --paginate "/orgs/${RUNNER_ORG}/actions/runners?per_page=100" |
+            jq -s --arg prefix "${RUNNER_NAME_PREFIX}" '
+              [.[].runners[] |
+               select(.name | startswith($prefix)) |
+               select(.status == "offline")] |
+              .[] | {id: .id, name: .name, status: .status}
+            ' 2>/dev/null || echo ""
+    )
 
     if [[ -z "${offline_runners}" ]]; then
         log "No offline runners found. All runners appear healthy."

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -520,7 +520,7 @@ install_health_cron() {
     local repo_root
     repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-    local cron_line="*/3 * * * * set -a && source ~/.omnibase/.env && set +a && cd ${repo_root} && PYTHONPATH=${repo_root}/src RUNNER_FLEET_CONFIG_PATH=${RUNNER_FLEET_CONFIG} RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
+    local cron_line="*/3 * * * * set -a && . ~/.omnibase/.env && set +a && cd ${repo_root} && PYTHONPATH=${repo_root}/src RUNNER_FLEET_CONFIG_PATH=${RUNNER_FLEET_CONFIG} RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
 
     # Filter out any existing runner-health-check line, then append new one
     local existing

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -16,7 +16,8 @@
 #   4. Deploy via SSH: docker compose up -d --build --force-recreate --remove-orphans
 #   5. Install docker prune cron idempotently (build cache + untagged images, tee)
 #   6. Install runner health monitor cron (Slack alerts on state transitions)
-#   7. Poll GitHub API until all 10 runners online (max 5 min, 15s interval)
+#   7. Poll GitHub API until the configured runner fleet is online
+#      (max 5 min, 15s interval)
 #   8. Retry once with fresh token if poll times out
 #   9. Print stale runner report (offline runners with no host container)
 #
@@ -41,21 +42,45 @@ set -euo pipefail
 # Constants
 # ---------------------------------------------------------------------------
 
-RUNNER_HOST="192.168.86.201"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNNER_FLEET_CONFIG="${RUNNER_FLEET_CONFIG_PATH:-${REPO_ROOT}/config/runner_fleet.yaml}"
+
+runner_config_field() {
+    local field="${1}"
+    [[ -f "${RUNNER_FLEET_CONFIG}" ]] || {
+        echo "[deploy-runners] ERROR: runner fleet config not found: ${RUNNER_FLEET_CONFIG}" >&2
+        exit 1
+    }
+    local value
+    value=$(awk -F':[[:space:]]*' -v key="${field}" '
+        $1 == key {
+            gsub(/^[[:space:]"]+|[[:space:]"]+$/, "", $2)
+            print $2
+            found=1
+        }
+        END { if (!found) exit 1 }
+    ' "${RUNNER_FLEET_CONFIG}") || {
+        echo "[deploy-runners] ERROR: missing ${field} in ${RUNNER_FLEET_CONFIG}" >&2
+        exit 1
+    }
+    echo "${value}"
+}
+
+RUNNER_HOST="$(runner_config_field runner_host)"
 # Remote path on the CI host — NOT local $HOME (which differs between macOS and Linux)
 RUNNER_HOST_DIR="/home/jonah/.omnibase/runners"
-RUNNER_ORG="OmniNode-ai"
-RUNNER_GROUP="omnibase-ci"
-RUNNER_NAME_PREFIX="omninode-runner"
-RUNNER_COUNT=10
+RUNNER_ORG="$(runner_config_field github_org)"
+RUNNER_GROUP="$(runner_config_field runner_group)"
+RUNNER_NAME_PREFIX="$(runner_config_field runner_name_prefix)"
+RUNNER_COUNT="$(runner_config_field expected_count)"
 COMPOSE_FILE="docker/docker-compose.runners.yml"
 POLL_MAX_SECONDS=300
 POLL_INTERVAL_SECONDS=15
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Artifacts to sync to the host (relative to repo root)
 SYNC_PATHS=(
+    "config/runner_fleet.yaml"
     "docker/runners/Dockerfile"
     "docker/runners/entrypoint.sh"
     "docker/runners/runner-monitor.sh"
@@ -151,14 +176,18 @@ rsync_artifacts() {
     log "Rsyncing runner artifacts to ${RUNNER_HOST}:${RUNNER_HOST_DIR}/ ..."
 
     # Ensure remote directory structure exists
-    run_ssh "mkdir -p ${RUNNER_HOST_DIR}/docker/runners ${RUNNER_HOST_DIR}/docker"
+    run_ssh "mkdir -p ${RUNNER_HOST_DIR}/config ${RUNNER_HOST_DIR}/docker/runners ${RUNNER_HOST_DIR}/docker"
 
     if "${DRY_RUN}"; then
         log "[DRY RUN] rsync ${SYNC_PATHS[*]} -> ${RUNNER_HOST}:${RUNNER_HOST_DIR}/"
         return 0
     fi
 
-    # Sync Dockerfile, entrypoint, and monitor into docker/runners/
+    # Sync fleet config, Dockerfile, entrypoint, and monitor.
+    rsync -av --checksum \
+        "${REPO_ROOT}/config/runner_fleet.yaml" \
+        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/config/"
+
     rsync -av --checksum \
         "${REPO_ROOT}/docker/runners/Dockerfile" \
         "${REPO_ROOT}/docker/runners/entrypoint.sh" \
@@ -235,16 +264,26 @@ install_monitor_cron() {
     # Source local .env to get Slack credentials
     local slack_bot_token=""
     local slack_channel_id=""
+    local runner_github_token="${RUNNER_GITHUB_TOKEN:-${GH_PAT:-${GITHUB_TOKEN:-}}}"
     if [[ -f "${HOME}/.omnibase/.env" ]]; then
         # shellcheck disable=SC1091
         set -a && source "${HOME}/.omnibase/.env" && set +a
         slack_bot_token="${SLACK_BOT_TOKEN:-}"
         slack_channel_id="${SLACK_CHANNEL_ID:-}"
+        runner_github_token="${RUNNER_GITHUB_TOKEN:-${GH_PAT:-${GITHUB_TOKEN:-${runner_github_token}}}}"
     fi
 
     if [[ -z "${slack_bot_token}" ]] || [[ -z "${slack_channel_id}" ]]; then
         warn "SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set in ~/.omnibase/.env"
         warn "Skipping monitor cron install. Monitor script is deployed but cron won't work without credentials."
+        return 0
+    fi
+    if [[ -z "${runner_github_token}" ]]; then
+        runner_github_token="$(gh auth token 2>/dev/null || true)"
+    fi
+    if [[ -z "${runner_github_token}" ]]; then
+        warn "RUNNER_GITHUB_TOKEN/GH_PAT/GITHUB_TOKEN not set and gh auth token unavailable"
+        warn "Skipping monitor cron install. GitHub-aware monitor requires org runner API access."
         return 0
     fi
 
@@ -259,6 +298,8 @@ install_monitor_cron() {
         ssh "${RUNNER_HOST}" "cat > ${RUNNER_HOST_DIR}/.monitor-env" <<ENVEOF
 SLACK_BOT_TOKEN=${slack_bot_token}
 SLACK_CHANNEL_ID=${slack_channel_id}
+RUNNER_GITHUB_TOKEN=${runner_github_token}
+RUNNER_FLEET_CONFIG_PATH=${RUNNER_HOST_DIR}/config/runner_fleet.yaml
 ENVEOF
         ssh "${RUNNER_HOST}" "chmod 600 ${RUNNER_HOST_DIR}/.monitor-env"
     fi
@@ -277,7 +318,8 @@ ENVEOF
 }
 
 # ---------------------------------------------------------------------------
-# Step 7: Poll GitHub API until all 10 runners are online and validated
+# Step 7: Poll GitHub API until the configured runner fleet is online
+# and validated
 # ---------------------------------------------------------------------------
 
 poll_runners_online() {
@@ -296,7 +338,6 @@ poll_runners_online() {
           [.runners[] |
            select(.name | startswith(\"${RUNNER_NAME_PREFIX}\")) |
            select(.status == \"online\") |
-           select(.runner_group_name == \"${RUNNER_GROUP}\") |
            select(any(.labels[]; .name == \"${RUNNER_GROUP}\"))] | length
         ")
 
@@ -468,7 +509,7 @@ install_health_cron() {
     local repo_root
     repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-    local cron_line="*/3 * * * * set -a && source ~/.omnibase/.env && set +a && cd ${repo_root} && RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
+    local cron_line="*/3 * * * * set -a && source ~/.omnibase/.env && set +a && cd ${repo_root} && PYTHONPATH=${repo_root}/src RUNNER_FLEET_CONFIG_PATH=${repo_root}/config/runner_fleet.yaml RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
 
     # Filter out any existing runner-health-check line, then append new one
     local existing

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -44,7 +44,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-RUNNER_FLEET_CONFIG="${RUNNER_FLEET_CONFIG_PATH:-${REPO_ROOT}/config/runner_fleet.yaml}"
+RUNNER_FLEET_CONFIG="${RUNNER_FLEET_CONFIG_PATH:-${RUNNER_FLEET_CONFIG:-${REPO_ROOT}/config/runner_fleet.yaml}}"
 
 runner_config_field() {
     local field="${1}"
@@ -80,7 +80,7 @@ POLL_INTERVAL_SECONDS=15
 
 # Artifacts to sync to the host (relative to repo root)
 SYNC_PATHS=(
-    "config/runner_fleet.yaml"
+    "${RUNNER_FLEET_CONFIG}"
     "docker/runners/Dockerfile"
     "docker/runners/entrypoint.sh"
     "docker/runners/runner-monitor.sh"
@@ -185,8 +185,8 @@ rsync_artifacts() {
 
     # Sync fleet config, Dockerfile, entrypoint, and monitor.
     rsync -av --checksum \
-        "${REPO_ROOT}/config/runner_fleet.yaml" \
-        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/config/"
+        "${RUNNER_FLEET_CONFIG}" \
+        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/config/runner_fleet.yaml"
 
     rsync -av --checksum \
         "${REPO_ROOT}/docker/runners/Dockerfile" \
@@ -509,7 +509,7 @@ install_health_cron() {
     local repo_root
     repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-    local cron_line="*/3 * * * * set -a && source ~/.omnibase/.env && set +a && cd ${repo_root} && PYTHONPATH=${repo_root}/src RUNNER_FLEET_CONFIG_PATH=${repo_root}/config/runner_fleet.yaml RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
+    local cron_line="*/3 * * * * set -a && source ~/.omnibase/.env && set +a && cd ${repo_root} && PYTHONPATH=${repo_root}/src RUNNER_FLEET_CONFIG_PATH=${RUNNER_FLEET_CONFIG} RUNNER_HEALTH_HOST=${RUNNER_HOST} uv run python -m omnibase_infra.observability.runner_health.cli_runner_health --emit --alert >> /tmp/runner-health.log 2>&1 # runner-health-check"
 
     # Filter out any existing runner-health-check line, then append new one
     local existing

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -83,6 +83,7 @@ SYNC_PATHS=(
     "${RUNNER_FLEET_CONFIG}"
     "docker/runners/Dockerfile"
     "docker/runners/entrypoint.sh"
+    "docker/runners/runner-job-started.sh"
     "docker/runners/runner-monitor.sh"
     "docker/docker-compose.runners.yml"
 )
@@ -147,7 +148,7 @@ run_local() {
 # ---------------------------------------------------------------------------
 
 fetch_registration_token() {
-    log "Fetching GitHub Actions registration token for org ${RUNNER_ORG}..."
+    log "Fetching GitHub Actions registration token for org ${RUNNER_ORG}..." >&2
     # Separate declaration from assignment so set -e catches gh api failures
     local token
     token=$(gh api --method POST "/orgs/${RUNNER_ORG}/actions/runners/registration-token" --jq .token) \
@@ -191,6 +192,7 @@ rsync_artifacts() {
     rsync -av --checksum \
         "${REPO_ROOT}/docker/runners/Dockerfile" \
         "${REPO_ROOT}/docker/runners/entrypoint.sh" \
+        "${REPO_ROOT}/docker/runners/runner-job-started.sh" \
         "${REPO_ROOT}/docker/runners/runner-monitor.sh" \
         "${RUNNER_HOST}:${RUNNER_HOST_DIR}/docker/runners/"
 
@@ -208,6 +210,7 @@ rsync_artifacts() {
 
 deploy_runners() {
     local token_b64="${1}"
+    local remote_token_b64="${token_b64}"
 
     local compose_cmd="docker compose -f ${RUNNER_HOST_DIR}/docker/docker-compose.runners.yml"
 
@@ -219,10 +222,14 @@ deploy_runners() {
 
     log "Deploying runners on ${RUNNER_HOST} (force-recreate ensures fresh env)..."
 
+    if "${DRY_RUN}"; then
+        remote_token_b64="<redacted-token-b64>"
+    fi
+
     # Decode token on remote side to avoid shell metacharacter issues
     run_ssh "
         set -euo pipefail
-        RUNNER_TOKEN=\$(echo '${token_b64}' | base64 -d)
+        RUNNER_TOKEN=\$(echo '${remote_token_b64}' | base64 -d)
         export RUNNER_TOKEN
         cd ${RUNNER_HOST_DIR}
         ${compose_cmd} up -d ${up_flags}
@@ -267,7 +274,11 @@ install_monitor_cron() {
     local runner_github_token="${RUNNER_GITHUB_TOKEN:-${GH_PAT:-${GITHUB_TOKEN:-}}}"
     if [[ -f "${HOME}/.omnibase/.env" ]]; then
         # shellcheck disable=SC1091
-        set -a && source "${HOME}/.omnibase/.env" && set +a
+        set +u
+        set -a
+        source "${HOME}/.omnibase/.env"
+        set +a
+        set -u
         slack_bot_token="${SLACK_BOT_TOKEN:-}"
         slack_channel_id="${SLACK_CHANNEL_ID:-}"
         runner_github_token="${RUNNER_GITHUB_TOKEN:-${GH_PAT:-${GITHUB_TOKEN:-${runner_github_token}}}}"

--- a/scripts/publish_pr_merged_event.py
+++ b/scripts/publish_pr_merged_event.py
@@ -126,7 +126,9 @@ def _build_event(
         title=title,
         merged_at=merged_at if merged_at else None,
     )
-    return json.loads(event.model_dump_json())
+    if hasattr(event, "model_dump_json"):
+        return json.loads(event.model_dump_json())
+    return json.loads(event.json())
 
 
 def _publish(

--- a/scripts/publish_pr_webhook_event.py
+++ b/scripts/publish_pr_webhook_event.py
@@ -135,7 +135,9 @@ def _build_event(
         actor=actor or None,
         merged=merged,
     )
-    return dict(json.loads(event.model_dump_json()))
+    if hasattr(event, "model_dump_json"):
+        return dict(json.loads(event.model_dump_json()))
+    return dict(json.loads(event.json()))
 
 
 def _publish(

--- a/src/omnibase_infra/observability/runner_health/__init__.py
+++ b/src/omnibase_infra/observability/runner_health/__init__.py
@@ -5,6 +5,10 @@
 from omnibase_infra.observability.runner_health.enum_runner_health_state import (
     EnumRunnerHealthState,
 )
+from omnibase_infra.observability.runner_health.model_runner_fleet_config import (
+    ModelRunnerFleetConfig,
+    load_runner_fleet_config,
+)
 from omnibase_infra.observability.runner_health.model_runner_health_alert import (
     ModelRunnerHealthAlert,
 )
@@ -20,4 +24,6 @@ __all__ = [
     "ModelRunnerHealthAlert",
     "ModelRunnerHealthSnapshot",
     "ModelRunnerStatus",
+    "ModelRunnerFleetConfig",
+    "load_runner_fleet_config",
 ]

--- a/src/omnibase_infra/observability/runner_health/cli_runner_health.py
+++ b/src/omnibase_infra/observability/runner_health/cli_runner_health.py
@@ -13,9 +13,10 @@ Flags:
     --host    Override RUNNER_HEALTH_HOST env var
 
 Environment:
-    RUNNER_HEALTH_HOST            CI host address (required if --host not given)
-    RUNNER_HEALTH_GITHUB_ORG      GitHub org (default: OmniNode-ai)
-    RUNNER_HEALTH_EXPECTED_COUNT  Expected runner count (default: 10)
+    RUNNER_FLEET_CONFIG_PATH      Path to config/runner_fleet.yaml
+    RUNNER_HEALTH_HOST            Optional CI host override
+    RUNNER_HEALTH_GITHUB_ORG      Optional GitHub org override
+    RUNNER_HEALTH_RUNNER_PREFIX   Optional runner name prefix override
     KAFKA_BOOTSTRAP_SERVERS       Kafka brokers for --emit
     SLACK_BOT_TOKEN               Slack bot token for --alert
     SLACK_CHANNEL_ID              Slack channel for --alert
@@ -35,6 +36,9 @@ from omnibase_infra.observability.runner_health.collector_runner_health import (
 from omnibase_infra.observability.runner_health.enum_runner_health_state import (
     EnumRunnerHealthState,
 )
+from omnibase_infra.observability.runner_health.model_runner_fleet_config import (
+    load_runner_fleet_config,
+)
 from omnibase_infra.observability.runner_health.model_runner_health_alert import (
     ModelRunnerHealthAlert,
 )
@@ -42,16 +46,17 @@ from omnibase_infra.observability.runner_health.model_runner_health_snapshot imp
     ModelRunnerHealthSnapshot,
 )
 
-# Config from environment -- no hardcoded lab values
-GITHUB_ORG = os.environ.get("RUNNER_HEALTH_GITHUB_ORG", "OmniNode-ai")
-RUNNER_HOST = os.environ.get("RUNNER_HEALTH_HOST", "")
-RUNNER_COUNT = int(os.environ.get("RUNNER_HEALTH_EXPECTED_COUNT", "10"))
-
 
 async def main(args: list[str]) -> int:
     """Run runner health collection with optional Kafka emit and Slack alert."""
+    try:
+        fleet_config = load_runner_fleet_config()
+    except Exception as exc:
+        print(f"[runner-health] ERROR: {exc}")
+        return 1
+
     # CLI flag overrides for env vars
-    host = RUNNER_HOST
+    host = os.environ.get("RUNNER_HEALTH_HOST", fleet_config.runner_host)
     for i, arg in enumerate(args):
         if arg == "--host" and i + 1 < len(args):
             host = args[i + 1]
@@ -60,11 +65,16 @@ async def main(args: list[str]) -> int:
             "[runner-health] ERROR: RUNNER_HEALTH_HOST not set and --host not provided."
         )
         return 1
+    github_org = os.environ.get("RUNNER_HEALTH_GITHUB_ORG", fleet_config.github_org)
+    runner_prefix = os.environ.get(
+        "RUNNER_HEALTH_RUNNER_PREFIX", fleet_config.runner_name_prefix
+    )
 
     collector = CollectorRunnerHealth(
-        github_org=GITHUB_ORG,
+        github_org=github_org,
         runner_host=host,
-        runner_count=RUNNER_COUNT,
+        runner_count=fleet_config.expected_count,
+        runner_prefix=runner_prefix,
     )
 
     correlation_id = uuid4()

--- a/src/omnibase_infra/observability/runner_health/collector_runner_health.py
+++ b/src/omnibase_infra/observability/runner_health/collector_runner_health.py
@@ -51,6 +51,8 @@ class CollectorRunnerHealth:
         """Compute health state from GitHub and Docker status signals."""
         if docker_status == "not_found":
             return EnumRunnerHealthState.MISSING
+        if docker_status == "oom_killed":
+            return EnumRunnerHealthState.OOM_KILLED
         if (
             "restarting" in docker_status.lower()
             or "restarting" in docker_uptime.lower()
@@ -90,8 +92,15 @@ class CollectorRunnerHealth:
     ) -> tuple[dict[str, dict[str, str]], str | None]:
         """Fetch Docker container status via SSH. Returns (statuses, error)."""
         cmd = (
-            f"docker ps -a --filter 'name={self._runner_prefix}' "
-            f"--format '{{{{.Names}}}}\\t{{{{.Status}}}}'"
+            "for name in $(docker ps -a "
+            f"--filter 'name={self._runner_prefix}' "
+            "--format '{{.Names}}'); do "
+            "status=$(docker inspect --format '{{.State.Status}}' \"$name\"); "
+            "health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' \"$name\"); "
+            "oom_killed=$(docker inspect --format '{{.State.OOMKilled}}' \"$name\"); "
+            "uptime=$(docker ps -a --filter \"name=^/${name}$\" --format '{{.Status}}'); "
+            'printf "%s\\t%s\\t%s\\t%s\\t%s\\n" "$name" "$status" "$health" "$oom_killed" "$uptime"; '
+            "done"
         )
         proc = await asyncio.create_subprocess_exec(
             "ssh",
@@ -108,13 +117,22 @@ class CollectorRunnerHealth:
             )
         result: dict[str, dict[str, str]] = {}
         for line in stdout.decode().strip().splitlines():
-            parts = line.split("\t", 1)
-            if len(parts) == 2:
-                name, uptime = parts
+            parts = line.split("\t", 4)
+            if len(parts) == 5:
+                name, container_status, health, oom_killed, uptime = parts
                 status = (
-                    "healthy"
-                    if "(healthy)" in uptime
-                    else ("restarting" if "Restarting" in uptime else "running")
+                    "oom_killed"
+                    if oom_killed == "true"
+                    else (
+                        "healthy"
+                        if health == "healthy" or "(healthy)" in uptime
+                        else (
+                            "restarting"
+                            if container_status == "restarting"
+                            or "Restarting" in uptime
+                            else container_status
+                        )
+                    )
                 )
                 result[name] = {"status": status, "uptime": uptime}
         return result, None

--- a/src/omnibase_infra/observability/runner_health/collector_runner_health.py
+++ b/src/omnibase_infra/observability/runner_health/collector_runner_health.py
@@ -41,6 +41,15 @@ class CollectorRunnerHealth:
         self._runner_count = runner_count
         self._runner_prefix = runner_prefix
 
+    def _runner_index(self, name: str) -> int | None:
+        prefix = f"{self._runner_prefix}-"
+        if not name.startswith(prefix):
+            return None
+        suffix = name.removeprefix(prefix)
+        if not suffix.isdigit():
+            return None
+        return int(suffix)
+
     def _classify_runner(
         self,
         github_status: str,
@@ -179,6 +188,9 @@ class CollectorRunnerHealth:
         seen_docker_names: set[str] = set()
         for gh in github_runners:
             name = str(gh["name"])
+            index = self._runner_index(name)
+            if index is None or index > self._runner_count:
+                continue
             seen_docker_names.add(name)
             docker = docker_statuses.get(name, {"status": "not_found", "uptime": ""})
             state = self._classify_runner(
@@ -200,6 +212,9 @@ class CollectorRunnerHealth:
 
         # Reverse pass: Docker containers not in GitHub -> orphaned
         for docker_name, docker_info in docker_statuses.items():
+            index = self._runner_index(docker_name)
+            if index is None or index > self._runner_count:
+                continue
             if docker_name not in seen_docker_names:
                 statuses.append(
                     ModelRunnerStatus(

--- a/src/omnibase_infra/observability/runner_health/enum_runner_health_state.py
+++ b/src/omnibase_infra/observability/runner_health/enum_runner_health_state.py
@@ -13,6 +13,7 @@ class EnumRunnerHealthState(StrEnum):
     HEALTHY = "healthy"
     GITHUB_OFFLINE = "github_offline"
     DOCKER_UNHEALTHY = "docker_unhealthy"
+    OOM_KILLED = "oom_killed"
     CRASH_LOOPING = "crash_looping"
     STALE_REGISTRATION = "stale_registration"
     MISSING = "missing"

--- a/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
@@ -30,7 +30,8 @@ def default_runner_fleet_config_path() -> Path:
     env_path = os.environ.get("RUNNER_FLEET_CONFIG_PATH", "")
     if env_path:
         return Path(env_path).expanduser()
-    return Path.cwd() / "config" / "runner_fleet.yaml"
+    repo_root = Path(__file__).resolve().parents[4]
+    return repo_root / "config" / "runner_fleet.yaml"
 
 
 def load_runner_fleet_config(path: Path | None = None) -> ModelRunnerFleetConfig:

--- a/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Typed runner fleet configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRunnerFleetConfig(BaseModel):
+    """Authoritative configuration for the self-hosted runner fleet."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    version: str = Field(..., description="Runner fleet config schema version")
+    github_org: str = Field(..., min_length=1)
+    runner_host: str = Field(..., min_length=1)
+    runner_group: str = Field(..., min_length=1)
+    runner_name_prefix: str = Field(..., min_length=1)
+    expected_count: int = Field(..., ge=1)
+
+
+def default_runner_fleet_config_path() -> Path:
+    """Return the default repo-local runner fleet config path."""
+    env_path = os.environ.get("RUNNER_FLEET_CONFIG_PATH", "")
+    if env_path:
+        return Path(env_path).expanduser()
+    return Path.cwd() / "config" / "runner_fleet.yaml"
+
+
+def load_runner_fleet_config(path: Path | None = None) -> ModelRunnerFleetConfig:
+    """Load and validate runner fleet config.
+
+    The config file is required; missing config is a deployment error, not a
+    signal to fall back to embedded lab values.
+    """
+    config_path = path or default_runner_fleet_config_path()
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Runner fleet config not found: {config_path}")
+
+    raw = cast("object", yaml.safe_load(config_path.read_text(encoding="utf-8")) or {})
+    return ModelRunnerFleetConfig.model_validate(raw)
+
+
+__all__ = [
+    "ModelRunnerFleetConfig",
+    "default_runner_fleet_config_path",
+    "load_runner_fleet_config",
+]

--- a/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_fleet_config.py
@@ -23,6 +23,11 @@ class ModelRunnerFleetConfig(BaseModel):
     runner_group: str = Field(..., min_length=1)
     runner_name_prefix: str = Field(..., min_length=1)
     expected_count: int = Field(..., ge=1)
+    burst_count: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional maximum runner count enabled only by the compose burst profile.",
+    )
 
 
 def default_runner_fleet_config_path() -> Path:

--- a/src/omnibase_infra/observability/runner_health/model_runner_status.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_status.py
@@ -29,3 +29,6 @@ class ModelRunnerStatus(BaseModel):
     docker_uptime: str = Field(default="", description="Docker ps status string")
     state: EnumRunnerHealthState = Field(..., description="Computed health state")
     error: str = Field(default="", description="Error detail if degraded")
+
+
+__all__ = ["EnumRunnerHealthState", "ModelRunnerStatus"]

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -15,6 +15,10 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 DOCKER_BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-build.yml"
+ENV_PARITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "env-parity.yml"
+SETUP_PYTHON_UV_ACTION = (
+    REPO_ROOT / ".github" / "actions" / "setup-python-uv" / "action.yml"
+)
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -137,3 +141,29 @@ def test_docker_integration_installs_compose_plugin_before_tests() -> None:
     assert "docker compose version" in compose_step["run"]
     assert "DOCKER_COMPOSE_VERSION" in compose_step["run"]
     assert "docker-compose-linux-x86_64" in compose_step["run"]
+
+
+def test_short_gates_can_disable_uv_cache_cleanup() -> None:
+    action = _load_yaml(SETUP_PYTHON_UV_ACTION)
+    assert action["inputs"]["cache-enabled"]["default"] == "true"
+    cache_step = next(
+        step for step in action["runs"]["steps"] if step.get("name") == "Load cached uv"
+    )
+    assert cache_step["if"] == "inputs.cache-enabled != 'false'"
+
+    ci_workflow = _load_yaml(CI_WORKFLOW)
+    for job_name in ("fingerprint-check", "topic-naming-lint"):
+        setup_step = next(
+            step
+            for step in ci_workflow["jobs"][job_name]["steps"]
+            if step.get("uses") == "./.github/actions/setup-python-uv"
+        )
+        assert setup_step["with"]["cache-enabled"] == "false"
+
+    env_parity_workflow = _load_yaml(ENV_PARITY_WORKFLOW)
+    setup_step = next(
+        step
+        for step in env_parity_workflow["jobs"]["env-parity"]["steps"]
+        if step.get("uses") == "./omnibase_infra/.github/actions/setup-python-uv"
+    )
+    assert setup_step["with"]["cache-enabled"] == "false"

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -71,6 +71,8 @@ def test_migration_integration_resolves_reachable_postgres_host() -> None:
     assert_step_index = steps.index(assert_step)
     assert install_step_index < assert_step_index
     install_step = steps[install_step_index]
+    assert "command -v psql" in install_step["run"]
+    assert "command -v sudo" in install_step["run"]
     assert "postgresql-client" in install_step["run"]
 
 

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -63,6 +63,16 @@ def test_migration_integration_resolves_reachable_postgres_host() -> None:
     assert '-h "$POSTGRES_HOST"' in assert_step["run"]
     assert '-p "$POSTGRES_PORT"' in assert_step["run"]
 
+    install_step_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Install Postgres client"
+    )
+    assert_step_index = steps.index(assert_step)
+    assert install_step_index < assert_step_index
+    install_step = steps[install_step_index]
+    assert "postgresql-client" in install_step["run"]
+
 
 def test_migration_conflict_action_startup_failure_is_warn_only() -> None:
     workflow = _load_yaml(CI_WORKFLOW)

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for CI resilience fixes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCKER_BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-build.yml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_migration_integration_uses_dynamic_postgres_port() -> None:
+    workflow = _load_yaml(CI_WORKFLOW)
+    job = workflow["jobs"]["migration-integration"]
+
+    ports = job["services"]["postgres"]["ports"]
+    assert ports == ["5432/tcp"]
+
+    steps = job["steps"]
+    apply_step = next(
+        step for step in steps if step.get("name") == "Apply all migrations"
+    )
+    assert (
+        apply_step["env"]["OMNIBASE_INFRA_DB_URL"]
+        == "postgresql://postgres:test_password@localhost:${{ job.services.postgres.ports[5432] }}/omnibase_infra"
+    )
+
+    assert_step = next(
+        step for step in steps if step.get("name") == "Assert manifest tables exist"
+    )
+    assert (
+        assert_step["env"]["POSTGRES_PORT"]
+        == "${{ job.services.postgres.ports[5432] }}"
+    )
+    assert '-p "$POSTGRES_PORT"' in assert_step["run"]
+
+
+def test_migration_conflict_action_startup_failure_is_warn_only() -> None:
+    workflow = _load_yaml(CI_WORKFLOW)
+    job = workflow["jobs"]["migration-conflict-check"]
+
+    validate_step = next(
+        step
+        for step in job["steps"]
+        if step.get("uses")
+        == "OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@main"
+    )
+    assert validate_step["continue-on-error"] is True
+    assert validate_step["with"]["warn-only"] == "true"
+
+    report_step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Report non-blocking boundary validator startup failure"
+    )
+    assert report_step["if"] == "steps.migration_conflicts.outcome == 'failure'"
+
+
+def test_docker_integration_build_timeout_matches_workflow_budget() -> None:
+    workflow = _load_yaml(DOCKER_BUILD_WORKFLOW)
+    job = workflow["jobs"]["docker-integration-tests"]
+    step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Run Docker integration tests"
+    )
+
+    assert step["env"]["OMNI_DOCKER_BUILD_TIMEOUT_SECONDS"] == "1200"
+    assert '--timeout="${OMNI_DOCKER_BUILD_TIMEOUT_SECONDS}"' in step["run"]

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -156,7 +156,8 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
         setup_steps = [
             step
             for step in job.get("steps", [])
-            if step.get("uses") == "./.github/actions/setup-python-uv"
+            if str(step.get("uses", "")).endswith("/.github/actions/setup-python-uv")
+            or step.get("uses") == "./.github/actions/setup-python-uv"
         ]
         if not setup_steps:
             continue

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -60,20 +60,25 @@ def test_migration_integration_resolves_reachable_postgres_host() -> None:
         assert_step["env"]["POSTGRES_PORT"]
         == "${{ job.services.postgres.ports['5432'] }}"
     )
-    assert '-h "$POSTGRES_HOST"' in assert_step["run"]
-    assert '-p "$POSTGRES_PORT"' in assert_step["run"]
+    assert 'host=os.environ["POSTGRES_HOST"]' in assert_step["run"]
+    assert 'port=int(os.environ["POSTGRES_PORT"])' in assert_step["run"]
 
-    install_step_index = next(
+    client_step_index = next(
         index
         for index, step in enumerate(steps)
-        if step.get("name") == "Install Postgres client"
+        if step.get("name") == "Verify Python Postgres client"
     )
     assert_step_index = steps.index(assert_step)
-    assert install_step_index < assert_step_index
-    install_step = steps[install_step_index]
-    assert "command -v psql" in install_step["run"]
-    assert "command -v sudo" in install_step["run"]
-    assert "postgresql-client" in install_step["run"]
+    assert client_step_index < assert_step_index
+    client_step = steps[client_step_index]
+    assert "import asyncpg" in client_step["run"]
+    assert "apt-get" not in client_step["run"]
+    assert "sudo" not in client_step["run"]
+
+    assert "import asyncpg" in assert_step["run"]
+    assert "asyncpg.connect" in assert_step["run"]
+    assert "EXPECTED_TABLES" in assert_step["run"]
+    assert "psql" not in assert_step["run"]
 
 
 def test_migration_conflict_action_startup_failure_is_warn_only() -> None:

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -23,7 +23,7 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return loaded
 
 
-def test_migration_integration_uses_dynamic_postgres_port() -> None:
+def test_migration_integration_resolves_reachable_postgres_host() -> None:
     workflow = _load_yaml(CI_WORKFLOW)
     job = workflow["jobs"]["migration-integration"]
 
@@ -31,21 +31,36 @@ def test_migration_integration_uses_dynamic_postgres_port() -> None:
     assert ports == ["5432/tcp"]
 
     steps = job["steps"]
+    resolve_step = next(
+        step for step in steps if step.get("name") == "Resolve Postgres service host"
+    )
+    assert resolve_step["id"] == "postgres_host"
+    assert (
+        resolve_step["env"]["POSTGRES_PORT"]
+        == "${{ job.services.postgres.ports['5432'] }}"
+    )
+    assert "socket.create_connection" in resolve_step["run"]
+    assert "/proc/net/route" in resolve_step["run"]
+
     apply_step = next(
         step for step in steps if step.get("name") == "Apply all migrations"
     )
     assert (
         apply_step["env"]["OMNIBASE_INFRA_DB_URL"]
-        == "postgresql://postgres:test_password@localhost:${{ job.services.postgres.ports[5432] }}/omnibase_infra"
+        == "postgresql://postgres:test_password@${{ steps.postgres_host.outputs.host }}:${{ job.services.postgres.ports['5432'] }}/omnibase_infra"
     )
 
     assert_step = next(
         step for step in steps if step.get("name") == "Assert manifest tables exist"
     )
     assert (
-        assert_step["env"]["POSTGRES_PORT"]
-        == "${{ job.services.postgres.ports[5432] }}"
+        assert_step["env"]["POSTGRES_HOST"] == "${{ steps.postgres_host.outputs.host }}"
     )
+    assert (
+        assert_step["env"]["POSTGRES_PORT"]
+        == "${{ job.services.postgres.ports['5432'] }}"
+    )
+    assert '-h "$POSTGRES_HOST"' in assert_step["run"]
     assert '-p "$POSTGRES_PORT"' in assert_step["run"]
 
 

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -172,3 +172,12 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
         if step.get("uses") == "./omnibase_infra/.github/actions/setup-python-uv"
     )
     assert setup_step["with"]["cache-enabled"] == "false"
+
+    docker_workflow = _load_yaml(DOCKER_BUILD_WORKFLOW)
+    docker_cache_step = next(
+        step
+        for step in docker_workflow["jobs"]["docker-integration-tests"]["steps"]
+        if step.get("name") == "Load cached uv"
+    )
+    assert docker_cache_step["if"] == "${{ false }}"
+    assert docker_cache_step["uses"] == "actions/cache/restore@v5"

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -152,12 +152,17 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
     assert cache_step["if"] == "inputs.cache-enabled != 'false'"
 
     ci_workflow = _load_yaml(CI_WORKFLOW)
-    for job_name in ("fingerprint-check", "topic-naming-lint"):
-        setup_step = next(
+    for job_name, job in ci_workflow["jobs"].items():
+        setup_steps = [
             step
-            for step in ci_workflow["jobs"][job_name]["steps"]
+            for step in job.get("steps", [])
             if step.get("uses") == "./.github/actions/setup-python-uv"
-        )
+        ]
+        if not setup_steps:
+            continue
+
+        assert len(setup_steps) == 1
+        setup_step = setup_steps[0]
         assert setup_step["with"]["cache-enabled"] == "false"
 
     env_parity_workflow = _load_yaml(ENV_PARITY_WORKFLOW)

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -96,3 +96,27 @@ def test_docker_integration_build_timeout_matches_workflow_budget() -> None:
 
     assert step["env"]["OMNI_DOCKER_BUILD_TIMEOUT_SECONDS"] == "1200"
     assert '--timeout="${OMNI_DOCKER_BUILD_TIMEOUT_SECONDS}"' in step["run"]
+
+
+def test_docker_integration_installs_compose_plugin_before_tests() -> None:
+    workflow = _load_yaml(DOCKER_BUILD_WORKFLOW)
+    assert workflow["env"]["DOCKER_COMPOSE_VERSION"] == "v2.40.3"
+
+    job = workflow["jobs"]["docker-integration-tests"]
+    steps = job["steps"]
+    compose_step_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Install Docker Compose plugin"
+    )
+    test_step_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Run Docker integration tests"
+    )
+
+    compose_step = steps[compose_step_index]
+    assert compose_step_index < test_step_index
+    assert "docker compose version" in compose_step["run"]
+    assert "DOCKER_COMPOSE_VERSION" in compose_step["run"]
+    assert "docker-compose-linux-x86_64" in compose_step["run"]

--- a/tests/ci/test_reusable_runtime_boot_schema.py
+++ b/tests/ci/test_reusable_runtime_boot_schema.py
@@ -12,8 +12,8 @@ Tier-2 regression (OMN-9252) can safely call it via `workflow_call`. Asserts:
   matches POSTGRES_PORT in docker/docker-compose.e2e.yml)
 * `on.workflow_call.inputs.real_ssh_user` present (empty default, falls back to
   `whoami` on the runner — avoids hardcoded operator identity)
-* `jobs.boot.runs-on` uses the exact USE_SELF_HOSTED_RUNNERS conditional from
-  ci-baseline.md §B (shared with ci.yml)
+* `jobs.boot.runs-on` uses the fork-safe OMNI_RUNNER_SELECTOR_V1 expression
+  shared with ci.yml
 * `jobs.boot.steps` contains checkout, uv setup, conditional compose bring-up,
   launch + hard-gate checks for both runtime (`:8085`) and runtime-effects
   (`:8086`) health (matches service_health.py::_handle_health response shape),
@@ -155,25 +155,23 @@ def test_real_ssh_user_input_has_empty_default(workflow: Workflow) -> None:
 
 
 def test_boot_job_runs_on_uses_self_hosted_conditional(workflow: Workflow) -> None:
-    """runs-on must match the shared ci-baseline §B conditional verbatim.
-
-    Pattern (whitespace-normalized):
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
-    """
+    """runs-on must keep public forks off trusted self-hosted runners."""
     runs_on = _boot_job(workflow)["runs-on"]
     assert isinstance(runs_on, str), "runs-on must be a string expression"
     normalized = " ".join(runs_on.split())
-    assert "vars.USE_SELF_HOSTED_RUNNERS == 'true'" in normalized
-    assert "github.event_name == 'push'" in normalized
-    assert "github.event_name == 'workflow_dispatch'" in normalized
-    assert "github.event_name == 'schedule'" in normalized
-    assert 'fromJSON(\'["self-hosted","omnibase-ci"]\')' in normalized
-    assert "fromJSON('[\"ubuntu-latest\"]')" in normalized
+    assert "github.event_name == 'pull_request'" in normalized
+    assert "github.event.pull_request.head.repo.full_name != github.repository" in (
+        normalized
+    )
+    assert "vars.OMNI_PUBLIC_PR_RUNS_ON_JSON" in normalized
+    assert "vars.OMNI_TRUSTED_CI_RUNS_ON_JSON" in normalized
+    assert "fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '[\"ubuntu-latest\"]')" in (
+        normalized
+    )
+    assert (
+        'fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || \'["self-hosted","omnibase-ci"]\')'
+        in normalized
+    )
 
 
 def test_boot_env_parameterizes_runtime_host_and_pg_port(workflow: Workflow) -> None:

--- a/tests/integration/docker/conftest.py
+++ b/tests/integration/docker/conftest.py
@@ -330,7 +330,7 @@ def built_test_image(
         build_cmd,
         capture_output=True,
         text=True,
-        timeout=600,  # 10 minute timeout for build
+        timeout=int(os.getenv("OMNI_DOCKER_BUILD_TIMEOUT_SECONDS", "1200")),
         env=env,
         check=False,
         shell=False,

--- a/tests/integration/docker/test_docker_integration.py
+++ b/tests/integration/docker/test_docker_integration.py
@@ -47,7 +47,7 @@ pytestmark = [
 TEST_CONTAINER_PREFIX = "omnibase-infra-test"
 
 # Timeout constants (seconds)
-BUILD_TIMEOUT = 600  # 10 minutes for full build
+BUILD_TIMEOUT = int(os.getenv("OMNI_DOCKER_BUILD_TIMEOUT_SECONDS", "1200"))
 CONTAINER_START_TIMEOUT = 60
 HEALTH_CHECK_TIMEOUT = 90
 SHUTDOWN_TIMEOUT = 30

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -124,6 +124,18 @@ def _docker_compose_command(*args: str) -> list[str]:
     ]
 
 
+def _docker_compose_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    result = subprocess.run(
+        ["docker", "compose", "version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
 def _compose_render_env() -> dict[str, str]:
     return {
         "HOME": os.environ.get("HOME", ""),
@@ -133,15 +145,19 @@ def _compose_render_env() -> dict[str, str]:
     }
 
 
-def _compose_config_json() -> dict:
-    result = subprocess.run(
-        _docker_compose_command("config", "--format", "json"),
+def _run_compose_config(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _docker_compose_command("config", *args),
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         env=_compose_render_env(),
         text=True,
     )
+
+
+def _compose_config_json() -> dict:
+    result = _run_compose_config("--format", "json")
 
     rendered_config = json.loads(result.stdout)
     assert isinstance(rendered_config, dict)
@@ -166,21 +182,14 @@ def _label_value(service_config: dict, key: str) -> str | None:
 
 
 pytestmark = pytest.mark.skipif(
-    shutil.which("docker") is None,
-    reason="docker is required for non-mutating compose render validation",
+    not _docker_compose_available(),
+    reason="docker compose is required for non-mutating compose render validation",
 )
 
 
 @pytest.mark.integration
 def test_stability_lane_runtime_services_render_with_runtime_profile() -> None:
-    result = subprocess.run(
-        _docker_compose_command("config", "--services"),
-        cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        env=_compose_render_env(),
-        text=True,
-    )
+    result = _run_compose_config("--services")
 
     rendered_services = set(result.stdout.splitlines())
 

--- a/tests/integration/observability/test_hook_observability.py
+++ b/tests/integration/observability/test_hook_observability.py
@@ -45,6 +45,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from omnibase_infra.observability.hooks import HookObservability
+from omnibase_infra.observability.hooks import hook_observability as hook_obs_mod
 
 # =============================================================================
 # CONTEXTVARS ISOLATION TESTS - CRITICAL
@@ -307,15 +308,31 @@ class TestTiming:
         # Should measure at least ~1ms (perf_counter is high resolution)
         assert duration >= 0.5, f"Duration {duration}ms should measure sub-ms precision"
 
-    def test_multiple_timing_cycles(self) -> None:
+    def test_multiple_timing_cycles(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify multiple timing cycles work correctly."""
         hook = HookObservability(metrics_sink=None)
+        perf_values = iter(
+            [
+                0.00,
+                0.01,
+                1.00,
+                1.02,
+                2.00,
+                2.03,
+                3.00,
+                3.04,
+                4.00,
+                4.05,
+            ]
+        )
+        monkeypatch.setattr(
+            hook_obs_mod.time, "perf_counter", lambda: next(perf_values)
+        )
 
         durations: list[float] = []
 
         for i in range(5):
             hook.before_operation(f"cycle_{i}")
-            time.sleep(0.01 * (i + 1))  # 10ms, 20ms, 30ms, 40ms, 50ms
             durations.append(hook.after_operation())
 
         # Each duration should be progressively longer

--- a/tests/integration/observability/test_runner_fleet_config_contract.py
+++ b/tests/integration/observability/test_runner_fleet_config_contract.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration checks for runner fleet config path propagation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.observability.runner_health.model_runner_fleet_config import (
+    default_runner_fleet_config_path,
+    load_runner_fleet_config,
+)
+
+REPO_ROOT = Path(__file__).parents[3]
+
+
+def test_runner_fleet_config_default_is_repo_anchored(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("RUNNER_FLEET_CONFIG_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    config_path = default_runner_fleet_config_path()
+
+    assert config_path == REPO_ROOT / "config" / "runner_fleet.yaml"
+    assert load_runner_fleet_config(config_path).runner_name_prefix == "omninode-runner"
+
+
+def test_deploy_runner_config_path_is_propagated_to_sync_and_cron() -> None:
+    deploy_script = (REPO_ROOT / "scripts" / "deploy-runners.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        'RUNNER_FLEET_CONFIG="${RUNNER_FLEET_CONFIG_PATH:-${RUNNER_FLEET_CONFIG:-'
+        '${REPO_ROOT}/config/runner_fleet.yaml}}"'
+    ) in deploy_script
+    assert '"${RUNNER_FLEET_CONFIG}" \\' in deploy_script
+    assert "RUNNER_FLEET_CONFIG_PATH=${RUNNER_FLEET_CONFIG}" in deploy_script
+    assert "RUNNER_FLEET_CONFIG_PATH=${repo_root}/config/runner_fleet.yaml" not in (
+        deploy_script
+    )

--- a/tests/integration/observability/test_runner_fleet_config_contract.py
+++ b/tests/integration/observability/test_runner_fleet_config_contract.py
@@ -16,6 +16,7 @@ from omnibase_infra.observability.runner_health.model_runner_fleet_config import
 REPO_ROOT = Path(__file__).parents[3]
 
 
+@pytest.mark.integration
 def test_runner_fleet_config_default_is_repo_anchored(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -28,6 +29,7 @@ def test_runner_fleet_config_default_is_repo_anchored(
     assert load_runner_fleet_config(config_path).runner_name_prefix == "omninode-runner"
 
 
+@pytest.mark.integration
 def test_deploy_runner_config_path_is_propagated_to_sync_and_cron() -> None:
     deploy_script = (REPO_ROOT / "scripts" / "deploy-runners.sh").read_text(
         encoding="utf-8"

--- a/tests/integration/test_setup_orchestrator_e2e.py
+++ b/tests/integration/test_setup_orchestrator_e2e.py
@@ -292,10 +292,49 @@ class TestSetupOrchestratorE2E:
                 detail=None,
             )
 
+        def _mock_docker_version_check() -> ModelPreflightCheckResult:
+            return ModelPreflightCheckResult(
+                check_key="docker_version",
+                passed=True,
+                message="Docker version ok (mocked)",
+                detail=None,
+            )
+
+        def _mock_compose_version_check() -> ModelPreflightCheckResult:
+            return ModelPreflightCheckResult(
+                check_key="compose_version",
+                passed=True,
+                message="Compose version ok (mocked)",
+                detail=None,
+            )
+
+        def _mock_docker_daemon_check() -> ModelPreflightCheckResult:
+            return ModelPreflightCheckResult(
+                check_key="docker_daemon",
+                passed=True,
+                message="Docker daemon ok (mocked)",
+                detail=None,
+            )
+
         with (
             patch.object(preflight_handler_mod, "_check_port_free", _mock_port_free),
             patch.object(
+                preflight_handler_mod,
+                "_check_docker_version",
+                _mock_docker_version_check,
+            ),
+            patch.object(
+                preflight_handler_mod,
+                "_check_compose_version",
+                _mock_compose_version_check,
+            ),
+            patch.object(
                 preflight_handler_mod, "_check_postgres_password", _mock_postgres_check
+            ),
+            patch.object(
+                preflight_handler_mod,
+                "_check_docker_daemon",
+                _mock_docker_daemon_check,
             ),
             patch.object(
                 preflight_handler_mod, "_check_omnibase_dir", _mock_omnibase_dir_check

--- a/tests/unit/observability/runner_health/test_cli_runner_health.py
+++ b/tests/unit/observability/runner_health/test_cli_runner_health.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -14,6 +15,23 @@ from omnibase_infra.observability.runner_health.cli_runner_health import main
 from omnibase_infra.observability.runner_health.model_runner_health_snapshot import (
     ModelRunnerHealthSnapshot,
 )
+
+
+def _write_runner_fleet_config(path: Path, *, expected_count: int = 10) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                'version: "1.0"',
+                "github_org: OmniNode-ai",
+                "runner_host: 192.168.86.201",
+                "runner_group: omnibase-ci",
+                "runner_name_prefix: omninode-runner",
+                f"expected_count: {expected_count}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
 
 def _make_snapshot(**overrides: object) -> ModelRunnerHealthSnapshot:
@@ -30,26 +48,31 @@ def _make_snapshot(**overrides: object) -> ModelRunnerHealthSnapshot:
         "host_disk_percent": 25.0,
     }
     defaults.update(overrides)
-    return ModelRunnerHealthSnapshot(**defaults)  # type: ignore[arg-type]
+    return ModelRunnerHealthSnapshot(**defaults)
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cli_missing_host(capsys: pytest.CaptureFixture[str]) -> None:
-    """CLI exits 1 with clear message when host is not set."""
-    with patch(
-        "omnibase_infra.observability.runner_health.cli_runner_health.RUNNER_HOST", ""
-    ):
-        result = await main([])
+async def test_cli_missing_config(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """CLI exits 1 with clear message when fleet config is missing."""
+    monkeypatch.setenv("RUNNER_FLEET_CONFIG_PATH", str(tmp_path / "missing.yaml"))
+    result = await main([])
     assert result == 1
     captured = capsys.readouterr()
-    assert "RUNNER_HEALTH_HOST" in captured.out
+    assert "Runner fleet config not found" in captured.out
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cli_default_summary(capsys: pytest.CaptureFixture[str]) -> None:
+async def test_cli_default_summary(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Default mode prints human-readable summary."""
+    config_path = tmp_path / "runner_fleet.yaml"
+    _write_runner_fleet_config(config_path)
+    monkeypatch.setenv("RUNNER_FLEET_CONFIG_PATH", str(config_path))
     mock_snapshot = _make_snapshot()
     with patch(
         "omnibase_infra.observability.runner_health.cli_runner_health.CollectorRunnerHealth"
@@ -64,8 +87,13 @@ async def test_cli_default_summary(capsys: pytest.CaptureFixture[str]) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cli_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+async def test_cli_json_output(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """--json flag outputs valid JSON."""
+    config_path = tmp_path / "runner_fleet.yaml"
+    _write_runner_fleet_config(config_path)
+    monkeypatch.setenv("RUNNER_FLEET_CONFIG_PATH", str(config_path))
     mock_snapshot = _make_snapshot()
     with patch(
         "omnibase_infra.observability.runner_health.cli_runner_health.CollectorRunnerHealth"
@@ -82,8 +110,13 @@ async def test_cli_json_output(capsys: pytest.CaptureFixture[str]) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cli_alert_all_healthy(capsys: pytest.CaptureFixture[str]) -> None:
+async def test_cli_alert_all_healthy(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """--alert prints healthy summary when no runners are degraded."""
+    config_path = tmp_path / "runner_fleet.yaml"
+    _write_runner_fleet_config(config_path)
+    monkeypatch.setenv("RUNNER_FLEET_CONFIG_PATH", str(config_path))
     mock_snapshot = _make_snapshot()
     with patch(
         "omnibase_infra.observability.runner_health.cli_runner_health.CollectorRunnerHealth"
@@ -94,3 +127,29 @@ async def test_cli_alert_all_healthy(capsys: pytest.CaptureFixture[str]) -> None
     assert result == 0
     captured = capsys.readouterr()
     assert "healthy" in captured.out.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cli_uses_configured_runner_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """CLI passes the fleet config count into the collector."""
+    config_path = tmp_path / "runner_fleet.yaml"
+    _write_runner_fleet_config(config_path, expected_count=12)
+    monkeypatch.setenv("RUNNER_FLEET_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("RUNNER_HEALTH_EXPECTED_COUNT", "10")
+    mock_snapshot = _make_snapshot(expected_runners=12, healthy_count=12)
+    with patch(
+        "omnibase_infra.observability.runner_health.cli_runner_health.CollectorRunnerHealth"
+    ) as mock_cls:
+        mock_cls.return_value.collect = AsyncMock(return_value=mock_snapshot)
+        result = await main(["--host", "192.168.86.201"])
+
+    assert result == 0
+    mock_cls.assert_called_once_with(
+        github_org="OmniNode-ai",
+        runner_host="192.168.86.201",
+        runner_count=12,
+        runner_prefix="omninode-runner",
+    )

--- a/tests/unit/observability/runner_health/test_collector_runner_health.py
+++ b/tests/unit/observability/runner_health/test_collector_runner_health.py
@@ -57,6 +57,15 @@ class TestCollectorRunnerHealth:
         )
         assert state == EnumRunnerHealthState.CRASH_LOOPING
 
+    def test_classify_oom_killed(self, handler: CollectorRunnerHealth) -> None:
+        state = handler._classify_runner(
+            github_status="online",
+            github_busy=False,
+            docker_status="oom_killed",
+            docker_uptime="Up 7 days (healthy)",
+        )
+        assert state == EnumRunnerHealthState.OOM_KILLED
+
     def test_classify_missing(self, handler: CollectorRunnerHealth) -> None:
         state = handler._classify_runner(
             github_status="offline",
@@ -110,6 +119,46 @@ class TestCollectorRunnerHealth:
         assert snapshot.runners[1].state == EnumRunnerHealthState.CRASH_LOOPING
         assert snapshot.github_source_ok
         assert snapshot.docker_source_ok
+
+    @pytest.mark.asyncio
+    async def test_collect_marks_oom_killed_runner_degraded(
+        self, handler: CollectorRunnerHealth
+    ) -> None:
+        github_data: list[dict[str, object]] = [
+            {"name": "omninode-runner-1", "status": "online", "busy": False},
+        ]
+        docker_data: dict[str, dict[str, str]] = {
+            "omninode-runner-1": {
+                "status": "oom_killed",
+                "uptime": "Up 7 days (healthy)",
+            },
+        }
+
+        with (
+            patch.object(
+                handler,
+                "_fetch_github_runners",
+                new_callable=AsyncMock,
+                return_value=(github_data, None),
+            ),
+            patch.object(
+                handler,
+                "_fetch_docker_status",
+                new_callable=AsyncMock,
+                return_value=(docker_data, None),
+            ),
+            patch.object(
+                handler,
+                "_fetch_host_disk",
+                new_callable=AsyncMock,
+                return_value=38.0,
+            ),
+        ):
+            snapshot = await handler.collect(correlation_id=uuid4())
+
+        assert snapshot.healthy_count == 0
+        assert snapshot.degraded_count == 1
+        assert snapshot.runners[0].state == EnumRunnerHealthState.OOM_KILLED
 
     @pytest.mark.asyncio
     async def test_collect_github_failure(self, handler: CollectorRunnerHealth) -> None:

--- a/tests/unit/observability/runner_health/test_collector_runner_health.py
+++ b/tests/unit/observability/runner_health/test_collector_runner_health.py
@@ -199,7 +199,7 @@ class TestCollectorRunnerHealth:
         ]
         docker_data: dict[str, dict[str, str]] = {
             "omninode-runner-1": {"status": "healthy", "uptime": "Up 2h (healthy)"},
-            "omninode-runner-99": {"status": "running", "uptime": "Up 5d"},
+            "omninode-runner-3": {"status": "running", "uptime": "Up 5d"},
         }
 
         with (
@@ -225,6 +225,46 @@ class TestCollectorRunnerHealth:
             snapshot = await handler.collect(correlation_id=uuid4())
 
         assert snapshot.observed_runners == 2
-        orphan = [r for r in snapshot.runners if r.name == "omninode-runner-99"]
+        orphan = [r for r in snapshot.runners if r.name == "omninode-runner-3"]
         assert len(orphan) == 1
         assert orphan[0].state == EnumRunnerHealthState.STALE_REGISTRATION
+
+    @pytest.mark.asyncio
+    async def test_collect_ignores_profile_gated_burst_runners(
+        self, handler: CollectorRunnerHealth
+    ) -> None:
+        github_data: list[dict[str, object]] = [
+            {"name": "omninode-runner-1", "status": "online", "busy": False},
+            {"name": "omninode-runner-13", "status": "offline", "busy": False},
+        ]
+        docker_data: dict[str, dict[str, str]] = {
+            "omninode-runner-1": {"status": "healthy", "uptime": "Up 2h (healthy)"},
+            "omninode-runner-13": {"status": "not_found", "uptime": ""},
+        }
+
+        with (
+            patch.object(
+                handler,
+                "_fetch_github_runners",
+                new_callable=AsyncMock,
+                return_value=(github_data, None),
+            ),
+            patch.object(
+                handler,
+                "_fetch_docker_status",
+                new_callable=AsyncMock,
+                return_value=(docker_data, None),
+            ),
+            patch.object(
+                handler,
+                "_fetch_host_disk",
+                new_callable=AsyncMock,
+                return_value=25.0,
+            ),
+        ):
+            snapshot = await handler.collect(correlation_id=uuid4())
+
+        assert snapshot.expected_runners == 10
+        assert snapshot.observed_runners == 1
+        assert snapshot.healthy_count == 1
+        assert [runner.name for runner in snapshot.runners] == ["omninode-runner-1"]

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -51,6 +51,20 @@ def test_runner_compose_matches_configured_count() -> None:
     assert len(all_runner_services) == config.burst_count
 
 
+def test_runner_compose_resource_limits_match_live_capacity() -> None:
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker" / "docker-compose.runners.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    base = compose["x-runner-base"]
+    assert base["mem_limit"] == "6g"
+    assert base["memswap_limit"] == "12g"
+    assert base["cpus"] == "2.0"
+    assert base["pids_limit"] == 4096
+
+
 def test_runner_scripts_do_not_embed_legacy_count() -> None:
     deploy_script = (REPO_ROOT / "scripts" / "deploy-runners.sh").read_text(
         encoding="utf-8"

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -22,7 +22,7 @@ def test_runner_fleet_config_loads_from_repo_config() -> None:
     assert config.github_org == "OmniNode-ai"
     assert config.runner_group == "omnibase-ci"
     assert config.runner_name_prefix == "omninode-runner"
-    assert config.expected_count == 12
+    assert config.expected_count == 20
 
 
 def test_runner_compose_matches_configured_count() -> None:

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -22,7 +22,7 @@ def test_runner_fleet_config_loads_from_repo_config() -> None:
     assert config.github_org == "OmniNode-ai"
     assert config.runner_group == "omnibase-ci"
     assert config.runner_name_prefix == "omninode-runner"
-    assert config.expected_count == 12
+    assert config.expected_count == 14
     assert config.burst_count == 20
 
 

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for authoritative runner fleet configuration."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.observability.runner_health.model_runner_fleet_config import (
+    load_runner_fleet_config,
+)
+
+REPO_ROOT = Path(__file__).parents[4]
+
+
+def test_runner_fleet_config_loads_from_repo_config() -> None:
+    config = load_runner_fleet_config(REPO_ROOT / "config" / "runner_fleet.yaml")
+
+    assert config.github_org == "OmniNode-ai"
+    assert config.runner_group == "omnibase-ci"
+    assert config.runner_name_prefix == "omninode-runner"
+    assert config.expected_count == 12
+
+
+def test_runner_compose_matches_configured_count() -> None:
+    config = load_runner_fleet_config(REPO_ROOT / "config" / "runner_fleet.yaml")
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker" / "docker-compose.runners.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    services = compose["services"]
+    runner_services = [
+        name
+        for name in services
+        if re.fullmatch(rf"{config.runner_name_prefix}-\d+", name)
+    ]
+
+    assert len(runner_services) == config.expected_count
+
+
+def test_runner_scripts_do_not_embed_legacy_count() -> None:
+    deploy_script = (REPO_ROOT / "scripts" / "deploy-runners.sh").read_text(
+        encoding="utf-8"
+    )
+    monitor_script = (REPO_ROOT / "docker" / "runners" / "runner-monitor.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "RUNNER_COUNT=10" not in deploy_script
+    assert "EXPECTED_RUNNERS=10" not in monitor_script

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -22,7 +22,8 @@ def test_runner_fleet_config_loads_from_repo_config() -> None:
     assert config.github_org == "OmniNode-ai"
     assert config.runner_group == "omnibase-ci"
     assert config.runner_name_prefix == "omninode-runner"
-    assert config.expected_count == 20
+    assert config.expected_count == 12
+    assert config.burst_count == 20
 
 
 def test_runner_compose_matches_configured_count() -> None:
@@ -34,13 +35,20 @@ def test_runner_compose_matches_configured_count() -> None:
     )
 
     services = compose["services"]
-    runner_services = [
+    steady_runner_services = [
+        name
+        for name, definition in services.items()
+        if re.fullmatch(rf"{config.runner_name_prefix}-\d+", name)
+        and "profiles" not in definition
+    ]
+    all_runner_services = [
         name
         for name in services
         if re.fullmatch(rf"{config.runner_name_prefix}-\d+", name)
     ]
 
-    assert len(runner_services) == config.expected_count
+    assert len(steady_runner_services) == config.expected_count
+    assert len(all_runner_services) == config.burst_count
 
 
 def test_runner_scripts_do_not_embed_legacy_count() -> None:


### PR DESCRIPTION
## Summary
- add `config/runner_fleet.yaml` as the typed source of truth for runner host/org/group/prefix/count
- update deploy and monitor paths to read the fleet config instead of embedding legacy runner counts
- standardize trusted/public CI runner selectors across infra workflows with a single defaulted selector expression
- make runner health GitHub-aware and Docker-OOM-aware so Docker `OOMKilled=true` is degraded even when Docker health is still `healthy`
- align runner compose to the configured 14 steady / 20 burst-capable fleet with `6g` memory, `12g` swap, and `2.0` CPU limits per runner
- add a self-hosted runner `ACTIONS_RUNNER_HOOK_JOB_STARTED` workspace reset hook, fix cached credential dotfile restore/ownership, and bind-mount both hook and entrypoint for live rollout

## Evidence
- Live `.201` read-only sample: 14 runner containers currently running, source compose has 20 services with burst profile gating, and `omninode-runner-1` effective Docker limits are `Memory=6442450944`, `MemorySwap=12884901888`, `NanoCpus=2000000000`, `PidsLimit=4096`
- Runner source now preserves the approved 6g memory / 12g swap change in `docker/docker-compose.runners.yml` instead of relying only on live `docker update`
- Central OCC evidence is tracked in OmniNode-ai/onex_change_control#680 for OMN-10445 and is being refreshed for infra head `d7a9646cd181879842583c285acd8f0b6d0dff5f`
- `Evidence-Ticket: OMN-10445`
- `Evidence-Source: OCC#680`

## Verification
- `PYTHONPATH=src uv run pytest tests/unit/observability/runner_health/test_cli_runner_health.py tests/unit/observability/runner_health/test_runner_fleet_config.py tests/unit/observability/runner_health/test_collector_runner_health.py tests/integration/observability/test_runner_fleet_config_contract.py -q` -> `21 passed in 0.51s`
- `PYTHONPATH=src uv run mypy src/omnibase_infra/observability/runner_health tests/unit/observability/runner_health --strict` -> `Success: no issues found in 13 source files`
- `uv run ruff check src/omnibase_infra/observability/runner_health tests/unit/observability/runner_health tests/integration/observability/test_runner_fleet_config_contract.py`
- `uv run validate-yaml contracts/OMN-10445.yaml`
- `bash -n docker/runners/runner-monitor.sh docker/runners/runner-job-started.sh docker/runners/entrypoint.sh`
- Python YAML parse asserted 14 steady runners, 20 total services, `mem_limit=6g`, `memswap_limit=12g`, `cpus=2.0`
- `git diff --check`

## CI Notes
- This PR intentionally does not deploy/restart `.201`; it only makes the already-applied live 6g/12g runner limits durable in source. Future deploys should preserve those limits.
