### PR TITLE
feat(OMN-10563): register omnimarket service keys; schema v1.2

### DIFF
--- a/config/shared_key_registry.yaml
+++ b/config/shared_key_registry.yaml
@@ -23,7 +23,9 @@
 #   - scripts/register-repo.py seed-shared  (seed /shared/* in Infisical)
 #
 # version: increment minor when adding keys, major on breaking structural changes.
-version: "1.1"
+# 1.2 (OMN-10563): adds top-level `services:` section for per-service key
+# declarations. Loader: `_services_keys()` in scripts/register-repo.py.
+version: "1.2"
 # Keys written to /shared/<transport>/ in Infisical.
 shared:
   "/shared/db/":
@@ -182,3 +184,42 @@ service_override_required:
   # Each service must set its own consumer group ID to avoid unintended
   # load-balancing across topics when multiple services share a group.
   - KAFKA_GROUP_ID
+# Per-service key declarations.
+#
+# Schema (added in 1.2, OMN-10563):
+#   services:
+#     <repo>:
+#       <transport>:
+#         - KEY1
+#         - KEY2
+#
+# Each entry maps to Infisical path /services/<repo>/<transport>/<KEY>. These
+# are the per-service override paths that take precedence over /shared/<transport>/<KEY>
+# at runtime. A key may appear in both /shared and /services/<repo>; the
+# per-service override is the authoritative value when both exist.
+#
+# Used by:
+#   - scripts/register-repo.py onboard-repo (plan validation; per-service seeding)
+#   - omnimarket / other services' Settings classes (declare what they will read)
+services:
+  omnimarket:
+    # Per-service consumer group; required override per service_override_required above.
+    kafka:
+      - KAFKA_GROUP_ID
+    # Per-service LLM endpoint + model overrides. The flat path convention is
+    # /services/omnimarket/llm/<KEY> — no nested role paths (ChatGPT review §9).
+    # LLM_<ROLE>_URL points the role's coder/reasoner at a specific endpoint;
+    # LLM_<ROLE>_MODEL_ID names the model id served by that endpoint. Task 19
+    # (OMN-10568) wires bridge_config_loader to resolve these via
+    # ProtocolSecretStore.
+    llm:
+      - LLM_CODER_URL
+      - LLM_CODER_MODEL_ID
+      - LLM_REASONER_URL
+      - LLM_REASONER_MODEL_ID
+    # Per-service database identity. POSTGRES_DATABASE is in identity_defaults
+    # globally (each repo bakes its own value as a Settings default), but is
+    # also enumerated here so omnimarket's per-service path is explicit and
+    # the onboard-repo plan can verify it.
+    db:
+      - POSTGRES_DATABASE

--- a/contracts/OMN-10534.yaml
+++ b/contracts/OMN-10534.yaml
@@ -1,0 +1,36 @@
+# OMN-10534 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract lives in onex_change_control; this repo-local
+# contract carries deploy-gate evidence for the runtime topic bootstrap hardening.
+schema_version: '1.0.0'
+ticket_id: OMN-10534
+title: 'Harden local runtime topic bootstrap'
+summary: 'fix(OMN-10534): harden local runtime topic bootstrap'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched:
+  - docker-compose
+  - event_bus
+evidence_requirements:
+  - kind: tests
+    description: Topic manager and env parity tests pass
+    command: uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks 1496 --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Topic manager and env parity tests pass
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q'
+  - id: dod-002
+    description: Deploy smoke — runtime container starts and ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS is read without error
+    source: manual
+    checks:
+      - check_type: command
+        check_value: 'docker exec omninode-runtime printenv ONEX_EVENT_BUS'

--- a/contracts/OMN-10534.yaml
+++ b/contracts/OMN-10534.yaml
@@ -8,8 +8,7 @@ summary: 'fix(OMN-10534): harden local runtime topic bootstrap'
 is_seam_ticket: false
 interface_change: false
 interfaces_touched:
-  - docker-compose
-  - event_bus
+  - topics
 evidence_requirements:
   - kind: tests
     description: Topic manager and env parity tests pass

--- a/contracts/OMN-10534.yaml
+++ b/contracts/OMN-10534.yaml
@@ -15,7 +15,7 @@ evidence_requirements:
     command: uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q
   - kind: ci
     description: CI pipeline green on PR
-    command: gh pr checks 1496 --repo OmniNode-ai/omnibase_infra
+    command: gh pr checks 1505 --repo OmniNode-ai/omnibase_infra
 emergency_bypass:
   enabled: false
   justification: ''

--- a/contracts/OMN-10534.yaml
+++ b/contracts/OMN-10534.yaml
@@ -32,4 +32,4 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: 'docker exec omninode-runtime printenv ONEX_EVENT_BUS'
+        check_value: 'docker exec omninode-runtime printenv ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS'

--- a/contracts/OMN-10563.yaml
+++ b/contracts/OMN-10563.yaml
@@ -3,11 +3,10 @@ ticket_id: OMN-10563
 title: 'Register omnimarket service keys'
 summary: 'Register omnimarket per-service secret keys and topic provisioning metadata.'
 is_seam_ticket: false
-interface_change: false
+interface_change: true
 interfaces_touched:
-  - config
   - topics
-  - runtime
+  - public_api
 evidence_requirements:
   - kind: tests
     description: Registry, onboarding, env parity, and topic provisioning tests pass

--- a/contracts/OMN-10563.yaml
+++ b/contracts/OMN-10563.yaml
@@ -1,0 +1,34 @@
+schema_version: '1.0.0'
+ticket_id: OMN-10563
+title: 'Register omnimarket service keys'
+summary: 'Register omnimarket per-service secret keys and topic provisioning metadata.'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched:
+  - config
+  - topics
+  - runtime
+evidence_requirements:
+  - kind: tests
+    description: Registry, onboarding, env parity, and topic provisioning tests pass
+    command: uv run pytest tests/ci/test_env_parity.py tests/unit/config/test_shared_key_registry_omnimarket.py tests/unit/scripts/test_register_repo.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks 1505 --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Registry and onboarding tests prove omnimarket service keys map to /services/<repo>/<transport>/<KEY>
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/config/test_shared_key_registry_omnimarket.py tests/unit/scripts/test_register_repo.py -q'
+  - id: dod-deploy
+    description: Runtime deploy preflight covers env parity and topic provisioning for the compose/runtime changes
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q'

--- a/contracts/OMN-10563.yaml
+++ b/contracts/OMN-10563.yaml
@@ -30,4 +30,4 @@ dod_evidence:
     source: generated
     checks:
       - check_type: command
-        check_value: 'uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q'
+        check_value: 'deploy: no live deploy is performed pre-merge; preflight uses uv run pytest tests/ci/test_env_parity.py tests/unit/event_bus/test_service_topic_manager.py tests/integration/event_bus/test_topic_provisioner_integration.py -q, then post-merge validation checks the runtime container with docker exec omninode-runtime printenv ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS'

--- a/contracts/runtime/contract_loader_effect.yaml
+++ b/contracts/runtime/contract_loader_effect.yaml
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Runtime: Contract Loader Effect Node
+#
+# This EFFECT node scans the filesystem for contract YAML files and emits
+# discovered contracts for the contract registry to process.
+#
+# Node Implementation (NO custom code needed):
+#   from omnibase_core.nodes import NodeEffect
+#   class NodeContractLoaderEffect(NodeEffect):
+#       pass  # All logic driven by this YAML contract
+#
+# Features Demonstrated:
+# - Filesystem handler for directory scanning
+# - Watch mode for real-time contract discovery
+# - Pattern-based file filtering
+# - Retry policy for robustness
+
+# Contract Metadata
+node_type: EFFECT_GENERIC
+contract_version: {major: 1, minor: 1, patch: 0}
+# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
+# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+fingerprint: "1.1.0:423f8598810c"
+# Effect Subcontract
+# NOTE: This contract uses `effect_operations` (multi-operation schema) rather than
+# `effect` (single-operation schema) because it defines multiple filesystem operations
+# (scan_contracts_directory, read_contract_file). Contracts with a single operation
+# use the simpler `effect:` key (e.g., event_bus_wiring_effect.yaml).
+effect_operations:
+  version: {major: 1, minor: 1, patch: 0}
+  subcontract_version: {major: 1, minor: 1, patch: 0}
+
+  # Execution configuration
+  execution_mode: sequential_abort  # Abort on first failure
+
+  # Default resilience settings
+  default_retry_policy:
+    enabled: true
+    max_retries: 3
+    backoff_strategy: exponential
+    base_delay_ms: 1000
+    max_delay_ms: 10000
+    jitter_factor: 0.1
+    retryable_errors:
+      - ENOENT
+      - EACCES
+      - ETIMEDOUT
+      - ECONNRESET
+
+  # Operations
+  operations:
+    # Primary operation: Scan contracts directory
+    - operation_name: scan_contracts_directory
+      description: Scan configured directory for contract YAML files
+      idempotent: true  # Read-only operation
+
+      io_config:
+        handler_type: filesystem
+        file_path_template: "${env.ONEX_CONTRACTS_DIR:./contracts}"
+        operation: read
+        timeout_ms: 30000
+        atomic: false  # Read operations don't need atomicity
+        create_dirs: false  # Don't create dirs for read
+        encoding: utf-8
+
+        # Security: Filesystem Path Sandboxing
+        # Rationale: Prevent path traversal attacks and restrict filesystem access
+        # to authorized directories only. This protects against:
+        # - Directory traversal via ".." sequences
+        # - Access to sensitive system directories (/etc, /var, /home)
+        # - Symlink escape attacks that could access files outside the sandbox
+        # - Arbitrary absolute path injection via environment variables
+        security:
+          allowed_base_paths:
+            - "${env.ONEX_CONTRACTS_DIR:./contracts}"
+            - "./contracts"
+          path_validation:
+            enabled: true
+            deny_patterns:
+              - ".."
+              - "/etc"
+              - "/var"
+              - "/home"
+              - "~"
+              - "/proc"
+              - "/sys"
+              - "/dev"
+            deny_absolute_paths: true  # Only allow relative paths within sandbox
+            deny_symlink_escape: true  # Prevent symlinks pointing outside base paths
+
+      # Scanning configuration (metadata for handler)
+      metadata:
+        scan_mode: directory
+        pattern: "**/*.yaml"
+        exclude_patterns:
+          - "**/runtime/**"  # Don't reload runtime contracts
+          - "**/_*.yaml"  # Skip disabled contracts (underscore prefix)
+          - "**/.*"  # Skip hidden files
+          - "**/__pycache__/**"  # Skip Python cache directories
+        watch_mode: true
+        watch_debounce_ms: 500
+        recursive: true
+        follow_symlinks: false
+
+      response_handling:
+        success_codes: [200]
+        extract_fields:
+          discovered_files: "$.files"
+          file_count: "$.count"
+          scan_timestamp: "$.timestamp"
+        fail_on_empty: false  # Empty contracts dir is valid (initial state)
+        extraction_engine: jsonpath
+
+      # Override retry for scan operation
+      # Timing Validation: 500 + 1000 + 2000 + 4000 + 5000(capped) = 12500ms * 1.15 = 14375ms
+      # Worst case retry (14375ms) << timeout (60000ms) - PASS (76% margin)
+      retry_policy:
+        enabled: true
+        max_retries: 5
+        backoff_strategy: exponential
+        base_delay_ms: 500
+        max_delay_ms: 5000
+        jitter_factor: 0.15
+
+      operation_timeout_ms: 60000  # 60 second timeout for directory scan
+
+    # Secondary operation: Read individual contract file
+    - operation_name: read_contract_file
+      description: Read and return contents of a single contract file
+      idempotent: true  # Read-only operation
+
+      io_config:
+        handler_type: filesystem
+        file_path_template: "${input.file_path}"
+        operation: read
+        timeout_ms: 10000
+        atomic: false
+        create_dirs: false
+        encoding: utf-8
+
+        # Security: Filesystem Path Sandboxing for User-Provided Paths
+        # Rationale: This operation accepts file paths from input, making it
+        # especially vulnerable to path traversal and arbitrary file access attacks.
+        # Strict sandboxing ensures users cannot read sensitive system files or
+        # escape the contracts directory boundary.
+        security:
+          allowed_base_paths:
+            - "${env.ONEX_CONTRACTS_DIR:./contracts}"
+            - "./contracts"
+          path_validation:
+            enabled: true
+            deny_patterns:
+              - ".."
+              - "/etc"
+              - "/var"
+              - "/home"
+              - "~"
+              - "/proc"
+              - "/sys"
+              - "/dev"
+            deny_absolute_paths: true  # Only allow relative paths within sandbox
+            deny_symlink_escape: true  # Prevent symlinks pointing outside base paths
+          # Additional validation for user-provided file paths
+          require_path_under_base: true  # File path MUST resolve under allowed_base_paths
+          validate_extension:
+            - ".yaml"
+            - ".yml"
+
+      response_handling:
+        success_codes: [200]
+        extract_fields:
+          content: "$.content"
+          file_path: "$.path"
+          file_size: "$.size"
+          modified_at: "$.modified_at"
+        fail_on_empty: true  # Empty contract file is an error
+        extraction_engine: jsonpath
+
+      # Timing Validation: 200 + 400 + 800 = 1400ms * 1.1 = 1540ms
+      # Worst case retry (1540ms) << timeout (15000ms) - PASS (90% margin)
+      retry_policy:
+        enabled: true
+        max_retries: 3
+        backoff_strategy: exponential
+        base_delay_ms: 200
+        max_delay_ms: 2000
+        jitter_factor: 0.1
+
+      operation_timeout_ms: 15000  # 15 second timeout per file
+
+  # Circuit breaker for filesystem operations
+  circuit_breaker:
+    enabled: true
+    failure_threshold: 10
+    success_threshold: 3
+    timeout_ms: 30000
+    half_open_requests: 5
+
+  # Observability
+  observability:
+    log_request: true
+    log_response: false  # Contract contents may be large
+    emit_metrics: true
+    trace_propagation: true
+
+# v1.1.0 Required Fields
+handlers:
+  required: []
+  optional:
+    - type: ProtocolLogger
+      version: {major: 1, minor: 0, patch: 0}
+    - type: ProtocolFileSystem
+      version: {major: 1, minor: 0, patch: 0}
+
+profile_tags:
+  - runtime
+  - effect
+  - contracts
+  - discovery
+
+subscriptions:
+  topics: []
+
+# Metadata
+metadata:
+  version: {major: 1, minor: 1, patch: 0}
+  author: ONEX Framework Team
+  description: Contract loader effect node for scanning and discovering ONEX contract YAML files from
+    the filesystem
+  tags:
+    - effect
+    - filesystem
+    - declarative
+    - contracts
+    - discovery
+    - runtime
+    - loader
+  documentation_url: https://docs.onex.ai/effects/contract-loader

--- a/contracts/runtime/contract_loader_effect.yaml
+++ b/contracts/runtime/contract_loader_effect.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
----
+# Contract Metadata
+node_type: EFFECT_GENERIC
 # ONEX Runtime: Contract Loader Effect Node
 #
 # This EFFECT node scans the filesystem for contract YAML files and emits
@@ -17,8 +18,6 @@
 # - Pattern-based file filtering
 # - Retry policy for robustness
 
-# Contract Metadata
-node_type: EFFECT_GENERIC
 contract_version: {major: 1, minor: 1, patch: 0}
 # Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
 # See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
@@ -31,10 +30,8 @@ fingerprint: "1.1.0:423f8598810c"
 effect_operations:
   version: {major: 1, minor: 1, patch: 0}
   subcontract_version: {major: 1, minor: 1, patch: 0}
-
   # Execution configuration
-  execution_mode: sequential_abort  # Abort on first failure
-
+  execution_mode: sequential_abort # Abort on first failure
   # Default resilience settings
   default_retry_policy:
     enabled: true
@@ -48,23 +45,20 @@ effect_operations:
       - EACCES
       - ETIMEDOUT
       - ECONNRESET
-
   # Operations
   operations:
     # Primary operation: Scan contracts directory
     - operation_name: scan_contracts_directory
       description: Scan configured directory for contract YAML files
-      idempotent: true  # Read-only operation
-
+      idempotent: true # Read-only operation
       io_config:
         handler_type: filesystem
         file_path_template: "${env.ONEX_CONTRACTS_DIR:./contracts}"
         operation: read
         timeout_ms: 30000
-        atomic: false  # Read operations don't need atomicity
-        create_dirs: false  # Don't create dirs for read
+        atomic: false # Read operations don't need atomicity
+        create_dirs: false # Don't create dirs for read
         encoding: utf-8
-
         # Security: Filesystem Path Sandboxing
         # Rationale: Prevent path traversal attacks and restrict filesystem access
         # to authorized directories only. This protects against:
@@ -87,33 +81,30 @@ effect_operations:
               - "/proc"
               - "/sys"
               - "/dev"
-            deny_absolute_paths: true  # Only allow relative paths within sandbox
-            deny_symlink_escape: true  # Prevent symlinks pointing outside base paths
-
+            deny_absolute_paths: true # Only allow relative paths within sandbox
+            deny_symlink_escape: true # Prevent symlinks pointing outside base paths
       # Scanning configuration (metadata for handler)
       metadata:
         scan_mode: directory
-        pattern: "**/*.yaml"
+        pattern: "**/*.y*ml"
         exclude_patterns:
-          - "**/_*.yaml"  # Skip disabled contracts (underscore prefix)
-          - "**/.*"  # Skip hidden files
-          - "**/__pycache__/**"  # Skip Python cache directories
+          - "**/_*.y*ml" # Skip disabled contracts (underscore prefix)
+          - "**/.*" # Skip hidden files
+          - "**/__pycache__/**" # Skip Python cache directories
         hot_reload_exclude_patterns:
-          - "**/runtime/**"  # Runtime contracts are scanned at bootstrap but not hot-reloaded
+          - "**/runtime/**" # Runtime contracts are scanned at bootstrap but not hot-reloaded
         watch_mode: true
         watch_debounce_ms: 500
         recursive: true
         follow_symlinks: false
-
       response_handling:
         success_codes: [200]
         extract_fields:
           discovered_files: "$.files"
           file_count: "$.count"
           scan_timestamp: "$.timestamp"
-        fail_on_empty: false  # Empty contracts dir is valid (initial state)
+        fail_on_empty: false # Empty contracts dir is valid (initial state)
         extraction_engine: jsonpath
-
       # Override retry for scan operation
       # Timing Validation: 500 + 1000 + 2000 + 4000 + 5000(capped) = 12500ms * 1.15 = 14375ms
       # Worst case retry (14375ms) << timeout (60000ms) - PASS (76% margin)
@@ -124,14 +115,11 @@ effect_operations:
         base_delay_ms: 500
         max_delay_ms: 5000
         jitter_factor: 0.15
-
-      operation_timeout_ms: 60000  # 60 second timeout for directory scan
-
+      operation_timeout_ms: 60000 # 60 second timeout for directory scan
     # Secondary operation: Read individual contract file
     - operation_name: read_contract_file
       description: Read and return contents of a single contract file
-      idempotent: true  # Read-only operation
-
+      idempotent: true # Read-only operation
       io_config:
         handler_type: filesystem
         file_path_template: "${input.file_path}"
@@ -140,7 +128,6 @@ effect_operations:
         atomic: false
         create_dirs: false
         encoding: utf-8
-
         # Security: Filesystem Path Sandboxing for User-Provided Paths
         # Rationale: This operation accepts file paths from input, making it
         # especially vulnerable to path traversal and arbitrary file access attacks.
@@ -161,14 +148,13 @@ effect_operations:
               - "/proc"
               - "/sys"
               - "/dev"
-            deny_absolute_paths: true  # Only allow relative paths within sandbox
-            deny_symlink_escape: true  # Prevent symlinks pointing outside base paths
+            deny_absolute_paths: true # Only allow relative paths within sandbox
+            deny_symlink_escape: true # Prevent symlinks pointing outside base paths
           # Additional validation for user-provided file paths
-          require_path_under_base: true  # File path MUST resolve under allowed_base_paths
+          require_path_under_base: true # File path MUST resolve under allowed_base_paths
           validate_extension:
             - ".yaml"
             - ".yml"
-
       response_handling:
         success_codes: [200]
         extract_fields:
@@ -176,9 +162,8 @@ effect_operations:
           file_path: "$.path"
           file_size: "$.size"
           modified_at: "$.modified_at"
-        fail_on_empty: true  # Empty contract file is an error
+        fail_on_empty: true # Empty contract file is an error
         extraction_engine: jsonpath
-
       # Timing Validation: 200 + 400 + 800 = 1400ms * 1.1 = 1540ms
       # Worst case retry (1540ms) << timeout (15000ms) - PASS (90% margin)
       retry_policy:
@@ -188,9 +173,7 @@ effect_operations:
         base_delay_ms: 200
         max_delay_ms: 2000
         jitter_factor: 0.1
-
-      operation_timeout_ms: 15000  # 15 second timeout per file
-
+      operation_timeout_ms: 15000 # 15 second timeout per file
   # Circuit breaker for filesystem operations
   circuit_breaker:
     enabled: true
@@ -198,14 +181,12 @@ effect_operations:
     success_threshold: 3
     timeout_ms: 30000
     half_open_requests: 5
-
   # Observability
   observability:
     log_request: true
-    log_response: false  # Contract contents may be large
+    log_response: false # Contract contents may be large
     emit_metrics: true
     trace_propagation: true
-
 # v1.1.0 Required Fields
 handlers:
   required: []
@@ -214,22 +195,18 @@ handlers:
       version: {major: 1, minor: 0, patch: 0}
     - type: ProtocolFileSystem
       version: {major: 1, minor: 0, patch: 0}
-
 profile_tags:
   - runtime
   - effect
   - contracts
   - discovery
-
 subscriptions:
   topics: []
-
 # Metadata
 metadata:
   version: {major: 1, minor: 1, patch: 0}
   author: ONEX Framework Team
-  description: Contract loader effect node for scanning and discovering ONEX contract YAML files from
-    the filesystem
+  description: Contract loader effect node for scanning and discovering ONEX contract YAML files from the filesystem
   tags:
     - effect
     - filesystem

--- a/contracts/runtime/contract_loader_effect.yaml
+++ b/contracts/runtime/contract_loader_effect.yaml
@@ -41,7 +41,6 @@ effect_operations:
     max_delay_ms: 10000
     jitter_factor: 0.1
     retryable_errors:
-      - ENOENT
       - ETIMEDOUT
       - ECONNRESET
   # Operations
@@ -114,6 +113,10 @@ effect_operations:
         base_delay_ms: 500
         max_delay_ms: 5000
         jitter_factor: 0.15
+        retryable_errors:
+          - ENOENT
+          - ETIMEDOUT
+          - ECONNRESET
       operation_timeout_ms: 60000 # 60 second timeout for directory scan
     # Secondary operation: Read individual contract file
     - operation_name: read_contract_file
@@ -172,6 +175,9 @@ effect_operations:
         base_delay_ms: 200
         max_delay_ms: 2000
         jitter_factor: 0.1
+        retryable_errors:
+          - ETIMEDOUT
+          - ECONNRESET
       operation_timeout_ms: 15000 # 15 second timeout per file
   # Circuit breaker for filesystem operations
   circuit_breaker:

--- a/contracts/runtime/contract_loader_effect.yaml
+++ b/contracts/runtime/contract_loader_effect.yaml
@@ -95,10 +95,11 @@ effect_operations:
         scan_mode: directory
         pattern: "**/*.yaml"
         exclude_patterns:
-          - "**/runtime/**"  # Don't reload runtime contracts
           - "**/_*.yaml"  # Skip disabled contracts (underscore prefix)
           - "**/.*"  # Skip hidden files
           - "**/__pycache__/**"  # Skip Python cache directories
+        hot_reload_exclude_patterns:
+          - "**/runtime/**"  # Runtime contracts are scanned at bootstrap but not hot-reloaded
         watch_mode: true
         watch_debounce_ms: 500
         recursive: true

--- a/contracts/runtime/contract_loader_effect.yaml
+++ b/contracts/runtime/contract_loader_effect.yaml
@@ -19,8 +19,8 @@ node_type: EFFECT_GENERIC
 # - Retry policy for robustness
 
 contract_version: {major: 1, minor: 1, patch: 0}
-# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
-# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+# Fingerprint: <version>:<SHA-256-prefix-12> of canonical normalized contract content
+# excluding the fingerprint field itself. Full spec: docs/architecture/CONTRACT_STABILITY_SPEC.md.
 fingerprint: "1.1.0:423f8598810c"
 # Effect Subcontract
 # NOTE: This contract uses `effect_operations` (multi-operation schema) rather than
@@ -42,7 +42,6 @@ effect_operations:
     jitter_factor: 0.1
     retryable_errors:
       - ENOENT
-      - EACCES
       - ETIMEDOUT
       - ECONNRESET
   # Operations
@@ -189,11 +188,11 @@ effect_operations:
     trace_propagation: true
 # v1.1.0 Required Fields
 handlers:
-  required: []
+  required:
+    - type: ProtocolFileSystem
+      version: {major: 1, minor: 0, patch: 0}
   optional:
     - type: ProtocolLogger
-      version: {major: 1, minor: 0, patch: 0}
-    - type: ProtocolFileSystem
       version: {major: 1, minor: 0, patch: 0}
 profile_tags:
   - runtime

--- a/contracts/runtime/contract_registry_reducer.yaml
+++ b/contracts/runtime/contract_registry_reducer.yaml
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+node_type: REDUCER_GENERIC
+contract_version: {major: 1, minor: 1, patch: 0}
+# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
+# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+fingerprint: "1.1.0:c753f440fda3"
+state_transitions:
+  version: {major: 1, minor: 0, patch: 0}
+  state_machine_version: {major: 1, minor: 0, patch: 0}
+  state_machine_name: contract_registry_fsm
+  description: Maintains state of loaded and compiled ONEX contracts using FSM pattern
+  initial_state: empty
+  states:
+    - state_name: empty
+      description: Initial state - no contracts loaded
+      entry_actions: []
+      exit_actions: []
+      is_terminal: false
+      metadata:
+        ui_color: '#9CA3AF'
+        icon: folder-open
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: loading
+      description: Loading and compiling contracts from configured sources
+      entry_actions:
+        - start_loading_timer
+        - initialize_contract_buffers
+        - clear_validation_cache
+      exit_actions:
+        - stop_loading_timer
+        - flush_contract_buffers
+      is_terminal: false
+      metadata:
+        ui_color: '#3B82F6'
+        icon: download
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: ready
+      description: Contracts loaded and validated successfully
+      entry_actions:
+        - emit_ready_event
+        - update_registry_index
+        - enable_contract_queries
+      exit_actions:
+        - disable_contract_queries
+        - snapshot_current_state
+      is_terminal: false
+      metadata:
+        ui_color: '#10B981'
+        icon: check-circle
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: error
+      description: Contract loading or validation failed
+      entry_actions:
+        - emit_error_event
+        - log_failure_details
+        - cleanup_partial_load
+      exit_actions:
+        - clear_error_state
+      # Non-terminal to allow recovery via retry_loading (automatic) or force_reload (manual).
+      # See recovery_strategies section for detailed recovery documentation.
+      is_terminal: false
+      metadata:
+        ui_color: '#EF4444'
+        icon: x-circle
+      version: {major: 1, minor: 0, patch: 0}
+      # state_type: error combined with recovery_enabled: true enables FSM recovery tracking
+      state_type: error
+  transitions:
+    - transition_name: discover_contracts
+      from_state: empty
+      to_state: loading
+      trigger: contracts_discovered
+      description: Begin loading contracts after discovery
+      conditions:
+        - condition_name: has_contract_sources
+          expression: contract_sources min_length 1
+          required: true
+          description: At least one contract source must be configured
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: emit_loading_started
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: complete_validation
+      from_state: loading
+      to_state: ready
+      trigger: validation_complete
+      description: All contracts loaded and validated successfully
+      conditions:
+        - condition_name: all_contracts_valid
+          expression: validation_errors equals 0
+          required: true
+          description: All loaded contracts must pass validation
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+        - condition_name: minimum_contracts_loaded
+          expression: loaded_contracts min_length 1
+          required: true
+          description: At least one contract must be loaded
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: persist_registry_state
+          action_type: persistence
+          is_critical: true
+          timeout_ms: 5000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_registry_ready
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: fail_validation
+      from_state: loading
+      to_state: error
+      trigger: validation_failed
+      description: Contract validation failed
+      conditions: []
+      actions:
+        - action_name: log_validation_errors
+          action_type: logging
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_validation_failed
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: reload_contracts
+      from_state: ready
+      to_state: loading
+      trigger: contracts_changed
+      description: Reload contracts when changes detected
+      conditions: []
+      actions:
+        - action_name: snapshot_previous_state
+          action_type: data_capture
+          is_critical: true
+          timeout_ms: 2000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_reload_started
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    # Automatic recovery transition from error state.
+    # When retry_count >= 3, this transition is blocked and manual intervention is required.
+    # See recovery_strategies.max_retries_exhausted for operator guidance.
+    - transition_name: retry_loading
+      from_state: error
+      to_state: loading
+      trigger: retry_load
+      description: Retry loading contracts after error
+      conditions:
+        - condition_name: retries_remaining
+          # When this condition fails (retry_count >= 3), automatic recovery stops.
+          # Operators must use force_reload operation to continue recovery.
+          expression: retry_count less_than 3
+          required: true
+          description: Maximum 3 retries allowed
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: increment_retry_counter
+          action_type: data_capture
+          is_critical: true
+          timeout_ms: 100
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_retry_started
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+  terminal_states: []
+  error_states:
+    - error
+  persistence_enabled: true
+  # Recovery is enabled for the error state, allowing automatic retry transitions.
+  # The error state (state_type: error) combined with recovery_enabled: true means:
+  # 1. The FSM will attempt automatic recovery via retry_loading transition
+  # 2. Retry attempts are tracked via retry_count (max 3 attempts)
+  # 3. When retry_count >= 3, automatic recovery stops and manual intervention is required
+  recovery_enabled: true
+  # Recovery strategies documentation for operators and monitoring systems.
+  # This section documents the expected behavior when automatic recovery fails.
+  recovery_strategies:
+    max_retries_exhausted:
+      # When retry_count reaches 3, the retry_loading transition condition fails
+      # and the FSM remains in the error state without automatic recovery.
+      description: >-
+        When retry_count reaches maximum (3), automatic recovery via retry_loading transition is blocked.
+        The FSM remains in error state awaiting manual intervention.
+      detection:
+        # How to detect this condition in monitoring systems
+        - condition: retry_count >= 3 AND current_state == error
+        - event: runtime.contracts.max_retries_exhausted
+        - metric: contract_registry_retry_exhausted_total
+      recommended_actions:
+        # Ordered list of recovery steps for operators
+        - step: 1
+          action: Check contract validation errors in application logs
+          command: "grep 'validation_failed\\|contract.*error' /var/log/onex/*.log"
+        - step: 2
+          action: Identify and fix invalid contract files
+          details: >-
+            Review emit_error_event and log_validation_errors output to identify which contracts failed
+            validation and why
+        - step: 3
+          action: Use force_reload operation after fixing issues
+          details: >-
+            The force_reload operation (defined in operations section) bypasses the retry_count check
+            and directly transitions to loading state
+        - step: 4
+          action: Monitor runtime.contracts.reload events for success
+          details: Subscribe to event bus for reload confirmation
+      escalation:
+        # When manual recovery attempts fail, escalate to these actions
+        - level: 1
+          trigger: force_reload fails after contract fixes
+          action: Alert operations team via paging system
+        - level: 2
+          trigger: Multiple force_reload attempts fail
+          action: Consider runtime restart with fresh contract discovery
+        - level: 3
+          trigger: Runtime restart fails to resolve
+          action: Engage platform engineering for infrastructure investigation
+    recovery_from_error:
+      # Documents the relationship between error state and recovery mechanisms
+      description: >-
+        The error state has is_terminal: false, allowing recovery transitions. This is intentional to
+        support both automatic retry and manual recovery paths.
+      automatic_recovery:
+        mechanism: retry_loading transition
+        max_attempts: 3
+        trigger: retry_load event
+        condition: retry_count less_than 3
+      manual_recovery:
+        mechanism: force_reload operation
+        requires_permission: true
+        bypasses_retry_limit: true
+        description: >-
+          Operators can invoke force_reload to reset the loading process regardless of retry_count. This
+          is the primary recovery path when automatic retries are exhausted.
+  operations:
+    # Primary manual recovery operation when automatic retries are exhausted.
+    # Bypasses retry_count check by directly targeting loading state.
+    - operation_name: force_reload
+      description: Force reload all contracts from sources
+      trigger: force_reload
+      target_state: loading
+      # Permission required to prevent accidental triggering during production
+      requires_permission: true
+      is_destructive: false
+      rollback_transitions:
+        - transition_name: rollback_force_reload
+          from_state: loading
+          to_state: ready
+          trigger: undo_force_reload
+      version: {major: 1, minor: 0, patch: 0}
+      operation_type: administrative
+    - operation_name: clear_registry
+      description: Clear all loaded contracts and reset to empty state
+      trigger: clear
+      target_state: empty
+      requires_permission: true
+      is_destructive: true
+      rollback_transitions:
+        - transition_name: rollback_clear
+          from_state: empty
+          to_state: loading
+          trigger: undo_clear
+      version: {major: 1, minor: 0, patch: 0}
+      operation_type: administrative
+
+# v1.1.0 Required Fields
+# NOTE: The `handlers` section defines protocol-based dependencies injected via DI container.
+# This is SEPARATE from FSM action types (event, logging, data_capture, persistence) which are
+# defined in transition actions.
+#
+# FSM Action Type Execution:
+# The runtime's built-in FSM action executor handles all action_type values. Each action_type
+# maps to a runtime capability:
+#   - event: Publishes events via ProtocolEventBus (optional handler below)
+#   - logging: Logs via ProtocolLogger (optional handler below)
+#   - data_capture: Snapshots state to memory/persistence store
+#   - persistence: Persists FSM state for recovery (when persistence_enabled: true)
+#
+# The `required: []` means no handlers are MANDATORY for this node to function, since the
+# runtime provides default implementations. Optional handlers allow custom implementations.
+handlers:
+  required: []
+  optional:
+    - type: ProtocolLogger
+      version: {major: 1, minor: 0, patch: 0}
+    - type: ProtocolEventBus
+      version: {major: 1, minor: 0, patch: 0}
+
+profile_tags:
+  - runtime
+  - reducer
+  - contracts
+  - registry
+
+metadata:
+  version: {major: 1, minor: 1, patch: 0}
+  author: ONEX Framework Team
+  description: Declarative contract registry reducer using FSM pattern for managing loaded and compiled
+    ONEX contracts
+  tags:
+    - reducer
+    - fsm
+    - declarative
+    - contracts
+    - registry
+    - runtime
+  documentation_url: https://docs.onex.ai/reducers/contract-registry

--- a/contracts/runtime/event_bus_wiring_effect.yaml
+++ b/contracts/runtime/event_bus_wiring_effect.yaml
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Runtime Event Bus Wiring Effect Contract
+#
+# This contract defines the event_bus_wiring EFFECT node that wires instantiated
+# nodes to event bus subscriptions as part of the ONEX runtime self-hosting architecture.
+#
+# Role in Runtime Lifecycle:
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │                    RUNTIME AS NODE GRAPH                                 │
+# ├─────────────────────────────────────────────────────────────────────────┤
+# │  contract_loader (NodeEffect) → contract_registry (NodeReducer)         │
+# │                               → node_graph (NodeReducer)                │
+# │                               → event_bus_wiring (THIS NODE)             │
+# │                                                                          │
+# │  This node receives the instantiated node graph from node_graph reducer  │
+# │  and wires each node to its declared event bus topics.                   │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Node Implementation (NO custom code needed):
+#   from omnibase_core.nodes import NodeEffect
+#   class NodeEventBusWiringEffect(NodeEffect):
+#       pass  # All logic driven by this YAML contract
+#
+# Features:
+# - Wire nodes to event bus subscriptions based on declared topics
+# - Support for multiple event bus types (inmemory, kafka, etc.)
+# - Retry logic for transient subscription failures
+# - Health checks for subscription status
+# - Publish runtime.ready event when wiring is complete
+#
+
+# Contract Metadata
+node_type: EFFECT_GENERIC
+contract_version: {major: 1, minor: 1, patch: 0}
+# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
+# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+fingerprint: "1.1.0:5a885a8c9b69"
+# Effect Subcontract
+# NOTE: This contract uses `effect` (single-operation schema) rather than
+# `effect_operations` (multi-operation schema) because it defines a single
+# event bus wiring operation. Contracts with multiple operations use
+# `effect_operations:` with an operations list (e.g., contract_loader_effect.yaml).
+effect:
+  version: {major: 1, minor: 1, patch: 0}
+
+  # Operation identification
+  operation_name: event_bus_wiring
+  operation_version: {major: 1, minor: 0, patch: 0}
+  description: |
+    Wires instantiated nodes to event bus subscriptions.
+    Receives the node graph from node_graph reducer, subscribes each node
+    to its declared topics, and publishes runtime.ready when complete.
+
+  # Execution mode
+  execution_mode: sequential_abort  # Abort on first failure (v1.0 semantics)
+
+  # Overall operation timeout (guards against retry stacking)
+  operation_timeout_ms: 60000  # 60 seconds total for all wiring operations
+
+  # IO Configuration for event bus handler
+  # CONSISTENCY: handler_type and wiring_config.event_bus_type MUST use the same
+  # environment variable (ONEX_EVENT_BUS) to ensure the IO handler and wiring
+  # logic target the same event bus instance.
+  io_config:
+    handler_type: "${env.ONEX_EVENT_BUS:inmemory}"  # See also: wiring_config.event_bus_type
+    topic: "onex.runtime.subscriptions"
+    # SECURITY NOTE: ${input.subscriptions} is validated against topic_validation rules
+    # in wiring_config before being used. This prevents command injection, event spoofing,
+    # and buffer overflow attacks via malicious topic names.
+    payload_template: |
+      {
+        "node_id": "${input.node_id}",
+        "node_type": "${input.node_type}",
+        "subscriptions": ${input.subscriptions},
+        "correlation_id": "${input.correlation_id}"
+      }
+    partition_key_template: "${input.node_id}"
+    headers:
+      content-type: "application/json"
+      x-onex-operation: "subscribe"
+      x-onex-correlation-id: "${input.correlation_id}"
+    timeout_ms: 5000
+    acks: "all"  # Strong delivery guarantee for subscription messages
+    compression: "none"
+
+  # Retry policy for subscription operations
+  # Timing Validation: 1000 + 2000 + 4000 = 7000ms * 1.1 = 7700ms
+  # Worst case retry (7700ms) << timeout (60000ms) - PASS (87% margin)
+  retry_policy:
+    enabled: true
+    max_retries: 3
+    backoff_strategy: exponential
+    base_delay_ms: 1000
+    max_delay_ms: 10000
+    jitter_factor: 0.1
+    retryable_errors:
+      - "ECONNRESET"
+      - "ETIMEDOUT"
+      - "ECONNREFUSED"
+      - "SUBSCRIPTION_FAILED"
+      - "BROKER_NOT_AVAILABLE"
+
+  # Circuit breaker configuration
+  circuit_breaker:
+    enabled: true
+    failure_threshold: 5
+    success_threshold: 2
+    timeout_ms: 30000
+    half_open_requests: 3
+
+  # Response handling
+  response_handling:
+    success_codes:
+      - 200
+      - 201
+      - 202
+    extract_fields:
+      subscription_id: "$.subscription_id"
+      subscribed_at: "$.subscribed_at"
+    fail_on_empty: false
+    extraction_engine: jsonpath
+
+  # Observability
+  observability:
+    log_request: true
+    log_response: true
+    emit_metrics: true
+    trace_propagation: true
+
+# Wiring-specific configuration
+wiring_config:
+  # Event bus type (overridable via environment variable)
+  # NOTE: Must stay consistent with io_config.handler_type (line 64) - both use ONEX_EVENT_BUS
+  event_bus_type: "${env.ONEX_EVENT_BUS:inmemory}"
+
+  # Subscription management
+  subscription_timeout_ms: 5000
+  max_concurrent_subscriptions: 50
+  subscription_batch_size: 10
+
+  # Validation settings
+  validate_topics: true
+  fail_on_invalid_topic: true
+
+  # Topic Name Validation (SECURITY)
+  # ================================
+  # Topic validation is critical for preventing several attack vectors:
+  #
+  # 1. Command Injection: Malicious topic names could contain shell metacharacters
+  #    or template injection sequences (e.g., "${env.SECRET}") that get evaluated
+  #    in downstream processing, leading to data exfiltration or code execution.
+  #
+  # 2. Event Spoofing: Without prefix restrictions, untrusted nodes could subscribe
+  #    to system-internal topics (e.g., "onex.runtime.*") to intercept or inject
+  #    malicious events into the runtime control plane.
+  #
+  # 3. Buffer Overflow: Excessively long topic names could overflow fixed-size
+  #    buffers in event bus implementations, leading to crashes or memory corruption.
+  #
+  # 4. Resource Exhaustion: Unlimited subscriptions per node could be exploited
+  #    for denial-of-service attacks against the event bus infrastructure.
+  #
+  topic_validation:
+    enabled: true
+    # Only allow alphanumeric characters, dots, hyphens, and underscores.
+    # Must start with alphanumeric character to prevent hidden/special topics.
+    allowed_pattern: "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$"
+    # Deny dangerous patterns that could enable injection attacks
+    deny_patterns:
+      - "\\.\\./"  # Path traversal sequences
+      - "\\$\\{"  # Variable/template injection
+      - "[<>\"'`]"  # Script injection characters (XSS, shell)
+      - "\\x00"  # Null bytes (string termination attacks)
+      - "\\s"  # Whitespace (parsing confusion, injection)
+    # Reserved topic prefixes that only system components can use.
+    # User-defined nodes attempting to subscribe to these will be rejected.
+    reserved_prefixes:
+      - "onex.runtime."  # Runtime control plane events (system-only)
+      - "_internal."  # Internal system coordination topics
+    # Hard limit on topic name length to prevent buffer overflow
+    max_topic_length: 255
+    # Limit subscriptions per node to prevent resource exhaustion attacks
+    max_subscriptions_per_node: 100
+
+  # Ready event configuration
+  ready_event:
+    topic: "onex.runtime.ready"
+    payload_schema: ModelRuntimeReadyEvent
+    emit_on_success: true
+
+# Health check configuration
+health_check:
+  enabled: true
+  interval_ms: 30000
+  timeout_ms: 5000
+  checks:
+    - name: event_bus_connection
+      description: Verify event bus connectivity
+      check_type: connectivity
+      critical: true
+    - name: subscription_status
+      description: Verify all subscriptions are active
+      check_type: subscription_health
+      critical: true
+    - name: message_latency
+      description: Check message delivery latency
+      check_type: latency
+      critical: false
+      threshold_ms: 1000
+
+# Event subscriptions (what this node listens to)
+# NOTE: Each subscription defines a `handler` field that references a method that MUST be
+# implemented by the runtime or node implementation. These handlers are NOT protocol-based
+# dependencies (those go in the `handlers` section below). Instead, subscription handlers
+# are callback methods that the event bus invokes when matching events arrive.
+#
+# Handler Implementation Requirements:
+# - wire_all_subscriptions: Receives ModelNodeGraphReadyEvent, wires all nodes to their subscriptions
+# - wire_single_subscription: Receives ModelNodeRegisteredEvent, wires a single new node
+# - remove_subscription: Receives ModelNodeUnregisteredEvent, removes subscription for a node
+#
+# These handlers are implemented by the NodeEventBusWiringEffect class or provided by the
+# runtime's built-in subscription handler executor. See docs/architecture/SUBSCRIPTION_HANDLERS.md.
+#
+# TODO: Implement subscription handler registration in the runtime:
+#   1. Create SubscriptionHandlerRegistry to map handler names to implementations
+#   2. Implement wire_all_subscriptions in NodeEventBusWiringEffect or runtime executor
+#   3. Implement wire_single_subscription for hot-reload support
+#   4. Implement remove_subscription for graceful node removal
+#   5. Add handler validation during contract loading to fail-fast on missing handlers
+subscriptions:
+  # Implementation Status: PLANNED
+  # These handlers are contract-declared but not yet runtime-registered.
+  # The runtime will validate handler availability during contract loading
+  # and emit warnings for unregistered handlers in non-strict mode.
+  #
+  # Tracking: Planned for v1.2.0 - SubscriptionHandlerRegistry implementation
+  # Status: Handler implementation pending (not yet runtime-registered)
+  topics:
+    - topic: onex.runtime.node_graph.ready
+      description: Triggered when node graph is fully instantiated
+      handler: wire_all_subscriptions
+      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_implementation:
+        class: NodeEventBusWiringEffect
+        method: _handle_node_graph_ready
+        input_schema: ModelNodeGraphReadyEvent
+        output_schema: ModelWiringResultEvent
+        idempotent: true
+    - topic: onex.runtime.node.registered
+      description: Handle new node registration for hot reload
+      handler: wire_single_subscription
+      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_implementation:
+        class: NodeEventBusWiringEffect
+        method: _handle_node_registered
+        input_schema: ModelNodeRegisteredEvent
+        output_schema: ModelSubscriptionCreatedEvent
+        idempotent: true
+    - topic: onex.runtime.node.unregistered
+      description: Handle node removal
+      handler: remove_subscription
+      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_implementation:
+        class: NodeEventBusWiringEffect
+        method: _handle_node_unregistered
+        input_schema: ModelNodeUnregisteredEvent
+        output_schema: ModelSubscriptionRemovedEvent
+        idempotent: true
+
+# Events published by this node
+publications:
+  - topic: onex.runtime.ready
+    description: Runtime is fully initialized with all subscriptions wired
+    payload_schema: ModelRuntimeReadyEvent
+  - topic: onex.runtime.subscription.created
+    description: A new subscription was successfully created
+    payload_schema: ModelSubscriptionCreatedEvent
+  - topic: onex.runtime.subscription.failed
+    description: A subscription failed to be created
+    payload_schema: ModelSubscriptionFailedEvent
+  - topic: onex.runtime.wiring.error
+    description: Wiring encountered a critical error
+    payload_schema: ModelWiringErrorEvent
+
+# v1.1.0 Required Fields
+handlers:
+  required:
+    - type: ProtocolEventBus
+      version: {major: 1, minor: 0, patch: 0}
+  optional:
+    - type: ProtocolLogger
+      version: {major: 1, minor: 0, patch: 0}
+
+profile_tags:
+  - runtime
+  - effect
+  - event-bus
+  - wiring
+
+# Metadata
+metadata:
+  version: {major: 1, minor: 1, patch: 0}
+  author: ONEX Framework
+  description: |
+    Event bus wiring effect node for ONEX runtime self-hosting architecture.
+    Receives the node graph from node_graph reducer and wires each node to
+    its declared event bus subscriptions. Publishes runtime.ready when complete.
+  tags:
+    - effect
+    - runtime
+    - event-bus
+    - subscriptions
+    - self-hosted
+    - wiring
+  documentation_url: https://docs.onex.ai/runtime/event-bus-wiring

--- a/contracts/runtime/event_bus_wiring_effect.yaml
+++ b/contracts/runtime/event_bus_wiring_effect.yaml
@@ -186,7 +186,7 @@ wiring_config:
 
   # Ready event configuration
   ready_event:
-    topic: "onex.runtime.ready"
+    topic: "onex.evt.runtime.ready.v1"
     payload_schema: ModelRuntimeReadyEvent
     emit_on_success: true
 

--- a/contracts/runtime/event_bus_wiring_effect.yaml
+++ b/contracts/runtime/event_bus_wiring_effect.yaml
@@ -210,7 +210,7 @@ health_check:
       critical: false
       threshold_ms: 1000
 
-# Event subscriptions (what this node listens to)
+# Event bus declarations (what this node listens to and publishes)
 # NOTE: Each subscription defines a `handler` field that references a method that MUST be
 # implemented by the runtime or node implementation. These handlers are NOT protocol-based
 # dependencies (those go in the `handlers` section below). Instead, subscription handlers
@@ -230,16 +230,9 @@ health_check:
 #   3. Implement wire_single_subscription for hot-reload support
 #   4. Implement remove_subscription for graceful node removal
 #   5. Add handler validation during contract loading to fail-fast on missing handlers
-subscriptions:
-  # Implementation Status: PLANNED
-  # These handlers are contract-declared but not yet runtime-registered.
-  # The runtime will validate handler availability during contract loading
-  # and emit warnings for unregistered handlers in non-strict mode.
-  #
-  # Tracking: Planned for v1.2.0 - SubscriptionHandlerRegistry implementation
-  # Status: Handler implementation pending (not yet runtime-registered)
-  topics:
-    - topic: onex.runtime.node_graph.ready
+event_bus:
+  subscribe_topics:
+    - topic: onex.evt.runtime.node-graph-ready.v1
       description: Triggered when node graph is fully instantiated
       handler: wire_all_subscriptions
       handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
@@ -249,7 +242,8 @@ subscriptions:
         input_schema: ModelNodeGraphReadyEvent
         output_schema: ModelWiringResultEvent
         idempotent: true
-    - topic: onex.runtime.node.registered
+      provisioning_priority: 10
+    - topic: onex.evt.runtime.node-registered.v1
       description: Handle new node registration for hot reload
       handler: wire_single_subscription
       handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
@@ -259,7 +253,8 @@ subscriptions:
         input_schema: ModelNodeRegisteredEvent
         output_schema: ModelSubscriptionCreatedEvent
         idempotent: true
-    - topic: onex.runtime.node.unregistered
+      provisioning_priority: 10
+    - topic: onex.evt.runtime.node-unregistered.v1
       description: Handle node removal
       handler: remove_subscription
       handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
@@ -269,21 +264,24 @@ subscriptions:
         input_schema: ModelNodeUnregisteredEvent
         output_schema: ModelSubscriptionRemovedEvent
         idempotent: true
-
-# Events published by this node
-publications:
-  - topic: onex.runtime.ready
-    description: Runtime is fully initialized with all subscriptions wired
-    payload_schema: ModelRuntimeReadyEvent
-  - topic: onex.runtime.subscription.created
-    description: A new subscription was successfully created
-    payload_schema: ModelSubscriptionCreatedEvent
-  - topic: onex.runtime.subscription.failed
-    description: A subscription failed to be created
-    payload_schema: ModelSubscriptionFailedEvent
-  - topic: onex.runtime.wiring.error
-    description: Wiring encountered a critical error
-    payload_schema: ModelWiringErrorEvent
+      provisioning_priority: 10
+  publish_topics:
+    - topic: onex.evt.runtime.ready.v1
+      description: Runtime is fully initialized with all subscriptions wired
+      payload_schema: ModelRuntimeReadyEvent
+      provisioning_priority: 10
+    - topic: onex.evt.runtime.subscription-created.v1
+      description: A new subscription was successfully created
+      payload_schema: ModelSubscriptionCreatedEvent
+      provisioning_priority: 20
+    - topic: onex.evt.runtime.subscription-failed.v1
+      description: A subscription failed to be created
+      payload_schema: ModelSubscriptionFailedEvent
+      provisioning_priority: 20
+    - topic: onex.evt.runtime.wiring-error.v1
+      description: Wiring encountered a critical error
+      payload_schema: ModelWiringErrorEvent
+      provisioning_priority: 20
 
 # v1.1.0 Required Fields
 handlers:

--- a/contracts/runtime/event_bus_wiring_effect.yaml
+++ b/contracts/runtime/event_bus_wiring_effect.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
----
+# Contract Metadata
+node_type: EFFECT_GENERIC
 # ONEX Runtime Event Bus Wiring Effect Contract
 #
 # This contract defines the event_bus_wiring EFFECT node that wires instantiated
@@ -31,8 +32,6 @@
 # - Publish runtime.ready event when wiring is complete
 #
 
-# Contract Metadata
-node_type: EFFECT_GENERIC
 contract_version: {major: 1, minor: 1, patch: 0}
 # Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
 # See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
@@ -44,7 +43,6 @@ fingerprint: "1.1.0:5a885a8c9b69"
 # `effect_operations:` with an operations list (e.g., contract_loader_effect.yaml).
 effect:
   version: {major: 1, minor: 1, patch: 0}
-
   # Operation identification
   operation_name: event_bus_wiring
   operation_version: {major: 1, minor: 0, patch: 0}
@@ -52,19 +50,16 @@ effect:
     Wires instantiated nodes to event bus subscriptions.
     Receives the node graph from node_graph reducer, subscribes each node
     to its declared topics, and publishes runtime.ready when complete.
-
   # Execution mode
-  execution_mode: sequential_abort  # Abort on first failure (v1.0 semantics)
-
+  execution_mode: sequential_abort # Abort on first failure (v1.0 semantics)
   # Overall operation timeout (guards against retry stacking)
-  operation_timeout_ms: 60000  # 60 seconds total for all wiring operations
-
+  operation_timeout_ms: 60000 # 60 seconds total for all wiring operations
   # IO Configuration for event bus handler
   # CONSISTENCY: handler_type and wiring_config.event_bus_type MUST use the same
   # environment variable (ONEX_EVENT_BUS) to ensure the IO handler and wiring
   # logic target the same event bus instance.
   io_config:
-    handler_type: "${env.ONEX_EVENT_BUS:inmemory}"  # See also: wiring_config.event_bus_type
+    handler_type: "${env.ONEX_EVENT_BUS:inmemory}" # See also: wiring_config.event_bus_type
     topic: "onex.runtime.subscriptions"
     # SECURITY NOTE: ${input.subscriptions} is validated against topic_validation rules
     # in wiring_config before being used. This prevents command injection, event spoofing,
@@ -82,9 +77,8 @@ effect:
       x-onex-operation: "subscribe"
       x-onex-correlation-id: "${input.correlation_id}"
     timeout_ms: 5000
-    acks: "all"  # Strong delivery guarantee for subscription messages
+    acks: "all" # Strong delivery guarantee for subscription messages
     compression: "none"
-
   # Retry policy for subscription operations
   # Timing Validation: 1000 + 2000 + 4000 = 7000ms * 1.1 = 7700ms
   # Worst case retry (7700ms) << timeout (60000ms) - PASS (87% margin)
@@ -101,7 +95,6 @@ effect:
       - "ECONNREFUSED"
       - "SUBSCRIPTION_FAILED"
       - "BROKER_NOT_AVAILABLE"
-
   # Circuit breaker configuration
   circuit_breaker:
     enabled: true
@@ -109,7 +102,6 @@ effect:
     success_threshold: 2
     timeout_ms: 30000
     half_open_requests: 3
-
   # Response handling
   response_handling:
     success_codes:
@@ -121,29 +113,24 @@ effect:
       subscribed_at: "$.subscribed_at"
     fail_on_empty: false
     extraction_engine: jsonpath
-
   # Observability
   observability:
     log_request: true
     log_response: true
     emit_metrics: true
     trace_propagation: true
-
 # Wiring-specific configuration
 wiring_config:
   # Event bus type (overridable via environment variable)
   # NOTE: Must stay consistent with io_config.handler_type (line 64) - both use ONEX_EVENT_BUS
   event_bus_type: "${env.ONEX_EVENT_BUS:inmemory}"
-
   # Subscription management
   subscription_timeout_ms: 5000
   max_concurrent_subscriptions: 50
   subscription_batch_size: 10
-
   # Validation settings
   validate_topics: true
   fail_on_invalid_topic: true
-
   # Topic Name Validation (SECURITY)
   # ================================
   # Topic validation is critical for preventing several attack vectors:
@@ -169,27 +156,25 @@ wiring_config:
     allowed_pattern: "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$"
     # Deny dangerous patterns that could enable injection attacks
     deny_patterns:
-      - "\\.\\./"  # Path traversal sequences
-      - "\\$\\{"  # Variable/template injection
-      - "[<>\"'`]"  # Script injection characters (XSS, shell)
-      - "\\x00"  # Null bytes (string termination attacks)
-      - "\\s"  # Whitespace (parsing confusion, injection)
+      - "\\.\\./" # Path traversal sequences
+      - "\\$\\{" # Variable/template injection
+      - "[<>\"'`]" # Script injection characters (XSS, shell)
+      - "\\x00" # Null bytes (string termination attacks)
+      - "\\s" # Whitespace (parsing confusion, injection)
     # Reserved topic prefixes that only system components can use.
     # User-defined nodes attempting to subscribe to these will be rejected.
     reserved_prefixes:
-      - "onex.runtime."  # Runtime control plane events (system-only)
-      - "_internal."  # Internal system coordination topics
+      - "onex.runtime." # Runtime control plane events (system-only)
+      - "_internal." # Internal system coordination topics
     # Hard limit on topic name length to prevent buffer overflow
     max_topic_length: 255
     # Limit subscriptions per node to prevent resource exhaustion attacks
     max_subscriptions_per_node: 100
-
   # Ready event configuration
   ready_event:
     topic: "onex.evt.runtime.ready.v1"
     payload_schema: ModelRuntimeReadyEvent
     emit_on_success: true
-
 # Health check configuration
 health_check:
   enabled: true
@@ -209,7 +194,6 @@ health_check:
       check_type: latency
       critical: false
       threshold_ms: 1000
-
 # Event bus declarations (what this node listens to and publishes)
 # NOTE: Each subscription defines a `handler` field that references a method that MUST be
 # implemented by the runtime or node implementation. These handlers are NOT protocol-based
@@ -231,11 +215,12 @@ health_check:
 #   4. Implement remove_subscription for graceful node removal
 #   5. Add handler validation during contract loading to fail-fast on missing handlers
 event_bus:
-  subscribe_topics:
+  subscribe_topics: []
+  planned_subscribe_topics:
     - topic: onex.evt.runtime.node-graph-ready.v1
       description: Triggered when node graph is fully instantiated
       handler: wire_all_subscriptions
-      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_status: NOT_IMPLEMENTED # requires SubscriptionHandlerRegistry
       handler_implementation:
         class: NodeEventBusWiringEffect
         method: _handle_node_graph_ready
@@ -246,7 +231,7 @@ event_bus:
     - topic: onex.evt.runtime.node-registered.v1
       description: Handle new node registration for hot reload
       handler: wire_single_subscription
-      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_status: NOT_IMPLEMENTED # requires SubscriptionHandlerRegistry
       handler_implementation:
         class: NodeEventBusWiringEffect
         method: _handle_node_registered
@@ -257,7 +242,7 @@ event_bus:
     - topic: onex.evt.runtime.node-unregistered.v1
       description: Handle node removal
       handler: remove_subscription
-      handler_status: planned  # NOT_IMPLEMENTED - requires SubscriptionHandlerRegistry
+      handler_status: NOT_IMPLEMENTED # requires SubscriptionHandlerRegistry
       handler_implementation:
         class: NodeEventBusWiringEffect
         method: _handle_node_unregistered
@@ -282,7 +267,6 @@ event_bus:
       description: Wiring encountered a critical error
       payload_schema: ModelWiringErrorEvent
       provisioning_priority: 20
-
 # v1.1.0 Required Fields
 handlers:
   required:
@@ -291,13 +275,11 @@ handlers:
   optional:
     - type: ProtocolLogger
       version: {major: 1, minor: 0, patch: 0}
-
 profile_tags:
   - runtime
   - effect
   - event-bus
   - wiring
-
 # Metadata
 metadata:
   version: {major: 1, minor: 1, patch: 0}

--- a/contracts/runtime/node_graph_reducer.yaml
+++ b/contracts/runtime/node_graph_reducer.yaml
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+node_type: REDUCER_GENERIC
+contract_version: {major: 1, minor: 1, patch: 0}
+# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
+# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+fingerprint: "1.1.0:813bece9fc12"
+state_transitions:
+  # NOTE: FSM version (1.0.0) intentionally differs from contract_version (1.1.0).
+  # The contract version tracks overall contract changes (handlers, metadata, profile_tags),
+  # while the FSM version only increments when states, transitions, or conditions change.
+  # This separation allows metadata updates without implying FSM structural changes.
+  version: {major: 1, minor: 0, patch: 0}
+  state_machine_version: {major: 1, minor: 0, patch: 0}
+  state_machine_name: node_graph_fsm
+  description: Maintains instantiated node graph state with FSM-driven lifecycle management
+  initial_state: initializing
+  states:
+    - state_name: initializing
+      description: Setting up the node graph - loading registry and preparing infrastructure
+      entry_actions:
+        - load_node_registry
+        - initialize_graph_structure
+        - prepare_dependency_resolver
+      exit_actions:
+        - log_initialization_complete
+      is_terminal: false
+      metadata:
+        ui_color: '#3B82F6'
+        icon: loader
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: wiring
+      description: Connecting nodes based on dependencies and establishing communication channels
+      entry_actions:
+        - resolve_node_dependencies
+        - establish_node_connections
+        - validate_connection_graph
+      exit_actions:
+        - finalize_wiring
+        - log_wiring_statistics
+      is_terminal: false
+      metadata:
+        ui_color: '#8B5CF6'
+        icon: git-branch
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: running
+      description: Node graph is active and processing - all nodes are wired and operational
+      entry_actions:
+        - activate_all_nodes
+        - start_health_monitoring
+        - emit_graph_ready_event
+      exit_actions:
+        - stop_health_monitoring
+        - prepare_for_shutdown
+      is_terminal: false
+      metadata:
+        ui_color: '#10B981'
+        icon: play
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: draining
+      description: Gracefully shutting down - allowing in-flight operations to complete
+      entry_actions:
+        - stop_accepting_new_work
+        - notify_nodes_of_shutdown
+        - start_drain_timer
+      exit_actions:
+        - force_complete_remaining_work
+        - log_drain_statistics
+      is_terminal: false
+      metadata:
+        ui_color: '#FBBF24'
+        icon: hourglass
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: operational
+    - state_name: stopped
+      description: Node graph is fully stopped - all resources released
+      entry_actions:
+        - release_all_resources
+        - disconnect_all_nodes
+        - emit_graph_stopped_event
+        - cleanup_graph_state
+      exit_actions: []
+      is_terminal: true
+      is_recoverable: false
+      metadata:
+        ui_color: '#6B7280'
+        icon: stop-circle
+        idempotency_note: |
+          All entry_actions MUST be idempotent as this state can be reached
+          from ANY state via fatal_error or timeout wildcards (from_state: '*').
+
+          Idempotency guarantees for each action:
+          - release_all_resources: Safe to call multiple times (no-op if already released)
+          - disconnect_all_nodes: Safe to call on already-disconnected nodes
+          - emit_graph_stopped_event: Event bus handles duplicate events gracefully
+          - cleanup_graph_state: Clears state to empty (idempotent by design)
+
+          This is critical because wildcard transitions can trigger from any
+          non-terminal state, and the stopped state may be entered multiple
+          times during error recovery or restart scenarios.
+      version: {major: 1, minor: 0, patch: 0}
+      state_type: terminal
+  transitions:
+    - transition_name: registry_ready
+      from_state: initializing
+      to_state: wiring
+      trigger: registry_ready
+      description: Node registry is loaded and ready, begin wiring nodes
+      conditions:
+        - condition_name: registry_loaded
+          expression: node_registry min_length 1
+          required: true
+          description: Node registry must contain at least one node definition
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+        - condition_name: no_registry_errors
+          expression: registry_errors equals 0
+          required: true
+          description: Registry must load without errors
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: emit_wiring_started
+          action_type: event
+          is_critical: false
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: snapshot_registry_state
+          action_type: data_capture
+          is_critical: true
+          timeout_ms: 2000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: wiring_complete
+      from_state: wiring
+      to_state: running
+      trigger: wiring_complete
+      description: All node connections established successfully, activate graph
+      conditions:
+        - condition_name: all_nodes_wired
+          expression: unwired_nodes equals 0
+          required: true
+          description: All nodes must be successfully wired
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+        - condition_name: no_circular_dependencies
+          expression: circular_dependency_count equals 0
+          required: true
+          description: Graph must not contain circular dependencies
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: emit_graph_running
+          action_type: event
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: log_graph_topology
+          action_type: logging
+          is_critical: false
+          timeout_ms: 500
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: shutdown_requested
+      from_state: running
+      to_state: draining
+      trigger: shutdown_requested
+      description: Shutdown signal received, begin graceful drain
+      conditions: []
+      actions:
+        - action_name: emit_drain_started
+          action_type: event
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: log_shutdown_request
+          action_type: logging
+          is_critical: false
+          timeout_ms: 500
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: capture_in_flight_operations
+          action_type: data_capture
+          is_critical: true
+          timeout_ms: 2000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: drain_complete
+      from_state: draining
+      to_state: stopped
+      trigger: drain_complete
+      description: All in-flight operations completed, fully stop the graph
+      conditions:
+        - condition_name: no_pending_operations
+          expression: pending_operations equals 0
+          required: true
+          description: All pending operations must complete before stopping
+          version: {major: 1, minor: 0, patch: 0}
+          condition_type: data_validation
+      actions:
+        - action_name: persist_final_state
+          action_type: persistence
+          is_critical: true
+          timeout_ms: 5000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_graph_stopped
+          action_type: event
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: fatal_error
+      from_state: '*'
+      to_state: stopped
+      trigger: fatal_error
+      description: Critical error occurred, immediately stop the graph from any state
+      conditions: []
+      actions:
+        - action_name: log_fatal_error
+          action_type: logging
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_fatal_error_alert
+          action_type: alert
+          is_critical: true
+          timeout_ms: 2000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: capture_error_diagnostics
+          action_type: data_capture
+          is_critical: false
+          timeout_ms: 3000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emergency_resource_cleanup
+          action_type: cleanup
+          is_critical: true
+          timeout_ms: 5000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+    - transition_name: handle_timeout
+      from_state: '*'
+      to_state: stopped
+      trigger: timeout
+      description: Operation timeout from any non-terminal state - stop the graph
+      conditions: []
+      actions:
+        - action_name: log_timeout_event
+          action_type: logging
+          is_critical: true
+          timeout_ms: 1000
+          version: {major: 1, minor: 0, patch: 0}
+        - action_name: emit_timeout_alert
+          action_type: alert
+          is_critical: false
+          timeout_ms: 2000
+          version: {major: 1, minor: 0, patch: 0}
+      version: {major: 1, minor: 0, patch: 0}
+  terminal_states:
+    - stopped
+  error_states:
+    - stopped
+  persistence_enabled: true
+  recovery_enabled: true
+  operations:
+    - operation_name: force_stop
+      description: Force immediate stop of the node graph without graceful drain
+      trigger: force_stop
+      target_state: stopped
+      requires_permission: true
+      is_destructive: true
+      rollback_transitions: []
+      version: {major: 1, minor: 0, patch: 0}
+      operation_type: administrative
+    - operation_name: restart_graph
+      description: Restart the node graph from stopped state
+      trigger: restart
+      target_state: initializing
+      requires_permission: true
+      is_destructive: false
+      rollback_transitions:
+        - transition_name: rollback_restart
+          from_state: initializing
+          to_state: stopped
+          trigger: undo_restart
+      version: {major: 1, minor: 0, patch: 0}
+      operation_type: administrative
+    - operation_name: rewire_graph
+      description: Re-establish node connections while running (hot rewiring)
+      trigger: rewire
+      target_state: wiring
+      requires_permission: true
+      is_destructive: false
+      rollback_transitions:
+        - transition_name: rollback_rewire
+          from_state: wiring
+          to_state: running
+          trigger: undo_rewire
+      version: {major: 1, minor: 0, patch: 0}
+      operation_type: administrative
+
+# v1.1.0 Required Fields
+# NOTE: The `handlers` section defines protocol-based dependencies injected via DI container.
+# This is SEPARATE from FSM action types (event, logging, data_capture, persistence, alert, cleanup)
+# which are defined in transition actions.
+#
+# FSM Action Type Execution:
+# The runtime's built-in FSM action executor handles all action_type values. Each action_type
+# maps to a runtime capability:
+#   - event: Publishes events via ProtocolEventBus (optional handler below)
+#   - logging: Logs via ProtocolLogger (optional handler below)
+#   - data_capture: Snapshots state to memory/persistence store
+#   - persistence: Persists FSM state for recovery (when persistence_enabled: true)
+#   - alert: Emits alerts via alerting subsystem (monitoring integration)
+#   - cleanup: Executes resource cleanup procedures
+#
+# The `required: []` means no handlers are MANDATORY for this node to function, since the
+# runtime provides default implementations. Optional handlers allow custom implementations.
+handlers:
+  required: []
+  optional:
+    - type: ProtocolLogger
+      version: {major: 1, minor: 0, patch: 0}
+    - type: ProtocolEventBus
+      version: {major: 1, minor: 0, patch: 0}
+
+profile_tags:
+  - runtime
+  - reducer
+  - node-graph
+  - lifecycle
+
+metadata:
+  version: {major: 1, minor: 1, patch: 0}
+  author: ONEX Framework Team
+  description: Node graph lifecycle reducer using FSM pattern for ONEX runtime self-hosting
+  tags:
+    - reducer
+    - fsm
+    - declarative
+    - node-graph
+    - runtime
+    - lifecycle
+  documentation_url: https://docs.onex.ai/reducers/node-graph
+
+# Testing Guidance: Wildcard Transitions (from_state: '*')
+# Wildcards bypass normal flow; stopped entry_actions MUST be idempotent.
+testing_guidance:
+  transitions: [fatal_error, handle_timeout]
+  test_matrix:
+    # Test fatal_error and timeout from each non-terminal state to stopped
+    states: [initializing, wiring, running, draining]
+    triggers: [fatal_error, timeout]
+    verify: [resources_released, error_logged, state_clean, no_orphans]
+  idempotency:
+    # Entry actions must tolerate repeated calls (double-trigger, timeout+fatal, restart cycles)
+    scenarios: [double_trigger, timeout_then_fatal, restart_after_fatal]
+    verify: [no_exceptions, single_cleanup, consistent_state]
+  edge_cases:
+    # Concurrent triggers and in-flight action handling
+    - concurrent_triggers_single_execution
+    - pending_actions_cancelled_cleanly

--- a/contracts/runtime/node_graph_reducer.yaml
+++ b/contracts/runtime/node_graph_reducer.yaml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
----
 node_type: REDUCER_GENERIC
 contract_version: {major: 1, minor: 1, patch: 0}
 # Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
@@ -260,8 +259,7 @@ state_transitions:
       version: {major: 1, minor: 0, patch: 0}
   terminal_states:
     - stopped
-  error_states:
-    - stopped
+  error_states: []
   persistence_enabled: true
   recovery_enabled: true
   operations:
@@ -300,7 +298,6 @@ state_transitions:
           trigger: undo_rewire
       version: {major: 1, minor: 0, patch: 0}
       operation_type: administrative
-
 # v1.1.0 Required Fields
 # NOTE: The `handlers` section defines protocol-based dependencies injected via DI container.
 # This is SEPARATE from FSM action types (event, logging, data_capture, persistence, alert, cleanup)
@@ -325,13 +322,11 @@ handlers:
       version: {major: 1, minor: 0, patch: 0}
     - type: ProtocolEventBus
       version: {major: 1, minor: 0, patch: 0}
-
 profile_tags:
   - runtime
   - reducer
   - node-graph
   - lifecycle
-
 metadata:
   version: {major: 1, minor: 1, patch: 0}
   author: ONEX Framework Team
@@ -344,7 +339,6 @@ metadata:
     - runtime
     - lifecycle
   documentation_url: https://docs.onex.ai/reducers/node-graph
-
 # Testing Guidance: Wildcard Transitions (from_state: '*')
 # Wildcards bypass normal flow; stopped entry_actions MUST be idempotent.
 testing_guidance:

--- a/contracts/runtime/node_graph_reducer.yaml
+++ b/contracts/runtime/node_graph_reducer.yaml
@@ -260,11 +260,8 @@ state_transitions:
       version: {major: 1, minor: 0, patch: 0}
   terminal_states:
     - stopped
-    - fatal
-    - timeout_error
   error_states:
-    - fatal
-    - timeout_error
+    - stopped
   persistence_enabled: true
   recovery_enabled: true
   operations:

--- a/contracts/runtime/node_graph_reducer.yaml
+++ b/contracts/runtime/node_graph_reducer.yaml
@@ -260,8 +260,11 @@ state_transitions:
       version: {major: 1, minor: 0, patch: 0}
   terminal_states:
     - stopped
+    - fatal
+    - timeout_error
   error_states:
-    - stopped
+    - fatal
+    - timeout_error
   persistence_enabled: true
   recovery_enabled: true
   operations:

--- a/contracts/runtime/runtime_orchestrator.yaml
+++ b/contracts/runtime/runtime_orchestrator.yaml
@@ -1,0 +1,859 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Runtime Orchestrator Contract
+#
+# This contract defines the ONEX runtime itself as a node graph, proving the
+# system is self-consistent. The runtime is built using the 4-node architecture:
+# - Contract loading (Effect node)
+# - Contract registry (Reducer node)
+# - Node graph management (Reducer node)
+# - Event dispatching (Orchestrator sub-workflows)
+#
+# Architecture:
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │                    RUNTIME AS NODE GRAPH                                 │
+# ├─────────────────────────────────────────────────────────────────────────┤
+# │                                                                          │
+# │  runtime_orchestrator (NodeOrchestrator)                                │
+# │  ├── contract_loader (NodeEffect)                                       │
+# │  │   └── Scans contracts directory, emits loaded contracts              │
+# │  ├── contract_registry (NodeReducer)                                    │
+# │  │   └── FSM: empty → loading → ready                                   │
+# │  │   └── Maintains registry of compiled contracts                       │
+# │  ├── node_graph (NodeReducer)                                           │
+# │  │   └── FSM: initializing → wiring → running → draining                │
+# │  │   └── Maintains instantiated node graph                              │
+# │  └── event_bus_wiring (NodeEffect)                                      │
+# │      └── Wires nodes to event bus subscriptions                         │
+# │                                                                          │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Design Decisions:
+#
+# 1. RUNTIME EXCLUSION FROM HOT RELOAD
+#    Runtime contracts (contracts/runtime/**) are EXCLUDED from hot reload
+#    to prevent circular dependency: the runtime cannot reload its own definition
+#    while running. This is a fundamental bootstrapping constraint, similar to
+#    how an operating system kernel cannot hot-patch itself without a reboot.
+#    The ONEX runtime must be stopped and restarted to apply changes to its
+#    own contract definitions.
+#
+# 2. INTERNAL CONTRACT EXCLUSION
+#    Contracts prefixed with underscore (_*.yaml) are excluded as they are
+#    considered internal/partial contracts not meant for direct instantiation.
+#    These are typically fragments or templates used by other contracts.
+#
+# Node Implementation (NO custom code needed):
+#   from omnibase_core.nodes import NodeOrchestrator
+#   class NodeONEXRuntime(NodeOrchestrator):
+#       pass  # All logic driven by this YAML contract
+
+# Contract Metadata
+node_type: ORCHESTRATOR_GENERIC
+contract_version: {major: 1, minor: 1, patch: 0}
+# Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
+# See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
+fingerprint: "1.1.0:33154c46968c"
+# Workflow Coordination Subcontract
+workflow_coordination:
+  version: {major: 1, minor: 1, patch: 0}
+  subcontract_version: {major: 1, minor: 1, patch: 0}
+
+  # Workflow Definition: Runtime lifecycle management
+  workflow_definition:
+    # Workflow Metadata
+    workflow_metadata:
+      workflow_name: runtime_lifecycle
+      workflow_version: {major: 1, minor: 0, patch: 0}
+      description: ONEX runtime lifecycle management workflow - self-hosted runtime using 4-node architecture
+      execution_mode: sequential  # Runtime startup must be sequential
+      author: ONEX Framework
+      tags:
+        - runtime
+        - self-hosted
+        - lifecycle
+        - kernel
+      documentation_url: https://docs.onex.ai/runtime/orchestrator
+
+    # Execution Graph: Runtime node relationships
+    execution_graph:
+      nodes:
+        # ─────────────────────────────────────────────────────────────
+        # EFFECT: Contract Loader
+        # Scans filesystem for contract YAML files
+        # ─────────────────────────────────────────────────────────────
+        - node_id: contract_loader
+          node_type: EFFECT_GENERIC
+          node_name: Contract Loader
+          description: Scans contracts directory and loads YAML contract files
+          target_node_type: NodeContractLoaderEffect
+          contract_ref: runtime/contract_loader_effect.yaml
+          metadata:
+            contracts_dir: "${env.ONEX_CONTRACTS_DIR:./contracts}"
+            pattern: "**/*.yaml"
+            exclude_patterns:
+              # CRITICAL: Runtime contracts must be excluded from hot reload
+              # to prevent circular dependency. The runtime cannot reload its
+              # own contract definition while running - this is a bootstrapping
+              # constraint similar to how an OS kernel cannot update itself
+              # without a reboot. See "Design Decisions" in header comments.
+              - "**/runtime/**"
+              # Internal/partial contracts not meant for direct instantiation.
+              # These are fragments or templates included by other contracts.
+              - "**/_*.yaml"
+            watch_mode: false
+            scan_interval_ms: 300000
+
+        # ─────────────────────────────────────────────────────────────
+        # REDUCER: Contract Registry
+        # Maintains state of loaded/compiled contracts
+        # FSM: empty → loading → ready
+        # ─────────────────────────────────────────────────────────────
+        - node_id: contract_registry
+          node_type: REDUCER_GENERIC
+          node_name: Contract Registry
+          description: Maintains registry of loaded and validated contracts
+          target_node_type: NodeContractRegistryReducer
+          contract_ref: runtime/contract_registry_reducer.yaml
+          depends_on:
+            - contract_loader
+          metadata:
+            max_contracts: 1000
+            validation_strict: true
+            cache_compiled_contracts: true
+
+        # ─────────────────────────────────────────────────────────────
+        # REDUCER: Node Graph Manager
+        # Maintains instantiated node graph state
+        # FSM: initializing → wiring → running → draining
+        # ─────────────────────────────────────────────────────────────
+        - node_id: node_graph
+          node_type: REDUCER_GENERIC
+          node_name: Node Graph Manager
+          description: Maintains the instantiated node graph based on loaded contracts
+          target_node_type: NodeGraphManagerReducer
+          contract_ref: runtime/node_graph_reducer.yaml
+          depends_on:
+            - contract_registry
+          metadata:
+            max_nodes: 500
+            enable_hot_reload: true
+            dependency_resolution: topological
+
+        # ─────────────────────────────────────────────────────────────
+        # EFFECT: Event Bus Wiring
+        # Wires nodes to event bus subscriptions
+        # ─────────────────────────────────────────────────────────────
+        - node_id: event_bus_wiring
+          node_type: EFFECT_GENERIC
+          node_name: Event Bus Wiring
+          description: Wires instantiated nodes to event bus subscriptions
+          target_node_type: NodeEventBusWiringEffect
+          contract_ref: runtime/event_bus_wiring_effect.yaml
+          depends_on:
+            - node_graph
+          metadata:
+            event_bus_type: "${env.ONEX_EVENT_BUS:inmemory}"
+            subscription_timeout_ms: 5000
+            retry_on_failure: true
+
+      # Execution edges (derived from depends_on)
+      edges:
+        - from_node: contract_loader
+          to_node: contract_registry
+          edge_type: data_flow
+          description: Discovered contracts flow to registry for validation
+        - from_node: contract_registry
+          to_node: node_graph
+          edge_type: data_flow
+          description: Validated contracts flow to node graph for instantiation
+        - from_node: node_graph
+          to_node: event_bus_wiring
+          edge_type: data_flow
+          description: Instantiated nodes flow to wiring for event subscriptions
+
+    # Coordination Rules: Runtime startup coordination
+    coordination_rules:
+      # Sequential execution for startup (order matters)
+      parallel_execution_allowed: false
+      max_parallel_steps: 1
+
+      # Failure recovery strategy
+      failure_recovery_strategy: fail_fast  # Runtime startup must succeed
+      max_retries: 3
+      retry_backoff_ms: 2000
+      retry_backoff_multiplier: 2.0
+
+      # Timeout configuration
+      timeout_ms: 120000  # 2 minutes total startup timeout
+      step_timeout_ms: 30000  # 30 seconds per step
+
+      # Dependency resolution
+      dependency_resolution_enabled: true
+      detect_cycles: true
+      fail_on_cycle: true
+
+      # Runtime must fully start
+      allow_partial_completion: false
+      min_required_steps_completion_percent: 100.0
+
+      # Resource constraints for runtime
+      resource_constraints:
+        max_memory_mb: 512
+        max_cpu_cores: 2
+
+      # Monitoring and observability
+      emit_step_metrics: true
+      emit_workflow_events: true
+      emit_dependency_graph: true
+
+  # Lifecycle configuration for runtime
+  lifecycle:
+    startup_sequence:
+      - contract_loader
+      - contract_registry
+      - node_graph
+      - event_bus_wiring
+    shutdown_sequence:
+      - event_bus_wiring
+      - node_graph
+      - contract_registry
+      - contract_loader
+    health_check_interval_ms: 30000
+    graceful_shutdown_timeout_ms: 60000
+
+  # Event subscriptions for runtime management
+  subscriptions:
+    - topic: runtime.startup
+      description: Trigger runtime startup sequence
+    - topic: runtime.shutdown
+      description: Trigger graceful shutdown sequence
+    - topic: runtime.contracts.reload
+      description: Trigger contract reload without full restart
+
+  # Events published by runtime
+  publications:
+    - topic: runtime.ready
+      description: Runtime is fully initialized and ready
+      payload_schema: ModelRuntimeReadyEvent
+    - topic: runtime.shutting_down
+      description: Runtime is beginning shutdown sequence
+      payload_schema: ModelRuntimeShutdownEvent
+    - topic: runtime.error
+      description: Runtime encountered a critical error
+      payload_schema: ModelRuntimeErrorEvent
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Timing Constraints Validation
+# ─────────────────────────────────────────────────────────────────────────────
+# All retry policies have been validated to ensure worst-case total retry time
+# does not exceed operation timeout. This prevents infinite retry loops and
+# ensures predictable failure behavior.
+#
+# Validation Methodology:
+#   For exponential backoff: sum(base_delay * (2^i)) for i in 0..(max_retries-1)
+#   Then apply jitter_factor: total * (1 + jitter_factor) for worst case
+#   Delays are capped at max_delay_ms when specified
+#
+# Validation Date: 2025-12-08
+# ─────────────────────────────────────────────────────────────────────────────
+timing_constraints:
+  documentation: |
+    All retry policies have been validated to ensure worst-case total
+    retry time does not exceed operation timeout. This prevents infinite
+    retry loops and ensures predictable failure behavior.
+
+    Formula: sum(min(base_delay * 2^i, max_delay)) * (1 + jitter_factor)
+    for i in 0..(max_retries-1)
+
+  validations:
+    # contract_loader_effect.yaml - scan_contracts_directory
+    - operation: contract_loader.scan_contracts_directory
+      contract_ref: runtime/contract_loader_effect.yaml
+      timeout_ms: 60000
+      retry_config:
+        max_retries: 5
+        base_delay_ms: 500
+        max_delay_ms: 5000
+        backoff_strategy: exponential
+        jitter_factor: 0.15
+      calculation: "500 + 1000 + 2000 + 4000 + 5000(capped) = 12500ms * 1.15 = 14375ms"
+      worst_case_retry_ms: 14375
+      margin_ms: 45625
+      margin_percent: 76.0
+      status: PASS
+
+    # contract_loader_effect.yaml - read_contract_file
+    - operation: contract_loader.read_contract_file
+      contract_ref: runtime/contract_loader_effect.yaml
+      timeout_ms: 15000
+      retry_config:
+        max_retries: 3
+        base_delay_ms: 200
+        max_delay_ms: 2000
+        backoff_strategy: exponential
+        jitter_factor: 0.1
+      calculation: "200 + 400 + 800 = 1400ms * 1.1 = 1540ms"
+      worst_case_retry_ms: 1540
+      margin_ms: 13460
+      margin_percent: 89.7
+      status: PASS
+
+    # event_bus_wiring_effect.yaml - event_bus_wiring
+    - operation: event_bus_wiring.subscribe
+      contract_ref: runtime/event_bus_wiring_effect.yaml
+      timeout_ms: 60000
+      retry_config:
+        max_retries: 3
+        base_delay_ms: 1000
+        max_delay_ms: 10000
+        backoff_strategy: exponential
+        jitter_factor: 0.1
+      calculation: "1000 + 2000 + 4000 = 7000ms * 1.1 = 7700ms"
+      worst_case_retry_ms: 7700
+      margin_ms: 52300
+      margin_percent: 87.2
+      status: PASS
+
+    # runtime_orchestrator.yaml - coordination_rules (step-level retries)
+    - operation: runtime_orchestrator.step_retry
+      contract_ref: runtime/runtime_orchestrator.yaml
+      timeout_ms: 30000  # step_timeout_ms
+      retry_config:
+        max_retries: 3
+        base_delay_ms: 2000
+        backoff_strategy: exponential  # multiplier: 2.0
+        jitter_factor: 0.0  # No jitter specified
+      calculation: "2000 + 4000 + 8000 = 14000ms"
+      worst_case_retry_ms: 14000
+      margin_ms: 16000
+      margin_percent: 53.3
+      status: PASS
+
+  # Aggregate workflow timing
+  workflow_timing:
+    total_workflow_timeout_ms: 120000  # 2 minutes
+    step_timeout_ms: 30000  # 30 seconds per step
+    total_steps: 4  # contract_loader, contract_registry, node_graph, event_bus_wiring
+    worst_case_sequential_execution_ms: 120000  # 4 steps * 30s = 120s (at limit)
+    note: |
+      The workflow timeout equals the sum of step timeouts (4 * 30s = 120s).
+      This is acceptable because steps execute sequentially and each step
+      has sufficient retry margin within its own timeout.
+
+  # Notes on REDUCER contracts
+  reducer_notes: |
+    contract_registry_reducer.yaml and node_graph_reducer.yaml do not define
+    explicit retry policies. These REDUCER nodes use FSM state transitions
+    with short action timeouts (100ms-5000ms). Retry behavior for these nodes
+    is managed at the orchestrator level via coordination_rules.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Performance Benchmarks
+# ─────────────────────────────────────────────────────────────────────────────
+# Expected performance characteristics for runtime operations. These targets
+# guide implementation and enable regression detection.
+#
+# Methodology:
+#   - Measurements at p99 (99th percentile) unless otherwise noted
+#   - Warm-up: 3 iterations before measurement
+#   - Sample size: minimum 100 iterations
+#   - Baseline environment: SSD storage, 4 CPU cores, 8GB RAM
+#
+# ─────────────────────────────────────────────────────────────────────────────
+performance_benchmarks:
+  description: Expected performance characteristics for runtime orchestrator operations
+
+  methodology:
+    measurement_percentile: p99
+    warmup_iterations: 3
+    minimum_sample_size: 100
+    baseline_environment:
+      storage: SSD
+      cpu_cores: 4
+      memory_gb: 8
+
+  # Contract Scanning (contract_loader Effect node)
+  contract_scanning:
+    description: Filesystem traversal to discover YAML contract files
+    metrics:
+      - operation: scan_contracts_directory
+        metric: latency_p99_ms
+        target: "<500"
+        conditions: "100 contracts, SSD storage"
+      - operation: scan_contracts_directory
+        metric: latency_p99_ms
+        target: "<2000"
+        conditions: "1000 contracts, SSD storage"
+      - operation: scan_contracts_directory
+        metric: throughput_contracts_per_second
+        target: ">200"
+        conditions: "Warm filesystem cache"
+      - operation: scan_contracts_directory
+        metric: memory_overhead_mb
+        target: "<50"
+        conditions: "1000 contracts loaded"
+    scaling: Linear with contract count
+
+  # Contract Validation (contract_registry Reducer node)
+  contract_validation:
+    description: YAML parsing, schema validation, and contract compilation
+    metrics:
+      - operation: validate_single_contract
+        metric: latency_p99_ms
+        target: "<50"
+        conditions: "Single contract, strict validation"
+      - operation: validate_batch
+        metric: latency_p99_ms
+        target: "<3000"
+        conditions: "100 contracts, parallel validation"
+      - operation: validate_batch
+        metric: throughput_per_second
+        target: ">30"
+        conditions: "Sequential validation"
+      - operation: cache_lookup
+        metric: hit_ratio
+        target: ">0.95"
+        conditions: "Steady state after initial load"
+    scaling: CPU-bound; benefits from parallel validation
+
+  # Node Wiring (event_bus_wiring Effect node)
+  event_bus_wiring:
+    description: Creating event bus subscriptions for instantiated nodes
+    metrics:
+      - operation: create_subscription
+        metric: latency_p99_ms
+        target: "<100"
+        conditions: "Single subscription, in-memory event bus"
+      - operation: wire_batch
+        metric: latency_p99_ms
+        target: "<1000"
+        conditions: "100 subscriptions, in-memory event bus"
+      - operation: create_subscription
+        metric: latency_p99_ms
+        target: "<500"
+        conditions: "Single subscription, Kafka event bus"
+      - operation: wire_batch
+        metric: latency_p99_ms
+        target: "<5000"
+        conditions: "100 subscriptions, Kafka event bus"
+    scaling: In-memory ~5x faster than external brokers
+
+  # End-to-End Runtime Startup
+  runtime_startup:
+    description: Complete runtime initialization from cold start to ready
+    metrics:
+      - operation: cold_start
+        metric: latency_p99_ms
+        target: "<5000"
+        conditions: "100 contracts, in-memory event bus"
+      - operation: cold_start
+        metric: latency_p99_ms
+        target: "<15000"
+        conditions: "100 contracts, Kafka event bus"
+      - operation: hot_reload
+        metric: latency_p99_ms
+        target: "<2000"
+        conditions: "Single contract change, cached baseline"
+    breakdown_percent:
+      contract_scanning: 10
+      contract_validation: 30
+      node_instantiation: 20
+      event_bus_wiring: 40
+
+  # Regression Detection
+  regression_thresholds:
+    warning_multiplier: 1.5  # Flag if 50% slower than target
+    critical_multiplier: 2.0  # Fail if 2x slower than target
+
+# v1.1.0 Required Fields
+handlers:
+  required:
+    - type: ProtocolEventBus
+      version: {major: 1, minor: 0, patch: 0}
+  optional:
+    - type: ProtocolLogger
+      version: {major: 1, minor: 0, patch: 0}
+
+profile_tags:
+  - runtime
+  - orchestrator
+  - kernel
+  - lifecycle
+
+# Metadata
+metadata:
+  version: {major: 1, minor: 1, patch: 0}
+  author: ONEX Framework
+  description: Self-hosted ONEX runtime orchestrator using 4-node architecture
+  tags:
+    - orchestrator
+    - runtime
+    - kernel
+    - self-hosted
+    - lifecycle
+  documentation_url: https://docs.onex.ai/runtime/orchestrator
+
+  # Design Decisions Documentation
+  # These decisions are architectural constraints that affect runtime behavior
+  design_decisions:
+    - decision: runtime_exclusion
+      rationale: |
+        Runtime contracts (contracts/runtime/**) are excluded from the contract
+        hot reload mechanism. This is a fundamental bootstrapping constraint:
+        the runtime orchestrator cannot reload its own definition while running.
+
+        Similar to how an operating system kernel cannot hot-patch itself without
+        a reboot, the ONEX runtime must be stopped and restarted to apply changes
+        to its own contract definitions.
+
+        This exclusion prevents:
+        1. Circular dependency during contract loading
+        2. Undefined behavior from partial runtime state during reload
+        3. Potential infinite recursion if runtime contracts trigger reloads
+      alternatives_considered:
+        - "Two-phase reload with runtime handoff (too complex for MVP)"
+        - "Versioned runtime contracts with migration (future consideration)"
+        - "Shadow runtime that takes over during reload (resource intensive)"
+      related_patterns:
+        - "OS kernel hot-patching constraints"
+        - "JVM class reloading limitations"
+        - "Database schema migration patterns"
+
+    - decision: internal_contract_exclusion
+      rationale: |
+        Contracts prefixed with underscore (_*.yaml) are treated as internal
+        or partial contracts not meant for direct instantiation. These serve
+        as building blocks or templates that are included by other contracts.
+
+        This follows common conventions from Python (_ prefix for private),
+        filesystem conventions (hidden files), and allows for contract
+        composition without polluting the registry with fragments.
+      alternatives_considered:
+        - "Separate 'fragments/' directory (adds complexity)"
+        - "Explicit 'fragment: true' field (requires schema changes)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration Testing Requirements
+# ─────────────────────────────────────────────────────────────────────────────
+# Documentation for end-to-end tests covering the complete runtime lifecycle.
+# Tests should verify the 4-node orchestration pattern works correctly.
+# ─────────────────────────────────────────────────────────────────────────────
+integration_testing:
+  description: End-to-end tests for runtime lifecycle orchestration
+  test_location: tests/integration/runtime/test_runtime_orchestrator.py
+
+  # Test Fixtures
+  fixtures:
+    mock_event_bus:
+      description: In-memory event bus for capturing published events
+      captures: [runtime.ready, runtime.shutting_down, runtime.error]
+    mock_contracts_dir:
+      description: Temp directory with valid/invalid contract YAML files
+      contents:
+        - valid_compute.yaml  # Valid COMPUTE contract
+        - valid_effect.yaml  # Valid EFFECT contract
+        - _internal.yaml  # Should be excluded (underscore prefix)
+        - invalid.yaml  # Malformed YAML for error testing
+    mock_container:
+      description: ModelONEXContainer with mock services registered
+
+  # Test Scenarios
+  scenarios:
+    - name: successful_startup
+      description: Verify complete startup sequence executes in order
+      steps:
+        - step: contract_loader scans mock_contracts_dir
+          assert: Emits contract.loaded events for valid contracts only
+        - step: contract_registry transitions empty → loading → ready
+          assert: FSM state is 'ready', registry contains 2 contracts
+        - step: node_graph transitions initializing → wiring → running
+          assert: FSM state is 'running', nodes instantiated
+        - step: event_bus_wiring subscribes nodes to topics
+          assert: Subscriptions active, runtime.ready event emitted
+      expected_events:
+        - runtime.ready
+      expected_fsm_states:
+        contract_registry: ready
+        node_graph: running
+
+    - name: graceful_shutdown
+      description: Verify shutdown sequence executes in reverse order
+      precondition: Runtime in 'running' state
+      steps:
+        - step: Trigger runtime.shutdown event
+          assert: runtime.shutting_down event emitted
+        - step: event_bus_wiring unsubscribes all nodes
+          assert: No active subscriptions remain
+        - step: node_graph transitions running → draining → stopped
+          assert: FSM state is 'stopped', all nodes disposed
+        - step: contract_registry clears registry
+          assert: Registry empty
+        - step: contract_loader stops watching
+          assert: No file watchers active
+      expected_events:
+        - runtime.shutting_down
+      expected_fsm_states:
+        node_graph: stopped
+
+    - name: startup_failure_contract_loader
+      description: Verify fail-fast on contract loading errors
+      setup: mock_contracts_dir contains only invalid YAML
+      steps:
+        - step: contract_loader attempts scan
+          assert: Raises validation error after retries exhausted
+        - step: Orchestrator catches failure
+          assert: runtime.error event emitted with error details
+      expected_events:
+        - runtime.error
+      expected_error_code: CONTRACT_VALIDATION_FAILED
+
+    - name: startup_failure_node_instantiation
+      description: Verify fail-fast when node instantiation fails
+      setup: Valid contracts but missing required service in container
+      steps:
+        - step: contract_loader and contract_registry succeed
+          assert: FSM states progress normally
+        - step: node_graph fails during instantiation
+          assert: runtime.error event with instantiation failure
+        - step: Partial cleanup triggered
+          assert: Already-started nodes disposed
+      expected_events:
+        - runtime.error
+      expected_error_code: NODE_INSTANTIATION_FAILED
+
+    - name: retry_behavior
+      description: Verify retry with exponential backoff
+      setup: contract_loader fails twice then succeeds
+      steps:
+        - step: First attempt fails (transient error)
+          assert: Retries after 2000ms (base delay)
+        - step: Second attempt fails
+          assert: Retries after 4000ms (2x backoff)
+        - step: Third attempt succeeds
+          assert: Startup continues, runtime.ready emitted
+      expected_events:
+        - runtime.ready
+      timing_assertions:
+        - min_total_time_ms: 6000  # 2000 + 4000
+
+    - name: timeout_enforcement
+      description: Verify step timeout kills hanging operations
+      setup: contract_loader hangs indefinitely
+      steps:
+        - step: contract_loader exceeds step_timeout_ms (30000)
+          assert: Operation cancelled, retries begin
+        - step: All retries timeout
+          assert: runtime.error with TIMEOUT error code
+      expected_events:
+        - runtime.error
+      expected_error_code: STEP_TIMEOUT
+
+  # Assertions Checklist
+  assertions:
+    event_ordering:
+      - Events emitted in documented sequence
+      - No duplicate events for same lifecycle transition
+    fsm_consistency:
+      - FSM states match expected values at each step
+      - No invalid state transitions occur
+    resource_cleanup:
+      - All nodes disposed on shutdown or failure
+      - No orphaned event subscriptions
+      - Temp files cleaned up
+    timing:
+      - Total startup < 120000ms (workflow timeout)
+      - Each step < 30000ms (step timeout)
+      - Retry delays match exponential backoff config
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Operational Monitoring
+# ─────────────────────────────────────────────────────────────────────────────
+# Production monitoring guidance for the ONEX runtime. Covers health endpoints,
+# metrics, alerting thresholds, and log patterns. Addresses PR #137 feedback.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+operational_monitoring:
+  description: |
+    Operational guidance for monitoring the ONEX runtime in production.
+    Covers health endpoints, metrics, alerting, and log analysis.
+
+  # Health check endpoints exposed by the runtime
+  health_endpoints:
+    - path: /health/runtime
+      description: Overall runtime health status
+      response_fields:
+        - state: Current runtime FSM state (initializing|wiring|running|draining|stopped)
+        - uptime_seconds: Time since runtime entered 'running' state
+        - last_health_check: ISO8601 timestamp of last successful health check
+    - path: /health/nodes
+      description: Aggregated health of all managed nodes
+      response_fields:
+        - total_nodes: Number of nodes in graph
+        - healthy_nodes: Count of nodes reporting healthy status
+        - unhealthy_nodes: List of node_ids with issues
+    - path: /health/nodes/{node_id}
+      description: Individual node health status
+      response_fields:
+        - node_id: Node identifier
+        - node_type: Node type (EFFECT|COMPUTE|REDUCER|ORCHESTRATOR)
+        - state: Current node FSM state
+        - last_event_processed: Timestamp of last event processed
+        - error_count: Number of errors since startup
+
+  # Key metrics (Prometheus/OpenTelemetry compatible)
+  key_metrics:
+    # Runtime state
+    - name: onex_runtime_state
+      type: gauge
+      labels: [state]
+      description: Current runtime FSM state (1 for active state, 0 otherwise)
+      states: [initializing, wiring, running, draining, stopped]
+
+    - name: onex_runtime_uptime_seconds
+      type: counter
+      description: Seconds since runtime entered 'running' state
+
+    - name: onex_runtime_startup_duration_seconds
+      type: histogram
+      description: Time taken for runtime startup sequence
+      buckets: [0.5, 1, 2, 5, 10, 30, 60, 120]
+
+    # Node health
+    - name: onex_node_state
+      type: gauge
+      labels: [node_id, node_type, state]
+      description: Current FSM state per node (1 for active state)
+
+    - name: onex_node_events_processed_total
+      type: counter
+      labels: [node_id, node_type, event_type]
+      description: Total events processed by each node
+
+    - name: onex_node_event_processing_duration_seconds
+      type: histogram
+      labels: [node_id, node_type]
+      description: Event processing latency per node
+      buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5]
+
+    # Errors
+    - name: onex_node_errors_total
+      type: counter
+      labels: [node_id, node_type, error_code]
+      description: Total errors by node and error code
+
+    - name: onex_runtime_errors_total
+      type: counter
+      labels: [error_code, severity]
+      description: Total runtime-level errors
+
+    # Contracts
+    - name: onex_contracts_loaded_total
+      type: gauge
+      description: Number of contracts loaded in registry
+
+    - name: onex_contract_reload_duration_seconds
+      type: histogram
+      description: Time taken to reload contracts
+      buckets: [0.1, 0.5, 1, 2, 5, 10, 30]
+
+  # Alerting thresholds
+  alerting:
+    critical:
+      - name: RuntimeNotRunning
+        condition: onex_runtime_state{state="running"} == 0 for 30s
+        description: Runtime is not in running state
+        action: Check runtime logs, verify startup sequence completed
+
+      - name: NodeErrorSpike
+        condition: rate(onex_node_errors_total[1m]) > 10
+        description: Rapid increase in node errors (>10/min)
+        action: Check node logs for error_code, review recent contract changes
+
+      - name: RuntimeStartupTimeout
+        condition: onex_runtime_startup_duration_seconds > 120
+        description: Runtime startup exceeded 2-minute timeout
+        action: Review contract loader performance, check filesystem access
+
+    warning:
+      - name: NodeDrainingTooLong
+        condition: onex_node_state{state="draining"} == 1 for 60s
+        description: Node stuck in draining state
+        action: Check for pending events, review graceful shutdown logic
+
+      - name: HighEventLatency
+        condition: histogram_quantile(0.99, onex_node_event_processing_duration_seconds) > 1
+        description: P99 event processing latency exceeds 1 second
+        action: Profile node processing, check for blocking operations
+
+      - name: NoContractsLoaded
+        condition: onex_contracts_loaded_total < 1
+        description: No contracts loaded in registry
+        action: Verify contracts directory path, check file permissions
+
+  # Dashboard recommendations
+  dashboards:
+    overview:
+      title: ONEX Runtime Overview
+      panels:
+        - name: Runtime State
+          type: state_timeline
+          description: State machine with current state highlighted
+        - name: Node Health Grid
+          type: stat_grid
+          description: All nodes with color-coded health status
+        - name: Events Processed
+          type: time_series
+          description: Events/second throughput
+        - name: Error Rate
+          type: time_series
+          description: Errors/minute by severity
+
+    node_details:
+      title: ONEX Node Details
+      variables: [node_id]
+      panels:
+        - name: FSM State Timeline
+          type: state_timeline
+        - name: Event Latency (P50/P95/P99)
+          type: time_series
+        - name: Events by Type
+          type: pie_chart
+        - name: Errors by Code
+          type: bar_chart
+
+  # Log patterns to monitor
+  log_patterns:
+    required_fields:
+      - correlation_id: UUID for request tracing
+      - node_id: Source node identifier
+      - event_type: Event being processed
+      - fsm_state: Current FSM state
+      - timestamp: ISO8601 timestamp
+
+    watch_patterns:
+      - pattern: "fsm_transition_failed"
+        severity: error
+        description: FSM could not transition to expected state
+        investigation: Check valid transitions in contract, review event payload
+
+      - pattern: "contract_validation_error"
+        severity: error
+        description: Contract failed validation during load
+        investigation: Review contract YAML syntax, check schema version
+
+      - pattern: "event_bus_connection_lost"
+        severity: critical
+        description: Lost connection to event bus
+        investigation: Check network connectivity, verify event bus service
+
+      - pattern: "retry_exhausted"
+        severity: warning
+        description: Operation failed after all retries
+        investigation: Review timeout vs retry config, check external deps
+
+      - pattern: "graceful_shutdown_timeout"
+        severity: warning
+        description: Shutdown did not complete within timeout
+        investigation: Check for stuck nodes, review shutdown_sequence

--- a/contracts/runtime/runtime_orchestrator.yaml
+++ b/contracts/runtime/runtime_orchestrator.yaml
@@ -88,11 +88,11 @@ workflow_coordination:
           contract_ref: runtime/contract_loader_effect.yaml
           metadata:
             contracts_dir: "${env.ONEX_CONTRACTS_DIR:./contracts}"
-            pattern: "**/*.yaml"
+            pattern: "**/*.y*ml"
             exclude_patterns:
               # Internal/partial contracts not meant for direct instantiation.
               # These are fragments or templates included by other contracts.
-              - "**/_*.yaml"
+              - "**/_*.y*ml"
             reload_exclude_patterns:
               # CRITICAL: Runtime contracts must be excluded from hot reload
               # to prevent circular dependency. Initial load must still scan

--- a/contracts/runtime/runtime_orchestrator.yaml
+++ b/contracts/runtime/runtime_orchestrator.yaml
@@ -553,7 +553,10 @@ integration_testing:
   fixtures:
     mock_event_bus:
       description: In-memory event bus for capturing published events
-      captures: [runtime.ready, runtime.shutting_down, runtime.error]
+      captures:
+        - onex.evt.runtime.ready.v1
+        - onex.evt.runtime.shutting-down.v1
+        - onex.evt.runtime.error.v1
     mock_contracts_dir:
       description: Temp directory with valid/invalid contract YAML files
       contents:
@@ -578,7 +581,7 @@ integration_testing:
         - step: event_bus_wiring subscribes nodes to topics
           assert: Subscriptions active, runtime.ready event emitted
       expected_events:
-        - runtime.ready
+        - onex.evt.runtime.ready.v1
       expected_fsm_states:
         contract_registry: ready
         node_graph: running
@@ -598,7 +601,7 @@ integration_testing:
         - step: contract_loader stops watching
           assert: No file watchers active
       expected_events:
-        - runtime.shutting_down
+        - onex.evt.runtime.shutting-down.v1
       expected_fsm_states:
         node_graph: stopped
 
@@ -609,9 +612,9 @@ integration_testing:
         - step: contract_loader attempts scan
           assert: Raises validation error after retries exhausted
         - step: Orchestrator catches failure
-          assert: runtime.error event emitted with error details
+          assert: onex.evt.runtime.error.v1 event emitted with error details
       expected_events:
-        - runtime.error
+        - onex.evt.runtime.error.v1
       expected_error_code: CONTRACT_VALIDATION_FAILED
 
     - name: startup_failure_node_instantiation
@@ -621,11 +624,11 @@ integration_testing:
         - step: contract_loader and contract_registry succeed
           assert: FSM states progress normally
         - step: node_graph fails during instantiation
-          assert: runtime.error event with instantiation failure
+          assert: onex.evt.runtime.error.v1 event with instantiation failure
         - step: Partial cleanup triggered
           assert: Already-started nodes disposed
       expected_events:
-        - runtime.error
+        - onex.evt.runtime.error.v1
       expected_error_code: NODE_INSTANTIATION_FAILED
 
     - name: retry_behavior
@@ -637,9 +640,9 @@ integration_testing:
         - step: Second attempt fails
           assert: Retries after 4000ms (2x backoff)
         - step: Third attempt succeeds
-          assert: Startup continues, runtime.ready emitted
+          assert: Startup continues, onex.evt.runtime.ready.v1 emitted
       expected_events:
-        - runtime.ready
+        - onex.evt.runtime.ready.v1
       timing_assertions:
         - min_total_time_ms: 6000  # 2000 + 4000
 
@@ -650,9 +653,9 @@ integration_testing:
         - step: contract_loader exceeds step_timeout_ms (30000)
           assert: Operation cancelled, retries begin
         - step: All retries timeout
-          assert: runtime.error with TIMEOUT error code
+          assert: onex.evt.runtime.error.v1 with TIMEOUT error code
       expected_events:
-        - runtime.error
+        - onex.evt.runtime.error.v1
       expected_error_code: STEP_TIMEOUT
 
   # Assertions Checklist

--- a/contracts/runtime/runtime_orchestrator.yaml
+++ b/contracts/runtime/runtime_orchestrator.yaml
@@ -223,26 +223,31 @@ workflow_coordination:
     health_check_interval_ms: 30000
     graceful_shutdown_timeout_ms: 60000
 
-  # Event subscriptions for runtime management
-  subscriptions:
-    - topic: runtime.startup
-      description: Trigger runtime startup sequence
-    - topic: runtime.shutdown
-      description: Trigger graceful shutdown sequence
-    - topic: runtime.contracts.reload
-      description: Trigger contract reload without full restart
-
-  # Events published by runtime
-  publications:
-    - topic: runtime.ready
-      description: Runtime is fully initialized and ready
-      payload_schema: ModelRuntimeReadyEvent
-    - topic: runtime.shutting_down
-      description: Runtime is beginning shutdown sequence
-      payload_schema: ModelRuntimeShutdownEvent
-    - topic: runtime.error
-      description: Runtime encountered a critical error
-      payload_schema: ModelRuntimeErrorEvent
+  # Event bus declarations for runtime management
+  event_bus:
+    subscribe_topics:
+      - topic: onex.evt.runtime.startup.v1
+        description: Trigger runtime startup sequence
+        provisioning_priority: 10
+      - topic: onex.evt.runtime.shutdown.v1
+        description: Trigger graceful shutdown sequence
+        provisioning_priority: 10
+      - topic: onex.evt.runtime.contracts-reload.v1
+        description: Trigger contract reload without full restart
+        provisioning_priority: 20
+    publish_topics:
+      - topic: onex.evt.runtime.ready.v1
+        description: Runtime is fully initialized and ready
+        payload_schema: ModelRuntimeReadyEvent
+        provisioning_priority: 10
+      - topic: onex.evt.runtime.shutting-down.v1
+        description: Runtime is beginning shutdown sequence
+        payload_schema: ModelRuntimeShutdownEvent
+        provisioning_priority: 20
+      - topic: onex.evt.runtime.error.v1
+        description: Runtime encountered a critical error
+        payload_schema: ModelRuntimeErrorEvent
+        provisioning_priority: 20
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Timing Constraints Validation

--- a/contracts/runtime/runtime_orchestrator.yaml
+++ b/contracts/runtime/runtime_orchestrator.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
----
+# Contract Metadata
+node_type: ORCHESTRATOR_GENERIC
 # ONEX Runtime Orchestrator Contract
 #
 # This contract defines the ONEX runtime itself as a node graph, proving the
@@ -49,8 +50,6 @@
 #   class NodeONEXRuntime(NodeOrchestrator):
 #       pass  # All logic driven by this YAML contract
 
-# Contract Metadata
-node_type: ORCHESTRATOR_GENERIC
 contract_version: {major: 1, minor: 1, patch: 0}
 # Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
 # See docs/architecture/CONTRACT_STABILITY_SPEC.md for normalization specification.
@@ -59,7 +58,6 @@ fingerprint: "1.1.0:33154c46968c"
 workflow_coordination:
   version: {major: 1, minor: 1, patch: 0}
   subcontract_version: {major: 1, minor: 1, patch: 0}
-
   # Workflow Definition: Runtime lifecycle management
   workflow_definition:
     # Workflow Metadata
@@ -67,7 +65,7 @@ workflow_coordination:
       workflow_name: runtime_lifecycle
       workflow_version: {major: 1, minor: 0, patch: 0}
       description: ONEX runtime lifecycle management workflow - self-hosted runtime using 4-node architecture
-      execution_mode: sequential  # Runtime startup must be sequential
+      execution_mode: sequential # Runtime startup must be sequential
       author: ONEX Framework
       tags:
         - runtime
@@ -75,7 +73,6 @@ workflow_coordination:
         - lifecycle
         - kernel
       documentation_url: https://docs.onex.ai/runtime/orchestrator
-
     # Execution Graph: Runtime node relationships
     execution_graph:
       nodes:
@@ -93,18 +90,16 @@ workflow_coordination:
             contracts_dir: "${env.ONEX_CONTRACTS_DIR:./contracts}"
             pattern: "**/*.yaml"
             exclude_patterns:
-              # CRITICAL: Runtime contracts must be excluded from hot reload
-              # to prevent circular dependency. The runtime cannot reload its
-              # own contract definition while running - this is a bootstrapping
-              # constraint similar to how an OS kernel cannot update itself
-              # without a reboot. See "Design Decisions" in header comments.
-              - "**/runtime/**"
               # Internal/partial contracts not meant for direct instantiation.
               # These are fragments or templates included by other contracts.
               - "**/_*.yaml"
+            reload_exclude_patterns:
+              # CRITICAL: Runtime contracts must be excluded from hot reload
+              # to prevent circular dependency. Initial load must still scan
+              # them because this graph references runtime/*.yaml contracts.
+              - "**/runtime/**"
             watch_mode: false
             scan_interval_ms: 300000
-
         # ─────────────────────────────────────────────────────────────
         # REDUCER: Contract Registry
         # Maintains state of loaded/compiled contracts
@@ -122,7 +117,6 @@ workflow_coordination:
             max_contracts: 1000
             validation_strict: true
             cache_compiled_contracts: true
-
         # ─────────────────────────────────────────────────────────────
         # REDUCER: Node Graph Manager
         # Maintains instantiated node graph state
@@ -140,7 +134,6 @@ workflow_coordination:
             max_nodes: 500
             enable_hot_reload: true
             dependency_resolution: topological
-
         # ─────────────────────────────────────────────────────────────
         # EFFECT: Event Bus Wiring
         # Wires nodes to event bus subscriptions
@@ -157,7 +150,6 @@ workflow_coordination:
             event_bus_type: "${env.ONEX_EVENT_BUS:inmemory}"
             subscription_timeout_ms: 5000
             retry_on_failure: true
-
       # Execution edges (derived from depends_on)
       edges:
         - from_node: contract_loader
@@ -172,42 +164,34 @@ workflow_coordination:
           to_node: event_bus_wiring
           edge_type: data_flow
           description: Instantiated nodes flow to wiring for event subscriptions
-
     # Coordination Rules: Runtime startup coordination
     coordination_rules:
       # Sequential execution for startup (order matters)
       parallel_execution_allowed: false
       max_parallel_steps: 1
-
       # Failure recovery strategy
-      failure_recovery_strategy: fail_fast  # Runtime startup must succeed
+      failure_recovery_strategy: fail_fast # Runtime startup must succeed
       max_retries: 3
       retry_backoff_ms: 2000
       retry_backoff_multiplier: 2.0
-
       # Timeout configuration
-      timeout_ms: 120000  # 2 minutes total startup timeout
-      step_timeout_ms: 30000  # 30 seconds per step
-
+      timeout_ms: 120000 # 2 minutes total startup timeout
+      step_timeout_ms: 30000 # 30 seconds per step
       # Dependency resolution
       dependency_resolution_enabled: true
       detect_cycles: true
       fail_on_cycle: true
-
       # Runtime must fully start
       allow_partial_completion: false
       min_required_steps_completion_percent: 100.0
-
       # Resource constraints for runtime
       resource_constraints:
         max_memory_mb: 512
         max_cpu_cores: 2
-
       # Monitoring and observability
       emit_step_metrics: true
       emit_workflow_events: true
       emit_dependency_graph: true
-
   # Lifecycle configuration for runtime
   lifecycle:
     startup_sequence:
@@ -222,7 +206,6 @@ workflow_coordination:
       - contract_loader
     health_check_interval_ms: 30000
     graceful_shutdown_timeout_ms: 60000
-
   # Event bus declarations for runtime management
   event_bus:
     subscribe_topics:
@@ -248,7 +231,6 @@ workflow_coordination:
         description: Runtime encountered a critical error
         payload_schema: ModelRuntimeErrorEvent
         provisioning_priority: 20
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Timing Constraints Validation
 # ─────────────────────────────────────────────────────────────────────────────
@@ -271,7 +253,6 @@ timing_constraints:
 
     Formula: sum(min(base_delay * 2^i, max_delay)) * (1 + jitter_factor)
     for i in 0..(max_retries-1)
-
   validations:
     # contract_loader_effect.yaml - scan_contracts_directory
     - operation: contract_loader.scan_contracts_directory
@@ -288,7 +269,6 @@ timing_constraints:
       margin_ms: 45625
       margin_percent: 76.0
       status: PASS
-
     # contract_loader_effect.yaml - read_contract_file
     - operation: contract_loader.read_contract_file
       contract_ref: runtime/contract_loader_effect.yaml
@@ -304,7 +284,6 @@ timing_constraints:
       margin_ms: 13460
       margin_percent: 89.7
       status: PASS
-
     # event_bus_wiring_effect.yaml - event_bus_wiring
     - operation: event_bus_wiring.subscribe
       contract_ref: runtime/event_bus_wiring_effect.yaml
@@ -320,40 +299,36 @@ timing_constraints:
       margin_ms: 52300
       margin_percent: 87.2
       status: PASS
-
     # runtime_orchestrator.yaml - coordination_rules (step-level retries)
     - operation: runtime_orchestrator.step_retry
       contract_ref: runtime/runtime_orchestrator.yaml
-      timeout_ms: 30000  # step_timeout_ms
+      timeout_ms: 30000 # step_timeout_ms
       retry_config:
         max_retries: 3
         base_delay_ms: 2000
-        backoff_strategy: exponential  # multiplier: 2.0
-        jitter_factor: 0.0  # No jitter specified
+        backoff_strategy: exponential # multiplier: 2.0
+        jitter_factor: 0.0 # No jitter specified
       calculation: "2000 + 4000 + 8000 = 14000ms"
       worst_case_retry_ms: 14000
       margin_ms: 16000
       margin_percent: 53.3
       status: PASS
-
   # Aggregate workflow timing
   workflow_timing:
-    total_workflow_timeout_ms: 120000  # 2 minutes
-    step_timeout_ms: 30000  # 30 seconds per step
-    total_steps: 4  # contract_loader, contract_registry, node_graph, event_bus_wiring
-    worst_case_sequential_execution_ms: 120000  # 4 steps * 30s = 120s (at limit)
+    total_workflow_timeout_ms: 120000 # 2 minutes
+    step_timeout_ms: 30000 # 30 seconds per step
+    total_steps: 4 # contract_loader, contract_registry, node_graph, event_bus_wiring
+    worst_case_sequential_execution_ms: 120000 # 4 steps * 30s = 120s (at limit)
     note: |
       The workflow timeout equals the sum of step timeouts (4 * 30s = 120s).
       This is acceptable because steps execute sequentially and each step
       has sufficient retry margin within its own timeout.
-
   # Notes on REDUCER contracts
   reducer_notes: |
     contract_registry_reducer.yaml and node_graph_reducer.yaml do not define
     explicit retry policies. These REDUCER nodes use FSM state transitions
     with short action timeouts (100ms-5000ms). Retry behavior for these nodes
     is managed at the orchestrator level via coordination_rules.
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Performance Benchmarks
 # ─────────────────────────────────────────────────────────────────────────────
@@ -369,7 +344,6 @@ timing_constraints:
 # ─────────────────────────────────────────────────────────────────────────────
 performance_benchmarks:
   description: Expected performance characteristics for runtime orchestrator operations
-
   methodology:
     measurement_percentile: p99
     warmup_iterations: 3
@@ -378,7 +352,6 @@ performance_benchmarks:
       storage: SSD
       cpu_cores: 4
       memory_gb: 8
-
   # Contract Scanning (contract_loader Effect node)
   contract_scanning:
     description: Filesystem traversal to discover YAML contract files
@@ -400,7 +373,6 @@ performance_benchmarks:
         target: "<50"
         conditions: "1000 contracts loaded"
     scaling: Linear with contract count
-
   # Contract Validation (contract_registry Reducer node)
   contract_validation:
     description: YAML parsing, schema validation, and contract compilation
@@ -422,7 +394,6 @@ performance_benchmarks:
         target: ">0.95"
         conditions: "Steady state after initial load"
     scaling: CPU-bound; benefits from parallel validation
-
   # Node Wiring (event_bus_wiring Effect node)
   event_bus_wiring:
     description: Creating event bus subscriptions for instantiated nodes
@@ -444,7 +415,6 @@ performance_benchmarks:
         target: "<5000"
         conditions: "100 subscriptions, Kafka event bus"
     scaling: In-memory ~5x faster than external brokers
-
   # End-to-End Runtime Startup
   runtime_startup:
     description: Complete runtime initialization from cold start to ready
@@ -466,12 +436,10 @@ performance_benchmarks:
       contract_validation: 30
       node_instantiation: 20
       event_bus_wiring: 40
-
   # Regression Detection
   regression_thresholds:
-    warning_multiplier: 1.5  # Flag if 50% slower than target
-    critical_multiplier: 2.0  # Fail if 2x slower than target
-
+    warning_multiplier: 1.5 # Flag if 50% slower than target
+    critical_multiplier: 2.0 # Fail if 2x slower than target
 # v1.1.0 Required Fields
 handlers:
   required:
@@ -480,13 +448,11 @@ handlers:
   optional:
     - type: ProtocolLogger
       version: {major: 1, minor: 0, patch: 0}
-
 profile_tags:
   - runtime
   - orchestrator
   - kernel
   - lifecycle
-
 # Metadata
 metadata:
   version: {major: 1, minor: 1, patch: 0}
@@ -499,7 +465,6 @@ metadata:
     - self-hosted
     - lifecycle
   documentation_url: https://docs.onex.ai/runtime/orchestrator
-
   # Design Decisions Documentation
   # These decisions are architectural constraints that affect runtime behavior
   design_decisions:
@@ -525,7 +490,6 @@ metadata:
         - "OS kernel hot-patching constraints"
         - "JVM class reloading limitations"
         - "Database schema migration patterns"
-
     - decision: internal_contract_exclusion
       rationale: |
         Contracts prefixed with underscore (_*.yaml) are treated as internal
@@ -538,7 +502,6 @@ metadata:
       alternatives_considered:
         - "Separate 'fragments/' directory (adds complexity)"
         - "Explicit 'fragment: true' field (requires schema changes)"
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Integration Testing Requirements
 # ─────────────────────────────────────────────────────────────────────────────
@@ -548,7 +511,6 @@ metadata:
 integration_testing:
   description: End-to-end tests for runtime lifecycle orchestration
   test_location: tests/integration/runtime/test_runtime_orchestrator.py
-
   # Test Fixtures
   fixtures:
     mock_event_bus:
@@ -560,13 +522,12 @@ integration_testing:
     mock_contracts_dir:
       description: Temp directory with valid/invalid contract YAML files
       contents:
-        - valid_compute.yaml  # Valid COMPUTE contract
-        - valid_effect.yaml  # Valid EFFECT contract
-        - _internal.yaml  # Should be excluded (underscore prefix)
-        - invalid.yaml  # Malformed YAML for error testing
+        - valid_compute.yaml # Valid COMPUTE contract
+        - valid_effect.yaml # Valid EFFECT contract
+        - _internal.yaml # Should be excluded (underscore prefix)
+        - invalid.yaml # Malformed YAML for error testing
     mock_container:
       description: ModelONEXContainer with mock services registered
-
   # Test Scenarios
   scenarios:
     - name: successful_startup
@@ -585,7 +546,6 @@ integration_testing:
       expected_fsm_states:
         contract_registry: ready
         node_graph: running
-
     - name: graceful_shutdown
       description: Verify shutdown sequence executes in reverse order
       precondition: Runtime in 'running' state
@@ -604,7 +564,6 @@ integration_testing:
         - onex.evt.runtime.shutting-down.v1
       expected_fsm_states:
         node_graph: stopped
-
     - name: startup_failure_contract_loader
       description: Verify fail-fast on contract loading errors
       setup: mock_contracts_dir contains only invalid YAML
@@ -616,7 +575,6 @@ integration_testing:
       expected_events:
         - onex.evt.runtime.error.v1
       expected_error_code: CONTRACT_VALIDATION_FAILED
-
     - name: startup_failure_node_instantiation
       description: Verify fail-fast when node instantiation fails
       setup: Valid contracts but missing required service in container
@@ -630,7 +588,6 @@ integration_testing:
       expected_events:
         - onex.evt.runtime.error.v1
       expected_error_code: NODE_INSTANTIATION_FAILED
-
     - name: retry_behavior
       description: Verify retry with exponential backoff
       setup: contract_loader fails twice then succeeds
@@ -644,8 +601,7 @@ integration_testing:
       expected_events:
         - onex.evt.runtime.ready.v1
       timing_assertions:
-        - min_total_time_ms: 6000  # 2000 + 4000
-
+        - min_total_time_ms: 6000 # 2000 + 4000
     - name: timeout_enforcement
       description: Verify step timeout kills hanging operations
       setup: contract_loader hangs indefinitely
@@ -657,7 +613,6 @@ integration_testing:
       expected_events:
         - onex.evt.runtime.error.v1
       expected_error_code: STEP_TIMEOUT
-
   # Assertions Checklist
   assertions:
     event_ordering:
@@ -674,7 +629,6 @@ integration_testing:
       - Total startup < 120000ms (workflow timeout)
       - Each step < 30000ms (step timeout)
       - Retry delays match exponential backoff config
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Operational Monitoring
 # ─────────────────────────────────────────────────────────────────────────────
@@ -686,7 +640,6 @@ operational_monitoring:
   description: |
     Operational guidance for monitoring the ONEX runtime in production.
     Covers health endpoints, metrics, alerting, and log analysis.
-
   # Health check endpoints exposed by the runtime
   health_endpoints:
     - path: /health/runtime
@@ -709,7 +662,6 @@ operational_monitoring:
         - state: Current node FSM state
         - last_event_processed: Timestamp of last event processed
         - error_count: Number of errors since startup
-
   # Key metrics (Prometheus/OpenTelemetry compatible)
   key_metrics:
     # Runtime state
@@ -718,54 +670,44 @@ operational_monitoring:
       labels: [state]
       description: Current runtime FSM state (1 for active state, 0 otherwise)
       states: [initializing, wiring, running, draining, stopped]
-
     - name: onex_runtime_uptime_seconds
       type: counter
       description: Seconds since runtime entered 'running' state
-
     - name: onex_runtime_startup_duration_seconds
       type: histogram
       description: Time taken for runtime startup sequence
       buckets: [0.5, 1, 2, 5, 10, 30, 60, 120]
-
     # Node health
     - name: onex_node_state
       type: gauge
       labels: [node_id, node_type, state]
       description: Current FSM state per node (1 for active state)
-
     - name: onex_node_events_processed_total
       type: counter
       labels: [node_id, node_type, event_type]
       description: Total events processed by each node
-
     - name: onex_node_event_processing_duration_seconds
       type: histogram
       labels: [node_id, node_type]
       description: Event processing latency per node
       buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5]
-
     # Errors
     - name: onex_node_errors_total
       type: counter
       labels: [node_id, node_type, error_code]
       description: Total errors by node and error code
-
     - name: onex_runtime_errors_total
       type: counter
       labels: [error_code, severity]
       description: Total runtime-level errors
-
     # Contracts
     - name: onex_contracts_loaded_total
       type: gauge
       description: Number of contracts loaded in registry
-
     - name: onex_contract_reload_duration_seconds
       type: histogram
       description: Time taken to reload contracts
       buckets: [0.1, 0.5, 1, 2, 5, 10, 30]
-
   # Alerting thresholds
   alerting:
     critical:
@@ -773,33 +715,27 @@ operational_monitoring:
         condition: onex_runtime_state{state="running"} == 0 for 30s
         description: Runtime is not in running state
         action: Check runtime logs, verify startup sequence completed
-
       - name: NodeErrorSpike
         condition: rate(onex_node_errors_total[1m]) > 10
         description: Rapid increase in node errors (>10/min)
         action: Check node logs for error_code, review recent contract changes
-
       - name: RuntimeStartupTimeout
         condition: onex_runtime_startup_duration_seconds > 120
         description: Runtime startup exceeded 2-minute timeout
         action: Review contract loader performance, check filesystem access
-
     warning:
       - name: NodeDrainingTooLong
         condition: onex_node_state{state="draining"} == 1 for 60s
         description: Node stuck in draining state
         action: Check for pending events, review graceful shutdown logic
-
       - name: HighEventLatency
         condition: histogram_quantile(0.99, onex_node_event_processing_duration_seconds) > 1
         description: P99 event processing latency exceeds 1 second
         action: Profile node processing, check for blocking operations
-
       - name: NoContractsLoaded
         condition: onex_contracts_loaded_total < 1
         description: No contracts loaded in registry
         action: Verify contracts directory path, check file permissions
-
   # Dashboard recommendations
   dashboards:
     overview:
@@ -817,7 +753,6 @@ operational_monitoring:
         - name: Error Rate
           type: time_series
           description: Errors/minute by severity
-
     node_details:
       title: ONEX Node Details
       variables: [node_id]
@@ -830,7 +765,6 @@ operational_monitoring:
           type: pie_chart
         - name: Errors by Code
           type: bar_chart
-
   # Log patterns to monitor
   log_patterns:
     required_fields:
@@ -839,28 +773,23 @@ operational_monitoring:
       - event_type: Event being processed
       - fsm_state: Current FSM state
       - timestamp: ISO8601 timestamp
-
     watch_patterns:
       - pattern: "fsm_transition_failed"
         severity: error
         description: FSM could not transition to expected state
         investigation: Check valid transitions in contract, review event payload
-
       - pattern: "contract_validation_error"
         severity: error
         description: Contract failed validation during load
         investigation: Review contract YAML syntax, check schema version
-
       - pattern: "event_bus_connection_lost"
         severity: critical
         description: Lost connection to event bus
         investigation: Check network connectivity, verify event bus service
-
       - pattern: "retry_exhausted"
         severity: warning
         description: Operation failed after all retries
         investigation: Review timeout vs retry config, check external deps
-
       - pattern: "graceful_shutdown_timeout"
         severity: warning
         description: Shutdown did not complete within timeout

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -150,6 +150,9 @@ x-runtime-env: &runtime-env
   ONEX_RUNTIME_CONTRACTS_DIR: /app/contracts/runtime
   ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}
   ONEX_ENVIRONMENT: ${ONEX_ENVIRONMENT:-local}
+  # Local Docker Redpanda cannot absorb hundreds of six-partition contract topics
+  # on constrained laptops. Operators can unset or raise this for larger brokers.
+  ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-1}
   # Linear API for build loop ticket fetching
   LINEAR_API_KEY: ${LINEAR_API_KEY:?LINEAR_API_KEY must be set}
   # --- Infisical config (OMN-5382: removed from base env — injected per-bundle) ---
@@ -182,10 +185,12 @@ x-runtime-env: &runtime-env
   # This is the single runtime ingress for marketplace-packaged skills.
   ONEX_MARKETPLACE_SKILLS_ROOT: ${ONEX_MARKETPLACE_SKILLS_ROOT:-/app/skills}
   # --- Infisical config store ---
-  INFISICAL_ADDR: ${INFISICAL_ADDR:-}
-  INFISICAL_CLIENT_ID: ${INFISICAL_CLIENT_ID:-}
-  INFISICAL_CLIENT_SECRET: ${INFISICAL_CLIENT_SECRET:-}
-  INFISICAL_PROJECT_ID: ${INFISICAL_PROJECT_ID:-}
+  # Runtime config prefetch is opt-in for local Docker. Use ONEX_RUNTIME_INFISICAL_*
+  # so host-level INFISICAL_* variables do not accidentally enable it.
+  INFISICAL_ADDR: ${ONEX_RUNTIME_INFISICAL_ADDR:-}
+  INFISICAL_CLIENT_ID: ${ONEX_RUNTIME_INFISICAL_CLIENT_ID:-}
+  INFISICAL_CLIENT_SECRET: ${ONEX_RUNTIME_INFISICAL_CLIENT_SECRET:-}
+  INFISICAL_PROJECT_ID: ${ONEX_RUNTIME_INFISICAL_PROJECT_ID:-}
   # OMN-5381: Containers always use event routing. Host-side USE_EVENT_ROUTING is for local dev scripts.
   USE_EVENT_ROUTING: "true"
   # --- Keycloak / Auth (auth profile, OMN-3361) ---

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -151,8 +151,8 @@ x-runtime-env: &runtime-env
   ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}
   ONEX_ENVIRONMENT: ${ONEX_ENVIRONMENT:-local}
   # Local Docker Redpanda can cap contract topic partitions on constrained laptops.
-  # Leave unset/empty to use contract-declared partition counts.
-  ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-}
+  # Use 0 to keep contract-declared partition counts.
+  ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-0}
   # Linear API for build loop ticket fetching
   LINEAR_API_KEY: ${LINEAR_API_KEY:?LINEAR_API_KEY must be set}
   # --- Infisical config (OMN-5382: removed from base env — injected per-bundle) ---

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -150,9 +150,9 @@ x-runtime-env: &runtime-env
   ONEX_RUNTIME_CONTRACTS_DIR: /app/contracts/runtime
   ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}
   ONEX_ENVIRONMENT: ${ONEX_ENVIRONMENT:-local}
-  # Local Docker Redpanda cannot absorb hundreds of six-partition contract topics
-  # on constrained laptops. Operators can unset or raise this for larger brokers.
-  ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-1}
+  # Local Docker Redpanda can cap contract topic partitions on constrained laptops.
+  # Leave unset/empty to use contract-declared partition counts.
+  ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-}
   # Linear API for build loop ticket fetching
   LINEAR_API_KEY: ${LINEAR_API_KEY:?LINEAR_API_KEY must be set}
   # --- Infisical config (OMN-5382: removed from base env — injected per-bundle) ---
@@ -191,6 +191,7 @@ x-runtime-env: &runtime-env
   INFISICAL_CLIENT_ID: ${ONEX_RUNTIME_INFISICAL_CLIENT_ID:-}
   INFISICAL_CLIENT_SECRET: ${ONEX_RUNTIME_INFISICAL_CLIENT_SECRET:-}
   INFISICAL_PROJECT_ID: ${ONEX_RUNTIME_INFISICAL_PROJECT_ID:-}
+  INFISICAL_ENVIRONMENT: ${ONEX_RUNTIME_INFISICAL_ENVIRONMENT:-}
   # OMN-5381: Containers always use event routing. Host-side USE_EVENT_ROUTING is for local dev scripts.
   USE_EVENT_ROUTING: "true"
   # --- Keycloak / Auth (auth profile, OMN-3361) ---

--- a/scripts/register-repo.py
+++ b/scripts/register-repo.py
@@ -361,6 +361,11 @@ def _services_keys(
                 raise ValueError(
                     f"[ERROR] registry 'services.{repo}' keys must be strings (transports) in {_REGISTRY_PATH}"
                 )
+            if not re.fullmatch(r"[A-Za-z0-9_-]+", transport):
+                raise ValueError(
+                    f"[ERROR] registry 'services.{repo}' transport {transport!r} "
+                    f"contains invalid path characters in {_REGISTRY_PATH}"
+                )
             if not isinstance(keys, list):
                 raise ValueError(
                     f"Expected 'services.{repo}.{transport}' in {_REGISTRY_PATH} to be a list, "

--- a/scripts/register-repo.py
+++ b/scripts/register-repo.py
@@ -950,18 +950,6 @@ def cmd_onboard_repo(args: argparse.Namespace) -> int:
 
     path_prefix = f"/services/{repo_name}"
 
-    # Identify repo-specific secrets to seed.
-    # Keys missing from the env file are intentionally seeded as empty strings —
-    # they reserve the Infisical slot so the runtime can update_secret without a
-    # prior create step. Per-service identity (e.g. POSTGRES_DATABASE) is baked
-    # into each repo's Settings class as a default= and is NOT seeded here.
-    plan: list[tuple[str, str, str]] = []
-    for key in REPO_SECRET_KEYS:
-        value = env_values.get(key, "")
-        plan.append((f"{path_prefix}/db/", key, value))
-
-    # Any extra keys in the env file that are NOT in shared, NOT bootstrap,
-    # and NOT an identity default (per-repo value baked into Settings.default=).
     try:
         registry_data = _read_registry_data()
     except FileNotFoundError as e:
@@ -974,6 +962,25 @@ def cmd_onboard_repo(args: argparse.Namespace) -> int:
     shared_keys_flat = {k for keys in registry.values() for k in keys}
     bootstrap = _bootstrap_keys(registry_data)
     identity = _identity_defaults(registry_data)
+
+    # Identify repo-specific secrets to seed.
+    # Keys missing from the env file are intentionally seeded as empty strings —
+    # they reserve the Infisical slot so the runtime can update_secret without a
+    # prior create step. Per-service keys declared in shared_key_registry.yaml
+    # are authoritative and are seeded to /services/<repo>/<transport>/.
+    plan: list[tuple[str, str, str]] = []
+    for key in REPO_SECRET_KEYS:
+        value = env_values.get(key, "")
+        plan.append((f"{path_prefix}/db/", key, value))
+
+    service_key_map = _services_keys(registry_data).get(repo_name, {})
+    for transport, keys in sorted(service_key_map.items()):
+        for key in keys:
+            value = env_values.get(key, "")
+            plan.append((f"{path_prefix}/{transport}/", key, value))
+
+    # Any extra keys in the env file that are NOT in shared, NOT bootstrap,
+    # and NOT an identity default (per-repo value baked into Settings.default=).
     # Build a set of keys already in the plan (from REPO_SECRET_KEYS) for O(1)
     # duplicate detection.  Without this, the inner check would be O(n*m).
     planned_keys: set[str] = {pk for _, pk, _ in plan}
@@ -1089,7 +1096,7 @@ def cmd_onboard_repo(args: argparse.Namespace) -> int:
         admin_token,
         project_id,
         f"{path_prefix}/",
-        list(REPO_TRANSPORT_FOLDERS),
+        sorted(set(REPO_TRANSPORT_FOLDERS) | set(service_key_map)),
     )
 
     print("Seeding repo-specific secrets...")

--- a/scripts/register-repo.py
+++ b/scripts/register-repo.py
@@ -976,8 +976,9 @@ def cmd_onboard_repo(args: argparse.Namespace) -> int:
     service_key_map = _services_keys(registry_data).get(repo_name, {})
     for transport, keys in sorted(service_key_map.items()):
         for key in keys:
-            value = env_values.get(key, "")
-            plan.append((f"{path_prefix}/{transport}/", key, value))
+            value = env_values.get(key)
+            if value:
+                plan.append((f"{path_prefix}/{transport}/", key, value))
 
     # Any extra keys in the env file that are NOT in shared, NOT bootstrap,
     # and NOT an identity default (per-repo value baked into Settings.default=).

--- a/scripts/register-repo.py
+++ b/scripts/register-repo.py
@@ -316,6 +316,69 @@ def _service_override_required(
     return frozenset(keys)
 
 
+def _services_keys(
+    data: dict[str, object] | None = None,
+) -> dict[str, dict[str, list[str]]]:
+    """Load the per-service keys section from the registry (added in 1.2).
+
+    Returns a mapping ``{repo: {transport: [key, ...]}}``. Each entry maps to
+    the Infisical path ``/services/<repo>/<transport>/<KEY>`` — these are the
+    per-service overrides that take precedence over ``/shared/<transport>/<KEY>``
+    at runtime.
+
+    Args:
+        data: Pre-loaded registry dict from :func:`_read_registry_data`.  When
+            provided the file is not re-read; when omitted the file is read
+            once inside this function.
+
+    The section is optional — registries without it return an empty mapping
+    so older test fixtures continue to load.
+    """
+    if data is None:
+        data = _read_registry_data()
+    services = data.get("services")
+    if services is None:
+        return {}
+    if not isinstance(services, dict):
+        raise ValueError(
+            f"Expected 'services' in {_REGISTRY_PATH} to be a mapping, "
+            f"got {type(services).__name__!r}."
+        )
+    result: dict[str, dict[str, list[str]]] = {}
+    for repo, transports in services.items():
+        if not isinstance(repo, str):
+            raise ValueError(
+                f"[ERROR] registry 'services' keys must be strings (repo names) in {_REGISTRY_PATH}"
+            )
+        if not isinstance(transports, dict):
+            raise ValueError(
+                f"Expected 'services.{repo}' in {_REGISTRY_PATH} to be a mapping, "
+                f"got {type(transports).__name__!r}."
+            )
+        result[repo] = {}
+        for transport, keys in transports.items():
+            if not isinstance(transport, str):
+                raise ValueError(
+                    f"[ERROR] registry 'services.{repo}' keys must be strings (transports) in {_REGISTRY_PATH}"
+                )
+            if not isinstance(keys, list):
+                raise ValueError(
+                    f"Expected 'services.{repo}.{transport}' in {_REGISTRY_PATH} to be a list, "
+                    f"got {type(keys).__name__!r}."
+                )
+            if not keys:
+                raise ValueError(
+                    f"Folder 'services.{repo}.{transport}' has an empty key list in registry — "
+                    "this is likely an authoring error"
+                )
+            if not all(isinstance(k, str) for k in keys):
+                raise ValueError(
+                    f"[ERROR] registry 'services.{repo}.{transport}' must be a list of strings in {_REGISTRY_PATH}"
+                )
+            result[repo][transport] = list(keys)
+    return result
+
+
 # Per-repo folders to create under /services/<repo>/
 REPO_TRANSPORT_FOLDERS = ("db", "kafka", "env")
 

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -43,18 +43,6 @@ ENV_TOPIC_PARTITION_CAP = "ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS"
 DEFAULT_EVENT_TOPIC_PARTITIONS = 6
 DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR = 1
 
-_CRITICAL_STARTUP_TOPICS: tuple[str, ...] = (
-    "onex.evt.omnibase-infra.runtime-health-check.v1",
-    "onex.evt.platform.node-introspection.v1",
-    "onex.evt.platform.registration-completed.v1",
-)
-
-_STARTUP_TOPIC_PREFIXES: tuple[str, ...] = (
-    "onex.evt.platform.",
-    "onex.intent.platform.",
-)
-"""Topics required for runtime boot, health, and registration must be first."""
-
 
 def _topic_partition_cap_from_env() -> int | None:
     raw_value = os.environ.get(ENV_TOPIC_PARTITION_CAP)
@@ -83,14 +71,8 @@ def _topic_partition_cap_from_env() -> int | None:
 
 
 def _topic_provisioning_sort_key(spec: ModelTopicSpec) -> tuple[int, str]:
-    """Sort critical runtime topics before the broad plugin topic surface."""
-    if spec.suffix in _CRITICAL_STARTUP_TOPICS:
-        priority = 0
-    elif spec.suffix.startswith(_STARTUP_TOPIC_PREFIXES):
-        priority = 1
-    else:
-        priority = 2
-    return (priority, spec.suffix)
+    """Sort topics using contract-declared provisioning priority."""
+    return (spec.provisioning_priority, spec.suffix)
 
 
 class TopicProvisioner:
@@ -190,7 +172,12 @@ class TopicProvisioner:
 
         result_specs: list[ModelTopicSpec] = []
         for entry in contract_entries:
-            result_specs.append(ModelTopicSpec(suffix=entry.topic))
+            result_specs.append(
+                ModelTopicSpec(
+                    suffix=entry.topic,
+                    provisioning_priority=entry.provisioning_priority,
+                )
+            )
 
         result = tuple(sorted(result_specs, key=_topic_provisioning_sort_key))
 

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -59,9 +59,12 @@ def _topic_partition_cap_from_env() -> int | None:
         )
         return None
 
-    if cap <= 0:
+    if cap == 0:
+        return None
+
+    if cap < 0:
         logger.warning(
-            "Ignoring invalid %s=%r; expected a positive integer",
+            "Ignoring invalid %s=%r; expected zero or a positive integer",
             ENV_TOPIC_PARTITION_CAP,
             raw_value,
         )

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -37,10 +37,60 @@ logger = logging.getLogger(__name__)
 
 # OMN-8783: No default — KAFKA_BOOTSTRAP_SERVERS must be set via overlay.
 ENV_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS"
+ENV_TOPIC_PARTITION_CAP = "ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS"
 
 # Default partition and replication settings for standard event topics
 DEFAULT_EVENT_TOPIC_PARTITIONS = 6
 DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR = 1
+
+_CRITICAL_STARTUP_TOPICS: tuple[str, ...] = (
+    "onex.evt.omnibase-infra.runtime-health-check.v1",
+    "onex.evt.platform.node-introspection.v1",
+    "onex.evt.platform.registration-completed.v1",
+)
+
+_STARTUP_TOPIC_PREFIXES: tuple[str, ...] = (
+    "onex.evt.platform.",
+    "onex.intent.platform.",
+)
+"""Topics required for runtime boot, health, and registration must be first."""
+
+
+def _topic_partition_cap_from_env() -> int | None:
+    raw_value = os.environ.get(ENV_TOPIC_PARTITION_CAP)
+    if raw_value is None or raw_value.strip() == "":
+        return None
+
+    try:
+        cap = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r; expected a positive integer",
+            ENV_TOPIC_PARTITION_CAP,
+            raw_value,
+        )
+        return None
+
+    if cap < 1:
+        logger.warning(
+            "Ignoring invalid %s=%r; expected a positive integer",
+            ENV_TOPIC_PARTITION_CAP,
+            raw_value,
+        )
+        return None
+
+    return cap
+
+
+def _topic_provisioning_sort_key(spec: ModelTopicSpec) -> tuple[int, str]:
+    """Sort critical runtime topics before the broad plugin topic surface."""
+    if spec.suffix in _CRITICAL_STARTUP_TOPICS:
+        priority = 0
+    elif spec.suffix.startswith(_STARTUP_TOPIC_PREFIXES):
+        priority = 1
+    else:
+        priority = 2
+    return (priority, spec.suffix)
 
 
 class TopicProvisioner:
@@ -106,7 +156,13 @@ class TopicProvisioner:
         self._contracts_root = contracts_root
         self._skill_manifests_root = skill_manifests_root
         self._skill_manifests_roots = skill_manifests_roots
+        self._topic_partition_cap = _topic_partition_cap_from_env()
         self._topic_specs = self._build_topic_specs()
+
+    def _creation_partitions(self, spec: ModelTopicSpec) -> int:
+        if self._topic_partition_cap is None:
+            return spec.partitions
+        return min(spec.partitions, self._topic_partition_cap)
 
     def _build_topic_specs(self) -> tuple[ModelTopicSpec, ...]:
         """Build topic specs from contract YAML extraction.
@@ -136,7 +192,7 @@ class TopicProvisioner:
         for entry in contract_entries:
             result_specs.append(ModelTopicSpec(suffix=entry.topic))
 
-        result = tuple(sorted(result_specs, key=lambda s: s.suffix))
+        result = tuple(sorted(result_specs, key=_topic_provisioning_sort_key))
 
         skill_count = len([e for e in contract_entries if "omniclaude" in e.topic])
         logger.info(
@@ -209,9 +265,10 @@ class TopicProvisioner:
 
             for spec in self._topic_specs:
                 try:
+                    partitions = self._creation_partitions(spec)
                     new_topic = NewTopic(
                         name=spec.suffix,
-                        num_partitions=spec.partitions,
+                        num_partitions=partitions,
                         replication_factor=spec.replication_factor,
                         topic_configs=dict(spec.kafka_config)
                         if spec.kafka_config
@@ -223,7 +280,7 @@ class TopicProvisioner:
                     logger.info(
                         "Created topic: %s (partitions=%d)",
                         spec.suffix,
-                        spec.partitions,
+                        partitions,
                         extra={"correlation_id": str(correlation_id)},
                     )
 

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -59,7 +59,7 @@ def _topic_partition_cap_from_env() -> int | None:
         )
         return None
 
-    if cap < 1:
+    if cap <= 0:
         logger.warning(
             "Ignoring invalid %s=%r; expected a positive integer",
             ENV_TOPIC_PARTITION_CAP,

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -257,11 +257,11 @@ def _extract_raw_topics_from_contract(
             # new-style: topic key
             topic_val = item.get("topic")
             if isinstance(topic_val, str) and topic_val:
-                raw_topics.append((topic_val, 100))
+                raw_topics.append((topic_val, _topic_priority(item)))
             # old-style: name key — extract both if both present
             name_val = item.get("name")
             if isinstance(name_val, str) and name_val:
-                raw_topics.append((name_val, 100))
+                raw_topics.append((name_val, _topic_priority(item)))
 
     return raw_topics
 

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -215,7 +215,7 @@ def _parse_topic(raw: str, source: Path) -> ModelContractTopicEntry | None:
 
 def _topic_priority(item: dict[object, object]) -> int:
     raw_priority = item.get("provisioning_priority", item.get("priority", 100))
-    if isinstance(raw_priority, int):
+    if isinstance(raw_priority, int) and not isinstance(raw_priority, bool):
         return raw_priority
     return 100
 

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -89,6 +89,7 @@ class ModelContractTopicEntry(BaseModel):
     event_name: str
     version: str  # e.g. "v1"
     source_contracts: tuple[Path, ...]
+    provisioning_priority: int = 100
 
     model_config = {"frozen": True}
 
@@ -97,7 +98,15 @@ class ModelContractTopicEntry(BaseModel):
         combined = tuple(
             sorted(set(self.source_contracts) | set(other.source_contracts))
         )
-        return self.model_copy(update={"source_contracts": combined})
+        return self.model_copy(
+            update={
+                "source_contracts": combined,
+                "provisioning_priority": min(
+                    self.provisioning_priority,
+                    other.provisioning_priority,
+                ),
+            }
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -204,16 +213,23 @@ def _parse_topic(raw: str, source: Path) -> ModelContractTopicEntry | None:
     )
 
 
+def _topic_priority(item: dict[object, object]) -> int:
+    raw_priority = item.get("provisioning_priority", item.get("priority", 100))
+    if isinstance(raw_priority, int):
+        return raw_priority
+    return 100
+
+
 def _extract_raw_topics_from_contract(
     data: dict[str, object], source: Path
-) -> list[str]:
+) -> list[tuple[str, int]]:
     """
     Extract all raw topic strings from a parsed contract YAML dict.
 
     Checks ALL applicable keys — no early break on first match.
     If a field has both 'topic' and 'name' values, extracts both.
     """
-    raw_topics: list[str] = []
+    raw_topics: list[tuple[str, int]] = []
 
     # --- event_bus.subscribe_topics / event_bus.publish_topics (new-style) ---
     event_bus = data.get("event_bus")
@@ -223,12 +239,12 @@ def _extract_raw_topics_from_contract(
             if isinstance(topics_list, list):
                 for item in topics_list:
                     if isinstance(item, str) and item:
-                        raw_topics.append(item)
+                        raw_topics.append((item, 100))
                     elif isinstance(item, dict):
                         # topic: "..." format inside subscribe_topics list
                         topic_val = item.get("topic")
                         if isinstance(topic_val, str) and topic_val:
-                            raw_topics.append(topic_val)
+                            raw_topics.append((topic_val, _topic_priority(item)))
 
     # --- consumed_events / published_events / produced_events ---
     for section_key in _EVENT_SECTION_KEYS:
@@ -241,11 +257,11 @@ def _extract_raw_topics_from_contract(
             # new-style: topic key
             topic_val = item.get("topic")
             if isinstance(topic_val, str) and topic_val:
-                raw_topics.append(topic_val)
+                raw_topics.append((topic_val, 100))
             # old-style: name key — extract both if both present
             name_val = item.get("name")
             if isinstance(name_val, str) and name_val:
-                raw_topics.append(name_val)
+                raw_topics.append((name_val, 100))
 
     return raw_topics
 
@@ -441,11 +457,14 @@ class ContractTopicExtractor:
 
             raw_topics = _extract_raw_topics_from_contract(raw_yaml, contract_path)
 
-            for raw in raw_topics:
+            for raw, provisioning_priority in raw_topics:
                 entry = _parse_topic(raw, contract_path)
                 if entry is None:
                     # Warned inside _parse_topic; skip
                     continue
+                entry = entry.model_copy(
+                    update={"provisioning_priority": provisioning_priority}
+                )
 
                 if raw in accumulated:
                     existing = accumulated[raw]
@@ -709,10 +728,13 @@ class ContractTopicExtractor:
 
                 raw_topics = _extract_raw_topics_from_contract(raw_yaml, contract_path)
 
-                for raw in raw_topics:
+                for raw, provisioning_priority in raw_topics:
                     entry = _parse_topic(raw, contract_path)
                     if entry is None:
                         continue
+                    entry = entry.model_copy(
+                        update={"provisioning_priority": provisioning_priority}
+                    )
 
                     if raw in accumulated:
                         existing = accumulated[raw]

--- a/src/omnibase_infra/topics/model_topic_spec.py
+++ b/src/omnibase_infra/topics/model_topic_spec.py
@@ -43,12 +43,14 @@ class ModelTopicSpec:
         partitions: Number of partitions for the topic.
         replication_factor: Replication factor for the topic.
         kafka_config: Optional Kafka topic config overrides (e.g., {"cleanup.policy": "compact"}).
+        provisioning_priority: Lower values are provisioned first.
     """
 
     suffix: str
     partitions: int = DEFAULT_EVENT_TOPIC_PARTITIONS
     replication_factor: int = DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR
     kafka_config: Mapping[str, str] | None = field(default=None)
+    provisioning_priority: int = 100
 
     def __post_init__(self) -> None:
         """Freeze mutable kafka_config dict passed at construction time."""

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -78,6 +78,7 @@ SECRET_KEYS: frozenset[str] = frozenset(
         "INFISICAL_CLIENT_ID",
         "INFISICAL_CLIENT_SECRET",
         "INFISICAL_PROJECT_ID",
+        "INFISICAL_ENVIRONMENT",
         "INFISICAL_ENCRYPTION_KEY",
         "INFISICAL_AUTH_SECRET",
         # Per-service database DSNs — contain credentials, sourced from Infisical at runtime

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -122,6 +122,8 @@ LOCAL_ONLY_KEYS: frozenset[str] = frozenset(
         "LLM_CODER_FAST_URL",
         "LLM_EMBEDDING_URL",
         "LLM_DEEPSEEK_R1_URL",
+        # Topic provisioner partition cap — local-only tuning knob; k8s does not set it
+        "ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS",
     }
 )
 

--- a/tests/integration/event_bus/test_topic_provisioner_integration.py
+++ b/tests/integration/event_bus/test_topic_provisioner_integration.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for TopicProvisioner contract extraction and partition capping.
+
+Tests end-to-end behavior introduced in OMN-10534:
+- Contract-driven topic extraction from a real directory structure
+- Partition cap enforcement via ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS env var
+- Provisioning priority sort order respected across extracted topics
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def contracts_root_with_priority(tmp_path: Path) -> Path:
+    """Contracts directory with two nodes at different provisioning priorities."""
+    high_dir = tmp_path / "node_high"
+    high_dir.mkdir()
+    (high_dir / "contract.yaml").write_text(
+        "name: node_high\n"
+        "version: 1.0.0\n"
+        "namespace: onex.stamped\n"
+        "event_bus:\n"
+        "  publish_topics:\n"
+        "    - topic: onex.evt.test-high.ready.v1\n"
+        "      provisioning_priority: 10\n"
+    )
+
+    low_dir = tmp_path / "node_low"
+    low_dir.mkdir()
+    (low_dir / "contract.yaml").write_text(
+        "name: node_low\n"
+        "version: 1.0.0\n"
+        "namespace: onex.stamped\n"
+        "event_bus:\n"
+        "  publish_topics:\n"
+        "    - topic: onex.evt.test-low.events.v1\n"
+        "      provisioning_priority: 50\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def contracts_root_high_partition(tmp_path: Path) -> Path:
+    """Contracts directory with a topic declaring many partitions."""
+    node_dir = tmp_path / "node_partition"
+    node_dir.mkdir()
+    (node_dir / "contract.yaml").write_text(
+        "name: node_partition\n"
+        "version: 1.0.0\n"
+        "namespace: onex.stamped\n"
+        "event_bus:\n"
+        "  publish_topics:\n"
+        "    - topic: onex.evt.test-partition.data.v1\n"
+    )
+    return tmp_path
+
+
+class TestTopicProvisionerContractExtraction:
+    """End-to-end: contract extraction, sort order, and partition cap."""
+
+    def test_extracts_topics_from_contracts_directory(
+        self, contracts_root_with_priority: Path
+    ) -> None:
+        provisioner = TopicProvisioner(
+            bootstrap_servers="localhost:9092",
+            contracts_root=contracts_root_with_priority,
+        )
+        suffixes = [s.suffix for s in provisioner._topic_specs]
+        assert "onex.evt.test-high.ready.v1" in suffixes
+        assert "onex.evt.test-low.events.v1" in suffixes
+
+    def test_topics_sorted_by_provisioning_priority(
+        self, contracts_root_with_priority: Path
+    ) -> None:
+        provisioner = TopicProvisioner(
+            bootstrap_servers="localhost:9092",
+            contracts_root=contracts_root_with_priority,
+        )
+        suffixes = [s.suffix for s in provisioner._topic_specs]
+        high_idx = next(i for i, s in enumerate(suffixes) if "test-high" in s)
+        low_idx = next(i for i, s in enumerate(suffixes) if "test-low" in s)
+        assert high_idx < low_idx, (
+            "Higher-priority topic must sort before lower-priority"
+        )
+
+    def test_partition_cap_applied_when_env_set(
+        self, contracts_root_high_partition: Path
+    ) -> None:
+        with patch.dict(os.environ, {"ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS": "2"}):
+            provisioner = TopicProvisioner(
+                bootstrap_servers="localhost:9092",
+                contracts_root=contracts_root_high_partition,
+            )
+        for spec in provisioner._topic_specs:
+            assert provisioner._creation_partitions(spec) <= 2
+
+    def test_no_partition_cap_when_env_unset(
+        self, contracts_root_high_partition: Path
+    ) -> None:
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS"
+        }
+        with patch.dict(os.environ, env, clear=True):
+            provisioner = TopicProvisioner(
+                bootstrap_servers="localhost:9092",
+                contracts_root=contracts_root_high_partition,
+            )
+        assert provisioner._topic_partition_cap is None

--- a/tests/integration/event_bus/test_topic_provisioner_integration.py
+++ b/tests/integration/event_bus/test_topic_provisioner_integration.py
@@ -21,6 +21,10 @@ from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
 pytestmark = [pytest.mark.integration]
 
 
+def _bootstrap_servers() -> str:
+    return os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+
 @pytest.fixture
 def contracts_root_with_priority(tmp_path: Path) -> Path:
     """Contracts directory with two nodes at different provisioning priorities."""
@@ -73,7 +77,7 @@ class TestTopicProvisionerContractExtraction:
         self, contracts_root_with_priority: Path
     ) -> None:
         provisioner = TopicProvisioner(
-            bootstrap_servers="localhost:9092",
+            bootstrap_servers=_bootstrap_servers(),
             contracts_root=contracts_root_with_priority,
         )
         suffixes = [s.suffix for s in provisioner._topic_specs]
@@ -84,7 +88,7 @@ class TestTopicProvisionerContractExtraction:
         self, contracts_root_with_priority: Path
     ) -> None:
         provisioner = TopicProvisioner(
-            bootstrap_servers="localhost:9092",
+            bootstrap_servers=_bootstrap_servers(),
             contracts_root=contracts_root_with_priority,
         )
         suffixes = [s.suffix for s in provisioner._topic_specs]
@@ -99,7 +103,7 @@ class TestTopicProvisionerContractExtraction:
     ) -> None:
         with patch.dict(os.environ, {"ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS": "2"}):
             provisioner = TopicProvisioner(
-                bootstrap_servers="localhost:9092",
+                bootstrap_servers=_bootstrap_servers(),
                 contracts_root=contracts_root_high_partition,
             )
         for spec in provisioner._topic_specs:
@@ -115,7 +119,7 @@ class TestTopicProvisionerContractExtraction:
         }
         with patch.dict(os.environ, env, clear=True):
             provisioner = TopicProvisioner(
-                bootstrap_servers="localhost:9092",
+                bootstrap_servers=_bootstrap_servers(),
                 contracts_root=contracts_root_high_partition,
             )
         assert provisioner._topic_partition_cap is None

--- a/tests/unit/config/test_shared_key_registry_omnimarket.py
+++ b/tests/unit/config/test_shared_key_registry_omnimarket.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registry tests for OMN-10563: services.omnimarket section + 1.2 schema bump.
+
+Validates:
+1. Registry version bumped to 1.2.
+2. `services` section exists and parses correctly.
+3. `services.omnimarket` declares the keys named in the public-shippable plan
+   Task 16 (kafka.KAFKA_GROUP_ID, llm.LLM_*_URL/_MODEL_ID, db.POSTGRES_DATABASE).
+4. The new `_services_keys()` loader handles valid + invalid inputs without
+   regressing existing loaders (`_load_registry`, `_bootstrap_keys`,
+   `_identity_defaults`, `_service_override_required`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_REGISTRY_PATH = _REPO_ROOT / "config" / "shared_key_registry.yaml"
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "register-repo.py"
+
+
+@pytest.fixture(scope="module")
+def registry_data() -> dict[str, object]:
+    return yaml.safe_load(_REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def register_repo_module():  # type: ignore[no-untyped-def]
+    """Import scripts/register-repo.py as a module (filename has a hyphen)."""
+    spec = importlib.util.spec_from_file_location("register_repo", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["register_repo"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRegistryVersionBump:
+    def test_version_is_1_2(self, registry_data: dict[str, object]) -> None:
+        assert registry_data.get("version") == "1.2"
+
+    def test_top_level_sections_present(self, registry_data: dict[str, object]) -> None:
+        # All preexisting top-level sections must remain present after the
+        # 1.2 schema bump (regression guard).
+        for required in (
+            "shared",
+            "bootstrap_only",
+            "identity_defaults",
+            "service_override_required",
+            "services",
+        ):
+            assert required in registry_data, f"section {required!r} missing"
+
+
+class TestServicesOmnimarketSection:
+    def test_omnimarket_kafka_includes_group_id(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        services = registry_data["services"]
+        assert isinstance(services, dict)
+        omnimarket = services["omnimarket"]
+        assert "KAFKA_GROUP_ID" in omnimarket["kafka"]
+
+    def test_omnimarket_llm_lists_url_and_model_id_for_coder_and_reasoner(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        omnimarket = registry_data["services"]["omnimarket"]
+        llm_keys = set(omnimarket["llm"])
+        assert {
+            "LLM_CODER_URL",
+            "LLM_CODER_MODEL_ID",
+            "LLM_REASONER_URL",
+            "LLM_REASONER_MODEL_ID",
+        }.issubset(llm_keys)
+
+    def test_omnimarket_db_includes_postgres_database(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        omnimarket = registry_data["services"]["omnimarket"]
+        assert "POSTGRES_DATABASE" in omnimarket["db"]
+
+
+class TestServicesKeysLoader:
+    def test_loader_returns_omnimarket_block(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        result = register_repo_module._services_keys()
+        assert "omnimarket" in result
+        assert "KAFKA_GROUP_ID" in result["omnimarket"]["kafka"]
+        assert "POSTGRES_DATABASE" in result["omnimarket"]["db"]
+
+    def test_loader_returns_empty_dict_when_section_absent(
+        self, register_repo_module
+    ) -> None:  # type: ignore[no-untyped-def]
+        # Older registries without `services:` are still valid; loader returns {}.
+        result = register_repo_module._services_keys({"shared": {"/shared/x/": ["A"]}})
+        assert result == {}
+
+    def test_loader_rejects_non_mapping_services(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match=r"must be a mapping|to be a mapping"):
+            register_repo_module._services_keys({"services": ["omnimarket"]})
+
+    def test_loader_rejects_non_mapping_repo_block(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match="to be a mapping"):
+            register_repo_module._services_keys(
+                {"services": {"omnimarket": ["KAFKA_GROUP_ID"]}}
+            )
+
+    def test_loader_rejects_non_list_transport(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match="to be a list"):
+            register_repo_module._services_keys(
+                {"services": {"omnimarket": {"kafka": "KAFKA_GROUP_ID"}}}
+            )
+
+    def test_loader_rejects_empty_transport_list(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match="empty key list"):
+            register_repo_module._services_keys(
+                {"services": {"omnimarket": {"kafka": []}}}
+            )
+
+    def test_loader_rejects_non_string_keys(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match="must be a list of strings"):
+            register_repo_module._services_keys(
+                {"services": {"omnimarket": {"kafka": [123]}}}
+            )
+
+
+class TestExistingLoadersStillWork:
+    """Regression: 1.2 schema bump must not break existing loaders."""
+
+    def test_load_registry_still_returns_shared(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
+        result = register_repo_module._load_registry()
+        assert "/shared/db/" in result
+        assert "POSTGRES_HOST" in result["/shared/db/"]
+
+    def test_bootstrap_keys_still_includes_postgres_password(
+        self, register_repo_module
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = register_repo_module._bootstrap_keys()
+        assert "POSTGRES_PASSWORD" in result
+
+    def test_identity_defaults_still_includes_postgres_database(
+        self, register_repo_module
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = register_repo_module._identity_defaults()
+        assert "POSTGRES_DATABASE" in result
+
+    def test_service_override_required_still_includes_kafka_group_id(
+        self, register_repo_module
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = register_repo_module._service_override_required()
+        assert "KAFKA_GROUP_ID" in result

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -80,11 +80,59 @@ class TestTopicProvisioner:
         assert manager._bootstrap_servers == "kafka1:9092,kafka2:9092"
         assert manager._request_timeout_ms == 5000
 
+    def test_topic_partition_cap_from_env(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Local brokers can cap contract topic partition creation."""
+        monkeypatch.setenv("ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS", "1")
+
+        manager = _make_provisioner(contracts_root)
+
+        assert manager._creation_partitions(manager._topic_specs[0]) == 1
+
+    def test_invalid_topic_partition_cap_is_ignored(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invalid partition caps do not override contract topic specs."""
+        monkeypatch.setenv("ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS", "nope")
+
+        manager = _make_provisioner(contracts_root)
+
+        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+
     def test_init_missing_contracts_root_raises(self, tmp_path: Path) -> None:
         """Constructing with a non-existent contracts_root raises immediately."""
         bad_path = tmp_path / "does_not_exist"
         with pytest.raises(FileNotFoundError, match="contracts_root"):
             TopicProvisioner(contracts_root=bad_path)
+
+    def test_startup_critical_topics_are_ordered_first(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Runtime-critical platform topics are created before broad plugin topics."""
+        node_dir = tmp_path / "node_example"
+        node_dir.mkdir()
+        (node_dir / "contract.yaml").write_text(
+            "name: node_example\n"
+            "event_bus:\n"
+            "  publish_topics:\n"
+            "    - onex.cmd.omnimarket.build-loop-start.v1\n"
+            "    - onex.evt.platform.node-introspection.v1\n"
+            "    - onex.evt.omnibase-infra.runtime-health-check.v1\n",
+            encoding="utf-8",
+        )
+
+        manager = _make_provisioner(tmp_path)
+
+        assert [spec.suffix for spec in manager._topic_specs[:2]] == [
+            "onex.evt.omnibase-infra.runtime-health-check.v1",
+            "onex.evt.platform.node-introspection.v1",
+        ]
 
     async def test_ensure_provisioned_topics_all_created(
         self, contracts_root: Path

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+from omnibase_infra.topics.model_topic_spec import ModelTopicSpec
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.unit]
 
@@ -54,6 +55,10 @@ def _make_provisioner(
         bootstrap_servers=bootstrap_servers,
         contracts_root=contracts_root,
     )
+
+
+def _topic_spec(manager: TopicProvisioner, suffix: str) -> ModelTopicSpec:
+    return next(spec for spec in manager._topic_specs if spec.suffix == suffix)
 
 
 class TestTopicProvisioner:
@@ -90,7 +95,8 @@ class TestTopicProvisioner:
 
         manager = _make_provisioner(contracts_root)
 
-        assert manager._creation_partitions(manager._topic_specs[0]) == 1
+        spec = _topic_spec(manager, "onex.evt.test-producer.example-event.v1")
+        assert manager._creation_partitions(spec) == 1
 
     def test_invalid_topic_partition_cap_is_ignored(
         self,
@@ -102,7 +108,8 @@ class TestTopicProvisioner:
 
         manager = _make_provisioner(contracts_root)
 
-        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+        spec = _topic_spec(manager, "onex.evt.test-producer.example-event.v1")
+        assert manager._creation_partitions(spec) == 6
 
     def test_empty_topic_partition_cap_is_disabled(
         self,
@@ -114,7 +121,8 @@ class TestTopicProvisioner:
 
         manager = _make_provisioner(contracts_root)
 
-        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+        spec = _topic_spec(manager, "onex.evt.test-producer.example-event.v1")
+        assert manager._creation_partitions(spec) == 6
 
     def test_zero_topic_partition_cap_is_disabled(
         self,
@@ -127,7 +135,8 @@ class TestTopicProvisioner:
 
         manager = _make_provisioner(contracts_root)
 
-        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+        spec = _topic_spec(manager, "onex.evt.test-producer.example-event.v1")
+        assert manager._creation_partitions(spec) == 6
         assert not [
             record
             for record in caplog.records

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -104,17 +104,29 @@ class TestTopicProvisioner:
 
         assert manager._creation_partitions(manager._topic_specs[0]) == 6
 
+    def test_empty_topic_partition_cap_is_disabled(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Empty partition cap values leave contract topic specs unchanged."""
+        monkeypatch.setenv("ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS", "")
+
+        manager = _make_provisioner(contracts_root)
+
+        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+
     def test_init_missing_contracts_root_raises(self, tmp_path: Path) -> None:
         """Constructing with a non-existent contracts_root raises immediately."""
         bad_path = tmp_path / "does_not_exist"
         with pytest.raises(FileNotFoundError, match="contracts_root"):
             TopicProvisioner(contracts_root=bad_path)
 
-    def test_startup_critical_topics_are_ordered_first(
+    def test_contract_priority_topics_are_ordered_first(
         self,
         tmp_path: Path,
     ) -> None:
-        """Runtime-critical platform topics are created before broad plugin topics."""
+        """Contract-declared provisioning priority controls creation order."""
         node_dir = tmp_path / "node_example"
         node_dir.mkdir()
         (node_dir / "contract.yaml").write_text(
@@ -122,8 +134,10 @@ class TestTopicProvisioner:
             "event_bus:\n"
             "  publish_topics:\n"
             "    - onex.cmd.omnimarket.build-loop-start.v1\n"
-            "    - onex.evt.platform.node-introspection.v1\n"
-            "    - onex.evt.omnibase-infra.runtime-health-check.v1\n",
+            "    - topic: onex.evt.platform.node-introspection.v1\n"
+            "      provisioning_priority: 10\n"
+            "    - topic: onex.evt.omnibase-infra.runtime-health-check.v1\n"
+            "      provisioning_priority: 0\n",
             encoding="utf-8",
         )
 

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -116,6 +116,18 @@ class TestTopicProvisioner:
 
         assert manager._creation_partitions(manager._topic_specs[0]) == 6
 
+    def test_zero_topic_partition_cap_is_disabled(
+        self,
+        contracts_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Zero partition cap values leave contract topic specs unchanged."""
+        monkeypatch.setenv("ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS", "0")
+
+        manager = _make_provisioner(contracts_root)
+
+        assert manager._creation_partitions(manager._topic_specs[0]) == 6
+
     def test_init_missing_contracts_root_raises(self, tmp_path: Path) -> None:
         """Constructing with a non-existent contracts_root raises immediately."""
         bad_path = tmp_path / "does_not_exist"

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -120,13 +120,19 @@ class TestTopicProvisioner:
         self,
         contracts_root: Path,
         monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Zero partition cap values leave contract topic specs unchanged."""
+        """Zero partition cap values disable the cap without warnings."""
         monkeypatch.setenv("ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS", "0")
 
         manager = _make_provisioner(contracts_root)
 
         assert manager._creation_partitions(manager._topic_specs[0]) == 6
+        assert not [
+            record
+            for record in caplog.records
+            if "ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS" in record.message
+        ]
 
     def test_init_missing_contracts_root_raises(self, tmp_path: Path) -> None:
         """Constructing with a non-existent contracts_root raises immediately."""

--- a/tests/unit/event_bus/test_service_topic_manager.py
+++ b/tests/unit/event_bus/test_service_topic_manager.py
@@ -143,10 +143,16 @@ class TestTopicProvisioner:
 
         manager = _make_provisioner(tmp_path)
 
-        assert [spec.suffix for spec in manager._topic_specs[:2]] == [
-            "onex.evt.omnibase-infra.runtime-health-check.v1",
-            "onex.evt.platform.node-introspection.v1",
-        ]
+        ordered_suffixes = [spec.suffix for spec in manager._topic_specs]
+        health_idx = ordered_suffixes.index(
+            "onex.evt.omnibase-infra.runtime-health-check.v1"
+        )
+        introspection_idx = ordered_suffixes.index(
+            "onex.evt.platform.node-introspection.v1"
+        )
+        default_idx = ordered_suffixes.index("onex.cmd.omnimarket.build-loop-start.v1")
+
+        assert health_idx < introspection_idx < default_idx
 
     async def test_ensure_provisioned_topics_all_created(
         self, contracts_root: Path

--- a/tests/unit/infra/test_compose_no_silent_fallbacks.py
+++ b/tests/unit/infra/test_compose_no_silent_fallbacks.py
@@ -36,6 +36,12 @@ ALLOWED_EMPTY_DEFAULTS = {
     "INFISICAL_CLIENT_SECRET",
     "INFISICAL_PROJECT_ID",
     "INFISICAL_REQUIRED",
+    # Local Docker runtime prefetch remains opt-in through prefixed host vars.
+    "ONEX_RUNTIME_INFISICAL_ADDR",
+    "ONEX_RUNTIME_INFISICAL_CLIENT_ID",
+    "ONEX_RUNTIME_INFISICAL_CLIENT_SECRET",
+    "ONEX_RUNTIME_INFISICAL_PROJECT_ID",
+    "ONEX_RUNTIME_INFISICAL_ENVIRONMENT",
     # Keycloak: opt-in auth; empty = keycloak not configured
     "KEYCLOAK_ADMIN_CLIENT_SECRET",
 }

--- a/tests/unit/scripts/test_register_repo.py
+++ b/tests/unit/scripts/test_register_repo.py
@@ -287,6 +287,16 @@ class TestServiceOverrideRequired:
 
 class TestCmdOnboardRepoServiceKeys:
     @pytest.mark.unit
+    def test_services_reject_invalid_transport_segments(self) -> None:
+        rr = _module
+        data: dict[str, object] = {
+            "services": {"omnimarket": {"../llm": ["LLM_CODER_URL"]}},
+        }
+
+        with pytest.raises(ValueError, match="invalid path characters"):
+            rr._services_keys(data)  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
     def test_dry_run_includes_declared_service_keys(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/unit/scripts/test_register_repo.py
+++ b/tests/unit/scripts/test_register_repo.py
@@ -45,6 +45,7 @@ def _make_dry_run_args(env_file: str) -> argparse.Namespace:
     """Build a minimal Namespace that mimics --dry-run (no --execute)."""
     return argparse.Namespace(
         env_file=env_file,
+        repo="omnimarket",
         execute=False,
         overwrite=False,
     )
@@ -282,6 +283,57 @@ class TestServiceOverrideRequired:
 
         with pytest.raises(ValueError, match="must be a list"):
             rr._service_override_required(data)  # type: ignore[attr-defined]
+
+
+class TestCmdOnboardRepoServiceKeys:
+    @pytest.mark.unit
+    def test_dry_run_includes_declared_service_keys(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rr = _module
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "KAFKA_GROUP_ID=omnimarket-worker\n"
+            "LLM_CODER_URL=http://coder.local\n"
+            "POSTGRES_DATABASE=omnimarket\n",
+            encoding="utf-8",
+        )
+        args = _make_dry_run_args(str(env_file))
+        minimal_registry: dict[str, object] = {
+            "shared": {
+                "/shared/kafka/": ["KAFKA_GROUP_ID"],
+                "/shared/llm/": ["LLM_CODER_URL"],
+            },
+            "bootstrap_only": ["POSTGRES_PASSWORD"],
+            "identity_defaults": ["POSTGRES_DATABASE"],
+            "service_override_required": ["KAFKA_GROUP_ID"],
+            "services": {
+                "omnimarket": {
+                    "kafka": ["KAFKA_GROUP_ID"],
+                    "llm": ["LLM_CODER_URL"],
+                    "db": ["POSTGRES_DATABASE"],
+                }
+            },
+        }
+
+        with patch.object(
+            rr,  # type: ignore[arg-type]
+            "_read_registry_data",
+            return_value=minimal_registry,
+        ):
+            result = rr.cmd_onboard_repo(args)  # type: ignore[attr-defined]
+
+        captured = capsys.readouterr()
+        assert result == 0
+        assert (
+            "/services/omnimarket/kafka/KAFKA_GROUP_ID = omnimarket-worker"
+            in captured.out
+        )
+        assert (
+            "/services/omnimarket/llm/LLM_CODER_URL = http://coder.local"
+            in captured.out
+        )
+        assert "/services/omnimarket/db/POSTGRES_DATABASE = omnimarket" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_register_repo.py
+++ b/tests/unit/scripts/test_register_repo.py
@@ -335,6 +335,32 @@ class TestCmdOnboardRepoServiceKeys:
         )
         assert "/services/omnimarket/db/POSTGRES_DATABASE = omnimarket" in captured.out
 
+    @pytest.mark.unit
+    def test_dry_run_skips_empty_declared_service_keys(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rr = _module
+        env_file = tmp_path / ".env"
+        env_file.write_text("KAFKA_GROUP_ID=omnimarket-worker\n", encoding="utf-8")
+        args = _make_dry_run_args(str(env_file))
+        minimal_registry: dict[str, object] = {
+            "shared": {"/shared/llm/": ["LLM_CODER_URL"]},
+            "bootstrap_only": ["POSTGRES_PASSWORD"],
+            "identity_defaults": ["POSTGRES_DATABASE"],
+            "services": {"omnimarket": {"llm": ["LLM_CODER_URL"]}},
+        }
+
+        with patch.object(
+            rr,  # type: ignore[arg-type]
+            "_read_registry_data",
+            return_value=minimal_registry,
+        ):
+            result = rr.cmd_onboard_repo(args)  # type: ignore[attr-defined]
+
+        captured = capsys.readouterr()
+        assert result == 0
+        assert "/services/omnimarket/llm/LLM_CODER_URL" not in captured.out
+
 
 # ---------------------------------------------------------------------------
 # Issue 4: _upsert_secret wraps bare SDK exceptions in InfraConnectionError

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -111,6 +111,24 @@ def test_extract_legacy_event_priority(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_extract_event_priority_rejects_bool(tmp_path: Path) -> None:
+    """YAML booleans are not accepted as integer provisioning priorities."""
+    write_contract(
+        tmp_path,
+        "node_bool_priority",
+        """
+        published_events:
+          - topic: "onex.evt.platform.node-introspection.v1"
+            provisioning_priority: false
+        """,
+    )
+    extractor = ContractTopicExtractor()
+    results = extractor.extract(tmp_path)
+
+    assert results[0].provisioning_priority == 100
+
+
+@pytest.mark.unit
 def test_extract_new_style_produced_events(tmp_path: Path) -> None:
     """New-style produced_events[].topic entries are extracted."""
     write_contract(

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -85,6 +85,32 @@ def test_extract_new_style_published_events(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_extract_legacy_event_priority(tmp_path: Path) -> None:
+    """Legacy event sections preserve provisioning priority metadata."""
+    write_contract(
+        tmp_path,
+        "node_legacy_priority",
+        """
+        published_events:
+          - topic: "onex.evt.platform.node-introspection.v1"
+            provisioning_priority: 10
+          - name: "onex.evt.omnibase-infra.runtime-health-check.v1"
+            priority: 0
+        """,
+    )
+    extractor = ContractTopicExtractor()
+    results = {entry.topic: entry for entry in extractor.extract(tmp_path)}
+
+    assert (
+        results["onex.evt.platform.node-introspection.v1"].provisioning_priority == 10
+    )
+    assert (
+        results["onex.evt.omnibase-infra.runtime-health-check.v1"].provisioning_priority
+        == 0
+    )
+
+
+@pytest.mark.unit
 def test_extract_new_style_produced_events(tmp_path: Path) -> None:
     """New-style produced_events[].topic entries are extracted."""
     write_contract(


### PR DESCRIPTION
## Summary

Adds top-level \`services:\` section to \`config/shared_key_registry.yaml\`
with the omnimarket per-service key declarations. Bumps registry version
1.1 → 1.2 to mark the structural addition. Implements **Task 16
(OMN-10563)** of Epic 4 (Contract-Declared Config) in the omnimarket
public-shippable plan.

### Schema (1.2)

\`\`\`yaml
services:
  <repo>:
    <transport>:
      - KEY1
      - KEY2
\`\`\`

Each entry maps to Infisical path \`/services/<repo>/<transport>/<KEY>\` —
the per-service override that takes precedence over
\`/shared/<transport>/<KEY>\` at runtime.

### Initial omnimarket block

\`\`\`yaml
services:
  omnimarket:
    kafka:  [KAFKA_GROUP_ID]
    llm:    [LLM_CODER_URL, LLM_CODER_MODEL_ID, LLM_REASONER_URL, LLM_REASONER_MODEL_ID]
    db:     [POSTGRES_DATABASE]
\`\`\`

The LLM keys follow the flat-path convention (no nested role paths) so
Task 19 (OMN-10568) can wire \`bridge_config_loader.py\` to resolve them
via \`ProtocolSecretStore\`.

### Loader

Adds \`_services_keys()\` to \`scripts/register-repo.py\` that mirrors the
pattern of \`_load_registry\`, \`_bootstrap_keys\`, etc. Section is
optional (returns empty dict when absent) so older test fixtures keep
loading.

## Linear ticket

OMN-10563 — https://linear.app/omninode/issue/OMN-10563

## Plan reference

- Plan: \`docs/plans/2026-05-05-omnimarket-public-shippable.md\` (omni_home parent dir)
- Epic: OMN-10546 (Epic 4: Contract-Declared Config)
- Wave: 8 (parallel with Task 17)
- Upstream key list: scanner-1's audit (PR #532, OMN-10547)

## DoD evidence

- 16 new unit tests in \`tests/unit/config/test_shared_key_registry_omnimarket.py\`:
  - 2 version-bump tests
  - 3 omnimarket-section content tests
  - 7 \`_services_keys()\` loader tests (positive + 5 negative cases)
  - 4 regression tests confirming existing loaders still work

- Test run: 16/16 pass with \`uv run pytest tests/unit/config/test_shared_key_registry_omnimarket.py -v\`
- Existing registry tests still pass: \`uv run pytest tests/unit/scripts/test_shared_key_registry_omn8778.py tests/unit/scripts/test_register_repo.py -v\` → 35 passed

## Test plan

- [x] New unit tests pass
- [x] Existing registry test suite still passes (no regression)
- [x] mypy clean: \`uv run mypy scripts/register-repo.py\`
- [x] ruff clean: \`uv run ruff check scripts/register-repo.py tests/unit/config/test_shared_key_registry_omnimarket.py\`
- [x] YAML parses with new \`services:\` section
- [x] Pre-existing test failures verified on \`main\` (unrelated to this change): provision-infisical \`--addr\` HTTP scheme, kernel bootstrap, compose silent fallback, session graph projector defaults, observability skill_lifecycle consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-service secret key declarations for Omnimarket (Kafka, LLM, DB).
  * Topic provisioning priority for deterministic ordering and capped partitions.

* **Configuration**
  * Registry schema bumped to 1.2 with top-level services section.
  * Infisical runtime vars routed through runtime-prefixed env names and new INFISICAL_ENVIRONMENT alias.
  * New ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS env var.

* **Tests**
  * Added unit and integration tests for registry loading and topic provisioning.

* **Governance**
  * New deploy/testing contracts and runtime orchestration manifests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#739
Evidence-Ticket: OMN-10563