### PR TITLE
OMN-10079: project materialized runtime node dispatches

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -475,7 +475,77 @@ _DB_URL_ENV_MAP: dict[str, str] = {
 _TOPIC_TO_EVENT_TYPE: dict[str, str] = {
     "node-heartbeat": "heartbeat",
     "node-introspection": "introspection",
+    "node-state-change": "state_change",
 }
+
+
+def _derive_projection_event_type(
+    topic: str,
+    envelope_event_type: object,
+    subscribe_topics: tuple[str, ...],
+) -> str:
+    """Derive projection handler event type from topic or dispatch alias."""
+    topic_candidate = topic
+    if not topic_candidate and len(subscribe_topics) == 1:
+        topic_candidate = subscribe_topics[0]
+
+    segment_candidates: list[str] = []
+    if topic_candidate:
+        segment_candidates.append(
+            topic_candidate.split(".")[-2]
+            if "." in topic_candidate
+            else topic_candidate
+        )
+    if envelope_event_type:
+        event_type = str(envelope_event_type).strip()
+        if event_type:
+            segment_candidates.append(event_type.split(".")[-1])
+
+    for segment in segment_candidates:
+        if segment in _TOPIC_TO_EVENT_TYPE:
+            return _TOPIC_TO_EVENT_TYPE[segment]
+
+    raise ValueError(
+        "Unknown projection event type from "
+        f"topic={topic_candidate!r} event_type={envelope_event_type!r} — "
+        f"must resolve to one of {sorted(_TOPIC_TO_EVENT_TYPE)!r}"
+    )
+
+
+def _materialized_dispatch_trace_value(
+    envelope: object,
+    key: str,
+) -> object:
+    """Extract trace metadata from a materialized dispatch dict."""
+    if not isinstance(envelope, dict):
+        return None
+    trace = envelope.get("__debug_trace")
+    if isinstance(trace, dict):
+        return trace.get(key)
+    return None
+
+
+def _extract_projection_topic(envelope: object) -> str:
+    """Extract projection route topic from envelope or materialized dispatch."""
+    if isinstance(envelope, dict):
+        value = _materialized_dispatch_trace_value(envelope, "topic")
+    else:
+        value = getattr(envelope, "topic", None)
+    return str(value).strip() if value else ""
+
+
+def _extract_projection_event_type(envelope: object) -> object:
+    """Extract event_type from envelope or materialized dispatch trace."""
+    if isinstance(envelope, dict):
+        return _materialized_dispatch_trace_value(envelope, "event_type")
+    return getattr(envelope, "event_type", None)
+
+
+def _extract_projection_payload(envelope: object) -> object:
+    """Extract payload from envelope or materialized dispatch dict."""
+    if isinstance(envelope, dict):
+        return envelope.get("payload")
+    return getattr(envelope, "payload", None)
 
 
 def _is_raw_event_projection_contract(contract: ModelDiscoveredContract) -> bool:
@@ -562,6 +632,12 @@ def _build_sync_db_adapter(db_url: str) -> object:
             updates = ", ".join(
                 f'"{c}" = EXCLUDED."{c}"' for c in cols if c != conflict_key
             )
+            adapted_row = {
+                key: psycopg2.extras.Json(value)
+                if isinstance(value, (dict, list))
+                else value
+                for key, value in row.items()
+            }
             # table/conflict_key/cols validated by _TABLE_NAME_RE — not raw user input
             parts = [
                 f'INSERT INTO "{table}" ({quoted_cols})',
@@ -570,7 +646,7 @@ def _build_sync_db_adapter(db_url: str) -> object:
             ]
             insert_sql = " ".join(parts)
             with conn.cursor() as cur:  # type: ignore[union-attr, attr-defined]
-                cur.execute(insert_sql, row)
+                cur.execute(insert_sql, adapted_row)
             return True
 
         def query(
@@ -631,15 +707,13 @@ def _make_projection_dispatch_callback(
             return None
         try:
             adapter = _build_sync_db_adapter(db_url)
-            topic = getattr(envelope, "topic", "") or ""
-            topic_segment = topic.split(".")[-2] if "." in topic else topic
-            if topic_segment not in _TOPIC_TO_EVENT_TYPE:
-                raise ValueError(
-                    f"Unknown topic segment {topic_segment!r} from topic {topic!r} — "
-                    f"must be one of {sorted(_TOPIC_TO_EVENT_TYPE)!r}"
-                )
-            event_type = _TOPIC_TO_EVENT_TYPE[topic_segment]
-            payload = getattr(envelope, "payload", None)
+            topic = _extract_projection_topic(envelope)
+            event_type = _derive_projection_event_type(
+                topic,
+                _extract_projection_event_type(envelope),
+                subscribe_topics,
+            )
+            payload = _extract_projection_payload(envelope)
             input_data: dict[str, object] = (
                 dict(payload) if isinstance(payload, dict) else {}
             )
@@ -659,15 +733,16 @@ def _make_projection_dispatch_callback(
                 "Projection handler TypeError (likely missing _db or _event_type): "
                 "handler=%s topic=%s error_type=%s",
                 type(handler_instance).__name__,
-                getattr(envelope, "topic", "unknown"),
+                _extract_projection_topic(envelope) or "unknown",
                 type(exc).__name__,
             )
         except Exception as exc:  # noqa: BLE001
             logger.error(
-                "Projection handler error: handler=%s topic=%s error_type=%s",
+                "Projection handler error: handler=%s topic=%s error_type=%s error=%s",
                 type(handler_instance).__name__,
-                getattr(envelope, "topic", "unknown"),
+                _extract_projection_topic(envelope) or "unknown",
                 type(exc).__name__,
+                exc,
             )
         return None
 

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -131,6 +131,231 @@ def test_projection_callback_end_to_end_with_fake_db(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
+def test_projection_callback_uses_sole_subscribed_topic_when_envelope_has_no_topic(
+    tmp_path: Path,
+) -> None:
+    """Runtime-dispatched envelopes do not always carry topic metadata."""
+    upserted_rows: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            db = input_data.pop("_db")
+            event_type = input_data.pop("_event_type")
+            db.upsert(
+                "node_service_registry",
+                "service_name",
+                {**input_data, "event_type": event_type},
+            )
+            return {"rows_upserted": 1}
+
+    class FakeDb:
+        def upsert(self, table: str, key: str, row: dict) -> bool:
+            upserted_rows.append({"table": table, "key": key, "row": row})
+            return True
+
+        def query(self, table: str, filters: dict | None = None) -> list:
+            return []
+
+    callback = _make_projection_dispatch_callback(
+        FakeProjectionHandler(),
+        [{"name": "node_service_registry", "database": "omnidash_analytics"}],
+        ("onex.evt.platform.node-heartbeat.v1",),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = ""
+    envelope.payload = {"service_name": "runtime-host", "health_status": "healthy"}
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter",
+        return_value=FakeDb(),
+    ):
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            asyncio.run(callback(envelope))
+
+    assert len(upserted_rows) == 1
+    assert upserted_rows[0]["row"]["service_name"] == "runtime-host"
+    assert upserted_rows[0]["row"]["event_type"] == "heartbeat"
+
+
+@pytest.mark.integration
+def test_projection_callback_uses_event_type_when_multitopic_envelope_has_no_topic(
+    tmp_path: Path,
+) -> None:
+    """Runtime dispatch preserves event_type even when envelopes omit topic metadata."""
+    upserted_rows: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            db = input_data.pop("_db")
+            event_type = input_data.pop("_event_type")
+            db.upsert(
+                "node_service_registry",
+                "service_name",
+                {**input_data, "event_type": event_type},
+            )
+            return {"rows_upserted": 1}
+
+    class FakeDb:
+        def upsert(self, table: str, key: str, row: dict) -> bool:
+            upserted_rows.append({"table": table, "key": key, "row": row})
+            return True
+
+        def query(self, table: str, filters: dict | None = None) -> list:
+            return []
+
+    callback = _make_projection_dispatch_callback(
+        FakeProjectionHandler(),
+        [{"name": "node_service_registry", "database": "omnidash_analytics"}],
+        (
+            "onex.evt.platform.node-introspection.v1",
+            "onex.evt.platform.node-heartbeat.v1",
+        ),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = ""
+    envelope.event_type = "platform.node-heartbeat"
+    envelope.payload = {"service_name": "runtime-host", "health_status": "healthy"}
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter",
+        return_value=FakeDb(),
+    ):
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            asyncio.run(callback(envelope))
+
+    assert len(upserted_rows) == 1
+    assert upserted_rows[0]["row"]["service_name"] == "runtime-host"
+    assert upserted_rows[0]["row"]["event_type"] == "heartbeat"
+
+
+@pytest.mark.integration
+def test_projection_callback_uses_materialized_dispatch_trace_topic(
+    tmp_path: Path,
+) -> None:
+    """Dispatch engine passes projection callbacks materialized dispatch dicts."""
+    upserted_rows: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            db = input_data.pop("_db")
+            event_type = input_data.pop("_event_type")
+            db.upsert(
+                "node_service_registry",
+                "service_name",
+                {**input_data, "event_type": event_type},
+            )
+            return {"rows_upserted": 1}
+
+    class FakeDb:
+        def upsert(self, table: str, key: str, row: dict) -> bool:
+            upserted_rows.append({"table": table, "key": key, "row": row})
+            return True
+
+        def query(self, table: str, filters: dict | None = None) -> list:
+            return []
+
+    callback = _make_projection_dispatch_callback(
+        FakeProjectionHandler(),
+        [{"name": "node_service_registry", "database": "omnidash_analytics"}],
+        (
+            "onex.evt.platform.node-introspection.v1",
+            "onex.evt.platform.node-heartbeat.v1",
+        ),
+    )
+
+    materialized_dispatch = {
+        "payload": {"service_name": "runtime-host", "health_status": "healthy"},
+        "__bindings": {},
+        "__debug_trace": {
+            "event_type": None,
+            "topic": "onex.evt.platform.node-heartbeat.v1",
+        },
+    }
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter",
+        return_value=FakeDb(),
+    ):
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            asyncio.run(callback(materialized_dispatch))
+
+    assert len(upserted_rows) == 1
+    assert upserted_rows[0]["row"]["service_name"] == "runtime-host"
+    assert upserted_rows[0]["row"]["event_type"] == "heartbeat"
+
+
+@pytest.mark.integration
+def test_projection_callback_maps_node_state_change_topic(
+    tmp_path: Path,
+) -> None:
+    """Projection event aliases include all node registration subscribed topics."""
+    upserted_rows: list[dict] = []
+
+    class FakeProjectionHandler:
+        def handle(self, input_data: dict) -> dict:
+            db = input_data.pop("_db")
+            event_type = input_data.pop("_event_type")
+            db.upsert(
+                "node_service_registry",
+                "service_name",
+                {**input_data, "event_type": event_type},
+            )
+            return {"rows_upserted": 1}
+
+    class FakeDb:
+        def upsert(self, table: str, key: str, row: dict) -> bool:
+            upserted_rows.append({"table": table, "key": key, "row": row})
+            return True
+
+        def query(self, table: str, filters: dict | None = None) -> list:
+            return []
+
+    callback = _make_projection_dispatch_callback(
+        FakeProjectionHandler(),
+        [{"name": "node_service_registry", "database": "omnidash_analytics"}],
+        (
+            "onex.evt.platform.node-introspection.v1",
+            "onex.evt.platform.node-heartbeat.v1",
+            "onex.evt.platform.node-state-change.v1",
+        ),
+    )
+
+    materialized_dispatch = {
+        "payload": {"service_name": "runtime-host", "new_state": "active"},
+        "__bindings": {},
+        "__debug_trace": {
+            "event_type": None,
+            "topic": "onex.evt.platform.node-state-change.v1",
+        },
+    }
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter",
+        return_value=FakeDb(),
+    ):
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get",
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            asyncio.run(callback(materialized_dispatch))
+
+    assert len(upserted_rows) == 1
+    assert upserted_rows[0]["row"]["service_name"] == "runtime-host"
+    assert upserted_rows[0]["row"]["event_type"] == "state_change"
+
+
+@pytest.mark.integration
 def test_wire_handler_entry_uses_projection_path_when_db_io_declared(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Teach projection auto-wiring to read topic/payload metadata from materialized dispatch dictionaries as well as `ModelEventEnvelope` instances.
- Derive node registration projection event type from trace topic, envelope event type, or the sole subscribed topic.
- JSON-adapt dict/list projection rows before psycopg2 UPSERT so JSONB metadata does not fail at runtime.
- Add focused integration coverage for topic fallback, materialized dispatch trace, state-change topic mapping, and projection DB injection.

## Verification
- `uv run ruff format src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/integration/runtime/test_projection_handler_db_injection_integration.py`
- `uv run ruff check --fix src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/integration/runtime/test_projection_handler_db_injection_integration.py`
- `uv run pytest tests/integration/runtime/test_projection_handler_db_injection_integration.py -q` -> 8 passed
- pre-commit hooks during commit passed
- pre-push hooks passed, including mypy and ONEX Architecture Layer Validation

## Live .201 proof
Hotpatched into `omninode-runtime-effects` with the paired omnimarket fix. Runtime stayed healthy:

- `RestartCount=0 StartedAt=2026-05-07T05:41:23.079463944Z Health=healthy`
- Pattern B `session_bootstrap` dry-run completed with correlation `29af4d6b-cba7-42e4-a3e1-6ddc82de7f41`
- Adapter result: `status=completed`, node payload `status=ready`, `dry_run=true`
- Filtered logs after proof showed dispatch completions and no projection handler error, validation error, PostgreSQL adapter error, traceback, or runtime failure in the proof window.

## Notes
This PR is the infra half of the OMN-10079 runtime dogfood fix. The paired omnimarket PR makes node projection payloads and Pattern B command serialization match the live runtime path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved projection handler auto-wiring to more reliably determine event type values from Kafka topics and envelope metadata, with clearer error messaging.
  * Fixed JSON value serialization in projection database writes to properly handle complex payloads.

* **Tests**
  * Added integration tests for projection handler database injection covering multiple topic and envelope configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->