### PR TITLE
[OMN-9648] fix: check live runtime consumer groups

### DIFF
--- a/contracts/OMN-9648.yaml
+++ b/contracts/OMN-9648.yaml
@@ -8,7 +8,7 @@ interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: "Focused unit and integration coverage for runtime health monitor profile filtering passes."
-    command: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
+    command: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_live_event_bus.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
   - kind: manual
     description: "Stability runtime hotfix reaches healthy after redeploy and one-shot monitor proof records remaining real subscription gaps."
     command: "deploy: docker exec omninode-stability-test-runtime python -c 'from omnibase_infra.services.service_runtime_health_monitor import ServiceRuntimeHealthMonitor; print(ServiceRuntimeHealthMonitor.__name__)'"
@@ -22,7 +22,7 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_exact_groups.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
+        check_value: "uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_live_event_bus.py tests/integration/test_runtime_health_monitor_profile_filter.py -q"
   - id: dod-deploy
     description: "Deploy gate evidence: stability runtime hotfix was deployed and validated on .201."
     source: manual

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -256,6 +256,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "alembic>=1.13.0,<2.0.0" \
     "psycopg2-binary>=2.9.10,<3.0.0" \
     "mcp>=1.8.0,<2.0.0" \
+    "radon>=6.0.1,<7.0.0" \
+    "pytest>=8.4.0,<10.0.0" \
+    "pytest-asyncio>=1.3.0,<2.0.0" \
+    "docker>=7.0.0,<8.0.0" \
     "python-snappy>=0.7.0,<1.0.0"
 
 # Security: upgrade protobuf to clear CVE-2026-0994 (HIGH, DoS, fixed in >=5.29.6).

--- a/src/omnibase_infra/services/service_runtime_health_monitor.py
+++ b/src/omnibase_infra/services/service_runtime_health_monitor.py
@@ -24,10 +24,12 @@ cycle is logged and the next cycle proceeds normally.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import math
 import os
 import time
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
@@ -219,6 +221,55 @@ def _expected_consumer_groups_from_manifest(
     return expected
 
 
+def _expected_consumer_groups_from_event_bus(
+    event_bus: ProtocolEventBusLike | None,
+) -> list[ExpectedConsumerGroup]:
+    """Return live expected groups from the runtime event bus, when available.
+
+    ``discover_contracts()`` sees every installed contract, including contracts
+    skipped by auto-wiring because they lack handler routing or are superseded by
+    dedicated runtime wiring. The event bus registry is the authoritative source
+    for subscriptions that this runtime actually attempted to start.
+    """
+    if event_bus is None:
+        return []
+
+    get_consumer_groups = getattr(event_bus, "get_consumer_groups", None)
+    if not callable(get_consumer_groups):
+        return []
+
+    groups = get_consumer_groups()
+    if inspect.isawaitable(groups):
+        close = getattr(groups, "close", None)
+        if callable(close):
+            close()
+        return []
+    if not isinstance(groups, Mapping):
+        return []
+
+    expected: list[ExpectedConsumerGroup] = []
+    for key, effective_group_id in groups.items():
+        if (
+            not isinstance(key, tuple)
+            or len(key) != 2
+            or not isinstance(effective_group_id, str)
+            or not effective_group_id
+        ):
+            continue
+        topic, base_group_id = key
+        if not isinstance(topic, str) or not isinstance(base_group_id, str):
+            continue
+        expected.append(
+            ExpectedConsumerGroup(
+                topic=topic,
+                group_id=effective_group_id,
+                node_name=base_group_id,
+                package_name="event_bus",
+            )
+        )
+    return expected
+
+
 def _topic_is_covered_by_legacy_group(topic: str, group_id: str) -> bool:
     """Best-effort coverage check for manifests without contract records."""
     return (
@@ -375,6 +426,12 @@ class ServiceRuntimeHealthMonitor:
             expected_groups = _expected_consumer_groups_from_manifest(
                 manifest, os.environ.get("KAFKA_INSTANCE_ID")
             )
+            live_expected_groups = _expected_consumer_groups_from_event_bus(
+                self._event_bus
+            )
+            if live_expected_groups:
+                expected_groups = live_expected_groups
+                subscribe_topics = {expected.topic for expected in live_expected_groups}
 
             if discovery_error_count > 0:
                 dimensions.append(
@@ -422,14 +479,17 @@ class ServiceRuntimeHealthMonitor:
                 consumer_group_count = len(all_group_ids)
 
                 empty_states = {"DEAD", "EMPTY", "UNKNOWN"}
-                empty_groups = {
+                empty_group_ids = {
                     g.group_id for g in group_snapshots if g.state in empty_states
                 }
-                empty_consumer_group_count = len(empty_groups)
 
                 # Check which subscribe topics have a matching non-empty group.
-                non_empty_groups = set(all_group_ids) - empty_groups
+                non_empty_groups = set(all_group_ids) - empty_group_ids
                 if expected_groups:
+                    expected_group_ids = {
+                        expected.group_id for expected in expected_groups
+                    }
+                    empty_groups = empty_group_ids & expected_group_ids
                     missing_expected = [
                         expected
                         for expected in expected_groups
@@ -441,6 +501,7 @@ class ServiceRuntimeHealthMonitor:
                         for expected in missing_expected
                     ]
                 else:
+                    empty_groups = empty_group_ids
                     # Test doubles and older manifest protocols may only expose
                     # topic names. Keep a bounded fallback, but production
                     # manifests use exact expected group IDs above.
@@ -454,6 +515,7 @@ class ServiceRuntimeHealthMonitor:
                             uncovered_topics.append(topic)
                     uncovered_topic_count = len(uncovered_topics)
                     uncovered_details = uncovered_topics
+                empty_consumer_group_count = len(empty_groups)
 
                 if empty_consumer_group_count > 0:
                     dimensions.append(

--- a/tests/integration/test_runtime_health_monitor_live_event_bus.py
+++ b/tests/integration/test_runtime_health_monitor_live_event_bus.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for live EventBus-backed runtime health expectations.
+
+Integration Test Coverage gate: OMN-9648.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+)
+from omnibase_infra.services.service_runtime_health_monitor import (
+    ConsumerGroupSnapshot,
+    ServiceRuntimeHealthMonitor,
+)
+
+
+def _contract() -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="node_legacy_projection",
+        node_type="PROJECTION",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=__file__,
+        entry_point_name="node_legacy_projection",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=("onex.evt.omnimarket.legacy-projection.v1",),
+            publish_topics=(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_monitor_uses_live_event_bus_groups_for_runtime_liveness() -> None:
+    """Stale discovered contracts and empty broker groups do not degrade runtime."""
+    contract = _contract()
+    topic = contract.event_bus.subscribe_topics[0]
+    live_group = f"runtime.projection.consume.v1.__i.main.__t.{topic}"
+    stale_empty_group = f"old.projection.consume.v1.__i.main.__t.{topic}"
+    bus = MagicMock()
+    bus.get_consumer_groups.return_value = {
+        (topic, "runtime.projection.consume.v1"): live_group
+    }
+    monitor = ServiceRuntimeHealthMonitor(
+        event_bus=bus,
+        bootstrap_servers="localhost:9092",
+    )
+
+    with (
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+            return_value=ModelAutoWiringManifest(contracts=(contract,), errors=()),
+        ),
+        patch(
+            "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+            return_value=[
+                ConsumerGroupSnapshot(group_id=live_group, state="STABLE"),
+                ConsumerGroupSnapshot(group_id=stale_empty_group, state="EMPTY"),
+            ],
+        ),
+    ):
+        event = await monitor.run_once()
+
+    assert event.status == "HEALTHY"
+    assert event.discovery_error_count == 0
+    assert event.empty_consumer_group_count == 0
+    assert event.uncovered_topic_count == 0

--- a/tests/unit/services/test_service_runtime_health_monitor.py
+++ b/tests/unit/services/test_service_runtime_health_monitor.py
@@ -354,6 +354,42 @@ class TestRunOnceWithKafka:
         )
 
     @pytest.mark.asyncio
+    async def test_live_event_bus_groups_override_stale_discovered_contracts(self):
+        stale_contract = _make_discovered_contract(name="node_superseded_projection")
+        manifest = ModelAutoWiringManifest(contracts=(stale_contract,), errors=())
+        topic = stale_contract.event_bus.subscribe_topics[0]
+        live_group = f"runtime.projection.consume.v1.__i.instance-1.__t.{topic}"
+        stale_empty_group = f"old.projection.consume.v1.__i.instance-1.__t.{topic}"
+        snapshots = self._mock_admin(
+            [live_group, stale_empty_group],
+            empty_groups={stale_empty_group},
+        )
+        bus = MagicMock()
+        bus.get_consumer_groups.return_value = {
+            (topic, "runtime.projection.consume.v1"): live_group
+        }
+        monitor = ServiceRuntimeHealthMonitor(
+            event_bus=bus,
+            bootstrap_servers="localhost:9092",
+        )
+
+        with (
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._discover_contracts",
+                return_value=manifest,
+            ),
+            patch(
+                "omnibase_infra.services.service_runtime_health_monitor._list_consumer_group_snapshots",
+                return_value=snapshots,
+            ),
+        ):
+            event = await monitor.run_once()
+
+        assert event.uncovered_topic_count == 0
+        assert event.empty_consumer_group_count == 0
+        assert event.status == "HEALTHY"
+
+    @pytest.mark.asyncio
     async def test_topic_coverage_uses_runtime_profile_ownership_filter(self):
         main_contract = _make_discovered_contract(
             name="node_main_owner",


### PR DESCRIPTION
Ticket: OMN-9648

## Summary
- derive runtime health expected consumer groups from the live EventBus registry when available
- scope empty consumer group degradation to expected runtime groups instead of stale broker-wide groups
- add missing omnimarket runtime dependencies skipped by the --no-deps plugin install path
- add integration coverage for live EventBus-backed runtime liveness

## Verification
- uv run pytest tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_live_event_bus.py tests/integration/test_runtime_health_monitor_profile_filter.py -q
- uv run ruff check src/omnibase_infra/services/service_runtime_health_monitor.py tests/unit/services/test_service_runtime_health_monitor.py tests/integration/test_runtime_health_monitor_live_event_bus.py tests/integration/test_runtime_health_monitor_profile_filter.py
- uv run python scripts/check_dockerfile_pins.py --dockerfile docker/Dockerfile.runtime --no-pypi
- pre-push hooks passed, including mypy and architecture layer validation

## Live runtime evidence
- rebuilt stability runtime image from runtime-code commit `fefdfe7c` (PR head `70c7ea1f` only adds contract/test gate evidence after that image)
- recreated only `omninode-runtime` with `--no-deps` on `192.168.86.201`; core Postgres/Redpanda/Valkey were not recreated
- Docker: `status=running health=healthy restart=0 started=2026-05-08T12:06:45Z`
- Env marker: `RUNTIME_SOURCE_HASH=fefdfe7c`
- HTTP: `/health` healthy and `/ready` healthy on host `127.0.0.1:18085`
- Discovery inside container: `contracts=268 errors=0`
- Scheduled runtime monitor tick at `2026-05-08T12:12:12Z`: `status=HEALTHY contracts=252 errors=0 consumer_groups=709 empty=0 uncovered_topics=0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime health monitor now uses live event bus consumer groups, preventing false health degradation from stale contract expectations.

* **Tests**
  * Added test coverage validating live event bus consumer group handling in health monitoring scenarios.

* **Chores**
  * Extended runtime Docker image with additional development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->