### PR TITLE
fix(OMN-10445): reconcile runtime stability lane

### DIFF
--- a/contracts/OMN-10445.yaml
+++ b/contracts/OMN-10445.yaml
@@ -1,0 +1,41 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10445"
+title: "Runtime Stability Reconciliation -- runtime package activation"
+summary: "Pin active runtime package activation for omnibase_infra and omnimarket in the infra compose runtime environment."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "public_api"
+evidence_requirements:
+  - kind: "tests"
+    description: "Runtime package activation, env completeness, parity, and auto-wiring tests pass"
+    command: "uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q"
+  - kind: "manual"
+    description: "Sibling omninode_infra env parity checks pass with explicit OMNINODE_INFRA_DIR"
+    command: "OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
+  - kind: "manual"
+    description: "Post-merge deploy/readiness smoke command recorded; live deploy requires explicit approval"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} printenv ONEX_ACTIVE_RUNTIME_PACKAGES"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Runtime package activation, env completeness, parity, and auto-wiring tests pass"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q"
+  - id: "dod-002"
+    description: "Sibling omninode_infra env parity checks pass with explicit OMNINODE_INFRA_DIR"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
+  - id: "dod-deploy"
+    description: "Post-merge deploy/readiness smoke plan only; this PR has not deployed, restarted runtime, or mutated .201"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} printenv ONEX_ACTIVE_RUNTIME_PACKAGES"

--- a/contracts/OMN-10445.yaml
+++ b/contracts/OMN-10445.yaml
@@ -12,7 +12,7 @@ evidence_requirements:
     command: "uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py -q"
   - kind: "manual"
     description: "Sibling omninode_infra env parity checks pass with explicit OMNINODE_INFRA_DIR"
-    command: "OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
+    command: "OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
   - kind: "manual"
     description: "Post-merge deploy/readiness smoke command recorded; live deploy requires explicit approval"
     command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} printenv ONEX_ACTIVE_RUNTIME_PACKAGES"
@@ -32,7 +32,7 @@ dod_evidence:
     source: "generated"
     checks:
       - check_type: "command"
-        check_value: "OMNINODE_INFRA_DIR=/Users/jonah/Code/omni_home/omninode_infra uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
+        check_value: "OMNINODE_INFRA_DIR=${OMNINODE_INFRA_DIR:?set OMNINODE_INFRA_DIR to sibling omninode_infra checkout} uv run pytest tests/ci/test_env_parity.py tests/ci/test_plugin_env_service_completeness.py -q"
   - id: "dod-deploy"
     description: "Post-merge deploy/readiness smoke plan only; this PR has not deployed, restarted runtime, or mutated .201"
     source: "manual"

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -144,6 +144,7 @@ x-runtime-env: &runtime-env
   BUS_ID: "local"
   ONEX_CONTRACTS_DIR: /app/contracts
   ONEX_STATE_ROOT: /app/data/.onex_state
+  ONEX_ACTIVE_RUNTIME_PACKAGES: ${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}
   # OMN-6440: Runtime contract YAMLs from omnibase_core (env var override for Docker)
   ONEX_RUNTIME_CONTRACTS_DIR: /app/contracts/runtime
   ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -145,6 +145,10 @@ CONFIGMAP_DEBT_KEYS: frozenset[str] = frozenset(
         "OMNICLAUDE_SKILLS_ROOT",  # container-internal path — same as CONTRACTS_ROOT
         "ONEX_REGISTRATION_AUTO_ACK",
         "USE_EVENT_ROUTING",
+        # Runtime package activation selector. k8s ConfigMap parity is tracked
+        # with the OMN-10445 release/deploy follow-up because this PR cannot
+        # update the sibling omninode_infra checkout used by the parity job.
+        "ONEX_ACTIVE_RUNTIME_PACKAGES",
         # OpenTelemetry — opt-in observability (empty = disabled)
         "OTEL_EXPORTER_OTLP_ENDPOINT",
         "OTEL_SERVICE_NAME",

--- a/tests/ci/test_plugin_env_service_completeness.py
+++ b/tests/ci/test_plugin_env_service_completeness.py
@@ -76,3 +76,15 @@ def test_plugin_host_envvars_have_compose_services() -> None:
         "Plugin HOST env vars point at non-existent compose services:\n"
         + "\n".join(failures)
     )
+
+
+@pytest.mark.unit
+def test_runtime_env_declares_active_runtime_packages() -> None:
+    """Runtime must not scan inactive installed packages during boot."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    runtime_env: dict = compose.get("x-runtime-env", {})
+
+    assert (
+        runtime_env.get("ONEX_ACTIVE_RUNTIME_PACKAGES")
+        == "${ONEX_ACTIVE_RUNTIME_PACKAGES:-omnibase_infra,omnimarket}"
+    )


### PR DESCRIPTION
## Summary
- pin active runtime package activation for the infra runtime environment
- add deploy-gate contract evidence for OMN-10445
- keep the stability-test runtime lane render/parity checks covered

## Verification
- uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py tests/unit/services/snapshot/test_store_inmemory.py tests/unit/runtime/test_kernel_registry.py -q
- 2026-05-06 live .201 proof: omninode-stability-test-runtime /health healthy and /ready healthy on :18085
- push hooks passed through ONEX Architecture Layer Validation

## Runtime Notes
- No production restart is included in this PR.
- Production main runtime is healthy on :8085.
- Production runtime-effects is Docker healthy but still app-level runtime_pending while joining subscriptions; use stability-test runtime for test work until :8086 is app-level healthy.

## Evidence
- .201 evidence: /data/omninode/omni_home/docs/tracking/201-migration-20260506T183942Z/stability_runtime_20260506T200016Z.txt