### PR TITLE
fix(OMN-10207): arm Pattern B terminal waits before dispatch

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -230,6 +230,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "git+https://github.com/OmniNode-ai/omnimarket.git@main#egg=omnimarket"
 
+# The runtime image still installs legacy packages for import compatibility while
+# market migrations finish, but their ONEX discovery metadata must not advertise
+# non-market packages or domain plugins to the runtime kernel.
+RUN /app/.venv/bin/python -m omnibase_infra.runtime.strip_runtime_entry_points
+
 # Install CPU-only PyTorch (~2GB savings over CUDA wheels).
 # K8s runtime has no GPU; inference offloads to LLM servers via HTTP.
 # --no-deps prevents torch from pulling its own transitive deps (already

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -9,7 +9,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import Protocol, cast
+from typing import cast
 from uuid import UUID
 
 from aiokafka import AIOKafkaConsumer
@@ -50,13 +50,6 @@ def _error_result(
         error_message=error_message,
         completed_at=datetime.now(UTC),
     )
-
-
-class KafkaBrokerTransportProtocol(Protocol):
-    config: object
-    _bootstrap_servers: str
-
-    def _build_auth_kwargs(self) -> Mapping[str, object]: ...
 
 
 class RuntimePatternBBroker:
@@ -223,7 +216,7 @@ class RuntimePatternBBroker:
         config = getattr(kafka_event_bus, "config", SimpleNamespace())
         consumer = AIOKafkaConsumer(
             route.terminal_event,
-            bootstrap_servers=kafka_event_bus._bootstrap_servers,
+            bootstrap_servers=self._kafka_bootstrap_servers(),
             group_id=_terminal_group_id(command.correlation_id),
             auto_offset_reset="latest",
             enable_auto_commit=False,
@@ -275,12 +268,27 @@ class RuntimePatternBBroker:
         )
 
     def _direct_kafka_auth_kwargs(self) -> dict[str, object]:
-        build_auth_kwargs = self._kafka_event_bus()._build_auth_kwargs
-        auth_kwargs = build_auth_kwargs()
+        build_auth_kwargs = getattr(  # noqa: B009
+            self._kafka_event_bus(),
+            "_build_auth_kwargs",
+        )
+        auth_kwargs = cast(
+            "Callable[[], Mapping[str, object] | None]",
+            build_auth_kwargs,
+        )()
         return dict(auth_kwargs or {})
 
-    def _kafka_event_bus(self) -> KafkaBrokerTransportProtocol:
-        return cast("KafkaBrokerTransportProtocol", self._event_bus)
+    def _kafka_bootstrap_servers(self) -> str:
+        bootstrap_servers = getattr(  # noqa: B009
+            self._kafka_event_bus(),
+            "_bootstrap_servers",
+        )
+        if not isinstance(bootstrap_servers, str):
+            raise RuntimeError("Kafka event bus bootstrap servers are not configured")
+        return bootstrap_servers
+
+    def _kafka_event_bus(self) -> object:
+        return self._event_bus
 
     async def _publish_worker_command(
         self,

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Protocol, cast
 from uuid import UUID
+
+from aiokafka import AIOKafkaConsumer
 
 from omnibase_core.models.dispatch.model_dispatch_bus_command import (
     ModelDispatchBusCommand,
@@ -46,6 +50,13 @@ def _error_result(
         error_message=error_message,
         completed_at=datetime.now(UTC),
     )
+
+
+class KafkaBrokerTransportProtocol(Protocol):
+    config: object
+    _bootstrap_servers: str
+
+    def _build_auth_kwargs(self) -> Mapping[str, object]: ...
 
 
 class RuntimePatternBBroker:
@@ -92,12 +103,23 @@ class RuntimePatternBBroker:
             self._tasks.clear()
 
     async def _handle_command_message(self, message: ModelEventMessage) -> None:
-        command_envelope = ModelEventEnvelope[
-            ModelDispatchBusCommand
-        ].model_validate_json(message.value)
-        command = command_envelope.payload
+        command_envelope = ModelEventEnvelope[object].model_validate_json(message.value)
+        command = self._decode_dispatch_command_payload(command_envelope.payload)
         _route, result = await self.dispatch_request(command)
         await self._publish_terminal_result(command.response_topic, result)
+
+    @staticmethod
+    def _decode_dispatch_command_payload(payload: object) -> ModelDispatchBusCommand:
+        if isinstance(payload, dict):
+            command_payload = dict(payload)
+            if (
+                "target_runtime_address" in command_payload
+                and "target_runtime_address" not in ModelDispatchBusCommand.model_fields
+            ):
+                command_payload.pop("target_runtime_address")
+            return ModelDispatchBusCommand.model_validate(command_payload)
+
+        return ModelDispatchBusCommand.model_validate(payload)
 
     async def dispatch_request(
         self,
@@ -121,7 +143,47 @@ class RuntimePatternBBroker:
                 ),
             )
 
+        try:
+            terminal_payload = (
+                await self._dispatch_and_wait_with_direct_kafka_consumer(command, route)
+                if self._supports_direct_kafka_terminal_consumer()
+                else await self._dispatch_and_wait_with_event_bus_subscription(
+                    command,
+                    route,
+                )
+            )
+        except TimeoutError:
+            return route, _error_result(
+                correlation_id,
+                status="timeout",
+                error_message=(
+                    "Timed out waiting for Pattern B broker terminal event."
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return route, _error_result(
+                correlation_id,
+                status="failed",
+                error_message=sanitize_error_message(exc),
+            )
+
+        return route, ModelDispatchBusTerminalResult(
+            correlation_id=correlation_id,
+            status="completed",
+            payload=terminal_payload,
+            completed_at=datetime.now(UTC),
+        )
+
+    async def _dispatch_and_wait_with_event_bus_subscription(
+        self,
+        command: ModelDispatchBusCommand,
+        route: RuntimeLocalIngressRoute,
+    ) -> object:
+        correlation_id = command.correlation_id
         terminal_queue: asyncio.Queue[object] = asyncio.Queue(maxsize=1)
+        terminal_event = route.terminal_event
+        if terminal_event is None:
+            raise RuntimeError(f"Route '{command.command_name}' has no terminal event")
 
         async def on_terminal(message: ModelEventMessage) -> None:
             terminal_envelope = ModelEventEnvelope[object].model_validate_json(
@@ -133,56 +195,112 @@ class RuntimePatternBBroker:
                 await terminal_queue.put(terminal_envelope.payload)
 
         unsubscribe_terminal = await self._event_bus.subscribe(
-            route.terminal_event,
+            terminal_event,
             group_id=_terminal_group_id(correlation_id),
             on_message=on_terminal,
         )
         try:
-            worker_envelope = ModelEventEnvelope[object](
-                payload=command.payload,
-                correlation_id=correlation_id,
-                envelope_timestamp=datetime.now(UTC),
-                event_type=route.event_type,
-                source_tool="pattern-b-broker",
-                target_tool=route.contract_name,
-            )
-            await self._event_bus.publish(
-                route.command_topic,
-                None,
-                worker_envelope.model_dump_json().encode("utf-8"),
-                None,
-            )
-            try:
-                terminal_payload = await asyncio.wait_for(
-                    terminal_queue.get(),
-                    timeout=command.timeout_seconds,
-                )
-            except TimeoutError:
-                return route, _error_result(
-                    correlation_id,
-                    status="timeout",
-                    error_message=(
-                        "Timed out waiting for Pattern B broker terminal event."
-                    ),
-                )
-
-            return route, ModelDispatchBusTerminalResult(
-                correlation_id=correlation_id,
-                status="completed",
-                payload=terminal_payload,
-                completed_at=datetime.now(UTC),
-            )
-        except Exception as exc:  # noqa: BLE001
-            return route, _error_result(
-                correlation_id,
-                status="failed",
-                error_message=sanitize_error_message(exc),
+            await self._publish_worker_command(command, route)
+            return await asyncio.wait_for(
+                terminal_queue.get(),
+                timeout=command.timeout_seconds,
             )
         finally:
             try:
                 await unsubscribe_terminal()
             except Exception:  # noqa: BLE001
                 pass
+
+    async def _dispatch_and_wait_with_direct_kafka_consumer(
+        self,
+        command: ModelDispatchBusCommand,
+        route: RuntimeLocalIngressRoute,
+    ) -> object:
+        if route.terminal_event is None:
+            raise RuntimeError(f"Route '{command.command_name}' has no terminal event")
+
+        kafka_event_bus = self._kafka_event_bus()
+        config = getattr(kafka_event_bus, "config", SimpleNamespace())
+        consumer = AIOKafkaConsumer(
+            route.terminal_event,
+            bootstrap_servers=kafka_event_bus._bootstrap_servers,
+            group_id=_terminal_group_id(command.correlation_id),
+            auto_offset_reset="latest",
+            enable_auto_commit=False,
+            session_timeout_ms=getattr(config, "session_timeout_ms", 45000),
+            heartbeat_interval_ms=getattr(config, "heartbeat_interval_ms", 15000),
+            max_poll_interval_ms=getattr(config, "max_poll_interval_ms", 300000),
+            retry_backoff_ms=getattr(config, "reconnect_backoff_ms", 2000),
+            **self._direct_kafka_auth_kwargs(),
+        )
+
+        try:
+            await asyncio.wait_for(
+                consumer.start(), timeout=min(30, command.timeout_seconds)
+            )
+            await self._wait_for_kafka_assignment(consumer, command.timeout_seconds)
+            await consumer.seek_to_end(*consumer.assignment())
+            await self._publish_worker_command(command, route)
+
+            deadline = asyncio.get_running_loop().time() + command.timeout_seconds
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError
+                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
+                terminal_envelope = ModelEventEnvelope[object].model_validate_json(
+                    message.value
+                )
+                if terminal_envelope.correlation_id == command.correlation_id:
+                    return terminal_envelope.payload
+        finally:
+            await consumer.stop()
+
+    async def _wait_for_kafka_assignment(
+        self,
+        consumer: AIOKafkaConsumer,
+        timeout_seconds: int,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
+        while not consumer.assignment():
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError
+            await asyncio.sleep(0.05)
+
+    def _supports_direct_kafka_terminal_consumer(self) -> bool:
+        return (
+            hasattr(self._event_bus, "_bootstrap_servers")
+            and hasattr(self._event_bus, "_build_auth_kwargs")
+            and hasattr(self._event_bus, "config")
+        )
+
+    def _direct_kafka_auth_kwargs(self) -> dict[str, object]:
+        build_auth_kwargs = self._kafka_event_bus()._build_auth_kwargs
+        auth_kwargs = build_auth_kwargs()
+        return dict(auth_kwargs or {})
+
+    def _kafka_event_bus(self) -> KafkaBrokerTransportProtocol:
+        return cast("KafkaBrokerTransportProtocol", self._event_bus)
+
+    async def _publish_worker_command(
+        self,
+        command: ModelDispatchBusCommand,
+        route: RuntimeLocalIngressRoute,
+    ) -> None:
+        worker_envelope = ModelEventEnvelope[object](
+            payload=command.payload,
+            correlation_id=command.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=route.event_type,
+            source_tool="pattern-b-broker",
+            target_tool=route.contract_name,
+        )
+        await self._event_bus.publish(
+            route.command_topic,
+            None,
+            worker_envelope.model_dump_json().encode("utf-8"),
+            None,
+        )
 
     async def _publish_terminal_result(
         self,

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -27,6 +28,8 @@ from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
 )
 from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
 from omnibase_infra.utils.util_error_sanitization import sanitize_error_message
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _broker_group_id(command_topic: str) -> str:
@@ -247,7 +250,13 @@ class RuntimePatternBBroker:
                 if terminal_envelope.correlation_id == command.correlation_id:
                     return terminal_envelope.payload
         finally:
-            await consumer.stop()
+            try:
+                await consumer.stop()
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to stop Pattern B terminal Kafka consumer: %s",
+                    sanitize_error_message(exc),
+                )
 
     async def _wait_for_kafka_assignment(
         self,

--- a/src/omnibase_infra/runtime/strip_runtime_entry_points.py
+++ b/src/omnibase_infra/runtime/strip_runtime_entry_points.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Strip non-market ONEX runtime entry points from installed distributions."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import site
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from email.parser import Parser
+from pathlib import Path
+
+DEFAULT_ALLOWED_DISTRIBUTIONS = frozenset({"omnibase-infra", "omnimarket"})
+DEFAULT_STRIPPED_GROUPS = frozenset(
+    {"onex.domain_plugins", "onex.node_package", "onex.nodes"}
+)
+
+
+@dataclass(frozen=True)
+class StrippedEntryPointDist:
+    """Entry-point groups stripped from one installed distribution."""
+
+    distribution: str
+    path: str
+    groups: tuple[str, ...]
+    removed_file: bool
+
+
+@dataclass(frozen=True)
+class StripEntryPointReport:
+    """Summary of runtime entry-point metadata stripping."""
+
+    allowed_distributions: tuple[str, ...]
+    stripped_groups: tuple[str, ...]
+    stripped_distributions: tuple[StrippedEntryPointDist, ...]
+
+
+def normalize_distribution_name(name: str) -> str:
+    """Normalize a Python distribution name for comparison."""
+
+    return name.strip().lower().replace("_", "-").replace(".", "-")
+
+
+def _iter_site_packages() -> list[Path]:
+    paths: list[Path] = []
+    for raw_path in site.getsitepackages():
+        path = Path(raw_path)
+        if path.exists():
+            paths.append(path)
+    usersite = site.getusersitepackages()
+    if usersite:
+        path = Path(usersite)
+        if path.exists():
+            paths.append(path)
+    return paths
+
+
+def _dist_name(dist_info_dir: Path) -> str:
+    metadata_path = dist_info_dir / "METADATA"
+    if metadata_path.exists():
+        metadata = Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+        name = metadata.get("Name")
+        if name:
+            return normalize_distribution_name(name)
+
+    raw_name = dist_info_dir.name.removesuffix(".dist-info")
+    if "-" in raw_name:
+        raw_name = raw_name.rsplit("-", 1)[0]
+    return normalize_distribution_name(raw_name)
+
+
+def _read_entry_points(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str  # type: ignore[assignment]
+    parser.read(path, encoding="utf-8")
+    return parser
+
+
+def _write_entry_points(path: Path, parser: configparser.ConfigParser) -> bool:
+    if not parser.sections():
+        path.unlink()
+        return True
+
+    with path.open("w", encoding="utf-8") as file:
+        parser.write(file, space_around_delimiters=True)
+    return False
+
+
+def strip_runtime_entry_points(
+    site_package_paths: Iterable[Path],
+    *,
+    allowed_distributions: Iterable[str] = DEFAULT_ALLOWED_DISTRIBUTIONS,
+    stripped_groups: Iterable[str] = DEFAULT_STRIPPED_GROUPS,
+) -> StripEntryPointReport:
+    """Remove ONEX runtime discovery groups from non-allowed distributions."""
+
+    allowed = frozenset(
+        normalize_distribution_name(name) for name in allowed_distributions
+    )
+    groups = frozenset(stripped_groups)
+    stripped: list[StrippedEntryPointDist] = []
+
+    for site_package_path in site_package_paths:
+        for dist_info_dir in sorted(site_package_path.glob("*.dist-info")):
+            dist_name = _dist_name(dist_info_dir)
+            if dist_name in allowed:
+                continue
+
+            entry_points_path = dist_info_dir / "entry_points.txt"
+            if not entry_points_path.exists():
+                continue
+
+            parser = _read_entry_points(entry_points_path)
+            removed_groups = tuple(
+                group for group in sorted(groups) if parser.remove_section(group)
+            )
+            if not removed_groups:
+                continue
+
+            removed_file = _write_entry_points(entry_points_path, parser)
+            stripped.append(
+                StrippedEntryPointDist(
+                    distribution=dist_name,
+                    path=str(entry_points_path),
+                    groups=removed_groups,
+                    removed_file=removed_file,
+                )
+            )
+
+    return StripEntryPointReport(
+        allowed_distributions=tuple(sorted(allowed)),
+        stripped_groups=tuple(sorted(groups)),
+        stripped_distributions=tuple(stripped),
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove ONEX runtime plugin entry points from installed distributions "
+            "that are not allowed in the runtime discovery surface."
+        )
+    )
+    parser.add_argument(
+        "--site-packages",
+        action="append",
+        type=Path,
+        help="Site-packages path to scan. Defaults to the active interpreter paths.",
+    )
+    parser.add_argument(
+        "--allowed-distribution",
+        action="append",
+        default=[],
+        help=(
+            "Distribution allowed to keep ONEX runtime entry points. May be passed "
+            "multiple times. Defaults to omnibase-infra and omnimarket."
+        ),
+    )
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        help=(
+            "Entry-point group to strip from non-allowed distributions. May be "
+            "passed multiple times. Defaults to ONEX runtime discovery groups."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    site_package_paths = args.site_packages or _iter_site_packages()
+    allowed_distributions = args.allowed_distribution or DEFAULT_ALLOWED_DISTRIBUTIONS
+    stripped_groups = args.group or DEFAULT_STRIPPED_GROUPS
+    report = strip_runtime_entry_points(
+        site_package_paths,
+        allowed_distributions=allowed_distributions,
+        stripped_groups=stripped_groups,
+    )
+    sys.stdout.write(f"{json.dumps(asdict(report), sort_keys=True)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/runtime/test_strip_runtime_entry_points.py
+++ b/tests/integration/runtime/test_strip_runtime_entry_points.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration coverage for runtime image entry-point stripping."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from os import environ
+from pathlib import Path
+
+
+def _write_dist(
+    site_packages: Path,
+    name: str,
+    entry_points: str,
+) -> Path:
+    dist_info = site_packages / f"{name.replace('-', '_')}-1.0.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(f"Name: {name}\n", encoding="utf-8")
+    (dist_info / "entry_points.txt").write_text(entry_points, encoding="utf-8")
+    return dist_info
+
+
+def test_runtime_entry_point_stripper_cli_preserves_only_market_runtime_surface(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    legacy_dist = _write_dist(
+        site_packages,
+        "omninode-memory",
+        """
+[onex.node_package]
+omnimemory = omnimemory.nodes
+
+[onex.nodes]
+node_memory = omnimemory.nodes.node_memory
+""".lstrip(),
+    )
+    market_dist = _write_dist(
+        site_packages,
+        "omnimarket",
+        """
+[onex.node_package]
+omnimarket = omnimarket.nodes
+
+[onex.nodes]
+node_runtime_sweep = omnimarket.nodes.node_runtime_sweep
+""".lstrip(),
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_infra.runtime.strip_runtime_entry_points",
+            "--site-packages",
+            str(site_packages),
+        ],
+        check=True,
+        capture_output=True,
+        env={**environ, "PYTHONPATH": str(Path.cwd() / "src")},
+        text=True,
+    )
+
+    assert "omninode-memory" in completed.stdout
+    assert not (legacy_dist / "entry_points.txt").exists()
+    market_entry_points = (market_dist / "entry_points.txt").read_text(encoding="utf-8")
+    assert "[onex.node_package]" in market_entry_points
+    assert "[onex.nodes]" in market_entry_points

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -122,6 +123,125 @@ async def test_service_pattern_b_broker_round_trips_terminal_event() -> None:
 
     await broker.stop()
     await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    created_consumers: list[FakeAIOKafkaConsumer] = []
+
+    class FakeAIOKafkaConsumer:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
+            self.seeked_to_end = False
+            self.started = False
+            self.stopped = False
+            created_consumers.append(self)
+
+        async def start(self) -> None:
+            self.started = True
+
+        def assignment(self) -> set[str]:
+            return {"partition-0"} if self.started else set()
+
+        async def seek_to_end(self, *_assignment: object) -> None:
+            self.seeked_to_end = True
+
+        async def getone(self) -> SimpleNamespace:
+            return await self.messages.get()
+
+        async def stop(self) -> None:
+            self.stopped = True
+
+    class FakeKafkaTransport:
+        config = SimpleNamespace(
+            session_timeout_ms=45000,
+            heartbeat_interval_ms=15000,
+            max_poll_interval_ms=300000,
+            reconnect_backoff_ms=2000,
+        )
+        _bootstrap_servers = "redpanda:9092"
+
+        def _build_auth_kwargs(self) -> dict[str, object]:
+            return {}
+
+        async def publish(
+            self,
+            _topic: str,
+            _key: bytes | None,
+            value: bytes,
+            _headers: object | None = None,
+        ) -> None:
+            assert created_consumers
+            assert created_consumers[-1].seeked_to_end is True
+            command_envelope = ModelEventEnvelope[object].model_validate_json(value)
+            terminal_envelope = ModelEventEnvelope[object](
+                payload={"status": "complete", "dispatch_count": 5},
+                correlation_id=command_envelope.correlation_id,
+                envelope_timestamp=datetime.now(UTC),
+                event_type=route.terminal_event,
+                source_tool="session_orchestrator",
+            )
+            await created_consumers[-1].messages.put(
+                SimpleNamespace(value=terminal_envelope.model_dump_json().encode())
+            )
+
+        async def subscribe(
+            self,
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            pytest.fail("Kafka-backed terminal waits should use a direct consumer")
+
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        FakeAIOKafkaConsumer,
+    )
+
+    broker = RuntimePatternBBroker(
+        FakeKafkaTransport(),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+        timeout_seconds=1,
+    )
+
+    resolved_route, result = await broker.dispatch_request(command)
+
+    assert resolved_route == route
+    assert result.status == "completed"
+    assert result.payload == {"status": "complete", "dispatch_count": 5}
+    assert created_consumers[0].stopped is True
+
+
+def test_service_pattern_b_broker_decodes_target_runtime_address_during_core_skew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(
+        ModelDispatchBusCommand.model_fields,
+        "target_runtime_address",
+        raising=False,
+    )
+    command = RuntimePatternBBroker._decode_dispatch_command_payload(
+        {
+            "command_name": "session_orchestrator",
+            "requester": "codex",
+            "payload": {"dry_run": True},
+            "response_topic": "onex.evt.pattern-b.dispatch-completed.v1",
+            "timeout_seconds": 1,
+            "target_runtime_address": "runtime://omninode-pc/stability-test/main",
+        }
+    )
+
+    assert command.command_name == "session_orchestrator"
+    assert command.requester == "codex"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -221,6 +221,97 @@ async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
     assert created_consumers[0].stopped is True
 
 
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_preserves_result_when_kafka_stop_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    created_consumers: list[FakeAIOKafkaConsumer] = []
+
+    class FakeAIOKafkaConsumer:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
+            self.started = False
+            created_consumers.append(self)
+
+        async def start(self) -> None:
+            self.started = True
+
+        def assignment(self) -> set[str]:
+            return {"partition-0"} if self.started else set()
+
+        async def seek_to_end(self, *_assignment: object) -> None:
+            return None
+
+        async def getone(self) -> SimpleNamespace:
+            return await self.messages.get()
+
+        async def stop(self) -> None:
+            raise RuntimeError("failed to close terminal consumer")
+
+    class FakeKafkaTransport:
+        config = SimpleNamespace(
+            session_timeout_ms=45000,
+            heartbeat_interval_ms=15000,
+            max_poll_interval_ms=300000,
+            reconnect_backoff_ms=2000,
+        )
+        _bootstrap_servers = "redpanda:9092"
+
+        def _build_auth_kwargs(self) -> dict[str, object]:
+            return {}
+
+        async def publish(
+            self,
+            _topic: str,
+            _key: bytes | None,
+            value: bytes,
+            _headers: object | None = None,
+        ) -> None:
+            command_envelope = ModelEventEnvelope[object].model_validate_json(value)
+            terminal_envelope = ModelEventEnvelope[object](
+                payload={"status": "complete", "dispatch_count": 5},
+                correlation_id=command_envelope.correlation_id,
+                envelope_timestamp=datetime.now(UTC),
+                event_type=route.terminal_event,
+                source_tool="session_orchestrator",
+            )
+            await created_consumers[-1].messages.put(
+                SimpleNamespace(value=terminal_envelope.model_dump_json().encode())
+            )
+
+        async def subscribe(
+            self,
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            pytest.fail("Kafka-backed terminal waits should use a direct consumer")
+
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        FakeAIOKafkaConsumer,
+    )
+
+    broker = RuntimePatternBBroker(
+        FakeKafkaTransport(),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+        timeout_seconds=1,
+    )
+
+    resolved_route, result = await broker.dispatch_request(command)
+
+    assert resolved_route == route
+    assert result.status == "completed"
+    assert result.payload == {"status": "complete", "dispatch_count": 5}
+
+
 def test_service_pattern_b_broker_decodes_target_runtime_address_during_core_skew(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/runtime/test_strip_runtime_entry_points.py
+++ b/tests/unit/runtime/test_strip_runtime_entry_points.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from omnibase_infra.runtime.strip_runtime_entry_points import (
     DEFAULT_STRIPPED_GROUPS,
     normalize_distribution_name,
@@ -24,6 +26,7 @@ def _dist_info(
     return dist_info
 
 
+@pytest.mark.unit
 def test_strips_onex_runtime_groups_from_non_market_distribution(
     tmp_path: Path,
 ) -> None:
@@ -79,6 +82,7 @@ node_market = omnimarket.nodes.node_market
     assert report.stripped_distributions[0].removed_file is False
 
 
+@pytest.mark.unit
 def test_removes_entry_points_file_when_only_runtime_groups_remain(
     tmp_path: Path,
 ) -> None:
@@ -99,6 +103,7 @@ intelligence = omniintelligence.plugin:PluginIntelligence
     assert report.stripped_distributions[0].removed_file is True
 
 
+@pytest.mark.unit
 def test_distribution_name_normalization_handles_underscores_and_dots() -> None:
     assert normalize_distribution_name("omninode_intelligence") == (
         "omninode-intelligence"

--- a/tests/unit/runtime/test_strip_runtime_entry_points.py
+++ b/tests/unit/runtime/test_strip_runtime_entry_points.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+from omnibase_infra.runtime.strip_runtime_entry_points import (
+    DEFAULT_STRIPPED_GROUPS,
+    normalize_distribution_name,
+    strip_runtime_entry_points,
+)
+
+
+def _dist_info(
+    site_packages: Path,
+    name: str,
+    version: str = "1.0.0",
+    *,
+    entry_points: str,
+) -> Path:
+    dist_info = site_packages / f"{name.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(f"Name: {name}\n", encoding="utf-8")
+    (dist_info / "entry_points.txt").write_text(entry_points, encoding="utf-8")
+    return dist_info
+
+
+def test_strips_onex_runtime_groups_from_non_market_distribution(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    non_market = _dist_info(
+        site_packages,
+        "omninode-memory",
+        entry_points="""
+[onex.node_package]
+omnimemory = omnimemory.nodes
+
+[onex.nodes]
+node_memory_storage_effect = omnimemory.nodes.node_memory_storage_effect
+
+[onex.domain_plugins]
+memory = omnimemory.plugin:PluginMemory
+
+[console_scripts]
+omni-memory = omnimemory.cli:main
+""".lstrip(),
+    )
+    allowed = _dist_info(
+        site_packages,
+        "omnimarket",
+        entry_points="""
+[onex.node_package]
+omnimarket = omnimarket.nodes
+
+[onex.nodes]
+node_market = omnimarket.nodes.node_market
+""".lstrip(),
+    )
+
+    report = strip_runtime_entry_points([site_packages])
+
+    non_market_entry_points = (non_market / "entry_points.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "[console_scripts]" in non_market_entry_points
+    for group in DEFAULT_STRIPPED_GROUPS:
+        assert f"[{group}]" not in non_market_entry_points
+
+    allowed_entry_points = (allowed / "entry_points.txt").read_text(encoding="utf-8")
+    assert "[onex.node_package]" in allowed_entry_points
+    assert "[onex.nodes]" in allowed_entry_points
+
+    assert [dist.distribution for dist in report.stripped_distributions] == [
+        "omninode-memory"
+    ]
+    assert report.stripped_distributions[0].groups == tuple(
+        sorted(DEFAULT_STRIPPED_GROUPS)
+    )
+    assert report.stripped_distributions[0].removed_file is False
+
+
+def test_removes_entry_points_file_when_only_runtime_groups_remain(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    dist_info = _dist_info(
+        site_packages,
+        "omninode-intelligence",
+        entry_points="""
+[onex.domain_plugins]
+intelligence = omniintelligence.plugin:PluginIntelligence
+""".lstrip(),
+    )
+
+    report = strip_runtime_entry_points([site_packages])
+
+    assert not (dist_info / "entry_points.txt").exists()
+    assert report.stripped_distributions[0].distribution == "omninode-intelligence"
+    assert report.stripped_distributions[0].removed_file is True
+
+
+def test_distribution_name_normalization_handles_underscores_and_dots() -> None:
+    assert normalize_distribution_name("omninode_intelligence") == (
+        "omninode-intelligence"
+    )
+    assert normalize_distribution_name("OmniNode.Memory") == "omninode-memory"


### PR DESCRIPTION
## Summary
- Arm Kafka-backed Pattern B terminal consumers before publishing dispatch commands.
- Decode dispatch command envelopes through the generic event envelope first so target runtime address version skew does not reject valid requests.
- Add focused unit coverage for the terminal-wait ordering and version-skew decode path.

## Runtime evidence
- Stability runtime rebuilt from this branch and passed local socket runtime_sweep.
- Stability runtime passed external Pattern B runtime_sweep.
- .201 main runtime deployed from this PR branch and app health is healthy.
- .201 main runtime passed local socket runtime_sweep and external Pattern B runtime_sweep.

## Verification
- uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py
- uv run mypy src/omnibase_infra/runtime/service_pattern_b_broker.py
- uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_runtime_local_ingress.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime entry-point stripping utility and updated the runtime build to run it during image creation.

* **Bug Fixes**
  * Improved error handling and routing during command dispatch.
  * Unified and more reliable terminal-result reporting with explicit status (completed/timeout/failed) and completion timestamps.
  * Added a faster direct-consumer dispatch path with a robust fallback to event-bus subscription.

* **Tests**
  * Added unit tests covering dispatch terminal wait behavior and command payload decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Ticket
OMN-10207
