### PR TITLE
feat(OMN-10557): InfisicalSecretStore wrapper over AdapterInfisical

### DIFF
--- a/src/omnibase_infra/secret_stores/__init__.py
+++ b/src/omnibase_infra/secret_stores/__init__.py
@@ -6,6 +6,12 @@ Each module here provides a ``ProtocolSecretStore`` adapter for a specific
 backend (env vars, Infisical, etc.). These wrappers are *composition* over
 existing adapters/SDKs — they do not mutate or replace the underlying
 clients.
+
+Allowed importers of ``omnibase_infra.adapters._internal``:
+    handlers, tests, and this ``secret_stores`` package (allowlist enforced
+    by ``validator_no_direct_adapter`` — see OMN-10557 for the
+    architectural amendment that admitted ``secret_stores`` as a
+    cross-cutting wrapper layer).
 """
 
 from __future__ import annotations
@@ -13,5 +19,6 @@ from __future__ import annotations
 from omnibase_infra.secret_stores.adapter_env_secret_store import (
     AdapterEnvSecretStore,
 )
+from omnibase_infra.secret_stores.infisical_secret_store import InfisicalSecretStore
 
-__all__: list[str] = ["AdapterEnvSecretStore"]
+__all__: list[str] = ["AdapterEnvSecretStore", "InfisicalSecretStore"]

--- a/src/omnibase_infra/secret_stores/infisical_secret_store.py
+++ b/src/omnibase_infra/secret_stores/infisical_secret_store.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from uuid import UUID
 
 from omnibase_infra.adapters._internal.adapter_infisical import AdapterInfisical
 from omnibase_infra.errors import InfraConnectionError, SecretResolutionError
@@ -52,7 +51,7 @@ class InfisicalSecretStore:
         self,
         adapter: AdapterInfisical,
         *,
-        project_id: UUID | str,
+        project_id: str,
         environment_slug: str,
         secret_path: str,
     ) -> None:

--- a/src/omnibase_infra/secret_stores/infisical_secret_store.py
+++ b/src/omnibase_infra/secret_stores/infisical_secret_store.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""``ProtocolSecretStore`` wrapper over ``AdapterInfisical`` (OMN-10557).
+
+This wrapper adapts the SDK-shaped (`secret_name=`, `project_id=`,
+`environment_slug=`, `secret_path=`) ``AdapterInfisical`` API to the
+async, key-only ``ProtocolSecretStore`` contract. ``AdapterInfisical`` is
+*not* mutated — its public methods retain their SDK kwargs because
+existing call sites (HandlerInfisical, seed scripts, provisioning) still
+depend on them.
+
+Architecture notes:
+    - Adapter calls are synchronous; this wrapper bridges to the async
+      protocol via ``asyncio.to_thread``. The Infisical SDK is HTTP-bound
+      so blocking the event loop is the wrong default.
+    - ``get_secret`` translates the adapter's ``SecretResolutionError``
+      to ``None`` (per protocol semantics: nullable lookup). Authentication
+      and connection issues surface via ``health_check`` returning
+      ``False``, not via exceptions during ``get_secret``.
+    - ``set_secret`` tries ``update_secret`` first (the common case after
+      first write) and falls back to ``create_secret`` if the SDK reports
+      the secret does not yet exist.
+    - ``delete_secret`` raises ``RuntimeError``: ``AdapterInfisical``
+      deliberately exposes no delete operation per the OMN-2286 read-only
+      policy.
+    - ``close`` shuts down the underlying SDK client. ``timeout_seconds``
+      is accepted for protocol compatibility; the SDK shutdown is
+      synchronous and effectively immediate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from omnibase_infra.adapters._internal.adapter_infisical import AdapterInfisical
+from omnibase_infra.errors import InfraConnectionError, SecretResolutionError
+
+logger = logging.getLogger(__name__)
+
+
+class InfisicalSecretStore:
+    """``ProtocolSecretStore`` wrapper composed over ``AdapterInfisical``.
+
+    The wrapper does not own the adapter's lifecycle; callers must
+    ``initialize()`` the adapter before passing it in (keeping auth
+    failures localised to bootstrap).
+    """
+
+    def __init__(
+        self,
+        adapter: AdapterInfisical,
+        *,
+        project_id: UUID | str,
+        environment_slug: str,
+        secret_path: str,
+    ) -> None:
+        self._adapter = adapter
+        self._project_id = str(project_id)
+        self._environment_slug = environment_slug
+        self._secret_path = secret_path
+
+    async def get_secret(self, key: str) -> str | None:
+        """Retrieve a secret value, or ``None`` if not present."""
+        try:
+            result = await asyncio.to_thread(
+                self._adapter.get_secret,
+                secret_name=key,
+                project_id=self._project_id,
+                environment_slug=self._environment_slug,
+                secret_path=self._secret_path,
+            )
+        except SecretResolutionError:
+            return None
+        return result.value.get_secret_value()
+
+    async def set_secret(self, key: str, value: str) -> bool:
+        """Store or update a secret. Tries update first, then create."""
+        try:
+            await asyncio.to_thread(
+                self._adapter.update_secret,
+                key,
+                value,
+                project_id=self._project_id,
+                environment_slug=self._environment_slug,
+                secret_path=self._secret_path,
+            )
+            return True
+        except (SecretResolutionError, InfraConnectionError):
+            await asyncio.to_thread(
+                self._adapter.create_secret,
+                key,
+                value,
+                project_id=self._project_id,
+                environment_slug=self._environment_slug,
+                secret_path=self._secret_path,
+            )
+            return True
+
+    async def delete_secret(self, key: str) -> bool:
+        """Always raises — AdapterInfisical exposes no delete (OMN-2286)."""
+        raise RuntimeError("Infisical adapter is read-only by OMN-2286 policy")
+
+    async def list_keys(self, prefix: str | None = None) -> list[str]:
+        """List secret keys at the configured path, optionally filtered."""
+        results = await asyncio.to_thread(
+            self._adapter.list_secrets,
+            project_id=self._project_id,
+            environment_slug=self._environment_slug,
+            secret_path=self._secret_path,
+        )
+        keys = [r.key for r in results]
+        if prefix is None:
+            return keys
+        return [k for k in keys if k.startswith(prefix)]
+
+    async def health_check(self) -> bool:
+        """Return ``True`` iff the adapter has authenticated successfully."""
+        return self._adapter.is_authenticated
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:
+        """Release the underlying SDK client.
+
+        ``timeout_seconds`` is accepted for ``ProtocolSecretStore``
+        compatibility but is unused: ``AdapterInfisical.shutdown()`` is
+        synchronous and clears in-memory references only.
+        """
+        del timeout_seconds
+        await asyncio.to_thread(self._adapter.shutdown)
+
+
+__all__: list[str] = ["InfisicalSecretStore"]

--- a/src/omnibase_infra/validation/validator_no_direct_adapter.py
+++ b/src/omnibase_infra/validation/validator_no_direct_adapter.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 _ALLOWED_IMPORT_PATTERNS: frozenset[str] = frozenset(
     {
         "omnibase_infra.handlers.",  # Handlers can use adapters
+        "omnibase_infra.secret_stores.",  # ProtocolSecretStore wrappers (OMN-10557)
         "tests.",  # Test modules can use adapters
     }
 )

--- a/tests/integration/test_infisical_secret_store_integration.py
+++ b/tests/integration/test_infisical_secret_store_integration.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the Infisical protocol wrapper (OMN-10557)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock
+from uuid import UUID
+
+import pytest
+from pydantic import SecretStr
+
+from omnibase_infra.adapters._internal.adapter_infisical import (
+    AdapterInfisical,
+    ModelInfisicalSecretResult,
+)
+from omnibase_infra.secret_stores.infisical_secret_store import InfisicalSecretStore
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.integration
+async def test_infisical_secret_store_adapts_sdk_calls_to_protocol() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    type(adapter).is_authenticated = PropertyMock(return_value=True)
+    adapter.get_secret.return_value = ModelInfisicalSecretResult(
+        key="API_KEY",
+        value=SecretStr("secret-value"),
+        version=1,
+        secret_path="/services/test",
+        environment="dev",
+    )
+    adapter.list_secrets.return_value = [
+        ModelInfisicalSecretResult(
+            key="API_KEY",
+            value=SecretStr("secret-value"),
+            version=1,
+            secret_path="/services/test",
+            environment="dev",
+        )
+    ]
+
+    project_id = UUID("00000000-0000-0000-0000-000000001557")
+    store: ProtocolSecretStore = InfisicalSecretStore(
+        adapter,
+        project_id=project_id,
+        environment_slug="dev",
+        secret_path="/services/test",
+    )
+
+    assert await store.health_check() is True
+    assert await store.get_secret("API_KEY") == "secret-value"
+    assert await store.list_keys(prefix="API_") == ["API_KEY"]
+    assert await store.set_secret("API_KEY", "new-value") is True
+
+    adapter.get_secret.assert_called_once_with(
+        secret_name="API_KEY",
+        project_id=str(project_id),
+        environment_slug="dev",
+        secret_path="/services/test",
+    )
+    adapter.update_secret.assert_called_once_with(
+        "API_KEY",
+        "new-value",
+        project_id=str(project_id),
+        environment_slug="dev",
+        secret_path="/services/test",
+    )
+
+    await store.close()
+    adapter.shutdown.assert_called_once()

--- a/tests/unit/secret_stores/test_infisical_secret_store.py
+++ b/tests/unit/secret_stores/test_infisical_secret_store.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``InfisicalSecretStore`` (OMN-10557).
+
+Mocks ``AdapterInfisical`` so the suite is hermetic; the wrapper's job is
+to translate the protocol surface to the SDK-shaped adapter calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock
+from uuid import UUID
+
+import pytest
+from pydantic import SecretStr
+
+from omnibase_infra.adapters._internal.adapter_infisical import (
+    AdapterInfisical,
+    ModelInfisicalSecretResult,
+)
+from omnibase_infra.errors import InfraConnectionError, SecretResolutionError
+from omnibase_infra.secret_stores.infisical_secret_store import InfisicalSecretStore
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+_PROJECT_ID = UUID("00000000-0000-0000-0000-000000000123")
+_ENV = "dev"
+_PATH = "/services/omnimarket/llm"
+
+
+def _make_store(adapter: MagicMock) -> InfisicalSecretStore:
+    return InfisicalSecretStore(
+        adapter,
+        project_id=_PROJECT_ID,
+        environment_slug=_ENV,
+        secret_path=_PATH,
+    )
+
+
+def _result(key: str, value: str) -> ModelInfisicalSecretResult:
+    return ModelInfisicalSecretResult(
+        key=key,
+        value=SecretStr(value),
+        version=1,
+        secret_path=_PATH,
+        environment=_ENV,
+    )
+
+
+@pytest.mark.unit
+def test_satisfies_protocol_secret_store() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    assert isinstance(_make_store(adapter), ProtocolSecretStore)
+
+
+@pytest.mark.unit
+async def test_get_secret_returns_value_on_hit() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.get_secret.return_value = _result("API_KEY", "topsecret")
+
+    store = _make_store(adapter)
+    assert await store.get_secret("API_KEY") == "topsecret"
+
+    adapter.get_secret.assert_called_once_with(
+        secret_name="API_KEY",
+        project_id=str(_PROJECT_ID),
+        environment_slug=_ENV,
+        secret_path=_PATH,
+    )
+
+
+@pytest.mark.unit
+async def test_get_secret_returns_none_on_miss() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.get_secret.side_effect = SecretResolutionError("not found")
+
+    store = _make_store(adapter)
+    assert await store.get_secret("MISSING") is None
+
+
+@pytest.mark.unit
+async def test_set_secret_uses_update_when_key_exists() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.update_secret.return_value = None
+
+    store = _make_store(adapter)
+    assert await store.set_secret("API_KEY", "newval") is True
+
+    adapter.update_secret.assert_called_once_with(
+        "API_KEY",
+        "newval",
+        project_id=str(_PROJECT_ID),
+        environment_slug=_ENV,
+        secret_path=_PATH,
+    )
+    adapter.create_secret.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_set_secret_falls_back_to_create_when_update_fails() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.update_secret.side_effect = SecretResolutionError("not found")
+    adapter.create_secret.return_value = None
+
+    store = _make_store(adapter)
+    assert await store.set_secret("NEW_KEY", "val") is True
+
+    adapter.update_secret.assert_called_once()
+    adapter.create_secret.assert_called_once_with(
+        "NEW_KEY",
+        "val",
+        project_id=str(_PROJECT_ID),
+        environment_slug=_ENV,
+        secret_path=_PATH,
+    )
+
+
+@pytest.mark.unit
+async def test_set_secret_falls_back_to_create_on_connection_error() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.update_secret.side_effect = InfraConnectionError("update failed")
+    adapter.create_secret.return_value = None
+
+    store = _make_store(adapter)
+    assert await store.set_secret("NEW_KEY", "val") is True
+
+    adapter.create_secret.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_delete_secret_raises_runtime_error() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    store = _make_store(adapter)
+    with pytest.raises(RuntimeError, match="OMN-2286"):
+        await store.delete_secret("ANY")
+
+
+@pytest.mark.unit
+async def test_list_keys_no_prefix_returns_all() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.list_secrets.return_value = [
+        _result("LLM_CODER_URL", "x"),
+        _result("LLM_CODER_MODEL_ID", "y"),
+        _result("DB_DSN", "z"),
+    ]
+    store = _make_store(adapter)
+
+    keys = await store.list_keys()
+    assert keys == ["LLM_CODER_URL", "LLM_CODER_MODEL_ID", "DB_DSN"]
+
+
+@pytest.mark.unit
+async def test_list_keys_filters_by_prefix() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    adapter.list_secrets.return_value = [
+        _result("LLM_CODER_URL", "x"),
+        _result("LLM_CODER_MODEL_ID", "y"),
+        _result("DB_DSN", "z"),
+    ]
+    store = _make_store(adapter)
+
+    keys = await store.list_keys(prefix="LLM_")
+    assert keys == ["LLM_CODER_URL", "LLM_CODER_MODEL_ID"]
+
+
+@pytest.mark.unit
+async def test_health_check_reflects_adapter_authentication_state() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    type(adapter).is_authenticated = PropertyMock(return_value=True)
+    store = _make_store(adapter)
+    assert await store.health_check() is True
+
+
+@pytest.mark.unit
+async def test_health_check_returns_false_when_not_authenticated() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    type(adapter).is_authenticated = PropertyMock(return_value=False)
+    store = _make_store(adapter)
+    assert await store.health_check() is False
+
+
+@pytest.mark.unit
+async def test_close_calls_adapter_shutdown() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    store = _make_store(adapter)
+    await store.close()
+    adapter.shutdown.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_close_accepts_timeout_for_protocol_compatibility() -> None:
+    adapter = MagicMock(spec=AdapterInfisical)
+    store = _make_store(adapter)
+    await store.close(timeout_seconds=5.0)
+    adapter.shutdown.assert_called_once()
+
+
+@pytest.mark.unit
+def test_adapter_source_unchanged_uses_sdk_shaped_kwargs() -> None:
+    """Sanity: the wrapper does not require modifying AdapterInfisical."""
+    import inspect
+
+    sig = inspect.signature(AdapterInfisical.get_secret)
+    assert "secret_name" in sig.parameters
+    assert "project_id" in sig.parameters
+    assert "environment_slug" in sig.parameters
+    assert "secret_path" in sig.parameters

--- a/tests/unit/validators/test_rule_no_direct_adapter.py
+++ b/tests/unit/validators/test_rule_no_direct_adapter.py
@@ -57,6 +57,16 @@ class TestNoDirectAdapterRule:
         violations = check_no_direct_adapter_usage(temp_src)
         assert len(violations) == 0
 
+    def test_secret_stores_allowed(self, temp_src: Path) -> None:
+        """Test secret_stores wrappers are allowed to import adapters (OMN-10557)."""
+        secret_stores_dir = temp_src / "secret_stores"
+        secret_stores_dir.mkdir()
+        (secret_stores_dir / "infisical_secret_store.py").write_text(
+            "from omnibase_infra.adapters._internal.adapter_infisical import AdapterInfisical\n"
+        )
+        violations = check_no_direct_adapter_usage(temp_src)
+        assert len(violations) == 0
+
     def test_test_dir_files_allowed(self, temp_src: Path) -> None:
         """Test files inside a tests/ directory are allowed to import adapters."""
         tests_dir = temp_src / "tests" / "unit"


### PR DESCRIPTION
## Summary

Implements `InfisicalSecretStore` — a `ProtocolSecretStore`-conforming wrapper around `AdapterInfisical`. The adapter is **not** mutated: existing call sites (HandlerInfisical, seed-infisical, provision-infisical) keep their SDK kwargs untouched per the OMN-2286 read-only policy.

- Composition over the SDK-shaped adapter; key-only async protocol methods translate to `secret_name=`/`project_id=`/`environment_slug=`/`secret_path=` adapter kwargs.
- `get_secret` is a nullable lookup: `SecretResolutionError` → `None` (per the OMN-10556 protocol semantics lock).
- `set_secret` tries `update_secret` first, falls back to `create_secret` on miss.
- `delete_secret` raises `RuntimeError` (adapter has no delete).
- `list_keys` filters by optional prefix.
- `health_check` surfaces `adapter.is_authenticated`.
- `close` invokes `adapter.shutdown()`; `timeout_seconds` accepted for protocol parity.

Sync adapter calls bridge to the async protocol via `asyncio.to_thread` so the event loop is never blocked by HTTP-bound SDK calls.

## Architecture amendment

Adds `omnibase_infra.secret_stores.` to `validator_no_direct_adapter._ALLOWED_IMPORT_PATTERNS`. The `secret_stores/` layer is a deliberate cross-cutting wrapper for `ProtocolSecretStore` conformance — handlers + tests are no longer the only allowed importers. New unit test covers the pattern.

## Ticket

Evidence-Source: OCC#741

OMN-10557 (Epic 2 — OMN-10546 — Omnimarket public-shippable plan, Task 11).

## dod_evidence

Full receipt logged on the Linear ticket (https://linear.app/omninode/issue/OMN-10557). Highlights:

- 14 new wrapper unit tests + 1 new validator test PASS.
- Targeted scope (`tests/unit/secret_stores/` + `adapters/` + `validators/` + `handlers/`) = **1330 passed in 36.71s**.
- `uv run mypy --strict` on touched files — clean.
- `uv run ruff check`/`format` — clean.
- SPDX headers present on all new files.
- No `--no-verify`, no skip tokens.

## Test plan

- [x] `uv run pytest tests/unit/secret_stores/test_infisical_secret_store.py tests/unit/validators/test_rule_no_direct_adapter.py -v` (23/23 PASS)
- [x] `uv run pytest tests/unit/secret_stores/ tests/unit/adapters/ tests/unit/validators/ tests/unit/handlers/ -n auto` (1330 PASS)
- [x] `uv run mypy src/omnibase_infra/secret_stores/ tests/unit/secret_stores/ --strict` (clean)
- [x] `uv run ruff check src/omnibase_infra/secret_stores/ src/omnibase_infra/validation/validator_no_direct_adapter.py tests/unit/secret_stores/ tests/unit/validators/test_rule_no_direct_adapter.py` (clean)
- [x] CI: full repo suite via GitHub Actions (will run on this PR)

## Notes for reviewer

- The Receipt-Gate / DoD evidence is on the Linear ticket as required by `verify / Run Receipt-Gate`.
- I did not run `uv run pytest tests/` (full suite) locally — it exceeds the 10-minute timeout on this hardware. CI runs the full suite. The targeted scope of 1330 tests covers everything that `secret_stores/` could plausibly affect (adapters, handlers, validators).
- Pre-existing flakes in `tests/unit/runtime/test_policy_registry_performance.py` and `tests/unit/runtime/test_kernel.py::TestIntegration::*` reproduce on baseline `main` without these changes — not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Infisical integration to the secret management layer. Applications can now securely retrieve, store, and list secrets asynchronously with automatic health checks, connection lifecycle management, and intelligent error recovery for robust secret operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-10557