### PR TITLE
feat(OMN-10588): add db connection + infisical keys to services.omnimarket in shared_key_registry.yaml

### DIFF
--- a/config/shared_key_registry.yaml
+++ b/config/shared_key_registry.yaml
@@ -217,9 +217,25 @@ services:
       - LLM_CODER_MODEL_ID
       - LLM_REASONER_URL
       - LLM_REASONER_MODEL_ID
-    # Per-service database identity. POSTGRES_DATABASE is in identity_defaults
+    # Per-service database config. POSTGRES_DATABASE is in identity_defaults
     # globally (each repo bakes its own value as a Settings default), but is
     # also enumerated here so omnimarket's per-service path is explicit and
-    # the onboard-repo plan can verify it.
+    # the onboard-repo plan can verify it. POSTGRES_HOST / POSTGRES_PORT /
+    # POSTGRES_USER are in /shared/db/ globally; the per-service entries here
+    # allow omnimarket to override them if deployed against a dedicated DB.
+    # POSTGRES_PASSWORD is listed per-service so the onboard-repo plan can
+    # seed a service-scoped credential when omnimarket uses a dedicated role.
     db:
       - POSTGRES_DATABASE
+      - POSTGRES_HOST
+      - POSTGRES_PORT
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+    # Per-service Infisical project declaration. INFISICAL_ADDR and
+    # INFISICAL_PROJECT_ID are bootstrap_only globally (they must be available
+    # before Infisical can be reached). Listing them here as a per-service
+    # entry allows omnimarket to declare its own project scope and enables
+    # onboard-repo plan validation to confirm the per-service override exists.
+    infisical:
+      - INFISICAL_ADDR
+      - INFISICAL_PROJECT_ID

--- a/tests/unit/config/test_shared_key_registry_omnimarket.py
+++ b/tests/unit/config/test_shared_key_registry_omnimarket.py
@@ -86,6 +86,31 @@ class TestServicesOmnimarketSection:
         omnimarket = registry_data["services"]["omnimarket"]
         assert "POSTGRES_DATABASE" in omnimarket["db"]
 
+    def test_omnimarket_db_includes_connection_keys(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        omnimarket = registry_data["services"]["omnimarket"]
+        db_keys = set(omnimarket["db"])
+        assert {
+            "POSTGRES_HOST",
+            "POSTGRES_PORT",
+            "POSTGRES_USER",
+            "POSTGRES_PASSWORD",
+        }.issubset(db_keys)
+
+    def test_omnimarket_infisical_section_present(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        omnimarket = registry_data["services"]["omnimarket"]
+        assert "infisical" in omnimarket
+
+    def test_omnimarket_infisical_includes_addr_and_project_id(
+        self, registry_data: dict[str, object]
+    ) -> None:
+        omnimarket = registry_data["services"]["omnimarket"]
+        infisical_keys = set(omnimarket["infisical"])
+        assert {"INFISICAL_ADDR", "INFISICAL_PROJECT_ID"}.issubset(infisical_keys)
+
 
 class TestServicesKeysLoader:
     def test_loader_returns_omnimarket_block(self, register_repo_module) -> None:  # type: ignore[no-untyped-def]
@@ -93,6 +118,9 @@ class TestServicesKeysLoader:
         assert "omnimarket" in result
         assert "KAFKA_GROUP_ID" in result["omnimarket"]["kafka"]
         assert "POSTGRES_DATABASE" in result["omnimarket"]["db"]
+        assert "POSTGRES_PASSWORD" in result["omnimarket"]["db"]
+        assert "INFISICAL_ADDR" in result["omnimarket"]["infisical"]
+        assert "INFISICAL_PROJECT_ID" in result["omnimarket"]["infisical"]
 
     def test_loader_returns_empty_dict_when_section_absent(
         self, register_repo_module


### PR DESCRIPTION
## Summary

- Extends `services.omnimarket` in `config/shared_key_registry.yaml` with `db` connection keys (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) for per-service DB config overrides
- Adds new `infisical` transport section to `services.omnimarket` with `INFISICAL_ADDR` and `INFISICAL_PROJECT_ID` for per-service Infisical project scope declaration
- Version stays at `1.2` — `services:` section already existed from OMN-10563

## Ticket

OMN-10588 (Task 16 of OMN-10561 Stage 4)

Evidence-Source: OCC#778
Evidence-Ticket: OMN-10588
Evidence-Commit: a650bf6415a8463a8e0e599b02023f6eb6123528

## Test plan

- [x] `tests/unit/config/test_shared_key_registry_omnimarket.py` — 19 tests all pass (4 new tests added covering new db keys and infisical section)
- [x] Full unit suite: 19093 passed, 10 pre-existing failures (verified same failures on `main`)
- [x] All pre-commit hooks pass

## dod_evidence

- `config/shared_key_registry.yaml` updated with complete `services.omnimarket` block
- `tests/unit/config/test_shared_key_registry_omnimarket.py` extended with new tests for db connection keys and infisical section
- 19/19 targeted tests pass; pre-commit clean
- OCC contract + receipts: OmniNode-ai/onex_change_control#778