### PR TITLE
fix(OMN-10757): harden canonical env fallback validator

### DIFF
--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -123,7 +123,8 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
         stripped = line.strip()
         skip_line = False
 
-        # Track triple-quoted docstrings
+        # Track triple-quoted docstrings that begin a stripped line. Embedded
+        # triple quotes in executable code must not hide fallback violations.
         for delim in ('"""', "'''"):
             count = stripped.count(delim)
             if in_docstring and docstring_delim == delim:
@@ -132,13 +133,13 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
                     docstring_delim = None
                     skip_line = True
                 break
-            if not in_docstring and count == 1:
-                in_docstring = True
-                docstring_delim = delim
-                break
-            if count >= 2:
-                # Opens and closes on the same line — skip as a docstring line
-                skip_line = True
+            if not in_docstring and stripped.startswith(delim):
+                if count == 1:
+                    in_docstring = True
+                    docstring_delim = delim
+                else:
+                    # Opens and closes on the same line — skip as a docstring line
+                    skip_line = True
                 break
 
         if in_docstring or skip_line:

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -94,6 +94,7 @@ EXEMPT_MARKERS: tuple[str, ...] = (
 )
 
 _COMMENT_RE = re.compile(r"^\s*#")
+_TRIPLE_QUOTE_DELIMS = ('"""', "'''")
 
 
 def _is_pure_comment(line: str) -> bool:
@@ -102,6 +103,14 @@ def _is_pure_comment(line: str) -> bool:
 
 def _has_exempt_marker(line: str) -> bool:
     return any(marker in line for marker in EXEMPT_MARKERS)
+
+
+def _has_executable_suffix_after_closing_delim(line: str, delim: str) -> bool:
+    close_index = line.find(delim, len(delim))
+    if close_index == -1:
+        return False
+    suffix = line[close_index + len(delim) :].strip()
+    return bool(suffix and not suffix.startswith("#"))
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +134,7 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
 
         # Track triple-quoted docstrings that begin a stripped line. Embedded
         # triple quotes in executable code must not hide fallback violations.
-        for delim in ('"""', "'''"):
+        for delim in _TRIPLE_QUOTE_DELIMS:
             count = stripped.count(delim)
             if in_docstring and docstring_delim == delim:
                 if count >= 1:
@@ -137,8 +146,8 @@ def scan_python_file(path: Path) -> list[tuple[int, str]]:
                 if count == 1:
                     in_docstring = True
                     docstring_delim = delim
-                else:
-                    # Opens and closes on the same line — skip as a docstring line
+                elif not _has_executable_suffix_after_closing_delim(stripped, delim):
+                    # Opens and closes on the same line with no executable tail.
                     skip_line = True
                 break
 

--- a/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
+++ b/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
@@ -155,6 +155,24 @@ class TestDocstringSkipping:
         assert len(viols) == 1
         assert viols[0][0] == 3
 
+    def test_embedded_triple_quotes_do_not_start_docstring(
+        self, tmp_path: Path
+    ) -> None:
+        content = (
+            'marker = """not a docstring opener"""\nurl = os.getenv("X", "localhost")\n'
+        )
+        p = _py(tmp_path, content)
+        assert scan_python_file(p) == [(2, 'url = os.getenv("X", "localhost")')]
+
+    def test_embedded_triple_quotes_on_fallback_line_still_scans(
+        self, tmp_path: Path
+    ) -> None:
+        content = 'url = os.getenv("X", "localhost") + """suffix"""\n'
+        p = _py(tmp_path, content)
+        assert scan_python_file(p) == [
+            (1, 'url = os.getenv("X", "localhost") + """suffix"""')
+        ]
+
 
 @pytest.mark.unit
 class TestShellPatternBashVarDefault:

--- a/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
+++ b/tests/unit/scripts/validation/test_validate_no_env_fallbacks.py
@@ -173,6 +173,15 @@ class TestDocstringSkipping:
             (1, 'url = os.getenv("X", "localhost") + """suffix"""')
         ]
 
+    def test_line_start_triple_quote_with_trailing_fallback_still_scans(
+        self, tmp_path: Path
+    ) -> None:
+        content = '"""prefix"""; url = os.getenv("X", "localhost")\n'
+        p = _py(tmp_path, content)
+        assert scan_python_file(p) == [
+            (1, '"""prefix"""; url = os.getenv("X", "localhost")')
+        ]
+
 
 @pytest.mark.unit
 class TestShellPatternBashVarDefault:


### PR DESCRIPTION
Evidence-Source: OCC#896
Evidence-Ticket: OMN-10757

## Summary
- harden the canonical `validate_no_env_fallbacks.py` docstring scanner so embedded triple quotes in executable code do not hide fallback violations
- add regression coverage for embedded triple-quoted literals before or on fallback lines
- keeps the canonical infra validator byte-aligned with the hardened omniclaude copy from the merge sweep

## Verification
- `uv run pytest tests/unit/scripts/validation/test_validate_no_env_fallbacks.py -q`
- `uv run ruff check scripts/validate_no_env_fallbacks.py tests/unit/scripts/validation/test_validate_no_env_fallbacks.py`
- `uv run ruff format --check scripts/validate_no_env_fallbacks.py tests/unit/scripts/validation/test_validate_no_env_fallbacks.py`
- `uv run python scripts/validate_no_env_fallbacks.py`
- `diff -u /Volumes/PRO-G40/Code/omni_home/omni_worktrees/OMN-10658/omniclaude/scripts/validate_no_env_fallbacks.py scripts/validate_no_env_fallbacks.py`

## Worktree cleanup
- Worktree remains active at `/Volumes/PRO-G40/Code/omni_home/omni_worktrees/OMN-10757/omnibase_infra` until PR merges.