### PR TITLE
fix(OMN-9648): filter runtime health by profile

### DIFF
--- a/contracts/OMN-9648.yaml
+++ b/contracts/OMN-9648.yaml
@@ -1,0 +1,31 @@
+schema_version: "1.0.0"
+ticket_id: OMN-9648
+title: "Runtime health monitor profile-aware coverage"
+summary: "Filter runtime health monitor expected consumer groups by runtime profile and keep the expensive sweep out of pre-health startup."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Focused unit and integration coverage for runtime health monitor profile filtering passes."
+    command: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
+  - kind: manual
+    description: "Stability runtime hotfix reaches healthy after redeploy and one-shot monitor proof records remaining real subscription gaps."
+    command: "deploy: docker exec omninode-stability-test-runtime python -c 'from omnibase_infra.services.service_runtime_health_monitor import ServiceRuntimeHealthMonitor; print(ServiceRuntimeHealthMonitor.__name__)'"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-tests
+    description: "Focused health monitor tests cover profile filtering and non-blocking startup."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
+  - id: dod-deploy
+    description: "Deploy gate evidence: stability runtime hotfix was deployed and validated on .201."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: docker exec omninode-stability-test-runtime python -c 'from omnibase_infra.services.service_runtime_health_monitor import ServiceRuntimeHealthMonitor; print(ServiceRuntimeHealthMonitor.__name__)'"

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -71,6 +71,34 @@ def _discover_contracts() -> ProtocolAutoWiringManifestLike:
     return discover_contracts()  # type: ignore[return-value]
 
 
+def _filter_manifest_for_runtime_profile(
+    manifest: ProtocolAutoWiringManifestLike,
+) -> ProtocolAutoWiringManifestLike:
+    """Apply the same runtime-profile ownership filter used by service startup."""
+    from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+        ModelAutoWiringManifest,
+    )
+    from omnibase_infra.runtime.auto_wiring.profile_ownership import (
+        filter_manifest_for_runtime_profile,
+    )
+
+    if not isinstance(manifest, ModelAutoWiringManifest):
+        return manifest
+
+    ownership_result = filter_manifest_for_runtime_profile(
+        manifest=manifest,
+        runtime_profile=os.environ.get("RUNTIME_PROFILE", "main"),
+    )
+    if ownership_result.skipped_contracts:
+        logger.debug(
+            "Runtime health monitor profile ownership: profile=%s owned=%d skipped=%d",
+            ownership_result.runtime_profile,
+            ownership_result.manifest.total_discovered,
+            len(ownership_result.skipped_contracts),
+        )
+    return ownership_result.manifest
+
+
 class ConsumerGroupSnapshot(NamedTuple):
     """Minimal consumer group state used by runtime health checks."""
 
@@ -285,8 +313,11 @@ class ServiceRuntimeHealthMonitor:
     async def start(self) -> None:
         """Start the background health check loop. Idempotent.
 
-        Runs the first health check immediately before entering the periodic loop
-        so callers get an initial signal without waiting one full interval.
+        The first full health check is intentionally deferred to the background
+        loop. Contract discovery and Kafka group inspection are expensive on the
+        full runtime image; running them synchronously here delays health-server
+        binding and can make a healthy runtime appear stuck in Docker
+        ``starting``.
         """
         if self._running:
             return
@@ -297,13 +328,6 @@ class ServiceRuntimeHealthMonitor:
             logger.info(
                 "ServiceRuntimeHealthMonitor boot grace active for %.1fs",
                 self._boot_grace_seconds,
-            )
-        # Run the first check immediately so callers get an initial health signal.
-        try:
-            await self.run_once()
-        except Exception:  # noqa: BLE001 — best-effort; don't block startup
-            logger.warning(
-                "ServiceRuntimeHealthMonitor: initial check failed", exc_info=True
             )
         self._task = asyncio.create_task(self._loop(), name="runtime-health-monitor")
         logger.info(
@@ -344,7 +368,7 @@ class ServiceRuntimeHealthMonitor:
         subscribe_topics: set[str] = set()
         expected_groups: list[ExpectedConsumerGroup] = []
         try:
-            manifest = _discover_contracts()
+            manifest = _filter_manifest_for_runtime_profile(_discover_contracts())
             contract_count = manifest.total_discovered
             discovery_error_count = manifest.total_errors
             subscribe_topics = set(manifest.all_subscribe_topics())

--- a/tests/integration/test_runtime_health_monitor_profile_filter.py
+++ b/tests/integration/test_runtime_health_monitor_profile_filter.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -35,6 +36,7 @@ def _contract(name: str, topic: str, profile: str) -> ModelDiscoveredContract:
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_runtime_health_monitor_uses_profile_filtered_contracts() -> None:
     main_contract = _contract(
         "node_main_profile",
@@ -53,7 +55,9 @@ async def test_runtime_health_monitor_uses_profile_filtered_contracts() -> None:
     expected = _expected_consumer_groups_from_manifest(
         ModelAutoWiringManifest(contracts=(main_contract,), errors=())
     )[0]
-    monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="redpanda:9092")
+    monitor = ServiceRuntimeHealthMonitor(
+        bootstrap_servers=os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "redpanda:9092")
+    )
 
     with (
         patch.dict("os.environ", {"RUNTIME_PROFILE": "main"}),

--- a/tests/integration/test_runtime_health_monitor_profile_filter.py
+++ b/tests/integration/test_runtime_health_monitor_profile_filter.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime health monitor profile ownership."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+)
+from omnibase_infra.services.service_runtime_health_monitor import (
+    ConsumerGroupSnapshot,
+    ServiceRuntimeHealthMonitor,
+    _expected_consumer_groups_from_manifest,
+)
+
+
+def _contract(name: str, topic: str, profile: str) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=__file__,
+        entry_point_name=name,
+        package_name="omnimarket",
+        runtime_profiles=(profile,),
+        event_bus=ModelEventBusWiring(subscribe_topics=(topic,), publish_topics=()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_monitor_uses_profile_filtered_contracts() -> None:
+    main_contract = _contract(
+        "node_main_profile",
+        "onex.cmd.omnimarket.main-profile.v1",
+        "main",
+    )
+    effects_contract = _contract(
+        "node_effects_profile",
+        "onex.cmd.omnimarket.effects-profile.v1",
+        "effects",
+    )
+    manifest = ModelAutoWiringManifest(
+        contracts=(main_contract, effects_contract),
+        errors=(),
+    )
+    expected = _expected_consumer_groups_from_manifest(
+        ModelAutoWiringManifest(contracts=(main_contract,), errors=())
+    )[0]
+    monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="redpanda:9092")
+
+    with (
+        patch.dict("os.environ", {"RUNTIME_PROFILE": "main"}),
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=manifest,
+        ),
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+            return_value=[
+                ConsumerGroupSnapshot(group_id=expected.group_id, state="STABLE")
+            ],
+        ),
+    ):
+        event = await monitor.run_once()
+
+    assert event.contract_count == 1
+    assert event.uncovered_topic_count == 0
+    assert event.status == "HEALTHY"

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -63,6 +63,7 @@ def _make_discovered_contract(
     name: str = "node_contract_sweep",
     package_name: str = "omnimarket",
     topic: str = "onex.cmd.omnimarket.contract-sweep-start.v1",
+    runtime_profiles: tuple[str, ...] = (),
 ) -> ModelDiscoveredContract:
     return ModelDiscoveredContract(
         name=name,
@@ -71,6 +72,7 @@ def _make_discovered_contract(
         contract_path=__file__,
         entry_point_name=name,
         package_name=package_name,
+        runtime_profiles=runtime_profiles,
         event_bus=ModelEventBusWiring(subscribe_topics=(topic,), publish_topics=()),
     )
 
@@ -351,6 +353,45 @@ class TestRunOnceWithKafka:
             degraded_dims[0].detail
         )
 
+    @pytest.mark.asyncio
+    async def test_topic_coverage_uses_runtime_profile_ownership_filter(self):
+        main_contract = _make_discovered_contract(
+            name="node_main_owner",
+            topic="onex.cmd.omnimarket.main-owned.v1",
+            runtime_profiles=("main",),
+        )
+        effects_contract = _make_discovered_contract(
+            name="node_effects_owner",
+            topic="onex.cmd.omnimarket.effects-owned.v1",
+            runtime_profiles=("effects",),
+        )
+        manifest = ModelAutoWiringManifest(
+            contracts=(main_contract, effects_contract),
+            errors=(),
+        )
+        expected_main = _expected_consumer_groups_from_manifest(
+            ModelAutoWiringManifest(contracts=(main_contract,), errors=())
+        )[0]
+        snapshots = self._mock_admin([expected_main.group_id], empty_groups=set())
+        monitor = ServiceRuntimeHealthMonitor(bootstrap_servers="localhost:9092")
+
+        with (
+            patch.dict("os.environ", {"RUNTIME_PROFILE": "main"}),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+                return_value=snapshots,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.contract_count == 1
+        assert event.uncovered_topic_count == 0
+        assert event.status == "HEALTHY"
+
 
 # =============================================================================
 # ServiceRuntimeHealthMonitor — event emission
@@ -447,6 +488,18 @@ class TestLifecycle:
             task_before = monitor._task
             await monitor.start()  # second call — should not re-run initial check
         assert monitor._task is task_before
+        await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_does_not_run_health_check_synchronously(self):
+        monitor = ServiceRuntimeHealthMonitor(
+            bootstrap_servers="", check_interval_seconds=9999.0
+        )
+
+        with patch.object(monitor, "run_once", new=AsyncMock()) as run_once:
+            await monitor.start()
+            run_once.assert_not_called()
+
         await monitor.stop()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Ticket: OMN-9648
Evidence-Ticket: OMN-9648
Evidence-Source: OCC#804
Evidence-Commit: e318917cda64f2fe9d62a7d0539a374767f4d26c

## Summary
- apply runtime-profile ownership filtering inside ServiceRuntimeHealthMonitor before deriving expected consumer groups
- prevent main stability runtime from reporting missing consumers for contracts owned by effects/worker profiles
- defer the initial expensive health sweep out of start() so the health server can bind promptly
- add regression coverage for profile-filtered topic coverage

## Verification
- uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py -q
- uv run pytest tests/integration/test_runtime_health_monitor_profile_filter.py -q
- uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py
- uv run ruff check tests/integration/test_runtime_health_monitor_profile_filter.py
- uv run validate-yaml contracts/OMN-9648.yaml
- pre-commit hooks on commit
- pre-push hooks on push

## Runtime Evidence
- stability runtime image runtime:stability-test-20260508-omn9648-health-profile-4941c7419 reached healthy on .201
- latest sample: health=healthy, /health healthy=True, /ready healthy=True