### PR TITLE
feat(OMN-8063): add InvariantViolation exception

### DIFF
--- a/src/omnibase_infra/errors/__init__.py
+++ b/src/omnibase_infra/errors/__init__.py
@@ -26,6 +26,7 @@ Exports:
     EventBusRegistryError: Event bus registry operation errors
     ChainPropagationError: Correlation/causation chain validation errors
     ArchitectureViolationError: Architecture validation errors (blocks startup)
+    InvariantViolation: Runtime contract invariant violations
     BindingResolutionError: Binding resolution errors (declarative operation bindings)
     RepositoryError: Base error for repository operations
     RepositoryContractError: Contract-level errors (bad op_name, missing params)
@@ -142,6 +143,7 @@ from omnibase_infra.errors.error_infra import (
     SecretResolutionError,
     UnknownHandlerTypeError,
 )
+from omnibase_infra.errors.error_invariant_violation import InvariantViolation
 from omnibase_infra.errors.error_message_type_registry import MessageTypeRegistryError
 from omnibase_infra.errors.error_payload_registry import PayloadRegistryError
 from omnibase_infra.errors.error_policy_registry import PolicyRegistryError
@@ -195,6 +197,7 @@ __all__: list[str] = [
     "InfraRequestRejectedError",
     "InfraTimeoutError",
     "InfraUnavailableError",
+    "InvariantViolation",
     # Message type registry errors
     "MessageTypeRegistryError",
     # Configuration models

--- a/src/omnibase_infra/errors/error_invariant_violation.py
+++ b/src/omnibase_infra/errors/error_invariant_violation.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Invariant violation error."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from omnibase_core.enums import EnumCoreErrorCode
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.errors.error_infra import RuntimeHostError
+from omnibase_infra.models.errors.model_infra_error_context import (
+    ModelInfraErrorContext,
+)
+
+
+class InvariantViolation(RuntimeHostError):  # noqa: N818 - Linear ticket names this API
+    """Raised when an adapter action violates its declared contract invariants."""
+
+    def __init__(
+        self,
+        *,
+        action_name: str,
+        protocol_domain: str,
+        message: str | None = None,
+        allowed_actions: tuple[str, ...] = (),
+        context: ModelInfraErrorContext | None = None,
+        correlation_id: UUID | None = None,
+        **extra_context: object,
+    ) -> None:
+        """Initialize an invariant violation.
+
+        Args:
+            action_name: Action requested by the caller.
+            protocol_domain: Protocol domain that owns the allowed action set.
+            message: Optional human-readable error message.
+            allowed_actions: Declared actions that are valid for the domain.
+            context: Optional infrastructure error context.
+            correlation_id: Optional correlation ID for distributed tracing.
+            **extra_context: Additional diagnostic context.
+        """
+        self.action_name = action_name
+        self.protocol_domain = protocol_domain
+        self.allowed_actions = allowed_actions
+
+        if correlation_id is None:
+            correlation_id = uuid4()
+
+        if context is None:
+            context = ModelInfraErrorContext(
+                transport_type=EnumInfraTransportType.RUNTIME,
+                operation="validate_allowed_action",
+                target_name=protocol_domain,
+                correlation_id=correlation_id,
+            )
+
+        extra_context["action_name"] = action_name
+        extra_context["protocol_domain"] = protocol_domain
+        extra_context["allowed_actions"] = allowed_actions
+
+        if message is None:
+            message = (
+                f"Action {action_name!r} is not allowed for protocol domain "
+                f"{protocol_domain!r}"
+            )
+
+        super().__init__(
+            message=message,
+            error_code=EnumCoreErrorCode.CONTRACT_VIOLATION,
+            context=context,
+            **extra_context,
+        )
+
+
+__all__ = ["InvariantViolation"]

--- a/src/omnibase_infra/errors/error_invariant_violation.py
+++ b/src/omnibase_infra/errors/error_invariant_violation.py
@@ -43,16 +43,24 @@ class InvariantViolation(RuntimeHostError):  # noqa: N818 - Linear ticket names 
         self.protocol_domain = protocol_domain
         self.allowed_actions = allowed_actions
 
-        if correlation_id is None:
-            correlation_id = uuid4()
-
-        if context is None:
-            context = ModelInfraErrorContext(
-                transport_type=EnumInfraTransportType.RUNTIME,
-                operation="validate_allowed_action",
-                target_name=protocol_domain,
-                correlation_id=correlation_id,
-            )
+        resolved_correlation_id = (
+            correlation_id
+            or (context.correlation_id if context is not None else None)
+            or uuid4()
+        )
+        context_values = context.model_dump() if context is not None else {}
+        context_values.pop("correlation_id", None)
+        context_values.update(
+            {
+                "transport_type": EnumInfraTransportType.RUNTIME,
+                "operation": "validate_allowed_action",
+                "target_name": protocol_domain,
+            }
+        )
+        context = ModelInfraErrorContext.with_correlation(
+            correlation_id=resolved_correlation_id,
+            **context_values,
+        )
 
         extra_context["action_name"] = action_name
         extra_context["protocol_domain"] = protocol_domain

--- a/tests/integration/test_invariant_violation.py
+++ b/tests/integration/test_invariant_violation.py
@@ -3,7 +3,11 @@
 
 """Integration coverage for the exported InvariantViolation error."""
 
+import pytest
+
 from omnibase_infra.errors import InvariantViolation
+
+pytestmark = pytest.mark.integration
 
 
 def test_invariant_violation_export_preserves_structured_context() -> None:

--- a/tests/integration/test_invariant_violation.py
+++ b/tests/integration/test_invariant_violation.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration coverage for the exported InvariantViolation error."""
+
+from omnibase_infra.errors import InvariantViolation
+
+
+def test_invariant_violation_export_preserves_structured_context() -> None:
+    error = InvariantViolation(
+        action_name="delete_branch",
+        protocol_domain="code_repository",
+        allowed_actions=("create_branch",),
+    )
+
+    assert error.model.context["action_name"] == "delete_branch"
+    assert error.model.context["protocol_domain"] == "code_repository"
+    assert error.model.context["allowed_actions"] == ("create_branch",)

--- a/tests/unit/test_invariant_violation.py
+++ b/tests/unit/test_invariant_violation.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for InvariantViolation."""
+
+from omnibase_core.enums import EnumCoreErrorCode
+from omnibase_infra.errors import InvariantViolation, RuntimeHostError
+
+
+def test_invariant_violation_is_exception() -> None:
+    error = InvariantViolation(
+        action_name="delete_branch",
+        protocol_domain="code_repository",
+    )
+
+    assert isinstance(error, Exception)
+    assert isinstance(error, RuntimeHostError)
+    assert error.model.error_code == EnumCoreErrorCode.CONTRACT_VIOLATION
+
+
+def test_invariant_violation_includes_action_name() -> None:
+    error = InvariantViolation(
+        action_name="delete_branch",
+        protocol_domain="code_repository",
+        allowed_actions=("create_branch", "open_pull_request"),
+    )
+
+    assert error.action_name == "delete_branch"
+    assert "delete_branch" in str(error)
+    assert error.model.context["action_name"] == "delete_branch"
+    assert error.model.context["allowed_actions"] == (
+        "create_branch",
+        "open_pull_request",
+    )
+
+
+def test_invariant_violation_includes_protocol_domain() -> None:
+    error = InvariantViolation(
+        action_name="post_message",
+        protocol_domain="notification",
+    )
+
+    assert error.protocol_domain == "notification"
+    assert "notification" in str(error)
+    assert error.model.context["protocol_domain"] == "notification"
+    assert error.model.context["target_name"] == "notification"

--- a/tests/unit/test_invariant_violation.py
+++ b/tests/unit/test_invariant_violation.py
@@ -5,12 +5,16 @@
 
 from uuid import uuid4
 
+import pytest
+
 from omnibase_core.enums import EnumCoreErrorCode
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import InvariantViolation, RuntimeHostError
 from omnibase_infra.models.errors.model_infra_error_context import (
     ModelInfraErrorContext,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_invariant_violation_is_exception() -> None:

--- a/tests/unit/test_invariant_violation.py
+++ b/tests/unit/test_invariant_violation.py
@@ -3,8 +3,14 @@
 
 """Tests for InvariantViolation."""
 
+from uuid import uuid4
+
 from omnibase_core.enums import EnumCoreErrorCode
+from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import InvariantViolation, RuntimeHostError
+from omnibase_infra.models.errors.model_infra_error_context import (
+    ModelInfraErrorContext,
+)
 
 
 def test_invariant_violation_is_exception() -> None:
@@ -44,3 +50,28 @@ def test_invariant_violation_includes_protocol_domain() -> None:
     assert "notification" in str(error)
     assert error.model.context["protocol_domain"] == "notification"
     assert error.model.context["target_name"] == "notification"
+
+
+def test_invariant_violation_explicit_correlation_id_overrides_context() -> None:
+    context_correlation_id = uuid4()
+    explicit_correlation_id = uuid4()
+    context = ModelInfraErrorContext.with_correlation(
+        correlation_id=context_correlation_id,
+        transport_type=EnumInfraTransportType.HTTP,
+        operation="incoming_request",
+        target_name="external_api",
+        namespace="tenant-a",
+    )
+
+    error = InvariantViolation(
+        action_name="delete_branch",
+        protocol_domain="code_repository",
+        context=context,
+        correlation_id=explicit_correlation_id,
+    )
+
+    assert error.model.correlation_id == explicit_correlation_id
+    assert error.model.context["transport_type"] == EnumInfraTransportType.RUNTIME
+    assert error.model.context["operation"] == "validate_allowed_action"
+    assert error.model.context["target_name"] == "code_repository"
+    assert error.model.context["namespace"] == "tenant-a"


### PR DESCRIPTION
Evidence-Source: OCC#698
Evidence-Ticket: OMN-8063

## Summary
- Add InvariantViolation as a RuntimeHostError for adapter allowed-action contract violations.
- Export the new error from omnibase_infra.errors.
- Add focused unit and integration tests for exception inheritance and action/protocol-domain context.

## Verification
- uv run pytest tests/unit/test_invariant_violation.py tests/integration/test_invariant_violation.py -v
- uv run ruff check src/omnibase_infra/errors/__init__.py src/omnibase_infra/errors/error_invariant_violation.py tests/unit/test_invariant_violation.py tests/integration/test_invariant_violation.py
- uv run ruff check src/ --select UP007,UP006

## OCC Evidence
- Central contract and PASS receipts: OmniNode-ai/onex_change_control#698

## Ticket
- OMN-8063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an InvariantViolation error type to detect/report adapter contract violations; it records action name, protocol domain, allowed actions, and preserves contextual info with automatic correlation ID handling.

* **Tests**
  * Added unit and integration tests validating inheritance, message content, context preservation, allowed-actions exposure, and correlation ID precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->