### PR TITLE
feat(OMN-10586): finish ConfigPrefetcher implementation

### DIFF
--- a/contracts/OMN-10586.yaml
+++ b/contracts/OMN-10586.yaml
@@ -1,0 +1,31 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10586"
+title: "Finish ConfigPrefetcher contract-directory prefetch"
+summary: "Add ConfigPrefetcher.prefetch_for_contracts so runtime bootstrap can extract config requirements from contract YAML and prefetch matching Infisical keys."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Unit and integration coverage for ConfigPrefetcher.prefetch_for_contracts passes"
+    command: "uv run pytest tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py tests/integration/test_config_prefetcher_for_contracts_integration.py -q"
+  - kind: "manual"
+    description: "Post-merge deploy/readiness smoke plan for runtime config prefetch availability; live deploy requires explicit approval"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.runtime.config_discovery.config_prefetcher import ConfigPrefetcher; assert hasattr(ConfigPrefetcher, 'prefetch_for_contracts')\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-unit-integration-tests"
+    description: "Unit and integration coverage for ConfigPrefetcher.prefetch_for_contracts passes"
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py tests/integration/test_config_prefetcher_for_contracts_integration.py -q"
+  - id: "dod-deploy"
+    description: "Post-merge deploy/readiness smoke plan only; this PR does not deploy, restart runtime, or mutate .201"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.runtime.config_discovery.config_prefetcher import ConfigPrefetcher; assert hasattr(ConfigPrefetcher, 'prefetch_for_contracts')\""

--- a/src/omnibase_infra/runtime/config_discovery/config_prefetcher.py
+++ b/src/omnibase_infra/runtime/config_discovery/config_prefetcher.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
@@ -286,6 +287,31 @@ class ConfigPrefetcher:
         )
 
         return result
+
+    def prefetch_for_contracts(
+        self,
+        contracts_dir: Path,
+    ) -> ModelPrefetchResult:
+        """Extract requirements from a contracts directory and prefetch them.
+
+        Convenience wrapper: calls ``ContractConfigExtractor.extract_from_paths``
+        on ``contracts_dir``, then delegates to ``prefetch``.
+
+        Args:
+            contracts_dir: Path to a directory (or file) containing ONEX
+                contract YAML files.  Passed directly to
+                ``ContractConfigExtractor.extract_from_paths``.
+
+        Returns:
+            ``ModelPrefetchResult`` with resolved values and any errors.
+        """
+        from omnibase_infra.runtime.config_discovery.contract_config_extractor import (
+            ContractConfigExtractor,
+        )
+
+        extractor = ContractConfigExtractor()
+        requirements = extractor.extract_from_paths([contracts_dir])
+        return self.prefetch(requirements)
 
     def apply_to_environment(self, result: ModelPrefetchResult) -> int:
         """Apply prefetched values to the process environment.

--- a/tests/integration/test_config_prefetcher_for_contracts_integration.py
+++ b/tests/integration/test_config_prefetcher_for_contracts_integration.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for ConfigPrefetcher contract-directory prefetch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.runtime.config_discovery.config_prefetcher import ConfigPrefetcher
+from omnibase_infra.runtime.config_discovery.transport_config_map import (
+    TransportConfigMap,
+)
+
+
+class _RecordingResolver:
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = secrets
+        self.calls: list[tuple[str, str]] = []
+
+    def get_secret_sync(
+        self,
+        *,
+        secret_name: str,
+        secret_path: str,
+    ) -> SecretStr | None:
+        self.calls.append((secret_name, secret_path))
+        value = self._secrets.get(secret_name)
+        return SecretStr(value) if value is not None else None
+
+
+def test_prefetch_for_contracts_extracts_contract_yaml_and_resolves_secret(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(
+        """
+metadata:
+  transport_type: db
+""",
+        encoding="utf-8",
+    )
+
+    for key in TransportConfigMap.keys_for_transport(EnumInfraTransportType.DATABASE):
+        monkeypatch.delenv(key, raising=False)
+
+    resolver = _RecordingResolver({"POSTGRES_HOST": "db.integration.local"})
+    result = ConfigPrefetcher(handler=resolver).prefetch_for_contracts(tmp_path)
+
+    assert result.specs_attempted == 1
+    assert result.resolved["POSTGRES_HOST"].get_secret_value() == "db.integration.local"
+    assert ("POSTGRES_HOST", "/shared/db/") in resolver.calls

--- a/tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py
+++ b/tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ConfigPrefetcher.prefetch_for_contracts (OMN-10586)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from omnibase_infra.runtime.config_discovery.config_prefetcher import ConfigPrefetcher
+
+
+class _FakeSyncResolver:
+    """Minimal ProtocolSecretResolver backed by a dict for testing."""
+
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = secrets
+
+    def get_secret_sync(
+        self,
+        *,
+        secret_name: str,
+        secret_path: str,
+    ) -> SecretStr | None:
+        value = self._secrets.get(secret_name)
+        return SecretStr(value) if value is not None else None
+
+
+class TestPrefetchForContracts:
+    """Tests for ConfigPrefetcher.prefetch_for_contracts."""
+
+    def _write_contract(self, directory: Path, name: str, content: str) -> Path:
+        path = directory / name
+        path.write_text(textwrap.dedent(content), encoding="utf-8")
+        return path
+
+    def test_prefetch_for_contracts_resolves_db_keys(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should extract DB transport requirements from contract and resolve keys."""
+        self._write_contract(
+            tmp_path,
+            "contract.yaml",
+            """\
+            metadata:
+              transport_type: db
+            """,
+        )
+
+        # Remove POSTGRES_HOST from env so it must come from the resolver
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        monkeypatch.delenv("POSTGRES_PORT", raising=False)
+
+        resolver = _FakeSyncResolver({"POSTGRES_HOST": "db.test.local"})
+        prefetcher = ConfigPrefetcher(handler=resolver)
+
+        result = prefetcher.prefetch_for_contracts(tmp_path)
+
+        assert result.specs_attempted == 1
+        assert "POSTGRES_HOST" in result.resolved
+        assert result.resolved["POSTGRES_HOST"].get_secret_value() == "db.test.local"
+
+    def test_prefetch_for_contracts_two_contracts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two contracts with different transports should each contribute specs."""
+        self._write_contract(
+            tmp_path,
+            "contract_a.yaml",
+            """\
+            metadata:
+              transport_type: db
+            """,
+        )
+        self._write_contract(
+            tmp_path,
+            "contract_b.yaml",
+            """\
+            metadata:
+              transport_type: kafka
+            """,
+        )
+
+        # Remove env keys so they go through the resolver
+        from omnibase_infra.enums import EnumInfraTransportType
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        tcm = TransportConfigMap()
+        for transport in (
+            EnumInfraTransportType.DATABASE,
+            EnumInfraTransportType.KAFKA,
+        ):
+            for key in tcm.keys_for_transport(transport):
+                monkeypatch.delenv(key, raising=False)
+
+        resolver = _FakeSyncResolver(
+            {
+                "POSTGRES_HOST": "pg.test.local",
+                "KAFKA_GROUP_ID": "test-group",
+            }
+        )
+        prefetcher = ConfigPrefetcher(handler=resolver)
+
+        result = prefetcher.prefetch_for_contracts(tmp_path)
+
+        # specs_attempted = 1 per unique transport type (db + kafka = 2)
+        assert result.specs_attempted == 2
+        assert "POSTGRES_HOST" in result.resolved
+        assert result.resolved["POSTGRES_HOST"].get_secret_value() == "pg.test.local"
+        assert "KAFKA_GROUP_ID" in result.resolved
+        assert result.resolved["KAFKA_GROUP_ID"].get_secret_value() == "test-group"
+
+    def test_prefetch_for_contracts_missing_keys_reported(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keys not in resolver and not in env should appear in result.missing."""
+        self._write_contract(
+            tmp_path,
+            "contract.yaml",
+            """\
+            metadata:
+              transport_type: db
+            """,
+        )
+
+        from omnibase_infra.enums import EnumInfraTransportType
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        for key in TransportConfigMap.keys_for_transport(
+            EnumInfraTransportType.DATABASE
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        resolver = _FakeSyncResolver({})
+        prefetcher = ConfigPrefetcher(handler=resolver)
+
+        result = prefetcher.prefetch_for_contracts(tmp_path)
+
+        assert len(result.missing) > 0
+        assert "POSTGRES_HOST" in result.missing
+
+    def test_prefetch_for_contracts_empty_dir(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Empty contracts directory should return zero-count result without error."""
+        resolver = _FakeSyncResolver({})
+        prefetcher = ConfigPrefetcher(handler=resolver)
+
+        result = prefetcher.prefetch_for_contracts(tmp_path)
+
+        assert result.specs_attempted == 0
+        assert result.success_count == 0
+        assert result.failure_count == 0


### PR DESCRIPTION
## Summary

- Adds `ConfigPrefetcher.prefetch_for_contracts(contracts_dir: Path)` — a convenience wrapper that extracts config requirements from contract YAMLs via `ContractConfigExtractor.extract_from_paths`, then delegates to `prefetch()`. Closes the OMN-2287 P5 gap noted in `transport_config_map.py`.
- Adds `tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py` with 4 tests covering DB key resolution, two-contract merging (db + kafka), missing-key reporting, and empty-dir no-op.

## Ticket

OMN-10586

## Test plan

- [ ] `uv run pytest tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py -v` — 4 passed
- [ ] `pre-commit run --files src/omnibase_infra/runtime/config_discovery/config_prefetcher.py tests/unit/runtime/config_discovery/test_config_prefetcher_for_contracts.py` — all hooks passed
- [ ] mypy passed on push (pre-push hook)
- [ ] Pre-existing failure in `test_full_bootstrap_with_real_event_bus` (macOS `/var` path deny policy) confirmed on main before this branch — not introduced here

Evidence-Source: OCC#779
Evidence-Ticket: OMN-10586
Evidence-Commit: 2cf7f93edc5f16c3669b271f8ff8c20813902caf