### PR TITLE
feat(OMN-10655): add interactive_onboarding branching policy with local/cloud/hybrid paths

### DIFF
--- a/src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
+++ b/src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Interactive branching onboarding policy.
+# The generic reducer interprets the transition table to drive step selection.
+# No Python branching logic — all routing is declared here.
+#
+# Deployment modes:
+#   local   — Redpanda + Postgres + Valkey running locally via Docker
+#   cloud   — AWS or GCP managed services (no local Docker required)
+#   hybrid  — Local inference + cloud managed data services
+#
+# Terminal steps per path:
+#   local  -> write_config_local
+#   cloud  -> write_config_cloud
+#   hybrid -> write_config_hybrid
+policy_name: "interactive_onboarding"
+description: "Branching onboarding that adapts to local, cloud, or hybrid deployment modes"
+version: {major: 1, minor: 0, patch: 0}
+policy_type: "interactive"
+target_capabilities:
+  - "onboarding_config_written"
+max_estimated_minutes: 30
+# All interactive steps in declaration order.
+# The reducer uses the transition table below — step order here is for
+# human readability only; execution order is determined by transitions.
+steps:
+  - id: choose_deployment_mode
+    prompt: "How will you deploy ONEX?"
+    type: choice
+    options: [local, cloud, hybrid]
+    required: true
+  - id: configure_local_services
+    prompt: "Which local services do you need?"
+    type: multi_choice
+    options: [kafka, postgres, valkey, llm_inference]
+    condition: "deployment_mode in [local, hybrid]"
+    required: true
+  - id: configure_cloud_provider
+    prompt: "Which cloud provider?"
+    type: choice
+    options: [aws, gcp]
+    condition: "deployment_mode in [cloud, hybrid]"
+    required: true
+  - id: configure_aws_region
+    prompt: "Which AWS region? (e.g. us-east-1)"
+    type: text
+    condition: "cloud_provider == aws"
+    required: true
+  - id: configure_gcp_project
+    prompt: "Enter your GCP project ID"
+    type: text
+    condition: "cloud_provider == gcp"
+    required: true
+  - id: configure_llm_endpoint
+    prompt: "LLM inference endpoint URL (leave blank to skip)"
+    type: text
+    condition: "llm_inference in selected_local_services"
+    required: false
+  - id: write_config_local
+    prompt: "Writing local .env configuration"
+    type: action
+    action: "write_env"
+    condition: "deployment_mode == local"
+    produces_capabilities: ["onboarding_config_written"]
+  - id: write_config_cloud
+    prompt: "Writing cloud .env configuration"
+    type: action
+    action: "write_env"
+    condition: "deployment_mode == cloud"
+    produces_capabilities: ["onboarding_config_written"]
+  - id: write_config_hybrid
+    prompt: "Writing hybrid .env configuration"
+    type: action
+    action: "write_env"
+    condition: "deployment_mode == hybrid"
+    produces_capabilities: ["onboarding_config_written"]
+# Transition table — the reducer pattern-matches on (current_step, response)
+# and advances state. Every step must appear here; every valid response must
+# map to a next step. Missing entries are a contract violation.
+transitions:
+  - from: choose_deployment_mode
+    responses:
+      local:
+        next: configure_local_services
+        set_state:
+          deployment_mode: local
+      cloud:
+        next: configure_cloud_provider
+        set_state:
+          deployment_mode: cloud
+      hybrid:
+        next: configure_local_services
+        set_state:
+          deployment_mode: hybrid
+  - from: configure_local_services
+    # multi_choice — any selection is accepted; next depends on deployment_mode
+    on_submit:
+      - condition: "deployment_mode == local and llm_inference not in response"
+        next: write_config_local
+        set_state:
+          selected_local_services: "{response}"
+      - condition: "deployment_mode == local and llm_inference in response"
+        next: configure_llm_endpoint
+        set_state:
+          selected_local_services: "{response}"
+      - condition: "deployment_mode == hybrid"
+        next: configure_cloud_provider
+        set_state:
+          selected_local_services: "{response}"
+  - from: configure_cloud_provider
+    responses:
+      aws:
+        next: configure_aws_region
+        set_state:
+          cloud_provider: aws
+      gcp:
+        next: configure_gcp_project
+        set_state:
+          cloud_provider: gcp
+  - from: configure_aws_region
+    on_submit:
+      - condition: "deployment_mode == cloud"
+        next: write_config_cloud
+        set_state:
+          aws_region: "{response}"
+      - condition: "deployment_mode == hybrid and llm_inference in selected_local_services"
+        next: configure_llm_endpoint
+        set_state:
+          aws_region: "{response}"
+      - condition: "deployment_mode == hybrid and llm_inference not in selected_local_services"
+        next: write_config_hybrid
+        set_state:
+          aws_region: "{response}"
+  - from: configure_gcp_project
+    on_submit:
+      - condition: "deployment_mode == cloud"
+        next: write_config_cloud
+        set_state:
+          gcp_project: "{response}"
+      - condition: "deployment_mode == hybrid and llm_inference in selected_local_services"
+        next: configure_llm_endpoint
+        set_state:
+          gcp_project: "{response}"
+      - condition: "deployment_mode == hybrid and llm_inference not in selected_local_services"
+        next: write_config_hybrid
+        set_state:
+          gcp_project: "{response}"
+  - from: configure_llm_endpoint
+    on_submit:
+      - condition: "deployment_mode == local"
+        next: write_config_local
+        set_state:
+          llm_endpoint: "{response}"
+      - condition: "deployment_mode == hybrid"
+        next: write_config_hybrid
+        set_state:
+          llm_endpoint: "{response}"
+  # Terminal steps — no outgoing transitions
+  - from: write_config_local
+    terminal: true
+  - from: write_config_cloud
+    terminal: true
+  - from: write_config_hybrid
+    terminal: true
+# env_output declares what each terminal step writes to .env
+env_output:
+  write_config_local:
+    ONEX_DEPLOYMENT_MODE: "local"
+    KAFKA_BOOTSTRAP_SERVERS: "localhost:19092"
+    POSTGRES_HOST: "localhost"
+    POSTGRES_PORT: "5436"
+    VALKEY_HOST: "localhost"
+    VALKEY_PORT: "16379"
+    LLM_CODER_URL: "{state.llm_endpoint|}"
+  write_config_cloud:
+    ONEX_DEPLOYMENT_MODE: "cloud"
+    CLOUD_PROVIDER: "{state.cloud_provider}"
+    AWS_REGION: "{state.aws_region|}"
+    GCP_PROJECT: "{state.gcp_project|}"
+  write_config_hybrid:
+    ONEX_DEPLOYMENT_MODE: "hybrid"
+    CLOUD_PROVIDER: "{state.cloud_provider}"
+    AWS_REGION: "{state.aws_region|}"
+    GCP_PROJECT: "{state.gcp_project|}"
+    KAFKA_BOOTSTRAP_SERVERS: "localhost:19092"
+    POSTGRES_HOST: "localhost"
+    POSTGRES_PORT: "5436"
+    VALKEY_HOST: "localhost"
+    VALKEY_PORT: "16379"
+    LLM_CODER_URL: "{state.llm_endpoint|}"

--- a/tests/unit/onboarding/test_interactive_onboarding_policy.py
+++ b/tests/unit/onboarding/test_interactive_onboarding_policy.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the interactive_onboarding branching policy contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+TERMINAL_STEPS = {"write_config_local", "write_config_cloud", "write_config_hybrid"}
+DEPLOYMENT_MODES = ("local", "cloud", "hybrid")
+CLOUD_PROVIDERS = ("aws", "gcp")
+
+
+@pytest.fixture(scope="module")
+def policy() -> dict[str, Any]:
+    """Load the interactive onboarding policy YAML."""
+    return yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def step_ids(policy: dict[str, Any]) -> set[str]:
+    return {s["id"] for s in policy["steps"]}
+
+
+@pytest.fixture(scope="module")
+def transitions_by_from(policy: dict[str, Any]) -> dict[str, Any]:
+    return {t["from"]: t for t in policy["transitions"]}
+
+
+class TestPolicyLoads:
+    """Basic structural tests."""
+
+    def test_policy_file_exists(self) -> None:
+        assert POLICY_PATH.exists(), f"Policy file missing: {POLICY_PATH}"
+
+    def test_parses_as_dict(self, policy: dict[str, Any]) -> None:
+        assert isinstance(policy, dict)
+
+    def test_has_required_top_level_keys(self, policy: dict[str, Any]) -> None:
+        for key in ("policy_name", "steps", "transitions", "target_capabilities"):
+            assert key in policy, f"Missing top-level key: {key}"
+
+    def test_policy_name(self, policy: dict[str, Any]) -> None:
+        assert policy["policy_name"] == "interactive_onboarding"
+
+    def test_policy_type_is_interactive(self, policy: dict[str, Any]) -> None:
+        assert policy["policy_type"] == "interactive"
+
+    def test_produces_onboarding_config_written(self, policy: dict[str, Any]) -> None:
+        assert "onboarding_config_written" in policy["target_capabilities"]
+
+    def test_has_steps(self, policy: dict[str, Any]) -> None:
+        assert len(policy["steps"]) >= 3
+
+    def test_has_transitions(self, policy: dict[str, Any]) -> None:
+        assert len(policy["transitions"]) >= 3
+
+
+class TestStepStructure:
+    """Every step must have required fields and valid types."""
+
+    VALID_TYPES = {"choice", "multi_choice", "text", "action"}
+
+    def test_all_steps_have_id(self, policy: dict[str, Any]) -> None:
+        for step in policy["steps"]:
+            assert "id" in step, f"Step missing 'id': {step}"
+
+    def test_all_steps_have_prompt(self, policy: dict[str, Any]) -> None:
+        for step in policy["steps"]:
+            assert "prompt" in step, f"Step '{step.get('id')}' missing 'prompt'"
+
+    def test_all_steps_have_valid_type(self, policy: dict[str, Any]) -> None:
+        for step in policy["steps"]:
+            assert step.get("type") in self.VALID_TYPES, (
+                f"Step '{step['id']}' has invalid type '{step.get('type')}'"
+            )
+
+    def test_step_ids_are_unique(self, policy: dict[str, Any]) -> None:
+        ids = [s["id"] for s in policy["steps"]]
+        assert len(ids) == len(set(ids)), "Duplicate step IDs found"
+
+    def test_terminal_steps_declared(self, step_ids: set[str]) -> None:
+        for terminal in TERMINAL_STEPS:
+            assert terminal in step_ids, (
+                f"Terminal step '{terminal}' missing from steps"
+            )
+
+    def test_terminal_steps_produce_capability(self, policy: dict[str, Any]) -> None:
+        for step in policy["steps"]:
+            if step["id"] in TERMINAL_STEPS:
+                caps = step.get("produces_capabilities", [])
+                assert "onboarding_config_written" in caps, (
+                    f"Terminal step '{step['id']}' must produce 'onboarding_config_written'"
+                )
+
+    def test_first_step_is_choose_deployment_mode(self, policy: dict[str, Any]) -> None:
+        assert policy["steps"][0]["id"] == "choose_deployment_mode"
+
+    def test_choose_deployment_mode_has_all_options(
+        self, policy: dict[str, Any]
+    ) -> None:
+        first = policy["steps"][0]
+        assert set(first["options"]) == {"local", "cloud", "hybrid"}
+
+
+class TestTransitionTableCompleteness:
+    """Every step must appear in the transition table, and every response must map
+    to a valid next step."""
+
+    def test_every_step_has_transition_entry(
+        self, step_ids: set[str], transitions_by_from: dict[str, Any]
+    ) -> None:
+        for sid in step_ids:
+            assert sid in transitions_by_from, (
+                f"Step '{sid}' has no entry in transitions table"
+            )
+
+    def test_no_dangling_next_references(
+        self, step_ids: set[str], transitions_by_from: dict[str, Any]
+    ) -> None:
+        """Every 'next' in the transition table must point to a valid step id."""
+        for from_step, t in transitions_by_from.items():
+            if t.get("terminal"):
+                continue
+            # Collect all 'next' values from responses and on_submit lists
+            nexts: list[str] = []
+            if "responses" in t:
+                for resp in t["responses"].values():
+                    if isinstance(resp, dict) and "next" in resp:
+                        nexts.append(resp["next"])
+            if "on_submit" in t:
+                for branch in t["on_submit"]:
+                    if "next" in branch:
+                        nexts.append(branch["next"])
+            for nxt in nexts:
+                assert nxt in step_ids, (
+                    f"Transition from '{from_step}' references unknown step '{nxt}'"
+                )
+
+    def test_terminal_steps_marked_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        for terminal in TERMINAL_STEPS:
+            t = transitions_by_from[terminal]
+            assert t.get("terminal") is True, (
+                f"Step '{terminal}' is a terminal step but not marked terminal=true"
+            )
+
+    def test_non_terminal_steps_have_next(
+        self, step_ids: set[str], transitions_by_from: dict[str, Any]
+    ) -> None:
+        for sid in step_ids:
+            t = transitions_by_from[sid]
+            if t.get("terminal"):
+                continue
+            has_next = "responses" in t or "on_submit" in t
+            assert has_next, (
+                f"Non-terminal step '{sid}' has neither 'responses' nor 'on_submit'"
+            )
+
+
+class TestLocalPath:
+    """Simulate the local deployment path through the transition table."""
+
+    def _follow_path(
+        self, transitions_by_from: dict[str, Any], choices: dict[str, str]
+    ) -> list[str]:
+        """Walk through transitions using provided choices, return visited step ids."""
+        visited = []
+        current = "choose_deployment_mode"
+        while current is not None:
+            visited.append(current)
+            t = transitions_by_from[current]
+            if t.get("terminal"):
+                break
+            if "responses" in t:
+                response = choices.get(current)
+                assert response is not None, f"No choice provided for step '{current}'"
+                nxt = t["responses"][response]["next"]
+                current = nxt
+            elif "on_submit" in t:
+                # Take the first branch whose condition matches our choices context
+                # (simplified: just pick the first applicable branch)
+                response = choices.get(current)
+                assert response is not None, f"No choice provided for step '{current}'"
+                # For test purposes, pick the branch matching the response key
+                matched = None
+                for branch in t["on_submit"]:
+                    cond = branch.get("condition", "")
+                    if response in cond or "deployment_mode ==" in cond:
+                        matched = branch
+                        break
+                assert matched is not None, (
+                    f"No matching branch for step '{current}' with response '{response}'"
+                )
+                current = matched["next"]
+            else:
+                break
+        return visited
+
+    def test_local_no_llm_path_reaches_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        visited = ["choose_deployment_mode"]
+        # choose_deployment_mode -> configure_local_services
+        t = transitions_by_from["choose_deployment_mode"]
+        assert "local" in t["responses"]
+        nxt = t["responses"]["local"]["next"]
+        assert nxt == "configure_local_services"
+
+        # configure_local_services (no llm) -> write_config_local
+        t2 = transitions_by_from["configure_local_services"]
+        assert "on_submit" in t2
+        # Find branch for local without llm
+        local_no_llm = next(
+            b
+            for b in t2["on_submit"]
+            if "deployment_mode == local" in b.get("condition", "")
+            and "not in" in b.get("condition", "")
+        )
+        assert local_no_llm["next"] == "write_config_local"
+
+    def test_local_with_llm_path_visits_configure_llm_endpoint(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        t = transitions_by_from["configure_local_services"]
+        local_with_llm = next(
+            b
+            for b in t["on_submit"]
+            if "deployment_mode == local" in b.get("condition", "")
+            and "not in" not in b.get("condition", "")
+        )
+        assert local_with_llm["next"] == "configure_llm_endpoint"
+
+        t2 = transitions_by_from["configure_llm_endpoint"]
+        local_branch = next(
+            b
+            for b in t2["on_submit"]
+            if "deployment_mode == local" in b.get("condition", "")
+        )
+        assert local_branch["next"] == "write_config_local"
+
+
+class TestCloudPath:
+    """Cloud path covers both AWS and GCP branches."""
+
+    def test_cloud_aws_path_reaches_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        # choose_deployment_mode -> configure_cloud_provider
+        t = transitions_by_from["choose_deployment_mode"]
+        assert t["responses"]["cloud"]["next"] == "configure_cloud_provider"
+
+        # configure_cloud_provider -> configure_aws_region
+        t2 = transitions_by_from["configure_cloud_provider"]
+        assert t2["responses"]["aws"]["next"] == "configure_aws_region"
+
+        # configure_aws_region (cloud) -> write_config_cloud
+        t3 = transitions_by_from["configure_aws_region"]
+        cloud_branch = next(
+            b
+            for b in t3["on_submit"]
+            if "deployment_mode == cloud" in b.get("condition", "")
+        )
+        assert cloud_branch["next"] == "write_config_cloud"
+
+    def test_cloud_gcp_path_reaches_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        t2 = transitions_by_from["configure_cloud_provider"]
+        assert t2["responses"]["gcp"]["next"] == "configure_gcp_project"
+
+        t3 = transitions_by_from["configure_gcp_project"]
+        cloud_branch = next(
+            b
+            for b in t3["on_submit"]
+            if "deployment_mode == cloud" in b.get("condition", "")
+        )
+        assert cloud_branch["next"] == "write_config_cloud"
+
+
+class TestHybridPath:
+    """Hybrid path exercises both local services and cloud provider steps."""
+
+    def test_hybrid_routes_through_local_services_then_cloud_provider(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        # choose_deployment_mode -> configure_local_services
+        t = transitions_by_from["choose_deployment_mode"]
+        assert t["responses"]["hybrid"]["next"] == "configure_local_services"
+
+        # configure_local_services (hybrid) -> configure_cloud_provider
+        t2 = transitions_by_from["configure_local_services"]
+        hybrid_branch = next(
+            b
+            for b in t2["on_submit"]
+            if "deployment_mode == hybrid" in b.get("condition", "")
+        )
+        assert hybrid_branch["next"] == "configure_cloud_provider"
+
+    def test_hybrid_aws_no_llm_reaches_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        t3 = transitions_by_from["configure_aws_region"]
+        hybrid_no_llm = next(
+            b
+            for b in t3["on_submit"]
+            if "deployment_mode == hybrid" in b.get("condition", "")
+            and "not in" in b.get("condition", "")
+        )
+        assert hybrid_no_llm["next"] == "write_config_hybrid"
+
+    def test_hybrid_gcp_no_llm_reaches_terminal(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        t3 = transitions_by_from["configure_gcp_project"]
+        hybrid_no_llm = next(
+            b
+            for b in t3["on_submit"]
+            if "deployment_mode == hybrid" in b.get("condition", "")
+            and "not in" in b.get("condition", "")
+        )
+        assert hybrid_no_llm["next"] == "write_config_hybrid"
+
+    def test_hybrid_with_llm_visits_configure_llm_endpoint(
+        self, transitions_by_from: dict[str, Any]
+    ) -> None:
+        t3 = transitions_by_from["configure_aws_region"]
+        hybrid_llm = next(
+            b
+            for b in t3["on_submit"]
+            if "deployment_mode == hybrid" in b.get("condition", "")
+            and "llm_inference in" in b.get("condition", "")
+        )
+        assert hybrid_llm["next"] == "configure_llm_endpoint"
+
+        t4 = transitions_by_from["configure_llm_endpoint"]
+        hybrid_branch = next(
+            b
+            for b in t4["on_submit"]
+            if "deployment_mode == hybrid" in b.get("condition", "")
+        )
+        assert hybrid_branch["next"] == "write_config_hybrid"
+
+
+class TestEnvOutput:
+    """env_output section declares what gets written to .env per terminal step."""
+
+    def test_env_output_exists(self, policy: dict[str, Any]) -> None:
+        assert "env_output" in policy, "Policy missing 'env_output' section"
+
+    def test_every_terminal_step_has_env_output(self, policy: dict[str, Any]) -> None:
+        env_output = policy["env_output"]
+        for terminal in TERMINAL_STEPS:
+            assert terminal in env_output, (
+                f"Terminal step '{terminal}' missing from env_output"
+            )
+
+    def test_local_env_output_has_required_keys(self, policy: dict[str, Any]) -> None:
+        local = policy["env_output"]["write_config_local"]
+        assert "ONEX_DEPLOYMENT_MODE" in local
+        assert local["ONEX_DEPLOYMENT_MODE"] == "local"
+        assert "KAFKA_BOOTSTRAP_SERVERS" in local
+        assert "POSTGRES_HOST" in local
+
+    def test_cloud_env_output_has_required_keys(self, policy: dict[str, Any]) -> None:
+        cloud = policy["env_output"]["write_config_cloud"]
+        assert "ONEX_DEPLOYMENT_MODE" in cloud
+        assert cloud["ONEX_DEPLOYMENT_MODE"] == "cloud"
+        assert "CLOUD_PROVIDER" in cloud
+
+    def test_hybrid_env_output_has_both_local_and_cloud_keys(
+        self, policy: dict[str, Any]
+    ) -> None:
+        hybrid = policy["env_output"]["write_config_hybrid"]
+        assert hybrid["ONEX_DEPLOYMENT_MODE"] == "hybrid"
+        assert "KAFKA_BOOTSTRAP_SERVERS" in hybrid
+        assert "CLOUD_PROVIDER" in hybrid

--- a/tests/unit/onboarding/test_interactive_onboarding_policy.py
+++ b/tests/unit/onboarding/test_interactive_onboarding_policy.py
@@ -11,6 +11,8 @@ from typing import Any
 import pytest
 import yaml
 
+pytestmark = pytest.mark.unit
+
 POLICY_PATH = (
     Path(__file__).parent.parent.parent.parent
     / "src"

--- a/tests/unit/onboarding/test_interactive_onboarding_policy.py
+++ b/tests/unit/onboarding/test_interactive_onboarding_policy.py
@@ -217,7 +217,6 @@ class TestLocalPath:
     def test_local_no_llm_path_reaches_terminal(
         self, transitions_by_from: dict[str, Any]
     ) -> None:
-        visited = ["choose_deployment_mode"]
         # choose_deployment_mode -> configure_local_services
         t = transitions_by_from["choose_deployment_mode"]
         assert "local" in t["responses"]

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -14,6 +14,8 @@ from omnibase_infra.onboarding.policy_resolver import (
     resolve_policy,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def canonical_graph():

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -103,11 +103,12 @@ class TestLoadBuiltinPolicies:
 
     def test_loads_three_policies(self) -> None:
         policies = load_builtin_policies()
-        assert len(policies) == 4
+        assert len(policies) == 5
         assert "standalone_quickstart" in policies
         assert "contributor_local" in policies
         assert "full_platform" in policies
         assert "new_employee" in policies
+        assert "interactive_onboarding" in policies
 
     def test_standalone_targets(self) -> None:
         policies = load_builtin_policies()


### PR DESCRIPTION
## Summary

- Adds \`interactive_onboarding.yaml\` — a contract-declared transition table policy that drives the generic reducer through local, cloud (AWS/GCP), and hybrid deployment-mode paths without any Python branching logic
- All routing decisions, conditional step activation, and env_output declarations live in the YAML; the reducer interprets the transition table at runtime
- Updates \`test_policy_resolver.py\` policy count (4 → 5) to account for the new policy

Closes OMN-10655

## dod_evidence

\`\`\`yaml
dod_evidence:
  - check_type: test_suite
    description: "33 unit tests in test_interactive_onboarding_policy.py — 73/73 onboarding suite passing"
    status: passing
    details: "uv run pytest tests/unit/onboarding/ -v → 73 passed"
    ticket: OMN-10655
  - check_type: file_exists
    description: "Policy file created at canonical path"
    path: "src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml"
    status: verified
    ticket: OMN-10655
  - check_type: contract_completeness
    description: "Transition table complete — every step has entry, no dangling refs, terminals marked"
    status: verified
    ticket: OMN-10655
\`\`\`

## Test plan

- [x] \`uv run pytest tests/unit/onboarding/ -v\` — 73/73 passed
- [x] \`uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/\` — clean
- [x] \`pre-commit run --all-files\` — all hooks passed (two pre-existing failures identical to main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive onboarding that guides setup based on deployment mode (local, cloud, hybrid), including provider selection, region/project configuration, and optional LLM endpoint.
  * On completion, configuration is written to environment variables so the app is configured automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#794
Evidence-Ticket: OMN-10655
Evidence-Commit: 7d4599dcfbeed3c3a35c600e46c26a70a44d1b95