### PR TITLE
feat: add seed-keycloak orchestrator + make keycloak default-on [OMN-10089]

### DIFF
--- a/contracts/OMN-10089.yaml
+++ b/contracts/OMN-10089.yaml
@@ -3,6 +3,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: "OMN-10089"
+title: "Wire seed-keycloak-clients reconciler into Makefile (local install)"
 summary: "feat(OMN-10089): add Keycloak readiness healthcheck to docker-compose"
 is_seam_ticket: true
 interface_change: true

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -8,7 +8,7 @@
 #
 #
 # Usage:
-#   # Core infrastructure only (postgres, valkey, redpanda)
+#   # Core infrastructure (postgres, valkey, redpanda, keycloak)
 #   docker compose -f docker/docker-compose.infra.yml up -d
 #
 #   # With runtime services
@@ -16,9 +16,6 @@
 #
 #   # With secrets management (Infisical)
 #   docker compose -f docker/docker-compose.infra.yml --profile secrets up -d
-#
-#   # With Keycloak (local OIDC/auth)
-#   docker compose -f docker/docker-compose.infra.yml --profile auth up -d
 #
 #   # Full stack (all services)
 #   docker compose -f docker/docker-compose.infra.yml --profile full up -d
@@ -37,12 +34,15 @@
 #   docker compose -f docker/docker-compose.infra.yml down -v
 #
 # Profiles:
-#   - (default): Core infrastructure (postgres, valkey, redpanda)
+#   - (default): Core infrastructure (postgres, valkey, redpanda, keycloak)
 #   - runtime: ONEX runtime services (omninode-runtime, effects, workers, observability)
 #   - secrets: Infisical for secrets management
-#   - auth: Keycloak OIDC/auth service (local dev)
-#   - full: All services (infrastructure + runtime + secrets + auth)
+#   - full: All services (infrastructure + runtime + secrets)
 #   - bootstrap: Infrastructure + secrets (for bootstrap-infisical.sh sequence)
+# Note (OMN-10089): keycloak moved into the default profile so a vanilla
+# `docker compose up -d` brings up the full local auth stack with no extra
+# flags. Operators who want to skip keycloak can `docker compose stop keycloak`
+# after startup.
 #
 # Redpanda / Kafka:
 #   OMN-3431: Local Docker Redpanda is the default event bus (always-on, no profile needed).
@@ -56,7 +56,7 @@
 #     - Valkey: 16379 (internal 6379)
 #     - Redpanda: 19092 (internal 9092) [always-on]
 #     - Infisical: 8880 (internal 8080) [secrets profile]
-#     - Keycloak: 28080 (internal 8080) [auth profile]
+#     - Keycloak: 28080 (internal 8080) [default — OMN-10089]
 #   Runtime:
 #     - omninode-runtime: 8085 [runtime profile]
 #     - runtime-effects: 8086 [runtime profile]
@@ -442,25 +442,29 @@ services:
       - "com.omninode.service=infisical"
       - "com.omninode.layer=infrastructure"
   # ==========================================================================
-  # Keycloak - OIDC / Auth Service (Auth Profile) [OMN-3361]
+  # Keycloak - OIDC / Auth Service (Default Profile) [OMN-3361, OMN-10089]
   # ==========================================================================
   # Local Keycloak for OIDC authentication in dev. Eliminates dependency on
   # auth.omninode.ai for local development.
   #
+  # OMN-10089: Moved out of the `auth` profile into the default profile so a
+  # vanilla `docker compose up -d` brings up the full local auth stack. The
+  # top-level omnibase Makefile (`make docker-up`) no longer needs to pass
+  # `--profile auth`. Skip locally with `docker compose stop keycloak` after
+  # startup if not needed.
+  #
   # Usage:
-  #   docker compose -f docker/docker-compose.infra.yml --profile auth up -d
-  #   # Then provision service clients:
-  #   uv run python scripts/provision-keycloak.py --kc-url http://localhost:28080 \
-  #     --realm omninode --admin-username admin \
-  #     --admin-password "${KEYCLOAK_ADMIN_PASSWORD:-keycloak-dev-password}"
+  #   docker compose -f docker/docker-compose.infra.yml up -d
+  #   # Then reconcile service clients (idempotent):
+  #   bash scripts/seed-keycloak.sh
   #
   # Realm JSON is imported at startup via --import-realm (start-dev command).
-  # onex-service and onex-admin clients are created dynamically by provision-keycloak.py.
+  # Service clients (onex-service, onex-admin, etc.) are reconciled by
+  # seed-keycloak.sh → seed-keycloak-clients.py from desired-clients.json.
   # Compose healthcheck uses Keycloak's management readiness endpoint.
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.3
     container_name: omnibase-infra-keycloak
-    profiles: ["auth", "full"]
     command: start-dev --import-realm
     environment:
       KC_DB: postgres

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -71,6 +71,10 @@ services:
     container_name: omnibase-infra-stability-test-valkey
     ports: !override
       - "${STABILITY_TEST_VALKEY_EXTERNAL_PORT:-26379}:6379"
+  keycloak:
+    container_name: omnibase-infra-stability-test-keycloak
+    ports: !override
+      - "${STABILITY_TEST_KEYCLOAK_EXTERNAL_PORT:-38080}:8080"
   infisical:
     profiles: !override ["stability-test-disabled"]
   forward-migration:
@@ -192,6 +196,8 @@ volumes:
     name: omnibase-infra-stability-test-redpanda-data
   valkey_data:
     name: omnibase-infra-stability-test-valkey-data
+  keycloak_data:
+    name: omnibase-infra-stability-test-keycloak-data
   runtime_data:
     name: omninode-stability-test-runtime-data
   runtime_logs:

--- a/docs/plans/2026-05-04-seed-keycloak-orchestrator.md
+++ b/docs/plans/2026-05-04-seed-keycloak-orchestrator.md
@@ -1,0 +1,52 @@
+---
+ticket_id: OMN-10089
+---
+
+# Seed-Keycloak Orchestrator Split
+
+> **For Claude:** small two-file change; no sub-skill required.
+
+**Goal:** Move the Keycloak seed orchestration (env sourcing, KC_URL polling, localhost-gated `--reset-bootstrap-admin`, `seed-keycloak-clients.py` invocation) out of the top-level `omnibase` Makefile and into `omnibase_infra` where the Docker/Keycloak knowledge belongs. Make Keycloak start on a default `docker compose up -d` so the omnibase distribution Makefile no longer needs to pass `--profile auth`.
+
+**Why:** The top-level `omnibase` repo is the user-facing distribution point — users clone it to run the platform but are not guaranteed to be running Docker. Anything Docker-specific belongs in `omnibase_infra`. Reviewer (jonahgabriel) called this out during PR review of `harsh-omni/omnibase#2`. OMN-10089's acceptance criterion explicitly offers two paths to enable Keycloak by default; this plan picks **"move keycloak service into default profile"** since it preserves the architectural boundary.
+
+**Scope:** Two files in `omnibase_infra`. No application code; no contract changes; no migrations.
+
+---
+
+## Files
+
+- **Create:** `scripts/seed-keycloak.sh` — orchestration shell wrapper. Owns:
+  - Sourcing `${OMNIBASE_ENV_FILE:-$HOME/.omnibase/.env}` (skips silently if absent so callers can pre-populate the env vars another way)
+  - Validating required vars (`KEYCLOAK_ADMIN_USERNAME`, `KEYCLOAK_ADMIN_PASSWORD`) with fail-fast `${VAR:?}` syntax
+  - Polling `${KC_URL:-http://localhost:28080}/realms/${KC_REALM:-omninode}/.well-known/openid-configuration` with a configurable timeout (default 90s)
+  - Emitting `docker ps` + `docker logs --tail 40` diagnostics on timeout
+  - Caller-side localhost gate for `--reset-bootstrap-admin` (defense in depth alongside the callee gate already in `seed-keycloak-clients.py`)
+  - `cd` into repo root and `exec uv run python scripts/seed-keycloak-clients.py ...`
+- **Modify:** `docker/docker-compose.infra.yml` — remove `profiles: ["auth", "full"]` from the `keycloak` service so `docker compose up -d` brings it up by default. Update the explanatory comments at the top of the file to reflect the change. The `auth` profile name itself remains valid for selective service startup (e.g., to bring up *only* keycloak); removing the profile gate makes keycloak default-on, which is the OMN-10089 acceptance criterion.
+
+## Acceptance criteria
+
+- `bash scripts/seed-keycloak.sh` from a fresh checkout produces all-`unchanged` output on a re-run against an already-seeded Keycloak (idempotent).
+- A clean `docker compose -f docker/docker-compose.infra.yml up -d` (no `--profile` flag) brings up Postgres, Redpanda, Valkey, **and** Keycloak.
+- Running `bash scripts/seed-keycloak.sh` with `OMNIBASE_ENV_FILE` pointing at a missing file fails with a clear "must be set" error from the `${VAR:?}` guard, not a confusing shell error.
+- Running with `KC_URL=https://staging.example.com/auth` does NOT pass `--reset-bootstrap-admin` to the Python script (caller-side localhost gate works).
+- On Keycloak-not-ready timeout, the script prints the last 40 lines of the keycloak container logs before exiting nonzero.
+
+## Out of scope
+
+- Changing `seed-keycloak-clients.py` (already merged in PR #1432, OMN-10088).
+- Changing the catalog/`bundles.yaml` system. Keycloak's `auth` bundle membership stays intact for users who want bundle-driven startup; this plan only touches the legacy direct-compose path.
+- Wiring this script into a top-level Makefile in omnibase_infra (no such Makefile exists today; not creating one in this PR).
+
+## Cross-repo coordination
+
+This PR must merge before [`harsh-omni/omnibase#2`](https://github.com/harsh-omni/omnibase/pull/2) (OMN-10089 Makefile-side) can be updated to call `bash $(REPOS_DIR)/omnibase_infra/scripts/seed-keycloak.sh` as a thin pass-through and to drop its own `--profile auth` additions. The omnibase PR will be rebased + the body updated to link this PR's merge SHA after merge.
+
+## Test plan
+
+- [ ] Local clean run: `docker compose -f docker/docker-compose.infra.yml down -v && docker compose -f docker/docker-compose.infra.yml up -d` — verify keycloak container is in the resulting `docker ps`.
+- [ ] `bash scripts/seed-keycloak.sh` against the freshly-started Keycloak — verify exit 0 and JSON `op` lines.
+- [ ] Re-run `bash scripts/seed-keycloak.sh` — verify all `op=unchanged`.
+- [ ] `OMNIBASE_ENV_FILE=/nonexistent bash scripts/seed-keycloak.sh` — verify clear failure message naming the missing env vars.
+- [ ] `KC_URL=https://example.invalid bash scripts/seed-keycloak.sh` (without admin vars set) — verify the `--reset-bootstrap-admin` flag is NOT in the final `uv run python` invocation (`bash -x` to inspect).

--- a/docs/plans/2026-05-04-seed-keycloak-orchestrator.md
+++ b/docs/plans/2026-05-04-seed-keycloak-orchestrator.md
@@ -23,7 +23,7 @@ ticket_id: OMN-10089
   - Emitting `docker ps` + `docker logs --tail 40` diagnostics on timeout
   - Caller-side localhost gate for `--reset-bootstrap-admin` (defense in depth alongside the callee gate already in `seed-keycloak-clients.py`)
   - `cd` into repo root and `exec uv run python scripts/seed-keycloak-clients.py ...`
-- **Modify:** `docker/docker-compose.infra.yml` — remove `profiles: ["auth", "full"]` from the `keycloak` service so `docker compose up -d` brings it up by default. Update the explanatory comments at the top of the file to reflect the change. The `auth` profile name itself remains valid for selective service startup (e.g., to bring up *only* keycloak); removing the profile gate makes keycloak default-on, which is the OMN-10089 acceptance criterion.
+- **Modify:** `docker/docker-compose.infra.yml` — remove `profiles: ["auth", "full"]` from the `keycloak` service so `docker compose up -d` brings it up by default. Update the explanatory comments at the top of the file to reflect the change. Note: with no `profiles:` key, `--profile auth` no longer selectively targets keycloak — it would start the full default stack plus any other service tagged `auth`. To bring up *only* keycloak (and its postgres dep), operators should use `docker compose up -d keycloak` (compose resolves `depends_on` to start postgres automatically).
 
 ## Acceptance criteria
 
@@ -49,4 +49,4 @@ This PR must merge before [`harsh-omni/omnibase#2`](https://github.com/harsh-omn
 - [ ] `bash scripts/seed-keycloak.sh` against the freshly-started Keycloak — verify exit 0 and JSON `op` lines.
 - [ ] Re-run `bash scripts/seed-keycloak.sh` — verify all `op=unchanged`.
 - [ ] `OMNIBASE_ENV_FILE=/nonexistent bash scripts/seed-keycloak.sh` — verify clear failure message naming the missing env vars.
-- [ ] `KC_URL=https://example.invalid bash scripts/seed-keycloak.sh` (without admin vars set) — verify the `--reset-bootstrap-admin` flag is NOT in the final `uv run python` invocation (`bash -x` to inspect).
+- [ ] `KEYCLOAK_ADMIN_USERNAME=x KEYCLOAK_ADMIN_PASSWORD=y KC_URL=http://staging.example.invalid bash -x scripts/seed-keycloak.sh 2>&1 | grep "uv run"` — verify the `--reset-bootstrap-admin` flag is NOT in the final `uv run python` invocation when `KC_URL` is non-localhost. Admin vars are required because the `${VAR:?}` guard fires before the `case` localhost-gate; CSI runs need the vars set so the assertion can actually inspect the `case` output.

--- a/scripts/seed-keycloak.sh
+++ b/scripts/seed-keycloak.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Wait for a running Keycloak to become ready, then reconcile its clients
+# from desired-clients.json via seed-keycloak-clients.py. Idempotent.
+#
+# Env vars (all optional):
+#   KC_URL              Keycloak base URL (default: http://localhost:28080)
+#   KC_REALM            Realm to seed (default: omninode)
+#   OMNIBASE_ENV_FILE   Path to env file with KEYCLOAK_ADMIN_* vars
+#                       (default: $HOME/.omnibase/.env)
+#   KC_READY_TIMEOUT    Max seconds to wait for Keycloak readiness (default: 90)
+#   KC_CONTAINER_NAME   Container name for diagnostics on timeout
+#                       (default: omnibase-infra-keycloak)
+#
+# Required in OMNIBASE_ENV_FILE (or already in environment):
+#   KEYCLOAK_ADMIN_USERNAME
+#   KEYCLOAK_ADMIN_PASSWORD
+#
+# This script is the canonical entry point for seeding a local Keycloak from
+# the omnibase platform installer. The top-level omnibase Makefile delegates
+# `make seed-keycloak` here so all Docker/Keycloak knowledge stays in
+# omnibase_infra.
+
+set -euo pipefail
+
+KC_URL="${KC_URL:-http://localhost:28080}"
+KC_REALM="${KC_REALM:-omninode}"
+OMNIBASE_ENV_FILE="${OMNIBASE_ENV_FILE:-${HOME}/.omnibase/.env}"
+KC_READY_TIMEOUT="${KC_READY_TIMEOUT:-90}"
+KC_CONTAINER_NAME="${KC_CONTAINER_NAME:-omnibase-infra-keycloak}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${OMNIBASE_ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${OMNIBASE_ENV_FILE}"
+  set +a
+fi
+
+: "${KEYCLOAK_ADMIN_USERNAME:?KEYCLOAK_ADMIN_USERNAME must be set in ${OMNIBASE_ENV_FILE} or environment}"
+: "${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD must be set in ${OMNIBASE_ENV_FILE} or environment}"
+
+echo "==> Waiting for Keycloak at ${KC_URL} to become ready (max ${KC_READY_TIMEOUT}s)..."
+attempts=$((KC_READY_TIMEOUT / 3))
+i=0
+until curl -fsS -m 3 "${KC_URL}/realms/${KC_REALM}/.well-known/openid-configuration" > /dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "${i}" -gt "${attempts}" ]; then
+    echo "ERROR: Keycloak at ${KC_URL} did not become ready within ${KC_READY_TIMEOUT}s." >&2
+    if command -v docker > /dev/null 2>&1; then
+      echo "--- docker ps (${KC_CONTAINER_NAME}) ---" >&2
+      docker ps -a --filter "name=${KC_CONTAINER_NAME}" \
+        --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' >&2 || true
+      echo "--- last 40 lines of ${KC_CONTAINER_NAME} logs ---" >&2
+      docker logs --tail 40 "${KC_CONTAINER_NAME}" >&2 2>&1 || true
+    fi
+    exit 1
+  fi
+  echo "   Keycloak not ready — retrying in 3s... (${i}/${attempts})"
+  sleep 3
+done
+
+echo "==> Keycloak ready. Running client reconciler..."
+
+# Caller-side gate for --reset-bootstrap-admin: only when targeting localhost.
+# The callee (seed-keycloak-clients.py) has its own localhost guard for
+# defense-in-depth, but gating here too prevents the flag from ever being
+# passed against a remote Keycloak.
+reset_flag=()
+case "${KC_URL}" in
+  http://localhost:* | http://127.0.0.1:*)
+    reset_flag=(--reset-bootstrap-admin)
+    ;;
+esac
+
+cd "${REPO_ROOT}"
+exec uv run python scripts/seed-keycloak-clients.py \
+  --kc-url "${KC_URL}" \
+  --realm "${KC_REALM}" \
+  --admin-username "${KEYCLOAK_ADMIN_USERNAME}" \
+  --admin-password "${KEYCLOAK_ADMIN_PASSWORD}" \
+  "${reset_flag[@]}" \
+  --config "${REPO_ROOT}/docker/keycloak/desired-clients.json"

--- a/scripts/seed-keycloak.sh
+++ b/scripts/seed-keycloak.sh
@@ -83,5 +83,5 @@ exec uv run python scripts/seed-keycloak-clients.py \
   --realm "${KC_REALM}" \
   --admin-username "${KEYCLOAK_ADMIN_USERNAME}" \
   --admin-password "${KEYCLOAK_ADMIN_PASSWORD}" \
-  "${reset_flag[@]}" \
+  ${reset_flag[@]+"${reset_flag[@]}"} \
   --config "${REPO_ROOT}/docker/keycloak/desired-clients.json"

--- a/scripts/seed-keycloak.sh
+++ b/scripts/seed-keycloak.sh
@@ -45,11 +45,11 @@ fi
 : "${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD must be set in ${OMNIBASE_ENV_FILE} or environment}"
 
 echo "==> Waiting for Keycloak at ${KC_URL} to become ready (max ${KC_READY_TIMEOUT}s)..."
-attempts=$((KC_READY_TIMEOUT / 3))
+deadline=$((SECONDS + KC_READY_TIMEOUT))
 i=0
 until curl -fsS -m 3 "${KC_URL}/realms/${KC_REALM}/.well-known/openid-configuration" > /dev/null 2>&1; do
   i=$((i + 1))
-  if [ "${i}" -gt "${attempts}" ]; then
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
     echo "ERROR: Keycloak at ${KC_URL} did not become ready within ${KC_READY_TIMEOUT}s." >&2
     if command -v docker > /dev/null 2>&1; then
       echo "--- docker ps (${KC_CONTAINER_NAME}) ---" >&2
@@ -60,7 +60,7 @@ until curl -fsS -m 3 "${KC_URL}/realms/${KC_REALM}/.well-known/openid-configurat
     fi
     exit 1
   fi
-  echo "   Keycloak not ready — retrying in 3s... (${i}/${attempts})"
+  echo "   Keycloak not ready — retrying in 3s... (attempt ${i})"
   sleep 3
 done
 

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -30,6 +30,7 @@ EXPECTED_RENDERED_SERVICES = {
     "forward-migration",
     "intelligence-migration",
     "migration-gate",
+    "keycloak",
     *REQUIRED_RUNTIME_SERVICES,
 }
 OUT_OF_LANE_SERVICES = {
@@ -53,6 +54,7 @@ EXPECTED_PUBLISHED_PORTS = {
     "intelligence-migration": set(),
     "migration-gate": set(),
     "redpanda-partition-cap": set(),
+    "keycloak": {"38080"},
 }
 PRODUCTION_PUBLISHED_PORTS = {
     "5436",
@@ -70,6 +72,7 @@ PRODUCTION_PUBLISHED_PORTS = {
     "8092",
     "8093",
     "6006",
+    "28080",
 }
 PRODUCTION_CONTAINER_NAMES = {
     "omninode-runtime",
@@ -87,6 +90,7 @@ PRODUCTION_CONTAINER_NAMES = {
     "omninode-contract-resolver",
     "omnibase-infra-phoenix",
     "omnibase-infra-autoheal",
+    "omnibase-infra-keycloak",
 }
 COMPOSE_RENDER_ENV = {
     "INFISICAL_AUTH_SECRET": "render-only-infisical-auth-secret",
@@ -107,6 +111,7 @@ COMPOSE_RENDER_ENV = {
     "STABILITY_TEST_REDPANDA_ADMIN_PORT": "29644",
     "STABILITY_TEST_REDPANDA_EXTERNAL_PORT": "39092",
     "STABILITY_TEST_REDPANDA_PANDAPROXY_PORT": "28082",
+    "STABILITY_TEST_KEYCLOAK_EXTERNAL_PORT": "38080",
 }
 
 


### PR DESCRIPTION
Evidence-Ticket: OMN-10089
## Summary

Moves the Keycloak seed orchestration logic (env sourcing, KC_URL polling, localhost-gated `--reset-bootstrap-admin`, `seed-keycloak-clients.py` invocation) out of the top-level [`harsh-omni/omnibase` Makefile](https://github.com/harsh-omni/omnibase/pull/2) and into `omnibase_infra`, where the Docker/Keycloak knowledge belongs.

Pulls keycloak out of the `auth` profile so a vanilla `docker compose up -d` brings up the full local auth stack with no extra flags.

Evidence-Source: OCC#701

(Current `OmniNode-ai/onex_change_control` `main` HEAD; the canonical OMN-10089 contract is present at this SHA.)

## Architectural rationale

The top-level `omnibase` distribution repo is the user-facing entry point — users clone it to run the platform but are not guaranteed to be running Docker (could be k8s, hosted services, etc.). Anything Docker-specific belongs in `omnibase_infra`. Reviewer feedback on [`harsh-omni/omnibase#2`](https://github.com/harsh-omni/omnibase/pull/2) flagged that `--profile auth`, `localhost:28080` polling, container names, and `uv run` invocations should not live in the distribution Makefile. This PR is the omnibase_infra-side fix.

## Changes

- **`scripts/seed-keycloak.sh`** (new) — orchestration shell wrapper. Sources `${OMNIBASE_ENV_FILE:-$HOME/.omnibase/.env}`, validates required vars with `${VAR:?}`, polls `${KC_URL:-http://localhost:28080}/realms/${KC_REALM:-omninode}/.well-known/openid-configuration` with a 90s timeout (configurable), emits `docker ps`/`docker logs --tail 40` diagnostics on timeout, applies a caller-side localhost gate for `--reset-bootstrap-admin`, then `exec`s `uv run python scripts/seed-keycloak-clients.py` with the right flags.
- **`docker/docker-compose.infra.yml`** — removes `profiles: ["auth", "full"]` from the `keycloak` service so it starts on a default `docker compose up -d`. Header comments and the keycloak service block updated to reflect the new behavior. Compose semantics: services with no `profiles:` field are always-enabled, so `--profile runtime`/`--profile secrets`/`--profile full` invocations all continue to bring keycloak up alongside their target services. Operators who want to skip keycloak can `docker compose stop keycloak` after startup.
- **`contracts/OMN-10089.yaml`** — add missing top-level `title:` field. The schema was bumped to require it; the existing per-repo carrier was committed before the bump and never backfilled. Several other contracts in this dir have the same drift but are out of scope here.

## Foundation already on main

- [#1431](https://github.com/OmniNode-ai/omnibase_infra/pull/1431) — desired-clients.json split [OMN-10087]
- [#1432](https://github.com/OmniNode-ai/omnibase_infra/pull/1432) — seed-keycloak-clients.py reconciler [OMN-10088]
- [#1433](https://github.com/OmniNode-ai/omnibase_infra/pull/1433) — Keycloak healthcheck (commit `6aee45c6`) [OMN-10089]

## Cross-repo coordination

This PR must merge **before** [`harsh-omni/omnibase#2`](https://github.com/harsh-omni/omnibase/pull/2) is updated. Once this lands:
1. `harsh-omni/omnibase#2` Makefile gets slimmed: `seed-keycloak` becomes a thin pass-through (`bash $(REPOS_DIR)/omnibase_infra/scripts/seed-keycloak.sh`).
2. The `--profile auth` additions on `docker-up`/`docker-down` in that PR get reverted (no longer needed).
3. The omnibase PR body gets updated to link this PR's merge SHA.

## Test plan

- [ ] Local clean run: `docker compose -f docker/docker-compose.infra.yml down -v && docker compose -f docker/docker-compose.infra.yml up -d` — verify `omnibase-infra-keycloak` is in the resulting `docker ps`.
- [ ] `bash scripts/seed-keycloak.sh` against the freshly-started Keycloak — verify exit 0 and JSON `op` lines.
- [ ] Re-run `bash scripts/seed-keycloak.sh` — verify all `op=unchanged`.
- [ ] `OMNIBASE_ENV_FILE=/nonexistent bash scripts/seed-keycloak.sh` — verify clear failure message naming the missing env vars.
- [ ] `KEYCLOAK_ADMIN_USERNAME=x KEYCLOAK_ADMIN_PASSWORD=y KC_URL=http://staging.example.invalid bash -x scripts/seed-keycloak.sh 2>&1 | grep "uv run"` — verify `--reset-bootstrap-admin` is NOT in the final invocation when `KC_URL` is non-localhost.
- [ ] Verify `--profile runtime up -d` still brings up keycloak alongside runtime services (no regression for runtime-profile users).

## Plan

`docs/plans/2026-05-04-seed-keycloak-orchestrator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keycloak now starts by default with the local Docker Compose infrastructure.
  * Added an automated Keycloak seeding step to initialize/reconcile clients during local bring-up.

* **Documentation**
  * Added a plan describing the Keycloak orchestration, readiness checks, safety gates, and acceptance criteria.

* **Tests**
  * Stability-test environment updated to include Keycloak and validate its external port mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


