### PR TITLE
fix(OMN-10518): avoid recursive runtime image chown

### DIFF
--- a/contracts/OMN-10518.yaml
+++ b/contracts/OMN-10518.yaml
@@ -18,6 +18,9 @@ evidence_requirements:
   - kind: "manual"
     description: "Patch has no whitespace errors."
     command: "git diff --check"
+  - kind: "manual"
+    description: "Live stability-test runtime deploy proof remains healthy after the rebuild that exposed the ownership bottleneck."
+    command: "docker exec omninode-stability-test-runtime /app/.venv/bin/python - <<'PY'\nimport inspect\nfrom omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import HandlerA2ATask\nprint(inspect.signature(HandlerA2ATask))\nPY"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -41,3 +44,9 @@ dod_evidence:
     checks:
       - check_type: "command"
         check_value: "git diff --check"
+  - id: "dod-stability-runtime-deploy"
+    description: "The stability-test runtime deploy remains live and can import the runtime-wired A2A handler after the rebuild."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec omninode-stability-test-runtime /app/.venv/bin/python - <<'PY'\nimport inspect\nfrom omnibase_infra.nodes.node_remote_agent_invoke_effect.handlers.handler_a2a_task import HandlerA2ATask\nprint(inspect.signature(HandlerA2ATask))\nPY"

--- a/contracts/OMN-10518.yaml
+++ b/contracts/OMN-10518.yaml
@@ -1,0 +1,43 @@
+# OMN-10518 contract file for omnibase_infra deploy-gate (OMN-8912).
+# Central overnight-loop evidence remains in omni_home/Linear; this repo-local
+# contract carries deploy-gate evidence for the runtime image ownership fix.
+schema_version: "1.0.0"
+ticket_id: "OMN-10518"
+title: "Avoid recursive runtime image ownership walk"
+summary: "Preserve runtime image file ownership at COPY time so Docker builds do not stall on recursive chown over the large virtualenv."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "manual"
+    description: "Dockerfile copies the runtime virtualenv with omniinfra ownership."
+    command: "grep -n 'COPY --from=builder --chown=omniinfra:omniinfra /app/.venv /app/.venv' docker/Dockerfile.runtime"
+  - kind: "manual"
+    description: "Dockerfile no longer recursively chowns all of /app in the runtime stage."
+    command: "! grep -n 'chown -R omniinfra:omniinfra /app' docker/Dockerfile.runtime"
+  - kind: "manual"
+    description: "Patch has no whitespace errors."
+    command: "git diff --check"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-copy-ownership"
+    description: "Runtime virtualenv COPY uses --chown=omniinfra:omniinfra."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "grep -n 'COPY --from=builder --chown=omniinfra:omniinfra /app/.venv /app/.venv' docker/Dockerfile.runtime"
+  - id: "dod-no-recursive-app-chown"
+    description: "Runtime image build no longer performs a recursive ownership walk over /app."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "! grep -n 'chown -R omniinfra:omniinfra /app' docker/Dockerfile.runtime"
+  - id: "dod-diff-check"
+    description: "Patch has no whitespace errors."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "git diff --check"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -390,9 +390,9 @@ RUN groupadd --gid 1000 omniinfra && \
 
 WORKDIR /app
 
-# Copy virtual environment from builder stage
+# Copy virtual environment from builder stage with runtime ownership.
 # This contains all installed Python packages
-COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder --chown=omniinfra:omniinfra /app/.venv /app/.venv
 
 # Copy source code with proper ownership
 COPY --chown=omniinfra:omniinfra src/ /app/src/
@@ -418,9 +418,11 @@ COPY --from=builder --chown=omniinfra:omniinfra \
 COPY --chown=omniinfra:omniinfra docker/entrypoint-runtime.sh /app/entrypoint-runtime.sh
 RUN chmod +x /app/entrypoint-runtime.sh
 
-# Create runtime directories with proper permissions
-RUN mkdir -p /app/logs /app/data /app/tmp && \
-    chown -R omniinfra:omniinfra /app
+# Create runtime directories with proper permissions.
+# Avoid a recursive chown over /app here: the venv and copied artifacts already
+# preserve ownership at COPY time, and the recursive walk can dominate Docker
+# builds on the large runtime image.
+RUN install -d -o omniinfra -g omniinfra /app/logs /app/data /app/tmp
 
 # Switch to non-root user for security
 USER omniinfra


### PR DESCRIPTION
## Summary
- copy the runtime virtualenv with `--chown=omniinfra:omniinfra` during image build
- replace the final recursive `chown -R /app` with ownership-aware creation of writable runtime dirs
- add repo-local deploy-gate contract evidence for OMN-10518

## Why
During the .201 stability runtime rebuild, Dockerfile.runtime reached the final `chown -R omniinfra:omniinfra /app` layer and spent about 10 minutes in uninterruptible disk I/O. The venv is the large tree; ownership should be preserved during COPY rather than repaired afterward.

## Verification
- `grep -n 'COPY --from=builder --chown=omniinfra:omniinfra /app/.venv /app/.venv' docker/Dockerfile.runtime`\n- `! grep -n 'chown -R omniinfra:omniinfra /app' docker/Dockerfile.runtime`\n- `git diff --check`\n- `uv run validate-yaml contracts/OMN-10518.yaml`\n- `VALIDATE_PR_FILES=$'docker/Dockerfile.runtime\\ncontracts/OMN-10518.yaml' VALIDATE_PR_COMMIT_MESSAGES='fix(OMN-10518): avoid recursive runtime image chown' bash scripts/validate-pr-contract-sync.sh --from-env`\n- commit hooks passed\n- pre-push hooks passed\n\nEvidence-Ticket: OMN-10518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved runtime image build to set correct ownership for runtime files and avoid broad recursive ownership changes, reducing startup overhead and improving container stability.
  * Added a deployment-gate contract to enforce these build and runtime checks across future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#690
Evidence-Ticket: OMN-10518
