### PR TITLE
fix(OMN-10207): enable main runtime Pattern B ingress

### DIFF
--- a/contracts/OMN-10207.yaml
+++ b/contracts/OMN-10207.yaml
@@ -10,13 +10,14 @@ interfaces_touched:
 evidence_requirements:
   - kind: tests
     description: "Focused runtime config, local ingress, Pattern B broker, and serialization coverage passes."
-    command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
+    command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/integration/test_runtime_pattern_b_ingress_config.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
   - kind: tests
     description: "Runtime config loader validates the shipped local ingress and Pattern B broker contract settings."
     command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run python -c \"from pathlib import Path; from omnibase_infra.runtime.service_kernel import load_runtime_config; c=load_runtime_config(Path('contracts')); print(c.local_ingress.enabled, c.pattern_b_broker.command_topic)\""
   - kind: manual
     description: "Deploy-gate proof: after rebuilding/recreating the stability runtime, the live container reports enabled local ingress and can consume the OmniMarket Pattern B command topic."
-    command: "deploy: docker exec omninode-stability-test-runtime python -c \"import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])\" && docker exec omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1"
+    command: >-
+      deploy: docker exec omninode-stability-test-runtime python -c "import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])" && printf '%s\n' '{"command_name":"runtime_sweep","requester":"deploy-gate","payload":{"dry_run":true},"correlation_id":"00000000-0000-0000-0000-000000000000","response_topic":"onex.evt.omnimarket.pattern-b-dispatch-completed.v1","timeout_seconds":5}' | docker exec -i omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1
 emergency_bypass:
   enabled: false
   justification: ""
@@ -27,7 +28,7 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
+        check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/integration/test_runtime_pattern_b_ingress_config.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
   - id: dod-runtime-config-loader
     description: "The runtime config loader accepts the shipped ingress/broker settings."
     source: manual
@@ -45,4 +46,5 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "deploy: docker exec omninode-stability-test-runtime python -c \"import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])\" && docker exec omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1"
+        check_value: >-
+          deploy: docker exec omninode-stability-test-runtime python -c "import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])" && printf '%s\n' '{"command_name":"runtime_sweep","requester":"deploy-gate","payload":{"dry_run":true},"correlation_id":"00000000-0000-0000-0000-000000000000","response_topic":"onex.evt.omnimarket.pattern-b-dispatch-completed.v1","timeout_seconds":5}' | docker exec -i omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1

--- a/contracts/OMN-10207.yaml
+++ b/contracts/OMN-10207.yaml
@@ -1,0 +1,48 @@
+schema_version: "1.0.0"
+ticket_id: OMN-10207
+title: "Host-live Pattern B broker proof"
+summary: "Enable the main runtime profile's local ingress and Pattern B broker path so host-live market skill dispatch can be proven through the runtime-owned command surface."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - topics
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: "Focused runtime config, local ingress, Pattern B broker, and serialization coverage passes."
+    command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
+  - kind: tests
+    description: "Runtime config loader validates the shipped local ingress and Pattern B broker contract settings."
+    command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run python -c \"from pathlib import Path; from omnibase_infra.runtime.service_kernel import load_runtime_config; c=load_runtime_config(Path('contracts')); print(c.local_ingress.enabled, c.pattern_b_broker.command_topic)\""
+  - kind: manual
+    description: "Deploy-gate proof: after rebuilding/recreating the stability runtime, the live container reports enabled local ingress and can consume the OmniMarket Pattern B command topic."
+    command: "deploy: docker exec omninode-stability-test-runtime python -c \"import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])\" && docker exec omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-focused-tests
+    description: "Focused unit tests cover runtime config loading, profile-gated ingress startup, broker startup, and model serialization."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q"
+  - id: dod-runtime-config-loader
+    description: "The runtime config loader accepts the shipped ingress/broker settings."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run python -c \"from pathlib import Path; from omnibase_infra.runtime.service_kernel import load_runtime_config; c=load_runtime_config(Path('contracts')); print(c.local_ingress.model_dump(mode='json')); print(c.pattern_b_broker.model_dump(mode='json'))\""
+  - id: dod-compose-config
+    description: "Stability compose render includes the host-visible local runtime socket mount on the main runtime service."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "POSTGRES_PASSWORD=postgres LINEAR_API_KEY=dummy docker compose --profile runtime -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml config"
+  - id: dod-deploy-proof
+    description: "Post-deploy live proof must show the stability runtime socket ingress running and the OmniMarket Pattern B topic accepting commands."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: docker exec omninode-stability-test-runtime python -c \"import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); print(h['local_ingress'])\" && docker exec omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1"

--- a/contracts/runtime/runtime_config.yaml
+++ b/contracts/runtime/runtime_config.yaml
@@ -76,6 +76,26 @@ contract_registry:
   # [ACTIVE] tick_interval_seconds controls periodic staleness check frequency
   # The registry will check for stale contracts at this interval (in seconds)
   tick_interval_seconds: 60
+# Local runtime ingress configuration [ACTIVE - used by RuntimeHostProcess]
+# Enables the runtime-owned Unix-socket ingress for host-local clients.
+local_ingress:
+  enabled: true
+  socket_path: "/run/onex-runtime/onex-runtime.sock"
+  package_names:
+    - omnibase_infra
+    - omnimarket
+  enabled_profiles:
+    - main
+# Pattern B broker configuration [ACTIVE - used by RuntimeHostProcess]
+# The command topic is aligned with the OmniMarket Codex runtime adapter.
+pattern_b_broker:
+  enabled: true
+  command_topic: "onex.cmd.omnimarket.pattern-b-dispatch.v1"
+  package_names:
+    - omnibase_infra
+    - omnimarket
+  enabled_profiles:
+    - main
 # Handler configuration [RESERVED - not currently used]
 # Future: Will be used for dynamic protocol loading and configuration
 handlers:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -646,6 +646,7 @@ services:
       - runtime_data:/app/data
       - ../contracts:/app/contracts:ro
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
+      - ${ONEX_LOCAL_RUNTIME_SOCKET_DIR:-/data/omninode/runtime-local-ingress}:/run/onex-runtime
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -114,6 +114,7 @@ services:
       - runtime_logs:/app/logs
       - runtime_data:/app/data
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
+      - ${ONEX_LOCAL_RUNTIME_SOCKET_DIR:-/data/omninode/runtime-local-ingress}:/run/onex-runtime
     labels:
       - "com.omninode.lane=stability-test"
       - "com.omninode.ticket=OMN-10281"

--- a/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
+++ b/src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py
@@ -48,6 +48,13 @@ class ModelLocalRuntimeIngressConfig(BaseModel):
         default=("omnibase_infra",),
         description="Package roots scanned for runtime-executable node contracts.",
     )
+    enabled_profiles: tuple[str, ...] = Field(
+        default=("main", "default", "local-dev", "test"),
+        description=(
+            "Runtime profiles allowed to bind local ingress when enabled is true. "
+            "Use '*' to allow every profile."
+        ),
+    )
 
     @field_validator("socket_path")
     @classmethod
@@ -64,12 +71,27 @@ class ModelLocalRuntimeIngressConfig(BaseModel):
             return tuple(value)
         return value
 
+    @field_validator("enabled_profiles", mode="before")
+    @classmethod
+    def _coerce_enabled_profiles(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
     @field_validator("package_names")
     @classmethod
     def _validate_package_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         normalized = tuple(part.strip() for part in value if part.strip())
         if not normalized:
             raise ValueError("package_names must contain at least one package name")
+        return normalized
+
+    @field_validator("enabled_profiles")
+    @classmethod
+    def _validate_enabled_profiles(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(part.strip().lower() for part in value if part.strip())
+        if not normalized:
+            raise ValueError("enabled_profiles must contain at least one profile")
         return normalized
 
 

--- a/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
+++ b/src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py
@@ -34,6 +34,13 @@ class ModelPatternBBrokerConfig(BaseModel):
         default=("omnibase_infra",),
         description="Package roots scanned for broker-addressable node contracts.",
     )
+    enabled_profiles: tuple[str, ...] = Field(
+        default=("main", "default", "local-dev", "test"),
+        description=(
+            "Runtime profiles allowed to start the Pattern B broker when enabled "
+            "is true. Use '*' to allow every profile."
+        ),
+    )
 
     @field_validator("command_topic")
     @classmethod
@@ -50,12 +57,27 @@ class ModelPatternBBrokerConfig(BaseModel):
             return tuple(value)
         return value
 
+    @field_validator("enabled_profiles", mode="before")
+    @classmethod
+    def _coerce_enabled_profiles(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
     @field_validator("package_names")
     @classmethod
     def _validate_package_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         normalized = tuple(part.strip() for part in value if part.strip())
         if not normalized:
             raise ValueError("package_names must contain at least one package name")
+        return normalized
+
+    @field_validator("enabled_profiles")
+    @classmethod
+    def _validate_enabled_profiles(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(part.strip().lower() for part in value if part.strip())
+        if not normalized:
+            raise ValueError("enabled_profiles must contain at least one profile")
         return normalized
 
 

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -239,7 +239,11 @@ _RAW_EVENT_PROJECTION_CONSUMER_PURPOSES: frozenset[str] = frozenset(
 
 
 def _current_runtime_profile_name() -> str:
-    return (os.getenv("RUNTIME_PROFILE") or "default").strip().lower()
+    raw_profile = os.getenv("RUNTIME_PROFILE")
+    if raw_profile is None:
+        return "default"
+    profile = raw_profile.strip()
+    return profile.lower() if profile else "default"
 
 
 def _runtime_profile_is_enabled(enabled_profiles: tuple[str, ...]) -> bool:
@@ -2285,7 +2289,10 @@ class RuntimeHostProcess:
         if not self._is_pattern_b_broker_effectively_enabled():
             if local_ingress_enabled:
                 raise ProtocolConfigurationError(
-                    "local runtime ingress requires pattern_b_broker.enabled=true",
+                    "local runtime ingress requires pattern_b_broker to be "
+                    "effectively enabled: pattern_b_broker.enabled=true and "
+                    "current RUNTIME_PROFILE allowed by "
+                    "pattern_b_broker.enabled_profiles",
                     context=ModelInfraErrorContext.with_correlation(
                         transport_type=EnumInfraTransportType.RUNTIME,
                         operation="pattern_b_broker.start",

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -238,6 +238,16 @@ _RAW_EVENT_PROJECTION_CONSUMER_PURPOSES: frozenset[str] = frozenset(
 )
 
 
+def _current_runtime_profile_name() -> str:
+    return (os.getenv("RUNTIME_PROFILE") or "default").strip().lower()
+
+
+def _runtime_profile_is_enabled(enabled_profiles: tuple[str, ...]) -> bool:
+    current_profile = _current_runtime_profile_name()
+    normalized_profiles = {profile.strip().lower() for profile in enabled_profiles}
+    return "*" in normalized_profiles or current_profile in normalized_profiles
+
+
 def _normalize_prefetch_policy(value: str) -> PrefetchPolicy:
     """Normalize and validate the runtime config prefetch policy."""
     policy = value.strip().lower()
@@ -2236,7 +2246,7 @@ class RuntimeHostProcess:
 
     async def _start_local_ingress(self) -> None:
         """Start the runtime-owned local command ingress when enabled."""
-        if not self._local_ingress_config.enabled:
+        if not self._is_local_ingress_effectively_enabled():
             self._local_ingress_routes.clear()
             self._local_ingress_active_packages = ()
             return
@@ -2271,8 +2281,9 @@ class RuntimeHostProcess:
 
     async def _start_pattern_b_broker(self) -> None:
         """Start the runtime-owned Pattern B broker when enabled."""
-        if not self._pattern_b_broker_config.enabled:
-            if self._local_ingress_config.enabled:
+        local_ingress_enabled = self._is_local_ingress_effectively_enabled()
+        if not self._is_pattern_b_broker_effectively_enabled():
+            if local_ingress_enabled:
                 raise ProtocolConfigurationError(
                     "local runtime ingress requires pattern_b_broker.enabled=true",
                     context=ModelInfraErrorContext.with_correlation(
@@ -2283,7 +2294,7 @@ class RuntimeHostProcess:
             self._pattern_b_broker = None
             return
 
-        if self._local_ingress_config.enabled:
+        if local_ingress_enabled:
             routes = dict(self._local_ingress_routes)
         else:
             package_names = tuple(
@@ -2298,6 +2309,16 @@ class RuntimeHostProcess:
             routes=routes,
         )
         await self._pattern_b_broker.start()
+
+    def _is_local_ingress_effectively_enabled(self) -> bool:
+        return self._local_ingress_config.enabled and _runtime_profile_is_enabled(
+            self._local_ingress_config.enabled_profiles
+        )
+
+    def _is_pattern_b_broker_effectively_enabled(self) -> bool:
+        return self._pattern_b_broker_config.enabled and _runtime_profile_is_enabled(
+            self._pattern_b_broker_config.enabled_profiles
+        )
 
     async def _dispatch_local_ingress_request(
         self,
@@ -5044,18 +5065,15 @@ class RuntimeHostProcess:
 
     def _build_local_ingress_health(self) -> ModelLocalRuntimeIngressHealth:
         """Build typed health details for local runtime ingress."""
+        enabled = self._is_local_ingress_effectively_enabled()
         return ModelLocalRuntimeIngressHealth(
-            enabled=self._local_ingress_config.enabled,
+            enabled=enabled,
             running=(
                 self._local_ingress_server.is_running
                 if self._local_ingress_server is not None
                 else False
             ),
-            socket_path=(
-                self._local_ingress_config.socket_path
-                if self._local_ingress_config.enabled
-                else None
-            ),
+            socket_path=(self._local_ingress_config.socket_path if enabled else None),
             route_count=len(self._local_ingress_routes),
             active_packages=self._local_ingress_active_packages,
         )

--- a/tests/integration/test_runtime_pattern_b_ingress_config.py
+++ b/tests/integration/test_runtime_pattern_b_ingress_config.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.service_kernel import load_runtime_config
+
+pytestmark = pytest.mark.integration
+
+
+def test_runtime_config_enables_main_profile_pattern_b_ingress() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    config = load_runtime_config(repo_root / "contracts")
+
+    assert config.local_ingress.enabled is True
+    assert config.local_ingress.socket_path == "/run/onex-runtime/onex-runtime.sock"
+    assert config.local_ingress.package_names == ("omnibase_infra", "omnimarket")
+    assert config.local_ingress.enabled_profiles == ("main",)
+    assert config.pattern_b_broker.enabled is True
+    assert (
+        config.pattern_b_broker.command_topic
+        == "onex.cmd.omnimarket.pattern-b-dispatch.v1"
+    )
+    assert config.pattern_b_broker.package_names == ("omnibase_infra", "omnimarket")
+    assert config.pattern_b_broker.enabled_profiles == ("main",)

--- a/tests/unit/runtime/test_kernel.py
+++ b/tests/unit/runtime/test_kernel.py
@@ -88,6 +88,27 @@ class TestLoadRuntimeConfig:
         assert config.output_topic == "test-responses"
         assert config.consumer_group == "test-group"
 
+    def test_repo_runtime_config_enables_main_profile_ingress(self) -> None:
+        """The shipped runtime config enables the main-profile skill ingress path."""
+        repo_root = Path(__file__).resolve().parents[3]
+
+        config = load_runtime_config(repo_root / "contracts")
+
+        assert config.local_ingress.enabled is True
+        assert config.local_ingress.socket_path == "/run/onex-runtime/onex-runtime.sock"
+        assert config.local_ingress.package_names == ("omnibase_infra", "omnimarket")
+        assert config.local_ingress.enabled_profiles == ("main",)
+        assert config.pattern_b_broker.enabled is True
+        assert (
+            config.pattern_b_broker.command_topic
+            == "onex.cmd.omnimarket.pattern-b-dispatch.v1"
+        )
+        assert config.pattern_b_broker.package_names == (
+            "omnibase_infra",
+            "omnimarket",
+        )
+        assert config.pattern_b_broker.enabled_profiles == ("main",)
+
     def test_load_config_file_not_found_uses_defaults(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -119,10 +119,40 @@ def test_parse_active_runtime_packages_honors_env_override() -> None:
 
 def test_local_runtime_ingress_config_accepts_yaml_list_package_names() -> None:
     config = ModelLocalRuntimeIngressConfig.model_validate(
-        {"package_names": ["omnibase_infra", "omnimarket"]}
+        {
+            "package_names": ["omnibase_infra", "omnimarket"],
+            "enabled_profiles": ["main"],
+        }
     )
 
     assert config.package_names == ("omnibase_infra", "omnimarket")
+    assert config.enabled_profiles == ("main",)
+
+
+@pytest.mark.asyncio
+async def test_runtime_host_process_skips_local_ingress_for_disallowed_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_PROFILE", "effects")
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.discover_runtime_local_ingress_routes",
+        lambda _packages: pytest.fail("effects profile must not discover routes"),
+    )
+
+    process = RuntimeHostProcess(
+        config=make_runtime_config(
+            local_ingress={
+                "enabled": True,
+                "enabled_profiles": ["main"],
+            }
+        ),
+        dispatch_engine=AsyncMock(),
+    )
+
+    await process._start_local_ingress()
+
+    assert process._local_ingress_routes == {}
+    assert process._local_ingress_active_packages == ()
 
 
 def test_discover_runtime_local_ingress_routes_registers_aliases(

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -360,6 +360,29 @@ async def test_runtime_host_process_skips_pattern_b_broker_for_disallowed_profil
     assert process._pattern_b_broker is None
 
 
+def test_runtime_host_process_treats_blank_runtime_profile_as_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_PROFILE", "   ")
+
+    process = RuntimeHostProcess(
+        event_bus=EventBusInmemory(environment="test", group="pattern-b"),
+        config={
+            "service_name": "test-service",
+            "node_name": "test-node",
+            "env": "test",
+            "version": "v1",
+            "pattern_b_broker": {
+                "enabled": True,
+                "enabled_profiles": ["default"],
+            },
+        },
+        dispatch_engine=AsyncMock(),
+    )
+
+    assert process._is_pattern_b_broker_effectively_enabled() is True
+
+
 @pytest.mark.asyncio
 async def test_runtime_host_process_broker_package_names_ignore_active_runtime_env(
     monkeypatch: pytest.MonkeyPatch,
@@ -477,6 +500,6 @@ async def test_runtime_host_process_rejects_enabled_ingress_without_pattern_b_br
 
     with pytest.raises(
         ProtocolConfigurationError,
-        match=r"local runtime ingress requires pattern_b_broker\.enabled=true",
+        match=r"local runtime ingress requires pattern_b_broker to be effectively enabled",
     ):
         await process._start_pattern_b_broker()

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -324,6 +324,43 @@ async def test_runtime_host_process_starts_pattern_b_broker_when_enabled(
 
 
 @pytest.mark.asyncio
+async def test_runtime_host_process_skips_pattern_b_broker_for_disallowed_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_PROFILE", "effects")
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.discover_runtime_local_ingress_routes",
+        lambda _packages: pytest.fail("effects profile must not discover routes"),
+    )
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_runtime_host_process.RuntimePatternBBroker",
+        lambda *_args, **_kwargs: pytest.fail(
+            "effects profile must not start Pattern B broker"
+        ),
+    )
+
+    process = RuntimeHostProcess(
+        event_bus=EventBusInmemory(environment="test", group="pattern-b"),
+        config={
+            "service_name": "test-service",
+            "node_name": "test-node",
+            "env": "test",
+            "version": "v1",
+            "pattern_b_broker": {
+                "enabled": True,
+                "enabled_profiles": ["main"],
+                "package_names": ["omnibase_infra", "omnimarket"],
+            },
+        },
+        dispatch_engine=AsyncMock(),
+    )
+
+    await process._start_pattern_b_broker()
+
+    assert process._pattern_b_broker is None
+
+
+@pytest.mark.asyncio
 async def test_runtime_host_process_broker_package_names_ignore_active_runtime_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- enable runtime local ingress and Pattern B broker in the runtime contract for the main runtime profile
- align the broker command topic with the OmniMarket Codex adapter topic
- add a host-visible socket bind mount for the main/stability runtime and profile gates so effects/workers do not bind ingress

## Evidence
- PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py -q
- PYTHONPATH=$PWD/src:$PYTHONPATH uv run ruff check src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_kernel.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/models/test_model_serialization_roundtrip.py
- PYTHONPATH=$PWD/src:$PYTHONPATH uv run ruff format --check src/omnibase_infra/runtime/models/model_local_runtime_ingress_config.py src/omnibase_infra/runtime/models/model_pattern_b_broker_config.py src/omnibase_infra/runtime/service_runtime_host_process.py tests/unit/runtime/test_kernel.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/models/test_model_serialization_roundtrip.py
- uv run validate-yaml contracts/OMN-10207.yaml
- POSTGRES_PASSWORD=postgres LINEAR_API_KEY=dummy docker compose --profile runtime -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml config

## Deploy gate
Post-merge stability runtime proof will rebuild/recreate only omninode-stability-test-runtime, then verify /health local_ingress and produce a canary command to onex.cmd.omnimarket.pattern-b-dispatch.v1.

## OCC
Central OCC evidence is being prepared for OMN-10207 before this PR is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile-based gating for local runtime ingress and Pattern B broker activation.
  * Added a new contract specifying validation steps and deploy checks.

* **Configuration**
  * Runtime config now supports local socket ingress and Pattern B broker command-topic settings.
  * Docker compose updated to mount host runtime socket directories.

* **Tests**
  * New unit and integration tests validating profile-based activation and runtime config loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->