### PR TITLE
feat(OMN-10715): port change-aware CI test selection to omnibase_infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,11 +658,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  # Parallel test execution - 15 splits for ~618 tests each
-  # Split strategy: 9265 tests / 15 = ~618 tests per split (~2-3 min each)
-  # Reduced from 10 splits + -n auto after repeated xdist OOM crashes on shard 3
-  test-parallel:
-    name: Tests (Split ${{ matrix.split }}/15)
+  # ---------------------------------------------------------------------------
+  # Phase 1.6 - Detect Changes (OMN-10715)
+  # ---------------------------------------------------------------------------
+  # Runs detect_test_paths and emits outputs for dynamic matrix shaping.
+  # When ENABLE_SMART_TESTS is off (default), emits a 15-shard matrix with
+  # full_suite_reason=FEATURE_FLAG_OFF so the full-suite pytest step runs.
+  # When the flag is on and the change set is small, emits a smaller matrix
+  # and selected_paths, activating the smart-selection pytest step instead.
+
+  detect-changes:
+    name: Detect Changes
     needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, plugin-env-service-completeness, compose-required-env-coverage, contract-path-preflight, contract-compliance, contract-sync-gate]
     # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
     runs-on: >-
@@ -672,11 +678,12 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    outputs:
+      is_full_suite: ${{ steps.detect.outputs.is_full_suite }}
+      full_suite_reason: ${{ steps.detect.outputs.full_suite_reason }}
+      split_count: ${{ steps.detect.outputs.split_count }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      selected_paths: ${{ steps.detect.outputs.selected_paths }}
 
     steps:
       - name: Checkout code
@@ -692,12 +699,110 @@ jobs:
           cache-version: ${{ env.CACHE_VERSION }}
           cache-enabled: "false"
 
-      - name: Run test split ${{ matrix.split }}/15
+      - name: Compute changed files
+        id: diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            git fetch --no-tags --depth=1 origin "$base" || true
+            git diff --name-only "$base"...HEAD > changed.txt
+          else
+            git diff --name-only HEAD~1 HEAD > changed.txt || echo "" > changed.txt
+          fi
+          echo "Changed files:"
+          cat changed.txt
+
+      - name: Resolve test selection
+        id: detect
+        env:
+          FLAG: ${{ vars.ENABLE_SMART_TESTS == 'true' && 'on' || 'off' }}
+        run: |
+          uv run python -m scripts.ci.detect_test_paths \
+            --changed-files-from changed.txt \
+            --ref-name "${{ github.ref_name }}" \
+            --event-name "${{ github.event_name }}" \
+            --feature-flag "$FLAG" \
+            > selection.json
+          cat selection.json
+          is_full=$(jq -r '.is_full_suite' selection.json)
+          reason=$(jq -r '.full_suite_reason // ""' selection.json)
+          split_count=$(jq -r '.split_count' selection.json)
+          matrix=$(jq -c '.matrix' selection.json)
+          paths=$(jq -c '.selected_paths' selection.json)
+          echo "is_full_suite=$is_full" >> "$GITHUB_OUTPUT"
+          echo "full_suite_reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "split_count=$split_count" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "selected_paths=$paths" >> "$GITHUB_OUTPUT"
+
+      - name: Upload selection artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-selection
+          path: selection.json
+          retention-days: 7
+
+  # Parallel test execution — matrix shape driven by detect-changes output (OMN-10715).
+  # When ENABLE_SMART_TESTS is off (default), detect-changes emits a 15-shard matrix
+  # with full_suite_reason=FEATURE_FLAG_OFF so the full-suite pytest step runs.
+  # When the flag is on and the change set is small, detect-changes emits a smaller
+  # matrix and selected_paths, activating the smart-selection pytest step instead.
+  #
+  # Split strategy: 9265 tests / 15 = ~618 tests per split (~2-3 min each)
+  # Reduced from 10 splits + -n auto after repeated xdist OOM crashes on shard 3
+  test-parallel:
+    name: Tests (Split ${{ matrix.split }}/${{ needs.detect-changes.outputs.split_count }})
+    needs: [lint, onex-validation, migration-freeze, fingerprint-check, demo-loop-gate, topic-enum-drift, topic-naming-lint, topic-drift-check, arch-invariants, schema-handshake, plugin-env-service-completeness, compose-required-env-coverage, contract-path-preflight, contract-compliance, contract-sync-gate, detect-changes]
+    # OMNI_RUNNER_SELECTOR_V1 — trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        split: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
+
+      - name: Run pytest (smart selection)
+        if: vars.ENABLE_SMART_TESTS == 'true' && needs.detect-changes.outputs.is_full_suite == 'false'
+        run: |
+          paths=$(echo '${{ needs.detect-changes.outputs.selected_paths }}' | jq -r '.[]')
+          uv run pytest $paths \
+            --ignore=tests/integration/docker \
+            -m "not slow and not chaos and not kafka and not performance" \
+            --splits ${{ needs.detect-changes.outputs.split_count }} \
+            --group ${{ matrix.split }} \
+            -n 2 --dist loadgroup \
+            --timeout=60 \
+            --timeout-method=thread \
+            --tb=short \
+            --junitxml=junit-${{ matrix.split }}.xml
+
+      - name: Run pytest (full suite)
+        if: vars.ENABLE_SMART_TESTS != 'true' || needs.detect-changes.outputs.is_full_suite == 'true'
         run: |
           uv run pytest tests/ \
             --ignore=tests/integration/docker \
             -m "not slow and not chaos and not kafka and not performance" \
-            --splits 15 \
+            --splits ${{ needs.detect-changes.outputs.split_count }} \
             --group ${{ matrix.split }} \
             -n 2 --dist loadgroup \
             --timeout=60 \
@@ -862,18 +967,19 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    needs: test-parallel
+    needs: [test-parallel, detect-changes]
     if: always()
     steps:
       - name: Check test matrix results
         env:
           TESTS_RESULT: ${{ needs.test-parallel.result }}
+          SPLIT_COUNT: ${{ needs.detect-changes.outputs.split_count }}
         run: |
           if [ "$TESTS_RESULT" != "success" ]; then
             echo "::error::Test matrix failed (result: $TESTS_RESULT)"
             exit 1
           fi
-          echo "All 15 test splits passed"
+          echo "All ${SPLIT_COUNT} test splits passed"
 
   # ============================================================================
   # CROSS-REPO MIGRATION CONFLICT CHECK (OMN-5772)

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Change-aware test path resolution for omnibase_infra CI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+SRC_PREFIX = "src/omnibase_infra/"
+TEST_UNIT_PREFIX = "tests/unit/"
+TEST_INTEGRATION_PREFIX = "tests/integration/"
+
+FULL_SUITE_BRANCHES = {"main"}
+
+# Full suite uses 15 splits (infra CI split count)
+_FULL_SUITE_SPLIT_COUNT = 15
+
+
+def resolve_test_paths(
+    changed_files: list[str],
+    adjacency_path: Path,
+) -> list[str]:
+    """Map changed file paths to deterministic UNIT test directories.
+
+    Behavior:
+      - Source changes under src/omnibase_infra/<module>: include
+        tests/unit/<module>/.
+      - Test-only changes under tests/unit/: include the changed unit-test directory.
+      - Test-only changes under tests/integration/: ignored (integration runs always).
+      - Files outside src/ and tests/unit/: no contribution; caller decides
+        whether to escalate to full suite.
+
+    Adjacency expansion maps each changed module to its reverse dependents,
+    ensuring downstream tests run when a shared module changes.
+    """
+    config = load_adjacency_map(adjacency_path)
+    return _resolve(changed_files, config)
+
+
+def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
+    direct_modules: set[str] = set()
+    selected: set[str] = set()
+
+    for path in changed_files:
+        if path.startswith(SRC_PREFIX):
+            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
+            if module in config.adjacency:
+                direct_modules.add(module)
+        elif path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+
+    expanded: set[str] = set(direct_modules)
+    for module in direct_modules:
+        expanded.update(config.adjacency[module].reverse_deps)
+
+    for module in expanded:
+        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+
+    return sorted(selected)
+
+
+def compute_selection(
+    changed_files: list[str],
+    adjacency_path: Path,
+    ref_name: str,
+    event_name: str = "pull_request",
+    feature_flag_enabled: bool = True,
+) -> ModelTestSelection:
+    config = load_adjacency_map(adjacency_path)
+
+    # 0. Feature flag short-circuit: off → legacy 15-split full suite.
+    if not feature_flag_enabled:
+        return _full_suite(EnumFullSuiteReason.FEATURE_FLAG_OFF)
+
+    # 1. Branch / event escalation.
+    if ref_name in FULL_SUITE_BRANCHES:
+        return _full_suite(EnumFullSuiteReason.MAIN_BRANCH)
+    if event_name == "merge_group":
+        return _full_suite(EnumFullSuiteReason.MERGE_GROUP)
+    if event_name == "schedule":
+        return _full_suite(EnumFullSuiteReason.SCHEDULED)
+
+    # 2. Test infrastructure escalation.
+    for changed in changed_files:
+        if any(
+            changed == infra or changed.startswith(infra.rstrip("/") + "/")
+            for infra in config.test_infrastructure_paths
+        ):
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
+    # 3. Shared module escalation.
+    changed_modules = {
+        path[len(SRC_PREFIX) :].split("/", 1)[0]
+        for path in changed_files
+        if path.startswith(SRC_PREFIX)
+    } & set(config.adjacency.keys())
+    if changed_modules & set(config.shared_modules):
+        return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
+
+    # 4. Threshold escalation: too many distinct modules.
+    if len(changed_modules) >= config.thresholds.modules_changed_for_full_suite:
+        return _full_suite(EnumFullSuiteReason.THRESHOLD_MODULES)
+
+    # 5. Smart selection.
+    selected = _resolve(changed_files, config)
+    if not selected:
+        # Conservative one-shard fallback over the full tests/unit/ tree. This
+        # is NOT a no-op — it runs ~3-5 min of unit tests. It fires for changes
+        # that have no unit-test mapping (doc-only, workflow-only, integration-
+        # only). Per Selector Truth Boundary: safer to run something than nothing.
+        selected = ["tests/unit/"]
+    split_count = _split_count_for(selected)
+
+    return ModelTestSelection(
+        selected_paths=selected,
+        split_count=split_count,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=list(range(1, split_count + 1)),
+    )
+
+
+def _full_suite(reason: EnumFullSuiteReason) -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=_FULL_SUITE_SPLIT_COUNT,
+        is_full_suite=True,
+        full_suite_reason=reason,
+        matrix=list(range(1, _FULL_SUITE_SPLIT_COUNT + 1)),
+    )
+
+
+def _split_count_for(selected_paths: list[str]) -> int:
+    """Conservative heuristic mapping selected path count to split count.
+
+    Thresholds keep small PRs on a single shard (cheap) while preventing
+    pathologically slow runs when many paths survive selection.
+    Infra has a smaller test suite than core, so the ceiling is 5 splits
+    (vs core's 5 — same cap, smaller absolute counts per split).
+    """
+    n = len(selected_paths)
+    if n <= 2:
+        return 1
+    if n <= 5:
+        return 2
+    if n <= 10:
+        return 3
+    if n <= 16:
+        return 4
+    return 5
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve change-aware test paths")
+    parser.add_argument(
+        "--changed-files-from",
+        type=Path,
+        required=True,
+        help="Path to a file with one changed-file path per line.",
+    )
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--event-name", default="pull_request")
+    parser.add_argument(
+        "--adjacency",
+        type=Path,
+        default=Path(__file__).parent / "test_selection_adjacency.yaml",
+    )
+    parser.add_argument(
+        "--feature-flag",
+        choices=("on", "off"),
+        default="on",
+        help="When 'off', emit a FEATURE_FLAG_OFF full-suite selection regardless of changed files.",
+    )
+    args = parser.parse_args(argv)
+
+    changed = [
+        line.strip()
+        for line in args.changed_files_from.read_text().splitlines()
+        if line.strip()
+    ]
+    selection = compute_selection(
+        changed_files=changed,
+        adjacency_path=args.adjacency,
+        ref_name=args.ref_name,
+        event_name=args.event_name,
+        feature_flag_enabled=(args.feature_flag == "on"),
+    )
+    sys.stdout.write(selection.model_dump_json())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+schema_version: 1
+# scripts/ci/test_selection_adjacency.yaml
+# Static adjacency map from src/omnibase_infra/<module> to dependent modules.
+# When a key module changes, every module in `reverse_deps` ALSO has its tests run.
+# Treated as CI contract data — manually curated, reviewed in PRs that change it.
+
+# `shared_modules` is a FULL-SUITE ESCALATION POLICY, not an architectural ontology.
+# Listing a module here means "if this module changes, run the full suite" — it does
+# NOT claim the module is fundamentally more important than others, nor does it map
+# to a permanent layering invariant. Curate based on operational risk + import fan-out.
+# Removing a module from this list is allowed once we have shadow data showing its
+# changes don't surface broad regressions.
+#
+# Selected based on grep import counts (>100 files importing each module):
+#   nodes:   1342 imports  (highest absolute count — many handlers import node contracts)
+#   models:   886 imports  (widest structural fan-out)
+#   enums:    660 imports
+#   runtime:  635 imports
+#   errors:   300 imports
+#   topics:   103 imports  (Kafka contract wiring — any drift has broad impact)
+shared_modules:
+  - models
+  - enums
+  - runtime
+  - errors
+  - nodes
+  - topics
+# Per-repo full-suite escalation thresholds.
+# Infra has ~40 source modules; 6 changed at once indicates a broad cross-cutting change.
+thresholds:
+  modules_changed_for_full_suite: 6
+# Test infrastructure — any change forces the full suite.
+test_infrastructure_paths:
+  - tests/conftest.py
+  - tests/fixtures/
+  - tests/helpers/
+  - pytest.ini
+  - pyproject.toml
+# Reverse dependency edges. Key = changed module; value = modules that import it.
+# When `models` changes, also run tests for everything in `models.reverse_deps`.
+# Note: shared_modules entries here are not consulted at runtime
+# (they trigger full suite first), but kept for completeness/documentation.
+#
+# Discovery method: grep -r "from omnibase_infra.<module>" src/omnibase_infra/ --include="*.py" -l
+# | sed 's|src/omnibase_infra/||' | cut -d'/' -f1 | sort -u
+adjacency:
+  # --- shared modules (full-suite escalation; reverse_deps kept for documentation) ---
+  models:
+    reverse_deps: [adapters, capabilities, cli, dlq, errors, event_bus, handlers, mixins, nodes, observability, probes, projectors, protocols, runtime, services, sinks, topics, utils, validation, verification]
+  enums:
+    reverse_deps: [adapters, cli, dlq, errors, event_bus, gateway, handlers, idempotency, mixins, nodes, observability, projectors, protocols, runtime, services, sinks, topics, types, utils, validation, verification]
+  runtime:
+    reverse_deps: [adapters, cli, dlq, models, nodes, protocols, services, validation]
+  errors:
+    reverse_deps: [adapters, cli, dlq, event_bus, gateway, handlers, idempotency, mixins, nodes, observability, projectors, secret_stores, services, topics, utils, validation]
+  nodes:
+    reverse_deps: [adapters, cli, handlers, models, onboarding, runtime, services, validation]
+  topics:
+    reverse_deps: [adapters, cli, event_bus, handlers, mixins, models, observability, runtime, services, tui, validation]
+  # --- high-impact non-shared modules ---
+  services:
+    reverse_deps: [adapters, dlq, handlers, protocols, runtime]
+  protocols:
+    reverse_deps: [adapters, models, observability, plugins, runtime, services]
+  event_bus:
+    reverse_deps: [adapters, backends, cli, observability, protocols, runtime, services]
+  mixins:
+    reverse_deps: [adapters, dlq, event_bus, handlers, observability, plugins, projectors, runtime, services, utils]
+  utils:
+    reverse_deps: [adapters, cli, dlq, errors, event_bus, handlers, idempotency, observability, onboarding, projectors, runtime, scope, services, verification]
+  handlers:
+    reverse_deps: [adapters, observability, runtime, services]
+  observability:
+    reverse_deps: [event_bus, runtime]
+  adapters:
+    reverse_deps: [handlers, runtime, secret_stores, services]
+  types:
+    reverse_deps: [errors, event_bus, mixins, models, runtime, utils, validation]
+  projectors:
+    reverse_deps: [cli, protocols, runtime, services]
+  validation:
+    reverse_deps: [cli, runtime]
+  idempotency:
+    reverse_deps: [runtime]
+  gateway:
+    reverse_deps: [gateways, runtime]
+  diagnostics:
+    reverse_deps: []
+  dlq:
+    reverse_deps: [runtime]
+  backends:
+    reverse_deps: [runtime]
+  capabilities:
+    reverse_deps: [mixins]
+  onboarding:
+    reverse_deps: []
+  plugins:
+    reverse_deps: [protocols]
+  probes:
+    reverse_deps: []
+  registry:
+    reverse_deps: []
+  tools:
+    reverse_deps: [event_bus, topics]
+  # --- leaf / near-leaf modules ---
+  cli: {reverse_deps: []}
+  clients: {reverse_deps: []}
+  configs: {reverse_deps: []}
+  contracts: {reverse_deps: []}
+  decorators: {reverse_deps: []}
+  docker: {reverse_deps: []}
+  gateways: {reverse_deps: []}
+  hooks: {reverse_deps: []}
+  infrastructure: {reverse_deps: []}
+  migrations: {reverse_deps: []}
+  resources: {reverse_deps: []}
+  schemas: {reverse_deps: []}
+  scope: {reverse_deps: []}
+  scripts: {reverse_deps: []}
+  secret_stores: {reverse_deps: []}
+  sinks: {reverse_deps: []}
+  test_utils: {reverse_deps: []}
+  testing: {reverse_deps: []}
+  tui: {reverse_deps: []}
+  verification: {reverse_deps: []}
+  validators: {reverse_deps: []}
+  shared: {reverse_deps: []}
+  workflows: {reverse_deps: []}

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Load and validate the static module adjacency map."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelAdjacencyEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reverse_deps: list[str] = Field(default_factory=list)
+
+
+class ModelThresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    modules_changed_for_full_suite: int = Field(..., ge=1)
+
+
+class ModelAdjacencyMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(..., ge=1)
+    shared_modules: list[str]
+    thresholds: ModelThresholds
+    test_infrastructure_paths: list[str]
+    adjacency: dict[str, ModelAdjacencyEntry]
+
+    @model_validator(mode="after")
+    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        for shared in self.shared_modules:
+            if shared not in self.adjacency:
+                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
+        for module, entry in self.adjacency.items():
+            for dep in entry.reverse_deps:
+                if dep not in self.adjacency:
+                    raise ValueError(
+                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                    )
+        return self
+
+
+def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pydantic output contract for change-aware test selection."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"
+
+
+TestPath = Annotated[
+    str,
+    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
+]
+
+
+class ModelTestSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_paths: list[TestPath] = Field(..., min_length=1)
+    split_count: int = Field(..., ge=1, le=15)
+    is_full_suite: bool
+    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
+    matrix: list[int] = Field(...)
+
+    @model_validator(mode="after")
+    def validate_full_suite_reason(self) -> Self:
+        if self.is_full_suite and self.full_suite_reason is None:
+            raise ValueError("full_suite_reason required when is_full_suite=True")
+        if not self.is_full_suite and self.full_suite_reason is not None:
+            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
+        if len(self.matrix) != self.split_count:
+            raise ValueError(
+                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
+            )
+        return self

--- a/tests/unit/scripts/ci/__init__.py
+++ b/tests/unit/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.detect_test_paths import compute_selection, resolve_test_paths
+from scripts.ci.test_selection_models import EnumFullSuiteReason
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+
+
+# ---------------------------------------------------------------------------
+# resolve_test_paths — direct path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_single_module_change_resolves_to_one_test_dir() -> None:
+    changed_files = ["src/omnibase_infra/cli/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == ["tests/unit/cli/"]
+
+
+def test_test_only_change_runs_only_changed_test_dir() -> None:
+    changed_files = ["tests/unit/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == ["tests/unit/nodes/"]
+
+
+def test_integration_test_only_change_does_not_select_unit_tests() -> None:
+    # Integration test changes do not contribute to unit-job selection;
+    # the integration job runs all integration tests on every PR anyway.
+    changed_files = ["tests/integration/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []
+
+
+def test_unknown_source_path_produces_no_selection() -> None:
+    # Files outside src/ and tests/unit/ — no unit-test mapping.
+    changed_files = ["docs/README.md", ".github/workflows/foo.yml"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []
+
+
+def test_leaf_module_change_expands_to_its_reverse_deps() -> None:
+    # `diagnostics` has no reverse deps — only its own unit tests run.
+    changed_files = ["src/omnibase_infra/diagnostics/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == ["tests/unit/diagnostics/"]
+
+
+def test_services_module_expands_to_reverse_deps() -> None:
+    # services is imported by adapters, dlq, handlers, protocols, runtime
+    changed_files = ["src/omnibase_infra/services/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    expected = sorted(
+        f"tests/unit/{m}/"
+        for m in ("services", "adapters", "dlq", "handlers", "protocols", "runtime")
+    )
+    assert paths == expected
+
+
+# ---------------------------------------------------------------------------
+# compute_selection — escalation logic
+# ---------------------------------------------------------------------------
+
+
+def test_shared_module_change_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+    assert selection.split_count == 15
+    assert selection.matrix == list(range(1, 16))
+
+
+def test_test_infrastructure_change_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["tests/conftest.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_pyproject_toml_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["pyproject.toml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_threshold_module_count_escalates() -> None:
+    # 6 distinct non-shared modules changed → THRESHOLD_MODULES.
+    changed_files = [
+        f"src/omnibase_infra/{m}/x.py"
+        for m in ["cli", "clients", "configs", "decorators", "docker", "gateways"]
+    ]
+    selection = compute_selection(
+        changed_files=changed_files,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.THRESHOLD_MODULES
+
+
+def test_main_branch_always_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/cli/x.py"],
+        adjacency_path=ADJ,
+        ref_name="main",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.MAIN_BRANCH
+
+
+def test_small_change_returns_smart_selection_no_reason() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert "tests/unit/cli/" in selection.selected_paths
+    assert 1 <= selection.split_count <= 5
+    assert selection.matrix == list(range(1, selection.split_count + 1))
+
+
+def test_no_matching_files_falls_back_to_unit_root() -> None:
+    # Doc-only change has no unit-test mapping → conservative fallback.
+    selection = compute_selection(
+        changed_files=["docs/something.md"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.split_count == 1
+
+
+def test_feature_flag_off_returns_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        feature_flag_enabled=False,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.FEATURE_FLAG_OFF
+    assert selection.split_count == 15
+    assert selection.matrix == list(range(1, 16))
+
+
+def test_schedule_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="schedule",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SCHEDULED
+    assert selection.split_count == 15
+    assert selection.matrix == list(range(1, 16))
+
+
+def test_merge_group_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="merge_group",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.MERGE_GROUP
+    assert selection.split_count == 15
+    assert selection.matrix == list(range(1, 16))
+
+
+def test_full_suite_split_count_is_15() -> None:
+    """Infra uses 15 splits (not 40 like core)."""
+    selection = compute_selection(
+        changed_files=["src/omnibase_infra/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.split_count == 15
+    assert len(selection.matrix) == 15

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_load_adjacency_map_parses_repo_yaml() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    assert isinstance(config, ModelAdjacencyMap)
+    assert config.schema_version == 1
+    assert "models" in config.shared_modules
+    assert "models" in config.adjacency
+
+
+def test_load_rejects_unknown_shared_module(tmp_path: Path) -> None:
+    bad_yaml = """
+schema_version: 1
+shared_modules: [does_not_exist]
+thresholds:
+  modules_changed_for_full_suite: 6
+test_infrastructure_paths: []
+adjacency:
+  nodes: { reverse_deps: [] }
+"""
+    tmp = tmp_path / "bad_adj.yaml"
+    tmp.write_text(bad_yaml)
+    with pytest.raises(ValueError, match="shared_module 'does_not_exist'"):
+        load_adjacency_map(tmp)
+
+
+def test_every_src_module_has_adjacency_entry() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    src_root = REPO_ROOT / "src/omnibase_infra"
+    src_modules = {
+        p.name for p in src_root.iterdir() if p.is_dir() and not p.name.startswith("_")
+    }
+    missing = src_modules - set(config.adjacency.keys())
+    assert not missing, f"Modules missing adjacency entry: {missing}"
+
+
+def test_load_rejects_invalid_reverse_dep_reference(tmp_path: Path) -> None:
+    bad_yaml = """
+schema_version: 1
+shared_modules: [models]
+thresholds:
+  modules_changed_for_full_suite: 6
+test_infrastructure_paths: []
+adjacency:
+  models: { reverse_deps: [nonexistent_module] }
+"""
+    tmp = tmp_path / "bad_rev.yaml"
+    tmp.write_text(bad_yaml)
+    with pytest.raises(ValueError, match="unknown module 'nonexistent_module'"):
+        load_adjacency_map(tmp)
+
+
+def test_threshold_loaded_correctly() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    assert config.thresholds.modules_changed_for_full_suite == 6

--- a/tests/unit/scripts/ci/test_test_selection_models.py
+++ b/tests/unit/scripts/ci/test_test_selection_models.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import pytest
+from pydantic import ValidationError
+
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_full_suite_selection_serializes_with_reason() -> None:
+    selection = ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=15,
+        is_full_suite=True,
+        full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+        matrix=list(range(1, 16)),
+    )
+    payload = selection.model_dump(mode="json")
+    assert payload == {
+        "selected_paths": ["tests/"],
+        "split_count": 15,
+        "is_full_suite": True,
+        "full_suite_reason": "shared_module",
+        "matrix": list(range(1, 16)),
+    }
+
+
+def test_smart_selection_disallows_full_suite_reason() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=2,
+            is_full_suite=False,
+            full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+            matrix=[1, 2],
+        )
+
+
+def test_matrix_length_matches_split_count() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=3,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=[1, 2],  # length mismatch
+        )
+
+
+def test_split_count_bounded_by_15() -> None:
+    """Infra max split count is 15, not 40."""
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/"],
+            split_count=40,  # core uses 40; infra max is 15
+            is_full_suite=True,
+            full_suite_reason=EnumFullSuiteReason.MAIN_BRANCH,
+            matrix=list(range(1, 41)),
+        )
+
+
+def test_smart_selection_no_reason() -> None:
+    selection = ModelTestSelection(
+        selected_paths=["tests/unit/cli/"],
+        split_count=1,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=[1],
+    )
+    assert selection.split_count == 1
+    assert selection.matrix == [1]
+    assert selection.full_suite_reason is None


### PR DESCRIPTION
## Summary

- Ports the change-aware CI test selection system from `omnibase_core` to `omnibase_infra`
- Adds `detect-changes` CI job that maps changed source files to affected test paths, emitting a dynamic matrix
- `test-parallel` now uses `fromJson(needs.detect-changes.outputs.matrix)` — small PRs run 1–5 shards instead of all 15; full suite is preserved for shared modules / main branch / merge_group / schedule / feature-flag-off
- Feature flag: `ENABLE_SMART_TESTS` GitHub Actions repo variable (default off = legacy 15-split full suite)

## Files added

| File | Purpose |
|------|---------|
| `scripts/ci/test_selection_models.py` | Pydantic contract: `ModelTestSelection`, `EnumFullSuiteReason`; `split_count` capped at 15 |
| `scripts/ci/test_selection_loader.py` | YAML adjacency map loader with Pydantic validation |
| `scripts/ci/detect_test_paths.py` | CLI + `compute_selection()` with full escalation logic |
| `scripts/ci/test_selection_adjacency.yaml` | Static adjacency map for all 51 infra source modules |
| `tests/unit/scripts/ci/` | 27 unit tests (27/27 passing) |

## Escalation policy

- **Full suite always**: `main` branch, `merge_group`, `schedule` event, `ENABLE_SMART_TESTS=off`
- **Full suite on shared modules** (>100 import fan-out): `models` (886), `nodes` (1342), `enums` (660), `runtime` (635), `errors` (300), `topics` (103)
- **Full suite on threshold**: ≥6 distinct non-shared modules changed
- **Full suite on test infrastructure**: `tests/conftest.py`, `tests/fixtures/`, `tests/helpers/`, `pyproject.toml`, `pytest.ini`
- **Smart selection otherwise**: changed modules expanded via reverse-dep graph → 1–5 shards

## Test plan

- [x] `uv run pytest tests/unit/scripts/ci/ -v` → 27/27 passed
- [x] `pre-commit run --all-files` → all hooks pass
- [x] `uv run ruff format scripts/ci/ tests/unit/scripts/ci/` → no changes
- [x] `yamlfmt` auto-corrected adjacency YAML formatting; re-validated all reverse_deps references after reformatting

Ticket: OMN-10715

## Evidence

Evidence-Source: OCC#828
Evidence-Ticket: OMN-10715