### PR TITLE
fix(OMN-10728): bust BuildKit uv-cache for omnimarket and onex_change_control installs

### DIFF
--- a/contracts/OMN-10728.yaml
+++ b/contracts/OMN-10728.yaml
@@ -1,0 +1,27 @@
+# OMN-10728 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control
+# (contracts/OMN-10728.yaml in OmniNode-ai/onex_change_control).
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: OMN-10728
+summary: "Fix BuildKit uv-cache silently serving stale omnimarket on runtime deploys"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "Dockerfile.runtime uses ARG OMNIMARKET_REF and ARG ONEX_CHANGE_CONTROL_REF in install URLs so uv cache mount misses on SHA change."
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "grep -q 'ARG OMNIMARKET_REF' docker/Dockerfile.runtime"
+  - id: dod-deploy
+    description: "Post-deploy verification: docker exec into omninode-runtime confirms import omnimarket.adapters.adr succeeds, proving stale-cache bug is resolved."
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "docker exec omninode-runtime python -c 'import omnimarket.adapters.adr; print(\"ok\")'"

--- a/contracts/OMN-10728.yaml
+++ b/contracts/OMN-10728.yaml
@@ -4,6 +4,7 @@
 # This file is the per-repo deploy-evidence carrier only.
 schema_version: "1.0.0"
 ticket_id: OMN-10728
+title: "Fix BuildKit uv-cache silently serving stale omnimarket on runtime deploys"
 summary: "Fix BuildKit uv-cache silently serving stale omnimarket on runtime deploys"
 is_seam_ticket: false
 interface_change: false

--- a/contracts/OMN-10728.yaml
+++ b/contracts/OMN-10728.yaml
@@ -20,6 +20,8 @@ dod_evidence:
     checks:
       - check_type: command
         check_value: "grep -q 'ARG OMNIMARKET_REF' docker/Dockerfile.runtime"
+      - check_type: command
+        check_value: "grep -q 'ARG ONEX_CHANGE_CONTROL_REF' docker/Dockerfile.runtime"
   - id: dod-deploy
     description: "Post-deploy verification: docker exec into omninode-runtime confirms import omnimarket.adapters.adr succeeds, proving stale-cache bug is resolved."
     source: generated

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -218,17 +218,25 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Install onex_change_control before omnimarket — omnimarket's node_overseer_verifier
 # imports it at module level but omnimarket is installed --no-deps, so it must
 # be present first. Pinned to git main until PyPI publishing is automated.
+# OMN-10728: ONEX_CHANGE_CONTROL_REF must be the full commit SHA so that the
+# install URL itself changes when main advances — this busts the uv cache mount
+# (keyed on URL, not on resolved HEAD) and forces a fresh fetch.
+ARG ONEX_CHANGE_CONTROL_REF=main
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "git+https://github.com/OmniNode-ai/onex_change_control.git@main#egg=onex-change-control"
+    "git+https://github.com/OmniNode-ai/onex_change_control.git@${ONEX_CHANGE_CONTROL_REF}#egg=onex-change-control"
 
 # Install omnimarket from git main until PyPI releases are automated (OMN-7980).
 # Pinned to main so every image rebuild picks up the latest merged nodes.
 # Switch back to PyPI range pin once the auto-tag-on-merge release pipeline
 # is confirmed publishing on each merge: "omnimarket>=0.2.0,<2.0.0"
+# OMN-10728: OMNIMARKET_REF must be the full commit SHA so that the install URL
+# itself changes when main advances — this busts the uv cache mount (keyed on
+# URL, not on resolved HEAD) and forces a fresh fetch.
+ARG OMNIMARKET_REF=main
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "git+https://github.com/OmniNode-ai/omnimarket.git@main#egg=omnimarket"
+    "git+https://github.com/OmniNode-ai/omnimarket.git@${OMNIMARKET_REF}#egg=omnimarket"
 
 # The runtime image still installs legacy packages for import compatibility while
 # market migrations finish, but their ONEX discovery metadata must not advertise

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -605,6 +605,32 @@ class DeployExecutor:
         self._compose_up(phase, scope, services, on_phase_update)
         return services if services else services_for_scope(scope)
 
+    @staticmethod
+    def _resolve_plugin_ref(repo_dir: str) -> str:
+        """Return the HEAD SHA of a plugin repo for uv cache busting (OMN-10728).
+
+        BuildKit's uv cache mount is keyed on the install URL, not the resolved
+        git HEAD. Passing @main always hits the stale cache entry. Passing the
+        full SHA forces a cache miss and a fresh fetch every time main advances.
+
+        Falls back to "main" so manual docker builds without omni_home still work.
+        """
+        result = subprocess.run(
+            ["git", "-C", repo_dir, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        logger.warning(
+            "_resolve_plugin_ref: git rev-parse failed for %s (exit=%d): %s — falling back to 'main'",
+            repo_dir,
+            result.returncode,
+            result.stderr[:200],
+        )
+        return "main"
+
     def _compose_build(
         self,
         scope: Scope,
@@ -618,11 +644,31 @@ class DeployExecutor:
 
         Without this arg, Docker serves a cached layer even after git pull, so
         the running container silently ships pre-pull code (root cause: PR #1231).
+
+        Also passes OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF as full commit
+        SHAs so the uv cache mount (keyed on URL) misses and fetches fresh code
+        every time main advances (OMN-10728).
         """
         timeout = PHASE_TIMEOUTS.get(
             Phase.CORE if scope == Scope.CORE else Phase.RUNTIME, 300
         )
         profile = "core" if scope == Scope.CORE else "runtime"
+
+        omni_home = os.environ.get("OMNI_HOME", "").strip()
+        omnimarket_ref = (
+            self._resolve_plugin_ref(f"{omni_home}/omnimarket") if omni_home else "main"
+        )
+        occ_ref = (
+            self._resolve_plugin_ref(f"{omni_home}/onex_change_control")
+            if omni_home
+            else "main"
+        )
+        logger.info(
+            "_compose_build: OMNIMARKET_REF=%s ONEX_CHANGE_CONTROL_REF=%s",
+            omnimarket_ref[:12],
+            occ_ref[:12],
+        )
+
         cmd = [
             "docker",
             "compose",
@@ -635,6 +681,10 @@ class DeployExecutor:
             "build",
             "--build-arg",
             f"GIT_SHA={git_sha}",
+            "--build-arg",
+            f"OMNIMARKET_REF={omnimarket_ref}",
+            "--build-arg",
+            f"ONEX_CHANGE_CONTROL_REF={occ_ref}",
         ]
         cmd.extend(
             _build_source_build_args(

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -4,12 +4,15 @@
 
 Without this, Docker's layer cache silently serves stale COPY src/ layers even when
 git is at the correct SHA (root cause of PR #1231 verification failure).
+
+Also covers OMN-10728: OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF must be passed as
+full commit SHAs so the uv cache mount (keyed on URL) misses when main advances.
 """
 
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from deploy_agent.events import Phase, PhaseStatus, Scope
 from deploy_agent.executor import DeployExecutor
@@ -119,4 +122,148 @@ class TestCacheBust:
         assert git_sha_seen_in_build == [sentinel_sha], (
             f"Expected git_sha={sentinel_sha!r} forwarded to _compose_build, "
             f"got {git_sha_seen_in_build}"
+        )
+
+
+class TestUvCacheBustPluginRefs:
+    """OMN-10728: _compose_build must pass OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF
+    as full commit SHAs so the BuildKit uv cache mount (keyed on URL) misses when
+    main advances — preventing stale plugin sdists from being served.
+    """
+
+    def _fake_run_ok(
+        self, cmd: list[str], timeout: int, **kwargs
+    ) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    def test_compose_build_passes_omnimarket_ref_build_arg(self) -> None:
+        """_compose_build must include --build-arg OMNIMARKET_REF=<sha>."""
+        executor = DeployExecutor()
+        sentinel_sha = "cafe1234abcd5678"
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(
+                DeployExecutor, "_resolve_plugin_ref", return_value=sentinel_sha
+            ),
+        ):
+            executor._compose_build(Scope.RUNTIME, "abc123", _noop_phase_update)
+
+        build_cmds = [c for c in captured_cmds if "build" in c]
+        assert build_cmds, "Expected at least one 'docker compose build' call"
+        build_cmd = build_cmds[0]
+
+        # Collect all --build-arg values from the command
+        build_args = {
+            build_cmd[i + 1]
+            for i, tok in enumerate(build_cmd)
+            if tok == "--build-arg" and i + 1 < len(build_cmd)
+        }
+        assert f"OMNIMARKET_REF={sentinel_sha}" in build_args, (
+            f"Expected OMNIMARKET_REF={sentinel_sha!r} in build args; got {build_args}"
+        )
+
+    def test_compose_build_passes_onex_change_control_ref_build_arg(self) -> None:
+        """_compose_build must include --build-arg ONEX_CHANGE_CONTROL_REF=<sha>."""
+        executor = DeployExecutor()
+        sentinel_sha = "dead0000beef1111"
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(
+                DeployExecutor, "_resolve_plugin_ref", return_value=sentinel_sha
+            ),
+        ):
+            executor._compose_build(Scope.RUNTIME, "abc123", _noop_phase_update)
+
+        build_cmds = [c for c in captured_cmds if "build" in c]
+        assert build_cmds, "Expected at least one 'docker compose build' call"
+        build_cmd = build_cmds[0]
+
+        build_args = {
+            build_cmd[i + 1]
+            for i, tok in enumerate(build_cmd)
+            if tok == "--build-arg" and i + 1 < len(build_cmd)
+        }
+        assert f"ONEX_CHANGE_CONTROL_REF={sentinel_sha}" in build_args, (
+            f"Expected ONEX_CHANGE_CONTROL_REF={sentinel_sha!r} in build args; got {build_args}"
+        )
+
+    def test_resolve_plugin_ref_returns_sha_from_git(self) -> None:
+        """_resolve_plugin_ref must return the SHA from git rev-parse HEAD."""
+        expected_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=f"{expected_sha}\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            sha = DeployExecutor._resolve_plugin_ref("/fake/repo")
+        assert sha == expected_sha
+
+    def test_resolve_plugin_ref_falls_back_to_main_on_git_failure(self) -> None:
+        """_resolve_plugin_ref must return 'main' when git rev-parse fails."""
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=128, stdout="", stderr="fatal: not a git repo"
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            sha = DeployExecutor._resolve_plugin_ref("/nonexistent/repo")
+        assert sha == "main"
+
+    def test_compose_build_uses_main_fallback_when_omni_home_unset(self) -> None:
+        """When OMNI_HOME is not set, OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF default to 'main'."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        import os
+
+        env_without_omni_home = {
+            k: v for k, v in os.environ.items() if k != "OMNI_HOME"
+        }
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.dict("os.environ", env_without_omni_home, clear=True),
+        ):
+            executor._compose_build(Scope.RUNTIME, "abc123", _noop_phase_update)
+
+        build_cmds = [c for c in captured_cmds if "build" in c]
+        assert build_cmds
+        build_cmd = build_cmds[0]
+        build_args = {
+            build_cmd[i + 1]
+            for i, tok in enumerate(build_cmd)
+            if tok == "--build-arg" and i + 1 < len(build_cmd)
+        }
+        assert "OMNIMARKET_REF=main" in build_args, (
+            f"Expected OMNIMARKET_REF=main when OMNI_HOME unset; got {build_args}"
+        )
+        assert "ONEX_CHANGE_CONTROL_REF=main" in build_args, (
+            f"Expected ONEX_CHANGE_CONTROL_REF=main when OMNI_HOME unset; got {build_args}"
         )

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
 from deploy_agent.events import Phase, PhaseStatus, Scope
+
+pytestmark = pytest.mark.unit
 from deploy_agent.executor import DeployExecutor
 
 

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -155,6 +155,7 @@ class TestUvCacheBustPluginRefs:
             )
 
         with (
+            patch.dict("os.environ", {"OMNI_HOME": "/workspace/omni_home"}),
             patch("deploy_agent.executor._run", side_effect=fake_run),
             patch.object(
                 DeployExecutor, "_resolve_plugin_ref", return_value=sentinel_sha
@@ -192,6 +193,7 @@ class TestUvCacheBustPluginRefs:
             )
 
         with (
+            patch.dict("os.environ", {"OMNI_HOME": "/workspace/omni_home"}),
             patch("deploy_agent.executor._run", side_effect=fake_run),
             patch.object(
                 DeployExecutor, "_resolve_plugin_ref", return_value=sentinel_sha

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -12,7 +12,7 @@ full commit SHAs so the uv cache mount (keyed on URL) misses when main advances.
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from deploy_agent.events import Phase, PhaseStatus, Scope


### PR DESCRIPTION
## Summary

Fixes a silent deploy doctrine violation where BuildKit's uv cache mount served stale omnimarket/onex_change_control sdists even after \`main\` advanced.

**Root cause:** \`Dockerfile.runtime\` installed both plugins via \`git+https://...@main\` inside \`--mount=type=cache\` RUN steps. The uv cache is keyed on URL — \`@main\` never changes, so the cached sdist was always served.

**Evidence of failure:** 2026-05-09 deploy \`c05986ba-f201-4606-a4b8-97e702ff531d\` produced \`RUNTIME_SOURCE_HASH=omnimarket-5546204d\` (pre-OMN-10724); \`import omnimarket.adapters.adr\` → ModuleNotFoundError.

## Changes

- **\`docker/Dockerfile.runtime\`**: Add \`ARG OMNIMARKET_REF=main\` and \`ARG ONEX_CHANGE_CONTROL_REF=main\`; embed them in the install URLs so the URL changes with each new SHA → uv cache miss → fresh fetch.
- **\`scripts/deploy-agent/deploy_agent/executor.py\`**: Add \`_resolve_plugin_ref()\` static method that runs \`git rev-parse HEAD\` in the plugin repo dir. \`_compose_build()\` now passes \`--build-arg OMNIMARKET_REF=<sha>\` and \`--build-arg ONEX_CHANGE_CONTROL_REF=<sha>\` to every \`docker compose build\` invocation.
- **\`scripts/deploy-agent/tests/unit/test_executor_cache_bust.py\`**: 5 new TDD tests covering SHA resolution from git, fallback to \`main\` on failure, and build-arg propagation in both OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF paths.

## Test results

\`\`\`
9 passed (TestUvCacheBustPluginRefs x 5 new + TestCacheBust x 4 pre-existing)
0 regressions in full deploy-agent suite (76 passing, 1 pre-existing failure on main)
\`\`\`

## Verification path (post-merge)

1. Trigger a deploy via deploy-agent on .201.
2. In the running container: \`docker exec omninode-runtime python -c "import omnimarket.adapters.adr; print('ok')"\` — must succeed.
3. \`docker inspect omninode-runtime | grep RUNTIME_SOURCE_HASH\` — must match \`git -C /data/omninode/omni_home/omnibase_infra rev-parse --short HEAD\`.

Ticket: OMN-10728
Evidence-Ticket: OMN-10728
Evidence-Source: OCC#857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker build configuration to use specific commit references for dependency packages instead of branch names, ensuring fresh content is retrieved on each deployment and preventing stale package issues in runtime environments.

* **Tests**
  * Added comprehensive test coverage for build parameter passing and fallback mechanisms in deployment pipelines, verifying correct handling of dependency references during build processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1540)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->