### PR TITLE
feat(OMN-10778): interactive policy + step Pydantic models

### DIFF
--- a/src/omnibase_infra/onboarding/model_interactive_policy.py
+++ b/src/omnibase_infra/onboarding/model_interactive_policy.py
@@ -16,7 +16,7 @@ from omnibase_infra.onboarding.model_transition import ModelTransition
 class ModelInteractivePolicy(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    policy_name: str
+    policy_name: str  # ONEX_EXCLUDE: pattern_validator - policy_name is the policy's own identifier, not an entity reference
     description: str
     version: dict[str, int]
     policy_type: Literal["interactive"]

--- a/src/omnibase_infra/onboarding/models_interactive.py
+++ b/src/omnibase_infra/onboarding/models_interactive.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Re-export shim for interactive onboarding models (OMN-10778).
+
+Individual model files follow the one-model-per-file architecture rule.
+This module re-exports all four for convenient single-import access.
+"""
+
+from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+from omnibase_infra.onboarding.model_transition import ModelTransition
+from omnibase_infra.onboarding.model_transition_branch import ModelTransitionBranch
+
+__all__ = [
+    "ModelInteractivePolicy",
+    "ModelInteractiveStep",
+    "ModelTransition",
+    "ModelTransitionBranch",
+]

--- a/tests/integration/test_interactive_onboarding_policy_model_validation.py
+++ b/tests/integration/test_interactive_onboarding_policy_model_validation.py
@@ -47,3 +47,19 @@ def test_interactive_policy_rejects_unknown_explicit_start_step() -> None:
 
     with pytest.raises(ValidationError, match="start_step references unknown step"):
         ModelInteractivePolicy.model_validate(raw)
+
+
+def test_interactive_models_reexport_validates_policy_graph() -> None:
+    from omnibase_infra.onboarding.models_interactive import (
+        ModelInteractivePolicy as ReexportedInteractivePolicy,
+    )
+
+    raw = deepcopy(_load_policy_raw())
+    raw["start_step"] = None
+
+    policy = ReexportedInteractivePolicy.model_validate(raw)
+
+    assert policy.start_step == policy.steps[0].id
+    assert {step.id for step in policy.steps} >= {
+        transition.from_step for transition in policy.transitions
+    }

--- a/tests/integration/test_models_interactive_integration.py
+++ b/tests/integration/test_models_interactive_integration.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for interactive onboarding Pydantic models (OMN-10778).
+
+Validates the re-export shim (models_interactive.py) and the canonical
+interactive_onboarding.yaml policy against the full model stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.integration
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+def test_models_interactive_shim_exports_all_four_models() -> None:
+    from omnibase_infra.onboarding.models_interactive import (
+        ModelInteractivePolicy,
+        ModelInteractiveStep,
+        ModelTransition,
+        ModelTransitionBranch,
+    )
+
+    assert ModelInteractivePolicy is not None
+    assert ModelInteractiveStep is not None
+    assert ModelTransition is not None
+    assert ModelTransitionBranch is not None
+
+
+def test_canonical_policy_loads_via_shim() -> None:
+    from omnibase_infra.onboarding.models_interactive import ModelInteractivePolicy
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+    assert policy.policy_name == "interactive_onboarding"
+    assert policy.start_step == "choose_deployment_mode"
+    assert len(policy.steps) == 9
+
+
+def test_transition_branch_set_state_roundtrip() -> None:
+    from omnibase_infra.onboarding.models_interactive import ModelTransitionBranch
+
+    branch = ModelTransitionBranch(
+        next="next_step",
+        set_state={"mode": "local", "flag": True, "count": 3},
+    )
+    dumped = branch.model_dump()
+    restored = ModelTransitionBranch.model_validate(dumped)
+    assert restored.set_state == branch.set_state
+
+
+def test_canonical_policy_graph_integrity() -> None:
+    from omnibase_infra.onboarding.models_interactive import ModelInteractivePolicy
+
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    policy = ModelInteractivePolicy.model_validate(raw)
+
+    step_ids = {s.id for s in policy.steps}
+    terminal_ids = {t.from_step for t in policy.transitions if t.terminal}
+
+    for t in policy.transitions:
+        assert t.from_step in step_ids
+        if not t.terminal:
+            for branch in (t.responses or {}).values():
+                assert branch.next in step_ids
+    for tid in terminal_ids:
+        assert tid in policy.env_output

--- a/tests/unit/onboarding/test_models_interactive.py
+++ b/tests/unit/onboarding/test_models_interactive.py
@@ -3,6 +3,8 @@
 
 """Tests for interactive onboarding policy Pydantic models."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest
@@ -82,7 +84,7 @@ def test_duplicate_step_ids_rejected() -> None:
 
     raw = yaml.safe_load(POLICY_PATH.read_text())
     raw["steps"].append(raw["steps"][0])
-    with pytest.raises(ValueError, match=r"[Dd]uplicate"):
+    with pytest.raises((ValueError, ValidationError), match=r"[Dd]uplicate"):
         ModelInteractivePolicy.model_validate(raw)
 
 
@@ -93,7 +95,7 @@ def test_transition_to_unknown_step_rejected() -> None:
 
     raw = yaml.safe_load(POLICY_PATH.read_text())
     raw["transitions"][0]["responses"]["local"]["next"] = "nonexistent_step"
-    with pytest.raises(ValueError, match="unknown step"):
+    with pytest.raises((ValueError, ValidationError), match="unknown step"):
         ModelInteractivePolicy.model_validate(raw)
 
 
@@ -104,7 +106,7 @@ def test_missing_terminal_env_output_rejected() -> None:
 
     raw = yaml.safe_load(POLICY_PATH.read_text())
     del raw["env_output"]["write_config_local"]
-    with pytest.raises(ValueError, match="env_output"):
+    with pytest.raises((ValueError, ValidationError), match="env_output"):
         ModelInteractivePolicy.model_validate(raw)
 
 
@@ -113,3 +115,22 @@ def test_extra_fields_rejected() -> None:
 
     with pytest.raises(ValidationError):
         ModelInteractiveStep(id="x", prompt="x", type="choice", bogus_field="y")
+
+
+def test_set_state_typed_as_json_type() -> None:
+    from omnibase_infra.onboarding.model_transition_branch import ModelTransitionBranch
+
+    branch = ModelTransitionBranch(
+        next="some_step", set_state={"key": "value", "flag": True, "count": 42}
+    )
+    assert branch.set_state["key"] == "value"
+    assert branch.set_state["flag"] is True
+    assert branch.set_state["count"] == 42
+
+
+def test_transition_from_field_alias() -> None:
+    from omnibase_infra.onboarding.model_transition import ModelTransition
+
+    t = ModelTransition.model_validate({"from": "some_step", "terminal": True})
+    assert t.from_step == "some_step"
+    assert t.terminal is True


### PR DESCRIPTION
## Summary

- Implements Task 1 of the interactive onboarding executor (OMN-10778, Epic OMN-10777)
- `ModelInteractiveStep`, `ModelTransitionBranch`, `ModelTransition`, `ModelInteractivePolicy` — one model per file per architecture rule; `models_interactive.py` re-exports all four
- Graph integrity validated at construction via `@model_validator`: rejects duplicate step IDs, unknown transition targets, terminal steps missing env_output; infers `start_step` from first step
- `set_state` typed as `dict[str, JsonType]` (full JSON value range: str, list, dict, bool, int, None)
- `extra="forbid"` on all models; `ModelTransition` uses `alias="from"` for YAML compatibility
- 11 unit tests + 4 integration tests — all passing
- `validation_exemptions.yaml`: `policy_name` exemption added (field is policy's own identifier, not an entity reference)

## Test plan

- [x] TDD: wrote failing tests first, confirmed `ModuleNotFoundError`, then implemented
- [x] `uv run pytest tests/unit/onboarding/test_models_interactive.py -v` — 11/11 passed
- [x] `uv run pytest tests/integration/test_models_interactive_integration.py -v` — 4/4 passed
- [x] Full unit suite: 19309 passed, 4 failed (all 4 pre-existing on main, confirmed via stash)
- [x] `uv run mypy --strict` on all 5 new source files — clean
- [x] `uv run ruff format` + `uv run ruff check --fix` — clean
- [x] `pre-commit run --all-files` — all hooks pass (Architecture, Patterns, Any Types, SPDX, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a consolidated re-export module for interactive onboarding models, providing convenient single-import access.

* **Documentation**
  * Added clarifying documentation to the policy identifier field.

* **Tests**
  * Expanded test coverage for interactive onboarding model validation, field aliasing, and graph integrity verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1551)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: 4d70e91cca930c15876b3454932867410301b5be
Evidence-Ticket: OMN-10778