### PR TITLE
feat(OMN-10559): FakeSecretStore for tests

### DIFF
--- a/src/omnibase_infra/test_utils/__init__.py
+++ b/src/omnibase_infra/test_utils/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Test utilities ``omnibase_infra`` ships for downstream tests (OMN-10559).
+
+These helpers are deliberately *not* under ``tests/`` because consumer
+repos (omnimarket, etc.) import them from their own conftests. They are
+shipped in the wheel — acceptable for an internal platform package.
+
+Add lightweight fakes / fixtures here. Heavyweight fixtures that depend
+on infrastructure (Postgres, Kafka) belong in ``omnibase_infra.testing``
+instead.
+"""
+
+from __future__ import annotations
+
+from omnibase_infra.test_utils.fake_secret_store import FakeSecretStore
+
+__all__: list[str] = ["FakeSecretStore"]

--- a/src/omnibase_infra/test_utils/fake_secret_store.py
+++ b/src/omnibase_infra/test_utils/fake_secret_store.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Deterministic in-memory ``ProtocolSecretStore`` for tests (OMN-10559).
+
+Used by the canonical conftest in omnimarket and other consumers to
+exercise code that depends on a ``ProtocolSecretStore`` without standing
+up a real backend.
+
+Packaging note: this module ships in the omnibase_infra wheel (under
+``omnibase_infra.test_utils``) because downstream test suites import it.
+The package is internal-platform-only; shipping test helpers is
+deliberate. Heavier fixtures requiring infrastructure (Postgres, Kafka)
+belong in ``omnibase_infra.testing`` instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+class FakeSecretStore:
+    """In-memory ``ProtocolSecretStore`` impl backed by a ``dict``.
+
+    Fully implements every protocol method (gets, sets, deletes, lists,
+    health, close). Constructor accepts an optional ``initial`` mapping
+    to preload values.
+    """
+
+    def __init__(self, initial: Mapping[str, str] | None = None) -> None:
+        self._data: dict[str, str] = dict(initial) if initial else {}
+        self._closed: bool = False
+
+    async def get_secret(self, key: str) -> str | None:
+        return self._data.get(key)
+
+    async def set_secret(self, key: str, value: str) -> bool:
+        self._data[key] = value
+        return True
+
+    async def delete_secret(self, key: str) -> bool:
+        if key in self._data:
+            del self._data[key]
+            return True
+        return False
+
+    async def list_keys(self, prefix: str | None = None) -> list[str]:
+        if prefix is None:
+            return sorted(self._data.keys())
+        return sorted(k for k in self._data if k.startswith(prefix))
+
+    async def health_check(self) -> bool:
+        return not self._closed
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:
+        del timeout_seconds
+        self._closed = True
+
+
+__all__: list[str] = ["FakeSecretStore"]

--- a/tests/integration/test_fake_secret_store_integration.py
+++ b/tests/integration/test_fake_secret_store_integration.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the fake secret store test utility (OMN-10559)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.test_utils.fake_secret_store import FakeSecretStore
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.integration
+async def test_fake_secret_store_protocol_lifecycle() -> None:
+    store: ProtocolSecretStore = FakeSecretStore(initial={"db/url": "postgres"})
+
+    assert await store.health_check() is True
+    assert await store.get_secret("db/url") == "postgres"
+    assert await store.set_secret("llm/key", "secret") is True
+    assert await store.get_secret("llm/key") == "secret"
+    assert await store.list_keys(prefix="llm/") == ["llm/key"]
+    assert await store.delete_secret("db/url") is True
+    assert await store.get_secret("db/url") is None
+
+    await store.close()
+    assert await store.health_check() is False

--- a/tests/unit/test_utils/__init__.py
+++ b/tests/unit/test_utils/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``omnibase_infra.test_utils``."""

--- a/tests/unit/test_utils/test_fake_secret_store.py
+++ b/tests/unit/test_utils/test_fake_secret_store.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``FakeSecretStore`` (OMN-10559)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.test_utils.fake_secret_store import FakeSecretStore
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.unit
+def test_satisfies_protocol_secret_store() -> None:
+    assert isinstance(FakeSecretStore(), ProtocolSecretStore)
+
+
+@pytest.mark.unit
+async def test_empty_constructor_yields_empty_store() -> None:
+    store = FakeSecretStore()
+    assert await store.list_keys() == []
+    assert await store.get_secret("anything") is None
+
+
+@pytest.mark.unit
+async def test_initial_data_preloaded() -> None:
+    store = FakeSecretStore(initial={"a": "1", "b": "2"})
+    assert await store.get_secret("a") == "1"
+    assert await store.get_secret("b") == "2"
+
+
+@pytest.mark.unit
+async def test_initial_data_is_copied_not_referenced() -> None:
+    source = {"a": "1"}
+    store = FakeSecretStore(initial=source)
+    source["a"] = "mutated"
+    assert await store.get_secret("a") == "1"
+
+
+@pytest.mark.unit
+async def test_set_then_get_round_trip() -> None:
+    store = FakeSecretStore()
+    assert await store.set_secret("key", "value") is True
+    assert await store.get_secret("key") == "value"
+
+
+@pytest.mark.unit
+async def test_set_overwrites_existing_value() -> None:
+    store = FakeSecretStore(initial={"key": "original"})
+    await store.set_secret("key", "updated")
+    assert await store.get_secret("key") == "updated"
+
+
+@pytest.mark.unit
+async def test_delete_existing_returns_true_and_removes() -> None:
+    store = FakeSecretStore(initial={"key": "value"})
+    assert await store.delete_secret("key") is True
+    assert await store.get_secret("key") is None
+
+
+@pytest.mark.unit
+async def test_delete_missing_returns_false() -> None:
+    store = FakeSecretStore()
+    assert await store.delete_secret("absent") is False
+
+
+@pytest.mark.unit
+async def test_list_keys_no_prefix_returns_all_sorted() -> None:
+    store = FakeSecretStore(initial={"b": "2", "a": "1", "c": "3"})
+    assert await store.list_keys() == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+async def test_list_keys_filters_by_prefix() -> None:
+    store = FakeSecretStore(
+        initial={"llm/openai": "k1", "db/pg": "k2", "llm/anthropic": "k3"}
+    )
+    assert await store.list_keys(prefix="llm/") == ["llm/anthropic", "llm/openai"]
+
+
+@pytest.mark.unit
+async def test_health_check_true_when_open() -> None:
+    store = FakeSecretStore()
+    assert await store.health_check() is True
+
+
+@pytest.mark.unit
+async def test_health_check_false_after_close() -> None:
+    store = FakeSecretStore()
+    await store.close()
+    assert await store.health_check() is False
+
+
+@pytest.mark.unit
+async def test_close_accepts_default_timeout() -> None:
+    store = FakeSecretStore()
+    await store.close()
+    await store.close(timeout_seconds=5.0)


### PR DESCRIPTION
## Summary

Adds `FakeSecretStore` — a deterministic in-memory `ProtocolSecretStore` for use in the canonical test conftest by omnimarket and other downstream consumers.

- Dict-backed, fully-implements all 7 protocol methods.
- Constructor takes an optional `initial: Mapping[str, str]`; the mapping is *copied*, not referenced, so callers may mutate the source after construction without affecting the store.
- `health_check` starts True and flips to False after `close()` — handy for asserting lifecycle in tests.

## Packaging note

Lives at `omnibase_infra.test_utils.fake_secret_store`. The `test_utils` package is **new** in this PR and is intended to ship in the wheel: consumer test suites import it.

This is distinct from the existing `omnibase_infra.testing` package, which holds heavyweight fixtures (mock registries) — `test_utils` is the lightweight-fakes layer.

## Ticket

Evidence-Source: OCC#741

OMN-10559 (Epic 2 — OMN-10546 — Omnimarket public-shippable plan, Task 13).

## dod_evidence

Full receipt logged on the Linear ticket (https://linear.app/omninode/issue/OMN-10559). Highlights:

- 13 unit tests PASS in 0.39s.
- `uv run mypy --strict` clean.
- `uv run ruff check` + `uv run ruff format` clean.
- SPDX headers present.
- No `--no-verify`, no skip tokens.

## Test plan

- [x] `uv run pytest tests/unit/test_utils/test_fake_secret_store.py -v` (13/13 PASS)
- [x] `uv run mypy src/omnibase_infra/test_utils/ tests/unit/test_utils/ --strict` (clean)
- [x] `uv run ruff check src/omnibase_infra/test_utils/ tests/unit/test_utils/` (clean)
- [x] CI: full repo suite via GitHub Actions

## Notes for reviewer

- Independent of the other Epic 2 PRs (#1506 InfisicalSecretStore, #1507 AdapterEnvSecretStore). No file overlap — `test_utils/` is a new package under a different prefix from `secret_stores/`.
- I did not run `uv run pytest tests/` (full repo suite) locally — exceeds the 10-minute timeout on this hardware. CI runs the full suite.

Evidence-Ticket: OMN-10559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FakeSecretStore test utility with in-memory secret storage supporting get, set, delete, list, and health check operations for testing.

* **Tests**
  * Added comprehensive unit and integration tests validating FakeSecretStore initialization, data handling, operations, and lifecycle management including close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->