### PR TITLE
fix(OMN-9713): harden deploy-agent runtime redeploy

### DIFF
--- a/contracts/OMN-9713.yaml
+++ b/contracts/OMN-9713.yaml
@@ -3,6 +3,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: "OMN-9713"
+title: "fix(OMN-9713): harden deploy-agent runtime redeploy — single Kafka bus, SASL_SSL support"
 summary: "fix(deploy-agent): use one explicit Kafka control bus for consume and publish"
 is_seam_ticket: false
 interface_change: false

--- a/scripts/deploy-agent/deploy-agent-trigger.sh
+++ b/scripts/deploy-agent/deploy-agent-trigger.sh
@@ -111,11 +111,13 @@ import os
 secret         = os.environ["DEPLOY_AGENT_HMAC_SECRET"]
 correlation_id = os.environ["_TRIGGER_CORRELATION_ID"]
 git_ref        = os.environ["_TRIGGER_GIT_REF"]
+reason         = os.environ["_TRIGGER_REASON"]
 requested_by   = os.environ["_TRIGGER_REQUESTED_BY"]
 
 envelope = {
     "correlation_id": correlation_id,
     "git_ref":        git_ref,
+    "reason":         reason,
     "requested_by":   requested_by,
     "scope":          "runtime",
     "services":       [],

--- a/scripts/deploy-agent/deploy-agent-trigger.sh
+++ b/scripts/deploy-agent/deploy-agent-trigger.sh
@@ -83,8 +83,10 @@ if command -v kcat &>/dev/null; then
     _publish_tool="kcat"
 elif command -v rpk &>/dev/null; then
     _publish_tool="rpk"
+elif command -v docker &>/dev/null && docker exec omnibase-infra-redpanda rpk version &>/dev/null; then
+    _publish_tool="docker-rpk"
 elif [[ $DRY_RUN -eq 0 ]]; then
-    echo "ERROR: kcat (or rpk) not found. Install kcat: brew install kcat" >&2
+    echo "ERROR: kcat, rpk, or dockerized redpanda rpk not found." >&2
     exit 1
 fi
 
@@ -106,19 +108,14 @@ import hashlib
 import hmac
 import json
 import os
-from datetime import UTC, datetime
-
 secret         = os.environ["DEPLOY_AGENT_HMAC_SECRET"]
 correlation_id = os.environ["_TRIGGER_CORRELATION_ID"]
 git_ref        = os.environ["_TRIGGER_GIT_REF"]
-reason         = os.environ["_TRIGGER_REASON"]
 requested_by   = os.environ["_TRIGGER_REQUESTED_BY"]
 
 envelope = {
     "correlation_id": correlation_id,
     "git_ref":        git_ref,
-    "reason":         reason,
-    "requested_at":   datetime.now(UTC).isoformat(),
     "requested_by":   requested_by,
     "scope":          "runtime",
     "services":       [],
@@ -172,8 +169,7 @@ if [[ "$_publish_tool" == "kcat" ]]; then
     fi
     # SIGNED_JSON piped via stdin — not passed as a shell argument
     echo "manual-${CORRELATION_ID}/${SIGNED_JSON}" | kcat "${KCAT_ARGS[@]}"
-else
-    # rpk fallback — used on .201 where rpk is available inside/outside containers
+elif [[ "$_publish_tool" == "rpk" ]]; then
     RPK_ARGS=(--brokers "${KAFKA_BOOTSTRAP_SERVERS}" --key "manual-${CORRELATION_ID}")
     if [[ -n "${KAFKA_SASL_USERNAME:-}" && -n "${KAFKA_SASL_PASSWORD:-}" ]]; then
         RPK_ARGS+=(
@@ -184,6 +180,10 @@ else
         )
     fi
     rpk topic produce "${TOPIC}" "${RPK_ARGS[@]}" <<< "${SIGNED_JSON}"
+else
+    docker exec -i omnibase-infra-redpanda \
+        rpk topic produce "${TOPIC}" --brokers localhost:9092 \
+        --key "manual-${CORRELATION_ID}" <<< "${SIGNED_JSON}"
 fi
 
 echo "Published. correlation_id=${CORRELATION_ID}"

--- a/scripts/deploy-agent/deploy_agent/consumer.py
+++ b/scripts/deploy-agent/deploy_agent/consumer.py
@@ -78,9 +78,11 @@ class DeployConsumer:
             self.consumer.commit()
             return None, "invalid_signature"
 
-        # Step 3: Validate payload
+        # Step 3: Validate payload. The signature is transport metadata, not
+        # part of the command contract itself.
         try:
-            cmd = ModelRebuildRequested.model_validate(payload)
+            command_payload = {k: v for k, v in payload.items() if k != "_signature"}
+            cmd = ModelRebuildRequested.model_validate(command_payload)
         except Exception as e:  # noqa: BLE001
             logger.warning(
                 "Invalid payload (correlation_id=%s): %s",
@@ -105,7 +107,7 @@ class DeployConsumer:
         # Step 6: Persist job state
         self.job_store.accept(
             correlation_id=cmd.correlation_id,
-            command=payload,
+            command=command_payload,
         )
 
         # Step 7: Commit offset

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -32,8 +32,10 @@ SCOPE_BUNDLES: dict[Scope, list[str]] = {
 
 logger = logging.getLogger(__name__)
 
-REPO_DIR = "/data/omninode/omnibase_infra"
-DEPLOY_AGENT_DIR = f"{REPO_DIR}/scripts/deploy-agent"
+REPO_DIR = os.environ.get(
+    "DEPLOY_AGENT_REPO_DIR", "/data/omninode/omni_home/omnibase_infra"
+)
+DEPLOY_AGENT_DIR = os.environ.get("DEPLOY_AGENT_DIR", "/data/omninode/deploy-agent")
 COMPOSE_FILE = f"{REPO_DIR}/docker/docker-compose.infra.yml"
 COMPOSE_PROJECT = "omnibase-infra"
 
@@ -133,6 +135,24 @@ def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
     )
 
 
+def _compose_env() -> dict[str, str]:
+    env = dict(os.environ)
+    postgres_dsn = env.get("OMNIDASH_ANALYTICS_DB_URL") or (
+        "postgresql://postgres:"
+        f"{env.get('POSTGRES_PASSWORD', 'postgres')}@127.0.0.1:5436/omnidash_analytics"
+    )
+    defaults = {
+        "CI_CALLBACK_TOKEN": "deploy-agent-compose-parse-only",
+        "LINEAR_WEBHOOK_SECRET": "deploy-agent-compose-parse-only",
+        "WAITLIST_NOTIFIER_SLACK_BOT_TOKEN": "deploy-agent-compose-parse-only",
+        "WAITLIST_NOTIFIER_SLACK_CHANNEL_ID": "deploy-agent-compose-parse-only",
+        "OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN": postgres_dsn,
+    }
+    for key, value in defaults.items():
+        env.setdefault(key, value)
+    return env
+
+
 def _runtime_health_passed(result: subprocess.CompletedProcess) -> bool:
     """Return whether a runtime /health response proves deploy readiness."""
     if result.returncode != 0:
@@ -153,51 +173,84 @@ def _runtime_health_passed(result: subprocess.CompletedProcess) -> bool:
     )
 
 
+def _compose_service_states() -> dict[str, tuple[str, int | None]]:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            COMPOSE_FILE,
+            "-p",
+            COMPOSE_PROJECT,
+            "ps",
+            "-a",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_compose_env(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr[:200])
+    states: dict[str, tuple[str, int | None]] = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        service = str(payload.get("Service") or "")
+        if not service:
+            continue
+        exit_code = payload.get("ExitCode")
+        states[service] = (
+            str(payload.get("State") or ""),
+            exit_code if isinstance(exit_code, int) else None,
+        )
+    return states
+
+
+def _service_satisfied(state: str, exit_code: int | None) -> bool:
+    if state == "running":
+        return True
+    return state == "exited" and exit_code == 0
+
+
 def verify_containers_up(
     expected_containers: list[str], timeout_s: int = 120
 ) -> tuple[bool, list[str]]:
-    """Poll docker ps until all expected containers are running or timeout expires."""
+    """Poll compose until services are running or completed successfully."""
     deadline = time.monotonic() + timeout_s
+    last_states: dict[str, tuple[str, int | None]] = {}
     while time.monotonic() < deadline:
-        result = subprocess.run(
-            ["docker", "ps", "--format", "{{.Names}}\t{{.State}}"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            logger.warning(
-                "verify_containers_up: docker ps failed: %s", result.stderr[:200]
-            )
+        try:
+            last_states = _compose_service_states()
+        except RuntimeError as exc:
+            logger.warning("verify_containers_up: docker compose ps failed: %s", exc)
             time.sleep(2)
             continue
-        states = {
-            parts[0]: parts[1]
-            for line in result.stdout.strip().splitlines()
-            if (parts := line.split("\t", 1)) and len(parts) == 2
-        }
-        missing = [c for c in expected_containers if states.get(c) != "running"]
+        missing = [
+            service
+            for service in expected_containers
+            if not _service_satisfied(*last_states.get(service, ("missing", None)))
+        ]
         if not missing:
             return True, []
         logger.info(
-            "verify_containers_up: waiting for %d container(s): %s",
+            "verify_containers_up: waiting for %d service(s): %s",
             len(missing),
             missing,
         )
         time.sleep(2)
-    # Final check to report exactly what is still not running
-    result = subprocess.run(
-        ["docker", "ps", "--format", "{{.Names}}\t{{.State}}"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    states = {
-        parts[0]: parts[1]
-        for line in result.stdout.strip().splitlines()
-        if (parts := line.split("\t", 1)) and len(parts) == 2
-    }
-    missing = [c for c in expected_containers if states.get(c) != "running"]
+    try:
+        last_states = _compose_service_states()
+    except RuntimeError:
+        last_states = {}
+    missing = [
+        service
+        for service in expected_containers
+        if not _service_satisfied(*last_states.get(service, ("missing", None)))
+    ]
     return False, missing
 
 
@@ -445,7 +498,7 @@ class DeployExecutor:
             COMPOSE_FILE,
         ]
 
-        result = _run(cmd, timeout=timeout, cwd=REPO_DIR)
+        result = _run(cmd, timeout=timeout, cwd=REPO_DIR, env=_compose_env())
         if result.returncode != 0:
             logger.warning(
                 "compose_gen returned non-zero (exit=%d) — continuing with existing compose file. stderr: %s",
@@ -506,7 +559,7 @@ class DeployExecutor:
         result = _run(
             cmd,
             timeout=timeout,
-            env={**__import__("os").environ, "PYTHONPATH": f"{REPO_DIR}/src"},
+            env={**_compose_env(), "PYTHONPATH": f"{REPO_DIR}/src"},
         )
         if result.returncode != 0:
             logger.warning(
@@ -587,9 +640,23 @@ class DeployExecutor:
                 expected_build_source=expected_build_source,
             )
         )
-        result = _run(cmd, timeout=timeout)
+        result = _run(cmd, timeout=timeout, env=_compose_env())
         if result.returncode != 0:
             raise RuntimeError(f"Docker compose build failed: {result.stderr}")
+        if scope == Scope.RUNTIME:
+            tag_result = _run(
+                [
+                    "docker",
+                    "tag",
+                    "omnibase-infra-omninode-runtime:latest",
+                    "runtime:latest",
+                ],
+                timeout=30,
+            )
+            if tag_result.returncode != 0:
+                raise RuntimeError(
+                    f"Docker runtime image tag failed: {tag_result.stderr}"
+                )
 
     def _compose_up(
         self,
@@ -616,7 +683,7 @@ class DeployExecutor:
             "-d",
             "--force-recreate",
             "--pull",
-            "always",
+            "never" if scope == Scope.RUNTIME else "always",
         ]
         # OMN-9455: runtime scope must pass --no-deps so compose cannot recreate
         # the core infra services (postgres/redpanda/valkey/infisical) declared
@@ -626,9 +693,13 @@ class DeployExecutor:
         if requested_services:
             cmd.extend(requested_services)
 
-        result = _run(cmd, timeout=timeout)
-        if result.returncode != 0:
-            raise RuntimeError(f"Docker compose up failed: {result.stderr}")
+        result = _run(cmd, timeout=timeout, env=_compose_env())
+        compose_up_error = result.stderr.strip() if result.returncode != 0 else ""
+        if compose_up_error:
+            logger.warning(
+                "Docker compose up returned non-zero; verifying live service state before failing: %s",
+                compose_up_error[:500],
+            )
 
         # Verify containers actually reached running state — docker compose up exits 0
         # even when containers land in Created state (hit twice in production, 01:33 + 04:48).
@@ -651,10 +722,22 @@ class DeployExecutor:
             )
             for name in stuck:
                 start_result = subprocess.run(
-                    ["docker", "start", name],
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        COMPOSE_FILE,
+                        "-p",
+                        COMPOSE_PROJECT,
+                        "up",
+                        "-d",
+                        "--no-deps",
+                        name,
+                    ],
                     capture_output=True,
                     text=True,
                     check=False,
+                    env=_compose_env(),
                 )
                 if start_result.returncode == 0:
                     logger.info("docker start %s: ok", name)
@@ -664,9 +747,12 @@ class DeployExecutor:
                     )
             ok, stuck = verify_containers_up(expected, timeout_s=60)
             if not ok:
-                raise RuntimeError(
+                detail = (
                     f"Containers still not running after docker start recovery: {stuck}"
                 )
+                if compose_up_error:
+                    detail = f"Docker compose up failed: {compose_up_error}; {detail}"
+                raise RuntimeError(detail)
             logger.info("Recovery succeeded — all containers now running")
 
         on_phase_update(phase, PhaseStatus.SUCCESS)

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -137,9 +137,11 @@ def _run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
 
 def _compose_env() -> dict[str, str]:
     env = dict(os.environ)
+    postgres_host = env.get("POSTGRES_HOST", "127.0.0.1")
+    postgres_port = env.get("POSTGRES_PORT", "5436")
     postgres_dsn = env.get("OMNIDASH_ANALYTICS_DB_URL") or (
         "postgresql://postgres:"
-        f"{env.get('POSTGRES_PASSWORD', 'postgres')}@127.0.0.1:5436/omnidash_analytics"
+        f"{env.get('POSTGRES_PASSWORD', 'postgres')}@{postgres_host}:{postgres_port}/omnidash_analytics"
     )
     defaults = {
         "CI_CALLBACK_TOKEN": "deploy-agent-compose-parse-only",

--- a/scripts/deploy-agent/tests/unit/test_consumer_signed_payload.py
+++ b/scripts/deploy-agent/tests/unit/test_consumer_signed_payload.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Signed transport envelopes should validate as deploy commands."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from deploy_agent.consumer import DeployConsumer
+
+
+def test_signed_payload_strips_signature_before_command_validation() -> None:
+    consumer = DeployConsumer.__new__(DeployConsumer)
+    consumer.consumer = Mock()
+    consumer.job_store = Mock()
+    consumer.job_store.has_active_job.return_value = False
+    consumer.job_store.is_duplicate.return_value = False
+
+    payload = {
+        "correlation_id": "aaaaaaaa-0000-0000-0000-000000000001",
+        "git_ref": "origin/main",
+        "requested_by": "operator-manual",
+        "scope": "runtime",
+        "services": [],
+        "_signature": "a" * 64,
+    }
+
+    with patch("deploy_agent.consumer.verify_command", return_value=True):
+        cmd, reason = consumer._process_message(SimpleNamespace(value=payload))
+
+    assert reason is None
+    assert cmd is not None
+    consumer.job_store.accept.assert_called_once()
+    accepted = consumer.job_store.accept.call_args.kwargs["command"]
+    assert "_signature" not in accepted

--- a/scripts/deploy-agent/tests/unit/test_consumer_signed_payload.py
+++ b/scripts/deploy-agent/tests/unit/test_consumer_signed_payload.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from deploy_agent.consumer import DeployConsumer
 
 
+@pytest.mark.unit
 def test_signed_payload_strips_signature_before_command_validation() -> None:
     consumer = DeployConsumer.__new__(DeployConsumer)
     consumer.consumer = Mock()

--- a/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
@@ -9,6 +9,7 @@ at 01:33 and 04:48 on 2026-04-13.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest.mock import call, patch
 
@@ -16,17 +17,29 @@ import pytest
 from deploy_agent.executor import verify_containers_up
 
 
-def _make_ps_result(
-    name_state_pairs: list[tuple[str, str]],
+def _make_compose_ps_result(
+    service_state_pairs: list[tuple[str, str]],
+    *,
+    exit_codes: dict[str, int] | None = None,
 ) -> subprocess.CompletedProcess:
-    stdout = "\n".join(f"{name}\t{state}" for name, state in name_state_pairs)
+    exit_codes = exit_codes or {}
+    stdout = "\n".join(
+        json.dumps(
+            {
+                "Service": service,
+                "State": state,
+                "ExitCode": exit_codes.get(service, 0),
+            }
+        )
+        for service, state in service_state_pairs
+    )
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
 def test_all_running_returns_true() -> None:
     """Returns (True, []) immediately when all containers are running."""
     containers = ["postgres", "redpanda", "valkey"]
-    ps_output = _make_ps_result([(c, "running") for c in containers])
+    ps_output = _make_compose_ps_result([(c, "running") for c in containers])
 
     with patch(
         "deploy_agent.executor.subprocess.run", return_value=ps_output
@@ -42,7 +55,9 @@ def test_created_state_detected_as_missing() -> None:
     """Containers in Created state are treated as not running (the OMN-8668 bug)."""
     containers = ["postgres", "redpanda"]
     # redpanda stuck in Created — the exact failure mode
-    ps_output = _make_ps_result([("postgres", "running"), ("redpanda", "created")])
+    ps_output = _make_compose_ps_result(
+        [("postgres", "running"), ("redpanda", "created")]
+    )
 
     call_count = 0
 
@@ -64,8 +79,12 @@ def test_created_state_detected_as_missing() -> None:
 def test_recovery_on_second_poll() -> None:
     """Returns (True, []) when container transitions to running on second poll."""
     containers = ["postgres", "redpanda"]
-    first_call = _make_ps_result([("postgres", "running"), ("redpanda", "created")])
-    second_call = _make_ps_result([("postgres", "running"), ("redpanda", "running")])
+    first_call = _make_compose_ps_result(
+        [("postgres", "running"), ("redpanda", "created")]
+    )
+    second_call = _make_compose_ps_result(
+        [("postgres", "running"), ("redpanda", "running")]
+    )
 
     responses = [first_call, second_call]
 
@@ -83,7 +102,7 @@ def test_docker_ps_failure_skips_iteration() -> None:
     fail_result = subprocess.CompletedProcess(
         args=[], returncode=1, stdout="", stderr="docker daemon unavailable"
     )
-    ok_result = _make_ps_result([("postgres", "running")])
+    ok_result = _make_compose_ps_result([("postgres", "running")])
 
     with patch(
         "deploy_agent.executor.subprocess.run", side_effect=[fail_result, ok_result]
@@ -97,7 +116,7 @@ def test_docker_ps_failure_skips_iteration() -> None:
 
 def test_empty_expected_list_returns_true() -> None:
     """Empty expected list means nothing to wait for — return True immediately."""
-    ps_output = _make_ps_result([])
+    ps_output = _make_compose_ps_result([])
 
     with patch("deploy_agent.executor.subprocess.run", return_value=ps_output):
         ok, stuck = verify_containers_up([], timeout_s=10)
@@ -109,7 +128,7 @@ def test_empty_expected_list_returns_true() -> None:
 def test_timeout_returns_false_with_stuck_list() -> None:
     """When timeout expires, returns (False, <stuck containers>)."""
     containers = ["postgres", "omninode-runtime"]
-    stuck_output = _make_ps_result(
+    stuck_output = _make_compose_ps_result(
         [("postgres", "running"), ("omninode-runtime", "created")]
     )
 
@@ -125,3 +144,18 @@ def test_timeout_returns_false_with_stuck_list() -> None:
     assert ok is False
     assert "omninode-runtime" in stuck
     assert "postgres" not in stuck
+
+
+def test_completed_one_shot_service_is_satisfied() -> None:
+    """Successful one-shot services do not need to remain running."""
+    containers = ["intelligence-migration", "omninode-runtime"]
+    ps_output = _make_compose_ps_result(
+        [("intelligence-migration", "exited"), ("omninode-runtime", "running")],
+        exit_codes={"intelligence-migration": 0},
+    )
+
+    with patch("deploy_agent.executor.subprocess.run", return_value=ps_output):
+        ok, stuck = verify_containers_up(containers, timeout_s=10)
+
+    assert ok is True
+    assert stuck == []

--- a/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_start_verify.py
@@ -36,6 +36,7 @@ def _make_compose_ps_result(
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
+@pytest.mark.unit
 def test_all_running_returns_true() -> None:
     """Returns (True, []) immediately when all containers are running."""
     containers = ["postgres", "redpanda", "valkey"]
@@ -51,6 +52,7 @@ def test_all_running_returns_true() -> None:
     assert mock_run.call_count == 1
 
 
+@pytest.mark.unit
 def test_created_state_detected_as_missing() -> None:
     """Containers in Created state are treated as not running (the OMN-8668 bug)."""
     containers = ["postgres", "redpanda"]
@@ -76,6 +78,7 @@ def test_created_state_detected_as_missing() -> None:
     assert "postgres" not in stuck
 
 
+@pytest.mark.unit
 def test_recovery_on_second_poll() -> None:
     """Returns (True, []) when container transitions to running on second poll."""
     containers = ["postgres", "redpanda"]
@@ -96,6 +99,7 @@ def test_recovery_on_second_poll() -> None:
     assert stuck == []
 
 
+@pytest.mark.unit
 def test_docker_ps_failure_skips_iteration() -> None:
     """When docker ps returns non-zero, loop retries rather than crashing."""
     containers = ["postgres"]
@@ -114,6 +118,7 @@ def test_docker_ps_failure_skips_iteration() -> None:
     assert stuck == []
 
 
+@pytest.mark.unit
 def test_empty_expected_list_returns_true() -> None:
     """Empty expected list means nothing to wait for — return True immediately."""
     ps_output = _make_compose_ps_result([])
@@ -125,6 +130,7 @@ def test_empty_expected_list_returns_true() -> None:
     assert stuck == []
 
 
+@pytest.mark.unit
 def test_timeout_returns_false_with_stuck_list() -> None:
     """When timeout expires, returns (False, <stuck containers>)."""
     containers = ["postgres", "omninode-runtime"]
@@ -146,6 +152,7 @@ def test_timeout_returns_false_with_stuck_list() -> None:
     assert "postgres" not in stuck
 
 
+@pytest.mark.unit
 def test_completed_one_shot_service_is_satisfied() -> None:
     """Successful one-shot services do not need to remain running."""
     containers = ["intelligence-migration", "omninode-runtime"]

--- a/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
+++ b/scripts/deploy-agent/tests/unit/test_trigger_helper_signature.py
@@ -31,8 +31,6 @@ def _sign_like_trigger_sh(envelope: dict, secret: str) -> dict:
 _SAMPLE_ENVELOPE = {
     "correlation_id": "aaaaaaaa-0000-0000-0000-000000000001",
     "git_ref": "origin/main",
-    "reason": "manual trigger by operator",
-    "requested_at": "2026-04-21T12:00:00+00:00",
     "requested_by": "operator-manual",
     "scope": "runtime",
     "services": [],
@@ -83,8 +81,6 @@ def test_sort_keys_order_is_canonical() -> None:
         "services": [],
         "scope": "runtime",
         "requested_by": "operator-manual",
-        "requested_at": "2026-04-21T12:00:00+00:00",
-        "reason": "manual trigger by operator",
         "git_ref": "origin/main",
         "correlation_id": "aaaaaaaa-0000-0000-0000-000000000001",
     }

--- a/tests/unit/services/observability/skill_lifecycle/test_consumer.py
+++ b/tests/unit/services/observability/skill_lifecycle/test_consumer.py
@@ -133,9 +133,7 @@ class TestConsumerMetrics:
     def test_record_received_increments(self) -> None:
         """record_received increments messages_received and sets last_poll_at."""
         metrics = ConsumerMetrics()
-        asyncio.get_event_loop().run_until_complete(
-            metrics.record_received(count=3, topic="topic-a")
-        )
+        asyncio.run(metrics.record_received(count=3, topic="topic-a"))
 
         assert metrics.messages_received == 3
         assert metrics.last_poll_at is not None
@@ -145,9 +143,7 @@ class TestConsumerMetrics:
     def test_record_processed_increments(self) -> None:
         """record_processed increments messages_processed and sets last_successful_write_at."""
         metrics = ConsumerMetrics()
-        asyncio.get_event_loop().run_until_complete(
-            metrics.record_processed(count=2, topic="topic-b")
-        )
+        asyncio.run(metrics.record_processed(count=2, topic="topic-b"))
 
         assert metrics.messages_processed == 2
         assert metrics.last_successful_write_at is not None
@@ -157,9 +153,7 @@ class TestConsumerMetrics:
     def test_record_failed_increments(self) -> None:
         """record_failed increments messages_failed."""
         metrics = ConsumerMetrics()
-        asyncio.get_event_loop().run_until_complete(
-            metrics.record_failed(count=1, topic="topic-c")
-        )
+        asyncio.run(metrics.record_failed(count=1, topic="topic-c"))
 
         assert metrics.messages_failed == 1
         assert metrics.per_topic_failed.get("topic-c") == 1
@@ -168,9 +162,7 @@ class TestConsumerMetrics:
     def test_record_batch_processed_increments(self) -> None:
         """record_batch_processed increments batches_processed."""
         metrics = ConsumerMetrics()
-        asyncio.get_event_loop().run_until_complete(
-            metrics.record_batch_processed(latency_ms=42.0)
-        )
+        asyncio.run(metrics.record_batch_processed(latency_ms=42.0))
 
         assert metrics.batches_processed == 1
         assert metrics.batch_latency_ms == [42.0]
@@ -179,7 +171,7 @@ class TestConsumerMetrics:
     def test_snapshot_contains_expected_keys(self) -> None:
         """Snapshot dict contains all expected metric keys."""
         metrics = ConsumerMetrics()
-        snapshot = asyncio.get_event_loop().run_until_complete(metrics.snapshot())
+        snapshot = asyncio.run(metrics.snapshot())
 
         expected_keys = {
             "messages_received",
@@ -204,9 +196,8 @@ class TestConsumerMetrics:
         """Latency ring buffer is capped at MAX_LATENCY_SAMPLES."""
         metrics = ConsumerMetrics()
 
-        loop = asyncio.get_event_loop()
         for i in range(ConsumerMetrics.MAX_LATENCY_SAMPLES + 10):
-            loop.run_until_complete(metrics.record_batch_processed(latency_ms=float(i)))
+            asyncio.run(metrics.record_batch_processed(latency_ms=float(i)))
 
         assert len(metrics.batch_latency_ms) == ConsumerMetrics.MAX_LATENCY_SAMPLES
 


### PR DESCRIPTION
## Summary
- strip deploy-agent HMAC `_signature` before validating the command model
- separate deploy-agent install dir from the target repo dir and pass compose parse-only env defaults
- make runtime deploys use local runtime image tags, compose service-state verification, one-shot completion handling, and dockerized rpk trigger fallback

## Verification
- `.201` live signed runtime deploy: `5fd6078d-cf9c-4d9a-a3b7-326c18e82b12` completed `success` through publish
- `.201` installed deploy-agent tests: `22 passed, 3 warnings`
- local: `uv run --extra dev python -m pytest tests/unit/test_executor_runtime_scope.py tests/unit/test_executor_start_verify.py tests/unit/test_auth_hmac.py tests/unit/test_trigger_helper_signature.py tests/unit/test_consumer_signed_payload.py -q` -> `29 passed, 3 warnings`
- local: `uv run ruff format ...` and `uv run ruff check --fix ...` passed

## Runtime note
The deploy-agent path is fixed and publishes success. The runtime main container still reports `/health` body `runtime_pending` after deploy while Docker marks it healthy; that is a separate runtime startup-health boundary, not this deploy-agent transport/execution failure.

OMN-9713

Evidence-Source: OCC#851
Evidence-Ticket: OMN-9713