### PR TITLE
feat(OMN-10558): AdapterEnvSecretStore (nullable env-var lookup)

### DIFF
--- a/src/omnibase_infra/secret_stores/__init__.py
+++ b/src/omnibase_infra/secret_stores/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Secret store implementations of ``ProtocolSecretStore``.
+
+Each module here provides a ``ProtocolSecretStore`` adapter for a specific
+backend (env vars, Infisical, etc.). These wrappers are *composition* over
+existing adapters/SDKs — they do not mutate or replace the underlying
+clients.
+"""
+
+from __future__ import annotations
+
+from omnibase_infra.secret_stores.adapter_env_secret_store import (
+    AdapterEnvSecretStore,
+)
+
+__all__: list[str] = ["AdapterEnvSecretStore"]

--- a/src/omnibase_infra/secret_stores/adapter_env_secret_store.py
+++ b/src/omnibase_infra/secret_stores/adapter_env_secret_store.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""``ProtocolSecretStore`` adapter backed by ``os.environ`` (OMN-10558).
+
+Used by local development and any runtime profile where Infisical is
+unavailable. ``get_secret`` is a *nullable lookup* — a missing key
+returns ``None``. Required-service validation is the caller's
+responsibility (e.g., ``omnimarket.config.Settings`` raises if a
+mandatory secret is unset). The protocol semantics (OMN-10556) are the
+contract.
+
+Mutating env vars at runtime is unsafe in multi-threaded/async
+processes, so ``set_secret`` and ``delete_secret`` raise ``RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class AdapterEnvSecretStore:
+    """``ProtocolSecretStore`` adapter that reads from ``os.environ``.
+
+    Read-only by design. ``health_check`` always returns ``True``;
+    ``close`` is a no-op.
+    """
+
+    async def get_secret(self, key: str) -> str | None:
+        """Return ``os.environ[key]`` or ``None`` if not set."""
+        return os.environ.get(key)
+
+    async def set_secret(self, key: str, value: str) -> bool:
+        raise RuntimeError("AdapterEnvSecretStore is read-only")
+
+    async def delete_secret(self, key: str) -> bool:
+        raise RuntimeError("AdapterEnvSecretStore is read-only")
+
+    async def list_keys(self, prefix: str | None = None) -> list[str]:
+        """Return env var names; filter by ``prefix`` when supplied."""
+        keys = list(os.environ.keys())
+        if prefix is None:
+            return keys
+        return [k for k in keys if k.startswith(prefix)]
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:
+        del timeout_seconds
+
+
+__all__: list[str] = ["AdapterEnvSecretStore"]

--- a/src/omnibase_infra/secret_stores/adapter_env_secret_store.py
+++ b/src/omnibase_infra/secret_stores/adapter_env_secret_store.py
@@ -46,7 +46,7 @@ class AdapterEnvSecretStore:
         return True
 
     async def close(self, timeout_seconds: float = 30.0) -> None:
-        del timeout_seconds
+        return None
 
 
 __all__: list[str] = ["AdapterEnvSecretStore"]

--- a/tests/integration/test_adapter_env_secret_store_integration.py
+++ b/tests/integration/test_adapter_env_secret_store_integration.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the env-backed secret store (OMN-10558)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.secret_stores.adapter_env_secret_store import (
+    AdapterEnvSecretStore,
+)
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.integration
+async def test_adapter_env_secret_store_protocol_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMN_INT_SECRET_A", "alpha")
+    monkeypatch.setenv("OMN_INT_SECRET_B", "bravo")
+    monkeypatch.delenv("OMN_INT_SECRET_MISSING", raising=False)
+
+    store: ProtocolSecretStore = AdapterEnvSecretStore()
+
+    assert await store.health_check() is True
+    assert await store.get_secret("OMN_INT_SECRET_A") == "alpha"
+    assert await store.get_secret("OMN_INT_SECRET_MISSING") is None
+    assert sorted(await store.list_keys(prefix="OMN_INT_SECRET_")) == [
+        "OMN_INT_SECRET_A",
+        "OMN_INT_SECRET_B",
+    ]
+
+    with pytest.raises(RuntimeError, match="read-only"):
+        await store.set_secret("OMN_INT_SECRET_C", "charlie")
+
+    await store.close()

--- a/tests/unit/secret_stores/__init__.py
+++ b/tests/unit/secret_stores/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``omnibase_infra.secret_stores``."""

--- a/tests/unit/secret_stores/test_adapter_env_secret_store.py
+++ b/tests/unit/secret_stores/test_adapter_env_secret_store.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``AdapterEnvSecretStore`` (OMN-10558).
+
+Asserts the env-backed implementation honours the OMN-10556
+``ProtocolSecretStore`` semantics: nullable lookup, read-only writes,
+prefix listing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.secret_stores.adapter_env_secret_store import (
+    AdapterEnvSecretStore,
+)
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.unit
+def test_satisfies_protocol_secret_store() -> None:
+    assert isinstance(AdapterEnvSecretStore(), ProtocolSecretStore)
+
+
+@pytest.mark.unit
+async def test_get_secret_returns_value_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMN_TEST_SECRET", "hunter2")
+    store = AdapterEnvSecretStore()
+    assert await store.get_secret("OMN_TEST_SECRET") == "hunter2"
+
+
+@pytest.mark.unit
+async def test_get_secret_returns_none_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OMN_TEST_ABSENT_KEY", raising=False)
+    store = AdapterEnvSecretStore()
+    assert await store.get_secret("OMN_TEST_ABSENT_KEY") is None
+
+
+@pytest.mark.unit
+async def test_set_secret_raises_runtime_error() -> None:
+    store = AdapterEnvSecretStore()
+    with pytest.raises(RuntimeError, match="read-only"):
+        await store.set_secret("OMN_TEST_SECRET", "value")
+
+
+@pytest.mark.unit
+async def test_delete_secret_raises_runtime_error() -> None:
+    store = AdapterEnvSecretStore()
+    with pytest.raises(RuntimeError, match="read-only"):
+        await store.delete_secret("OMN_TEST_SECRET")
+
+
+@pytest.mark.unit
+async def test_list_keys_no_prefix_returns_all_env_var_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMN_TEST_AAA", "1")
+    monkeypatch.setenv("OMN_TEST_BBB", "2")
+    store = AdapterEnvSecretStore()
+
+    keys = await store.list_keys()
+    assert "OMN_TEST_AAA" in keys
+    assert "OMN_TEST_BBB" in keys
+
+
+@pytest.mark.unit
+async def test_list_keys_filters_by_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMN_T12_FOO", "1")
+    monkeypatch.setenv("OMN_T12_BAR", "2")
+    monkeypatch.setenv("UNRELATED_KEY", "3")
+    store = AdapterEnvSecretStore()
+
+    keys = await store.list_keys(prefix="OMN_T12_")
+    assert sorted(keys) == ["OMN_T12_BAR", "OMN_T12_FOO"]
+
+
+@pytest.mark.unit
+async def test_health_check_always_true() -> None:
+    store = AdapterEnvSecretStore()
+    assert await store.health_check() is True
+
+
+@pytest.mark.unit
+async def test_close_is_noop() -> None:
+    store = AdapterEnvSecretStore()
+    await store.close()
+    await store.close(timeout_seconds=5.0)


### PR DESCRIPTION
## Summary

Adds `AdapterEnvSecretStore` — an env-var-backed `ProtocolSecretStore` for local-dev / no-Infisical runtime profiles. Read-only by design; mutating env vars at runtime is unsafe in async/threaded processes.

- `get_secret(key)` → `os.environ.get(key)` (nullable per OMN-10556 protocol semantics; missing key returns `None`, never raises).
- `set_secret` / `delete_secret` → `RuntimeError("AdapterEnvSecretStore is read-only")`.
- `list_keys(prefix)` → env var names, optionally prefix-filtered.
- `health_check` → always `True`.
- `close` → no-op.

Required-service validation lives in callers (e.g., `omnimarket.config.Settings`), not here.

## Ticket

Evidence-Source: OCC#741

OMN-10558 (Epic 2 — OMN-10546 — Omnimarket public-shippable plan, Task 12).

## dod_evidence

Full receipt logged on the Linear ticket (https://linear.app/omninode/issue/OMN-10558). Highlights:

- 9 unit tests PASS in 0.63s.
- `uv run mypy --strict` clean on touched files.
- `uv run ruff check` + `uv run ruff format` clean (one auto-fix applied for RET501/PLR1711).
- SPDX headers present.
- No `--no-verify`, no skip tokens.

## Test plan

- [x] `uv run pytest tests/unit/secret_stores/test_adapter_env_secret_store.py -v` (9/9 PASS)
- [x] `uv run mypy src/omnibase_infra/secret_stores/ tests/unit/secret_stores/ --strict` (clean)
- [x] `uv run ruff check src/omnibase_infra/secret_stores/ tests/unit/secret_stores/` (clean)
- [x] CI: full repo suite via GitHub Actions

## Notes for reviewer

- This PR creates `omnibase_infra.secret_stores/` (new package). Task 11 (OMN-10557, PR #1506) also creates this package with `infisical_secret_store.py`. Whichever lands second will extend the `__init__.py` exports rather than rewrite. Coordinated mechanically — no conflict on either secret store source file.
- I did not run `uv run pytest tests/` (full repo suite) locally — it exceeds the 10-minute timeout on this hardware. CI runs the full suite.

Evidence-Ticket: OMN-10558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment variable–backed, read-only secret store adapter for retrieving secrets, listing keys (optional prefix), checking health, and clean shutdown.
* **Bug Fixes**
  * None
* **Tests**
  * Added unit and integration tests validating read-only behavior, secret retrieval, key listing, health checks, and close semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->