### PR TITLE
feat(OMN-9159): extend ModelBifrostRequest with session_id, run_id; make correlation_id required

### DIFF
--- a/contracts/OMN-9159.yaml
+++ b/contracts/OMN-9159.yaml
@@ -1,0 +1,46 @@
+schema_version: "1.0.0"
+ticket_id: OMN-9159
+title: "Extend ModelBifrostRequest with session and run identity"
+summary: >
+  Add session_id and run_id to ModelBifrostRequest, require caller-provided correlation_id, and preserve these identity fields through Bifrost request validation for downstream dispatch correlation.
+
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - public_api
+evidence_requirements:
+  - kind: tests
+    description: Bifrost request identity unit and integration tests pass
+    command: uv run pytest tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py tests/integration/test_bifrost_request_session_fields.py -q
+  - kind: manual
+    description: Changed Bifrost request model and tests pass ruff
+    command: uv run ruff check src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_request.py tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py tests/integration/test_bifrost_request_session_fields.py
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-unit-integration-tests
+    description: Bifrost request identity unit and integration tests pass
+    source: manual
+    checks:
+      - check_type: command
+        check_value: uv run pytest tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py tests/integration/test_bifrost_request_session_fields.py -q
+  - id: dod-integration-coverage
+    description: Integration coverage proves session_id, run_id, and required correlation_id on the Bifrost request contract
+    source: manual
+    checks:
+      - check_type: command
+        check_value: uv run pytest tests/integration/test_bifrost_request_session_fields.py -q
+  - id: dod-ruff
+    description: Changed Bifrost request model and tests pass ruff
+    source: manual
+    checks:
+      - check_type: command
+        check_value: uv run ruff check src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_request.py tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py tests/integration/test_bifrost_request_session_fields.py
+  - id: dod-deploy
+    description: Deploy preflight for runtime-adjacent Bifrost request contract changes; no live runtime restart performed in this PR
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy validation plan: after merge, verify the runtime container can import ModelBifrostRequest and instantiate it with ONEX_SESSION_ID/ONEX_RUN_ID identity fields using docker exec ${RUNTIME_CONTAINER:-omninode-runtime}"

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/model_bifrost_request.py
@@ -55,8 +55,12 @@ class ModelBifrostRequest(BaseModel):
         system_prompt: Optional system prompt prepended to messages.
         max_tokens: Maximum tokens to generate.
         temperature: Sampling temperature.
-        correlation_id: Optional correlation ID for distributed tracing.
-            Auto-generated if not provided.
+        correlation_id: Correlation ID for distributed tracing. Required —
+            callers must supply a stable UUID; the gateway does not auto-generate.
+        session_id: Optional session identity string (e.g. ONEX_SESSION_ID)
+            grouping all requests from one orchestration session.
+        run_id: Optional run identity string (e.g. ONEX_RUN_ID) identifying
+            the specific dispatch invocation within a session.
 
     Example:
         >>> from uuid import UUID
@@ -68,6 +72,7 @@ class ModelBifrostRequest(BaseModel):
         ...     cost_tier=EnumCostTier.LOW,
         ...     tenant_id=UUID("12345678-1234-5678-1234-567812345678"),
         ...     messages=[{"role": "user", "content": "Hello"}],
+        ...     correlation_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
         ... )
     """
 
@@ -122,9 +127,31 @@ class ModelBifrostRequest(BaseModel):
         le=2.0,
         description="Sampling temperature.",
     )
-    correlation_id: UUID | None = Field(
+    correlation_id: UUID = Field(
+        ...,
+        description=(
+            "Correlation ID for distributed tracing. "
+            "Identity Invariant: callers must supply a stable UUID; "
+            "the gateway does not auto-generate one."
+        ),
+    )
+    session_id: str | None = Field(
         default=None,
-        description="Correlation ID for distributed tracing (auto-generated if None).",
+        max_length=255,
+        description=(
+            "Session identity string (e.g. ONEX_SESSION_ID) grouping all "
+            "requests from a single orchestration session. "
+            "Identity Invariant: set by the dispatch layer, preserved through routing."
+        ),
+    )
+    run_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Run identity string (e.g. ONEX_RUN_ID) identifying the specific "
+            "dispatch invocation within a session. "
+            "Identity Invariant: set by the dispatch layer, preserved through routing."
+        ),
     )
 
     @field_validator("capabilities", mode="before")

--- a/tests/integration/test_bifrost_request_session_fields.py
+++ b/tests/integration/test_bifrost_request_session_fields.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for ModelBifrostRequest session_id + run_id fields (OMN-9159)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.enums.enum_llm_operation_type import EnumLlmOperationType
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.model_bifrost_request import (
+    ModelBifrostRequest,
+)
+
+
+def _make_request(**kwargs: object) -> ModelBifrostRequest:
+    defaults: dict[str, object] = {
+        "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
+        "tenant_id": uuid4(),
+        "correlation_id": uuid4(),
+        "messages": ({"role": "user", "content": "hello"},),
+    }
+    defaults.update(kwargs)
+    return ModelBifrostRequest(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.integration
+def test_bifrost_request_session_and_run_id_propagated() -> None:
+    corr_id = uuid4()
+    req = _make_request(
+        correlation_id=corr_id,
+        session_id="onex-session-abc",
+        run_id="onex-run-001",
+    )
+    assert req.session_id == "onex-session-abc"
+    assert req.run_id == "onex-run-001"
+    assert req.correlation_id == corr_id
+
+
+@pytest.mark.integration
+def test_bifrost_request_session_and_run_id_optional() -> None:
+    req = _make_request()
+    assert req.session_id is None
+    assert req.run_id is None
+
+
+@pytest.mark.integration
+def test_bifrost_request_correlation_id_required() -> None:
+    with pytest.raises(ValidationError):
+        ModelBifrostRequest(
+            operation_type=EnumLlmOperationType.CHAT_COMPLETION,
+            tenant_id=uuid4(),
+            messages=({"role": "user", "content": "hello"},),
+        )

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_delegation_shadow.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_delegation_shadow.py
@@ -316,6 +316,7 @@ class TestShadowDoesNotAlterLiveRouting:
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             tenant_id=_TENANT_ID,
             messages=({"role": "user", "content": "test"},),
+            correlation_id=uuid4(),
         )
 
         response = await gateway.handle(request)
@@ -357,6 +358,7 @@ class TestShadowDoesNotAlterLiveRouting:
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             tenant_id=_TENANT_ID,
             messages=({"role": "user", "content": "test"},),
+            correlation_id=uuid4(),
         )
 
         response = await gateway.handle(request)
@@ -380,6 +382,7 @@ class TestShadowDoesNotAlterLiveRouting:
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             tenant_id=_TENANT_ID,
             messages=({"role": "user", "content": "test"},),
+            correlation_id=uuid4(),
         )
 
         await gateway.handle(request)
@@ -406,6 +409,7 @@ class TestShadowDoesNotAlterLiveRouting:
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             tenant_id=_TENANT_ID,
             messages=({"role": "user", "content": "test"},),
+            correlation_id=uuid4(),
         )
 
         responses = [await gateway.handle(request) for _ in range(5)]

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_failover.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_failover.py
@@ -119,6 +119,7 @@ def _make_request() -> ModelBifrostRequest:
         operation_type=EnumLlmOperationType.CHAT_COMPLETION,
         tenant_id=_TEST_TENANT_ID,
         messages=[{"role": "user", "content": "Hello"}],
+        correlation_id=uuid4(),
     )
 
 
@@ -245,6 +246,7 @@ class TestBifrostFailoverBackendADown:
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             tenant_id=_specific_tenant_id,
             messages=[{"role": "user", "content": "Hello"}],
+            correlation_id=uuid4(),
         )
         result = await gateway.handle(request)
 

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py
@@ -9,7 +9,6 @@ from uuid import UUID
 
 import pytest
 
-from omnibase_infra.enums.enum_cost_tier import EnumCostTier
 from omnibase_infra.enums.enum_llm_operation_type import EnumLlmOperationType
 from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.model_bifrost_request import (
     ModelBifrostRequest,

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_request.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelBifrostRequest identity fields (OMN-9159)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from omnibase_infra.enums.enum_cost_tier import EnumCostTier
+from omnibase_infra.enums.enum_llm_operation_type import EnumLlmOperationType
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.model_bifrost_request import (
+    ModelBifrostRequest,
+)
+
+_TENANT = UUID("12345678-1234-5678-1234-567812345678")
+_CORR = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+_BASE = {
+    "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
+    "tenant_id": _TENANT,
+    "messages": [{"role": "user", "content": "hi"}],
+    "correlation_id": _CORR,
+}
+
+
+@pytest.mark.unit
+def test_correlation_id_is_required() -> None:
+    """correlation_id must be provided; missing it raises ValidationError."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        ModelBifrostRequest(
+            operation_type=EnumLlmOperationType.CHAT_COMPLETION,
+            tenant_id=_TENANT,
+            messages=[{"role": "user", "content": "hi"}],
+            # correlation_id intentionally omitted
+        )
+
+
+@pytest.mark.unit
+def test_session_id_and_run_id_accepted() -> None:
+    """session_id and run_id can be provided and are preserved."""
+    req = ModelBifrostRequest(
+        **_BASE,
+        session_id="session-abc-123",
+        run_id="run-xyz-456",
+    )
+    assert req.session_id == "session-abc-123"
+    assert req.run_id == "run-xyz-456"
+    assert req.correlation_id == _CORR
+
+
+@pytest.mark.unit
+def test_session_id_and_run_id_optional() -> None:
+    """session_id and run_id default to None when omitted."""
+    req = ModelBifrostRequest(**_BASE)
+    assert req.session_id is None
+    assert req.run_id is None

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing.py
@@ -145,6 +145,7 @@ def _make_chat_request(
     capabilities: tuple[str, ...] = (),
     max_latency_ms: int = 10_000,
     tenant_id: UUID | None = None,
+    correlation_id: UUID | None = None,
 ) -> ModelBifrostRequest:
     """Build a minimal valid ModelBifrostRequest."""
     return ModelBifrostRequest(
@@ -154,6 +155,7 @@ def _make_chat_request(
         max_latency_ms=max_latency_ms,
         tenant_id=tenant_id or UUID("00000000-0000-0000-0000-000000000001"),
         messages=[{"role": "user", "content": "Hello"}],
+        correlation_id=correlation_id or uuid4(),
     )
 
 
@@ -551,8 +553,8 @@ class TestBifrostRoutingHandleEndToEnd:
         assert result.correlation_id == my_corr_id
 
     @pytest.mark.asyncio
-    async def test_bifrost_routing_handle_auto_generates_correlation_id(self) -> None:
-        """handle() auto-generates correlation_id when request has none."""
+    async def test_bifrost_routing_handle_propagates_correlation_id(self) -> None:
+        """handle() propagates correlation_id from the request to the response."""
         config = _make_two_backend_config(
             routing_rules=(),
             default_backends=("backend-a",),
@@ -560,7 +562,7 @@ class TestBifrostRoutingHandleEndToEnd:
         handler = _make_handler()
         gateway = HandlerBifrostGateway(config=config, inference_handler=handler)
 
-        request = _make_chat_request()  # No correlation_id
+        request = _make_chat_request()
         result = await gateway.handle(request)
 
         assert result.correlation_id != ""

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing.py
@@ -565,8 +565,7 @@ class TestBifrostRoutingHandleEndToEnd:
         request = _make_chat_request()
         result = await gateway.handle(request)
 
-        assert result.correlation_id != ""
-        assert result.correlation_id is not None
+        assert result.correlation_id == request.correlation_id
 
     @pytest.mark.asyncio
     async def test_bifrost_routing_n_synthetic_requests_select_expected_backends(

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing_callback.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_routing_callback.py
@@ -87,6 +87,7 @@ def _make_request() -> ModelBifrostRequest:
         cost_tier=EnumCostTier.MID,
         tenant_id=uuid4(),
         messages=({"role": "user", "content": "test"},),
+        correlation_id=uuid4(),
     )
 
 

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_shadow.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_shadow.py
@@ -91,6 +91,7 @@ def _make_request(
         operation_type=operation_type,
         tenant_id=_TENANT_ID,
         messages=({"role": "user", "content": "Hello"},),
+        correlation_id=uuid4(),
     )
 
 


### PR DESCRIPTION
## Summary

- Makes \`correlation_id\` required (UUID, not Optional) on \`ModelBifrostRequest\` — callers must supply a stable UUID; the gateway does not auto-generate one
- Adds \`session_id: str | None\` (max_length=255) for grouping all requests from a single orchestration session
- Adds \`run_id: str | None\` (max_length=255) for identifying the specific dispatch invocation within a session
- Updates all 6 bifrost test fixtures to supply \`correlation_id=uuid4()\` per the new contract
- Renames \`test_bifrost_routing_handle_auto_generates_correlation_id\` → \`test_bifrost_routing_handle_propagates_correlation_id\` (premise changed)
- Adds integration tests for session_id/run_id propagation and correlation_id enforcement

## Ticket

OMN-9159

## OCC Evidence

Evidence-Ticket: OMN-9159
Evidence-Source: OCC#872

## Test plan

- [x] All bifrost tests pass: \`uv run pytest tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/ -v\`
- [x] Integration tests: \`uv run pytest tests/integration/test_bifrost_request_session_fields.py -v\`
- [x] mypy --strict clean on changed files

<!-- receipts updated: b2454d62 -->