### PR TITLE
feat(OMN-10741): unified validate_no_env_fallbacks.py — all 6 pattern types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -327,14 +327,6 @@ repos:
         pass_filenames: false
         types: [python]
         stages: [pre-commit]
-      # OMN-10732: Reject localhost/hardcoded-URL env fallbacks in src/
-      - id: no-env-localhost-fallback
-        name: Reject localhost env fallbacks in src/ (OMN-10732)
-        entry: uv run --frozen python scripts/validate_no_env_fallbacks.py
-        language: system
-        pass_filenames: false
-        types: [python]
-        stages: [pre-commit]
       # OMN-7077: Prevent new direct imports of EventBusInmemory from infra path
       - id: no-infra-inmemory-import
         name: Block infra-path EventBusInmemory imports (OMN-7077)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -308,6 +308,16 @@ repos:
         pass_filenames: false
         files: contract\.yaml$
         stages: [pre-commit]
+      # OMN-10741: Unified localhost/hardcoded-endpoint fallback validator
+      # Covers all 6 pattern types from OMN-10658 enforcement sweep.
+      # Annotation: add  # fallback-ok: <reason>  to exempt a justified line.
+      - id: no-env-fallbacks
+        name: No localhost/hardcoded-endpoint fallbacks (OMN-10741)
+        entry: uv run python scripts/validate_no_env_fallbacks.py
+        language: system
+        pass_filenames: true
+        types_or: [python, shell]
+        stages: [pre-commit]
       # OMN-3554: Reject hardcoded Kafka broker address fallbacks
       # Detects os.getenv("KAFKA_*", non-empty) and private-IP Kafka broker ports
       - id: kafka-no-hardcoded-fallback

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -313,7 +313,7 @@ repos:
       # Annotation: add  # fallback-ok: <reason>  to exempt a justified line.
       - id: no-env-fallbacks
         name: No localhost/hardcoded-endpoint fallbacks (OMN-10741)
-        entry: uv run python scripts/validate_no_env_fallbacks.py
+        entry: uv run --frozen python scripts/validate_no_env_fallbacks.py
         language: system
         pass_filenames: true
         types_or: [python, shell]

--- a/contracts/OMN-10741.yaml
+++ b/contracts/OMN-10741.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10741"
+title: "Unified no-env-fallback validator for omnibase_infra"
+summary: "Ship the canonical fallback validator, wire pre-commit enforcement, and annotate justified local/dev defaults."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-validator-clean"
+    description: "Unified fallback validator reports zero unhandled violations across src/ and scripts/."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run --frozen python scripts/validate_no_env_fallbacks.py"
+  - id: "dod-integration-coverage"
+    description: "Integration coverage proves the validator remains clean for runtime roots."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/test_validate_no_env_fallbacks_integration.py -q"
+  - id: "dod-deploy"
+    description: "No runtime deploy required; changes are validator tooling and fallback-ok annotations only."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "printf '%s\n' 'No deploy required for OMN-10741 validator and fallback annotation changes'"

--- a/scripts/demo_registry_contracts.py
+++ b/scripts/demo_registry_contracts.py
@@ -248,7 +248,7 @@ def main() -> None:
         print(f"\n[ERROR] Cannot connect to Consul: {e}")
         print("        Check CONSUL_HOST and CONSUL_PORT environment variables")
         print(
-            f"        Current: CONSUL_HOST={os.environ.get('CONSUL_HOST', 'localhost')}"
+            f"        Current: CONSUL_HOST={os.environ.get('CONSUL_HOST', 'localhost')}"  # fallback-ok: error-diagnostic display only
         )
         print(f"                 CONSUL_PORT={os.environ.get('CONSUL_PORT', '8500')}")
         sys.exit(1)

--- a/scripts/emit_baselines_raw_snapshot.py
+++ b/scripts/emit_baselines_raw_snapshot.py
@@ -485,7 +485,10 @@ async def _emit_to_kafka(
 async def _run(dry_run: bool = False) -> int:
     """Main entry point."""
     db_url = os.environ.get("OMNIBASE_INFRA_DB_URL", "").strip()
-    kafka_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092").strip()
+    kafka_servers = os.environ.get(
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "localhost:19092",  # fallback-ok: ops script, env overrideable
+    ).strip()
 
     # Build snapshot payload
     if db_url:

--- a/scripts/monitor_logs.py
+++ b/scripts/monitor_logs.py
@@ -457,7 +457,10 @@ class PostgresErrorEmitter:
         try:
             import redis
 
-            valkey_host = os.environ.get("VALKEY_HOST", "localhost")
+            valkey_host = os.environ.get(
+                "VALKEY_HOST",
+                "localhost",  # fallback-ok: ops script, env overrideable
+            )
             valkey_port = int(os.environ.get("VALKEY_PORT", "16379"))
             valkey_db = int(os.environ.get("VALKEY_DB", "0"))
             valkey_password = os.environ.get("VALKEY_PASSWORD")
@@ -821,7 +824,10 @@ class RuntimeErrorEmitter:
         try:
             import redis
 
-            valkey_host = os.environ.get("VALKEY_HOST", "localhost")
+            valkey_host = os.environ.get(
+                "VALKEY_HOST",
+                "localhost",  # fallback-ok: ops script, env overrideable
+            )
             valkey_port = int(os.environ.get("VALKEY_PORT", "16379"))
             valkey_db = int(os.environ.get("VALKEY_DB", "0"))
             valkey_password = os.environ.get("VALKEY_PASSWORD")

--- a/scripts/provision-infisical.py
+++ b/scripts/provision-infisical.py
@@ -420,7 +420,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--addr",
-        default=os.environ.get("INFISICAL_ADDR", "http://localhost:8880"),
+        default=os.environ.get(
+            "INFISICAL_ADDR",
+            "http://localhost:8880",  # fallback-ok: local provisioning default
+        ),
         help="Infisical server address (default: http://localhost:8880)",
     )
     parser.add_argument(

--- a/scripts/provision-keycloak.py
+++ b/scripts/provision-keycloak.py
@@ -765,7 +765,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--kc-url",
-        default="http://localhost:28080",
+        default="http://localhost:28080",  # fallback-ok: local Keycloak provisioning default
         help=(
             "External base URL for Keycloak (no path prefix). "
             "Default: http://localhost:28080.  "

--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -93,7 +93,10 @@ async def _run() -> int:
         logger.error("OMNIBASE_INFRA_DB_URL is required but not set")
         return 1
 
-    kafka_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092").strip()
+    kafka_servers = os.environ.get(
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "localhost:19092",  # fallback-ok: ops script, env overrideable
+    ).strip()
     use_kafka = bool(kafka_servers)
 
     correlation_id = uuid4()

--- a/scripts/seed-infisical.py
+++ b/scripts/seed-infisical.py
@@ -199,7 +199,10 @@ def _load_infisical_credentials() -> tuple[str, str, str, str]:
     Raises:
         SystemExit: If required credentials are missing.
     """
-    infisical_addr = os.environ.get("INFISICAL_ADDR", "http://localhost:8880")
+    infisical_addr = os.environ.get(
+        "INFISICAL_ADDR",
+        "http://localhost:8880",  # fallback-ok: local seed default
+    )
     client_id = os.environ.get("INFISICAL_CLIENT_ID", "")
     client_secret = os.environ.get("INFISICAL_CLIENT_SECRET", "")
     project_id = os.environ.get("INFISICAL_PROJECT_ID", "")

--- a/scripts/seed-keycloak.sh
+++ b/scripts/seed-keycloak.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-KC_URL="${KC_URL:-http://localhost:28080}"
+KC_URL="${KC_URL:-http://localhost:28080}"  # fallback-ok: local Keycloak seed default
 KC_REALM="${KC_REALM:-omninode}"
 OMNIBASE_ENV_FILE="${OMNIBASE_ENV_FILE:-${HOME}/.omnibase/.env}"
 KC_READY_TIMEOUT="${KC_READY_TIMEOUT:-90}"

--- a/scripts/trigger-deploy.sh
+++ b/scripts/trigger-deploy.sh
@@ -19,12 +19,12 @@ LOG_DIR="${OMNI_HOME}/.onex_state/logs"
 LOG_FILE="${LOG_DIR}/deploy-$(date +%Y%m%d-%H%M%S).log"
 
 # .201 server (dev target)
-DEV_HOST="${DEV_HOST:-192.168.1.201}"
+DEV_HOST="${DEV_HOST:-192.168.1.201}"  # fallback-ok: dev deploy target
 DEV_USER="${DEV_USER:-jonah}"
 DEV_OMNI_HOME="${DEV_OMNI_HOME:-/home/${DEV_USER}/Code/omni_home}"
 
 # Health check
-HEALTH_CHECK_URL="${HEALTH_CHECK_URL:-http://localhost:8085/health}"
+HEALTH_CHECK_URL="${HEALTH_CHECK_URL:-http://localhost:8085/health}"  # fallback-ok: local health check target
 HEALTH_CHECK_RETRIES=15
 HEALTH_CHECK_INTERVAL=4
 

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Validate that no localhost fallbacks exist in src/ Python files.
+"""Canonical unified validator: no localhost/hardcoded-endpoint fallbacks.
 
-Scans src/**/*.py for patterns like:
-  - os.environ.get("...", "localhost...")
-  - default="localhost..."
-  - default="http://localhost..."
-  - default="bolt://localhost..."
-  - default="redis://localhost..."
-  - default="postgresql://localhost..."
+Covers all 6 pattern types from OMN-10658 enforcement sweep:
+  1. os.environ.get("X", "localhost...")
+  2. os.getenv("X", "localhost...")
+  3. default="localhost..." (Pydantic Field or function param)
+  4. ${VAR:-localhost} (shell scripts)
+  5. Hardcoded 192.168.* IPs as default values
+  6. 127.0.0.1 bind addresses as default values
 
-Exits non-zero if any violations are found.
-Skips test files (tests/, __tests__/).
+Exits 0 if clean, 1 if violations found.
+
+Annotation: add  # fallback-ok: <reason>  to a line to exempt it.
+[OMN-10741]
 """
 
 from __future__ import annotations
@@ -21,53 +23,239 @@ import re
 import sys
 from pathlib import Path
 
-VIOLATIONS_PATTERNS = [
+# ---------------------------------------------------------------------------
+# Pattern building blocks
+# ---------------------------------------------------------------------------
+_LOCALHOST_VARIANTS = (
+    r"(?:localhost|127\.0\.0\.1"
+    r"|http://localhost|https://localhost"
+    r"|bolt://localhost|redis://localhost"
+    r"|postgresql://localhost|amqp://localhost"
+    r"|http://127\.0\.0\.1|redis://127\.0\.0\.1|postgresql://127\.0\.0\.1)"
+)
+_PRIV_IP = r"192\.168\.\d{1,3}\.\d{1,3}"
+
+# ---------------------------------------------------------------------------
+# Python patterns
+# ---------------------------------------------------------------------------
+PYTHON_FALLBACK_PATTERNS: list[re.Pattern[str]] = [
+    # os.environ.get("VAR", "localhost...")
     re.compile(
-        r'os\.environ\.get\([^)]*,\s*"(localhost|http://localhost|bolt://localhost|redis://localhost|postgresql://localhost)'
+        rf"""os\.environ\.get\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""
     ),
+    # os.getenv("VAR", "localhost...")
     re.compile(
-        r'default="(localhost|http://localhost|bolt://localhost|redis://localhost|postgresql://localhost)'
+        rf"""os\.getenv\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""
+    ),
+    # default="localhost..." (Pydantic Field or keyword argument)
+    re.compile(rf"""default\s*=\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""),
+    # ": str = "localhost..." style parameter defaults
+    re.compile(rf""":\s*str\s*=\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""),
+    # os.environ.get / os.getenv with private-IP default
+    re.compile(
+        rf"""os\.(?:environ\.get|getenv)\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_PRIV_IP}[^"']*["']"""
+    ),
+    # default="192.168...." or ": str = "192.168...." style
+    re.compile(rf"""(?:default\s*=|:\s*str\s*=)\s*["'][^"']*{_PRIV_IP}[^"']*["']"""),
+    # bootstrap_servers="localhost:..." or private-IP
+    re.compile(
+        rf"""bootstrap_servers\s*=\s*["'](?:{_LOCALHOST_VARIANTS}|{_PRIV_IP})[^"']*["']"""
     ),
 ]
 
-SKIP_DIRS = {"tests", "__tests__", "test", "__pycache__"}
+# ---------------------------------------------------------------------------
+# Shell patterns
+# ---------------------------------------------------------------------------
+SHELL_FALLBACK_PATTERNS: list[re.Pattern[str]] = [
+    # ${VAR:-localhost} or ${VAR:-http://localhost:8080}
+    re.compile(
+        rf"""\$\{{[A-Za-z_][A-Za-z0-9_]*:-[^}}]*{_LOCALHOST_VARIANTS}[^}}]*\}}"""
+    ),
+    re.compile(rf"""\$\{{[A-Za-z_][A-Za-z0-9_]*:-[^}}]*{_PRIV_IP}[^}}]*\}}"""),
+]
+
+# ---------------------------------------------------------------------------
+# Skip / exempt configuration
+# ---------------------------------------------------------------------------
+SKIP_DIRS: frozenset[str] = frozenset(
+    {"tests", "node_tests", "__tests__", "test", "__pycache__", ".git", ".venv", "venv"}
+)
+
+SKIP_FILES: frozenset[str] = frozenset(
+    {
+        "validate_no_env_fallbacks.py",  # this script — patterns appear as strings
+    }
+)
+
+EXEMPT_MARKERS: tuple[str, ...] = (
+    "# fallback-ok",
+    "# cloud-bus-ok",
+    "# OMN-7227-exempt",
+)
+
+_COMMENT_RE = re.compile(r"^\s*#")
 
 
-def scan(root: Path) -> list[tuple[str, int, str]]:
-    violations: list[tuple[str, int, str]] = []
-    for py_file in sorted(root.rglob("*.py")):
-        # Skip test directories
-        if any(part in SKIP_DIRS for part in py_file.parts):
+def _is_pure_comment(line: str) -> bool:
+    return bool(_COMMENT_RE.match(line))
+
+
+def _has_exempt_marker(line: str) -> bool:
+    return any(marker in line for marker in EXEMPT_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# File scanners
+# ---------------------------------------------------------------------------
+
+
+def scan_python_file(path: Path) -> list[tuple[int, str]]:
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    violations: list[tuple[int, str]] = []
+    in_docstring = False
+    docstring_delim: str | None = None
+
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+
+        # Track triple-quoted docstrings
+        for delim in ('"""', "'''"):
+            count = stripped.count(delim)
+            if in_docstring and docstring_delim == delim:
+                if count >= 1:
+                    in_docstring = False
+                    docstring_delim = None
+                break
+            if not in_docstring and count == 1:
+                in_docstring = True
+                docstring_delim = delim
+                break
+            if count >= 2:
+                # Opens and closes on the same line — skip as a docstring line
+                break
+
+        if in_docstring:
             continue
-        try:
-            lines = py_file.read_text().splitlines()
-        except (OSError, UnicodeDecodeError):
+        if _is_pure_comment(line):
             continue
-        for lineno, line in enumerate(lines, start=1):
-            if "# fallback-ok" in line:
-                continue
-            for pattern in VIOLATIONS_PATTERNS:
-                if pattern.search(line):
-                    violations.append((str(py_file), lineno, line.strip()))
-                    break  # one violation per line is enough
+        if _has_exempt_marker(line):
+            continue
+
+        for pattern in PYTHON_FALLBACK_PATTERNS:
+            if pattern.search(line):
+                violations.append((lineno, line.rstrip()))
+                break
+
     return violations
 
 
+def scan_shell_file(path: Path) -> list[tuple[int, str]]:
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    violations: list[tuple[int, str]] = []
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        if _is_pure_comment(line):
+            continue
+        if _has_exempt_marker(line):
+            continue
+        for pattern in SHELL_FALLBACK_PATTERNS:
+            if pattern.search(line):
+                violations.append((lineno, line.rstrip()))
+                break
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(path: Path, repo_root: Path) -> bool:
+    rel = path.relative_to(repo_root)
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    if path.name in SKIP_FILES:
+        return True
+    return False
+
+
+def run(scan_roots: list[Path], repo_root: Path) -> list[tuple[str, int, str]]:
+    all_violations: list[tuple[str, int, str]] = []
+    for base in scan_roots:
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            if _should_skip(path, repo_root):
+                continue
+            rel = str(path.relative_to(repo_root))
+            if path.suffix == ".py":
+                file_viols = scan_python_file(path)
+            elif path.suffix in (".sh", ".bash"):
+                file_viols = scan_shell_file(path)
+            else:
+                continue
+            for lineno, line_text in file_viols:
+                all_violations.append((rel, lineno, line_text))
+    return all_violations
+
+
+def run_on_files(files: list[Path], repo_root: Path) -> list[tuple[str, int, str]]:
+    """Scan a specific list of files (pre-commit pass_filenames mode)."""
+    all_violations: list[tuple[str, int, str]] = []
+    for path in files:
+        path = path if path.is_absolute() else repo_root / path
+        if not path.is_file():
+            continue
+        if _should_skip(path, repo_root):
+            continue
+        rel = str(path.relative_to(repo_root))
+        if path.suffix == ".py":
+            file_viols = scan_python_file(path)
+        elif path.suffix in (".sh", ".bash"):
+            file_viols = scan_shell_file(path)
+        else:
+            continue
+        for lineno, line_text in file_viols:
+            all_violations.append((rel, lineno, line_text))
+    return all_violations
+
+
 def main() -> int:
-    src_dir = Path(__file__).resolve().parent.parent / "src"
-    if not src_dir.is_dir():
-        print(f"ERROR: src directory not found at {src_dir}", file=sys.stderr)
-        return 1
+    repo_root = Path(__file__).resolve().parent.parent
 
-    violations = scan(src_dir)
+    if len(sys.argv) > 1:
+        # pre-commit pass_filenames mode: scan only the files passed as args
+        files = [Path(f) for f in sys.argv[1:]]
+        violations = run_on_files(files, repo_root)
+    else:
+        # standalone mode: scan all of src/ and scripts/
+        scan_roots = [repo_root / "src", repo_root / "scripts"]
+        violations = run(scan_roots, repo_root)
+
     if violations:
-        print(f"Found {len(violations)} localhost fallback(s):\n")
-        for filepath, lineno, line in violations:
-            print(f"  {filepath}:{lineno}: {line}")
-        print("\nAll localhost/default fallbacks must be removed from src/.")
+        print(
+            f"FAIL: {len(violations)} localhost/hardcoded-endpoint fallback(s) found:\n"
+        )
+        for filepath, lineno, line_text in violations:
+            print(f"  {filepath}:{lineno}")
+            print(f"    {line_text}\n")
+        print(
+            'Fix: Replace with os.environ["VAR"] (fail-fast, no default) or raise explicitly.\n'
+            "Annotate justified exceptions with  # fallback-ok: <reason>  on the same line.\n"
+            "[OMN-10741]"
+        )
         return 1
 
-    print("OK: No localhost fallbacks found in src/.")
+    print("PASS: No localhost/hardcoded-endpoint fallbacks found.")
     return 0
 
 

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -121,6 +121,7 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
 
     for lineno, line in enumerate(content.splitlines(), start=1):
         stripped = line.strip()
+        skip_line = False
 
         # Track triple-quoted docstrings
         for delim in ('"""', "'''"):
@@ -129,6 +130,7 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
                 if count >= 1:
                     in_docstring = False
                     docstring_delim = None
+                    skip_line = True
                 break
             if not in_docstring and count == 1:
                 in_docstring = True
@@ -136,9 +138,10 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
                 break
             if count >= 2:
                 # Opens and closes on the same line — skip as a docstring line
+                skip_line = True
                 break
 
-        if in_docstring:
+        if in_docstring or skip_line:
             continue
         if _is_pure_comment(line):
             continue

--- a/scripts/verify-omnidash-health.sh
+++ b/scripts/verify-omnidash-health.sh
@@ -24,7 +24,7 @@
 
 set -euo pipefail
 
-OMNIDASH_URL="${OMNIDASH_URL:-http://localhost:3000}"
+OMNIDASH_URL="${OMNIDASH_URL:-http://localhost:3000}"  # fallback-ok: local dashboard health check
 EXPECTED_LIVE="${EXPECTED_LIVE:-3}"
 
 # ── Check if omnidash is running ──────────────────────────────────────────

--- a/src/omnibase_infra/cli/cli_env.py
+++ b/src/omnibase_infra/cli/cli_env.py
@@ -24,7 +24,10 @@ import click
 _MACHINES_YAML_DEFAULT = Path(__file__).parents[4] / "config" / "machines.yaml"
 
 # Fleet-wide constants — read from environment with fleet defaults
-_INFRA_HOST = os.environ.get("OMNI_INFRA_HOST", "192.168.86.201")
+_INFRA_HOST = os.environ.get(
+    "OMNI_INFRA_HOST",
+    "192.168.86.201",  # fallback-ok: lab-fixed IP
+)
 _KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", f"{_INFRA_HOST}:19092")
 _POSTGRES_HOST = os.environ.get("POSTGRES_HOST", _INFRA_HOST)
 _POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5436")

--- a/src/omnibase_infra/cli/infra_test/introspect.py
+++ b/src/omnibase_infra/cli/infra_test/introspect.py
@@ -82,7 +82,7 @@ def _build_introspection_payload(
         "discovered_capabilities": {},
         "contract_capabilities": None,
         "endpoints": {
-            "health": f"{os.environ.get('ONEX_RUNTIME_URL', 'http://localhost:8080')}/{nid}/health"
+            "health": f"{os.environ.get('ONEX_RUNTIME_URL', 'http://localhost:8080')}/{nid}/health"  # fallback-ok: local dev
         },
         "reason": "STARTUP",
         "correlation_id": cid,

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -956,7 +956,7 @@ class ModelKafkaEventBusConfig(BaseModel):
             Default configuration instance with environment overrides
         """
         base_config = cls(
-            bootstrap_servers="localhost:19092",
+            bootstrap_servers="localhost:19092",  # fallback-ok: local-dev default factory
             environment="local",
             timeout_seconds=30,
             max_retry_attempts=3,

--- a/src/omnibase_infra/nodes/node_scope_workflow_orchestrator/bin/scope_check.sh
+++ b/src/omnibase_infra/nodes/node_scope_workflow_orchestrator/bin/scope_check.sh
@@ -36,7 +36,7 @@ PAYLOAD=$(cat <<EOF
 EOF
 )
 
-echo "${PAYLOAD}" | kcat -P -b "${KAFKA_BOOTSTRAP_SERVERS:-${TEST_KAFKA_HOST:-localhost}:19092}" -t "${TOPIC}"
+echo "${PAYLOAD}" | kcat -P -b "${KAFKA_BOOTSTRAP_SERVERS:-${TEST_KAFKA_HOST:-localhost}:19092}" -t "${TOPIC}"  # fallback-ok: dev tool, env overrideable
 
 echo "scope-check command emitted"
 echo "  correlation_id: ${CORRELATION_ID}"

--- a/tests/integration/test_validate_no_env_fallbacks_integration.py
+++ b/tests/integration/test_validate_no_env_fallbacks_integration.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration coverage for the unified env fallback validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_no_env_fallbacks import run
+
+pytestmark = pytest.mark.integration
+
+
+def test_unified_env_fallback_validator_is_clean_for_runtime_roots() -> None:
+    repo_root = Path(__file__).parents[2]
+    violations = run([repo_root / "src", repo_root / "scripts"], repo_root)
+    assert violations == []

--- a/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
+++ b/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
@@ -137,6 +137,11 @@ class TestDocstringSkipping:
         p = _py(tmp_path, content)
         assert scan_python_file(p) == []
 
+    def test_skips_localhost_in_same_line_docstring(self, tmp_path: Path) -> None:
+        content = '"""Example: os.getenv("HOST", "localhost")"""\n'
+        p = _py(tmp_path, content)
+        assert scan_python_file(p) == []
+
     def test_skips_pure_comment_lines(self, tmp_path: Path) -> None:
         p = _py(tmp_path, '# host = os.environ.get("HOST", "localhost")\n')
         assert scan_python_file(p) == []

--- a/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
+++ b/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for canonical unified validate_no_env_fallbacks.py (OMN-10741)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_no_env_fallbacks import run, scan_python_file, scan_shell_file
+
+
+def _py(tmp_path: Path, content: str, name: str = "test_mod.py") -> Path:
+    f = tmp_path / "src" / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content)
+    return f
+
+
+def _sh(tmp_path: Path, content: str, name: str = "test_script.sh") -> Path:
+    f = tmp_path / "scripts" / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content)
+    return f
+
+
+@pytest.mark.unit
+class TestPythonPatternOsEnvironGet:
+    def test_detects_os_environ_get_with_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'host = os.environ.get("HOST", "localhost")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_detects_os_environ_get_with_http_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'url = os.environ.get("URL", "http://localhost:8080")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_clean_os_environ_raises(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'host = os.environ["HOST"]\n')
+        assert scan_python_file(p) == []
+
+    def test_fallback_ok_exempts_line(self, tmp_path: Path) -> None:
+        p = _py(
+            tmp_path,
+            'host = os.environ.get("HOST", "localhost")  # fallback-ok: test harness\n',
+        )
+        assert scan_python_file(p) == []
+
+
+@pytest.mark.unit
+class TestPythonPatternOsGetenv:
+    def test_detects_os_getenv_with_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'db = os.getenv("DB_HOST", "localhost")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_detects_os_getenv_with_redis_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'url = os.getenv("REDIS_URL", "redis://localhost:6379")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_clean_os_getenv_no_default(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'url = os.getenv("REDIS_URL")\n')
+        assert scan_python_file(p) == []
+
+    def test_cloud_bus_ok_exempts(self, tmp_path: Path) -> None:
+        p = _py(
+            tmp_path,
+            'db = os.getenv("DB_HOST", "localhost")  # cloud-bus-ok\n',
+        )
+        assert scan_python_file(p) == []
+
+
+@pytest.mark.unit
+class TestPythonPatternDefaultEquals:
+    def test_detects_pydantic_field_default_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, '    host: str = Field(default="localhost")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_detects_function_param_default_localhost(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, 'def connect(host: str = "localhost") -> None: ...\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_clean_field_no_default(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, "    host: str\n")
+        assert scan_python_file(p) == []
+
+
+@pytest.mark.unit
+class TestPythonPatternPrivateIpDefault:
+    def test_detects_os_getenv_private_ip(self, tmp_path: Path) -> None:
+        # Use a non-KAFKA_ var name so the kafka-no-hardcoded-fallback hook
+        # doesn't also match this test data string.
+        p = _py(tmp_path, 'host = os.getenv("INFRA_HOST", "192.168.86.201")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_detects_default_equals_private_ip(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, '    host: str = Field(default="192.168.1.100")\n')
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_fallback_ok_exempts_private_ip(self, tmp_path: Path) -> None:
+        p = _py(
+            tmp_path,
+            'host = os.getenv("INFRA_HOST", "192.168.86.201")  # fallback-ok: lab-only\n',
+        )
+        assert scan_python_file(p) == []
+
+
+@pytest.mark.unit
+class TestPythonPatternBootstrapServers:
+    def test_detects_bootstrap_servers_localhost(self, tmp_path: Path) -> None:
+        p = _py(
+            tmp_path, 'producer = KafkaProducer(bootstrap_servers="localhost:9092")\n'
+        )
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+
+    def test_clean_bootstrap_servers_from_env(self, tmp_path: Path) -> None:
+        p = _py(
+            tmp_path,
+            'producer = KafkaProducer(bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"])\n',
+        )
+        assert scan_python_file(p) == []
+
+
+@pytest.mark.unit
+class TestDocstringSkipping:
+    def test_skips_localhost_in_docstring(self, tmp_path: Path) -> None:
+        content = '"""\nExample: os.getenv("HOST", "localhost")\n"""\n'
+        p = _py(tmp_path, content)
+        assert scan_python_file(p) == []
+
+    def test_skips_pure_comment_lines(self, tmp_path: Path) -> None:
+        p = _py(tmp_path, '# host = os.environ.get("HOST", "localhost")\n')
+        assert scan_python_file(p) == []
+
+    def test_detects_violation_after_docstring(self, tmp_path: Path) -> None:
+        content = (
+            '"""Module docstring."""\n\nhost = os.environ.get("HOST", "localhost")\n'
+        )
+        p = _py(tmp_path, content)
+        viols = scan_python_file(p)
+        assert len(viols) == 1
+        assert viols[0][0] == 3
+
+
+@pytest.mark.unit
+class TestShellPatternBashVarDefault:
+    def test_detects_bash_var_localhost_default(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, 'HOST="${HOST:-localhost}"\n')
+        viols = scan_shell_file(s)
+        assert len(viols) == 1
+
+    def test_detects_bash_var_http_localhost_default(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, 'URL="${API_URL:-http://localhost:8080}"\n')
+        viols = scan_shell_file(s)
+        assert len(viols) == 1
+
+    def test_detects_bash_private_ip_default(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, 'HOST="${KAFKA_HOST:-192.168.86.201}"\n')
+        viols = scan_shell_file(s)
+        assert len(viols) == 1
+
+    def test_clean_bash_var_no_default(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, 'HOST="${HOST}"\n')
+        assert scan_shell_file(s) == []
+
+    def test_fallback_ok_exempts_shell(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, 'HOST="${HOST:-localhost}"  # fallback-ok: bind address\n')
+        assert scan_shell_file(s) == []
+
+    def test_skips_comment_lines_in_shell(self, tmp_path: Path) -> None:
+        s = _sh(tmp_path, '# HOST="${HOST:-localhost}"\n')
+        assert scan_shell_file(s) == []
+
+
+@pytest.mark.unit
+class TestRunFunction:
+    def test_run_finds_violations_across_src_and_scripts(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "src" / "config.py").write_text(
+            'url = os.environ.get("DB_URL", "postgresql://localhost/db")\n'
+        )
+        (tmp_path / "scripts" / "setup.sh").write_text('DB="${DB_URL:-localhost}"\n')
+
+        violations = run(
+            scan_roots=[tmp_path / "src", tmp_path / "scripts"],
+            repo_root=tmp_path,
+        )
+        assert len(violations) == 2
+
+    def test_run_skips_tests_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "tests").mkdir()
+        (tmp_path / "src" / "tests" / "conftest.py").write_text(
+            'url = os.environ.get("DB_URL", "localhost")\n'
+        )
+
+        violations = run(
+            scan_roots=[tmp_path / "src"],
+            repo_root=tmp_path,
+        )
+        assert violations == []
+
+    def test_run_skips_self(self, tmp_path: Path) -> None:
+        (tmp_path / "scripts").mkdir()
+        script = tmp_path / "scripts" / "validate_no_env_fallbacks.py"
+        script.write_text('# pattern references: os.environ.get("X", "localhost")\n')
+
+        violations = run(
+            scan_roots=[tmp_path / "scripts"],
+            repo_root=tmp_path,
+        )
+        assert violations == []
+
+    def test_run_returns_empty_when_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "settings.py").write_text('HOST = os.environ["HOST"]\n')
+
+        violations = run(
+            scan_roots=[tmp_path / "src"],
+            repo_root=tmp_path,
+        )
+        assert violations == []
+
+    def test_run_violation_tuple_format(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            'host = os.getenv("HOST", "localhost")\n'
+        )
+
+        violations = run(
+            scan_roots=[tmp_path / "src"],
+            repo_root=tmp_path,
+        )
+        assert len(violations) == 1
+        filepath, lineno, line_text = violations[0]
+        assert "app.py" in filepath
+        assert lineno == 1
+        assert "localhost" in line_text


### PR DESCRIPTION
## Summary

- Replaces 4 divergent per-repo `validate_no_env_fallbacks.py` scripts with a single canonical implementation in `omnibase_infra/scripts/`
- Covers all 6 fallback pattern types: `os.environ.get`, `os.getenv`, `default=`, shell `${VAR:-localhost}`, hardcoded `192.168.*` IPs, and `127.0.0.1` bind addresses
- Adds `# fallback-ok: <reason>` annotation support to exempt justified lines
- Wires the validator as a `no-env-fallbacks` pre-commit hook using `pass_filenames: true` for staged-files mode
- Adds unit and integration coverage for the validator and runtime-root scan

## Test plan

- [x] `uv run pytest tests/unit/scripts/validation/test_validate_no_env_fallbacks.py -q`
- [x] `uv run pytest tests/integration/test_validate_no_env_fallbacks_integration.py -q`
- [x] `uv run --frozen python scripts/validate_no_env_fallbacks.py`
- [x] Commit hooks passed locally

## DoD evidence

OMN-10741 — canonical unified validator shipped with test coverage and pre-commit gate wired.

Evidence-Ticket: OMN-10741
Evidence-Source: OCC#870