### PR TITLE
feat(OMN-10729): add canary catalog service for ADR runtime profile

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -148,3 +148,11 @@ omnidash:
     - core
   inject_required_env:
     - OMNIDASH_ANALYTICS_DB_URL
+canary:
+  description: "ONEX canary runtime — loads contracts with runtime_profiles=[canary] for ADR canary orchestrator demo path (OMN-10729). Use `onex up canary` to bring up alongside core."
+  services:
+    - runtime-canary
+  includes:
+    - core
+  inject_env: {}
+  inject_required_env: []

--- a/docker/catalog/services/runtime-canary.yaml
+++ b/docker/catalog/services/runtime-canary.yaml
@@ -1,0 +1,75 @@
+name: runtime-canary
+description: ONEX canary runtime — loads contracts with runtime_profiles=[canary] for ADR canary orchestrator demo path
+image: runtime:latest
+layer: runtime
+container_name: omninode-runtime-canary
+required_env:
+  - POSTGRES_PASSWORD
+  - VALKEY_PASSWORD
+  - KEYCLOAK_ADMIN_CLIENT_SECRET
+  - ONEX_SERVICE_CLIENT_SECRET
+  - ONEX_REGISTRATION_AUTO_ACK
+  - LLM_CODER_URL
+  - LLM_CODER_FAST_URL
+  - LLM_EMBEDDING_URL
+  - LLM_DEEPSEEK_R1_URL
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra'
+  OMNIINTELLIGENCE_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omniintelligence'
+  KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
+  KAFKA_BROKER_ALLOWLIST: 'redpanda:'
+  OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
+  BUS_ID: local
+  ONEX_CONTRACTS_DIR: /app/contracts
+  ONEX_STATE_ROOT: /app/data/.onex_state
+  VALKEY_HOST: valkey
+  VALKEY_PORT: '6379'
+  OMNICLAUDE_CONTRACTS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/nodes
+  OMNICLAUDE_SKILLS_ROOT: /app/.venv/lib/python3.12/site-packages/omniclaude/plugins/onex/skills
+  USE_EVENT_ROUTING: 'true'
+  KEYCLOAK_ADMIN_URL: http://keycloak:8080
+  RUNTIME_PROFILE: canary
+  OTEL_SERVICE_NAME: omninode-runtime-canary
+  ENABLE_RUNTIME_LOG_BRIDGE: 'true'
+operational_defaults:
+  POSTGRES_USER: postgres
+  ONEX_LOG_LEVEL: INFO
+  ONEX_ENVIRONMENT: local
+  KEYCLOAK_REALM: omninode
+  KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
+  KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
+  ONEX_SERVICE_CLIENT_ID: onex-service
+  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
+  # Topics come from each node's contract.yaml event_bus declaration.
+  ONEX_GROUP_ID: onex-runtime-canary
+ports:
+  external: 8088
+  internal: 8085
+healthcheck:
+  test: curl -sf http://localhost:8085/health
+  interval_s: 45
+  timeout_s: 10
+  retries: 5
+  start_period_s: 1800
+volumes:
+  - canary_logs:/app/logs
+  - canary_data:/app/data
+  - ../contracts:/app/contracts:ro
+depends_on:
+  - service: omninode-runtime
+    condition: service_healthy
+  - service: redpanda
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: '1.0'
+  memory: 1536M
+  cpus_reservation: '0.25'
+  memory_reservation: 256M
+stop_grace_period: 90s
+labels:
+  com.omninode.service: runtime-canary
+  com.omninode.layer: runtime
+  com.omninode.version: ${RUNTIME_VERSION:-0.1.0}
+  autoheal: 'true'

--- a/docker/catalog/services/runtime-canary.yaml
+++ b/docker/catalog/services/runtime-canary.yaml
@@ -57,9 +57,9 @@ volumes:
   - canary_data:/app/data
   - ../contracts:/app/contracts:ro
 depends_on:
-  - service: omninode-runtime
-    condition: service_healthy
   - service: redpanda
+    condition: service_healthy
+  - service: postgres
     condition: service_healthy
 restart: unless-stopped
 resources:

--- a/tests/unit/infra/test_canary_bundle.py
+++ b/tests/unit/infra/test_canary_bundle.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the canary runtime bundle (OMN-10729).
+
+Verifies that the canary bundle is well-formed: it resolves to exactly
+runtime-canary (plus core deps), declares RUNTIME_PROFILE=canary, and
+binds to the expected port :8088.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+
+CATALOG_DIR = str(Path(__file__).resolve().parents[3] / "docker" / "catalog")
+BUNDLES_FILE = (
+    Path(__file__).resolve().parents[3] / "docker" / "catalog" / "bundles.yaml"
+)
+SERVICES_DIR = Path(__file__).resolve().parents[3] / "docker" / "catalog" / "services"
+
+
+def _load_manifest(name: str) -> dict[str, object]:
+    path = SERVICES_DIR / f"{name}.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _load_bundles() -> dict[str, dict[str, object]]:
+    with open(BUNDLES_FILE) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.unit
+def test_canary_bundle_exists() -> None:
+    bundles = _load_bundles()
+    assert "canary" in bundles, "canary bundle missing from bundles.yaml"
+
+
+@pytest.mark.unit
+def test_canary_bundle_contains_runtime_canary_service() -> None:
+    bundles = _load_bundles()
+    services = bundles["canary"]["services"]
+    assert "runtime-canary" in services
+
+
+@pytest.mark.unit
+def test_canary_bundle_includes_core() -> None:
+    bundles = _load_bundles()
+    includes = bundles["canary"].get("includes", [])
+    assert "core" in includes, (
+        "canary bundle must include core for postgres/redpanda/valkey"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_canary_manifest_exists() -> None:
+    path = SERVICES_DIR / "runtime-canary.yaml"
+    assert path.exists(), "docker/catalog/services/runtime-canary.yaml missing"
+
+
+@pytest.mark.unit
+def test_runtime_canary_has_correct_runtime_profile() -> None:
+    manifest = _load_manifest("runtime-canary")
+    hardcoded = manifest.get("hardcoded_env", {})
+    assert hardcoded.get("RUNTIME_PROFILE") == "canary", (
+        f"expected RUNTIME_PROFILE=canary, got {hardcoded.get('RUNTIME_PROFILE')}"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_canary_uses_port_8088() -> None:
+    manifest = _load_manifest("runtime-canary")
+    ports = manifest.get("ports", {})
+    assert ports.get("external") == 8088, (
+        f"expected external port 8088, got {ports.get('external')}"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_canary_has_unique_group_id() -> None:
+    manifest = _load_manifest("runtime-canary")
+    defaults = manifest.get("operational_defaults", {})
+    group_id = defaults.get("ONEX_GROUP_ID")
+    assert group_id == "onex-runtime-canary", (
+        f"expected ONEX_GROUP_ID=onex-runtime-canary, got {group_id}"
+    )
+    main_manifest = _load_manifest("omninode-runtime")
+    main_defaults = main_manifest.get("operational_defaults", {})
+    assert group_id != main_defaults.get("ONEX_GROUP_ID"), (
+        "canary and main runtime must have distinct ONEX_GROUP_IDs"
+    )
+
+
+@pytest.mark.unit
+def test_runtime_canary_has_distinct_container_name() -> None:
+    manifest = _load_manifest("runtime-canary")
+    assert manifest.get("container_name") == "omninode-runtime-canary"
+
+
+@pytest.mark.unit
+def test_canary_bundle_resolves_without_error() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["canary"])
+    assert "runtime-canary" in resolved.service_names
+
+
+@pytest.mark.unit
+def test_canary_bundle_required_env_subset_of_core_baseline() -> None:
+    """canary bundle must not demand env vars beyond the standard runtime baseline."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["canary"])
+    _EXPECTED_CANARY_ENV = frozenset(
+        {
+            "POSTGRES_PASSWORD",
+            "VALKEY_PASSWORD",
+            "KEYCLOAK_ADMIN_CLIENT_SECRET",
+            "ONEX_SERVICE_CLIENT_SECRET",
+            "ONEX_REGISTRATION_AUTO_ACK",
+            "LLM_CODER_URL",
+            "LLM_CODER_FAST_URL",
+            "LLM_EMBEDDING_URL",
+            "LLM_DEEPSEEK_R1_URL",
+            "OMNIDASH_ANALYTICS_DB_URL",
+            # core bundle Infisical vars (transitive via includes: [core])
+            "INFISICAL_CLIENT_ID",
+            "INFISICAL_CLIENT_SECRET",
+            "INFISICAL_PROJECT_ID",
+            "INFISICAL_ENCRYPTION_KEY",
+            "INFISICAL_AUTH_SECRET",
+        }
+    )
+    unexpected = resolved.required_env - _EXPECTED_CANARY_ENV
+    assert not unexpected, f"canary bundle requires unexpected env vars: {unexpected}"


### PR DESCRIPTION
## Summary

- Adds `docker/catalog/services/runtime-canary.yaml` — a new service manifest modelled on `runtime-effects.yaml` with `RUNTIME_PROFILE=canary`, external port `:8088`, `ONEX_GROUP_ID=onex-runtime-canary`
- Adds `canary` bundle to `bundles.yaml` (includes `core` + `runtime-canary`), enabling `onex up canary`
- Adds 10 unit tests verifying bundle resolution, RUNTIME_PROFILE, port uniqueness, group ID isolation, and env var contract

## Motivation

`runtime_profiles: [canary]` in ADR orchestrator contracts was paper-only — no container with `RUNTIME_PROFILE=canary` existed. The ADR canary orchestrator never started via the real Kafka bus path; it only worked inline. This PR materialises the canary runtime as a deployable catalog entry.

## Usage

```bash
onex up canary            # bring up core + canary runtime
docker ps | grep canary   # confirm omninode-runtime-canary running on :8088
```

## Test plan

- [x] `uv run pytest tests/unit/infra/test_canary_bundle.py -v` — 10/10 pass
- [x] `uv run pytest tests/unit/infra/ tests/unit/models/catalog/ tests/unit/validation/ -v` — 1280 pass, 9 pre-existing failures on `omnibase_core.normalization.batch_validator` (present on main)
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] Post-merge: SSH to `.201`, run `onex up canary`, verify `docker ps | grep canary` and `rpk group list | grep -i adr`

## Related

OMN-10729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canary runtime bundle to enable deploying a canary ONEX runtime alongside core services (includes a new runtime service, health checks, port exposure, volumes, and operational defaults).

* **Tests**
  * Added unit tests to validate the canary bundle and runtime service configuration and resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1539)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#858
Evidence-Ticket: OMN-10729