### PR TITLE
fix(OMN-10755): warn on null correlation_id at event_ledger append site

### DIFF
--- a/contracts/OMN-10755.yaml
+++ b/contracts/OMN-10755.yaml
@@ -1,0 +1,33 @@
+# OMN-10755 contract file for omnibase_infra deploy-gate (OMN-8912).
+# Canonical ticket contract lives in onex_change_control; this file carries
+# deploy-gate evidence for the HandlerLedgerAppend null-correlation_id warning gate.
+schema_version: '1.0.0'
+ticket_id: OMN-10755
+title: "Remove stale event_bus_events references and add correlation_id forward gate"
+summary: >
+  Adds a WARNING-level log gate in HandlerLedgerAppend when correlation_id is None. Ledger never drops events; the warning makes envelope-contract violations observable. Bumps node_ledger_write_effect contract_version to 0.1.1. Adds 2 integration tests.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-infra-integration-tests
+    description: >-
+      2 integration tests pass against live PostgreSQL: test_null_correlation_id_emits_warning and test_null_correlation_id_auto_generates_for_db.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          uv run pytest tests/integration/ledger/test_ledger_append_null_correlation.py -v
+  - id: dod-deploy
+    description: >-
+      No runtime deploy required — change is a logger.warning addition and contract version bump. No new Kafka topics, no schema changes, no new node topology. Deploy-agent inactive per OMN-8841.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          deploy omninode-runtime not required: HandlerLedgerAppend change is a logger.warning addition only. No new behaviour deployed, no Docker restart required. Contract version bumped from 0.1.0 to 0.1.1 to satisfy Contract Sync Gate.

--- a/src/omnibase_infra/nodes/node_ledger_write_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_ledger_write_effect/contract.yaml
@@ -22,11 +22,11 @@ node_name: "node_ledger_write_effect"
 contract_version:
   major: 0
   minor: 1
-  patch: 0
+  patch: 1
 node_version:
   major: 0
   minor: 1
-  patch: 0
+  patch: 1
 # Node type
 node_type: "EFFECT_GENERIC"
 # Description

--- a/src/omnibase_infra/nodes/node_ledger_write_effect/handlers/handler_ledger_append.py
+++ b/src/omnibase_infra/nodes/node_ledger_write_effect/handlers/handler_ledger_append.py
@@ -185,6 +185,15 @@ class HandlerLedgerAppend:
             InfraConnectionError: If database connection fails.
             InfraTimeoutError: If operation times out.
         """
+        if payload.correlation_id is None:
+            logger.warning(
+                "Event appended to ledger without correlation_id — emitting source "
+                "is violating the envelope contract; trace chain will be broken for "
+                "topic=%s partition=%d offset=%d",
+                payload.topic,
+                payload.partition,
+                payload.kafka_offset,
+            )
         correlation_id = payload.correlation_id or uuid4()
 
         if not self._initialized:

--- a/tests/integration/ledger/test_ledger_append_null_correlation.py
+++ b/tests/integration/ledger/test_ledger_append_null_correlation.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Integration test: HandlerLedgerAppend emits WARNING when correlation_id is None.
+
+OMN-10755: Forward gate — events without correlation_id must produce a warning
+log entry so that missing-correlation violations are observable in production.
+The ledger still accepts and stores the event (never drops).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+
+if TYPE_CHECKING:
+    from omnibase_infra.nodes.node_ledger_write_effect.handlers.handler_ledger_append import (
+        HandlerLedgerAppend,
+    )
+    from omnibase_infra.nodes.node_registration_reducer.models.model_payload_ledger_append import (
+        ModelPayloadLedgerAppend,
+    )
+
+
+class TestLedgerAppendNullCorrelation:
+    """Verify null-correlation_id warning gate in HandlerLedgerAppend."""
+
+    @pytest.mark.asyncio
+    async def test_null_correlation_id_emits_warning(
+        self,
+        ledger_append_handler: HandlerLedgerAppend,
+        make_ledger_payload: ...,
+        cleanup_event_ledger: list[UUID | None],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Appending with correlation_id=None must emit a WARNING and still succeed."""
+        payload: ModelPayloadLedgerAppend = make_ledger_payload(correlation_id=None)
+
+        with caplog.at_level(logging.WARNING, logger="omnibase_infra"):
+            result = await ledger_append_handler.append(payload)
+
+        # Event must be stored — ledger never drops events
+        assert result.success is True
+        assert result.duplicate is False
+        assert result.ledger_entry_id is not None
+        cleanup_event_ledger.append(result.ledger_entry_id)
+
+        # Warning must appear in logs
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("correlation_id" in msg for msg in warning_messages), (
+            f"Expected correlation_id warning, got: {warning_messages}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_null_correlation_id_auto_generates_for_db(
+        self,
+        ledger_append_handler: HandlerLedgerAppend,
+        make_ledger_payload: ...,
+        cleanup_event_ledger: list[UUID | None],
+    ) -> None:
+        """With correlation_id=None the handler auto-generates one for the DB write."""
+        payload: ModelPayloadLedgerAppend = make_ledger_payload(correlation_id=None)
+        result = await ledger_append_handler.append(payload)
+
+        # Append succeeds and entry is stored
+        assert result.success is True
+        assert result.ledger_entry_id is not None
+        cleanup_event_ledger.append(result.ledger_entry_id)


### PR DESCRIPTION
Evidence-Source: OCC#877

## Summary

- Adds `logger.warning` in `HandlerLedgerAppend.append()` when `payload.correlation_id` is `None`
- Bumps `node_ledger_write_effect` contract_version from 0.1.0 to 0.1.1 (Contract Sync Gate)
- Adds 2 integration tests for the null-correlation_id warning path

Closes: OMN-10755 (partial — omnimarket stale-ref removal in companion PR)
Related: OMN-7892 (cancelled — source data gone)

## Test plan
- [x] 2 integration tests pass against live PostgreSQL
- [x] ruff + mypy --strict clean
- [x] pre-commit run --all-files passes
- [x] deploy-gate contract added to contracts/OMN-10755.yaml

Evidence-Ticket: OMN-10755