### PR TITLE
feat(OMN-9752): batch-validate all node contracts via model_validate() with CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,13 @@ jobs:
       - name: Check published_events consistency (OMN-4885)
         run: uv run python scripts/validation/check_published_events_consistency.py
 
+      - name: Batch-validate all node contracts via model_validate() (OMN-9752)
+        run: |
+          echo "================================================================"
+          echo "Batch contract node_type validation (OMN-9752)"
+          echo "================================================================"
+          uv run python scripts/batch_validate_node_contracts.py --verbose
+
   # Fingerprint drift detection -- CI twins for runtime assertions B2 and B3
   # Prevents stale fingerprint artifacts from being merged (OMN-2149)
   fingerprint-check:

--- a/scripts/batch_validate_node_contracts.py
+++ b/scripts/batch_validate_node_contracts.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Batch-validate all node contract.yaml files via model_validate().
+
+Walks all nodes/*/contract.yaml files under a given directory and runs
+load_and_validate_contract_yaml() (the OMN-9746 choke-point that uses
+model_validate()) on each one. Any contract that fails node_type validation,
+YAML parsing, or structure checks causes a non-zero exit.
+
+Usage:
+    uv run python scripts/batch_validate_node_contracts.py
+    uv run python scripts/batch_validate_node_contracts.py --directory src/omnibase_infra/nodes/
+    uv run python scripts/batch_validate_node_contracts.py --verbose
+
+Exit Codes:
+    0: All contracts passed model_validate()
+    1: One or more contracts failed validation
+    2: Runtime error (directory not found, import failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+def _discover_contract_paths(directory: Path, recursive: bool = True) -> list[Path]:
+    """Return sorted list of contract.yaml paths under directory."""
+    if not directory.is_dir():
+        return []
+    if recursive:
+        return sorted(directory.rglob("contract.yaml"))
+    return sorted(directory.glob("*/contract.yaml"))
+
+
+def _validate_contract_node_type(contract_path: Path) -> str:
+    """Validate a single contract.yaml and return the node_type value.
+
+    Uses ModelNodeTypeProbe.model_validate() — the OMN-9746 choke-point — to
+    validate node_type without requiring handler_routing (which is optional for
+    COMPUTE/REDUCER nodes that use FSM contracts instead of handler routing).
+
+    Args:
+        contract_path: Path to the contract.yaml file.
+
+    Returns:
+        The validated node_type string (e.g. "COMPUTE_GENERIC").
+
+    Raises:
+        ValueError: If YAML is invalid, empty, not a dict, or node_type is
+            missing/unrecognised.
+    """
+    import yaml
+    from pydantic import ValidationError
+
+    from omnibase_infra.runtime.contract_loaders.model_node_type_probe import (
+        ModelNodeTypeProbe,
+    )
+
+    try:
+        raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"YAML parse error: {exc}") from exc
+
+    if raw is None:
+        raise ValueError("Contract file is empty")
+    if not isinstance(raw, dict):
+        raise ValueError(f"Contract YAML root is not a dict: got {type(raw).__name__}")
+
+    node_type_str = raw.get("node_type", "")
+    if not node_type_str:
+        raise ValueError(f"Missing or empty node_type in contract: {list(raw.keys())}")
+
+    try:
+        probe = ModelNodeTypeProbe.model_validate(raw)
+    except ValidationError as exc:
+        raise ValueError(
+            f"node_type validation failed ({node_type_str!r}): {exc}"
+        ) from exc
+
+    return probe.node_type.value
+
+
+def run_batch_validation(
+    directory: Path,
+    *,
+    verbose: bool = False,
+    recursive: bool = True,
+) -> tuple[int, int, list[tuple[Path, str]]]:
+    """Validate all contract.yaml files under directory.
+
+    Returns:
+        (passed_count, failed_count, failures) where failures is a list of
+        (path, error_message) tuples.
+    """
+    contract_paths = _discover_contract_paths(directory, recursive=recursive)
+    if not contract_paths:
+        print(f"WARNING: No contract.yaml files found under {directory}")
+        return 0, 0, []
+
+    passed = 0
+    failures: list[tuple[Path, str]] = []
+
+    for path in contract_paths:
+        try:
+            node_type = _validate_contract_node_type(path)
+            passed += 1
+            if verbose:
+                print(f"  PASS  {path}  (node_type={node_type})")
+        except Exception as exc:  # noqa: BLE001
+            failures.append((path, str(exc)))
+            if verbose:
+                print(f"  FAIL  {path}")
+                print(f"        {exc}")
+            if not verbose:
+                print(str(exc), file=sys.stderr)
+
+    return passed, len(failures), failures
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Batch-validate all node contract.yaml files via model_validate().",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        default="src/omnibase_infra/nodes/",
+        help="Root directory to search for contract.yaml files (default: src/omnibase_infra/nodes/)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print each contract path and result",
+    )
+    parser.add_argument(
+        "--non-recursive",
+        action="store_true",
+        help="Only check contract.yaml one level deep (not recursive)",
+    )
+    args = parser.parse_args()
+
+    directory = Path(args.directory)
+    if not directory.exists():
+        print(f"ERROR: Directory not found: {directory}", file=sys.stderr)
+        return 2
+
+    try:
+        passed, failed, failures = run_batch_validation(
+            directory,
+            verbose=args.verbose,
+            recursive=not args.non_recursive,
+        )
+    except ImportError as exc:
+        print(
+            f"ERROR: Import failure — ensure omnibase_infra is installed: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    total = passed + failed
+    print(f"Batch contract validation: {passed}/{total} passed, {failed} failed")
+
+    if failures:
+        print("\nFailed contracts:")
+        for path, msg in failures:
+            print(f"  {path}")
+            print(f"    {msg}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/batch_validate_node_contracts.py
+++ b/scripts/batch_validate_node_contracts.py
@@ -4,9 +4,9 @@
 """Batch-validate all node contract.yaml files via model_validate().
 
 Walks all nodes/*/contract.yaml files under a given directory and runs
-load_and_validate_contract_yaml() (the OMN-9746 choke-point that uses
-model_validate()) on each one. Any contract that fails node_type validation,
-YAML parsing, or structure checks causes a non-zero exit.
+ModelNodeTypeProbe.model_validate() (the OMN-9746 choke-point for node_type)
+on each one. Any contract that fails node_type validation, YAML parsing, or
+structure checks causes a non-zero exit.
 
 Usage:
     uv run python scripts/batch_validate_node_contracts.py
@@ -112,6 +112,8 @@ def run_batch_validation(
             passed += 1
             if verbose:
                 print(f"  PASS  {path}  (node_type={node_type})")
+        except ImportError:
+            raise
         except Exception as exc:  # noqa: BLE001
             failures.append((path, str(exc)))
             if verbose:
@@ -151,8 +153,11 @@ def main() -> int:
     args = parser.parse_args()
 
     directory = Path(args.directory)
-    if not directory.exists():
-        print(f"ERROR: Directory not found: {directory}", file=sys.stderr)
+    if not directory.is_dir():
+        print(
+            f"ERROR: Directory not found or not a directory: {directory}",
+            file=sys.stderr,
+        )
         return 2
 
     try:

--- a/tests/unit/contracts/test_batch_validate_node_contracts.py
+++ b/tests/unit/contracts/test_batch_validate_node_contracts.py
@@ -12,9 +12,11 @@ Validates that the batch validator:
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 import yaml
@@ -61,6 +63,17 @@ def _run(directory: Path, *, verbose: bool = False) -> subprocess.CompletedProce
     if verbose:
         cmd.append("--verbose")
     return subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "batch_validate_node_contracts", SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestBatchValidateAllPass:
@@ -179,6 +192,38 @@ class TestBatchValidateCLI:
         nonexistent = tmp_path / "does_not_exist"
         result = _run(nonexistent)
         assert result.returncode == 2
+        assert "not found or not a directory" in result.stderr
+
+    def test_file_directory_argument_exits_2(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "not_a_directory"
+        file_path.write_text("not a directory", encoding="utf-8")
+
+        result = _run(file_path)
+
+        assert result.returncode == 2
+        assert "not found or not a directory" in result.stderr
+
+    def test_import_error_exits_2(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_contract(tmp_path, "node_import_error", "COMPUTE_GENERIC")
+        module = _load_script_module()
+
+        def fail_import(_path: Path) -> str:
+            raise ImportError("missing dependency")
+
+        monkeypatch.setattr(module, "_validate_contract_node_type", fail_import)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [str(SCRIPT), "--directory", str(tmp_path)],
+        )
+
+        assert module.main() == 2
+        assert "Import failure" in capsys.readouterr().err
 
     def test_verbose_flag_shows_paths(self, tmp_path: Path) -> None:
         _write_contract(tmp_path, "node_verbose_test", "EFFECT_GENERIC")

--- a/tests/unit/contracts/test_batch_validate_node_contracts.py
+++ b/tests/unit/contracts/test_batch_validate_node_contracts.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for batch_validate_node_contracts.py — OMN-9752.
+
+Validates that the batch validator:
+- Passes all well-formed contracts through model_validate()
+- Fails on invalid node_type values
+- Fails on missing required fields
+- Reports correct counts
+- Returns non-zero exit on any failure
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts" / "batch_validate_node_contracts.py"
+)
+
+
+def _write_contract(directory: Path, name: str, node_type: str) -> Path:
+    """Write a minimal valid contract.yaml into directory/name/contract.yaml."""
+    node_dir = directory / name
+    node_dir.mkdir(parents=True, exist_ok=True)
+    contract = {
+        "name": name,
+        "node_type": node_type,
+        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+        "node_version": "1.0.0",
+        "description": "Test contract",
+        "input_model": {
+            "name": "ModelInput",
+            "module": "omnibase_core.models.model_input",
+            "description": "Input",
+        },
+        "output_model": {
+            "name": "ModelOutput",
+            "module": "omnibase_core.models.model_output",
+            "description": "Output",
+        },
+        "handler_routing": {
+            "routing_strategy": "payload_type_match",
+            "handlers": [],
+        },
+    }
+    path = node_dir / "contract.yaml"
+    path.write_text(yaml.dump(contract, default_flow_style=False), encoding="utf-8")
+    return path
+
+
+def _run(directory: Path, *, verbose: bool = False) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--directory", str(directory)]
+    if verbose:
+        cmd.append("--verbose")
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+
+
+class TestBatchValidateAllPass:
+    """All valid contracts → exit 0, correct pass count."""
+
+    def test_all_valid_contracts_pass(self, tmp_path: Path) -> None:
+        for name, node_type in [
+            ("node_foo_effect", "EFFECT_GENERIC"),
+            ("node_bar_compute", "COMPUTE_GENERIC"),
+            ("node_baz_reducer", "REDUCER_GENERIC"),
+            ("node_qux_orchestrator", "ORCHESTRATOR_GENERIC"),
+        ]:
+            _write_contract(tmp_path, name, node_type)
+
+        result = _run(tmp_path)
+        assert result.returncode == 0, f"Expected exit 0; stderr: {result.stderr}"
+        assert "4/4 passed" in result.stdout
+
+    def test_lowercase_node_type_aliases_pass(self, tmp_path: Path) -> None:
+        """Lowercase aliases like 'effect' must be accepted (MixinNodeTypeValidator)."""
+        node_dir = tmp_path / "node_alias_effect"
+        node_dir.mkdir()
+        contract = {
+            "name": "node_alias_effect",
+            "node_type": "effect",
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "handlers": [],
+            },
+        }
+        (node_dir / "contract.yaml").write_text(
+            yaml.dump(contract, default_flow_style=False), encoding="utf-8"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 0, f"Expected exit 0; stderr: {result.stderr}"
+
+    def test_empty_directory_exits_zero(self, tmp_path: Path) -> None:
+        """No contracts found → exit 0 (nothing to fail)."""
+        result = _run(tmp_path)
+        assert result.returncode == 0
+
+
+class TestBatchValidateFailures:
+    """Invalid contracts → exit 1, failure listed in output."""
+
+    def test_invalid_node_type_fails(self, tmp_path: Path) -> None:
+        node_dir = tmp_path / "node_bad"
+        node_dir.mkdir()
+        bad = {
+            "name": "node_bad",
+            "node_type": "TOTALLY_WRONG",
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "handlers": [],
+            },
+        }
+        (node_dir / "contract.yaml").write_text(
+            yaml.dump(bad, default_flow_style=False), encoding="utf-8"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 1, f"Expected exit 1; stdout: {result.stdout}"
+        assert (
+            "0/1 passed, 1 failed" in result.stdout
+            or "Failed contracts:" in result.stdout
+        )
+
+    def test_missing_node_type_fails(self, tmp_path: Path) -> None:
+        node_dir = tmp_path / "node_missing_type"
+        node_dir.mkdir()
+        bad = {
+            "name": "node_missing_type",
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "handlers": [],
+            },
+        }
+        (node_dir / "contract.yaml").write_text(
+            yaml.dump(bad, default_flow_style=False), encoding="utf-8"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 1
+
+    def test_invalid_yaml_fails(self, tmp_path: Path) -> None:
+        node_dir = tmp_path / "node_bad_yaml"
+        node_dir.mkdir()
+        (node_dir / "contract.yaml").write_text(
+            "key: [unclosed bracket\n", encoding="utf-8"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 1
+
+    def test_mixed_valid_and_invalid_counts_correctly(self, tmp_path: Path) -> None:
+        _write_contract(tmp_path, "node_good", "COMPUTE_GENERIC")
+        node_dir = tmp_path / "node_bad"
+        node_dir.mkdir()
+        bad = {
+            "name": "node_bad",
+            "node_type": "NOT_A_TYPE",
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "handlers": [],
+            },
+        }
+        (node_dir / "contract.yaml").write_text(
+            yaml.dump(bad, default_flow_style=False), encoding="utf-8"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 1
+        assert "1/2 passed, 1 failed" in result.stdout
+
+
+class TestBatchValidateCLI:
+    """CLI argument tests."""
+
+    def test_missing_directory_exits_2(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        result = _run(nonexistent)
+        assert result.returncode == 2
+
+    def test_verbose_flag_shows_paths(self, tmp_path: Path) -> None:
+        _write_contract(tmp_path, "node_verbose_test", "EFFECT_GENERIC")
+        result = _run(tmp_path, verbose=True)
+        assert result.returncode == 0
+        assert "node_verbose_test" in result.stdout
+        assert "PASS" in result.stdout
+
+
+class TestBatchValidateRealContracts:
+    """Smoke test: all real node contracts in the repo must pass model_validate()."""
+
+    def test_all_infra_node_contracts_pass(self) -> None:
+        """Every contract.yaml under src/omnibase_infra/nodes/ must pass model_validate().
+
+        This is the CI gate: if any contract has an invalid node_type, this test fails.
+        """
+        nodes_dir = (
+            Path(__file__).resolve().parents[3] / "src" / "omnibase_infra" / "nodes"
+        )
+        assert nodes_dir.is_dir(), f"Nodes directory not found: {nodes_dir}"
+
+        result = _run(nodes_dir, verbose=True)
+        assert result.returncode == 0, (
+            f"Batch contract validation failed.\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Evidence

Evidence-Source: OCC#817
Evidence-Ticket: OMN-9752

## Summary

- Adds `scripts/batch_validate_node_contracts.py` that walks all `nodes/*/contract.yaml` files and runs `ModelNodeTypeProbe.model_validate()` on each, using the OMN-9746 choke-point introduced in Task 8
- Adds 10 unit tests covering: valid contracts (all 4 node types), lowercase aliases, missing `node_type`, invalid `node_type`, bad YAML, mixed pass/fail counts, CLI argument handling, and a smoke test against all 138 real infra node contracts
- Wires the script as a blocking step in the `onex-validation` CI job — any contract with an invalid `node_type` now blocks merge

## Design decision

Uses `ModelNodeTypeProbe.model_validate()` directly rather than `load_and_validate_contract_yaml()`. The latter requires a `handler_routing` section which is legitimately absent in many COMPUTE/REDUCER contracts (they use FSM or operation_match patterns). OMN-9752's mandate is specifically `node_type` validation via `model_validate()`.

## Test plan

- [x] `uv run pytest tests/unit/contracts/test_batch_validate_node_contracts.py -v` — 10/10 passed
- [x] `uv run pytest tests/ -m unit -q` — 12548 passed (pre-existing `test_kernel.py::TestIntegration` failure confirmed on main before this PR)
- [x] `pre-commit run --all-files` — all hooks passed
- [x] `uv run mypy scripts/batch_validate_node_contracts.py --ignore-missing-imports` — no issues

Closes OMN-9752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs an automated batch validator for node contract files as part of the validation job.
  * Added a new CLI tool to discover and validate node contracts, with verbose and non-recursive options.

* **Tests**
  * Added comprehensive tests covering valid/invalid contracts, malformed files, CLI error handling, verbose output, and validation of real-world contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
