### PR TITLE
feat: add user-facing infra Makefile + docs entrypoints [OMN-10377]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,115 @@
+# omnibase_infra Makefile — user-facing infra entrypoints
+#
+# Provides in-repo runnable commands so users can do
+#
+#     cd repos/omnibase_infra && make up
+#
+# instead of needing to know the bundle CLI path. All targets that touch Docker
+# detect a missing/stopped daemon and emit an actionable error before doing
+# anything destructive. See OMN-10377 for the architectural rationale (Docker
+# orchestration must live in this repo, not in the public `omnibase` shell).
+#
+# Usage:
+#
+#     make help            # List all targets
+#     make up              # Start core infra bundle (postgres, redpanda, valkey, infisical)
+#     make up-auth         # Start the auth bundle (keycloak)
+#     make up-runtime      # Start the runtime bundle (depends on core)
+#     make down            # Stop the core bundle
+#     make status          # Show running omnibase-infra containers
+#     make seed-keycloak   # Reconcile Keycloak clients from desired-clients.json
+#     make seed-infisical  # Seed Infisical from ONEX contracts (dry-run-safe)
+#
+# Environment:
+#
+#     OMNIBASE_ENV_FILE   Override env file path (default: ~/.omnibase/.env)
+#     KC_URL              Keycloak base URL for seed-keycloak (default: http://localhost:28080)
+#     KC_REALM            Realm to seed (default: omninode)
+#
+# All `up*` targets delegate to the catalog CLI documented in CLAUDE.md:
+#     uv run python -m omnibase_infra.docker.catalog.cli up <bundle>
+# `seed-keycloak` delegates to scripts/seed-keycloak.sh (PR #1500).
+# `seed-infisical` delegates to scripts/seed-infisical.py.
+
+.PHONY: help up up-auth up-runtime down status seed-keycloak seed-infisical \
+        _check-docker _check-env-file
+
+OMNIBASE_ENV_FILE ?= $(HOME)/.omnibase/.env
+ONEX_CLI := uv run python -m omnibase_infra.docker.catalog.cli
+
+help: ## Show this help
+	@echo "omnibase_infra targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(firstword $(MAKEFILE_LIST)) \
+	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
+
+up: _check-docker ## Start core infra bundle (postgres, redpanda, valkey, infisical)
+	@echo "==> Starting core infrastructure bundle..."
+	$(ONEX_CLI) up core
+	@echo "==> Done. Run 'make status' to verify, or 'make up-auth' to add Keycloak."
+
+up-auth: _check-docker ## Start the auth bundle (keycloak); core must be up first
+	@echo "==> Starting auth (keycloak) bundle..."
+	$(ONEX_CLI) up auth
+	@echo "==> Done. Run 'make seed-keycloak' to reconcile clients."
+
+up-runtime: _check-docker ## Start the full runtime bundle (extends core)
+	@echo "==> Starting runtime bundle..."
+	$(ONEX_CLI) up runtime
+
+down: _check-docker ## Stop the core bundle
+	@echo "==> Stopping core infrastructure bundle..."
+	$(ONEX_CLI) down core
+
+status: _check-docker ## Show running omnibase-infra containers
+	@docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' \
+	  | awk 'NR==1 || /omnibase-infra-/' \
+	  || true
+
+seed-keycloak: _check-docker _check-env-file ## Reconcile Keycloak clients from desired-clients.json
+	@bash scripts/seed-keycloak.sh
+
+seed-infisical: _check-env-file ## Seed Infisical from ONEX contracts (uses --execute)
+	@uv run python scripts/seed-infisical.py \
+	  --contracts-dir src/omnibase_infra/nodes \
+	  --create-missing-keys \
+	  --execute
+
+# ----------------------------------------------------------------------------
+# Internal helpers (not part of the public target surface)
+# ----------------------------------------------------------------------------
+
+# Detect a missing or stopped Docker daemon and emit an actionable error rather
+# than letting `docker compose ...` fail with a cryptic message. omnibase_infra
+# is the boundary where Docker becomes a hard requirement (per OMN-10377 /
+# OMN-10378); the public `omnibase` repo never assumes it.
+_check-docker:
+	@if ! command -v docker > /dev/null 2>&1; then \
+	  echo "ERROR: docker is not installed."; \
+	  echo "  Install from https://docs.docker.com/get-docker/"; \
+	  echo "  macOS:  brew install --cask docker"; \
+	  echo "  Linux:  see https://docs.docker.com/engine/install/"; \
+	  exit 1; \
+	fi
+	@if ! docker info > /dev/null 2>&1; then \
+	  echo "ERROR: docker daemon is not running."; \
+	  echo "  macOS:  open -a Docker"; \
+	  echo "  Linux:  sudo systemctl start docker"; \
+	  exit 1; \
+	fi
+
+# Check that ~/.omnibase/.env (or whatever OMNIBASE_ENV_FILE points to) exists.
+# Fail with a clear remediation path rather than a stack trace from a
+# downstream script.
+_check-env-file:
+	@if [ ! -f "$(OMNIBASE_ENV_FILE)" ]; then \
+	  echo "ERROR: env file not found at $(OMNIBASE_ENV_FILE)"; \
+	  echo ""; \
+	  echo "Create it with at minimum:"; \
+	  echo "    KEYCLOAK_ADMIN_USERNAME=admin"; \
+	  echo "    KEYCLOAK_ADMIN_PASSWORD=<secure-random>"; \
+	  echo ""; \
+	  echo "Generate a secure password: openssl rand -base64 24"; \
+	  echo "Or copy the template:       cp .env.example $(OMNIBASE_ENV_FILE)"; \
+	  echo "Then edit:                  \$$EDITOR $(OMNIBASE_ENV_FILE)"; \
+	  exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ status: _check-docker ## Show running omnibase-infra containers
 seed-keycloak: _check-docker _check-env-file ## Reconcile Keycloak clients from desired-clients.json
 	@bash scripts/seed-keycloak.sh
 
-seed-infisical: _check-env-file ## Seed Infisical from ONEX contracts (uses --execute)
+seed-infisical: _check-docker _check-env-file ## Seed Infisical from ONEX contracts (uses --execute)
 	@uv run python scripts/seed-infisical.py \
 	  --contracts-dir src/omnibase_infra/nodes \
 	  --create-missing-keys \
@@ -124,11 +124,13 @@ _check-env-file:
 	@if [ ! -f "$(OMNIBASE_ENV_FILE)" ]; then \
 	  echo "ERROR: env file not found at $(OMNIBASE_ENV_FILE)"; \
 	  echo ""; \
-	  echo "Create it with at minimum:"; \
+	  echo "Create it from the template and fill the required keys:"; \
 	  echo "    KEYCLOAK_ADMIN_USERNAME=admin"; \
 	  echo "    KEYCLOAK_ADMIN_PASSWORD=<secure-random>"; \
+	  echo "    # plus any Infisical variables required by seed-infisical"; \
 	  echo ""; \
-	  echo "Generate a secure password: openssl rand -base64 24"; \
+	  echo "See .env.example for the full required key list."; \
+	  echo "Generate secure passwords: openssl rand -base64 24"; \
 	  echo "Or copy the template:       cp .env.example $(OMNIBASE_ENV_FILE)"; \
 	  echo "Then edit:                  \$$EDITOR $(OMNIBASE_ENV_FILE)"; \
 	  exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@
 #     make up              # Start core infra bundle (postgres, redpanda, valkey, infisical)
 #     make up-auth         # Start the auth bundle (keycloak)
 #     make up-runtime      # Start the runtime bundle (depends on core)
-#     make down            # Stop the core bundle
+#     make down            # Stop the core bundle ONLY (auth/runtime stay running)
+#     make down-auth       # Stop the auth bundle
+#     make down-runtime    # Stop the runtime bundle
+#     make down-all        # Stop runtime, then auth, then core (full teardown)
 #     make status          # Show running omnibase-infra containers
 #     make seed-keycloak   # Reconcile Keycloak clients from desired-clients.json
-#     make seed-infisical  # Seed Infisical from ONEX contracts (dry-run-safe)
+#     make seed-infisical  # Seed Infisical from ONEX contracts (writes with --execute)
 #
 # Environment:
 #
@@ -31,8 +34,8 @@
 # `seed-keycloak` delegates to scripts/seed-keycloak.sh (PR #1500).
 # `seed-infisical` delegates to scripts/seed-infisical.py.
 
-.PHONY: help up up-auth up-runtime down status seed-keycloak seed-infisical \
-        _check-docker _check-env-file
+.PHONY: help up up-auth up-runtime down down-auth down-runtime down-all status \
+        seed-keycloak seed-infisical _check-docker _check-env-file
 
 OMNIBASE_ENV_FILE ?= $(HOME)/.omnibase/.env
 ONEX_CLI := uv run python -m omnibase_infra.docker.catalog.cli
@@ -56,9 +59,26 @@ up-runtime: _check-docker ## Start the full runtime bundle (extends core)
 	@echo "==> Starting runtime bundle..."
 	$(ONEX_CLI) up runtime
 
-down: _check-docker ## Stop the core bundle
+down: _check-docker ## Stop the core bundle ONLY (use down-all for full teardown)
 	@echo "==> Stopping core infrastructure bundle..."
 	$(ONEX_CLI) down core
+
+down-auth: _check-docker ## Stop the auth bundle (keycloak)
+	@echo "==> Stopping auth (keycloak) bundle..."
+	$(ONEX_CLI) down auth
+
+down-runtime: _check-docker ## Stop the runtime bundle
+	@echo "==> Stopping runtime bundle..."
+	$(ONEX_CLI) down runtime
+
+down-all: _check-docker ## Stop runtime, then auth, then core (full teardown)
+	@echo "==> Stopping runtime bundle (if running)..."
+	-$(ONEX_CLI) down runtime
+	@echo "==> Stopping auth bundle (if running)..."
+	-$(ONEX_CLI) down auth
+	@echo "==> Stopping core bundle..."
+	$(ONEX_CLI) down core
+	@echo "==> Done. All omnibase-infra bundles stopped."
 
 status: _check-docker ## Show running omnibase-infra containers
 	@docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' \

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ down-all: _check-docker ## Stop runtime, then auth, then core (full teardown)
 	-$(ONEX_CLI) down runtime
 	@echo "==> Stopping auth bundle (if running)..."
 	-$(ONEX_CLI) down auth
-	@echo "==> Stopping core bundle..."
-	$(ONEX_CLI) down core
+	@echo "==> Stopping core bundle (if running)..."
+	-$(ONEX_CLI) down core
 	@echo "==> Done. All omnibase-infra bundles stopped."
 
 status: _check-docker ## Show running omnibase-infra containers

--- a/README.md
+++ b/README.md
@@ -60,6 +60,40 @@ CI support, and requires a clone.
 
 ## Common Commands
 
+### Local infrastructure lifecycle
+
+The repo ships a top-level `Makefile` with user-facing infra entrypoints
+(OMN-10377). All Docker/Compose/Keycloak orchestration lives here, never in
+the public `omnibase` shell.
+
+```bash
+# Start core infra bundle (postgres, redpanda, valkey, infisical)
+make up
+
+# Add Keycloak (auth bundle) on top of core
+make up-auth
+
+# Reconcile Keycloak clients from desired-clients.json
+make seed-keycloak
+
+# Show running containers
+make status
+
+# Stop the core bundle
+make down
+
+# List all targets
+make help
+```
+
+`make` targets detect a missing/stopped Docker daemon and emit an actionable
+error before doing anything destructive. They also detect a missing
+`~/.omnibase/.env` and point at remediation rather than failing with a stack
+trace. See [`docs/getting-started/full-platform.md`](docs/getting-started/full-platform.md)
+for the full first-time bootstrap sequence.
+
+### Development and testing
+
 ```bash
 # Run unit tests
 uv run pytest tests/unit

--- a/README.md
+++ b/README.md
@@ -76,11 +76,20 @@ make up-auth
 # Reconcile Keycloak clients from desired-clients.json
 make seed-keycloak
 
+# Seed Infisical from ONEX contracts (writes with --execute)
+make seed-infisical
+
 # Show running containers
 make status
 
-# Stop the core bundle
+# Stop the core bundle ONLY (auth/runtime stay running)
 make down
+
+# Stop the auth bundle (keycloak)
+make down-auth
+
+# Stop everything (runtime + auth + core, in safe teardown order)
+make down-all
 
 # List all targets
 make help

--- a/docs/getting-started/full-platform.md
+++ b/docs/getting-started/full-platform.md
@@ -28,11 +28,19 @@ Install the core ONEX package with uv
 
 ## Start Docker Infrastructure
 
-Start PostgreSQL, Redpanda, and Valkey via Docker Compose
+Start PostgreSQL, Redpanda, Valkey, and Infisical via the in-repo Makefile.
+The `Makefile` (OMN-10377) detects a missing/stopped Docker daemon and emits
+an actionable error before doing anything destructive.
 
 - [ ] **Start Docker Infrastructure**
-  - Verify: `localhost:5436` (tcp_probe)
+  - Run: `make up`
+  - Verify: `localhost:5436` (tcp_probe) and `make status` shows all
+    `omnibase-infra-*` containers as healthy
   - Estimated time: 2m 0s
+
+To add Keycloak for local OIDC/auth flows, follow up with `make up-auth` and
+then `make seed-keycloak` (requires `~/.omnibase/.env` with
+`KEYCLOAK_ADMIN_USERNAME` and `KEYCLOAK_ADMIN_PASSWORD`).
 
 ## Configure Secrets
 

--- a/docs/getting-started/full-platform.md
+++ b/docs/getting-started/full-platform.md
@@ -38,9 +38,10 @@ an actionable error before doing anything destructive.
     `omnibase-infra-*` containers as healthy
   - Estimated time: 2m 0s
 
-To add Keycloak for local OIDC/auth flows, follow up with `make up-auth` and
-then `make seed-keycloak` (requires `~/.omnibase/.env` with
-`KEYCLOAK_ADMIN_USERNAME` and `KEYCLOAK_ADMIN_PASSWORD`).
+> Keycloak (auth bundle) requires secrets in `~/.omnibase/.env` and is
+> covered below — see "Add Keycloak (optional)" after the **Configure
+> Secrets** step. Do not run `make seed-keycloak` until that env file
+> exists.
 
 ## Configure Secrets
 
@@ -49,6 +50,25 @@ Set up ~/.omnibase/.env with required environment variables
 - [ ] **Configure Secrets**
   - Verify: `~/.omnibase/.env` (file_exists)
   - Estimated time: 2m 0s
+
+## Add Keycloak (optional)
+
+After completing **Configure Secrets** above, you can bring up the auth
+bundle and reconcile its clients. Skip this section if you don't need
+local OIDC/auth.
+
+- [ ] **Start Keycloak**
+  - Run: `make up-auth`
+  - Verify: `localhost:28080/realms/omninode/.well-known/openid-configuration` (http_health)
+  - Estimated time: 1m 0s
+- [ ] **Reconcile Keycloak clients**
+  - Run: `make seed-keycloak`
+  - Prerequisite: `~/.omnibase/.env` must contain `KEYCLOAK_ADMIN_USERNAME`
+    and `KEYCLOAK_ADMIN_PASSWORD` (the Makefile's `_check-env-file`
+    guard catches the missing-file case with an actionable error).
+  - Verify: 5 clients reconciled to `op=created` on first run, `op=unchanged`
+    on subsequent runs (idempotent)
+  - Estimated time: 30s
 
 ## Start Omnidash Dashboard
 


### PR DESCRIPTION
Closes OMN-10377.

## Summary

Adds a top-level `Makefile` to `omnibase_infra` exposing user-facing infra entrypoints so users can run `cd repos/omnibase_infra && make up` after `make install` in the public `omnibase` shell. **Unblocks [OMN-10378](https://linear.app/omninode/issue/OMN-10378)** (strip Docker glue from public omnibase Makefile).

## Targets

| Target | Action | Bundle |
|---|---|---|
| `make help` | List targets | — |
| `make up` | Start core infra | postgres, redpanda, valkey, infisical |
| `make up-auth` | Add Keycloak | keycloak |
| `make up-runtime` | Full runtime stack | extends core |
| `make down` | Stop core | — |
| `make status` | Show running `omnibase-infra-*` containers | — |
| `make seed-keycloak` | Reconcile clients from `desired-clients.json` | (calls `scripts/seed-keycloak.sh` from PR #1500) |
| `make seed-infisical` | Seed Infisical from contracts | (calls `scripts/seed-infisical.py --execute`) |

All lifecycle targets delegate to the catalog CLI documented in `CLAUDE.md`:
```
uv run python -m omnibase_infra.docker.catalog.cli up <bundle>
```

## Graceful error paths (OMN-10377 acceptance)

- **Missing or stopped Docker daemon:** every target that touches Docker runs through the `_check-docker` recipe which checks both `command -v docker` and `docker info`, then emits OS-specific remediation (Docker Desktop / `brew install --cask docker` / `systemctl start docker`). No stack trace; clear actionable error.
- **Missing `~/.omnibase/.env` (or `$OMNIBASE_ENV_FILE`):** `seed-keycloak` and `seed-infisical` run through `_check-env-file` which prints the minimum required keys (`KEYCLOAK_ADMIN_USERNAME`, `KEYCLOAK_ADMIN_PASSWORD`), the `openssl rand -base64 24` recipe, and the `cp .env.example` template path before exiting non-zero.

## Doc updates

- **`README.md` `Common Commands`** — leads with the lifecycle targets so they're discoverable from the repo root. The original test/lint commands are kept under a "Development and testing" subheading.
- **`docs/getting-started/full-platform.md` "Start Docker Infrastructure"** — replaces the "user figures out which compose file to invoke" gap with a single runnable command (`make up`). Adds a follow-up note for the Keycloak path (`make up-auth` → `make seed-keycloak`).

## Architectural alignment

This PR enforces the 2026-04-30 architectural rule (memorized as `feedback_docker_only_in_omnibase_infra.md`):

> Docker / Compose / Keycloak / infra orchestration lives ONLY in `OmniNode-ai/omnibase_infra`. The public `omnibase` workspace shell may NOT contain `docker-up` / `docker-down` / `seed-keycloak` targets — even as Makefile glue.

Once this PR merges, OMN-10378 can strip the existing `docker-up`/`docker-down`/`seed-keycloak` code from the public `omnibase` Makefile and update its README to direct users here.

## Test plan

- [x] `make help` lists all 8 targets with descriptions (verified locally).
- [x] Makefile parses cleanly (`make -n help`).
- [ ] `make up` brings up `omnibase-infra-postgres`, `omnibase-infra-redpanda`, `omnibase-infra-valkey`, `omnibase-infra-infisical` (verify by running on a clean clone).
- [ ] `make up` with Docker daemon stopped emits "ERROR: docker daemon is not running" and exits 1.
- [ ] `make seed-keycloak` with `~/.omnibase/.env` absent emits the multi-line remediation and exits 1.
- [ ] `make seed-keycloak` with valid env reconciles 5 clients to `op=created` (or `op=unchanged` on re-run).

## dod_evidence

- evidence_path: TBD on first CI green (will commit clean-clone log)
- verifier: GitHub Actions runner on this PR + manual smoke-test on a clean machine

OMN-10377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New infra lifecycle commands: start/stop core services, auth/runtime bundles, status, help, and seeders for auth and secrets; CLI wrapper and environment file default; pre-checks that validate Docker and required env file with actionable errors.

* **Documentation**
  * Updated local setup and full-platform guides to use the Makefile-based workflow, with health verification, Keycloak auth steps, and testing/dev guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->