### PR TITLE
feat(OMN-10790): add tokens_to_compliance + compliance_attempts to delegation models

### DIFF
--- a/contracts/OMN-10790.yaml
+++ b/contracts/OMN-10790.yaml
@@ -1,0 +1,34 @@
+schema_version: '1.0.0'
+ticket_id: OMN-10790
+title: 'Add tokens_to_compliance + compliance_attempts to delegation models'
+summary: 'Add compliance cost tracking fields to ModelDelegationResult and ModelTaskDelegatedEvent with backward-compatible defaults.'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: Unit and integration tests pass for compliance fields
+    command: uv run pytest tests/unit/nodes/node_delegation_orchestrator/models/test_compliance_fields.py tests/integration/delegation/test_compliance_fields_wire_compat.py -v
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-unit-tests
+    description: 8 unit tests pass covering defaults, explicit values, serialization roundtrip, extra=forbid
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/nodes/node_delegation_orchestrator/models/test_compliance_fields.py -v'
+  - id: dod-integration-tests
+    description: 5 integration tests pass covering wire-format roundtrip and backward compatibility
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/delegation/test_compliance_fields_wire_compat.py -v'
+  - id: dod-deploy-compat
+    description: Backward-compatible deploy -- existing Kafka payloads without compliance fields deserialize with correct defaults, no runtime restart required
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'echo "deploy backward-compat verified" && uv run pytest tests/integration/delegation/test_compliance_fields_wire_compat.py::TestComplianceFieldsWireCompat::test_backward_compat_event_without_compliance_fields tests/integration/delegation/test_compliance_fields_wire_compat.py::TestComplianceFieldsWireCompat::test_backward_compat_result_without_compliance_fields -v --tb=short'

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_result.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_result.py
@@ -91,6 +91,14 @@ class ModelDelegationResult(BaseModel):
         default="",
         description="Reason for failure, empty string if successful.",
     )
+    tokens_to_compliance: int = Field(
+        default=0,
+        description="Total tokens across all compliance attempts.",
+    )
+    compliance_attempts: int = Field(
+        default=1,
+        description="Number of LLM invocations to reach compliance.",
+    )
 
 
 __all__: list[str] = ["ModelDelegationResult"]

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_result.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_result.py
@@ -93,10 +93,12 @@ class ModelDelegationResult(BaseModel):
     )
     tokens_to_compliance: int = Field(
         default=0,
+        ge=0,
         description="Total tokens across all compliance attempts.",
     )
     compliance_attempts: int = Field(
         default=1,
+        ge=1,
         description="Number of LLM invocations to reach compliance.",
     )
 

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -75,10 +75,12 @@ class ModelTaskDelegatedEvent(BaseModel):
     )
     tokens_to_compliance: int = Field(
         default=0,
+        ge=0,
         description="Total tokens across all compliance attempts.",
     )
     compliance_attempts: int = Field(
         default=1,
+        ge=1,
         description="Number of LLM invocations to reach compliance.",
     )
 

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -73,6 +73,14 @@ class ModelTaskDelegatedEvent(BaseModel):
         default="",
         description="Upstream LLM call ID for JOIN with llm_cost_aggregates.",
     )
+    tokens_to_compliance: int = Field(
+        default=0,
+        description="Total tokens across all compliance attempts.",
+    )
+    compliance_attempts: int = Field(
+        default=1,
+        description="Number of LLM invocations to reach compliance.",
+    )
 
 
 __all__: list[str] = ["ModelTaskDelegatedEvent"]

--- a/tests/integration/delegation/test_compliance_fields_wire_compat.py
+++ b/tests/integration/delegation/test_compliance_fields_wire_compat.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: compliance fields wire-format compatibility (OMN-10790).
+
+Verifies that ``tokens_to_compliance`` and ``compliance_attempts`` survive the
+full delegation pipeline serialization path:
+
+1. ``ModelDelegationResult`` -> JSON -> ``ModelTaskDelegatedEvent`` field mapping
+2. ``ModelTaskDelegatedEvent`` -> Kafka JSON wire format -> deserialization
+3. Backward compatibility: payloads without the new fields deserialize with
+   correct defaults (existing Kafka consumers must not break).
+
+Unit tests cover individual model defaults and validation. This module proves
+the fields survive the cross-model mapping and JSON wire roundtrip that the
+real delegation orchestrator and omnidash projection consumer perform.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_result import (
+    ModelDelegationResult,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+    ModelTaskDelegatedEvent,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _make_delegation_result(
+    *,
+    tokens_to_compliance: int = 0,
+    compliance_attempts: int = 1,
+) -> ModelDelegationResult:
+    """Build a realistic ModelDelegationResult with compliance fields."""
+    return ModelDelegationResult(
+        correlation_id=uuid4(),
+        task_type="code_generation",
+        model_used="cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
+        endpoint_url="http://192.168.86.201:8000",  # onex-allow-internal-ip
+        content="def hello():\n    return 'world'",
+        quality_passed=True,
+        quality_score=0.92,
+        latency_ms=1500,
+        prompt_tokens=800,
+        completion_tokens=200,
+        total_tokens=1000,
+        fallback_to_claude=False,
+        tokens_to_compliance=tokens_to_compliance,
+        compliance_attempts=compliance_attempts,
+    )
+
+
+def _result_to_event(result: ModelDelegationResult) -> ModelTaskDelegatedEvent:
+    """Map a ModelDelegationResult to a ModelTaskDelegatedEvent.
+
+    Mirrors the field mapping performed by the real delegation orchestrator
+    handler (HandlerDelegationWorkflow._build_backward_compat_event).
+    """
+    return ModelTaskDelegatedEvent(
+        timestamp=datetime.now(tz=UTC).isoformat(),
+        correlation_id=result.correlation_id,
+        task_type=result.task_type,
+        delegated_to=result.endpoint_url,
+        model_name=result.model_used,
+        quality_gate_passed=result.quality_passed,
+        delegation_latency_ms=result.latency_ms,
+        tokens_to_compliance=result.tokens_to_compliance,
+        compliance_attempts=result.compliance_attempts,
+    )
+
+
+class TestComplianceFieldsWireCompat:
+    """Prove compliance fields survive cross-model mapping and wire roundtrip."""
+
+    def test_result_to_event_preserves_compliance_fields(self) -> None:
+        """Compliance fields map correctly from result to backward-compat event."""
+        result = _make_delegation_result(
+            tokens_to_compliance=4500,
+            compliance_attempts=3,
+        )
+        event = _result_to_event(result)
+        assert event.tokens_to_compliance == 4500
+        assert event.compliance_attempts == 3
+
+    def test_event_json_wire_roundtrip(self) -> None:
+        """Event -> JSON (Kafka wire) -> deserialization preserves compliance fields."""
+        result = _make_delegation_result(
+            tokens_to_compliance=7200,
+            compliance_attempts=4,
+        )
+        event = _result_to_event(result)
+
+        # Serialize to JSON (Kafka wire format)
+        wire_json = event.model_dump(mode="json")
+
+        # Deserialize as if a consumer received this from Kafka
+        restored = ModelTaskDelegatedEvent.model_validate(wire_json)
+
+        assert restored.tokens_to_compliance == 7200
+        assert restored.compliance_attempts == 4
+        assert restored.correlation_id == event.correlation_id
+
+    def test_backward_compat_event_without_compliance_fields(self) -> None:
+        """Existing Kafka payloads without compliance fields deserialize with defaults.
+
+        This simulates an omnidash consumer receiving a payload produced before
+        OMN-10790 was deployed -- the old payload lacks the new fields. The
+        consumer must not crash; defaults (0 tokens, 1 attempt) must apply.
+        """
+        legacy_payload = {
+            "timestamp": "2026-05-09T12:00:00Z",
+            "correlation_id": str(uuid4()),
+            "task_type": "code_generation",
+            "delegated_to": "local-qwen3",
+            "quality_gate_passed": True,
+        }
+        # No tokens_to_compliance or compliance_attempts in payload
+        event = ModelTaskDelegatedEvent.model_validate(legacy_payload)
+        assert event.tokens_to_compliance == 0
+        assert event.compliance_attempts == 1
+
+    def test_backward_compat_result_without_compliance_fields(self) -> None:
+        """Existing result payloads without compliance fields deserialize with defaults."""
+        legacy_payload = {
+            "correlation_id": str(uuid4()),
+            "task_type": "test",
+            "model_used": "test-model",
+            "endpoint_url": "http://192.168.86.201:8000",  # onex-allow-internal-ip
+            "content": "test content",
+            "quality_passed": True,
+            "quality_score": 0.9,
+            "latency_ms": 500,
+            "fallback_to_claude": False,
+        }
+        result = ModelDelegationResult.model_validate(legacy_payload)
+        assert result.tokens_to_compliance == 0
+        assert result.compliance_attempts == 1
+
+    def test_full_pipeline_roundtrip_with_multi_attempt_compliance(self) -> None:
+        """End-to-end: result with multi-attempt compliance -> event -> wire -> restore."""
+        result = _make_delegation_result(
+            tokens_to_compliance=12000,
+            compliance_attempts=5,
+        )
+
+        # Step 1: Result -> Event (orchestrator mapping)
+        event = _result_to_event(result)
+
+        # Step 2: Event -> JSON wire (Kafka producer)
+        wire = event.model_dump(mode="json")
+
+        # Step 3: JSON wire -> Event (Kafka consumer / omnidash projection)
+        consumed = ModelTaskDelegatedEvent.model_validate(wire)
+
+        # Verify end-to-end preservation
+        assert consumed.tokens_to_compliance == 12000
+        assert consumed.compliance_attempts == 5
+        assert consumed.task_type == "code_generation"
+        assert consumed.quality_gate_passed is True

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -144,6 +144,9 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     # [NODE] DI boundary for A2A transport — narrows the SDK surface so the handler
     # can be unit-tested without driving the real a2a-sdk client (OMN-9634).
     "ProtocolA2ATransport": "nodes/node_remote_agent_invoke_effect/handlers/handler_a2a_task.py",
+    # [NODE] DI boundary for onboarding input collection — narrows interactive
+    # input surface so the handler can be tested with a fake adapter (OMN-10780).
+    "ProtocolInputAdapter": "onboarding/protocol_input_adapter.py",
     # [NODE] DI boundary for lifecycle event emission — lets the remote-agent effect
     # test lifecycle publication without coupling the handler to EventBusKafka (OMN-9637).
     "ProtocolLifecycleEventSink": "nodes/node_remote_agent_invoke_effect/services/lifecycle_event_sink.py",

--- a/tests/unit/nodes/node_delegation_orchestrator/models/test_compliance_fields.py
+++ b/tests/unit/nodes/node_delegation_orchestrator/models/test_compliance_fields.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for tokens_to_compliance and compliance_attempts fields.
+
+Tests cover both ModelDelegationResult and ModelTaskDelegatedEvent:
+    - Defaults apply when fields are omitted
+    - Explicit values are accepted
+    - Serialization roundtrip preserves values
+    - extra="forbid" rejects unknown fields
+
+Related:
+    - OMN-10790: Add compliance cost tracking fields
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_result import (
+    ModelDelegationResult,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+    ModelTaskDelegatedEvent,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_delegation_result(**overrides: object) -> ModelDelegationResult:
+    """Build a valid ModelDelegationResult with sensible defaults."""
+    defaults: dict[str, object] = {
+        "correlation_id": uuid4(),
+        "task_type": "test",
+        "model_used": "Qwen3-Coder-30B-A3B",
+        "endpoint_url": "http://192.168.86.201:8000",  # onex-allow-internal-ip
+        "content": "def test_example():\n    assert True",
+        "quality_passed": True,
+        "quality_score": 0.95,
+        "latency_ms": 1200,
+        "fallback_to_claude": False,
+    }
+    defaults.update(overrides)
+    return ModelDelegationResult(**defaults)  # type: ignore[arg-type]
+
+
+def _valid_task_delegated_event(**overrides: object) -> ModelTaskDelegatedEvent:
+    """Build a valid ModelTaskDelegatedEvent with sensible defaults."""
+    defaults: dict[str, object] = {
+        "timestamp": "2026-05-09T12:00:00Z",
+        "correlation_id": uuid4(),
+        "task_type": "code_generation",
+        "delegated_to": "local-qwen3",
+        "quality_gate_passed": True,
+    }
+    defaults.update(overrides)
+    return ModelTaskDelegatedEvent(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ModelDelegationResult
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationResultComplianceDefaults:
+    """Verify default values when compliance fields are omitted."""
+
+    def test_defaults_apply(self) -> None:
+        result = _valid_delegation_result()
+        assert result.tokens_to_compliance == 0
+        assert result.compliance_attempts == 1
+
+    def test_explicit_values(self) -> None:
+        result = _valid_delegation_result(
+            tokens_to_compliance=4500,
+            compliance_attempts=3,
+        )
+        assert result.tokens_to_compliance == 4500
+        assert result.compliance_attempts == 3
+
+    def test_serialization_roundtrip(self) -> None:
+        result = _valid_delegation_result(
+            tokens_to_compliance=2000,
+            compliance_attempts=2,
+        )
+        data = result.model_dump(mode="json")
+        restored = ModelDelegationResult.model_validate(data)
+        assert restored == result
+        assert restored.tokens_to_compliance == 2000
+        assert restored.compliance_attempts == 2
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            _valid_delegation_result(bogus_extra_field="nope")
+
+
+# ---------------------------------------------------------------------------
+# ModelTaskDelegatedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDelegatedEventComplianceDefaults:
+    """Verify default values when compliance fields are omitted."""
+
+    def test_defaults_apply(self) -> None:
+        event = _valid_task_delegated_event()
+        assert event.tokens_to_compliance == 0
+        assert event.compliance_attempts == 1
+
+    def test_explicit_values(self) -> None:
+        event = _valid_task_delegated_event(
+            tokens_to_compliance=8000,
+            compliance_attempts=5,
+        )
+        assert event.tokens_to_compliance == 8000
+        assert event.compliance_attempts == 5
+
+    def test_serialization_roundtrip(self) -> None:
+        event = _valid_task_delegated_event(
+            tokens_to_compliance=3500,
+            compliance_attempts=4,
+        )
+        data = event.model_dump(mode="json")
+        restored = ModelTaskDelegatedEvent.model_validate(data)
+        assert restored == event
+        assert restored.tokens_to_compliance == 3500
+        assert restored.compliance_attempts == 4
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            _valid_task_delegated_event(bogus_extra_field="nope")


### PR DESCRIPTION
Evidence-Source: OCC#897
Evidence-Ticket: OMN-10790

## Summary

- Add `tokens_to_compliance` (default `0`) and `compliance_attempts` (default `1`) fields to `ModelDelegationResult` and `ModelTaskDelegatedEvent`
- Both models are `frozen=True, extra="forbid"` -- new fields have defaults so existing callers are unaffected
- 8 unit tests covering defaults, explicit values, serialization roundtrip, and extra="forbid" rejection
- 5 integration tests covering cross-model field mapping, Kafka wire-format roundtrip, backward compatibility with legacy payloads, and full pipeline roundtrip

## Ticket

OMN-10790

## Test plan

- [x] `uv run pytest tests/unit/nodes/node_delegation_orchestrator/models/test_compliance_fields.py -v` -- all 8 unit tests pass
- [x] `uv run pytest tests/integration/delegation/test_compliance_fields_wire_compat.py -v` -- all 5 integration tests pass
- [x] `pre-commit run --all-files` -- all hooks pass
- [x] `uv run ruff format && uv run ruff check --fix` -- clean

## dod_evidence

- 8 unit tests passing (defaults, explicit values, roundtrip, extra=forbid)
- 5 integration tests passing (wire-format compat, backward compat, full pipeline roundtrip)
- Backward-compatible: existing Kafka payloads without compliance fields deserialize with correct defaults (0 tokens, 1 attempt). No runtime restart required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Delegation results and delegated events now include compliance metrics: tokens-to-compliance and compliance-attempts; sensible defaults preserve prior behavior.

* **Tests**
  - Added integration tests for JSON/wire-format roundtrips and backward compatibility.
  - Added unit tests validating defaults, validation rules, and (de)serialization of the new compliance fields.

* **Chores**
  - Added contract metadata and updated protocol allowlist to acknowledge the new infra protocol.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1554)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->