### PR TITLE
feat(OMN-10655): add cloud + hybrid deployment paths to onboarding contracts

### DIFF
--- a/src/omnibase_infra/onboarding/graphs/canonical.yaml
+++ b/src/omnibase_infra/onboarding/graphs/canonical.yaml
@@ -9,6 +9,8 @@
 #                                              \-> start_docker_infra -> start_event_bus -> connect_node_to_bus
 #                                                                    \-> configure_secrets
 #                                                                                        \-> start_omnidash
+#                                                                                        \-> configure_cloud_credentials -> deploy_to_cloud
+#                                                                                                                       \-> configure_hybrid_split -> deploy_hybrid
 title: "onex_onboarding_canonical"
 description: "Canonical onboarding graph for the ONEX platform"
 version: {major: 1, minor: 0, patch: 0}
@@ -195,3 +197,59 @@ steps:
       target: "uv run python -m omnimarket.cli register-node --dry-run"
       timeout_seconds: 30
       description: "omnimarket register-node dry-run exits 0"
+  - step_key: "configure_cloud_credentials"
+    name: "Configure Cloud Credentials"
+    step_type: "action"
+    description: "Set up cloud provider credentials for remote deployment"
+    depends_on: ["configure_secrets"]
+    required_capabilities: ["secrets_configured"]
+    produces_capabilities: ["cloud_credentials_configured"]
+    tags: ["cloud", "infrastructure"]
+    estimated_duration_seconds: 120
+    verification:
+      check_type: "file_exists"
+      target: "~/.omnibase/cloud-config.yaml"
+      timeout_seconds: 5
+      description: "Cloud configuration file exists"
+  - step_key: "deploy_to_cloud"
+    name: "Deploy to Cloud"
+    step_type: "action"
+    description: "Deploy ONEX runtime to cloud provider"
+    depends_on: ["configure_cloud_credentials", "connect_node_to_bus"]
+    required_capabilities: ["cloud_credentials_configured", "event_bus_connected"]
+    produces_capabilities: ["cloud_deployed"]
+    tags: ["cloud", "deployment"]
+    estimated_duration_seconds: 300
+    verification:
+      check_type: "command_exit_0"
+      target: "uv run python -m omnibase_infra.cli cloud-health-check"
+      timeout_seconds: 60
+      description: "Cloud deployment responds to health check"
+  - step_key: "configure_hybrid_split"
+    name: "Configure Hybrid Service Split"
+    step_type: "action"
+    description: "Declare which services run locally and which run in the cloud"
+    depends_on: ["configure_cloud_credentials", "start_docker_infra"]
+    required_capabilities: ["cloud_credentials_configured", "docker_infra_running"]
+    produces_capabilities: ["hybrid_split_configured"]
+    tags: ["hybrid", "infrastructure"]
+    estimated_duration_seconds: 60
+    verification:
+      check_type: "file_exists"
+      target: "~/.omnibase/hybrid-split.yaml"
+      timeout_seconds: 5
+      description: "Hybrid split configuration file exists"
+  - step_key: "deploy_hybrid"
+    name: "Deploy Hybrid Topology"
+    step_type: "action"
+    description: "Deploy ONEX runtime in hybrid topology (local + cloud services)"
+    depends_on: ["configure_hybrid_split", "connect_node_to_bus"]
+    required_capabilities: ["hybrid_split_configured", "event_bus_connected"]
+    produces_capabilities: ["hybrid_deployed"]
+    tags: ["hybrid", "deployment"]
+    estimated_duration_seconds: 240
+    verification:
+      check_type: "command_exit_0"
+      target: "uv run python -m omnibase_infra.cli hybrid-health-check"
+      timeout_seconds: 60
+      description: "Hybrid deployment responds to health check"

--- a/src/omnibase_infra/onboarding/policies/contributor_cloud.yaml
+++ b/src/omnibase_infra/onboarding/policies/contributor_cloud.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+policy_name: "contributor_cloud"
+description: "Cloud deployment with managed services (~30 min)"
+target_capabilities:
+  - "cloud_deployed"
+max_estimated_minutes: 30

--- a/src/omnibase_infra/onboarding/policies/contributor_hybrid.yaml
+++ b/src/omnibase_infra/onboarding/policies/contributor_hybrid.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+policy_name: "contributor_hybrid"
+description: "Hybrid deployment — local inference + cloud managed data services (~30 min)"
+target_capabilities:
+  - "hybrid_deployed"
+max_estimated_minutes: 30

--- a/tests/unit/onboarding/test_cloud_hybrid_policies.py
+++ b/tests/unit/onboarding/test_cloud_hybrid_policies.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the contributor_cloud and contributor_hybrid onboarding policies."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.onboarding.loader import load_canonical_graph
+from omnibase_infra.onboarding.policy_resolver import (
+    load_builtin_policies,
+    resolve_policy,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def canonical_graph():
+    return load_canonical_graph()
+
+
+@pytest.fixture
+def policies():
+    return load_builtin_policies()
+
+
+class TestCloudPolicy:
+    def test_cloud_policy_loaded(self, policies) -> None:
+        assert "contributor_cloud" in policies
+        assert policies["contributor_cloud"]["target_capabilities"] == [
+            "cloud_deployed"
+        ]
+
+    def test_cloud_policy_resolves_with_prerequisites(
+        self, canonical_graph, policies
+    ) -> None:
+        cloud = policies["contributor_cloud"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=cloud["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+
+        # Cloud-specific steps must be present
+        assert "configure_cloud_credentials" in step_keys
+        assert "deploy_to_cloud" in step_keys
+
+        # Prerequisite chain must be present
+        assert "check_python" in step_keys
+        assert "install_uv" in step_keys
+        assert "install_core" in step_keys
+        assert "configure_secrets" in step_keys
+        assert "connect_node_to_bus" in step_keys
+
+    def test_cloud_policy_topological_order(self, canonical_graph, policies) -> None:
+        cloud = policies["contributor_cloud"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=cloud["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+
+        assert step_keys.index("configure_secrets") < step_keys.index(
+            "configure_cloud_credentials"
+        )
+        assert step_keys.index("configure_cloud_credentials") < step_keys.index(
+            "deploy_to_cloud"
+        )
+        assert step_keys.index("connect_node_to_bus") < step_keys.index(
+            "deploy_to_cloud"
+        )
+
+    def test_cloud_policy_excludes_omnidash(self, canonical_graph, policies) -> None:
+        cloud = policies["contributor_cloud"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=cloud["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+        assert "start_omnidash" not in step_keys
+
+
+class TestHybridPolicy:
+    def test_hybrid_policy_loaded(self, policies) -> None:
+        assert "contributor_hybrid" in policies
+        assert policies["contributor_hybrid"]["target_capabilities"] == [
+            "hybrid_deployed"
+        ]
+
+    def test_hybrid_policy_resolves_with_prerequisites(
+        self, canonical_graph, policies
+    ) -> None:
+        hybrid = policies["contributor_hybrid"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=hybrid["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+
+        # Hybrid-specific steps must be present
+        assert "configure_hybrid_split" in step_keys
+        assert "deploy_hybrid" in step_keys
+
+        # Hybrid depends on cloud credentials AND local docker infra
+        assert "configure_cloud_credentials" in step_keys
+        assert "start_docker_infra" in step_keys
+        assert "connect_node_to_bus" in step_keys
+
+    def test_hybrid_policy_topological_order(self, canonical_graph, policies) -> None:
+        hybrid = policies["contributor_hybrid"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=hybrid["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+
+        assert step_keys.index("configure_cloud_credentials") < step_keys.index(
+            "configure_hybrid_split"
+        )
+        assert step_keys.index("start_docker_infra") < step_keys.index(
+            "configure_hybrid_split"
+        )
+        assert step_keys.index("configure_hybrid_split") < step_keys.index(
+            "deploy_hybrid"
+        )
+
+    def test_hybrid_policy_excludes_pure_cloud_terminal(
+        self, canonical_graph, policies
+    ) -> None:
+        """Hybrid resolves deploy_hybrid, not the standalone deploy_to_cloud terminal."""
+        hybrid = policies["contributor_hybrid"]
+        steps = resolve_policy(
+            canonical_graph,
+            target_capabilities=hybrid["target_capabilities"],
+        )
+        step_keys = [s.step_key for s in steps]
+        assert "deploy_to_cloud" not in step_keys
+
+
+class TestCanonicalGraphCloudHybridSteps:
+    """Verify the canonical graph itself has the cloud + hybrid step shape."""
+
+    def test_cloud_credentials_depends_on_secrets(self, canonical_graph) -> None:
+        step = next(
+            s
+            for s in canonical_graph.steps
+            if s.step_key == "configure_cloud_credentials"
+        )
+        assert "configure_secrets" in step.depends_on
+        assert "cloud_credentials_configured" in step.produces_capabilities
+
+    def test_deploy_to_cloud_depends_on_credentials_and_bus(
+        self, canonical_graph
+    ) -> None:
+        step = next(s for s in canonical_graph.steps if s.step_key == "deploy_to_cloud")
+        assert "configure_cloud_credentials" in step.depends_on
+        assert "connect_node_to_bus" in step.depends_on
+        assert "cloud_deployed" in step.produces_capabilities
+
+    def test_hybrid_split_depends_on_cloud_creds_and_docker(
+        self, canonical_graph
+    ) -> None:
+        step = next(
+            s for s in canonical_graph.steps if s.step_key == "configure_hybrid_split"
+        )
+        assert "configure_cloud_credentials" in step.depends_on
+        assert "start_docker_infra" in step.depends_on
+        assert "hybrid_split_configured" in step.produces_capabilities
+
+    def test_deploy_hybrid_depends_on_split_and_bus(self, canonical_graph) -> None:
+        step = next(s for s in canonical_graph.steps if s.step_key == "deploy_hybrid")
+        assert "configure_hybrid_split" in step.depends_on
+        assert "connect_node_to_bus" in step.depends_on
+        assert "hybrid_deployed" in step.produces_capabilities

--- a/tests/unit/onboarding/test_loader.py
+++ b/tests/unit/onboarding/test_loader.py
@@ -24,15 +24,15 @@ class TestLoadCanonicalGraph:
         graph = load_canonical_graph()
         assert graph.title == "onex_onboarding_canonical"
 
-    def test_has_13_steps(self) -> None:
+    def test_has_17_steps(self) -> None:
         graph = load_canonical_graph()
-        assert len(graph.steps) == 13
+        assert len(graph.steps) == 17
 
     def test_dag_is_acyclic(self) -> None:
         """load_canonical_graph validates the DAG -- no exception means acyclic."""
         graph = load_canonical_graph()
         step_keys = {s.step_key for s in graph.steps}
-        assert len(step_keys) == 13  # All unique
+        assert len(step_keys) == 17  # All unique
 
     def test_all_depends_on_reference_valid_step_keys(self) -> None:
         graph = load_canonical_graph()
@@ -85,6 +85,10 @@ class TestLoadCanonicalGraph:
             "install_omnimarket",
             "validate_omnimarket_config",
             "register_omnimarket_node",
+            "configure_cloud_credentials",
+            "deploy_to_cloud",
+            "configure_hybrid_split",
+            "deploy_hybrid",
         ]
 
 

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -105,9 +105,11 @@ class TestLoadBuiltinPolicies:
 
     def test_loads_builtin_policies(self) -> None:
         policies = load_builtin_policies()
-        assert len(policies) == 6
+        assert len(policies) == 8
         assert "standalone_quickstart" in policies
         assert "contributor_local" in policies
+        assert "contributor_cloud" in policies
+        assert "contributor_hybrid" in policies
         assert "full_platform" in policies
         assert "new_employee" in policies
         assert "interactive_onboarding" in policies


### PR DESCRIPTION
## Summary

Extends the canonical onboarding graph and policy library with cloud and hybrid deployment paths so the contract-driven onboarding orchestrator can branch on deployment mode without any new code paths.

## What changed

**Canonical graph (`canonical.yaml`)** — adds 4 new steps:
- `configure_cloud_credentials` (depends on `configure_secrets`)
- `deploy_to_cloud` (depends on cloud creds + `connect_node_to_bus`) — terminal
- `configure_hybrid_split` (depends on cloud creds + `start_docker_infra`)
- `deploy_hybrid` (depends on hybrid split + `connect_node_to_bus`) — terminal

**Policies** — two new policy YAMLs:
- `contributor_cloud.yaml` (target: `cloud_deployed`)
- `contributor_hybrid.yaml` (target: `hybrid_deployed`)

The new steps reuse the existing prerequisite chain (`check_python` → `install_uv` → `install_core` → `start_docker_infra` → `start_event_bus` → `connect_node_to_bus`, plus `configure_secrets`) so the resolver pulls in the right ordering automatically via the topological sort.

## Architecture

All branching logic lives in the contract YAML — no Python code paths added. The `node_contract_reducer` (in omnimarket, merged via #550) interprets these transitions; the orthogonal reducer-integration test lives in [omnimarket PR for OMN-10655](https://github.com/OmniNode-ai/omnimarket/pulls).

## Test plan

- [x] `tests/unit/onboarding/test_cloud_hybrid_policies.py` — both policies load + resolve, topological order verified, DAG shape verified
- [x] `tests/unit/onboarding/test_loader.py` — updated step counts (13 → 17) and ordering
- [x] `tests/unit/onboarding/test_policy_resolver.py` — builtin policy count updated (6 → 8)
- [x] All 92 onboarding tests pass locally
- [x] `pre-commit run --files <changed>` clean

## OMN-10655

Linked to OMN-10655 (Wave 4 of the late-night build plan: extend onboarding contracts with cloud + hybrid paths). Plan doc: `docs/plans/2026-05-07-late-night-build-plan.md` Tasks 8 + 9.

dod_evidence:
- type: `unit_test_pass`
- target: `tests/unit/onboarding/test_cloud_hybrid_policies.py` (12 new tests, all passing)

Evidence-Ticket: OMN-10655
Evidence-Source: OCC#801
Evidence-Commit: cfa537dd85222fde72e617fd3e101385b679b1ab