### PR TITLE
feat(OMN-10592): add omnimarket_quickstart onboarding policy

### DIFF
--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -376,6 +376,8 @@ _LEGACY_ALLOWLIST: dict[str, str] = {
     # --- quality scoring pipeline topics (SOW Phase 2) ---
     "onex.cmd.omniintelligence.quality-assessment.v1": "SOW Phase 2; contract.yaml in omniintelligence repo (cross-repo provisioning); consumer: omniintelligence dispatch handler | owner: jonah | expiry: 2026-09-01",
     "onex.evt.omniintelligence.quality-assessment-completed.v1": "SOW Phase 2; contract.yaml in omniintelligence repo (cross-repo provisioning); consumer: omnidash pattern_quality_metrics projection | owner: jonah | expiry: 2026-09-01",
+    # --- platform registration events (OMN-10592 triage) ---
+    "onex.evt.platform.registration-completed.v1": "pre-existing gap; topic provisioned but no contract.yaml yet; owner: jonah | expiry: 2026-09-01",
 }
 # fmt: on
 

--- a/src/omnibase_infra/onboarding/graphs/canonical.yaml
+++ b/src/omnibase_infra/onboarding/graphs/canonical.yaml
@@ -153,3 +153,45 @@ steps:
       target: "http://localhost:3000"
       timeout_seconds: 30
       description: "Omnidash is serving on port 3000"
+  - step_key: "install_omnimarket"
+    name: "Install omnimarket"
+    step_type: "action"
+    description: "Install the omnimarket package with uv"
+    depends_on: ["install_uv"]
+    required_capabilities: ["uv_installed"]
+    produces_capabilities: ["omnimarket_installed"]
+    tags: ["setup", "dependencies", "omnimarket"]
+    estimated_duration_seconds: 60
+    verification:
+      check_type: "python_import"
+      target: "omnimarket"
+      timeout_seconds: 10
+      description: "omnimarket is importable"
+  - step_key: "validate_omnimarket_config"
+    name: "Validate omnimarket Config"
+    step_type: "action"
+    description: "Run the omnimarket config validator to confirm all required secrets and env vars are present"
+    depends_on: ["install_omnimarket", "configure_secrets"]
+    required_capabilities: ["omnimarket_installed", "secrets_configured"]
+    produces_capabilities: ["omnimarket_config_valid"]
+    tags: ["setup", "validation", "omnimarket"]
+    estimated_duration_seconds: 30
+    verification:
+      check_type: "command_exit_0"
+      target: "uv run python -m omnimarket.cli validate-config"
+      timeout_seconds: 30
+      description: "omnimarket validate-config exits 0"
+  - step_key: "register_omnimarket_node"
+    name: "Register omnimarket Node"
+    step_type: "action"
+    description: "Register the first omnimarket node with the runtime registry"
+    depends_on: ["validate_omnimarket_config", "connect_node_to_bus"]
+    required_capabilities: ["omnimarket_config_valid", "event_bus_connected"]
+    produces_capabilities: ["omnimarket_node_registered"]
+    tags: ["development", "omnimarket", "messaging"]
+    estimated_duration_seconds: 30
+    verification:
+      check_type: "command_exit_0"
+      target: "uv run python -m omnimarket.cli register-node --dry-run"
+      timeout_seconds: 30
+      description: "omnimarket register-node dry-run exits 0"

--- a/src/omnibase_infra/onboarding/policies/omnimarket_quickstart.yaml
+++ b/src/omnibase_infra/onboarding/policies/omnimarket_quickstart.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+policy_name: "omnimarket_quickstart"
+description: "Minimal omnimarket setup: install, validate config, register first node (~10 min)"
+target_capabilities:
+  - "omnimarket_node_registered"
+max_estimated_minutes: 10

--- a/tests/unit/onboarding/test_loader.py
+++ b/tests/unit/onboarding/test_loader.py
@@ -24,15 +24,15 @@ class TestLoadCanonicalGraph:
         graph = load_canonical_graph()
         assert graph.title == "onex_onboarding_canonical"
 
-    def test_has_10_steps(self) -> None:
+    def test_has_13_steps(self) -> None:
         graph = load_canonical_graph()
-        assert len(graph.steps) == 10
+        assert len(graph.steps) == 13
 
     def test_dag_is_acyclic(self) -> None:
         """load_canonical_graph validates the DAG -- no exception means acyclic."""
         graph = load_canonical_graph()
         step_keys = {s.step_key for s in graph.steps}
-        assert len(step_keys) == 10  # All unique
+        assert len(step_keys) == 13  # All unique
 
     def test_all_depends_on_reference_valid_step_keys(self) -> None:
         graph = load_canonical_graph()
@@ -82,6 +82,9 @@ class TestLoadCanonicalGraph:
             "connect_node_to_bus",
             "configure_secrets",
             "start_omnidash",
+            "install_omnimarket",
+            "validate_omnimarket_config",
+            "register_omnimarket_node",
         ]
 
 

--- a/tests/unit/onboarding/test_omnimarket_quickstart_policy.py
+++ b/tests/unit/onboarding/test_omnimarket_quickstart_policy.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for omnimarket_quickstart onboarding policy (OMN-10592)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.onboarding.loader import load_canonical_graph
+from omnibase_infra.onboarding.policy_resolver import (
+    load_builtin_policies,
+    resolve_policy,
+)
+
+_POLICIES_DIR = (
+    Path(__file__).parents[3] / "src" / "omnibase_infra" / "onboarding" / "policies"
+)
+_POLICY_FILE = _POLICIES_DIR / "omnimarket_quickstart.yaml"
+
+
+@pytest.fixture
+def canonical_graph():
+    return load_canonical_graph()
+
+
+@pytest.fixture
+def policy_data() -> dict:
+    assert _POLICY_FILE.exists(), (
+        f"omnimarket_quickstart.yaml not found at {_POLICY_FILE}. "
+        "Run this test from the omnibase_infra worktree."
+    )
+    with _POLICY_FILE.open() as f:
+        return yaml.safe_load(f)
+
+
+class TestOmnimarketQuickstartPolicy:
+    def test_policy_file_exists(self) -> None:
+        assert _POLICY_FILE.exists(), (
+            f"omnimarket_quickstart.yaml not found at {_POLICY_FILE}"
+        )
+
+    def test_policy_name(self, policy_data) -> None:
+        assert policy_data["policy_name"] == "omnimarket_quickstart"
+
+    def test_target_capabilities_present(self, policy_data) -> None:
+        caps = policy_data.get("target_capabilities", [])
+        assert isinstance(caps, list)
+        assert len(caps) > 0
+
+    def test_all_target_capabilities_in_canonical_graph(
+        self, policy_data, canonical_graph
+    ) -> None:
+        all_produced = {
+            cap for step in canonical_graph.steps for cap in step.produces_capabilities
+        }
+        for cap in policy_data["target_capabilities"]:
+            assert cap in all_produced, (
+                f"Capability '{cap}' declared in omnimarket_quickstart policy "
+                f"but not produced by any step in canonical.yaml. "
+                f"Available capabilities: {sorted(all_produced)}"
+            )
+
+    def test_resolve_policy_returns_omnimarket_steps(
+        self, policy_data, canonical_graph
+    ) -> None:
+        steps = resolve_policy(
+            canonical_graph, policy_data["target_capabilities"], None
+        )
+        step_keys = {s.step_key for s in steps}
+        assert "install_omnimarket" in step_keys
+        assert "validate_omnimarket_config" in step_keys
+        assert "register_omnimarket_node" in step_keys
+
+    def test_resolve_policy_includes_prerequisite_steps(
+        self, policy_data, canonical_graph
+    ) -> None:
+        steps = resolve_policy(
+            canonical_graph, policy_data["target_capabilities"], None
+        )
+        step_keys = {s.step_key for s in steps}
+        assert "install_uv" in step_keys
+        assert "configure_secrets" in step_keys
+        assert "connect_node_to_bus" in step_keys
+
+    def test_all_existing_policies_still_load(self) -> None:
+        policies = load_builtin_policies()
+        for name in [
+            "standalone_quickstart",
+            "contributor_local",
+            "full_platform",
+            "new_employee",
+            "omnimarket_quickstart",
+        ]:
+            assert name in policies, (
+                f"Policy '{name}' missing from load_builtin_policies()"
+            )

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -101,13 +101,14 @@ class TestResolvePolicy:
 class TestLoadBuiltinPolicies:
     """Tests for loading built-in policy YAML files."""
 
-    def test_loads_three_policies(self) -> None:
+    def test_loads_builtin_policies(self) -> None:
         policies = load_builtin_policies()
-        assert len(policies) == 4
+        assert len(policies) == 5
         assert "standalone_quickstart" in policies
         assert "contributor_local" in policies
         assert "full_platform" in policies
         assert "new_employee" in policies
+        assert "omnimarket_quickstart" in policies
 
     def test_standalone_targets(self) -> None:
         policies = load_builtin_policies()

--- a/tests/unit/scope/__init__.py
+++ b/tests/unit/scope/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Summary

- Adds three omnimarket-specific steps to `canonical.yaml`: `install_omnimarket`, `validate_omnimarket_config`, `register_omnimarket_node`
- Adds `omnimarket_quickstart.yaml` policy targeting `omnimarket_node_registered` (~10 min path)
- Updates `test_loader.py` and `test_policy_resolver.py` to reflect the expanded graph (10→13 steps, 4→5 policies)
- Adds `tests/unit/onboarding/test_omnimarket_quickstart_policy.py` with 7 tests: file exists, policy name, capabilities present, all capabilities in graph, named steps resolved, prerequisite steps resolved, all policies load

Also fixes two pre-existing issues encountered in CI: missing SPDX header in `tests/unit/scope/__init__.py` and a topic parity gate gap for `onex.evt.platform.registration-completed.v1` (added to `_LEGACY_ALLOWLIST` with owner/expiry).

## Test plan

- [x] 7 new policy tests pass
- [x] Full onboarding unit suite (47 tests) passes
- [x] All pre-commit hooks pass (including topic parity gate)
- [x] `gh pr checks` watched for green

OMN-10592

Evidence-Source: OCC#786
Evidence-Ticket: OMN-10592
Evidence-Commit: pending-OCC-786