### PR TITLE
fix(OMN-10079): publish terminal outputs for brokered runtime commands

### DIFF
--- a/contracts/OMN-10079.yaml
+++ b/contracts/OMN-10079.yaml
@@ -28,3 +28,9 @@ dod_evidence:
     checks:
       - check_type: "command"
         check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"
+  - id: "dod-003"
+    description: ".201 runtime dry-run market dispatch produced the declared terminal event with status ready"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "ssh jonah@192.168.86.201 'docker exec omninode-runtime-effects rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1 < /tmp/omn-10079-pattern-b-command.json'"

--- a/contracts/OMN-10079.yaml
+++ b/contracts/OMN-10079.yaml
@@ -1,0 +1,29 @@
+# OMN-10079 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-10079"
+summary: "fix runtime ingress terminal publication for brokered market commands"
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "events"
+  - "envelopes"
+  - "public_api"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Auto-wired contracts with multiple publish topics publish handler output to their declared terminal_event"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_wiring.py tests/integration/test_pattern_b_terminal_result_applier.py -q"
+  - id: "dod-002"
+    description: "Pattern B broker package route discovery honors pattern_b_broker.package_names independently of active runtime package env"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"

--- a/contracts/OMN-10079.yaml
+++ b/contracts/OMN-10079.yaml
@@ -3,6 +3,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: "OMN-10079"
+title: "Codex runtime local runtime ingress"
 summary: "fix runtime ingress terminal publication for brokered market commands"
 is_seam_ticket: true
 interface_change: true

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -293,6 +293,7 @@ def _parse_contract(
         package_name=package_name,
         package_version=package_version,
         runtime_profiles=runtime_profiles,
+        terminal_event=raw.get("terminal_event"),
         event_bus=event_bus,
         handler_routing=handler_routing,
     )

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1648,19 +1648,35 @@ async def _subscribe_contract_topics(
     if (
         effective_result_applier is None
         and contract.event_bus is not None
-        and len(contract.event_bus.publish_topics) == 1
+        and contract.event_bus.publish_topics
         and not _contract_declares_db_io(contract)
     ):
-        # ProtocolEventBusLike is @runtime_checkable; isinstance both narrows
-        # the type for mypy and provides a runtime use of the import (avoiding
-        # CodeQL py/unused-import false positive when cast() is the only ref).
-        assert isinstance(event_bus, ProtocolEventBusLike), (
-            f"event_bus must implement ProtocolEventBusLike, got {type(event_bus).__name__}"
-        )
-        effective_result_applier = DispatchResultApplier(
-            event_bus=event_bus,
-            output_topic=contract.event_bus.publish_topics[0],
-        )
+        output_topic: str | None = None
+        if len(contract.event_bus.publish_topics) == 1:
+            output_topic = contract.event_bus.publish_topics[0]
+        elif contract.terminal_event in contract.event_bus.publish_topics:
+            output_topic = contract.terminal_event
+        else:
+            logger.warning(
+                "Auto-wired contract declares multiple publish topics but no "
+                "terminal_event default for handler output application: "
+                "contract=%s publish_topics=%s terminal_event=%s",
+                contract.name,
+                contract.event_bus.publish_topics,
+                contract.terminal_event,
+            )
+
+        if output_topic is not None:
+            # ProtocolEventBusLike is @runtime_checkable; isinstance both narrows
+            # the type for mypy and provides a runtime use of the import (avoiding
+            # CodeQL py/unused-import false positive when cast() is the only ref).
+            assert isinstance(event_bus, ProtocolEventBusLike), (
+                f"event_bus must implement ProtocolEventBusLike, got {type(event_bus).__name__}"
+            )
+            effective_result_applier = DispatchResultApplier(
+                event_bus=event_bus,
+                output_topic=output_topic,
+            )
     node_identity = ModelNodeIdentity(
         env=environment,
         service=contract.package_name,

--- a/src/omnibase_infra/runtime/auto_wiring/models/model_discovered_contract.py
+++ b/src/omnibase_infra/runtime/auto_wiring/models/model_discovered_contract.py
@@ -50,6 +50,10 @@ class ModelDiscoveredContract(BaseModel):
             "Empty means backward-compatible ownership by every runtime profile."
         ),
     )
+    terminal_event: str | None = Field(
+        default=None,
+        description="Optional terminal event topic declared by orchestrator contracts.",
+    )
     event_bus: ModelEventBusWiring | None = Field(
         default=None, description="Event bus wiring if declared"
     )

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -2241,8 +2241,10 @@ class RuntimeHostProcess:
         if self._local_ingress_config.enabled:
             routes = dict(self._local_ingress_routes)
         else:
-            package_names = parse_active_runtime_packages(
-                self._pattern_b_broker_config.package_names
+            package_names = tuple(
+                part.strip()
+                for part in self._pattern_b_broker_config.package_names
+                if part.strip()
             )
             routes = discover_runtime_local_ingress_routes(package_names)
         self._pattern_b_broker = RuntimePatternBBroker(

--- a/tests/integration/test_pattern_b_terminal_result_applier.py
+++ b/tests/integration/test_pattern_b_terminal_result_applier.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import MessageDispatchEngine
+
+
+class ModelTerminalResult(BaseModel):
+    correlation_id: UUID
+    status: str
+
+
+class HandlerTerminalResult:
+    async def handle(self, envelope: object) -> ModelTerminalResult:
+        if isinstance(envelope, dict):
+            payload = envelope["payload"]
+            debug_trace = envelope["__debug_trace"]
+            assert isinstance(debug_trace, dict)
+            correlation_id = debug_trace["correlation_id"]
+        else:
+            payload = envelope.payload
+            correlation_id = envelope.correlation_id
+        return ModelTerminalResult(
+            correlation_id=UUID(str(correlation_id)),
+            status=str(payload["status"]),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_multi_publish_contract_emits_handler_result_to_terminal_event() -> None:
+    command_topic = "onex.cmd.omnimarket.session-bootstrap-start.v2"
+    terminal_topic = "onex.evt.omnimarket.session-bootstrap-completed.v2"
+    aux_topic = "onex.evt.omnimarket.session-cron-health-violation.v1"
+    correlation_id = UUID("11111111-1111-4111-8111-111111111111")
+
+    contract = ModelDiscoveredContract(
+        name="session_bootstrap",
+        node_type="orchestrator",
+        contract_version=ModelContractVersion(major=2, minor=0, patch=0),
+        contract_path=Path("/tmp/session_bootstrap/contract.yaml"),  # noqa: S108
+        entry_point_name="session_bootstrap",
+        package_name="omnimarket",
+        terminal_event=terminal_topic,
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(command_topic,),
+            publish_topics=(terminal_topic, aux_topic),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerTerminalResult",
+                        module=__name__,
+                    ),
+                    event_model=None,
+                ),
+            ),
+        ),
+    )
+    bus = EventBusInmemory(environment="test", group="pattern-b-terminal")
+    await bus.start()
+    try:
+        terminal_results: asyncio.Queue[ModelTerminalResult] = asyncio.Queue()
+
+        async def collect_terminal(message: ModelEventMessage) -> None:
+            envelope = ModelEventEnvelope[ModelTerminalResult].model_validate_json(
+                message.value
+            )
+            if envelope.correlation_id == correlation_id:
+                await terminal_results.put(envelope.payload)
+
+        await bus.subscribe(
+            terminal_topic,
+            group_id="terminal-collector",
+            on_message=collect_terminal,
+        )
+
+        engine = MessageDispatchEngine()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerTerminalResult,
+        ):
+            await wire_from_manifest(
+                ModelAutoWiringManifest(contracts=(contract,)),
+                engine,
+                event_bus=bus,
+                environment="local",
+            )
+        engine.freeze()
+
+        command = ModelEventEnvelope[object](
+            payload={"status": "ready"},
+            correlation_id=correlation_id,
+            event_type="omnimarket.session-bootstrap-start",
+        )
+        await bus.publish(
+            command_topic,
+            None,
+            command.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+        result = await asyncio.wait_for(terminal_results.get(), timeout=2)
+
+        assert result.status == "ready"
+        assert result.correlation_id == correlation_id
+    finally:
+        await bus.close()

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -11,6 +11,7 @@ from uuid import UUID
 import pytest
 from pydantic import BaseModel
 
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _derive_dispatcher_id,
     _derive_handler_entry_key,
@@ -82,6 +83,7 @@ def _make_contract(
     package_name: str = "test-package",
     subscribe_topics: tuple[str, ...] = ("onex.evt.platform.test-input.v1",),
     publish_topics: tuple[str, ...] = (),
+    terminal_event: str | None = None,
     handler_routing: ModelHandlerRouting | None = None,
     consumer_purpose: str | None = None,
 ) -> ModelDiscoveredContract:
@@ -92,6 +94,7 @@ def _make_contract(
         contract_path=Path("/fake/contract.yaml"),
         entry_point_name=name,
         package_name=package_name,
+        terminal_event=terminal_event,
         event_bus=ModelEventBusWiring(
             subscribe_topics=subscribe_topics,
             publish_topics=publish_topics,
@@ -264,6 +267,98 @@ class TestMakeDispatchCallback:
         assert len(result.output_events) == 1
         assert isinstance(result.output_events[0], FakeTypedOutput)
         assert result.output_events[0].result == "handled:market"
+
+
+class TestTerminalEventResultApplier:
+    @pytest.mark.asyncio
+    async def test_multi_publish_contract_applies_output_to_terminal_event(
+        self,
+    ) -> None:
+        from omnibase_infra.runtime.service_message_dispatch_engine import (
+            MessageDispatchEngine,
+        )
+
+        command_topic = "onex.cmd.omnimarket.session-bootstrap-start.v2"
+        terminal_topic = "onex.evt.omnimarket.session-bootstrap-completed.v2"
+        contract = _make_contract(
+            name="session_bootstrap",
+            subscribe_topics=(command_topic,),
+            publish_topics=(
+                terminal_topic,
+                "onex.evt.omnimarket.session-cron-health-violation.v1",
+            ),
+            terminal_event=terminal_topic,
+            handler_routing=_make_handler_routing(),
+        )
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+
+        class FakeEventBus:
+            def __init__(self) -> None:
+                self.subscribe_mock = AsyncMock(return_value=AsyncMock())
+                self.publish_envelope_mock = AsyncMock()
+
+            async def subscribe(self, **kwargs: object) -> object:
+                return await self.subscribe_mock(**kwargs)
+
+            async def publish_envelope(
+                self,
+                envelope: object,
+                topic: str,
+                *,
+                key: bytes | None = None,
+            ) -> None:
+                await self.publish_envelope_mock(
+                    envelope=envelope, topic=topic, key=key
+                )
+
+            async def publish(
+                self,
+                topic: str,
+                key: bytes | None,
+                value: bytes,
+            ) -> None:
+                return None
+
+        event_bus = FakeEventBus()
+
+        class Handler:
+            async def handle(self, _envelope: object) -> FakeTypedOutput:
+                return FakeTypedOutput(
+                    correlation_id=UUID("11111111-1111-4111-8111-111111111111"),
+                    result="ready",
+                )
+
+        engine = MessageDispatchEngine()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=Handler,
+        ):
+            await wire_from_manifest(
+                manifest,
+                engine,
+                event_bus=event_bus,
+                environment="local",
+            )
+        engine.freeze()
+
+        callback = event_bus.subscribe_mock.call_args.kwargs["on_message"]
+        envelope = ModelEventEnvelope[object](
+            payload={"session_id": "session-1"},
+            correlation_id=UUID("11111111-1111-4111-8111-111111111111"),
+            event_type="omnimarket.session-bootstrap-start",
+        )
+        message = MagicMock(value=envelope.model_dump_json().encode("utf-8"))
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._wait_for_dispatch_engine_freeze",
+            AsyncMock(return_value=True),
+        ):
+            await callback(message)
+
+        event_bus.publish_envelope_mock.assert_awaited_once()
+        assert (
+            event_bus.publish_envelope_mock.await_args.kwargs["topic"] == terminal_topic
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -288,7 +288,8 @@ async def test_runtime_host_process_starts_pattern_b_broker_when_enabled(
 
     monkeypatch.setattr(
         "omnibase_infra.runtime.service_runtime_host_process.discover_runtime_local_ingress_routes",
-        lambda _packages: {"session_orchestrator": route},
+        lambda packages: captured.setdefault("packages", packages)
+        and {"session_orchestrator": route},
     )
     monkeypatch.setattr(
         "omnibase_infra.runtime.service_runtime_host_process.RuntimePatternBBroker",
@@ -315,10 +316,61 @@ async def test_runtime_host_process_starts_pattern_b_broker_when_enabled(
 
     assert process._pattern_b_broker is not None
     assert captured["command_topic"] == "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+    assert captured["packages"] == ("omnibase_infra", "omnimarket")
     assert captured["routes"] == {"session_orchestrator": route}
     start_mock = captured["start_mock"]
     assert isinstance(start_mock, AsyncMock)
     start_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_broker_package_names_ignore_active_runtime_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    captured: dict[str, object] = {}
+
+    class FakeBroker:
+        def __init__(
+            self,
+            event_bus: object,
+            *,
+            command_topic: str,
+            routes: object,
+        ) -> None:
+            captured["routes"] = routes
+            self.start = AsyncMock()
+
+    monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra")
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.discover_runtime_local_ingress_routes",
+        lambda packages: captured.setdefault("packages", packages)
+        and {"session_orchestrator": route},
+    )
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.RuntimePatternBBroker",
+        FakeBroker,
+    )
+
+    process = RuntimeHostProcess(
+        event_bus=EventBusInmemory(environment="test", group="pattern-b"),
+        config={
+            "service_name": "test-service",
+            "node_name": "test-node",
+            "env": "test",
+            "version": "v1",
+            "pattern_b_broker": {
+                "enabled": True,
+                "package_names": ["omnimarket"],
+            },
+        },
+        dispatch_engine=AsyncMock(),
+    )
+
+    await process._start_pattern_b_broker()
+
+    assert captured["packages"] == ("omnimarket",)
+    assert captured["routes"] == {"session_orchestrator": route}
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2045,12 +2045,12 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.4,<1.1.0" },
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
-    { name = "aiokafka", specifier = ">=0.11.0,<0.14.0" },
+    { name = "aiokafka", specifier = ">=0.11.0,<0.15.0" },
     { name = "asyncpg", specifier = ">=0.29.0,<0.32.0" },
     { name = "circuitbreaker", specifier = ">=2.0.0,<3.0.0" },
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "confluent-kafka", specifier = ">=2.12.0,<3.0.0" },
-    { name = "cryptography", specifier = ">=46.0.3,<48.0.0" },
+    { name = "cryptography", specifier = ">=46.0.3,<49.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.1,<5.0.0" },
     { name = "fastapi", specifier = ">=0.120.1,<0.137.0" },
     { name = "grpcio", specifier = ">=1.62.0,<2.0.0" },


### PR DESCRIPTION
## Ticket
- OMN-10079

## Summary
- discover contract-level terminal_event for auto-wired contracts
- default handler output publication to terminal_event when a contract has multiple publish_topics
- keep Pattern B broker package route discovery scoped to pattern_b_broker.package_names instead of ONEX_ACTIVE_RUNTIME_PACKAGES

## Live proof
- On .201, Codex runtime adapter session_bootstrap returned ok=true via onex.cmd.omnimarket.pattern-b-dispatch.v1
- terminal payload came from onex.evt.omnimarket.session-bootstrap-completed.v2 with status=ready and dry_run=true
- deploy evidence command is recorded in contracts/OMN-10079.yaml

## Verification
- uv run pytest tests/integration/test_pattern_b_terminal_result_applier.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/test_service_pattern_b_broker.py -q
- uv run validate-yaml contracts/OMN-10079.yaml
- uv run ruff format <touched files>
- uv run ruff check --fix <touched files>
- git push hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal event support for orchestrator contracts, enabling designated topics for handler result publication.
  * Added a new ticket contract declaration (OMN-10079) including evidence checks and terminal-event metadata.

* **Tests**
  * Added integration and unit tests covering terminal-event result handling in the dispatch flow.

* **Chores**
  * Pattern B broker now derives package names from configured package list when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->