### PR TITLE
feat(OMN-9769): wire --mode flag into CLI validate contracts

### DIFF
--- a/contracts/OMN-9769.yaml
+++ b/contracts/OMN-9769.yaml
@@ -1,0 +1,29 @@
+# OMN-9769 contract file for omnibase_infra deploy-gate.
+# This PR wires CLI validation mode selection to the shared omnibase_core batch validator.
+schema_version: "1.0.0"
+ticket_id: "OMN-9769"
+title: "Wire validator mode selection into omni-infra contract validation CLI"
+summary: >
+  Adds --mode strict|migration_audit to omni-infra validate contracts and routes the command through omnibase_core.normalization.batch_validator.run_batch_validation. This is developer CLI validation plumbing only; it does not change runtime containers, docker images, broker topics, or deployed services.
+
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "public_api"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-cli-mode-tests"
+    description: "Focused CLI validator mode unit and integration tests pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-9769/omnibase_core/src:src uv run pytest tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py -q"
+  - id: "dod-deploy"
+    description: "No runtime deploy, restart, broker topic, container image, or live service change is required for this CLI-only validation wiring."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-9769 changes omni-infra validate contracts CLI mode wiring only; no runtime deploy or restart required'"

--- a/contracts/OMN-9769.yaml
+++ b/contracts/OMN-9769.yaml
@@ -20,7 +20,7 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-9769/omnibase_core/src:src uv run pytest tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py -q"
+        check_value: "env -u PYTHONPATH uv run pytest tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py tests/integration/test_env_render_settings_cli.py tests/unit/cli/test_cli_env.py tests/unit/test_cli_registry_commands.py -q"
   - id: "dod-deploy"
     description: "No runtime deploy, restart, broker topic, container image, or live service change is required for this CLI-only validation wiring."
     source: "manual"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "b42e6dae20f9ac02ef35a776c35ec32aae0023ed" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
 [tool.ruff]

--- a/src/omnibase_infra/cli/commands.py
+++ b/src/omnibase_infra/cli/commands.py
@@ -20,6 +20,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from omnibase_core.normalization.batch_validator import run_batch_validation
 from omnibase_infra.cli.artifact_reconcile import artifact_reconcile_cmd
 
 logger = logging.getLogger(__name__)
@@ -62,14 +63,46 @@ def validate_architecture_cmd(directory: str, max_violations: int | None) -> Non
 
 @validate.command("contracts")
 @click.argument("directory", default="src/omnibase_infra/nodes/")
-def validate_contracts_cmd(directory: str) -> None:
-    """Validate YAML contracts."""
-    from omnibase_infra.validation.infra_validators import validate_infra_contracts
+@click.option(
+    "--mode",
+    default="strict",
+    type=click.Choice(["strict", "migration_audit"], case_sensitive=False),
+    help="Validation mode: strict (default) or migration_audit for legacy corpus sweeps.",
+)
+def validate_contracts_cmd(directory: str, mode: str) -> None:
+    """Validate YAML contracts using batch validator with mode selection.
 
-    console.print(f"[bold blue]Validating contracts in {directory}...[/bold blue]")
-    result = validate_infra_contracts(directory)
-    _print_result("Contracts", result)
-    raise SystemExit(0 if result.is_valid else 1)
+    STRICT mode (default): enforces all required fields; fails on legacy shapes.
+    MIGRATION_AUDIT mode: normalizes legacy contracts before validating; used
+    for batch sweeps over the corpus to inventory substantive failures.
+    """
+    from pathlib import Path
+
+    from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+
+    validator_mode = EnumValidatorMode(mode.lower())
+    root = Path(directory)
+    console.print(
+        f"[bold blue]Validating contracts in {directory} "
+        f"(mode={validator_mode.value})...[/bold blue]"
+    )
+    summary = run_batch_validation(root, mode=validator_mode)
+
+    if summary.failed > 0:
+        console.print("[bold red]Contracts: FAIL[/bold red]")
+        for report in summary.reports:
+            if not report.passed:
+                console.print(f"  [red]{report.path}[/red]")
+                for err in report.errors:
+                    console.print(f"    [red]{err}[/red]")
+    else:
+        console.print("[bold green]Contracts: PASS[/bold green]")
+
+    console.print(
+        f"[bold]Summary: {summary.passed}/{summary.total} passed "
+        f"(mode={validator_mode.value})[/bold]"
+    )
+    raise SystemExit(0 if summary.failed == 0 else 1)
 
 
 @validate.command("patterns")

--- a/tests/integration/test_validate_contracts_mode_integration.py
+++ b/tests/integration/test_validate_contracts_mode_integration.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for omni-infra validate contracts mode wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from omnibase_infra.cli.commands import cli
+
+pytestmark = pytest.mark.integration
+
+
+def _effect_contract(name: str = "node_cli_mode_effect") -> dict[str, Any]:
+    return {
+        "name": name,
+        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+        "description": f"{name} integration fixture.",
+        "node_type": "EFFECT_GENERIC",
+        "input_model": "foo.bar.models.ModelFooRequest",
+        "output_model": "foo.bar.models.ModelFooResult",
+        "handler_routing": {
+            "version": {"major": 1, "minor": 0, "patch": 0},
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "routing_key": "foo.run",
+                    "handler_key": "handle_foo_run",
+                    "priority": 0,
+                }
+            ],
+        },
+        "io_operations": [
+            {
+                "operation_type": "read",
+                "resource_type": "external_api",
+                "resource_identifier": "foo.api/run",
+            }
+        ],
+    }
+
+
+def test_validate_contracts_cli_runs_batch_validator_with_migration_audit_mode(
+    tmp_path: Path,
+) -> None:
+    """Exercise the click command through the real batch validator integration."""
+    contract_path = tmp_path / "nodes" / "node_cli_mode_effect" / "contract.yaml"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text(yaml.safe_dump(_effect_contract()), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        ["validate", "contracts", str(tmp_path), "--mode", "migration_audit"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "mode=migration_audit" in result.output
+    assert "1/1 passed" in result.output

--- a/tests/unit/cli/test_validate_contracts_mode.py
+++ b/tests/unit/cli/test_validate_contracts_mode.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -97,7 +97,7 @@ class TestValidateContractsModeFlag:
             ["validate", "contracts", str(tmp_path)],
         )
         assert result.exit_code == 0, result.output
-        assert "strict" in result.output.lower() or result.exit_code == 0
+        assert "mode=strict" in result.output.lower()
 
     def test_validate_contracts_uses_batch_validator(self, tmp_path: Path) -> None:
         _write_node_contract(tmp_path, _clean_effect_contract())

--- a/tests/unit/cli/test_validate_contracts_mode.py
+++ b/tests/unit/cli/test_validate_contracts_mode.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for --mode flag on `omni-infra validate contracts` (OMN-9769).
+
+Phase 3, Task 12 — wires EnumValidatorMode into the CLI validate contracts
+command so the batch sweep can be invoked with either strict or
+migration_audit mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from omnibase_infra.cli.commands import cli
+
+
+def _clean_effect_contract(name: str = "node_foo_effect") -> dict[str, Any]:
+    return {
+        "name": name,
+        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+        "description": f"{name} test fixture.",
+        "node_type": "EFFECT_GENERIC",
+        "input_model": "foo.bar.models.ModelFooRequest",
+        "output_model": "foo.bar.models.ModelFooResult",
+        "handler_routing": {
+            "version": {"major": 1, "minor": 0, "patch": 0},
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "routing_key": "foo.run",
+                    "handler_key": "handle_foo_run",
+                    "priority": 0,
+                }
+            ],
+        },
+        "io_operations": [
+            {
+                "operation_type": "read",
+                "resource_type": "external_api",
+                "resource_identifier": "foo.api/run",
+            }
+        ],
+    }
+
+
+def _write_node_contract(tmp_path: Path, body: dict[str, Any]) -> Path:
+    p = tmp_path / "nodes" / body["name"] / "contract.yaml"
+    p.parent.mkdir(parents=True)
+    p.write_text(yaml.safe_dump(body))
+    return p
+
+
+@pytest.mark.unit
+class TestValidateContractsModeFlag:
+    """CLI validate contracts --mode flag routes to batch_validator with correct mode."""
+
+    def test_validate_contracts_accepts_strict_mode(self, tmp_path: Path) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["validate", "contracts", str(tmp_path), "--mode", "strict"],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_validate_contracts_accepts_migration_audit_mode(
+        self, tmp_path: Path
+    ) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["validate", "contracts", str(tmp_path), "--mode", "migration_audit"],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_validate_contracts_rejects_invalid_mode(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["validate", "contracts", str(tmp_path), "--mode", "bogus_mode"],
+        )
+        assert result.exit_code != 0
+
+    def test_validate_contracts_default_mode_is_strict(self, tmp_path: Path) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["validate", "contracts", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "strict" in result.output.lower() or result.exit_code == 0
+
+    def test_validate_contracts_uses_batch_validator(self, tmp_path: Path) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+
+        from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+        from omnibase_core.normalization.batch_validator import (
+            ModelBatchValidationSummary,
+            run_batch_validation,
+        )
+
+        mock_summary = ModelBatchValidationSummary(
+            total=1,
+            passed=1,
+            failed=0,
+            mode=EnumValidatorMode.STRICT,
+            reports=[],
+        )
+        with patch(
+            "omnibase_infra.cli.commands.run_batch_validation",
+            return_value=mock_summary,
+        ) as mock_run:
+            result = runner.invoke(
+                cli,
+                ["validate", "contracts", str(tmp_path), "--mode", "strict"],
+            )
+            mock_run.assert_called_once()
+            call_kwargs = mock_run.call_args
+            assert call_kwargs is not None
+        assert result.exit_code == 0
+
+    def test_validate_contracts_passes_migration_audit_to_batch_validator(
+        self, tmp_path: Path
+    ) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+
+        from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+        from omnibase_core.normalization.batch_validator import (
+            ModelBatchValidationSummary,
+        )
+
+        mock_summary = ModelBatchValidationSummary(
+            total=1,
+            passed=1,
+            failed=0,
+            mode=EnumValidatorMode.MIGRATION_AUDIT,
+            reports=[],
+        )
+        with patch(
+            "omnibase_infra.cli.commands.run_batch_validation",
+            return_value=mock_summary,
+        ) as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "validate",
+                    "contracts",
+                    str(tmp_path),
+                    "--mode",
+                    "migration_audit",
+                ],
+            )
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+
+            assert kwargs.get("mode") is EnumValidatorMode.MIGRATION_AUDIT
+        assert result.exit_code == 0
+
+    def test_validate_contracts_exits_nonzero_on_failures(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+
+        from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+        from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+        from omnibase_core.models.contracts.model_corpus_validation_report import (
+            ModelCorpusValidationReport,
+        )
+        from omnibase_core.normalization.batch_validator import (
+            ModelBatchValidationSummary,
+        )
+
+        failing_report = ModelCorpusValidationReport(
+            path=tmp_path / "nodes" / "node_bad" / "contract.yaml",
+            bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=False,
+            errors=["Missing required field: input_model"],
+            normalized=False,
+        )
+        mock_summary = ModelBatchValidationSummary(
+            total=1,
+            passed=0,
+            failed=1,
+            mode=EnumValidatorMode.STRICT,
+            reports=[failing_report],
+        )
+        with patch(
+            "omnibase_infra.cli.commands.run_batch_validation",
+            return_value=mock_summary,
+        ):
+            result = runner.invoke(
+                cli,
+                ["validate", "contracts", str(tmp_path), "--mode", "strict"],
+            )
+        assert result.exit_code == 1
+
+    def test_validate_contracts_output_shows_summary(self, tmp_path: Path) -> None:
+        _write_node_contract(tmp_path, _clean_effect_contract())
+        runner = CliRunner()
+
+        from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+        from omnibase_core.normalization.batch_validator import (
+            ModelBatchValidationSummary,
+        )
+
+        mock_summary = ModelBatchValidationSummary(
+            total=2,
+            passed=2,
+            failed=0,
+            mode=EnumValidatorMode.STRICT,
+            reports=[],
+        )
+        with patch(
+            "omnibase_infra.cli.commands.run_batch_validation",
+            return_value=mock_summary,
+        ):
+            result = runner.invoke(
+                cli,
+                ["validate", "contracts", str(tmp_path)],
+            )
+        assert "2" in result.output
+        assert result.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "omnibase-core", specifier = ">=0.40.1,<0.41.0" }]
+overrides = [{ name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.40.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed#b42e6dae20f9ac02ef35a776c35ec32aae0023ed" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1958,10 +1958,6 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tree-sitter" },
     { name = "tree-sitter-python" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/ee/437d2a59f3a08827c7688d2ddf62da6d0f2647ef7ca741f092da695c23d2/omnibase_core-0.40.1.tar.gz", hash = "sha256:ed9308f3cbca5dbcdcffd5cc7e6ce9d5ae3e4fa96b89b0dda6f69388fedac3bf", size = 8395663, upload-time = "2026-05-04T02:00:24.88Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/98/20316960a989aa24f5b851bf74402c0b8a0febc0a28ccb67cfc8b518d418/omnibase_core-0.40.1-py3-none-any.whl", hash = "sha256:1fa09caee8e9237397c42154b102704b4faacd4c881edf1d98aa3d1d897b6308", size = 5773507, upload-time = "2026-05-04T02:00:22.44Z" },
 ]
 
 [[package]]
@@ -2060,7 +2056,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", specifier = ">=0.40.1,<0.41.0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed" },
     { name = "omnibase-spi", specifier = ">=0.20.6" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Evidence

Evidence-Source: OCC#823
Evidence-Ticket: OMN-9769

## Summary

- Replaces `validate_infra_contracts` call with `run_batch_validation` (from `omnibase_core`) in the `omni-infra validate contracts` command
- Adds `--mode` flag accepting `strict` (default) or `migration_audit`
- Pins the unreleased merged `omnibase_core` validator commit through `tool.uv.sources` so CI resolves the batch validator deterministically
- Output now includes per-file error details and a summary line with mode and counts
- Exit code 0 if all pass, 1 if any fail

Closes OMN-9769 (infra half). Part of OMN-9757 Phase 3 Task 12.

## dod_evidence

- `env -u PYTHONPATH uv run pytest tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py tests/integration/test_env_render_settings_cli.py tests/unit/cli/test_cli_env.py tests/unit/test_cli_registry_commands.py -q` — 32 passed
- `uv lock --check` — lock resolved
- `uv run ruff format --check src/omnibase_infra/cli/commands.py tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py` — passed
- `uv run ruff check src/omnibase_infra/cli/commands.py tests/unit/cli/test_validate_contracts_mode.py tests/integration/test_validate_contracts_mode_integration.py` — passed
- pre-commit on `pyproject.toml` and `uv.lock` — passed during commit

## Test plan

- [ ] CI passes