### PR TITLE
feat(OMN-9743): add HookActivationResolver — package-driven hook bitmask

### DIFF
--- a/src/omnibase_infra/hooks/__init__.py
+++ b/src/omnibase_infra/hooks/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/hooks/hook_activation_resolver.py
+++ b/src/omnibase_infra/hooks/hook_activation_resolver.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from omnibase_core.models.contracts.subcontracts.model_hook_activation import (
+    ModelHookActivation,
+)
+
+_log = logging.getLogger(__name__)
+
+
+class HookActivationResolver:
+    """Resolves package hook_activations into a composite bitmask."""
+
+    def __init__(self, activations: list[ModelHookActivation]) -> None:
+        self._activations = activations
+
+    def compute_mask(self) -> int:
+        """Return bitmask with bits set for every enabled_by_default activation."""
+        mask = 0
+        for activation in self._activations:
+            try:
+                if activation.enabled_by_default:
+                    mask |= int(activation.hook_bit)
+            except Exception as exc:  # noqa: BLE001 — lenient rollout-safety policy: log and skip, never crash runtime
+                _log.warning(
+                    "Skipping unresolvable hook activation %s: %s",
+                    activation.hook_bit,
+                    exc,
+                )
+        return mask

--- a/tests/integration/test_hook_activation_resolver_integration.py
+++ b/tests/integration/test_hook_activation_resolver_integration.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for hook activation mask resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
+from omnibase_core.models.contracts.subcontracts.model_hook_activation import (
+    ModelHookActivation,
+)
+from omnibase_infra.hooks.hook_activation_resolver import HookActivationResolver
+
+pytestmark = pytest.mark.integration
+
+
+def test_hook_activations_resolve_to_runtime_hook_mask() -> None:
+    """Validate hook activation contracts resolve into a runtime hook mask."""
+    activations = [
+        ModelHookActivation.model_validate(
+            {
+                "hook_bit": "CI_REMINDER",
+                "enabled_by_default": True,
+                "description": "Enable CI reminder hook by default.",
+            }
+        ),
+        ModelHookActivation.model_validate(
+            {
+                "hook_bit": "AUTO_HOSTILE_REVIEW",
+                "enabled_by_default": False,
+                "description": "Keep hostile review opt-in for this package.",
+            }
+        ),
+    ]
+
+    mask = HookActivationResolver(activations=activations).compute_mask()
+
+    assert hook_enabled(EnumHookBit.CI_REMINDER, mask=mask)
+    assert not hook_enabled(EnumHookBit.AUTO_HOSTILE_REVIEW, mask=mask)

--- a/tests/unit/hooks/__init__.py
+++ b/tests/unit/hooks/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/hooks/test_hook_activation_resolver.py
+++ b/tests/unit/hooks/test_hook_activation_resolver.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit
+from omnibase_core.models.contracts.subcontracts.model_hook_activation import (
+    ModelHookActivation,
+)
+from omnibase_infra.hooks.hook_activation_resolver import HookActivationResolver
+
+
+@pytest.mark.unit
+def test_resolver_returns_activated_bits_for_installed_packages() -> None:
+    activations = [
+        ModelHookActivation(hook_bit=EnumHookBit.CI_REMINDER, enabled_by_default=True),
+        ModelHookActivation(
+            hook_bit=EnumHookBit.AUTO_HOSTILE_REVIEW, enabled_by_default=False
+        ),
+    ]
+    resolver = HookActivationResolver(activations=activations)
+    mask = resolver.compute_mask()
+    assert mask & int(EnumHookBit.CI_REMINDER) != 0
+    assert mask & int(EnumHookBit.AUTO_HOSTILE_REVIEW) == 0
+
+
+@pytest.mark.unit
+def test_resolver_empty_activations_returns_zero_mask() -> None:
+    resolver = HookActivationResolver(activations=[])
+    mask = resolver.compute_mask()
+    assert mask == 0
+
+
+@pytest.mark.unit
+def test_resolver_all_enabled_by_default_sets_all_bits() -> None:
+    activations = [
+        ModelHookActivation(hook_bit=EnumHookBit.CI_REMINDER, enabled_by_default=True),
+        ModelHookActivation(hook_bit=EnumHookBit.RUFF_FIX, enabled_by_default=True),
+    ]
+    resolver = HookActivationResolver(activations=activations)
+    mask = resolver.compute_mask()
+    assert mask & int(EnumHookBit.CI_REMINDER) != 0
+    assert mask & int(EnumHookBit.RUFF_FIX) != 0
+
+
+@pytest.mark.unit
+def test_resolver_none_enabled_by_default_returns_zero_mask() -> None:
+    activations = [
+        ModelHookActivation(hook_bit=EnumHookBit.CI_REMINDER, enabled_by_default=False),
+        ModelHookActivation(hook_bit=EnumHookBit.RUFF_FIX, enabled_by_default=False),
+    ]
+    resolver = HookActivationResolver(activations=activations)
+    mask = resolver.compute_mask()
+    assert mask == 0


### PR DESCRIPTION
## Evidence

Evidence-Source: OCC#818
Evidence-Ticket: OMN-9743

## Summary

Implements `HookActivationResolver` in `omnibase_infra/hooks/` — Track 1 Task 4 of the omniclaude restructure plan (parent epic OMN-9737).

- Creates `src/omnibase_infra/hooks/hook_activation_resolver.py` — resolves a `list[ModelHookActivation]` from omnibase_core into a composite bitmask, setting bits only for `enabled_by_default=True` activations
- Lenient rollout-safety policy: unresolvable activations log a warning and are skipped (never crash the runtime)
- Ships 4 unit tests: mixed enabled/disabled, empty list, all enabled, all disabled

## Context

Depends on `ModelHookActivation` (omnibase_core, already present) and `ModelPackageHookActivations` (omnibase_core PR: feat(OMN-9743): add ModelPackageHookActivations). This resolver is the compositing engine that turns per-package `hook_activations.yaml` declarations into the `ONEX_HOOKS_MASK` bitmask used by `EnumHookBit.hook_enabled()`.

The broad `Exception` catch uses `# noqa: BLE001` per plan spec: lenient rollout-safety policy means partial mask (skipping bad entries) is safer than crashing runtime on malformed activation declarations.

## Test plan

- [ ] `uv run pytest tests/unit/hooks/test_hook_activation_resolver.py -v` — 4 passed
- [ ] `uv run mypy src/omnibase_infra/hooks/hook_activation_resolver.py --strict` — no issues
- [ ] `pre-commit run --all-files` — all hooks passed
- [ ] `HookActivationResolver([ModelHookActivation(hook_bit=CI_REMINDER, enabled_by_default=True)]).compute_mask()` returns mask with `CI_REMINDER` bit set
- [ ] `enabled_by_default=False` activations do NOT set bits
- [ ] Empty activations list returns `0`
