### PR TITLE
feat(OMN-10768): interactive onboarding policy Pydantic models

### DIFF
--- a/src/omnibase_infra/onboarding/model_interactive_policy.py
+++ b/src/omnibase_infra/onboarding/model_interactive_policy.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for the interactive onboarding policy."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+from omnibase_infra.onboarding.model_transition import ModelTransition
+
+
+class ModelInteractivePolicy(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    policy_name: str
+    description: str
+    version: dict[str, int]
+    policy_type: Literal["interactive"]
+    target_capabilities: list[str]
+    max_estimated_minutes: int
+    steps: list[ModelInteractiveStep]
+    transitions: list[ModelTransition]
+    env_output: dict[str, dict[str, str]]
+    start_step: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_graph_integrity(self) -> ModelInteractivePolicy:
+        if self.start_step is None:
+            object.__setattr__(self, "start_step", self.steps[0].id)
+
+        step_ids = [s.id for s in self.steps]
+        step_id_set = set(step_ids)
+
+        if len(step_id_set) != len(step_ids):
+            raise ValueError("Duplicate step IDs found")
+
+        terminal_steps: set[str] = set()
+        for t in self.transitions:
+            if t.from_step not in step_id_set:
+                raise ValueError(f"Transition references unknown step '{t.from_step}'")
+            if t.terminal:
+                terminal_steps.add(t.from_step)
+                continue
+            for branch in (t.responses or {}).values():
+                if branch.next not in step_id_set:
+                    raise ValueError(
+                        f"Transition from '{t.from_step}' references unknown step '{branch.next}'"
+                    )
+            for branch in t.on_submit or []:
+                if branch.next not in step_id_set:
+                    raise ValueError(
+                        f"Transition from '{t.from_step}' references unknown step '{branch.next}'"
+                    )
+
+        for tid in terminal_steps:
+            if tid not in self.env_output:
+                raise ValueError(f"Terminal step '{tid}' missing from env_output")
+
+        return self
+
+
+__all__ = ["ModelInteractivePolicy"]

--- a/src/omnibase_infra/onboarding/model_interactive_policy.py
+++ b/src/omnibase_infra/onboarding/model_interactive_policy.py
@@ -29,14 +29,19 @@ class ModelInteractivePolicy(BaseModel):
 
     @model_validator(mode="after")
     def _validate_graph_integrity(self) -> ModelInteractivePolicy:
-        if self.start_step is None:
-            object.__setattr__(self, "start_step", self.steps[0].id)
-
         step_ids = [s.id for s in self.steps]
+        if not step_ids:
+            raise ValueError("Interactive policy must define at least one step")
+
         step_id_set = set(step_ids)
 
         if len(step_id_set) != len(step_ids):
             raise ValueError("Duplicate step IDs found")
+
+        if self.start_step is None:
+            object.__setattr__(self, "start_step", step_ids[0])
+        elif self.start_step not in step_id_set:
+            raise ValueError(f"start_step references unknown step '{self.start_step}'")
 
         terminal_steps: set[str] = set()
         for t in self.transitions:

--- a/src/omnibase_infra/onboarding/model_interactive_step.py
+++ b/src/omnibase_infra/onboarding/model_interactive_step.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for a single interactive onboarding step."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelInteractiveStep(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(description="Step identifier")
+    prompt: str = Field(description="User-facing prompt text")
+    type: Literal["choice", "multi_choice", "text", "action"]
+    options: list[str] = Field(default_factory=list)
+    condition: str | None = Field(default=None)
+    required: bool = Field(default=True)
+    action: str | None = Field(default=None)
+    produces_capabilities: list[str] = Field(default_factory=list)
+
+
+__all__ = ["ModelInteractiveStep"]

--- a/src/omnibase_infra/onboarding/model_transition.py
+++ b/src/omnibase_infra/onboarding/model_transition.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for an interactive onboarding transition."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.onboarding.model_transition_branch import ModelTransitionBranch
+
+
+class ModelTransition(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    from_step: str = Field(alias="from")
+    terminal: bool = Field(default=False)
+    responses: dict[str, ModelTransitionBranch] | None = Field(default=None)
+    on_submit: list[ModelTransitionBranch] | None = Field(default=None)
+
+
+__all__ = ["ModelTransition"]

--- a/src/omnibase_infra/onboarding/model_transition_branch.py
+++ b/src/omnibase_infra/onboarding/model_transition_branch.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for a single branch in an interactive onboarding transition."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelTransitionBranch(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    condition: str | None = Field(default=None)
+    next: str
+    set_state: dict[str, JsonType] = Field(default_factory=dict)
+
+
+__all__ = ["ModelTransitionBranch"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3377,6 +3377,17 @@ pattern_exemptions:
     documentation:
       - CLAUDE.md (Repo Invariants - contracts are source of truth)
     ticket: OMN-10237
+  # ==========================================================================
+  # ModelInteractivePolicy policy_name Field Exemption (OMN-10768)
+  # ==========================================================================
+  - file_pattern: 'model_interactive_policy\.py'
+    violation_pattern: "Field 'policy_name' might reference an entity"
+    reason: >
+      policy_name is the canonical string identifier of the interactive onboarding policy (e.g., "interactive_onboarding"), read directly from the YAML contract. It is not an entity reference requiring ID + display_name pattern — it IS the primary identifier used to select the policy by name.
+
+    documentation:
+      - src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
+    ticket: OMN-10768
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/integration/test_interactive_onboarding_policy_model_validation.py
+++ b/tests/integration/test_interactive_onboarding_policy_model_validation.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for interactive onboarding policy model validation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+
+pytestmark = pytest.mark.integration
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+def _load_policy_raw() -> dict[str, object]:
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    assert isinstance(raw, dict)
+    return raw
+
+
+def test_interactive_policy_rejects_empty_steps_before_defaulting_start() -> None:
+    raw = deepcopy(_load_policy_raw())
+    raw["steps"] = []
+    raw["transitions"] = []
+    raw["env_output"] = {}
+
+    with pytest.raises(ValidationError, match="at least one step"):
+        ModelInteractivePolicy.model_validate(raw)
+
+
+def test_interactive_policy_rejects_unknown_explicit_start_step() -> None:
+    raw = deepcopy(_load_policy_raw())
+    raw["start_step"] = "missing_start_step"
+
+    with pytest.raises(ValidationError, match="start_step references unknown step"):
+        ModelInteractivePolicy.model_validate(raw)

--- a/tests/unit/onboarding/test_models_interactive.py
+++ b/tests/unit/onboarding/test_models_interactive.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for interactive onboarding policy Pydantic models."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.unit
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+def test_interactive_policy_loads_into_model() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+    assert policy.policy_name == "interactive_onboarding"
+    assert policy.policy_type == "interactive"
+    assert len(policy.steps) == 9
+    assert len(policy.transitions) >= 7
+
+
+def test_step_types_are_valid() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+    valid_types = {"choice", "multi_choice", "text", "action"}
+    for step in policy.steps:
+        assert step.type in valid_types
+
+
+def test_terminal_steps_have_env_output() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+    terminal_ids = {t.from_step for t in policy.transitions if t.terminal}
+    for tid in terminal_ids:
+        assert tid in policy.env_output
+
+
+def test_start_step_field() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+    assert policy.start_step == "choose_deployment_mode"
+
+
+def test_invalid_step_type_rejected() -> None:
+    from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+
+    with pytest.raises(ValidationError):
+        ModelInteractiveStep(id="x", prompt="x", type="bogus")
+
+
+def test_duplicate_step_ids_rejected() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    raw["steps"].append(raw["steps"][0])
+    with pytest.raises(ValueError, match=r"[Dd]uplicate"):
+        ModelInteractivePolicy.model_validate(raw)
+
+
+def test_transition_to_unknown_step_rejected() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    raw["transitions"][0]["responses"]["local"]["next"] = "nonexistent_step"
+    with pytest.raises(ValueError, match="unknown step"):
+        ModelInteractivePolicy.model_validate(raw)
+
+
+def test_missing_terminal_env_output_rejected() -> None:
+    from omnibase_infra.onboarding.model_interactive_policy import (
+        ModelInteractivePolicy,
+    )
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    del raw["env_output"]["write_config_local"]
+    with pytest.raises(ValueError, match="env_output"):
+        ModelInteractivePolicy.model_validate(raw)
+
+
+def test_extra_fields_rejected() -> None:
+    from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+
+    with pytest.raises(ValidationError):
+        ModelInteractiveStep(id="x", prompt="x", type="choice", bogus_field="y")


### PR DESCRIPTION
## Summary

- Adds `ModelInteractiveStep`, `ModelTransitionBranch`, `ModelTransition`, `ModelInteractivePolicy` (one model per file per architecture invariant)
- Graph integrity validated at construction: duplicate step IDs, unknown transition targets, terminal steps missing from `env_output`
- `extra="forbid"` on all models; `set_state` uses `JsonType` (not `Any`)
- `start_step` inferred from first step when absent
- Adds `policy_name` pattern exemption to `validation_exemptions.yaml` (descriptive identifier, not entity ref)

## Ticket

OMN-10768 (child of OMN-10767 Interactive Onboarding Executor epic)

## Test plan

- [x] `uv run pytest tests/unit/onboarding/test_models_interactive.py -v` — 9/9 pass
- [x] All pre-commit hooks pass (architecture, pattern, union, any-type, SPDX, ruff)
- [x] `uv run mypy src/omnibase_infra/onboarding/model_interactive_policy.py --strict` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure components to support interactive onboarding policies with comprehensive validation rules.
  * Implemented automated validation to ensure onboarding policy integrity, including duplicate detection and cross-reference validation.
  * Added comprehensive test coverage for onboarding policy validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#885
Evidence-Ticket: OMN-10768