### PR TITLE
chore(release, OMN-10530): omnibase-infra 0.34.2

### DIFF
--- a/contracts/OMN-10530.yaml
+++ b/contracts/OMN-10530.yaml
@@ -1,0 +1,27 @@
+# OMN-10530 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-10530"
+summary: "Release omnibase_infra 0.34.2 against published core 0.40.1 and SPI 0.20.6"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "ci"
+    description: "omnibase_infra release PR checks pass, including deploy gate"
+    command: "gh pr checks 1498 --repo OmniNode-ai/omnibase_infra --watch"
+  - kind: "manual"
+    description: "Runtime deploy plan for release dependency floor change"
+    command: "deploy: no live deploy or restart is performed pre-merge; publish the 0.34.2 wheel, then validate runtime consumers during the normal post-merge rollout before claiming live runtime completion"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-deploy"
+    description: "deploy gate evidence: release dependency floor update is packaged pre-merge; live runtime validation remains a post-merge rollout step."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: no live deploy or restart is performed pre-merge for this PyPI checkpoint release; after v0.34.2 publishes, validate runtime consumers during the normal rollout before claiming live runtime completion"

--- a/contracts/OMN-10530.yaml
+++ b/contracts/OMN-10530.yaml
@@ -3,6 +3,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: "OMN-10530"
+title: "Release omnibase_infra 0.34.2"
 summary: "Release omnibase_infra 0.34.2 against published core 0.40.1 and SPI 0.20.6"
 is_seam_ticket: false
 interface_change: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.34.1"
+version = "0.34.2"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}
@@ -29,8 +29,8 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.40.0,<0.41.0",
-    "omnibase-spi>=0.20.5",
+    "omnibase-core>=0.40.1,<0.41.0",
+    "omnibase-spi>=0.20.6",
     "omnimarket>=0.1.0",
     # ============================================================================
     # External Dependency Security Guidance
@@ -161,15 +161,12 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.40.0,<0.41.0",
+    "omnibase-core>=0.40.1,<0.41.0",
 ]
 
 [tool.uv.sources]
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
-# OMN-10382 depends on the shared usage-source enum added in core.
-# Pinned to the core #993 merge commit until the next PyPI release includes it.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "6ddf546834ca8aa3affeedbc170845062351e4f7" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,12 +175,12 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.40.0",
+        min_version="0.40.1",
         max_version="0.41.0",
     ),
     VersionConstraint(
         package="omnibase_spi",
-        min_version="0.20.5",
+        min_version="0.20.6",
         max_version="0.21.0",
     ),
 ]

--- a/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
+++ b/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Integration sentinel for the omnibase-spi 0.20.5 runtime protocol floor.
+"""Integration sentinel for the omnibase-spi 0.20.6 runtime protocol floor.
 
 OMN-10169 raises the dependency floor because runtime auto-wiring imports
 ``omnibase_spi.protocols.runtime``. The fallback compatibility matrix must
@@ -30,7 +30,7 @@ def _minimum_for(package: str, matrix: Sequence[VersionConstraint]) -> str:
 
 
 @pytest.mark.integration
-def test_omnibase_spi_runtime_protocols_match_0205_floor() -> None:
+def test_omnibase_spi_runtime_protocols_match_0206_floor() -> None:
     """The declared and fallback SPI floors both expose runtime protocols."""
     from omnibase_spi.protocols.runtime.protocol_handler_ownership_query import (
         ProtocolHandlerOwnershipQuery,
@@ -39,7 +39,7 @@ def test_omnibase_spi_runtime_protocols_match_0205_floor() -> None:
         ProtocolHandlerResolver,
     )
 
-    assert _minimum_for("omnibase_spi", VERSION_MATRIX) == "0.20.5"
-    assert _minimum_for("omnibase_spi", _FALLBACK_MATRIX) == "0.20.5"
+    assert _minimum_for("omnibase_spi", VERSION_MATRIX) == "0.20.6"
+    assert _minimum_for("omnibase_spi", _FALLBACK_MATRIX) == "0.20.6"
     assert hasattr(ProtocolHandlerResolver, "__class_getitem__")
     assert hasattr(ProtocolHandlerOwnershipQuery, "__class_getitem__")

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7" }]
+overrides = [{ name = "omnibase-core", specifier = ">=0.40.1,<0.41.0" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -1943,8 +1943,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.40.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7#6ddf546834ca8aa3affeedbc170845062351e4f7" }
+version = "0.40.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1956,11 +1956,17 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-python" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/ee/437d2a59f3a08827c7688d2ddf62da6d0f2647ef7ca741f092da695c23d2/omnibase_core-0.40.1.tar.gz", hash = "sha256:ed9308f3cbca5dbcdcffd5cc7e6ce9d5ae3e4fa96b89b0dda6f69388fedac3bf", size = 8395663, upload-time = "2026-05-04T02:00:24.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/98/20316960a989aa24f5b851bf74402c0b8a0febc0a28ccb67cfc8b518d418/omnibase_core-0.40.1-py3-none-any.whl", hash = "sha256:1fa09caee8e9237397c42154b102704b4faacd4c881edf1d98aa3d1d897b6308", size = 5773507, upload-time = "2026-05-04T02:00:22.44Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.34.1"
+version = "0.34.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -2054,8 +2060,8 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=6ddf546834ca8aa3affeedbc170845062351e4f7" },
-    { name = "omnibase-spi", specifier = ">=0.20.5" },
+    { name = "omnibase-core", specifier = ">=0.40.1,<0.41.0" },
+    { name = "omnibase-spi", specifier = ">=0.20.6" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },
@@ -2109,16 +2115,16 @@ dev = [
 
 [[package]]
 name = "omnibase-spi"
-version = "0.20.5"
+version = "0.20.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c4/d2198088d22006d197ce75c335ac5b79d7be08e9fd82da1b23a71c56e88a/omnibase_spi-0.20.5.tar.gz", hash = "sha256:6245001d2c263dec93ac12612dbe2c19ce215b28413e8e7f208fae857d0c4747", size = 1143592, upload-time = "2026-04-23T15:49:56.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/52/d7623f3d4a063364639768240fe9d981ed95e4d631f9d477aca54499ed96/omnibase_spi-0.20.6.tar.gz", hash = "sha256:89c70b21fe1aeaa61a7622ae40bcf21e925ebb6d5282039ce5f4258eae22da48", size = 1135612, upload-time = "2026-05-04T02:20:10.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/f4/bdf41eefebadc983ef36bc44c2b32ac2c1695f5acfe779a103670ba0bc3e/omnibase_spi-0.20.5-py3-none-any.whl", hash = "sha256:57b4be9e53b630062032254fb9e98f98601712e8e372df7fd8bfc6c3ee792cba", size = 790932, upload-time = "2026-04-23T15:49:57.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/68/b8b917f1c6de94c5cca26a5af673fd164ee656953503000254edad4bd090/omnibase_spi-0.20.6-py3-none-any.whl", hash = "sha256:1e32893d1fabb9215a1cb2e314ca03a5362b89495be5f3ec049491ec4cc0d041", size = 792937, upload-time = "2026-05-04T02:20:08.691Z" },
 ]
 
 [[package]]
@@ -3367,6 +3373,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8b/c992ff0e768cb6768d5c96234579bf8842b3a633db641455d86dd30d5dac/tree_sitter_python-0.25.0.tar.gz", hash = "sha256:b13e090f725f5b9c86aa455a268553c65cadf325471ad5b65cd29cac8a1a68ac", size = 159845, upload-time = "2025-09-11T06:47:58.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/64/a4e503c78a4eb3ac46d8e72a29c1b1237fa85238d8e972b063e0751f5a94/tree_sitter_python-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14a79a47ddef72f987d5a2c122d148a812169d7484ff5c75a3db9609d419f361", size = 73790, upload-time = "2025-09-11T06:47:47.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/60d8c2a0cc63d6ec4ba4e99ce61b802d2e39ef9db799bdf2a8f932a6cd4b/tree_sitter_python-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:480c21dbd995b7fe44813e741d71fed10ba695e7caab627fb034e3828469d762", size = 76691, upload-time = "2025-09-11T06:47:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/d9b0b67d037922d60cbe0359e0c86457c2da721bc714381a63e2c8e35eba/tree_sitter_python-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:86f118e5eecad616ecdb81d171a36dde9bef5a0b21ed71ea9c3e390813c3baf5", size = 108133, upload-time = "2025-09-11T06:47:50.499Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bd/bf4787f57e6b2860f3f1c8c62f045b39fb32d6bac4b53d7a9e66de968440/tree_sitter_python-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be71650ca2b93b6e9649e5d65c6811aad87a7614c8c1003246b303f6b150f61b", size = 110603, upload-time = "2025-09-11T06:47:51.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/25/feff09f5c2f32484fbce15db8b49455c7572346ce61a699a41972dea7318/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e6d5b5799628cc0f24691ab2a172a8e676f668fe90dc60468bee14084a35c16d", size = 108998, upload-time = "2025-09-11T06:47:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Evidence-Ticket: OMN-10530
Evidence-Source: OCC#695

## Summary
- Release checkpoint: bump omnibase-infra to 0.34.2
- Require omnibase-core >=0.40.1,<0.41.0 and omnibase-spi >=0.20.6
- Remove the temporary omnibase-core git source pin so infra resolves the published core release from PyPI
- Refresh uv.lock to core 0.40.1 and spi 0.20.6
- Sync installed-wheel runtime fallback floors with the release dependency floors
- Add the repo-local deploy-gate contract for the runtime-path fallback update; no live deploy/restart was performed pre-merge

## Verification
- uv build
- uv run python version smoke for omnibase-infra 0.34.2, omnibase-core 0.40.1, omnibase-spi 0.20.6
- git diff --check
- uv run python scripts/check_version_pins.py via CI-style temp workspace: compliant
- uv run pytest tests/unit/runtime/test_fallback_matrix_sync.py tests/unit/runtime/test_version_compatibility.py tests/integration/test_omnibase_spi_runtime_protocol_floor.py -q: 28 passed
- uv run validate-yaml contracts/OMN-10530.yaml

## Release Notes
- Patch release for rollback checkpoint chaining after omnibase-core v0.40.1 and omnibase-spi v0.20.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.34.2.
  * Tightened minimum supported versions for internal dependencies to ensure compatibility.
  * Removed an explicit source pin for one internal package and added an override to align dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->