### PR TITLE
fix(OMN-10519): make A2A task handler runtime-wirable

### DIFF
--- a/contracts/OMN-10519.yaml
+++ b/contracts/OMN-10519.yaml
@@ -1,0 +1,43 @@
+# OMN-10519 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The central evidence remains in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the stability runtime wiring fix.
+schema_version: "1.0.0"
+ticket_id: "OMN-10519"
+title: "Make remote agent invoke effect runtime-wirable"
+summary: "Allow HandlerA2ATask to resolve through zero-arg runtime auto-wiring in fail-closed lockdown mode."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused A2A task handler tests prove injected behavior and zero-arg lockdown."
+    command: "uv run pytest tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py -q"
+  - kind: "tests"
+    description: "Touched handler and tests pass lint."
+    command: "uv run ruff check src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py"
+  - kind: "manual"
+    description: "Post-merge deploy/readiness smoke imports HandlerA2ATask and constructs it in the runtime container."
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python - <<'PY'\nfrom omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import HandlerA2ATask\nhandler = HandlerA2ATask()\nprint(handler.handler_category.value)\nPY"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-handler-tests"
+    description: "Focused A2A task handler tests pass, including zero-arg fail-closed construction."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py -q"
+  - id: "dod-ruff"
+    description: "Touched runtime handler and tests pass lint."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff check src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py"
+  - id: "dod-deploy"
+    description: "Deploy/readiness smoke constructs HandlerA2ATask with zero arguments inside the deployed runtime container."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python - <<'PY'\nfrom omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import HandlerA2ATask\nhandler = HandlerA2ATask()\nprint(handler.handler_category.value)\nPY"

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
@@ -12,14 +12,14 @@ node_name: "node_remote_agent_invoke_effect"
 contract_version:
   major: 0
   minor: 1
-  patch: 1
+  patch: 2
 node_version:
   major: 0
   minor: 1
   patch: 0
 node_type: "EFFECT_GENERIC"
 description: >
-  Remote-agent invocation effect node for the A2A delegation bridge. Consumes invocation commands emitted by the delegation orchestrator, delegates task submission and watch operations to protocol-specific handlers, persists remote task state, and emits lifecycle events back to the orchestration pipeline.
+  Remote-agent invocation effect node for the A2A delegation bridge. Consumes invocation commands emitted by the delegation orchestrator, delegates task submission and watch operations to protocol-specific handlers, persists remote task state, and emits lifecycle events back to the orchestration pipeline. Runtime auto-wiring may construct the A2A handler without injected repository, lifecycle sink, or target registry dependencies; that mode fails closed before network submission when no target is registered.
 
 input_model:
   name: "ModelInvocationCommand"
@@ -37,7 +37,7 @@ handler_routing:
         name: "HandlerA2ATask"
         module: "omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task"
         handler_type: "HTTP"
-      description: "Submit remote A2A tasks, persist lifecycle state, deduplicate artifact payloads, and emit terminal lifecycle outcomes."
+      description: "Submit remote A2A tasks, persist lifecycle state, deduplicate artifact payloads, and emit terminal lifecycle outcomes. Supports zero-argument runtime discovery by using no-op persistence/lifecycle dependencies and an empty target registry that rejects unknown target_ref values."
   execution_mode: "single"
   max_timeout_seconds: 600
 event_bus:
@@ -76,8 +76,10 @@ capabilities:
     description: "Watch remote task state and emit typed lifecycle events."
   - name: "remote_task_restart_resumption"
     description: "Reload unfinished remote task state on startup."
+  - name: "runtime_discovery_fail_closed"
+    description: "Allow runtime handler discovery to instantiate HandlerA2ATask with no arguments while rejecting unregistered targets before external side effects."
 metadata:
-  description: "A2A delegation bridge effect node scaffold."
+  description: "A2A delegation bridge effect node with fail-closed runtime discovery support."
   author: "OmniNode Team"
   license: "MIT"
   created: "2026-04-25"

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Protocol
@@ -76,6 +77,7 @@ _TERMINAL_LIFECYCLES = {
     EnumAgentTaskLifecycleType.TIMED_OUT,
     EnumAgentTaskLifecycleType.CANCELED,
 }
+logger = logging.getLogger(__name__)
 
 
 class ProtocolA2ATransport(Protocol):
@@ -96,6 +98,54 @@ class ProtocolA2ATransport(Protocol):
         remote_task_handle: str,
     ) -> ModelA2ATaskResponse:
         """Fetch the current status of a remote task by handle."""
+
+
+class NoopRemoteTaskStateRepository:
+    """Fail-closed repository used only for zero-arg runtime discovery."""
+
+    async def upsert(
+        self,
+        state: ModelRemoteTaskState,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> None:
+        del state, correlation_id
+        logger.warning("Dropping A2A remote task state in runtime lockdown mode")
+
+    async def get_by_remote_task_handle(
+        self,
+        remote_task_handle: str,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> ModelRemoteTaskState | None:
+        del remote_task_handle, correlation_id
+        return None
+
+    async def get_last_emitted_artifact_payload(
+        self,
+        task_id: UUID,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> list[dict[str, ModelSchemaValue]] | None:
+        del task_id, correlation_id
+        return None
+
+    async def set_last_emitted_artifact_payload(
+        self,
+        task_id: UUID,
+        payload: list[dict[str, ModelSchemaValue]],
+        *,
+        correlation_id: UUID | None = None,
+    ) -> None:
+        del task_id, payload, correlation_id
+
+
+class NoopLifecycleEventSink:
+    """Fail-closed lifecycle sink used only for zero-arg runtime discovery."""
+
+    async def write(self, event: ModelAgentTaskLifecycleEvent) -> None:
+        del event
+        logger.warning("Dropping A2A lifecycle event in runtime lockdown mode")
 
 
 def map_remote_status(raw_status: object) -> EnumAgentTaskLifecycleType:
@@ -269,18 +319,18 @@ class HandlerA2ATask:
     def __init__(
         self,
         *,
-        repository: RemoteTaskStateRepository,
-        lifecycle_sink: ProtocolLifecycleEventSink,
-        target_registry: Mapping[str, ModelTargetAgent],
+        repository: RemoteTaskStateRepository | None = None,
+        lifecycle_sink: ProtocolLifecycleEventSink | None = None,
+        target_registry: Mapping[str, ModelTargetAgent] | None = None,
         http_session: aiohttp.ClientSession | None = None,
         clock: Callable[[], datetime] | None = None,
         poll_interval_seconds: float = 1.0,
         transport: ProtocolA2ATransport | None = None,
     ) -> None:
-        self._repository = repository
-        self._lifecycle_sink = lifecycle_sink
+        self._repository = repository or NoopRemoteTaskStateRepository()
+        self._lifecycle_sink = lifecycle_sink or NoopLifecycleEventSink()
         self._lifecycle_target_name = "agent_task_lifecycle"
-        self._target_registry = target_registry
+        self._target_registry = target_registry or {}
         self._http_session = http_session
         self._clock = clock or (lambda: datetime.now(UTC))
         self._poll_interval_seconds = poll_interval_seconds
@@ -639,6 +689,8 @@ def _remote_status_value(raw_status: object) -> str:
 __all__ = [
     "A2ASdkTransport",
     "HandlerA2ATask",
+    "NoopLifecycleEventSink",
+    "NoopRemoteTaskStateRepository",
     "ProtocolA2ATransport",
     "_STATUS_MAP",
     "_TERMINAL_LIFECYCLES",

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py
@@ -327,10 +327,14 @@ class HandlerA2ATask:
         poll_interval_seconds: float = 1.0,
         transport: ProtocolA2ATransport | None = None,
     ) -> None:
-        self._repository = repository or NoopRemoteTaskStateRepository()
-        self._lifecycle_sink = lifecycle_sink or NoopLifecycleEventSink()
+        self._repository = (
+            repository if repository is not None else NoopRemoteTaskStateRepository()
+        )
+        self._lifecycle_sink = (
+            lifecycle_sink if lifecycle_sink is not None else NoopLifecycleEventSink()
+        )
         self._lifecycle_target_name = "agent_task_lifecycle"
-        self._target_registry = target_registry or {}
+        self._target_registry = target_registry if target_registry is not None else {}
         self._http_session = http_session
         self._clock = clock or (lambda: datetime.now(UTC))
         self._poll_interval_seconds = poll_interval_seconds

--- a/tests/integration/test_remote_agent_invoke_runtime_discovery.py
+++ b/tests/integration/test_remote_agent_invoke_runtime_discovery.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for remote-agent runtime discovery behavior."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import (
+    HandlerA2ATask,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a2a_handler_runtime_discovery_fails_closed_without_dependencies() -> (
+    None
+):
+    """Runtime-discovered A2A handler rejects unregistered targets before side effects."""
+    handler = HandlerA2ATask()
+    command = ModelInvocationCommand(
+        task_id=uuid4(),
+        correlation_id=uuid4(),
+        invocation_kind=EnumInvocationKind.AGENT,
+        agent_protocol=EnumAgentProtocol.A2A,
+        target_ref="agent:unregistered-runtime-target",
+        payload={"prompt": ModelSchemaValue.from_value("runtime discovery smoke")},
+    )
+
+    with pytest.raises(ValueError, match="Unknown target_ref"):
+        await handler.submit(command)

--- a/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
+++ b/tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py
@@ -194,6 +194,15 @@ def test_status_mapping_rejects_unknown() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_zero_arg_handler_fails_closed_for_unknown_target() -> None:
+    handler = HandlerA2ATask()
+
+    with pytest.raises(ValueError, match="Unknown target_ref"):
+        await handler.submit(_command())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_submit_emits_submitted_event_and_persists() -> None:
     repo = RecordingRepository()
     event_bus = RecordingEventBus()


### PR DESCRIPTION
## Summary
- make `HandlerA2ATask` zero-arg constructible for runtime auto-wiring
- use fail-closed no-op repository/lifecycle sinks when runtime discovery has no injected dependencies
- add OMN-10519 repo-local deploy-gate evidence and focused regression coverage

## Verification
- `uv run pytest tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py -q` -> 17 passed
- `uv run ruff check src/omnibase_infra/nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py`
- `uv run python` YAML parse for `contracts/OMN-10519.yaml`
- `git diff --check`
- local commit hook suite passed
- pre-push hooks passed, including mypy and architecture layer validation

## Runtime evidence
The .201 stability runtime advanced past the omnimarket PR-review handler blockers and then failed before health-server bind because `HandlerA2ATask` required `repository`, `lifecycle_sink`, and `target_registry`. This PR makes that handler resolve in lockdown mode so the next runtime boot can move to the next real boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zero-argument handler initialization with automatic dependency wiring; handlers reject unknown targets before side effects.
* **Behavioral Changes**
  * Safer default behavior when dependencies are absent (fail-closed/no-op persistence and lifecycle handling).
* **Tests**
  * New unit and integration tests verifying fail-closed runtime discovery and unknown-target rejection.
* **Deployment & Operations**
  * New deployment verification gate requiring tests, linting, and smoke checks (emergency bypass disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#688
Evidence-Ticket: OMN-10519