### PR TITLE
feat(OMN-10779): condition evaluator — pure guard expression evaluator

### DIFF
--- a/src/omnibase_infra/onboarding/condition_evaluator.py
+++ b/src/omnibase_infra/onboarding/condition_evaluator.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Condition evaluator for onboarding step visibility — OMN-10779.
+
+Evaluates boolean guard expressions against a state dict without eval().
+Supported operators: ==, in [...], not in [...], in <state_key>, and.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+class ConditionEvaluationError(Exception):
+    """Raised when a condition references an unknown state key or is malformed."""
+
+
+def _resolve_key(key: str, state: dict[str, object]) -> object:
+    if key not in state:
+        msg = f"Unknown state key: '{key}'"
+        raise ConditionEvaluationError(msg)
+    return state[key]
+
+
+def _parse_inline_list(raw: str) -> list[str]:
+    """Parse '[a, b, c]' into ['a', 'b', 'c']."""
+    inner = raw.strip()
+    if not (inner.startswith("[") and inner.endswith("]")):
+        msg = f"Expected inline list, got: {inner!r}"
+        raise ConditionEvaluationError(msg)
+    items = inner[1:-1].split(",")
+    return [item.strip().strip('"').strip("'") for item in items if item.strip()]
+
+
+def _strip_quotes(value: str) -> str:
+    return value.strip().strip('"').strip("'")
+
+
+def _evaluate_single(expr: str, state: dict[str, object]) -> bool:
+    expr = expr.strip()
+
+    # Pattern: key not in [list] or key not in state_key
+    not_in_match = re.match(r"^(\w+)\s+not\s+in\s+(.+)$", expr)
+    if not_in_match:
+        lhs_key = not_in_match.group(1)
+        rhs_raw = not_in_match.group(2).strip()
+        lhs_val = str(_resolve_key(lhs_key, state))
+        if rhs_raw.startswith("["):
+            items = _parse_inline_list(rhs_raw)
+        else:
+            rhs_key = rhs_raw
+            rhs_obj = _resolve_key(rhs_key, state)
+            if not isinstance(rhs_obj, (list, tuple, set)):
+                msg = f"State key '{rhs_key}' is not a collection"
+                raise ConditionEvaluationError(msg)
+            items = [str(x) for x in rhs_obj]
+        return lhs_val not in items
+
+    # Pattern: key in [list] or key in state_key
+    in_match = re.match(r"^(\w+)\s+in\s+(.+)$", expr)
+    if in_match:
+        lhs_key = in_match.group(1)
+        rhs_raw = in_match.group(2).strip()
+        lhs_val = str(_resolve_key(lhs_key, state))
+        if rhs_raw.startswith("["):
+            items = _parse_inline_list(rhs_raw)
+        else:
+            rhs_key = rhs_raw
+            rhs_obj = _resolve_key(rhs_key, state)
+            if not isinstance(rhs_obj, (list, tuple, set)):
+                msg = f"State key '{rhs_key}' is not a collection"
+                raise ConditionEvaluationError(msg)
+            items = [str(x) for x in rhs_obj]
+        return lhs_val in items
+
+    # Pattern: key == value
+    eq_match = re.match(r"^(\w+)\s*==\s*(.+)$", expr)
+    if eq_match:
+        lhs_key = eq_match.group(1)
+        rhs_val = _strip_quotes(eq_match.group(2))
+        lhs_val = str(_resolve_key(lhs_key, state))
+        return lhs_val == rhs_val
+
+    msg = f"Unrecognised condition syntax: {expr!r}"
+    raise ConditionEvaluationError(msg)
+
+
+def evaluate_condition(expr: str | None, state: dict[str, object]) -> bool:
+    """Evaluate a guard expression against state.
+
+    Args:
+        expr: Condition string or None. None always returns True.
+        state: Current onboarding state dict.
+
+    Returns:
+        True if the condition holds, False otherwise.
+
+    Raises:
+        ConditionEvaluationError: If a referenced state key is unknown or the
+            expression syntax is unrecognised.
+    """
+    if expr is None:
+        return True
+
+    # Split on ' and ' (space-bounded to avoid partial matches inside values)
+    clauses = re.split(r"\s+and\s+", expr)
+    return all(_evaluate_single(clause, state) for clause in clauses)
+
+
+__all__ = ["ConditionEvaluationError", "evaluate_condition"]

--- a/src/omnibase_infra/onboarding/condition_evaluator.py
+++ b/src/omnibase_infra/onboarding/condition_evaluator.py
@@ -37,6 +37,39 @@ def _strip_quotes(value: str) -> str:
     return value.strip().strip('"').strip("'")
 
 
+def _split_and_clauses(expr: str) -> list[str]:
+    """Split an expression on whitespace-bounded ``and`` outside quotes."""
+    clauses: list[str] = []
+    start = 0
+    quote: str | None = None
+    index = 0
+
+    while index < len(expr):
+        char = expr[index]
+        if char in {"'", '"'}:
+            if quote is None:
+                quote = char
+            elif quote == char:
+                quote = None
+            index += 1
+            continue
+
+        if quote is None and expr.startswith("and", index):
+            before_is_space = index > 0 and expr[index - 1].isspace()
+            after_index = index + len("and")
+            after_is_space = after_index < len(expr) and expr[after_index].isspace()
+            if before_is_space and after_is_space:
+                clauses.append(expr[start:index].strip())
+                start = after_index
+                index = after_index
+                continue
+
+        index += 1
+
+    clauses.append(expr[start:].strip())
+    return [clause for clause in clauses if clause]
+
+
 def _evaluate_single(expr: str, state: dict[str, object]) -> bool:
     expr = expr.strip()
 
@@ -103,8 +136,7 @@ def evaluate_condition(expr: str | None, state: dict[str, object]) -> bool:
     if expr is None:
         return True
 
-    # Split on ' and ' (space-bounded to avoid partial matches inside values)
-    clauses = re.split(r"\s+and\s+", expr)
+    clauses = _split_and_clauses(expr)
     return all(_evaluate_single(clause, state) for clause in clauses)
 
 

--- a/tests/integration/test_condition_evaluator_integration.py
+++ b/tests/integration/test_condition_evaluator_integration.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for condition_evaluator against canonical graph data — OMN-10779."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.onboarding.condition_evaluator import (
+    ConditionEvaluationError,
+    evaluate_condition,
+)
+from omnibase_infra.onboarding.loader import load_canonical_graph
+
+pytestmark = pytest.mark.integration
+
+
+class TestConditionEvaluatorWithCanonicalGraph:
+    """Verify evaluate_condition against step keys and capability names from the real graph."""
+
+    def test_canonical_graph_loads(self) -> None:
+        graph = load_canonical_graph()
+        assert len(graph.steps) > 0
+
+    def test_step_key_in_real_capability_list(self) -> None:
+        graph = load_canonical_graph()
+        all_capabilities = {
+            cap for step in graph.steps for cap in step.produces_capabilities
+        }
+        # All canonical capabilities are known strings — verify membership check works
+        for cap in all_capabilities:
+            result = evaluate_condition(
+                "current_cap in available_caps",
+                {"current_cap": cap, "available_caps": list(all_capabilities)},
+            )
+            assert result is True, f"Expected {cap} in capability list"
+
+    def test_none_condition_passes_for_all_steps(self) -> None:
+        graph = load_canonical_graph()
+        state: dict[str, object] = {}
+        for step in graph.steps:
+            assert evaluate_condition(None, state) is True
+
+    def test_step_key_equality_condition(self) -> None:
+        graph = load_canonical_graph()
+        first_step = graph.steps[0]
+        assert evaluate_condition(
+            f"current_step == {first_step.step_key}",
+            {"current_step": first_step.step_key},
+        )
+
+    def test_step_type_membership_condition(self) -> None:
+        graph = load_canonical_graph()
+        step_types = list({s.step_type for s in graph.steps})
+        for step in graph.steps:
+            result = evaluate_condition(
+                "step_type in valid_types",
+                {"step_type": step.step_type, "valid_types": step_types},
+            )
+            assert result is True
+
+    def test_unknown_capability_not_in_list(self) -> None:
+        graph = load_canonical_graph()
+        all_capabilities = [
+            cap for step in graph.steps for cap in step.produces_capabilities
+        ]
+        assert evaluate_condition(
+            "cap not in known_caps",
+            {"cap": "nonexistent_capability_xyz", "known_caps": all_capabilities},
+        )
+
+    def test_missing_state_key_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError):
+            evaluate_condition("unknown_step_key == check_python", {})

--- a/tests/unit/onboarding/test_condition_evaluator.py
+++ b/tests/unit/onboarding/test_condition_evaluator.py
@@ -12,6 +12,8 @@ from omnibase_infra.onboarding.condition_evaluator import (
     evaluate_condition,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestNoneCondition:
     def test_none_returns_true(self) -> None:
@@ -133,6 +135,15 @@ class TestAnd:
     def test_and_unknown_key_raises(self) -> None:
         with pytest.raises(ConditionEvaluationError):
             evaluate_condition("env == local and missing_key == x", {"env": "local"})
+
+    def test_and_inside_quoted_value_is_not_clause_split(self) -> None:
+        assert (
+            evaluate_condition(
+                'mode == "research and development" and env == local',
+                {"mode": "research and development", "env": "local"},
+            )
+            is True
+        )
 
 
 class TestCanonicalGraphConditions:

--- a/tests/unit/onboarding/test_condition_evaluator.py
+++ b/tests/unit/onboarding/test_condition_evaluator.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for condition_evaluator — OMN-10779."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.onboarding.condition_evaluator import (
+    ConditionEvaluationError,
+    evaluate_condition,
+)
+
+
+class TestNoneCondition:
+    def test_none_returns_true(self) -> None:
+        assert evaluate_condition(None, {}) is True
+
+    def test_none_ignores_state(self) -> None:
+        assert evaluate_condition(None, {"foo": "bar"}) is True
+
+
+class TestEquality:
+    def test_eq_matching_value(self) -> None:
+        assert evaluate_condition("env == local", {"env": "local"}) is True
+
+    def test_eq_non_matching_value(self) -> None:
+        assert evaluate_condition("env == cloud", {"env": "local"}) is False
+
+    def test_eq_quoted_string_value(self) -> None:
+        assert (
+            evaluate_condition('mode == "production"', {"mode": "production"}) is True
+        )
+
+    def test_eq_unknown_key_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="unknown_key"):
+            evaluate_condition("unknown_key == foo", {})
+
+
+class TestInList:
+    def test_in_list_match(self) -> None:
+        assert evaluate_condition("env in [local, dev]", {"env": "local"}) is True
+
+    def test_in_list_no_match(self) -> None:
+        assert evaluate_condition("env in [local, dev]", {"env": "cloud"}) is False
+
+    def test_in_list_unknown_key_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="env"):
+            evaluate_condition("env in [local, dev]", {})
+
+    def test_in_list_single_item(self) -> None:
+        assert (
+            evaluate_condition("mode in [production]", {"mode": "production"}) is True
+        )
+
+
+class TestNotIn:
+    def test_not_in_list_match(self) -> None:
+        assert (
+            evaluate_condition("env not in [cloud, staging]", {"env": "local"}) is True
+        )
+
+    def test_not_in_list_no_match(self) -> None:
+        assert evaluate_condition("env not in [local, dev]", {"env": "local"}) is False
+
+    def test_not_in_list_unknown_key_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="env"):
+            evaluate_condition("env not in [local, dev]", {})
+
+
+class TestInStateKey:
+    def test_in_state_key_match(self) -> None:
+        assert (
+            evaluate_condition(
+                "env in allowed_envs",
+                {"env": "local", "allowed_envs": ["local", "dev"]},
+            )
+            is True
+        )
+
+    def test_in_state_key_no_match(self) -> None:
+        assert (
+            evaluate_condition(
+                "env in allowed_envs",
+                {"env": "cloud", "allowed_envs": ["local", "dev"]},
+            )
+            is False
+        )
+
+    def test_in_state_key_lhs_unknown_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="env"):
+            evaluate_condition("env in allowed_envs", {"allowed_envs": ["local"]})
+
+    def test_in_state_key_rhs_unknown_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="allowed_envs"):
+            evaluate_condition("env in allowed_envs", {"env": "local"})
+
+
+class TestAnd:
+    def test_and_both_true(self) -> None:
+        assert (
+            evaluate_condition(
+                "env == local and mode == dev", {"env": "local", "mode": "dev"}
+            )
+            is True
+        )
+
+    def test_and_first_false(self) -> None:
+        assert (
+            evaluate_condition(
+                "env == cloud and mode == dev", {"env": "local", "mode": "dev"}
+            )
+            is False
+        )
+
+    def test_and_second_false(self) -> None:
+        assert (
+            evaluate_condition(
+                "env == local and mode == prod", {"env": "local", "mode": "dev"}
+            )
+            is False
+        )
+
+    def test_and_both_false(self) -> None:
+        assert (
+            evaluate_condition(
+                "env == cloud and mode == prod", {"env": "local", "mode": "dev"}
+            )
+            is False
+        )
+
+    def test_and_unknown_key_raises(self) -> None:
+        with pytest.raises(ConditionEvaluationError):
+            evaluate_condition("env == local and missing_key == x", {"env": "local"})
+
+
+class TestCanonicalGraphConditions:
+    """Tests based on real condition patterns that would appear in onboarding contracts."""
+
+    def test_deployment_mode_condition(self) -> None:
+        assert (
+            evaluate_condition(
+                "deployment_mode in [cloud, hybrid]",
+                {"deployment_mode": "cloud"},
+            )
+            is True
+        )
+
+    def test_deployment_mode_local_excluded(self) -> None:
+        assert (
+            evaluate_condition(
+                "deployment_mode in [cloud, hybrid]",
+                {"deployment_mode": "local"},
+            )
+            is False
+        )
+
+    def test_user_role_not_in(self) -> None:
+        assert (
+            evaluate_condition(
+                "user_role not in [guest, viewer]",
+                {"user_role": "admin"},
+            )
+            is True
+        )
+
+    def test_combined_role_and_env(self) -> None:
+        assert (
+            evaluate_condition(
+                "user_role == admin and env == production",
+                {"user_role": "admin", "env": "production"},
+            )
+            is True
+        )
+
+    def test_value_in_state_list(self) -> None:
+        assert (
+            evaluate_condition(
+                "selected_track in available_tracks",
+                {
+                    "selected_track": "omnimarket",
+                    "available_tracks": ["omnimarket", "standalone"],
+                },
+            )
+            is True
+        )
+
+
+class TestUnknownKeyErrors:
+    def test_unknown_key_message_includes_key_name(self) -> None:
+        with pytest.raises(ConditionEvaluationError, match="my_missing_key"):
+            evaluate_condition("my_missing_key == foo", {})
+
+    def test_unknown_key_is_not_eval_error(self) -> None:
+        exc = None
+        try:
+            evaluate_condition("missing == x", {})
+        except ConditionEvaluationError as e:
+            exc = e
+        assert exc is not None
+        assert not isinstance(exc, SyntaxError)


### PR DESCRIPTION
## Summary

- Adds `evaluate_condition(expr: str | None, state: dict) -> bool` in `src/omnibase_infra/onboarding/condition_evaluator.py`
- Adds `ConditionEvaluationError` raised on unknown state key references
- Supports: `==`, `in [...]`, `not in [...]`, `in <state_key>`, `and` conjunctions
- No `eval()` — regex-based parser only
- `None` condition returns `True`
- 29 unit tests at `tests/unit/onboarding/test_condition_evaluator.py` covering all operator patterns + canonical graph conditions

Closes OMN-10779. Part of OMN-10777 epic (Task 2).

## Test plan

- [x] `uv run pytest tests/unit/onboarding/test_condition_evaluator.py -v` — 29/29 passed
- [x] `uv run pytest tests/unit/onboarding/` — 121/121 passed
- [x] `uv run mypy src/omnibase_infra/onboarding/condition_evaluator.py --strict` — clean
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] `pre-commit run --all-files` — all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional visibility for onboarding steps enhanced: supports equality, list membership, and combined AND conditions with more robust handling of malformed or missing state data.
* **Tests**
  * Added unit and integration tests to validate condition evaluation against real onboarding scenarios and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1548)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#885
Evidence-Ticket: OMN-10779