### PR TITLE
feat(OMN-10782): interactive executor — drives onboarding flow via adapter + reducer

### DIFF
--- a/contracts/OMN-10782.yaml
+++ b/contracts/OMN-10782.yaml
@@ -1,0 +1,44 @@
+# OMN-10782 contract file — interactive executor for onboarding.
+# deploy-gate checks `contracts/<OMN-XXXX>.yaml` for dod_evidence items.
+schema_version: '1.0.0'
+ticket_id: OMN-10782
+summary: 'feat(OMN-10782): interactive executor — drives onboarding flow via adapter + reducer'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: Unit and integration tests for interactive executor
+    command: uv run pytest tests/unit/onboarding/test_interactive_executor.py tests/integration/onboarding/test_interactive_executor_integration.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Contract artifact file present in repo
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-10782.yaml'
+  - id: dod-002
+    description: Unit tests prove executor drives 2-step policy, produces env dict, records step results, handles action and multi-choice steps
+    source: generated
+    checks:
+      - check_type: unit_test
+        check_value: 'uv run pytest tests/unit/onboarding/test_interactive_executor.py -v'
+  - id: dod-003
+    description: Integration tests prove full traversal of local, cloud, and hybrid paths through real policy with correct env output and step ordering
+    source: generated
+    checks:
+      - check_type: integration_test
+        check_value: 'uv run pytest tests/integration/onboarding/test_interactive_executor_integration.py -v'
+  - id: dod-004
+    description: Deploy-compatible — no file writes, no side effects, pure executor composable with handler layer
+    source: manual
+    checks:
+      - check_type: deploy-compat
+        check_value: 'interactive executor is pure except for adapter I/O — no file writes, no config mutations, no runtime side effects'

--- a/contracts/OMN-10782.yaml
+++ b/contracts/OMN-10782.yaml
@@ -28,17 +28,17 @@ dod_evidence:
     description: Unit tests prove executor drives 2-step policy, produces env dict, records step results, handles action and multi-choice steps
     source: generated
     checks:
-      - check_type: unit_test
+      - check_type: command
         check_value: 'uv run pytest tests/unit/onboarding/test_interactive_executor.py -v'
   - id: dod-003
     description: Integration tests prove full traversal of local, cloud, and hybrid paths through real policy with correct env output and step ordering
     source: generated
     checks:
-      - check_type: integration_test
+      - check_type: command
         check_value: 'uv run pytest tests/integration/onboarding/test_interactive_executor_integration.py -v'
   - id: dod-004
     description: Deploy-compatible — no file writes, no side effects, pure executor composable with handler layer
     source: manual
     checks:
-      - check_type: deploy-compat
+      - check_type: behavior_proven
         check_value: 'interactive executor is pure except for adapter I/O — no file writes, no config mutations, no runtime side effects'

--- a/contracts/OMN-10782.yaml
+++ b/contracts/OMN-10782.yaml
@@ -2,6 +2,7 @@
 # deploy-gate checks `contracts/<OMN-XXXX>.yaml` for dod_evidence items.
 schema_version: '1.0.0'
 ticket_id: OMN-10782
+title: 'feat(OMN-10782): interactive executor — drives onboarding flow via adapter + reducer'
 summary: 'feat(OMN-10782): interactive executor — drives onboarding flow via adapter + reducer'
 is_seam_ticket: false
 interface_change: false

--- a/src/omnibase_infra/onboarding/interactive_executor.py
+++ b/src/omnibase_infra/onboarding/interactive_executor.py
@@ -18,7 +18,10 @@ from omnibase_infra.onboarding.model_interactive_result import (
 )
 from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
 from omnibase_infra.onboarding.protocol_input_adapter import ProtocolInputAdapter
-from omnibase_infra.onboarding.transition_reducer import TransitionReducer
+from omnibase_infra.onboarding.transition_reducer import (
+    TransitionError,
+    TransitionReducer,
+)
 
 
 class InteractiveExecutorError(Exception):
@@ -35,6 +38,10 @@ class InteractiveExecutor:
     Args:
         policy: The interactive onboarding policy to execute.
         adapter: Input adapter for collecting user responses.
+
+    Raises:
+        InteractiveExecutorError: If the policy graph is invalid
+            (wraps ``TransitionError`` from the reducer).
     """
 
     def __init__(
@@ -44,7 +51,10 @@ class InteractiveExecutor:
     ) -> None:
         self._policy = policy
         self._adapter = adapter
-        self._reducer = TransitionReducer(policy)
+        try:
+            self._reducer = TransitionReducer(policy)
+        except TransitionError as exc:
+            raise InteractiveExecutorError(str(exc)) from exc
         self._steps_by_id: dict[str, ModelInteractiveStep] = {
             s.id: s for s in policy.steps
         }

--- a/src/omnibase_infra/onboarding/interactive_executor.py
+++ b/src/omnibase_infra/onboarding/interactive_executor.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Interactive executor — drives the full onboarding flow via adapter + reducer.
+
+Pure except for adapter I/O (input collection). Never writes files.
+Produces a ``ModelInteractiveResult`` with env dict, step results, and provenance.
+
+OMN-10782 / Task 5 of the interactive-onboarding-executor plan.
+"""
+
+from __future__ import annotations
+
+from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+from omnibase_infra.onboarding.model_interactive_result import (
+    ModelInteractiveResult,
+    ModelStepResult,
+)
+from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+from omnibase_infra.onboarding.protocol_input_adapter import ProtocolInputAdapter
+from omnibase_infra.onboarding.transition_reducer import TransitionReducer
+
+
+class InteractiveExecutorError(Exception):
+    """Raised when the executor encounters an unrecoverable error."""
+
+
+class InteractiveExecutor:
+    """Drives an interactive onboarding policy to completion.
+
+    Composes the ``TransitionReducer`` (pure state machine) with a
+    ``ProtocolInputAdapter`` (I/O for input collection).  The executor
+    is pure except for adapter calls — it never writes files.
+
+    Args:
+        policy: The interactive onboarding policy to execute.
+        adapter: Input adapter for collecting user responses.
+    """
+
+    def __init__(
+        self,
+        policy: ModelInteractivePolicy,
+        adapter: ProtocolInputAdapter,
+    ) -> None:
+        self._policy = policy
+        self._adapter = adapter
+        self._reducer = TransitionReducer(policy)
+        self._steps_by_id: dict[str, ModelInteractiveStep] = {
+            s.id: s for s in policy.steps
+        }
+
+    async def execute(self) -> ModelInteractiveResult:
+        """Run the interactive flow from start to terminal step.
+
+        Returns:
+            ``ModelInteractiveResult`` containing the env dict, ordered step
+            results, and provenance metadata.  Does NOT write any files.
+
+        Raises:
+            InteractiveExecutorError: If the start step is missing or
+                an unknown step is encountered during traversal.
+        """
+        start_step = self._policy.start_step
+        if start_step is None:
+            msg = "Policy has no start_step"
+            raise InteractiveExecutorError(msg)
+
+        current_step_id = start_step
+        state: dict[str, object] = {}
+        step_results: list[ModelStepResult] = []
+
+        while True:
+            step = self._steps_by_id.get(current_step_id)
+            if step is None:
+                msg = f"Unknown step: '{current_step_id}'"
+                raise InteractiveExecutorError(msg)
+
+            # Terminal step: notify (action display) and produce env output.
+            if self._reducer.is_terminal(current_step_id):
+                if step.type == "action":
+                    await self._adapter.notify_action(step)
+                env_dict = self._reducer.get_env_output(current_step_id, state)
+                return ModelInteractiveResult(
+                    env_dict=env_dict,
+                    step_results=step_results,
+                    policy_name=self._policy.policy_name,
+                    completed=True,
+                    terminal_step=current_step_id,
+                )
+
+            # Non-terminal step: collect input via adapter.
+            response = await self._collect_response(step)
+
+            # Record step result (action steps have no user response).
+            step_results.append(
+                ModelStepResult(
+                    step_key=step.id,
+                    step_title=step.prompt,
+                    response=response,
+                )
+            )
+
+            # Advance through the reducer.
+            current_step_id, state = self._reducer.advance(
+                current_step_id, response, state
+            )
+
+    async def _collect_response(self, step: ModelInteractiveStep) -> str | list[str]:
+        """Dispatch to the appropriate adapter method based on step type.
+
+        Returns:
+            The user's response: ``str`` for choice/text, ``list[str]`` for
+            multi_choice.
+
+        Raises:
+            InteractiveExecutorError: If the step type is unsupported.
+        """
+        if step.type == "choice":
+            return await self._adapter.collect_choice(step)
+        if step.type == "multi_choice":
+            return await self._adapter.collect_multi_choice(step)
+        if step.type == "text":
+            return await self._adapter.collect_text(step)
+        if step.type == "action":
+            await self._adapter.notify_action(step)
+            # Action steps are notification-only — return empty string as
+            # a no-op response for the reducer.
+            return ""
+
+        msg = f"Unsupported step type: '{step.type}'"
+        raise InteractiveExecutorError(msg)
+
+
+__all__ = ["InteractiveExecutor", "InteractiveExecutorError"]

--- a/src/omnibase_infra/onboarding/model_interactive_result.py
+++ b/src/omnibase_infra/onboarding/model_interactive_result.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for interactive onboarding execution results.
+
+OMN-10782 / Task 5 of the interactive-onboarding-executor plan.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.onboarding.model_step_result import ModelStepResult
+
+
+class ModelInteractiveResult(BaseModel):
+    """Complete result of an interactive onboarding execution."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    env_dict: dict[str, str] = Field(
+        description="Environment variables produced by the terminal step"
+    )
+    step_results: list[ModelStepResult] = Field(
+        description="Ordered list of step results from the execution"
+    )
+    policy_name: str  # ONEX_EXCLUDE: pattern_validator - policy_name is the policy's own identifier, not an entity reference
+    completed: bool = Field(description="Whether execution reached a terminal step")
+    terminal_step: str = Field(
+        description="ID of the terminal step where execution ended"
+    )
+
+
+__all__ = ["ModelInteractiveResult", "ModelStepResult"]

--- a/src/omnibase_infra/onboarding/model_step_result.py
+++ b/src/omnibase_infra/onboarding/model_step_result.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic model for a single interactive onboarding step result.
+
+OMN-10782 / Task 5 of the interactive-onboarding-executor plan.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelStepResult(BaseModel):
+    """Result of executing a single interactive onboarding step."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    step_key: str = Field(description="Step identifier (= ModelInteractiveStep.id)")
+    step_title: str = Field(description="User-facing prompt text of the step")
+    response: str | list[str] = Field(
+        description="User response — str for choice/text, list for multi_choice"
+    )
+
+
+__all__ = ["ModelStepResult"]

--- a/src/omnibase_infra/onboarding/models_interactive.py
+++ b/src/omnibase_infra/onboarding/models_interactive.py
@@ -8,13 +8,19 @@ This module re-exports all four for convenient single-import access.
 """
 
 from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+from omnibase_infra.onboarding.model_interactive_result import (
+    ModelInteractiveResult,
+    ModelStepResult,
+)
 from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
 from omnibase_infra.onboarding.model_transition import ModelTransition
 from omnibase_infra.onboarding.model_transition_branch import ModelTransitionBranch
 
 __all__ = [
     "ModelInteractivePolicy",
+    "ModelInteractiveResult",
     "ModelInteractiveStep",
+    "ModelStepResult",
     "ModelTransition",
     "ModelTransitionBranch",
 ]

--- a/src/omnibase_infra/validation/infra_validators.py
+++ b/src/omnibase_infra/validation/infra_validators.py
@@ -485,7 +485,8 @@ INFRA_NODES_PATH = "src/omnibase_infra/nodes/"
 # - 148 (2026-04-05): LINEAR_API_KEY :? required-env addition (OMN-6489)
 # - 150 (2026-05-09): interactive onboarding models — ModelTransition alias + ModelTransitionBranch JsonType (OMN-10771)
 #                     + StepResponse type alias in transition_reducer (OMN-10780)
-INFRA_MAX_UNIONS = 150
+# - 152 (2026-05-10): interactive executor + result models (OMN-10782)
+INFRA_MAX_UNIONS = 152
 
 # Maximum allowed architecture violations in infrastructure code.
 # Set to 0 (strict enforcement) to ensure one-model-per-file principle is always followed.

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3388,6 +3388,17 @@ pattern_exemptions:
     documentation:
       - src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
     ticket: OMN-10768
+  # ==========================================================================
+  # ModelInteractiveResult policy_name Field Exemption (OMN-10782)
+  # ==========================================================================
+  - file_pattern: 'model_interactive_result\.py'
+    violation_pattern: "Field 'policy_name' might reference an entity"
+    reason: >
+      policy_name is a provenance field recording which interactive onboarding policy was executed. It mirrors ModelInteractivePolicy.policy_name and is not an entity reference requiring ID + display_name pattern.
+
+    documentation:
+      - src/omnibase_infra/onboarding/model_interactive_policy.py
+    ticket: OMN-10782
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:

--- a/tests/integration/onboarding/test_interactive_executor_integration.py
+++ b/tests/integration/onboarding/test_interactive_executor_integration.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests — full traversal of all paths through the interactive executor.
+
+OMN-10782: exercises local, cloud (AWS/GCP), and hybrid (AWS/GCP, with/without LLM)
+paths end-to-end using the real ``interactive_onboarding.yaml`` policy file
+driven by ``InteractiveExecutor`` + ``AdapterFakeInput``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.onboarding.adapter_fake_input import AdapterFakeInput
+from omnibase_infra.onboarding.interactive_executor import InteractiveExecutor
+from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+
+pytestmark = pytest.mark.integration
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+@pytest.fixture
+def policy() -> ModelInteractivePolicy:
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    return ModelInteractivePolicy.model_validate(raw)
+
+
+# ------------------------------------------------------------------
+# Local paths
+# ------------------------------------------------------------------
+
+
+class TestLocalPaths:
+    @pytest.mark.asyncio
+    async def test_local_minimal(self, policy: ModelInteractivePolicy) -> None:
+        """local → services (no llm) → write_config_local."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": ["kafka", "postgres", "valkey"],
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_local"
+        assert result.policy_name == "interactive_onboarding"
+
+        env = result.env_dict
+        assert env["ONEX_DEPLOYMENT_MODE"] == "local"
+        assert env["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:19092"
+        assert env["POSTGRES_HOST"] == "localhost"
+        assert env["POSTGRES_PORT"] == "5436"
+        assert env["VALKEY_HOST"] == "localhost"
+        assert env["VALKEY_PORT"] == "16379"
+        assert env["LLM_CODER_URL"] == ""
+
+        # Step order verification
+        step_keys = [sr.step_key for sr in result.step_results]
+        assert step_keys == ["choose_deployment_mode", "configure_local_services"]
+
+    @pytest.mark.asyncio
+    async def test_local_with_llm(self, policy: ModelInteractivePolicy) -> None:
+        """local → services (with llm) → llm endpoint → write_config_local."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": ["kafka", "postgres", "llm_inference"],
+                "configure_llm_endpoint": "http://localhost:8000",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_local"
+        assert result.env_dict["LLM_CODER_URL"] == "http://localhost:8000"
+
+        step_keys = [sr.step_key for sr in result.step_results]
+        assert step_keys == [
+            "choose_deployment_mode",
+            "configure_local_services",
+            "configure_llm_endpoint",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_local_all_services_with_llm(
+        self, policy: ModelInteractivePolicy
+    ) -> None:
+        """local → all 4 services → llm endpoint → write_config_local."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": [
+                    "kafka",
+                    "postgres",
+                    "valkey",
+                    "llm_inference",
+                ],
+                "configure_llm_endpoint": "http://192.168.86.201:8000",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_local"
+        assert result.env_dict["LLM_CODER_URL"] == "http://192.168.86.201:8000"
+
+
+# ------------------------------------------------------------------
+# Cloud paths
+# ------------------------------------------------------------------
+
+
+class TestCloudPaths:
+    @pytest.mark.asyncio
+    async def test_cloud_aws(self, policy: ModelInteractivePolicy) -> None:
+        """cloud → aws → region → write_config_cloud."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "cloud",
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "us-east-1",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_cloud"
+
+        env = result.env_dict
+        assert env["ONEX_DEPLOYMENT_MODE"] == "cloud"
+        assert env["CLOUD_PROVIDER"] == "aws"
+        assert env["AWS_REGION"] == "us-east-1"
+        assert env["GCP_PROJECT"] == ""
+
+        step_keys = [sr.step_key for sr in result.step_results]
+        assert step_keys == [
+            "choose_deployment_mode",
+            "configure_cloud_provider",
+            "configure_aws_region",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_cloud_gcp(self, policy: ModelInteractivePolicy) -> None:
+        """cloud → gcp → project → write_config_cloud."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "cloud",
+                "configure_cloud_provider": "gcp",
+                "configure_gcp_project": "my-gcp-project-123",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_cloud"
+
+        env = result.env_dict
+        assert env["ONEX_DEPLOYMENT_MODE"] == "cloud"
+        assert env["CLOUD_PROVIDER"] == "gcp"
+        assert env["GCP_PROJECT"] == "my-gcp-project-123"
+        assert env["AWS_REGION"] == ""
+
+
+# ------------------------------------------------------------------
+# Hybrid paths
+# ------------------------------------------------------------------
+
+
+class TestHybridPaths:
+    @pytest.mark.asyncio
+    async def test_hybrid_aws_with_llm(self, policy: ModelInteractivePolicy) -> None:
+        """hybrid → services (with llm) → aws → region → llm → write_config_hybrid."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["kafka", "postgres", "llm_inference"],
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "eu-west-1",
+                "configure_llm_endpoint": "http://my-llm:8080",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_hybrid"
+
+        env = result.env_dict
+        assert env["ONEX_DEPLOYMENT_MODE"] == "hybrid"
+        assert env["CLOUD_PROVIDER"] == "aws"
+        assert env["AWS_REGION"] == "eu-west-1"
+        assert env["GCP_PROJECT"] == ""
+        assert env["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:19092"
+        assert env["LLM_CODER_URL"] == "http://my-llm:8080"
+
+        step_keys = [sr.step_key for sr in result.step_results]
+        assert step_keys == [
+            "choose_deployment_mode",
+            "configure_local_services",
+            "configure_cloud_provider",
+            "configure_aws_region",
+            "configure_llm_endpoint",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_hybrid_aws_no_llm(self, policy: ModelInteractivePolicy) -> None:
+        """hybrid → services (no llm) → aws → region → write_config_hybrid."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["kafka", "postgres"],
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "ap-southeast-1",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_hybrid"
+        assert result.env_dict["AWS_REGION"] == "ap-southeast-1"
+        assert result.env_dict["LLM_CODER_URL"] == ""
+
+    @pytest.mark.asyncio
+    async def test_hybrid_gcp_with_llm(self, policy: ModelInteractivePolicy) -> None:
+        """hybrid → services (with llm) → gcp → project → llm → write_config_hybrid."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["kafka", "llm_inference"],
+                "configure_cloud_provider": "gcp",
+                "configure_gcp_project": "hybrid-project",
+                "configure_llm_endpoint": "http://inference:9000",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_hybrid"
+
+        env = result.env_dict
+        assert env["CLOUD_PROVIDER"] == "gcp"
+        assert env["GCP_PROJECT"] == "hybrid-project"
+        assert env["LLM_CODER_URL"] == "http://inference:9000"
+
+    @pytest.mark.asyncio
+    async def test_hybrid_gcp_no_llm(self, policy: ModelInteractivePolicy) -> None:
+        """hybrid → services (no llm) → gcp → project → write_config_hybrid."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["valkey"],
+                "configure_cloud_provider": "gcp",
+                "configure_gcp_project": "another-project",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_hybrid"
+
+        env = result.env_dict
+        assert env["CLOUD_PROVIDER"] == "gcp"
+        assert env["GCP_PROJECT"] == "another-project"
+        assert env["AWS_REGION"] == ""
+        assert env["LLM_CODER_URL"] == ""
+
+
+# ------------------------------------------------------------------
+# Provenance and step ordering
+# ------------------------------------------------------------------
+
+
+class TestProvenance:
+    @pytest.mark.asyncio
+    async def test_step_results_ordered(self, policy: ModelInteractivePolicy) -> None:
+        """Step results are in execution order."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["kafka", "postgres", "llm_inference"],
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "us-east-1",
+                "configure_llm_endpoint": "http://llm:8000",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        # Verify ordering matches the actual traversal
+        assert len(result.step_results) == 5
+        assert result.step_results[0].step_key == "choose_deployment_mode"
+        assert result.step_results[1].step_key == "configure_local_services"
+        assert result.step_results[2].step_key == "configure_cloud_provider"
+        assert result.step_results[3].step_key == "configure_aws_region"
+        assert result.step_results[4].step_key == "configure_llm_endpoint"
+
+    @pytest.mark.asyncio
+    async def test_step_titles_populated(self, policy: ModelInteractivePolicy) -> None:
+        """Each step_result has the correct step_title from the policy."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": ["kafka"],
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+
+        assert result.step_results[0].step_title == "How will you deploy ONEX?"
+        assert result.step_results[1].step_title == "Which local services do you need?"
+
+    @pytest.mark.asyncio
+    async def test_policy_name_populated(self, policy: ModelInteractivePolicy) -> None:
+        """Result includes policy_name from the executed policy."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "cloud",
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "us-east-1",
+            }
+        )
+        result = await InteractiveExecutor(policy, adapter).execute()
+        assert result.policy_name == "interactive_onboarding"

--- a/tests/unit/onboarding/test_interactive_executor.py
+++ b/tests/unit/onboarding/test_interactive_executor.py
@@ -12,11 +12,13 @@ import pytest
 import yaml
 
 from omnibase_infra.onboarding.adapter_fake_input import AdapterFakeInput
-from omnibase_infra.onboarding.interactive_executor import InteractiveExecutor
+from omnibase_infra.onboarding.interactive_executor import (
+    InteractiveExecutor,
+    InteractiveExecutorError,
+)
 from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
 from omnibase_infra.onboarding.model_interactive_result import ModelInteractiveResult
 from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
-from omnibase_infra.onboarding.transition_reducer import TransitionError
 
 pytestmark = pytest.mark.unit
 
@@ -347,11 +349,10 @@ class TestRealPolicyHybrid:
 class TestErrorCases:
     @pytest.mark.asyncio
     async def test_missing_start_step_raises(self) -> None:
-        """Policy with no start_step raises at construction time.
+        """Policy with no start_step raises InteractiveExecutorError at construction.
 
-        The TransitionReducer validates graph integrity at __init__ and
-        raises TransitionError when start_step is None.  This is defense-
-        in-depth — the Pydantic validator normally prevents this state.
+        The executor wraps TransitionError from the reducer into
+        InteractiveExecutorError to present a consistent error surface.
         """
         raw: dict[str, Any] = {
             "policy_name": "broken",
@@ -372,6 +373,6 @@ class TestErrorCases:
 
         adapter = AdapterFakeInput(responses={})
 
-        # TransitionReducer catches the invalid graph at construction time
-        with pytest.raises(TransitionError, match="no start_step"):
+        # Executor wraps TransitionError into InteractiveExecutorError
+        with pytest.raises(InteractiveExecutorError, match="no start_step"):
             InteractiveExecutor(policy, adapter)

--- a/tests/unit/onboarding/test_interactive_executor.py
+++ b/tests/unit/onboarding/test_interactive_executor.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for InteractiveExecutor — OMN-10782."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any  # onex-any-ok: state dicts in test assertions
+
+import pytest
+import yaml
+
+from omnibase_infra.onboarding.adapter_fake_input import AdapterFakeInput
+from omnibase_infra.onboarding.interactive_executor import InteractiveExecutor
+from omnibase_infra.onboarding.model_interactive_policy import ModelInteractivePolicy
+from omnibase_infra.onboarding.model_interactive_result import ModelInteractiveResult
+from omnibase_infra.onboarding.model_interactive_step import ModelInteractiveStep
+from omnibase_infra.onboarding.transition_reducer import TransitionError
+
+pytestmark = pytest.mark.unit
+
+POLICY_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+@pytest.fixture
+def policy() -> ModelInteractivePolicy:
+    raw = yaml.safe_load(POLICY_PATH.read_text())
+    return ModelInteractivePolicy.model_validate(raw)
+
+
+def _make_simple_policy() -> ModelInteractivePolicy:
+    """Build a minimal 2-step policy for isolated unit tests."""
+    raw: dict[str, Any] = {
+        "policy_name": "test_simple",
+        "description": "Minimal 2-step test policy",
+        "version": {"major": 1, "minor": 0, "patch": 0},
+        "policy_type": "interactive",
+        "target_capabilities": ["test"],
+        "max_estimated_minutes": 1,
+        "steps": [
+            {
+                "id": "step_one",
+                "prompt": "Pick A or B",
+                "type": "choice",
+                "options": ["a", "b"],
+            },
+            {
+                "id": "step_terminal",
+                "prompt": "Done",
+                "type": "action",
+                "action": "write_env",
+            },
+        ],
+        "transitions": [
+            {
+                "from": "step_one",
+                "responses": {
+                    "a": {"next": "step_terminal", "set_state": {"picked": "a"}},
+                    "b": {"next": "step_terminal", "set_state": {"picked": "b"}},
+                },
+            },
+            {"from": "step_terminal", "terminal": True},
+        ],
+        "env_output": {
+            "step_terminal": {
+                "MY_VAR": "{state.picked}",
+            },
+        },
+    }
+    return ModelInteractivePolicy.model_validate(raw)
+
+
+def _make_multi_choice_policy() -> ModelInteractivePolicy:
+    """Build a policy with a multi_choice step for testing list responses."""
+    raw: dict[str, Any] = {
+        "policy_name": "test_multi_choice",
+        "description": "Multi-choice test policy",
+        "version": {"major": 1, "minor": 0, "patch": 0},
+        "policy_type": "interactive",
+        "target_capabilities": ["test"],
+        "max_estimated_minutes": 1,
+        "steps": [
+            {
+                "id": "select_items",
+                "prompt": "Pick items",
+                "type": "multi_choice",
+                "options": ["x", "y", "z"],
+            },
+            {
+                "id": "done",
+                "prompt": "Done",
+                "type": "action",
+                "action": "write_env",
+            },
+        ],
+        "transitions": [
+            {
+                "from": "select_items",
+                "on_submit": [
+                    {
+                        "condition": None,
+                        "next": "done",
+                        "set_state": {"items": "{response}"},
+                    },
+                ],
+            },
+            {"from": "done", "terminal": True},
+        ],
+        "env_output": {
+            "done": {
+                "SELECTED": "multi",
+            },
+        },
+    }
+    return ModelInteractivePolicy.model_validate(raw)
+
+
+# ------------------------------------------------------------------
+# Basic 2-step policy tests
+# ------------------------------------------------------------------
+
+
+class TestSimplePolicy:
+    @pytest.mark.asyncio
+    async def test_executor_two_step_policy(self) -> None:
+        """Executor drives a simple 2-step policy to completion."""
+        policy = _make_simple_policy()
+        adapter = AdapterFakeInput(responses={"step_one": "a"})
+
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert isinstance(result, ModelInteractiveResult)
+        assert result.completed is True
+        assert result.terminal_step == "step_terminal"
+        assert result.policy_name == "test_simple"
+
+    @pytest.mark.asyncio
+    async def test_executor_produces_correct_env_dict(self) -> None:
+        """Executor produces correct env_dict at terminal step."""
+        policy = _make_simple_policy()
+        adapter = AdapterFakeInput(responses={"step_one": "b"})
+
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.env_dict == {"MY_VAR": "b"}
+
+    @pytest.mark.asyncio
+    async def test_executor_records_step_results(self) -> None:
+        """Executor records all step results with step_key mapping."""
+        policy = _make_simple_policy()
+        adapter = AdapterFakeInput(responses={"step_one": "a"})
+
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert len(result.step_results) == 1  # terminal action step not in results
+        step_result = result.step_results[0]
+        assert step_result.step_key == "step_one"
+        assert step_result.step_title == "Pick A or B"
+        assert step_result.response == "a"
+
+
+# ------------------------------------------------------------------
+# Action step tests
+# ------------------------------------------------------------------
+
+
+class TestActionSteps:
+    @pytest.mark.asyncio
+    async def test_action_step_calls_notify_action(self) -> None:
+        """Action steps call adapter.notify_action, not collect_*."""
+        policy = _make_simple_policy()
+        adapter = AdapterFakeInput(responses={"step_one": "a"})
+
+        # Wrap with a mock to verify notify_action is called
+        original_notify = adapter.notify_action
+        notify_calls: list[ModelInteractiveStep] = []
+
+        async def tracking_notify(step: ModelInteractiveStep) -> None:
+            notify_calls.append(step)
+            await original_notify(step)
+
+        adapter.notify_action = tracking_notify  # type: ignore[assignment]
+
+        executor = InteractiveExecutor(policy, adapter)
+        await executor.execute()
+
+        # Terminal action step triggers notify_action
+        assert len(notify_calls) == 1
+        assert notify_calls[0].id == "step_terminal"
+
+
+# ------------------------------------------------------------------
+# Multi-choice tests
+# ------------------------------------------------------------------
+
+
+class TestMultiChoiceSteps:
+    @pytest.mark.asyncio
+    async def test_multi_choice_stores_list_response(self) -> None:
+        """Multi-choice steps store list responses in step_results."""
+        policy = _make_multi_choice_policy()
+        adapter = AdapterFakeInput(responses={"select_items": ["x", "z"]})
+
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert len(result.step_results) == 1
+        assert result.step_results[0].response == ["x", "z"]
+        assert result.step_results[0].step_key == "select_items"
+
+
+# ------------------------------------------------------------------
+# Real policy traversals with FakeInputAdapter
+# ------------------------------------------------------------------
+
+
+class TestRealPolicyLocal:
+    @pytest.mark.asyncio
+    async def test_local_no_llm(self, policy: ModelInteractivePolicy) -> None:
+        """Local path without LLM: 2 input steps → write_config_local."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": ["kafka", "postgres"],
+            }
+        )
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_local"
+        assert result.policy_name == "interactive_onboarding"
+
+        # Env dict assertions
+        assert result.env_dict["ONEX_DEPLOYMENT_MODE"] == "local"
+        assert result.env_dict["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:19092"
+        assert result.env_dict["POSTGRES_HOST"] == "localhost"
+        assert result.env_dict["LLM_CODER_URL"] == ""  # not selected
+
+        # Step results: 2 input steps recorded
+        assert len(result.step_results) == 2
+        assert result.step_results[0].step_key == "choose_deployment_mode"
+        assert result.step_results[1].step_key == "configure_local_services"
+
+    @pytest.mark.asyncio
+    async def test_local_with_llm(self, policy: ModelInteractivePolicy) -> None:
+        """Local path with LLM: 3 input steps → write_config_local."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "local",
+                "configure_local_services": ["kafka", "postgres", "llm_inference"],
+                "configure_llm_endpoint": "http://localhost:8000",
+            }
+        )
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_local"
+        assert result.env_dict["LLM_CODER_URL"] == "http://localhost:8000"
+        assert len(result.step_results) == 3
+
+
+class TestRealPolicyCloud:
+    @pytest.mark.asyncio
+    async def test_cloud_aws(self, policy: ModelInteractivePolicy) -> None:
+        """Cloud AWS path: 3 input steps → write_config_cloud."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "cloud",
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "us-east-1",
+            }
+        )
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_cloud"
+        assert result.env_dict["ONEX_DEPLOYMENT_MODE"] == "cloud"
+        assert result.env_dict["CLOUD_PROVIDER"] == "aws"
+        assert result.env_dict["AWS_REGION"] == "us-east-1"
+        assert result.env_dict["GCP_PROJECT"] == ""
+
+    @pytest.mark.asyncio
+    async def test_cloud_gcp(self, policy: ModelInteractivePolicy) -> None:
+        """Cloud GCP path: 3 input steps → write_config_cloud."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "cloud",
+                "configure_cloud_provider": "gcp",
+                "configure_gcp_project": "my-project",
+            }
+        )
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_cloud"
+        assert result.env_dict["CLOUD_PROVIDER"] == "gcp"
+        assert result.env_dict["GCP_PROJECT"] == "my-project"
+
+
+class TestRealPolicyHybrid:
+    @pytest.mark.asyncio
+    async def test_hybrid_aws_with_llm(self, policy: ModelInteractivePolicy) -> None:
+        """Hybrid AWS+LLM path: 5 input steps → write_config_hybrid."""
+        adapter = AdapterFakeInput(
+            responses={
+                "choose_deployment_mode": "hybrid",
+                "configure_local_services": ["kafka", "postgres", "llm_inference"],
+                "configure_cloud_provider": "aws",
+                "configure_aws_region": "us-west-2",
+                "configure_llm_endpoint": "http://my-llm:8000",
+            }
+        )
+        executor = InteractiveExecutor(policy, adapter)
+        result = await executor.execute()
+
+        assert result.completed is True
+        assert result.terminal_step == "write_config_hybrid"
+        assert result.env_dict["ONEX_DEPLOYMENT_MODE"] == "hybrid"
+        assert result.env_dict["CLOUD_PROVIDER"] == "aws"
+        assert result.env_dict["AWS_REGION"] == "us-west-2"
+        assert result.env_dict["LLM_CODER_URL"] == "http://my-llm:8000"
+        assert result.env_dict["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:19092"
+        assert len(result.step_results) == 5
+
+
+# ------------------------------------------------------------------
+# Error cases
+# ------------------------------------------------------------------
+
+
+class TestErrorCases:
+    @pytest.mark.asyncio
+    async def test_missing_start_step_raises(self) -> None:
+        """Policy with no start_step raises at construction time.
+
+        The TransitionReducer validates graph integrity at __init__ and
+        raises TransitionError when start_step is None.  This is defense-
+        in-depth — the Pydantic validator normally prevents this state.
+        """
+        raw: dict[str, Any] = {
+            "policy_name": "broken",
+            "description": "test",
+            "version": {"major": 1, "minor": 0, "patch": 0},
+            "policy_type": "interactive",
+            "target_capabilities": [],
+            "max_estimated_minutes": 1,
+            "steps": [
+                {"id": "s1", "prompt": "p", "type": "choice", "options": ["a"]},
+            ],
+            "transitions": [{"from": "s1", "terminal": True}],
+            "env_output": {"s1": {"X": "1"}},
+        }
+        policy = ModelInteractivePolicy.model_validate(raw)
+        # start_step is auto-set to "s1" by validator; force override for test
+        object.__setattr__(policy, "start_step", None)
+
+        adapter = AdapterFakeInput(responses={})
+
+        # TransitionReducer catches the invalid graph at construction time
+        with pytest.raises(TransitionError, match="no start_step"):
+            InteractiveExecutor(policy, adapter)

--- a/tests/unit/validation/test_validator_defaults.py
+++ b/tests/unit/validation/test_validator_defaults.py
@@ -129,10 +129,10 @@ class TestInfraValidatorConstants:
         - 131 (2026-03-01): OMN-3202 graph handler signature fix (+1 union)
           - HandlerGraph.initialize(): dict[str, object] | str
 
-        Current: 150 (as of interactive onboarding models OMN-10771 + transition reducer OMN-10780). Target: Keep below 160 - if this grows, consider typed patterns from omnibase_core.
+        Current: 152 (as of interactive executor + result models OMN-10782). Target: Keep below 160 - if this grows, consider typed patterns from omnibase_core.
         """
-        assert INFRA_MAX_UNIONS == 150, (
-            "INFRA_MAX_UNIONS should be 150 (non-optional unions only, X | None excluded)"
+        assert INFRA_MAX_UNIONS == 152, (
+            "INFRA_MAX_UNIONS should be 152 (non-optional unions only, X | None excluded)"
         )
 
     def test_infra_max_violations_constant(self) -> None:


### PR DESCRIPTION
## Summary

- Add `InteractiveExecutor` that composes `TransitionReducer` + `ProtocolInputAdapter` to drive interactive onboarding policies from start step to terminal step, producing a `ModelInteractiveResult` with env dict, step results, and provenance
- Add `ModelInteractiveResult` and `ModelStepResult` Pydantic models (one-model-per-file, `extra="forbid"`, `frozen=True`)
- The executor is pure except for adapter I/O -- it never writes files; config writing is handled separately by the handler layer (Task 7)

**Ticket:** OMN-10782

Evidence-Source: OCC#901
Evidence-Ticket: OMN-10782

## Test plan

- [x] 11 unit tests: 2-step synthetic policy, env dict production, step result recording, action step notification, multi-choice list responses, error cases (missing start_step)
- [x] 12 integration tests: full traversal of local (with/without LLM), cloud (AWS/GCP), hybrid (AWS/GCP with/without LLM) paths through real interactive_onboarding.yaml with AdapterFakeInput
- [x] Step result ordering verified against traversal order
- [x] Provenance fields (policy_name, terminal_step) verified
- [x] Pre-commit hooks pass (all 46 hooks green)
- [x] uv run pytest tests/unit/onboarding/ tests/integration/onboarding/ -v -- 23/23 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive onboarding executor added — runs guided onboarding flows and produces environment configuration, completion status, terminal step, and ordered step results across local, AWS, GCP, and hybrid scenarios.

* **Tests**
  * Extensive unit and integration coverage exercising all onboarding paths, response types, provenance/ordering, and error handling.

* **Chores**
  * New contract/check configuration and validation exemption added; infrastructure union usage threshold increased.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1555)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->