### PR TITLE
fix(OMN-10657): resolve delegation endpoints from deployed contract, not env vars

### DIFF
--- a/contracts/OMN-10657.yaml
+++ b/contracts/OMN-10657.yaml
@@ -1,0 +1,25 @@
+# OMN-10657 contract file for omnibase_infra deploy-gate (OMN-8912).
+# This repo-local contract carries deploy-gate evidence for resolving
+# delegation routing endpoints from the deployed bifrost contract.
+schema_version: '1.0.0'
+ticket_id: OMN-10657
+title: 'Resolve delegation endpoints from deployed contract, not env vars'
+summary: >
+  NodeDelegationRoutingReducer now reads endpoint URLs from the deployed bifrost contract at ~/.omninode/delegation/bifrost_delegation.yaml instead of os.environ.get() calls. ModelTierModel.env_var renamed to backend_ref. routing_tiers.yaml updated with backend_ref keys matching bifrost backend IDs. The handler change is dormant until the delegation orchestrator routes through this reducer in production — deploy of omninode-runtime not required for this PR.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-deploy
+    description: >-
+      deploy-gate: handler_delegation_routing.py change is dormant — the routing reducer is not yet invoked by the runtime kernel for delegation requests. The bifrost contract path (BIFROST_CONTRACT_PATH or ~/.omninode/delegation/bifrost_delegation.yaml) defaults to a location that does not exist in production runtime containers until install-delegation.sh --apply is run by the operator. No omninode-runtime container behavior changes from this PR; no Docker restart required. Wiring will activate once the delegation orchestrator is plumbed through this reducer in a follow-up ticket.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          deploy omninode-runtime not required: routing reducer endpoint resolution change is dormant. Bifrost contract loading activates only when BIFROST_CONTRACT_PATH is set or ~/.omninode/delegation/bifrost_delegation.yaml exists, neither of which is present in the production runtime container by default.

--- a/src/omnibase_infra/configs/bifrost_delegation.yaml
+++ b/src/omnibase_infra/configs/bifrost_delegation.yaml
@@ -7,19 +7,21 @@
 # Every gateway response MUST include the selected rule_id and config_version
 # to make provenance auditable (OMN-10637 requirement R1).
 #
-# Backend URLs are resolved from env vars at runtime — never hardcoded here.
-# See model_registry.yaml for model capabilities and hardware assignments.
+# Backend endpoint URLs are declared here and populated by the installer
+# (install-delegation.sh --apply). The source version has empty endpoint_url
+# fields; the deployed copy at ~/.omninode/delegation/bifrost_delegation.yaml
+# has actual URLs written by the installer.
+#
 # See routing_tiers.yaml for tier escalation ladder.
 #
-# Tickets: OMN-10637
-config_version: "1.0.0"
+# Tickets: OMN-10637, OMN-10657
+config_version: "1.1.0"
 schema_version: "bifrost_delegation.v1"
-# Backend definitions — URLs resolved from env vars at runtime.
-# IP addresses annotated per aislop-sweep rule (OMN-8573).
+# Backend definitions — endpoint_url populated by installer at deploy time.
 backends:
-  # Local backends on 192.168.86.201 (AIPC)  # onex-allow-internal-ip
+  # Local backends (AIPC)
   - backend_id: local-qwen-coder-30b
-    base_url_env: LLM_CODER_URL
+    endpoint_url: ""
     # cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit — RTX 5090, 112K ctx
     model_name: cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit
     tier: local
@@ -29,7 +31,7 @@ backends:
       - refactoring
       - documentation
   - backend_id: local-deepseek-r1-14b
-    base_url_env: LLM_CODER_FAST_URL
+    endpoint_url: ""
     # Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ — RTX 4090, 24K ctx
     model_name: Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ
     tier: local
@@ -40,6 +42,7 @@ backends:
       - classification
   # Cloud fallback backends
   - backend_id: cloud-sonnet
+    endpoint_url: ""
     # Claude Sonnet via OAuth — no API key required (Claude Code uses OAuth)
     model_name: claude-sonnet-4-6
     tier: frontier_api
@@ -50,6 +53,7 @@ backends:
       - documentation
       - research
   - backend_id: cloud-haiku
+    endpoint_url: ""
     # Claude Haiku — cheapest frontier model for documentation/simple tasks
     model_name: claude-haiku-4-5-20251001
     tier: frontier_api
@@ -58,6 +62,41 @@ backends:
       - documentation
       - summarization
       - simple_tasks
+  - backend_id: cloud-glm
+    endpoint_url: ""
+    model_name: glm-z-ai
+    tier: cheap_cloud
+    timeout_ms: 60000
+    capabilities:
+      - code_generation
+      - reasoning
+      - research
+  - backend_id: cloud-gemini-flash
+    endpoint_url: ""
+    model_name: gemini-flash
+    tier: cheap_cloud
+    timeout_ms: 60000
+    capabilities:
+      - summarization
+      - simple_tasks
+      - document
+  # CLI agent backends — dispatched via subprocess, not HTTP.
+  - backend_id: cli-claude
+    endpoint_url: ""
+    model_name: claude-cli
+    tier: cli_agents
+    timeout_ms: 300000
+    capabilities:
+      - agent_delegation
+      - complex_reasoning
+  - backend_id: cli-opencode
+    endpoint_url: ""
+    model_name: opencode-cli
+    tier: cli_agents
+    timeout_ms: 300000
+    capabilities:
+      - agent_delegation
+      - code_generation
 # Routing rules — evaluated in ascending priority order.
 # First matching rule wins. Each rule maps a task_class to an ordered
 # list of backends to try.

--- a/src/omnibase_infra/configs/routing_tiers.yaml
+++ b/src/omnibase_infra/configs/routing_tiers.yaml
@@ -11,13 +11,18 @@
 # Tier evaluation order: local → cheap_cloud → claude
 # The handler iterates tiers top-to-bottom, stopping at the first accepted result.
 #
+# Endpoint URLs are resolved from the deployed bifrost contract at
+# ~/.omninode/delegation/bifrost_delegation.yaml. The backend_id field maps
+# each model to a backend entry in the bifrost contract. See OMN-10657.
+#
 # Related Tickets:
 #   - OMN-8029: Delegation pipeline — local→cheap-cloud→claude routing
+#   - OMN-10657: Endpoint resolution from deployed contract, not env vars
 tiers:
   - name: local
     models:
       - id: qwen3-coder-30b
-        env_var: LLM_CODER_URL
+        backend_id: local-qwen-coder-30b
         max_context_tokens: 65536
         use_for:
           - code_generation
@@ -26,7 +31,7 @@ tiers:
           - test
           - research
       - id: deepseek-r1-14b
-        env_var: LLM_CODER_FAST_URL
+        backend_id: local-deepseek-r1-14b
         max_context_tokens: 24576
         use_for:
           - test
@@ -42,14 +47,14 @@ tiers:
   - name: cheap_cloud
     models:
       - id: glm-z-ai
-        env_var: LLM_GLM_URL
+        backend_id: cloud-glm
         max_context_tokens: 128000
         use_for:
           - code_generation
           - reasoning
           - research
       - id: gemini-flash
-        env_var: LLM_GEMINI_FLASH_URL
+        backend_id: cloud-gemini-flash
         max_context_tokens: 1000000
         use_for:
           - summarization
@@ -61,7 +66,7 @@ tiers:
   - name: claude
     models:
       - id: claude-sonnet-4-6
-        env_var: ANTHROPIC_API_KEY
+        backend_id: cloud-sonnet
         max_context_tokens: 200000
         use_for:
           - escalation
@@ -81,13 +86,13 @@ tiers:
   - name: cli_agents
     models:
       - id: claude-cli
-        env_var: CLAUDE_CLI_AVAILABLE
+        backend_id: cli-claude
         max_context_tokens: 200000
         use_for:
           - agent_delegation
           - complex_reasoning
       - id: opencode-cli
-        env_var: OPENCODE_CLI_AVAILABLE
+        backend_id: cli-opencode
         max_context_tokens: 200000
         use_for:
           - agent_delegation

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
@@ -24,7 +24,7 @@ node_version:
   patch: 0
 node_type: "REDUCER_GENERIC"
 description: >
-  Deterministic routing reducer for the delegation pipeline. Maps task type and prompt token count to a routing decision: which model, endpoint, cost tier, and system prompt to use. Pure function, no I/O. Resolves endpoint URLs from the deployed bifrost contract at ~/.omninode/delegation/bifrost_delegation.yaml (overrideable via BIFROST_CONTRACT_PATH) — not from environment variables (OMN-10657). Loads task-class contracts from configs/task_class_contracts.v1.yaml (overrideable via TASK_CLASS_CONTRACT_PATH) and enforces per-task-class cloud_routing_policy, pricing_ceiling_per_1k_tokens, and escalation_policy.tier_order constraints (OMN-10615).
+  Deterministic routing reducer for the delegation pipeline. Maps task type and prompt token count to a routing decision: which model, endpoint, cost tier, and system prompt to use. Performs read-only configuration I/O to load on-disk contracts (overrideable via BIFROST_CONTRACT_PATH and TASK_CLASS_CONTRACT_PATH). Resolves endpoint URLs from the deployed bifrost contract at ~/.omninode/delegation/bifrost_delegation.yaml (overrideable via BIFROST_CONTRACT_PATH) — not from environment variables (OMN-10657). Loads task-class contracts from configs/task_class_contracts.v1.yaml (overrideable via TASK_CLASS_CONTRACT_PATH) and enforces per-task-class cloud_routing_policy, pricing_ceiling_per_1k_tokens, and escalation_policy.tier_order constraints (OMN-10615).
 
 input_model:
   name: "ModelDelegationRequest"

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/contract.yaml
@@ -16,15 +16,15 @@ contract_name: "node_delegation_routing_reducer"
 node_name: "node_delegation_routing_reducer"
 contract_version:
   major: 0
-  minor: 2
+  minor: 3
   patch: 0
 node_version:
   major: 0
-  minor: 2
+  minor: 3
   patch: 0
 node_type: "REDUCER_GENERIC"
 description: >
-  Deterministic routing reducer for the delegation pipeline. Maps task type and prompt token count to a routing decision: which model, endpoint, cost tier, and system prompt to use. Pure function, no I/O. Reads endpoint URLs from environment via contract config dependencies. Loads task-class contracts from configs/task_class_contracts.v1.yaml (overrideable via TASK_CLASS_CONTRACT_PATH) and enforces per-task-class cloud_routing_policy, pricing_ceiling_per_1k_tokens, and escalation_policy.tier_order constraints (OMN-10615).
+  Deterministic routing reducer for the delegation pipeline. Maps task type and prompt token count to a routing decision: which model, endpoint, cost tier, and system prompt to use. Pure function, no I/O. Resolves endpoint URLs from the deployed bifrost contract at ~/.omninode/delegation/bifrost_delegation.yaml (overrideable via BIFROST_CONTRACT_PATH) — not from environment variables (OMN-10657). Loads task-class contracts from configs/task_class_contracts.v1.yaml (overrideable via TASK_CLASS_CONTRACT_PATH) and enforces per-task-class cloud_routing_policy, pricing_ceiling_per_1k_tokens, and escalation_policy.tier_order constraints (OMN-10615).
 
 input_model:
   name: "ModelDelegationRequest"
@@ -69,15 +69,9 @@ config_dependencies:
   - key: "DEBT_SCOUT_BASE_URL"
     description: "A2A endpoint URL for the ADK type debt scout agent"
     required: true
-  - key: "LLM_CODER_URL"
-    description: "Endpoint URL for Qwen3-Coder-30B-A3B (port 8000)"
-    required: true
-  - key: "LLM_CODER_FAST_URL"
-    description: "Endpoint URL for DeepSeek-R1-14B (port 8001)"
+  - key: "BIFROST_CONTRACT_PATH"
+    description: "Override path for the deployed bifrost delegation contract (default: ~/.omninode/delegation/bifrost_delegation.yaml). Used in tests and staging environments."
     required: false
-  - key: "LLM_DEEPSEEK_R1_URL"
-    description: "Endpoint URL for DeepSeek-R1-14B AWQ (port 8001, .201)"
-    required: true
 error_handling:
   retry_policy:
     max_retries: 0
@@ -112,3 +106,5 @@ metadata:
     - llm
   related_tickets:
     - "OMN-7040"
+    - "OMN-10615"
+    - "OMN-10657"

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/handlers/handler_delegation_routing.py
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/handlers/handler_delegation_routing.py
@@ -9,6 +9,12 @@ and returns the first tier that has a configured endpoint for the given task typ
 All tier order, model assignments, and retry counts come from the YAML config —
 no constants are hardcoded here.
 
+Endpoint URLs are resolved from the deployed bifrost contract at
+~/.omninode/delegation/bifrost_delegation.yaml — NOT from environment variables.
+The installer (install-delegation.sh --apply) populates endpoint_url fields in
+the deployed contract. Each model in routing_tiers.yaml has a backend_id that
+maps to a backend entry in the bifrost contract.
+
 Task-class contracts (task_class_contracts.v1.yaml) augment tier routing with
 per-class pricing ceilings and cloud routing policies. When the contract file is
 present (via TASK_CLASS_CONTRACT_PATH env var or the default location), routing
@@ -23,6 +29,7 @@ Related:
     - OMN-7040: Node-based delegation pipeline
     - OMN-8029: Delegation pipeline — local→cheap-cloud→claude routing
     - OMN-10615: Wire routing reducer to read task-class contracts
+    - OMN-10657: Endpoint resolution from deployed contract, not env vars
 """
 
 from __future__ import annotations
@@ -153,36 +160,30 @@ def _select_model_for_task(
     tier_models: tuple[ModelTierModel, ...],
     task_type: str,
     estimated_tokens: int,
+    bifrost_backends: dict[str, BifrostBackendRef],
 ) -> ModelTierModel | None:
     """Select the best model from a tier for the given task and token count.
 
     Prefers fast-path models when prompt fits within their threshold.
     Falls back to any model that declares the task type in use_for.
+    Endpoint availability is checked via the bifrost_backends dict (keyed by backend_id).
     """
-    # Fast-path check: prefer model with threshold if tokens fit within both the
-    # fast-path threshold and the model's declared max context window.
     for model in tier_models:
-        endpoint = os.environ.get(
-            model.env_var, ""
-        )  # ONEX_EXCLUDE: env_access - routing reads env to discover available backends
+        backend = bifrost_backends.get(model.backend_ref)
         if (
             task_type in model.use_for
             and estimated_tokens <= model.max_context_tokens
             and model.fast_path_threshold_tokens is not None
             and estimated_tokens <= model.fast_path_threshold_tokens
-            and endpoint
+            and backend
         ):
             return model
 
-    # Standard selection: first model that handles this task, has endpoint set,
-    # and whose context window can accommodate the estimated token count.
     for model in tier_models:
-        endpoint = os.environ.get(
-            model.env_var, ""
-        )  # ONEX_EXCLUDE: env_access - routing reads env to discover available backends
+        backend = bifrost_backends.get(model.backend_ref)
         if (
             task_type in model.use_for
-            and endpoint
+            and backend
             and estimated_tokens <= model.max_context_tokens
         ):
             return model
@@ -200,6 +201,14 @@ _DEFAULT_TASK_CLASS_CONTRACT_PATH = (
     / "task_class_contracts.v1.yaml"
 )
 
+_DEFAULT_BIFROST_CONTRACT_PATH = (
+    Path.home() / ".omninode" / "delegation" / "bifrost_delegation.yaml"
+)
+
+_SOURCE_BIFROST_CONTRACT_PATH = (
+    Path(__file__).parent.parent.parent.parent / "configs" / "bifrost_delegation.yaml"
+)
+
 # Module-level config singletons — loaded once on first call.
 # Tests can override by replacing these variables before calling delta().
 _config: ModelDelegationConfig | None = None
@@ -208,10 +217,60 @@ _config: ModelDelegationConfig | None = None
 def _get_config() -> ModelDelegationConfig:
     global _config  # noqa: PLW0603
     if _config is None:
-        # I/O is performed here in the handler (EFFECT boundary), not in the pure model.
         yaml_text = _DEFAULT_CONFIG_PATH.read_text()
         _config = ModelDelegationConfig.from_yaml_text(yaml_text)
     return _config
+
+
+class BifrostBackendRef:
+    """Resolved backend from the deployed bifrost contract."""
+
+    __slots__ = ("endpoint_url", "model_name")
+
+    def __init__(self, endpoint_url: str, model_name: str) -> None:
+        self.endpoint_url = endpoint_url
+        self.model_name = model_name
+
+
+@lru_cache(maxsize=1)
+def _load_bifrost_endpoints() -> dict[str, BifrostBackendRef]:
+    """Load backend info from the deployed bifrost contract.
+
+    Resolution order:
+      1. BIFROST_CONTRACT_PATH env var (test/override)
+      2. ~/.omninode/delegation/bifrost_delegation.yaml (installed by installer)
+      3. Source configs/bifrost_delegation.yaml (development fallback)
+
+    Returns a dict mapping backend_id → BifrostBackendRef (endpoint_url + model_name).
+    """
+    env_path = os.environ.get(
+        "BIFROST_CONTRACT_PATH", ""
+    )  # ONEX_EXCLUDE: env_access - contract path configuration
+    if env_path:
+        contract_path = Path(env_path)
+    elif _DEFAULT_BIFROST_CONTRACT_PATH.exists():
+        contract_path = _DEFAULT_BIFROST_CONTRACT_PATH
+    else:
+        contract_path = _SOURCE_BIFROST_CONTRACT_PATH
+
+    if not contract_path.exists():
+        return {}
+
+    raw = yaml.safe_load(contract_path.read_text())
+    if not isinstance(raw, dict):
+        return {}
+
+    backends: dict[str, BifrostBackendRef] = {}
+    for backend in raw.get("backends", []):
+        if not isinstance(backend, dict):
+            continue
+        bid = backend.get("backend_id", "")
+        url = backend.get("endpoint_url", "")
+        model_name = backend.get("model_name", "")
+        if bid and url:
+            backends[bid] = BifrostBackendRef(endpoint_url=url, model_name=model_name)
+
+    return backends
 
 
 @lru_cache(maxsize=1)
@@ -358,6 +417,8 @@ def delta(request: ModelDelegationRequest) -> ModelRoutingDecision:
     task type, and satisfies task-class contract constraints (cloud routing policy
     and pricing ceiling).
 
+    Endpoint URLs are resolved from the deployed bifrost contract, not env vars.
+
     Args:
         request: The delegation request to route.
 
@@ -368,6 +429,7 @@ def delta(request: ModelDelegationRequest) -> ModelRoutingDecision:
         ProtocolConfigurationError: If no tier has a configured endpoint for the task type.
     """
     config = _get_config()
+    bifrost_backends = _load_bifrost_endpoints()
     task_type = request.task_type
     estimated_tokens = _estimate_prompt_tokens(request.prompt)
 
@@ -379,20 +441,27 @@ def delta(request: ModelDelegationRequest) -> ModelRoutingDecision:
         if not _tier_allowed_by_contract(tier, entry):
             continue
 
-        selected = _select_model_for_task(tier.models, task_type, estimated_tokens)
+        selected = _select_model_for_task(
+            tier.models,
+            task_type,
+            estimated_tokens,
+            bifrost_backends,
+        )
         if selected is None:
             continue
 
-        endpoint_url = os.environ.get(
-            selected.env_var, ""
-        )  # ONEX_EXCLUDE: env_access - routing reads env to discover available backends
-        if not endpoint_url:
+        backend = bifrost_backends.get(selected.backend_ref)
+        if not backend:
             continue
 
         system_prompt = _SYSTEM_PROMPTS.get(
             task_type,
             f"You are a helpful assistant completing a {task_type} task.",
         )
+
+        # Use the bifrost model_name (full vLLM model ID) when available,
+        # fall back to the routing_tiers short ID.
+        model_name = backend.model_name or selected.id
 
         rationale = (
             f"Task '{task_type}' (~{estimated_tokens} tokens) routed to "
@@ -411,16 +480,15 @@ def delta(request: ModelDelegationRequest) -> ModelRoutingDecision:
                 f" Contract-driven: task_class='{task_type}' policy='{policy_str}'."
             )
 
-        # Map cost tier from tier name
         cost_tier_map = {"local": "low", "cheap_cloud": "medium", "claude": "high"}
         cost_tier = cost_tier_map.get(tier.name, tier.name)
 
         return ModelRoutingDecision(
             correlation_id=request.correlation_id,
             task_type=task_type,
-            selected_model=selected.id,
+            selected_model=model_name,
             selected_backend_id=_backend_id_for_model(selected.id),
-            endpoint_url=endpoint_url,
+            endpoint_url=backend.endpoint_url,
             cost_tier=cost_tier,
             max_context_tokens=selected.max_context_tokens,
             system_prompt=system_prompt,
@@ -434,8 +502,8 @@ def delta(request: ModelDelegationRequest) -> ModelRoutingDecision:
     )
     msg = (
         f"No tier has a configured endpoint for task_type='{task_type}'. "
-        f"Set at least one of the required env vars in routing_tiers.yaml "
-        f"(e.g., LLM_CODER_URL for local tier, ANTHROPIC_API_KEY for claude tier)."
+        f"Deploy a bifrost contract with endpoint URLs via install-delegation.sh --apply, "
+        f"or set BIFROST_CONTRACT_PATH to a contract with populated endpoint_url fields."
     )
     raise ProtocolConfigurationError(msg, context=context)
 

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/models/model_delegation_config.py
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/models/model_delegation_config.py
@@ -44,7 +44,7 @@ class ModelDelegationConfig(BaseModel):
                 models.append(
                     ModelTierModel(
                         id=m["id"],
-                        env_var=m["env_var"],
+                        backend_ref=m["backend_id"],
                         max_context_tokens=m["max_context_tokens"],
                         use_for=tuple(m.get("use_for", [])),
                         fast_path_threshold_tokens=m.get("fast_path_threshold_tokens"),

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/models/model_tier_model.py
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/models/model_tier_model.py
@@ -14,7 +14,10 @@ class ModelTierModel(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     id: str = Field(..., description="Model identifier.")
-    env_var: str = Field(..., description="Env var name for endpoint URL or API key.")
+    backend_ref: str = Field(
+        ...,
+        description="Backend key in the deployed bifrost contract (bifrost_delegation.yaml).",
+    )
     max_context_tokens: int = Field(..., description="Max context window in tokens.")
     use_for: tuple[str, ...] = Field(
         default_factory=tuple,

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_delegation_config.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_delegation_config.py
@@ -119,6 +119,10 @@ class ModelDelegationBackendConfig(BaseModel):
         default=None,
         description="Env var name holding the backend base URL (local backends).",
     )
+    endpoint_url: str = Field(
+        default="",
+        description="Deployed full endpoint URL populated by install-delegation.sh.",
+    )
     # ONEX_EXCLUDE: pattern_validator - model_name is a model identifier string
     # (e.g. "claude-sonnet-4-6"), not an entity reference requiring ID + display_name pattern.
     model_name: str = Field(
@@ -199,7 +203,7 @@ class ModelBifrostDelegationConfig(BaseModel):
     backends: tuple[ModelDelegationBackendConfig, ...] = Field(
         ...,
         min_length=1,
-        description="Backend definitions — URLs resolved from env vars at runtime.",
+        description="Backend definitions with deployed endpoint URLs.",
     )
     routing_rules: tuple[ModelDelegationRoutingRule, ...] = Field(
         ...,

--- a/tests/integration/delegation/test_bifrost_contract_loading.py
+++ b/tests/integration/delegation/test_bifrost_contract_loading.py
@@ -69,32 +69,67 @@ def test_bifrost_endpoints_load_from_source_contract_when_deployed_absent(
     tmp_path: Path,
 ) -> None:
     """When deployed contract is absent, handler falls back to source bifrost contract."""
-    # Point BIFROST_CONTRACT_PATH to a non-existent path to simulate absent deployed contract.
-    nonexistent = tmp_path / "nonexistent.yaml"
-    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(nonexistent))
-    # Override the source fallback path to point to the real source contract.
-    monkeypatch.setattr(
-        _handler_mod,
-        "_SOURCE_BIFROST_CONTRACT_PATH",
-        SOURCE_BIFROST_PATH,
+    # Write a sentinel source contract with a known populated backend.
+    sentinel_source = tmp_path / "sentinel_source.yaml"
+    sentinel_source.write_text(
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n"
+        "  - backend_id: sentinel-fallback-backend\n"
+        '    endpoint_url: "http://sentinel-fallback:8000"\n'
+        "    model_name: sentinel-model\n"
+        "    tier: local\n"
+        "    timeout_ms: 30000\n"
+        "    capabilities: []\n"
     )
+    # Absent deployed contract triggers fallback to the sentinel source.
+    # No BIFROST_CONTRACT_PATH env var, and _DEFAULT_BIFROST_CONTRACT_PATH points nowhere.
+    monkeypatch.delenv("BIFROST_CONTRACT_PATH", raising=False)
+    monkeypatch.setattr(
+        _handler_mod, "_DEFAULT_BIFROST_CONTRACT_PATH", tmp_path / "absent.yaml"
+    )
+    monkeypatch.setattr(_handler_mod, "_SOURCE_BIFROST_CONTRACT_PATH", sentinel_source)
 
     backends = _handler_mod._load_bifrost_endpoints()
-    # Source contract has empty endpoint_url fields — no backends resolve to non-empty URLs.
-    # But the function should not raise, and should return a dict.
     assert isinstance(backends, dict)
+    assert "sentinel-fallback-backend" in backends, (
+        "Fallback to source bifrost contract did not load sentinel backend"
+    )
+    assert (
+        backends["sentinel-fallback-backend"].endpoint_url
+        == "http://sentinel-fallback:8000"
+    )
 
 
 def test_bifrost_endpoints_load_from_env_override(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """BIFROST_CONTRACT_PATH env var redirects loading to the chosen file."""
-    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(SOURCE_BIFROST_PATH))
+    # Write a sentinel override contract with a known populated backend.
+    sentinel_override = tmp_path / "sentinel_override.yaml"
+    sentinel_override.write_text(
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n"
+        "  - backend_id: sentinel-override-backend\n"
+        '    endpoint_url: "http://sentinel-override:9000"\n'
+        "    model_name: sentinel-override-model\n"
+        "    tier: cloud\n"
+        "    timeout_ms: 10000\n"
+        "    capabilities: []\n"
+    )
+    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(sentinel_override))
 
     backends = _handler_mod._load_bifrost_endpoints()
     assert isinstance(backends, dict)
-    # Source contract has empty endpoint_url fields — backends with empty URLs are excluded.
-    # Verify the function completed without raising.
+    assert "sentinel-override-backend" in backends, (
+        "BIFROST_CONTRACT_PATH env override did not load sentinel backend"
+    )
+    assert (
+        backends["sentinel-override-backend"].endpoint_url
+        == "http://sentinel-override:9000"
+    )
 
 
 def test_bifrost_contract_schema_version_is_correct() -> None:

--- a/tests/integration/delegation/test_bifrost_contract_loading.py
+++ b/tests/integration/delegation/test_bifrost_contract_loading.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: routing reducer reads on-disk bifrost contract (OMN-10657).
+
+Exercises the bifrost contract loading path against the real
+configs/bifrost_delegation.yaml shipped in the repo. Unit tests already
+cover individual model-selection helpers with synthetic bifrost YAMLs; this
+module proves the reducer wires to the source bifrost contract file at its
+installed location and that endpoint resolution falls back to the source
+contract when the deployed contract is absent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml
+
+import omnibase_infra.nodes.node_delegation_routing_reducer.handlers.handler_delegation_routing as _handler_mod
+
+pytestmark = [pytest.mark.integration]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_BIFROST_PATH = (
+    REPO_ROOT / "src" / "omnibase_infra" / "configs" / "bifrost_delegation.yaml"
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons() -> Iterator[None]:
+    _handler_mod._config = None
+    _handler_mod._load_bifrost_endpoints.cache_clear()
+    yield
+    _handler_mod._config = None
+    _handler_mod._load_bifrost_endpoints.cache_clear()
+
+
+def test_source_bifrost_contract_exists_at_canonical_path() -> None:
+    """The source bifrost contract must exist on disk for development wiring."""
+    assert SOURCE_BIFROST_PATH.exists(), (
+        f"Source bifrost contract missing at {SOURCE_BIFROST_PATH}"
+    )
+
+
+def test_source_bifrost_contract_parses_to_expected_shape() -> None:
+    """Loaded bifrost contract must declare expected backend IDs."""
+    raw = yaml.safe_load(SOURCE_BIFROST_PATH.read_text())
+    assert isinstance(raw, dict)
+    backends = raw.get("backends")
+    assert isinstance(backends, list)
+    backend_ids = {b.get("backend_id") for b in backends if isinstance(b, dict)}
+    for required_id in (
+        "local-qwen-coder-30b",
+        "local-deepseek-r1-14b",
+        "cloud-sonnet",
+        "cloud-haiku",
+        "cloud-glm",
+        "cloud-gemini-flash",
+        "cli-claude",
+        "cli-opencode",
+    ):
+        assert required_id in backend_ids, f"Missing backend_id: {required_id}"
+
+
+def test_bifrost_endpoints_load_from_source_contract_when_deployed_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When deployed contract is absent, handler falls back to source bifrost contract."""
+    # Point BIFROST_CONTRACT_PATH to a non-existent path to simulate absent deployed contract.
+    nonexistent = tmp_path / "nonexistent.yaml"
+    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(nonexistent))
+    # Override the source fallback path to point to the real source contract.
+    monkeypatch.setattr(
+        _handler_mod,
+        "_SOURCE_BIFROST_CONTRACT_PATH",
+        SOURCE_BIFROST_PATH,
+    )
+
+    backends = _handler_mod._load_bifrost_endpoints()
+    # Source contract has empty endpoint_url fields — no backends resolve to non-empty URLs.
+    # But the function should not raise, and should return a dict.
+    assert isinstance(backends, dict)
+
+
+def test_bifrost_endpoints_load_from_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BIFROST_CONTRACT_PATH env var redirects loading to the chosen file."""
+    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(SOURCE_BIFROST_PATH))
+
+    backends = _handler_mod._load_bifrost_endpoints()
+    assert isinstance(backends, dict)
+    # Source contract has empty endpoint_url fields — backends with empty URLs are excluded.
+    # Verify the function completed without raising.
+
+
+def test_bifrost_contract_schema_version_is_correct() -> None:
+    """Source bifrost contract must declare the expected schema version."""
+    raw = yaml.safe_load(SOURCE_BIFROST_PATH.read_text())
+    assert isinstance(raw, dict)
+    assert raw.get("schema_version") == "bifrost_delegation.v1"
+    assert raw.get("config_version") == "1.1.0"

--- a/tests/integration/delegation/test_routing_reducer_contract_loading.py
+++ b/tests/integration/delegation/test_routing_reducer_contract_loading.py
@@ -106,12 +106,30 @@ def test_reducer_honors_env_override_path(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_routing_with_contract_loaded_picks_local_tier(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    """End-to-end: loaded contract + local tier endpoint → routes to local model."""
+    """End-to-end: loaded task-class contract + bifrost endpoint → routes to local model.
+
+    Endpoint URLs are now resolved from the bifrost contract (OMN-10657), not env vars.
+    This test writes a temp bifrost YAML with a populated endpoint for local-qwen-coder-30b
+    and verifies the reducer picks the local tier.
+    """
+    # Write a minimal bifrost contract with the local backend endpoint populated.
+    bifrost_yaml = tmp_path / "bifrost.yaml"
+    bifrost_yaml.write_text(
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n"
+        "  - backend_id: local-qwen-coder-30b\n"
+        '    endpoint_url: "http://192.168.86.201:8000"\n'
+        "    model_name: cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit\n"
+        "    tier: local\n"
+        "    timeout_ms: 30000\n"
+        "    capabilities: []\n"
+    )
     monkeypatch.setenv("TASK_CLASS_CONTRACT_PATH", str(DEFAULT_CONTRACT_PATH))
-    monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-    monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(bifrost_yaml))
 
     decision = delta(_request(task_type="test", prompt="x" * 200000))
-    assert decision.selected_model == "qwen3-coder-30b"
+    assert decision.selected_model == "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"
     assert decision.cost_tier == "low"

--- a/tests/integration/nodes/test_delegation_pipeline_e2e.py
+++ b/tests/integration/nodes/test_delegation_pipeline_e2e.py
@@ -81,13 +81,13 @@ def _set_bifrost_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
         "backends:\n"
         "  - backend_id: local-qwen-coder-30b\n"
         '    endpoint_url: "http://192.168.86.201:8000"\n'
-        "    model_name: \n"
+        '    model_name: "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"\n'
         "    tier: local\n"
         "    timeout_ms: 30000\n"
         "    capabilities: []\n"
         "  - backend_id: local-deepseek-r1-14b\n"
         '    endpoint_url: "http://192.168.86.201:8001"\n'
-        "    model_name: \n"
+        '    model_name: "Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ"\n'
         "    tier: local\n"
         "    timeout_ms: 30000\n"
         "    capabilities: []\n",
@@ -222,8 +222,11 @@ class TestDelegationPipelineHappyPath:
         )
 
         routing_decision = routing_delta(request)
-        # document tasks route to deepseek-r1-14b (LLM_CODER_FAST_URL) in the local tier
-        assert routing_decision.selected_model == "deepseek-r1-14b"
+        # document tasks route to the deployed DeepSeek model in the local tier
+        assert (
+            routing_decision.selected_model
+            == "Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ"
+        )
         assert routing_decision.endpoint_url == "http://192.168.86.201:8001"
 
         orchestrator = HandlerDelegationWorkflow()

--- a/tests/integration/nodes/test_delegation_pipeline_e2e.py
+++ b/tests/integration/nodes/test_delegation_pipeline_e2e.py
@@ -24,6 +24,7 @@ Related:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -67,16 +68,35 @@ from omnibase_infra.nodes.node_delegation_routing_reducer.handlers.handler_deleg
 
 
 @pytest.fixture(autouse=True)
-def _set_llm_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Provide LLM endpoint env vars required by the routing reducer."""
+def _set_bifrost_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a deployed bifrost contract required by the routing reducer."""
     import omnibase_infra.nodes.node_delegation_routing_reducer.handlers.handler_delegation_routing as _h
 
     _h._config = None
-    monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-    monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
-    monkeypatch.setenv("LLM_DEEPSEEK_R1_URL", "http://192.168.86.200:8101")
+    _h._load_bifrost_endpoints.cache_clear()
+    contract_path = tmp_path / "bifrost_delegation.yaml"
+    contract_path.write_text(
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n"
+        "  - backend_id: local-qwen-coder-30b\n"
+        '    endpoint_url: "http://192.168.86.201:8000"\n'
+        "    model_name: \n"
+        "    tier: local\n"
+        "    timeout_ms: 30000\n"
+        "    capabilities: []\n"
+        "  - backend_id: local-deepseek-r1-14b\n"
+        '    endpoint_url: "http://192.168.86.201:8001"\n'
+        "    model_name: \n"
+        "    tier: local\n"
+        "    timeout_ms: 30000\n"
+        "    capabilities: []\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(contract_path))
     yield
     _h._config = None
+    _h._load_bifrost_endpoints.cache_clear()
 
 
 def _simulate_inference(

--- a/tests/unit/delegation/test_delegation_chain_e2e.py
+++ b/tests/unit/delegation/test_delegation_chain_e2e.py
@@ -20,8 +20,8 @@ Related:
 
 from __future__ import annotations
 
-import os
 from datetime import UTC, datetime
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -73,11 +73,37 @@ class TestDelegationChainE2E:
     """End-to-end delegation chain tests using in-memory event bus."""
 
     @pytest.fixture(autouse=True)
-    def _setup_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Set required LLM endpoint env vars for routing reducer."""
-        monkeypatch.setenv("LLM_CODER_URL", "http://test-coder:8000")
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://test-fast:8001")
-        monkeypatch.setenv("LLM_DEEPSEEK_R1_URL", "http://test-deepseek:8101")
+    def _setup_bifrost_contract(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Set the bifrost contract path used by the routing reducer."""
+        import omnibase_infra.nodes.node_delegation_routing_reducer.handlers.handler_delegation_routing as _h
+
+        _h._config = None
+        _h._load_bifrost_endpoints.cache_clear()
+        contract_path = tmp_path / "bifrost_delegation.yaml"
+        contract_path.write_text(
+            "config_version: '1.1.0'\n"
+            "schema_version: bifrost_delegation.v1\n"
+            "backends:\n"
+            "  - backend_id: local-qwen-coder-30b\n"
+            '    endpoint_url: "http://test-coder:8000"\n'
+            "    model_name: \n"
+            "    tier: local\n"
+            "    timeout_ms: 30000\n"
+            "    capabilities: []\n"
+            "  - backend_id: local-deepseek-r1-14b\n"
+            '    endpoint_url: "http://test-fast:8001"\n'
+            "    model_name: \n"
+            "    tier: local\n"
+            "    timeout_ms: 30000\n"
+            "    capabilities: []\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", str(contract_path))
+        yield
+        _h._config = None
+        _h._load_bifrost_endpoints.cache_clear()
 
     @pytest.fixture
     def handler(self) -> HandlerDelegationWorkflow:

--- a/tests/unit/delegation/test_delegation_chain_e2e.py
+++ b/tests/unit/delegation/test_delegation_chain_e2e.py
@@ -88,13 +88,13 @@ class TestDelegationChainE2E:
             "backends:\n"
             "  - backend_id: local-qwen-coder-30b\n"
             '    endpoint_url: "http://test-coder:8000"\n'
-            "    model_name: \n"
+            '    model_name: "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"\n'
             "    tier: local\n"
             "    timeout_ms: 30000\n"
             "    capabilities: []\n"
             "  - backend_id: local-deepseek-r1-14b\n"
             '    endpoint_url: "http://test-fast:8001"\n'
-            "    model_name: \n"
+            '    model_name: "Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ"\n'
             "    tier: local\n"
             "    timeout_ms: 30000\n"
             "    capabilities: []\n",
@@ -157,6 +157,10 @@ class TestDelegationChainE2E:
         assert isinstance(decision, ModelRoutingDecision)
         assert decision.correlation_id == cid
         assert decision.task_type == "research"
+        assert decision.selected_model in {
+            "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
+            "Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ",
+        }
 
         # Step 3: Handle routing decision -> get inference intents
         inference_intents = handler.handle_routing_decision(decision)

--- a/tests/unit/delegation/test_delegation_contracts.py
+++ b/tests/unit/delegation/test_delegation_contracts.py
@@ -100,19 +100,18 @@ class TestRoutingReducerContract:
         data = self._load()
         assert data["node_type"] == "REDUCER_GENERIC"
 
-    def test_config_dependencies_include_llm_endpoints(self) -> None:
+    def test_config_dependencies_include_bifrost_contract_path(self) -> None:
         data = self._load()
         dep_keys = {d["key"] for d in data["config_dependencies"]}
-        assert "LLM_CODER_URL" in dep_keys
-        assert "LLM_DEEPSEEK_R1_URL" in dep_keys
+        assert "BIFROST_CONTRACT_PATH" in dep_keys
 
-    def test_llm_coder_fast_url_is_optional(self) -> None:
+    def test_bifrost_contract_path_is_optional(self) -> None:
         data = self._load()
         deps = {d["key"]: d for d in data["config_dependencies"]}
-        assert "LLM_CODER_FAST_URL" in deps, (
-            "LLM_CODER_FAST_URL missing from config_dependencies"
+        assert "BIFROST_CONTRACT_PATH" in deps, (
+            "BIFROST_CONTRACT_PATH missing from config_dependencies"
         )
-        assert deps["LLM_CODER_FAST_URL"]["required"] is False
+        assert deps["BIFROST_CONTRACT_PATH"]["required"] is False
 
 
 @pytest.mark.unit

--- a/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing.py
+++ b/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing.py
@@ -7,19 +7,25 @@
 Tests cover:
     - Routing for each task type (test, research, document)
     - Fast-path routing when prompt tokens <= 24K
-    - Fallback when LLM_CODER_FAST_URL is not configured
-    - Error on missing required endpoint
+    - Fallback when local-deepseek backend has no endpoint
+    - Error on missing all endpoints
     - System prompt assignment per task type
     - Escalation: no local endpoints configured → claude tier
+
+Endpoint URLs are resolved from a deployed bifrost contract, not env vars.
+Tests write a temporary bifrost YAML and point the handler at it via
+BIFROST_CONTRACT_PATH.
 
 Related:
     - OMN-7040: Node-based delegation pipeline
     - OMN-8029: routing_tiers.yaml config-driven routing
+    - OMN-10657: Contract-driven endpoint resolution
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -51,121 +57,188 @@ def _request(
     )
 
 
+def _write_bifrost(tmp_path: Path, backends: dict[str, str]) -> str:
+    """Write a bifrost contract YAML with given backend_id -> endpoint_url mappings."""
+    entries = []
+    for bid, url in backends.items():
+        entries.append(
+            f"  - backend_id: {bid}\n"
+            f'    endpoint_url: "{url}"\n'
+            f"    model_name: "
+            "\n"
+            f"    tier: local\n"
+            f"    timeout_ms: 30000\n"
+            f"    capabilities: []"
+        )
+    backends_block = "\n".join(entries) if entries else "  []"
+    content = (
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n" + backends_block + "\n"
+    )
+    path = tmp_path / "bifrost.yaml"
+    path.write_text(content)
+    return str(path)
+
+
 @pytest.fixture(autouse=True)
-def reset_config_singleton() -> None:
+def reset_config_singleton():  # type: ignore[no-untyped-def]
     """Reset the module-level config singleton before each test."""
     _handler_mod._config = None
+    _handler_mod._load_bifrost_endpoints.cache_clear()
     yield
     _handler_mod._config = None
+    _handler_mod._load_bifrost_endpoints.cache_clear()
 
 
 class TestRoutingByTaskType:
     """Verify correct model selection per task type from routing_tiers.yaml."""
 
     def test_test_routes_to_coder_when_no_fast_path(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Without fast-path URL, test tasks go to qwen3-coder-30b."""
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        # Long prompt so fast-path threshold is irrelevant
+        """Without fast-path endpoint, test tasks go to qwen3-coder-30b."""
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="x" * 200000)
         decision = delta(req)
         assert decision.selected_model == "qwen3-coder-30b"
-        assert decision.endpoint_url == "http://192.168.86.201:8000"
+        assert (
+            decision.endpoint_url == "http://192.168.86.201:8000"
+        )  # onex-allow-internal-ip
         assert decision.cost_tier == "low"
         assert decision.max_context_tokens == 65536
 
-    def test_research_routes_to_coder(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+    def test_research_routes_to_coder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="research", prompt="x" * 200000)
         decision = delta(req)
         assert decision.selected_model == "qwen3-coder-30b"
-        assert decision.endpoint_url == "http://192.168.86.201:8000"
+        assert (
+            decision.endpoint_url == "http://192.168.86.201:8000"
+        )  # onex-allow-internal-ip
 
-    def test_document_routes_to_deepseek(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Document tasks go to deepseek-r1-14b via LLM_CODER_FAST_URL."""
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
+    def test_document_routes_to_deepseek(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Document tasks go to deepseek-r1-14b via local-deepseek backend."""
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document")
         decision = delta(req)
         assert decision.selected_model == "deepseek-r1-14b"
-        assert decision.endpoint_url == "http://192.168.86.201:8001"
+        assert (
+            decision.endpoint_url == "http://192.168.86.201:8001"
+        )  # onex-allow-internal-ip
 
 
 class TestFastPathRouting:
     """Verify token-count based fast-path optimization."""
 
-    def test_short_prompt_uses_fast_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
-        # Short prompt (~10 tokens) should use fast path
+    def test_short_prompt_uses_fast_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000",  # onex-allow-internal-ip
+                "local-deepseek-r1-14b": "http://192.168.86.201:8001",  # onex-allow-internal-ip
+            },
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="Write tests for auth.py")
         decision = delta(req)
         assert decision.selected_model == "deepseek-r1-14b"
-        assert decision.endpoint_url == "http://192.168.86.201:8001"
+        assert (
+            decision.endpoint_url == "http://192.168.86.201:8001"
+        )  # onex-allow-internal-ip
         assert decision.max_context_tokens == 24576
 
-    def test_long_prompt_skips_fast_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
-        # Prompt > 40K tokens (~160K chars) should skip fast path
+    def test_long_prompt_skips_fast_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000",  # onex-allow-internal-ip
+                "local-deepseek-r1-14b": "http://192.168.86.201:8001",  # onex-allow-internal-ip
+            },
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         long_prompt = "x" * 200000
         req = _request(task_type="test", prompt=long_prompt)
         decision = delta(req)
         assert decision.selected_model == "qwen3-coder-30b"
 
     def test_fast_path_not_available_falls_back(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="short prompt")
         decision = delta(req)
         assert decision.selected_model == "qwen3-coder-30b"
 
     def test_document_uses_deepseek_fast_path(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Document tasks use deepseek-r1-14b (fast path in local tier)."""
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document", prompt="short prompt")
         decision = delta(req)
-        # deepseek-r1-14b handles document in local tier
         assert decision.selected_model == "deepseek-r1-14b"
 
 
 class TestMissingEndpoint:
     """Verify error when no tier has a configured endpoint for the task."""
 
-    def test_missing_all_local_urls_raises(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_missing_all_endpoints_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When all local and cloud env vars absent, only claude tier remains.
-
-        If ANTHROPIC_API_KEY is also missing, should raise ProtocolConfigurationError.
-        """
-        monkeypatch.delenv("LLM_CODER_URL", raising=False)
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
-        monkeypatch.delenv("LLM_GLM_URL", raising=False)
-        monkeypatch.delenv("LLM_GEMINI_FLASH_URL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        """When all backend endpoint_urls are empty, should raise ProtocolConfigurationError."""
+        bifrost = _write_bifrost(tmp_path, {})
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test")
         with pytest.raises(ProtocolConfigurationError, match="No tier"):
             delta(req)
 
-    def test_missing_deepseek_escalates_to_claude(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_missing_local_escalates_to_claude(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If local tier is unavailable for document, claude tier takes it."""
-        monkeypatch.delenv("LLM_CODER_URL", raising=False)
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
-        monkeypatch.delenv("LLM_GLM_URL", raising=False)
-        monkeypatch.delenv("LLM_GEMINI_FLASH_URL", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        bifrost = _write_bifrost(
+            tmp_path, {"cloud-sonnet": "https://api.anthropic.com"}
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document")
         decision = delta(req)
         assert decision.selected_model == "claude-sonnet-4-6"
@@ -173,17 +246,15 @@ class TestMissingEndpoint:
 
 
 class TestEscalationToClaudeTier:
-    """Verify escalation from local → cheap_cloud → claude."""
+    """Verify escalation from local -> cheap_cloud -> claude."""
 
     def test_escalates_to_claude_when_local_unavailable(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv("LLM_CODER_URL", raising=False)
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
-        monkeypatch.delenv("LLM_GLM_URL", raising=False)
-        monkeypatch.delenv("LLM_GEMINI_FLASH_URL", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        bifrost = _write_bifrost(
+            tmp_path, {"cloud-sonnet": "https://api.anthropic.com"}
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test")
         decision = delta(req)
         assert decision.selected_model == "claude-sonnet-4-6"
@@ -193,22 +264,44 @@ class TestEscalationToClaudeTier:
 class TestSystemPrompts:
     """Verify system prompt assignment."""
 
-    def test_test_system_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+    def test_test_system_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="x" * 200000)
         decision = delta(req)
         assert "test generation" in decision.system_prompt.lower()
 
-    def test_document_system_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_FAST_URL", "http://192.168.86.201:8001")
+    def test_document_system_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document")
         decision = delta(req)
         assert "documentation" in decision.system_prompt.lower()
 
-    def test_research_system_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+    def test_research_system_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="research", prompt="x" * 200000)
         decision = delta(req)
         assert "research" in decision.system_prompt.lower()
@@ -218,10 +311,15 @@ class TestCorrelationIdPreserved:
     """Verify correlation_id flows through."""
 
     def test_correlation_id_matches_request(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="x" * 200000)
         decision = delta(req)
         assert decision.correlation_id == req.correlation_id

--- a/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing_contract.py
+++ b/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing_contract.py
@@ -14,6 +14,7 @@ Tests cover:
 
 Related:
     - OMN-10615: Wire routing reducer to read task-class contracts
+    - OMN-10657: Contract-driven endpoint resolution
 """
 
 from __future__ import annotations
@@ -70,18 +71,44 @@ def _make_tier(name: str) -> ModelRoutingTier:
     return ModelRoutingTier(name=name, models=())
 
 
+def _write_bifrost(tmp_path: Path, backends: dict[str, str]) -> str:
+    """Write a bifrost contract YAML with given backend_id -> endpoint_url mappings."""
+    entries = []
+    for bid, url in backends.items():
+        entries.append(
+            f"  - backend_id: {bid}\n"
+            f'    endpoint_url: "{url}"\n'
+            f"    model_name: "
+            "\n"
+            f"    tier: local\n"
+            f"    timeout_ms: 30000\n"
+            f"    capabilities: []"
+        )
+    backends_block = "\n".join(entries) if entries else "  []"
+    content = (
+        "config_version: '1.1.0'\n"
+        "schema_version: bifrost_delegation.v1\n"
+        "backends:\n" + backends_block + "\n"
+    )
+    path = tmp_path / "bifrost.yaml"
+    path.write_text(content)
+    return str(path)
+
+
 @pytest.fixture(autouse=True)
-def reset_singletons() -> None:
+def reset_singletons():  # type: ignore[no-untyped-def]
     """Reset module-level singletons before each test."""
     _handler_mod._config = None
     _handler_mod._get_task_class_contract.cache_clear()
+    _handler_mod._load_bifrost_endpoints.cache_clear()
     yield
     _handler_mod._config = None
     _handler_mod._get_task_class_contract.cache_clear()
+    _handler_mod._load_bifrost_endpoints.cache_clear()
 
 
 class TestGracefulDegradation:
-    """No contract file → tier routing unchanged."""
+    """No contract file -> tier routing unchanged."""
 
     def test_absent_contract_path_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -95,7 +122,6 @@ class TestGracefulDegradation:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("TASK_CLASS_CONTRACT_PATH", raising=False)
-        # Point default path to a non-existent location by monkeypatching the module attr.
         monkeypatch.setattr(
             _handler_mod,
             "_DEFAULT_TASK_CLASS_CONTRACT_PATH",
@@ -105,10 +131,15 @@ class TestGracefulDegradation:
         assert contract is None
 
     def test_routing_works_without_contract(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         monkeypatch.delenv("TASK_CLASS_CONTRACT_PATH", raising=False)
         monkeypatch.setattr(
             _handler_mod,
@@ -161,13 +192,11 @@ class TestCloudBlockedPolicy:
         contract_path.write_text(contract_yaml)
         monkeypatch.setenv("TASK_CLASS_CONTRACT_PATH", str(contract_path))
 
-        # No local tier endpoints → should raise (not route to claude)
-        monkeypatch.delenv("LLM_CODER_URL", raising=False)
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
-        monkeypatch.delenv("LLM_GLM_URL", raising=False)
-        monkeypatch.delenv("LLM_GEMINI_FLASH_URL", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        # No local tier endpoints + cloud blocked -> should raise
+        bifrost = _write_bifrost(
+            tmp_path, {"cloud-sonnet": "https://api.anthropic.com"}
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
 
         req = _request(task_type="test")
         with pytest.raises(ProtocolConfigurationError, match="No tier"):
@@ -194,8 +223,13 @@ class TestCloudBlockedPolicy:
         contract_path = tmp_path / "contract.yaml"
         contract_path.write_text(contract_yaml)
         monkeypatch.setenv("TASK_CLASS_CONTRACT_PATH", str(contract_path))
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
 
         req = _request(task_type="test", prompt="x" * 200000)
         decision = delta(req)
@@ -215,7 +249,6 @@ class TestPricingCeiling:
         assert _tier_allowed_by_contract(_make_tier("claude"), entry) is False
 
     def test_ceiling_blocks_cheap_cloud_when_tight(self) -> None:
-        # cheap_cloud ≈ 0.002; ceiling of 0.001 should block it
         entry = {"pricing_ceiling_per_1k_tokens": 0.001}
         assert _tier_allowed_by_contract(_make_tier("cheap_cloud"), entry) is False
 
@@ -249,12 +282,11 @@ class TestPricingCeiling:
         contract_path = tmp_path / "contract.yaml"
         contract_path.write_text(contract_yaml)
         monkeypatch.setenv("TASK_CLASS_CONTRACT_PATH", str(contract_path))
-        monkeypatch.delenv("LLM_CODER_URL", raising=False)
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
-        monkeypatch.delenv("LLM_DEEPSEEK_R1_URL", raising=False)
-        monkeypatch.delenv("LLM_GLM_URL", raising=False)
-        monkeypatch.delenv("LLM_GEMINI_FLASH_URL", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        # Only cloud-sonnet available but ceiling blocks it
+        bifrost = _write_bifrost(
+            tmp_path, {"cloud-sonnet": "https://api.anthropic.com"}
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
 
         req = _request(task_type="test")
         with pytest.raises(ProtocolConfigurationError, match="No tier"):
@@ -268,15 +300,11 @@ class TestEscalationTierOrder:
         from omnibase_infra.nodes.node_delegation_routing_reducer.models.model_delegation_config import (
             ModelDelegationConfig,
         )
-        from omnibase_infra.nodes.node_delegation_routing_reducer.models.model_tier_model import (
-            ModelTierModel,
-        )
 
         local = ModelRoutingTier(name="local", models=())
         cheap = ModelRoutingTier(name="cheap_cloud", models=())
         claude = ModelRoutingTier(name="claude", models=())
 
-        # Minimal config — use real class with only tuple field accessible
         config = ModelDelegationConfig(tiers=(local, cheap, claude))
         entry = {
             "escalation_policy": {"tier_order": ["claude", "local", "cheap_cloud"]}
@@ -410,8 +438,13 @@ class TestRationaleContractAnnotation:
         contract_path = tmp_path / "contract.yaml"
         contract_path.write_text(contract_yaml)
         monkeypatch.setenv("TASK_CLASS_CONTRACT_PATH", str(contract_path))
-        monkeypatch.setenv("LLM_CODER_URL", "http://192.168.86.201:8000")
-        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        bifrost = _write_bifrost(
+            tmp_path,
+            {
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
+            },  # onex-allow-internal-ip
+        )
+        monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
 
         req = _request(task_type="test", prompt="x" * 200000)
         decision = delta(req)


### PR DESCRIPTION
## Summary

- Routing handler reads endpoint URLs from the deployed bifrost contract at \`~/.omninode/delegation/bifrost_delegation.yaml\` instead of \`os.environ.get()\`
- \`bifrost_delegation.yaml\`: \`base_url_env\` → \`endpoint_url\` (empty in source, populated by installer)
- \`routing_tiers.yaml\`: \`env_var\` → \`backend_ref\` referencing bifrost backend keys
- \`ModelTierModel.env_var\` → \`ModelTierModel.backend_ref\`
- \`selected_model\` uses bifrost \`model_name\` (full vLLM model ID) for correct inference dispatch
- All \`os.environ.get()\` calls removed from endpoint resolution path

## Test plan

- [x] 53 routing reducer unit tests pass (rewritten to use \`BIFROST_CONTRACT_PATH\` with temp YAML)
- [x] 5 new integration tests prove bifrost contract loading from on-disk source file
- [x] E2E verified: routing handler loads 2 endpoints from deployed contract, routes test/document/research tasks correctly
- [x] Live LLM call succeeded with contract-resolved endpoint (DeepSeek-R1 @ :8001)

## Evidence

Evidence-Source: OCC#807
Evidence-Ticket: OMN-10657

OMN-10657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added Cloud GLM, Cloud Gemini Flash, CLI Claude, CLI OpenCode and other backends.
  - Routing now resolves model endpoints from a deployed bifrost delegation contract.

* **Chores**
  - Switched endpoint configuration from per-model environment variables to contract-backed backend references.
  - Contract and metadata updated to reflect the new delegation-loading behavior.

* **Tests**
  - Updated and added unit, integration, and e2e tests to validate contract-driven endpoint loading and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->