### PR TITLE
feat(OMN-10584): AdapterEnvSecretStore — nullable env-var-backed ProtocolSecretStore

### DIFF
--- a/contracts/runtime/contract_registry_reducer.yaml
+++ b/contracts/runtime/contract_registry_reducer.yaml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
----
 node_type: REDUCER_GENERIC
 contract_version: {major: 1, minor: 1, patch: 0}
 # Fingerprint: SHA-256 hash of canonical normalized contract content (excluding fingerprint field).
@@ -202,8 +201,7 @@ state_transitions:
       # When retry_count reaches 3, the retry_loading transition condition fails
       # and the FSM remains in the error state without automatic recovery.
       description: >-
-        When retry_count reaches maximum (3), automatic recovery via retry_loading transition is blocked.
-        The FSM remains in error state awaiting manual intervention.
+        When retry_count reaches maximum (3), automatic recovery via retry_loading transition is blocked. The FSM remains in error state awaiting manual intervention.
       detection:
         # How to detect this condition in monitoring systems
         - condition: retry_count >= 3 AND current_state == error
@@ -217,13 +215,11 @@ state_transitions:
         - step: 2
           action: Identify and fix invalid contract files
           details: >-
-            Review emit_error_event and log_validation_errors output to identify which contracts failed
-            validation and why
+            Review emit_error_event and log_validation_errors output to identify which contracts failed validation and why
         - step: 3
           action: Use force_reload operation after fixing issues
           details: >-
-            The force_reload operation (defined in operations section) bypasses the retry_count check
-            and directly transitions to loading state
+            The force_reload operation (defined in operations section) bypasses the retry_count check and directly transitions to loading state
         - step: 4
           action: Monitor runtime.contracts.reload events for success
           details: Subscribe to event bus for reload confirmation
@@ -241,8 +237,7 @@ state_transitions:
     recovery_from_error:
       # Documents the relationship between error state and recovery mechanisms
       description: >-
-        The error state has is_terminal: false, allowing recovery transitions. This is intentional to
-        support both automatic retry and manual recovery paths.
+        The error state has is_terminal: false, allowing recovery transitions. This is intentional to support both automatic retry and manual recovery paths.
       automatic_recovery:
         mechanism: retry_loading transition
         max_attempts: 3
@@ -253,8 +248,7 @@ state_transitions:
         requires_permission: true
         bypasses_retry_limit: true
         description: >-
-          Operators can invoke force_reload to reset the loading process regardless of retry_count. This
-          is the primary recovery path when automatic retries are exhausted.
+          Operators can invoke force_reload to reset the loading process regardless of retry_count. This is the primary recovery path when automatic retries are exhausted.
   operations:
     # Primary manual recovery operation when automatic retries are exhausted.
     # Bypasses retry_count check by directly targeting loading state.
@@ -285,7 +279,6 @@ state_transitions:
           trigger: undo_clear
       version: {major: 1, minor: 0, patch: 0}
       operation_type: administrative
-
 # v1.1.0 Required Fields
 # NOTE: The `handlers` section defines protocol-based dependencies injected via DI container.
 # This is SEPARATE from FSM action types (event, logging, data_capture, persistence) which are
@@ -308,18 +301,15 @@ handlers:
       version: {major: 1, minor: 0, patch: 0}
     - type: ProtocolEventBus
       version: {major: 1, minor: 0, patch: 0}
-
 profile_tags:
   - runtime
   - reducer
   - contracts
   - registry
-
 metadata:
   version: {major: 1, minor: 1, patch: 0}
   author: ONEX Framework Team
-  description: Declarative contract registry reducer using FSM pattern for managing loaded and compiled
-    ONEX contracts
+  description: Declarative contract registry reducer using FSM pattern for managing loaded and compiled ONEX contracts
   tags:
     - reducer
     - fsm

--- a/src/omnibase_infra/adapters/adapter_env_secret_store.py
+++ b/src/omnibase_infra/adapters/adapter_env_secret_store.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Env-var-backed implementation of ProtocolSecretStore for local dev / no-Infisical path."""
+
+from __future__ import annotations
+
+import os
+
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+class AdapterEnvSecretStore:
+    """ProtocolSecretStore backed by os.environ.
+
+    Intended for local development and tests where Infisical is unavailable.
+    get_secret returns None on miss — never raises. Required-value validation
+    is the caller's responsibility (e.g. Settings).
+    """
+
+    async def get_secret(self, key: str) -> str | None:
+        return os.environ.get(key)
+
+    async def set_secret(self, key: str, value: str) -> bool:
+        os.environ[key] = value
+        return True
+
+    async def delete_secret(self, key: str) -> bool:
+        existed = key in os.environ
+        os.environ.pop(key, None)
+        return existed
+
+    async def list_keys(self, prefix: str | None = None) -> list[str]:
+        if prefix is None:
+            return list(os.environ.keys())
+        return [k for k in os.environ if k.startswith(prefix)]
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def close(self, timeout_seconds: float = 30.0) -> None:  # stub-ok
+        pass
+
+
+# Runtime-checkable structural check — ensures protocol satisfaction is verified at import.
+_: ProtocolSecretStore = AdapterEnvSecretStore()

--- a/tests/integration/adapters/test_env_secret_store_integration.py
+++ b/tests/integration/adapters/test_env_secret_store_integration.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the env-backed ProtocolSecretStore adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.adapters.adapter_env_secret_store import AdapterEnvSecretStore
+from omnibase_spi.protocols.services.protocol_secret_store import ProtocolSecretStore
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_env_secret_store_protocol_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = "_ONEX_INTEGRATION_ENV_SECRET_STORE"
+    monkeypatch.delenv(key, raising=False)
+
+    store: ProtocolSecretStore = AdapterEnvSecretStore()
+
+    assert await store.get_secret(key) is None
+    assert await store.set_secret(key, "integration-value") is True
+    assert await store.get_secret(key) == "integration-value"
+    assert key in await store.list_keys(prefix="_ONEX_INTEGRATION_")
+    assert await store.delete_secret(key) is True
+    assert await store.get_secret(key) is None
+    assert await store.health_check() is True
+    await store.close()

--- a/tests/unit/adapters/test_env_secret_store.py
+++ b/tests/unit/adapters/test_env_secret_store.py
@@ -14,6 +14,7 @@ def store() -> AdapterEnvSecretStore:
     return AdapterEnvSecretStore()
 
 
+@pytest.mark.unit
 class TestAdapterEnvSecretStoreGet:
     @pytest.mark.asyncio
     async def test_get_missing_key_returns_none(
@@ -32,6 +33,7 @@ class TestAdapterEnvSecretStoreGet:
         assert result == "secret-value"
 
 
+@pytest.mark.unit
 class TestAdapterEnvSecretStoreSet:
     @pytest.mark.asyncio
     async def test_set_and_get_roundtrip(
@@ -44,6 +46,7 @@ class TestAdapterEnvSecretStoreSet:
         assert result == "my-value"
 
 
+@pytest.mark.unit
 class TestAdapterEnvSecretStoreDelete:
     @pytest.mark.asyncio
     async def test_delete_existing_key_returns_true(
@@ -62,6 +65,7 @@ class TestAdapterEnvSecretStoreDelete:
         assert result is False
 
 
+@pytest.mark.unit
 class TestAdapterEnvSecretStoreListKeys:
     @pytest.mark.asyncio
     async def test_list_keys_no_prefix_returns_all(
@@ -91,6 +95,7 @@ class TestAdapterEnvSecretStoreListKeys:
         assert keys == []
 
 
+@pytest.mark.unit
 class TestAdapterEnvSecretStoreHealthAndClose:
     @pytest.mark.asyncio
     async def test_health_check_always_true(self, store: AdapterEnvSecretStore) -> None:

--- a/tests/unit/adapters/test_env_secret_store.py
+++ b/tests/unit/adapters/test_env_secret_store.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for AdapterEnvSecretStore."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.adapters.adapter_env_secret_store import AdapterEnvSecretStore
+
+
+@pytest.fixture
+def store() -> AdapterEnvSecretStore:
+    return AdapterEnvSecretStore()
+
+
+class TestAdapterEnvSecretStoreGet:
+    @pytest.mark.asyncio
+    async def test_get_missing_key_returns_none(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("_ONEX_TEST_KEY_MISSING", raising=False)
+        result = await store.get_secret("_ONEX_TEST_KEY_MISSING")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_present_key_returns_value(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("_ONEX_TEST_KEY", "secret-value")
+        result = await store.get_secret("_ONEX_TEST_KEY")
+        assert result == "secret-value"
+
+
+class TestAdapterEnvSecretStoreSet:
+    @pytest.mark.asyncio
+    async def test_set_and_get_roundtrip(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("_ONEX_SET_KEY", raising=False)
+        success = await store.set_secret("_ONEX_SET_KEY", "my-value")
+        assert success is True
+        result = await store.get_secret("_ONEX_SET_KEY")
+        assert result == "my-value"
+
+
+class TestAdapterEnvSecretStoreDelete:
+    @pytest.mark.asyncio
+    async def test_delete_existing_key_returns_true(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("_ONEX_DEL_KEY", "val")
+        result = await store.delete_secret("_ONEX_DEL_KEY")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_key_returns_false(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("_ONEX_DEL_MISSING", raising=False)
+        result = await store.delete_secret("_ONEX_DEL_MISSING")
+        assert result is False
+
+
+class TestAdapterEnvSecretStoreListKeys:
+    @pytest.mark.asyncio
+    async def test_list_keys_no_prefix_returns_all(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("_ONEX_LIST_A", "1")
+        keys = await store.list_keys()
+        assert "_ONEX_LIST_A" in keys
+
+    @pytest.mark.asyncio
+    async def test_list_keys_prefix_filters(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("_ONEX_PFXA_1", "1")
+        monkeypatch.setenv("_ONEX_PFXA_2", "2")
+        monkeypatch.setenv("_ONEX_OTHER", "3")
+        keys = await store.list_keys(prefix="_ONEX_PFXA")
+        assert "_ONEX_PFXA_1" in keys
+        assert "_ONEX_PFXA_2" in keys
+        assert "_ONEX_OTHER" not in keys
+
+    @pytest.mark.asyncio
+    async def test_list_keys_prefix_no_match_returns_empty(
+        self, store: AdapterEnvSecretStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        keys = await store.list_keys(prefix="__ONEX_NO_MATCH_XYZ__")
+        assert keys == []
+
+
+class TestAdapterEnvSecretStoreHealthAndClose:
+    @pytest.mark.asyncio
+    async def test_health_check_always_true(self, store: AdapterEnvSecretStore) -> None:
+        assert await store.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self, store: AdapterEnvSecretStore) -> None:
+        await store.close()


### PR DESCRIPTION
## Summary

- Implements Task 12 of the omnimarket public-shippable plan (epic OMN-10561)
- Adds `AdapterEnvSecretStore`: env-var-backed `ProtocolSecretStore` for local dev / no-Infisical path
- `get_secret` returns `None` on miss; required-value validation is the caller's responsibility
- `set_secret` / `delete_secret` / `list_keys` operate directly on `os.environ`; `health_check` always returns `True`; `close` is a no-op

## Ticket

OMN-10584

## Evidence

Evidence-Source: OCC#776
Evidence-Ticket: OMN-10584
Evidence-Commit: b8aa3a7f802fa1eb9c857cea62cd5e4104186e55

## Test plan

- [x] `uv run --group dev python -m pytest tests/unit/adapters/test_env_secret_store.py tests/integration/adapters/test_env_secret_store_integration.py -q` - 11 passed in 0.12s
- [x] `uv run --group dev python -m mypy src/omnibase_infra/adapters/adapter_env_secret_store.py --strict` - clean
- [x] `uv run ruff check src/omnibase_infra/adapters/adapter_env_secret_store.py tests/unit/adapters/test_env_secret_store.py tests/integration/adapters/test_env_secret_store_integration.py`
- [x] Central OCC evidence merged: OmniNode-ai/onex_change_control#776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variable-backed secret storage adapter added, supporting storage, retrieval, deletion, and enumeration of secrets with optional prefix filtering

* **Tests**
  * Unit and integration tests added to validate adapter behavior and lifecycle

* **Documentation**
  * Contract registry metadata/description and profile-tags formatting updated for clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->