### PR TITLE
fix(OMN-10732): remove silent env fallbacks in omnibase_infra src/ and wire validator gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Check Kafka bootstrap no localhost fallback (OMN-8783)
         run: uv run python scripts/ci_check_kafka_no_localhost_default.py
 
+      - name: Check no localhost env fallbacks in src/ (OMN-10732)
+        run: uv run python scripts/validate_no_env_fallbacks.py
+
       - name: Check topic suffix exports (F56)
         run: python scripts/validation/check_topic_suffix_exports.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -317,6 +317,14 @@ repos:
         pass_filenames: false
         types: [python]
         stages: [pre-commit]
+      # OMN-10732: Reject localhost/hardcoded-URL env fallbacks in src/
+      - id: no-env-localhost-fallback
+        name: Reject localhost env fallbacks in src/ (OMN-10732)
+        entry: uv run --frozen python scripts/validate_no_env_fallbacks.py
+        language: system
+        pass_filenames: false
+        types: [python]
+        stages: [pre-commit]
       # OMN-7077: Prevent new direct imports of EventBusInmemory from infra path
       - id: no-infra-inmemory-import
         name: Block infra-path EventBusInmemory imports (OMN-7077)

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -44,6 +44,8 @@ def scan(root: Path) -> list[tuple[str, int, str]]:
         except (OSError, UnicodeDecodeError):
             continue
         for lineno, line in enumerate(lines, start=1):
+            if "# fallback-ok" in line:
+                continue
             for pattern in VIOLATIONS_PATTERNS:
                 if pattern.search(line):
                     violations.append((str(py_file), lineno, line.strip()))

--- a/src/omnibase_infra/adapters/models/model_infisical_config.py
+++ b/src/omnibase_infra/adapters/models/model_infisical_config.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import os
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
@@ -32,7 +33,7 @@ class ModelInfisicalAdapterConfig(BaseModel):
     )
 
     host: str = Field(
-        default="https://app.infisical.com",
+        default_factory=lambda: os.environ["INFISICAL_ADDR"],
         description="Infisical server URL.",
     )
     client_id: SecretStr = Field(

--- a/src/omnibase_infra/backends/backend_probe.py
+++ b/src/omnibase_infra/backends/backend_probe.py
@@ -191,7 +191,7 @@ def probe_postgres(
     """
     backend_name = "state_postgres"
 
-    effective_host: str = host or os.getenv("PGHOST", "localhost") or "localhost"
+    effective_host: str = host or os.environ["PGHOST"]
     try:
         effective_port = port or int(os.getenv("PGPORT", "5436"))
     except ValueError:

--- a/src/omnibase_infra/handlers/models/infisical/model_infisical_handler_config.py
+++ b/src/omnibase_infra/handlers/models/infisical/model_infisical_handler_config.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import os
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
@@ -36,7 +37,7 @@ class ModelInfisicalHandlerConfig(BaseModel):
     )
 
     host: str = Field(
-        default="https://app.infisical.com",
+        default_factory=lambda: os.environ["INFISICAL_ADDR"],
         description="Infisical server URL.",
     )
     client_id: SecretStr = Field(

--- a/src/omnibase_infra/observability/handlers/model_metrics_handler_config.py
+++ b/src/omnibase_infra/observability/handlers/model_metrics_handler_config.py
@@ -105,7 +105,7 @@ class ModelMetricsHandlerConfig(BaseModel):
     """
 
     host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description=(
             "Bind address for the HTTP metrics server. "
             "Default is localhost (127.0.0.1) for security. "

--- a/src/omnibase_infra/runtime/models/model_postgres_pool_config.py
+++ b/src/omnibase_infra/runtime/models/model_postgres_pool_config.py
@@ -27,7 +27,7 @@ class ModelPostgresPoolConfig(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     host: str = Field(
-        default_factory=lambda: os.environ.get("POSTGRES_HOST", "localhost"),
+        default_factory=lambda: os.environ["POSTGRES_HOST"],
         description="PostgreSQL host",
     )
     port: int = Field(default=5432, ge=1, le=65535, description="PostgreSQL port")
@@ -208,18 +208,15 @@ class ModelPostgresPoolConfig(BaseModel):
         # NOTE: Credentials are stored *decoded* (unquote). If a DSN is later
         # reconstructed from these fields, the values must be re-encoded with
         # urllib.parse.quote_plus() to produce a valid connection string.
-        # NOTE: parsed.hostname returns None for Unix-socket DSNs
-        # (e.g., "postgresql:///dbname"). The fallback to "localhost" means
-        # Unix-socket DSNs are silently rewritten to TCP connections.
         hostname = parsed.hostname
         if hostname is None:
-            logger.warning(
-                "DSN has no hostname (Unix-socket?); falling back to TCP localhost:5432. "
-                "Original DSN scheme: %s",
-                parsed.scheme,
+            msg = (
+                "DSN has no hostname — Unix-socket DSNs are not supported. "
+                f"Provide a TCP DSN: postgresql://user:pass@host:port/dbname (scheme: {parsed.scheme})"
             )
+            raise ValueError(msg)
         return cls(
-            host=hostname or "localhost",
+            host=hostname,
             port=parsed.port or 5432,
             user=unquote(parsed.username) if parsed.username else "postgres",
             password=unquote(parsed.password) if parsed.password else "",

--- a/src/omnibase_infra/services/agent_learning_extraction/config.py
+++ b/src/omnibase_infra/services/agent_learning_extraction/config.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.topics.platform_topic_suffixes import (
@@ -31,8 +33,8 @@ class ModelAgentLearningExtractionConfig(BaseModel):
         description="Kafka consumer group ID",
     )
     llm_summary_url: str = Field(
-        default="http://localhost:8001/v1/chat/completions",
-        description="Qwen3-14B endpoint for generating resolution summaries",
+        default_factory=lambda: os.environ["LLM_CODER_FAST_URL"],
+        description="LLM endpoint for generating resolution summaries",
     )
     llm_summary_timeout_seconds: float = Field(
         default=30.0,

--- a/src/omnibase_infra/services/observability/agent_actions/config.py
+++ b/src/omnibase_infra/services/observability/agent_actions/config.py
@@ -197,7 +197,7 @@ class ConfigAgentActionsConsumer(BaseSettings):
         description="Port for HTTP health check endpoint",
     )
     health_check_host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description=(
             "Host/IP for health check server binding. Default '127.0.0.1' restricts "
             "to localhost-only access for security. For container/Kubernetes deployments, "

--- a/src/omnibase_infra/services/observability/consumer_health/config.py
+++ b/src/omnibase_infra/services/observability/consumer_health/config.py
@@ -123,7 +123,8 @@ class ConfigConsumerHealthProjection(BaseSettings):
         default=8094, ge=1024, le=65535, description="Port for HTTP health check"
     )
     health_check_host: str = Field(
-        default="127.0.0.1", description="Host for health check server"
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
+        description="Host for health check server",
     )
     health_check_staleness_seconds: int = Field(
         default=300,

--- a/src/omnibase_infra/services/observability/context_audit/config.py
+++ b/src/omnibase_infra/services/observability/context_audit/config.py
@@ -183,7 +183,7 @@ class ConfigContextAuditConsumer(BaseSettings):
         description="Port for HTTP health check endpoint",
     )
     health_check_host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description=(
             "Host/IP for health check server binding. Default '127.0.0.1' restricts "
             "to localhost-only access for security. For container/Kubernetes deployments, "

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/config.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/config.py
@@ -207,7 +207,7 @@ class ConfigLlmCostAggregation(BaseSettings):
         description="Port for HTTP health check endpoint",
     )
     health_check_host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description=(
             "Host/IP for health check server binding. Defaults to localhost-only "
             "for safety. Container deployments should explicitly set '0.0.0.0' to "

--- a/src/omnibase_infra/services/observability/skill_lifecycle/config.py
+++ b/src/omnibase_infra/services/observability/skill_lifecycle/config.py
@@ -179,7 +179,7 @@ class ConfigSkillLifecycleConsumer(BaseSettings):
         description="Port for HTTP health check endpoint",
     )
     health_check_host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description=(
             "Host/IP for health check server binding. Default '127.0.0.1' restricts "
             "to localhost-only access for security. For container/Kubernetes deployments, "

--- a/src/omnibase_infra/services/post_merge/config.py
+++ b/src/omnibase_infra/services/post_merge/config.py
@@ -124,7 +124,7 @@ class ConfigPostMergeConsumer(BaseSettings):
         description="Port for HTTP health check endpoint",
     )
     health_check_host: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1",  # fallback-ok: bind 127.0.0.1 to prevent unauthenticated network exposure; override via env for cluster deployments
         description="Host/IP for health check server binding",
     )
 

--- a/tests/integration/adapters/test_postgres_pool_config_defaults.py
+++ b/tests/integration/adapters/test_postgres_pool_config_defaults.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Integration tests for ModelPostgresPoolConfig env-fallback behaviour.
+"""Integration tests for ModelPostgresPoolConfig env-var behaviour (OMN-10732).
 
-Verifies that the model returns sensible defaults when POSTGRES_HOST is absent,
-exercising the os.environ.get fallback added in OMN-8605.
+Verifies fail-fast on missing POSTGRES_HOST and correct env-var resolution.
 """
 
 from __future__ import annotations
@@ -17,24 +16,23 @@ from omnibase_infra.runtime.models.model_postgres_pool_config import (
 )
 
 
-def test_defaults_without_postgres_host(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ModelPostgresPoolConfig should fall back to 'localhost' when POSTGRES_HOST is unset."""
+def test_missing_postgres_host_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ModelPostgresPoolConfig raises KeyError when POSTGRES_HOST is unset."""
     monkeypatch.delenv("POSTGRES_HOST", raising=False)
 
-    config = ModelPostgresPoolConfig(database="testdb")
-
-    assert config.host == "localhost"
-    assert config.port == 5432
-    assert config.user == "postgres"
-    assert config.database == "testdb"
-    assert config.min_size == 2
-    assert config.max_size == 10
+    with pytest.raises(KeyError):
+        ModelPostgresPoolConfig(database="testdb")
 
 
 def test_host_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ModelPostgresPoolConfig should use POSTGRES_HOST when set."""
+    """ModelPostgresPoolConfig uses POSTGRES_HOST when set."""
     monkeypatch.setenv("POSTGRES_HOST", "db.internal")
 
     config = ModelPostgresPoolConfig(database="testdb")
 
     assert config.host == "db.internal"
+    assert config.port == 5432
+    assert config.user == "postgres"
+    assert config.database == "testdb"
+    assert config.min_size == 2
+    assert config.max_size == 10

--- a/tests/unit/runtime/test_dependency_materializer.py
+++ b/tests/unit/runtime/test_dependency_materializer.py
@@ -175,14 +175,21 @@ class TestModelPostgresPoolConfig:
     """Tests for PostgreSQL pool configuration."""
 
     def test_default_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        monkeypatch.setenv("POSTGRES_HOST", "db.test")
         config = ModelPostgresPoolConfig(database="testdb")
-        assert config.host == "localhost"
+        assert config.host == "db.test"
         assert config.port == 5432
         assert config.user == "postgres"
         assert config.database == "testdb"
         assert config.min_size == 2
         assert config.max_size == 10
+
+    def test_default_values_missing_host_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        with pytest.raises(KeyError):
+            ModelPostgresPoolConfig(database="testdb")
 
     def test_from_env(self) -> None:
         with patch.dict(
@@ -199,7 +206,7 @@ class TestModelPostgresPoolConfig:
             assert config.database == "envdb"
 
     def test_frozen(self) -> None:
-        config = ModelPostgresPoolConfig(database="testdb")
+        config = ModelPostgresPoolConfig(host="myhost", database="testdb")
         with pytest.raises(Exception):
             config.host = "other"  # type: ignore[misc]
 


### PR DESCRIPTION
## OMN-10732

Fixes all 6 src/ silent fallback violations and annotates the 7 approved 127.0.0.1 bind-address defaults. Wires the existing validator into pre-commit and CI as a required gate.

## Changes

**src/ violations fixed (fail-fast):**
- `runtime/models/model_postgres_pool_config.py:30` — POSTGRES_HOST default_factory → os.environ["POSTGRES_HOST"]
- `runtime/models/model_postgres_pool_config.py:222` — from_dsn() raises ValueError on missing hostname instead of silently falling back to localhost
- `backends/backend_probe.py:194` — PGHOST fallback → os.environ["PGHOST"]
- `services/agent_learning_extraction/config.py:34` — hardcoded http://localhost:8001 → os.environ["LLM_CODER_FAST_URL"]
- `adapters/models/model_infisical_config.py:35` — https://app.infisical.com → os.environ["INFISICAL_ADDR"]
- `handlers/models/infisical/model_infisical_handler_config.py:39` — same

**127.0.0.1 bind-address defaults annotated fallback-ok** (7 fields across health/metrics servers): bind 127.0.0.1 by default to prevent unauthenticated network exposure; override via env var for cluster deployments.

**Validator + hook wiring:**
- scripts/validate_no_env_fallbacks.py — skip lines annotated fallback-ok
- .pre-commit-config.yaml — new no-env-localhost-fallback hook
- .github/workflows/ci.yml — new CI step

**Tests updated:**
- tests/integration/adapters/test_postgres_pool_config_defaults.py — replaced fallback-expectation test with fail-fast assertion
- tests/unit/runtime/test_dependency_materializer.py — updated test_default_values to set POSTGRES_HOST; added test_default_values_missing_host_raises; fixed test_frozen to pass explicit host=

## OCC Evidence

Contract and DoD receipts in onex_change_control PR #873 (jonah/omn-10732-occ-contract):
- contracts/OMN-10732.yaml — ticket contract with 4 DoD evidence items
- drift/dod_receipts/OMN-10732/dod-tests/command.yaml — 52 tests PASS
- drift/dod_receipts/OMN-10732/dod-validator/command.yaml — validator PASS
- drift/dod_receipts/OMN-10732/dod-deploy/command.yaml — no deploy required (PASS)
- drift/dod_receipts/OMN-10732/dod-occ-pr/command.yaml — OCC PR #873 receipt (PASS)

## dod_evidence

- OCC PR #873: contracts/OMN-10732.yaml + 4 DoD receipts
- validator passes clean on src/
- pre-commit hook wired and passing
- CI gate added as required step
- 52 tests pass covering all changed modules
- 1 pre-existing test failure confirmed on main (unrelated to this PR)