### PR TITLE
fix(OMN-10797): condition evaluator supports quoted-literal LHS

### DIFF
--- a/contracts/OMN-10797.yaml
+++ b/contracts/OMN-10797.yaml
@@ -1,0 +1,39 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10797"
+title: "Condition evaluator: support quoted-string literal LHS"
+summary: "OMN-10779 followup. The interactive onboarding policy uses LHS literals such as `\"llm_inference\" in selected_local_services`; the evaluator was treating every LHS as a state key and raising. Extend the LHS grammar to accept quoted literals; quote the affected policy conditions."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Condition evaluator unit + integration tests pass."
+    command: "uv run pytest tests/unit/onboarding/test_condition_evaluator.py tests/integration/onboarding/test_condition_evaluator_policy_integration.py -q"
+  - kind: "tests"
+    description: "Interactive onboarding policy tests pass."
+    command: "uv run pytest tests/unit/onboarding/test_interactive_onboarding_policy.py -q"
+dod_evidence:
+  - id: "dod-001"
+    description: "Unit tests for condition evaluator (incl. new TestQuotedLiteralLhs class) pass."
+    source: "generated"
+    checks:
+      - check_type: "test-pass"
+        check_value: "tests/unit/onboarding/test_condition_evaluator.py"
+  - id: "dod-002"
+    description: "Integration tests for condition evaluator against real policy YAML pass."
+    source: "generated"
+    checks:
+      - check_type: "test-pass"
+        check_value: "tests/integration/onboarding/test_condition_evaluator_policy_integration.py"
+  - id: "dod-003"
+    description: "Interactive onboarding policy tests still pass after policy YAML quoted-literal updates."
+    source: "generated"
+    checks:
+      - check_type: "test-pass"
+        check_value: "tests/unit/onboarding/test_interactive_onboarding_policy.py"
+  - id: "dod-deploy"
+    description: "Non-deployable pure compute module + static policy YAML — no runtime deploy required."
+    source: "manual"
+    checks:
+      - check_type: "deploy"
+        check_value: "non-deployable pure compute + static policy — deploy gate compat"

--- a/contracts/OMN-10797.yaml
+++ b/contracts/OMN-10797.yaml
@@ -1,39 +1,38 @@
 schema_version: "1.0.0"
 ticket_id: "OMN-10797"
-title: "Condition evaluator: support quoted-string literal LHS"
-summary: "OMN-10779 followup. The interactive onboarding policy uses LHS literals such as `\"llm_inference\" in selected_local_services`; the evaluator was treating every LHS as a state key and raising. Extend the LHS grammar to accept quoted literals; quote the affected policy conditions."
+title: "fix(OMN-10797): condition evaluator supports quoted-literal LHS"
+summary: >
+  OMN-10779 followup. The interactive onboarding policy uses LHS literals such as `"llm_inference" in selected_local_services`; the evaluator was treating every LHS as a state key and raising. Extend the LHS grammar to accept quoted literals; quote the affected policy conditions.
+
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
-evidence_requirements:
-  - kind: "tests"
-    description: "Condition evaluator unit + integration tests pass."
-    command: "uv run pytest tests/unit/onboarding/test_condition_evaluator.py tests/integration/onboarding/test_condition_evaluator_policy_integration.py -q"
-  - kind: "tests"
-    description: "Interactive onboarding policy tests pass."
-    command: "uv run pytest tests/unit/onboarding/test_interactive_onboarding_policy.py -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
 dod_evidence:
-  - id: "dod-001"
-    description: "Unit tests for condition evaluator (incl. new TestQuotedLiteralLhs class) pass."
-    source: "generated"
+  - id: dod-001
+    description: Condition evaluator unit tests pass (49 tests, includes new TestQuotedLiteralLhs class).
+    source: generated
     checks:
-      - check_type: "test-pass"
-        check_value: "tests/unit/onboarding/test_condition_evaluator.py"
-  - id: "dod-002"
-    description: "Integration tests for condition evaluator against real policy YAML pass."
-    source: "generated"
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/onboarding/test_condition_evaluator.py -v'
+  - id: dod-002
+    description: Condition evaluator integration tests pass against real policy YAML.
+    source: generated
     checks:
-      - check_type: "test-pass"
-        check_value: "tests/integration/onboarding/test_condition_evaluator_policy_integration.py"
-  - id: "dod-003"
-    description: "Interactive onboarding policy tests still pass after policy YAML quoted-literal updates."
-    source: "generated"
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/onboarding/test_condition_evaluator_policy_integration.py -v'
+  - id: dod-003
+    description: Interactive onboarding policy structural tests still pass after policy YAML quoted-literal updates (243 onboarding tests total).
+    source: generated
     checks:
-      - check_type: "test-pass"
-        check_value: "tests/unit/onboarding/test_interactive_onboarding_policy.py"
-  - id: "dod-deploy"
-    description: "Non-deployable pure compute module + static policy YAML — no runtime deploy required."
-    source: "manual"
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/onboarding/test_interactive_onboarding_policy.py -v'
+  - id: dod-deploy
+    description: Non-deployable pure compute module + static policy YAML — no runtime artifact changes, no side effects, no I/O.
+    source: manual
     checks:
-      - check_type: "deploy"
-        check_value: "non-deployable pure compute + static policy — deploy gate compat"
+      - check_type: behavior_proven
+        check_value: 'condition_evaluator is pure compute (no env reads, no fs, no network, no time); policy YAML is static config consumed by reducer at runtime — deploy gate compat'

--- a/src/omnibase_infra/onboarding/condition_evaluator.py
+++ b/src/omnibase_infra/onboarding/condition_evaluator.py
@@ -5,11 +5,23 @@
 
 Evaluates boolean guard expressions against a state dict without eval().
 Supported operators: ==, in [...], not in [...], in <state_key>, and.
+
+LHS may be either a bareword (resolved as a state key) or a quoted string
+literal (e.g. ``"llm_inference" in selected_local_services``). RHS supports
+quoted literals for ``==``, inline lists for ``in [..]`` / ``not in [..]``,
+and bareword state keys resolving to collections.
 """
 
 from __future__ import annotations
 
 import re
+
+# A LHS token is either a bareword (\w+) or a single/double-quoted string.
+_LHS_TOKEN = r"""(?:"[^"]*"|'[^']*'|\w+)"""
+
+_NOT_IN_RE = re.compile(rf"^({_LHS_TOKEN})\s+not\s+in\s+(.+)$")
+_IN_RE = re.compile(rf"^({_LHS_TOKEN})\s+in\s+(.+)$")
+_EQ_RE = re.compile(rf"^({_LHS_TOKEN})\s*==\s*(.+)$")
 
 
 class ConditionEvaluationError(Exception):
@@ -21,6 +33,25 @@ def _resolve_key(key: str, state: dict[str, object]) -> object:
         msg = f"Unknown state key: '{key}'"
         raise ConditionEvaluationError(msg)
     return state[key]
+
+
+def _is_quoted(token: str) -> bool:
+    token = token.strip()
+    return len(token) >= 2 and (
+        (token[0] == '"' and token[-1] == '"') or (token[0] == "'" and token[-1] == "'")
+    )
+
+
+def _resolve_lhs(token: str, state: dict[str, object]) -> str:
+    """Resolve a LHS token to its string value.
+
+    Quoted tokens (``"foo"`` / ``'foo'``) are literal values; bareword tokens
+    are resolved as state keys.
+    """
+    token = token.strip()
+    if _is_quoted(token):
+        return token[1:-1]
+    return str(_resolve_key(token, state))
 
 
 def _parse_inline_list(raw: str) -> list[str]:
@@ -73,12 +104,11 @@ def _split_and_clauses(expr: str) -> list[str]:
 def _evaluate_single(expr: str, state: dict[str, object]) -> bool:
     expr = expr.strip()
 
-    # Pattern: key not in [list] or key not in state_key
-    not_in_match = re.match(r"^(\w+)\s+not\s+in\s+(.+)$", expr)
+    not_in_match = _NOT_IN_RE.match(expr)
     if not_in_match:
-        lhs_key = not_in_match.group(1)
+        lhs_token = not_in_match.group(1)
         rhs_raw = not_in_match.group(2).strip()
-        lhs_val = str(_resolve_key(lhs_key, state))
+        lhs_val = _resolve_lhs(lhs_token, state)
         if rhs_raw.startswith("["):
             items = _parse_inline_list(rhs_raw)
         else:
@@ -90,12 +120,11 @@ def _evaluate_single(expr: str, state: dict[str, object]) -> bool:
             items = [str(x) for x in rhs_obj]
         return lhs_val not in items
 
-    # Pattern: key in [list] or key in state_key
-    in_match = re.match(r"^(\w+)\s+in\s+(.+)$", expr)
+    in_match = _IN_RE.match(expr)
     if in_match:
-        lhs_key = in_match.group(1)
+        lhs_token = in_match.group(1)
         rhs_raw = in_match.group(2).strip()
-        lhs_val = str(_resolve_key(lhs_key, state))
+        lhs_val = _resolve_lhs(lhs_token, state)
         if rhs_raw.startswith("["):
             items = _parse_inline_list(rhs_raw)
         else:
@@ -107,12 +136,11 @@ def _evaluate_single(expr: str, state: dict[str, object]) -> bool:
             items = [str(x) for x in rhs_obj]
         return lhs_val in items
 
-    # Pattern: key == value
-    eq_match = re.match(r"^(\w+)\s*==\s*(.+)$", expr)
+    eq_match = _EQ_RE.match(expr)
     if eq_match:
-        lhs_key = eq_match.group(1)
+        lhs_token = eq_match.group(1)
         rhs_val = _strip_quotes(eq_match.group(2))
-        lhs_val = str(_resolve_key(lhs_key, state))
+        lhs_val = _resolve_lhs(lhs_token, state)
         return lhs_val == rhs_val
 
     msg = f"Unrecognised condition syntax: {expr!r}"

--- a/src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
+++ b/src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml
@@ -55,7 +55,7 @@ steps:
   - id: configure_llm_endpoint
     prompt: "LLM inference endpoint URL (leave blank to skip)"
     type: text
-    condition: "llm_inference in selected_local_services"
+    condition: '"llm_inference" in selected_local_services'
     required: false
   - id: write_config_local
     prompt: "Writing local .env configuration"
@@ -96,11 +96,11 @@ transitions:
   - from: configure_local_services
     # multi_choice — any selection is accepted; next depends on deployment_mode
     on_submit:
-      - condition: "deployment_mode == local and llm_inference not in response"
+      - condition: 'deployment_mode == local and "llm_inference" not in response'
         next: write_config_local
         set_state:
           selected_local_services: "{response}"
-      - condition: "deployment_mode == local and llm_inference in response"
+      - condition: 'deployment_mode == local and "llm_inference" in response'
         next: configure_llm_endpoint
         set_state:
           selected_local_services: "{response}"
@@ -124,11 +124,11 @@ transitions:
         next: write_config_cloud
         set_state:
           aws_region: "{response}"
-      - condition: "deployment_mode == hybrid and llm_inference in selected_local_services"
+      - condition: 'deployment_mode == hybrid and "llm_inference" in selected_local_services'
         next: configure_llm_endpoint
         set_state:
           aws_region: "{response}"
-      - condition: "deployment_mode == hybrid and llm_inference not in selected_local_services"
+      - condition: 'deployment_mode == hybrid and "llm_inference" not in selected_local_services'
         next: write_config_hybrid
         set_state:
           aws_region: "{response}"
@@ -138,11 +138,11 @@ transitions:
         next: write_config_cloud
         set_state:
           gcp_project: "{response}"
-      - condition: "deployment_mode == hybrid and llm_inference in selected_local_services"
+      - condition: 'deployment_mode == hybrid and "llm_inference" in selected_local_services'
         next: configure_llm_endpoint
         set_state:
           gcp_project: "{response}"
-      - condition: "deployment_mode == hybrid and llm_inference not in selected_local_services"
+      - condition: 'deployment_mode == hybrid and "llm_inference" not in selected_local_services'
         next: write_config_hybrid
         set_state:
           gcp_project: "{response}"

--- a/tests/integration/onboarding/test_condition_evaluator_quoted_lhs_integration.py
+++ b/tests/integration/onboarding/test_condition_evaluator_quoted_lhs_integration.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration test: quoted-literal LHS support against the real policy YAML.
+
+OMN-10797 adds the ability for `condition_evaluator` to treat a quoted-string
+LHS as a literal value rather than a state key. The interactive onboarding
+policy in `interactive_onboarding.yaml` depends on this for branches such as
+``"llm_inference" in selected_local_services``. This test loads the *real*
+deployed policy YAML and verifies that every branch condition is parseable
+and produces the expected routing for representative state inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_infra.onboarding.condition_evaluator import evaluate_condition
+
+POLICY_PATH = (
+    Path(__file__).parents[3]
+    / "src"
+    / "omnibase_infra"
+    / "onboarding"
+    / "policies"
+    / "interactive_onboarding.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def policy() -> dict[str, Any]:
+    return yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def transitions(policy: dict[str, Any]) -> dict[str, Any]:
+    return {t["from"]: t for t in policy["transitions"]}
+
+
+def _resolve_branch(transition: dict[str, Any], state: dict[str, object]) -> str:
+    for branch in transition["on_submit"]:
+        if evaluate_condition(branch["condition"], state):
+            return str(branch["next"])
+    pytest.fail(f"No matching branch for state={state} in transition {transition}")
+
+
+class TestQuotedLhsAcrossPolicy:
+    """Every transition with a quoted-LHS condition routes correctly end-to-end."""
+
+    def test_local_without_llm_routes_to_write_local(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        # `"llm_inference" not in response` should match when response lacks llm_inference.
+        t = transitions["configure_local_services"]
+        state: dict[str, object] = {
+            "deployment_mode": "local",
+            "response": ["kafka", "postgres", "valkey"],
+        }
+        assert _resolve_branch(t, state) == "write_config_local"
+
+    def test_local_with_llm_routes_to_configure_endpoint(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        # `"llm_inference" in response` should match when response contains llm_inference.
+        t = transitions["configure_local_services"]
+        state: dict[str, object] = {
+            "deployment_mode": "local",
+            "response": ["kafka", "llm_inference"],
+        }
+        assert _resolve_branch(t, state) == "configure_llm_endpoint"
+
+    def test_hybrid_aws_with_llm_routes_to_configure_endpoint(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        t = transitions["configure_aws_region"]
+        state: dict[str, object] = {
+            "deployment_mode": "hybrid",
+            "selected_local_services": ["llm_inference"],
+        }
+        assert _resolve_branch(t, state) == "configure_llm_endpoint"
+
+    def test_hybrid_aws_without_llm_routes_to_write_hybrid(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        t = transitions["configure_aws_region"]
+        state: dict[str, object] = {
+            "deployment_mode": "hybrid",
+            "selected_local_services": ["kafka", "postgres"],
+        }
+        assert _resolve_branch(t, state) == "write_config_hybrid"
+
+    def test_hybrid_gcp_with_llm_routes_to_configure_endpoint(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        t = transitions["configure_gcp_project"]
+        state: dict[str, object] = {
+            "deployment_mode": "hybrid",
+            "selected_local_services": ["llm_inference", "valkey"],
+        }
+        assert _resolve_branch(t, state) == "configure_llm_endpoint"
+
+    def test_hybrid_gcp_without_llm_routes_to_write_hybrid(
+        self, transitions: dict[str, Any]
+    ) -> None:
+        t = transitions["configure_gcp_project"]
+        state: dict[str, object] = {
+            "deployment_mode": "hybrid",
+            "selected_local_services": ["postgres"],
+        }
+        assert _resolve_branch(t, state) == "write_config_hybrid"
+
+    def test_step_visibility_quoted_literal_matches_state_list(
+        self, policy: dict[str, Any]
+    ) -> None:
+        # The configure_llm_endpoint step has visibility condition
+        # `"llm_inference" in selected_local_services` — verify that condition
+        # on the loaded step parses against state.
+        endpoint_step = next(
+            s for s in policy["steps"] if s["id"] == "configure_llm_endpoint"
+        )
+        condition = endpoint_step["condition"]
+        assert (
+            evaluate_condition(
+                condition,
+                {"selected_local_services": ["kafka", "llm_inference"]},
+            )
+            is True
+        )
+        assert (
+            evaluate_condition(
+                condition,
+                {"selected_local_services": ["kafka", "postgres"]},
+            )
+            is False
+        )

--- a/tests/unit/onboarding/test_condition_evaluator.py
+++ b/tests/unit/onboarding/test_condition_evaluator.py
@@ -252,6 +252,66 @@ class TestInteractiveOnboardingConditions:
         assert evaluate_condition("item in response", state_kafka) is True
 
 
+class TestQuotedLiteralLhs:
+    """OMN-10779 followup — LHS may be a quoted literal (not a state key).
+
+    Required by interactive onboarding policy syntax such as
+    ``"llm_inference" in selected_local_services`` where the LHS is a value to
+    test for membership rather than a state key to resolve.
+    """
+
+    def test_double_quoted_literal_in_state_list_true(self) -> None:
+        assert (
+            evaluate_condition(
+                '"llm_inference" in selected_local_services',
+                {"selected_local_services": ["llm_inference", "kafka"]},
+            )
+            is True
+        )
+
+    def test_double_quoted_literal_in_state_list_false(self) -> None:
+        assert (
+            evaluate_condition(
+                '"llm_inference" in selected_local_services',
+                {"selected_local_services": ["kafka", "postgres"]},
+            )
+            is False
+        )
+
+    def test_single_quoted_literal_not_in_state_list_true(self) -> None:
+        assert (
+            evaluate_condition(
+                "'llm_inference' not in response",
+                {"response": ["kafka", "postgres"]},
+            )
+            is True
+        )
+
+    def test_quoted_literal_does_not_resolve_state(self) -> None:
+        # The literal must NOT be looked up as a state key, even if a state key
+        # of that name exists.
+        assert (
+            evaluate_condition(
+                '"llm_inference" in selected_local_services',
+                {
+                    "llm_inference": "this_should_be_ignored",
+                    "selected_local_services": ["kafka"],
+                },
+            )
+            is False
+        )
+
+    def test_quoted_literal_compound_with_state_key(self) -> None:
+        # The exact pattern from interactive_onboarding.yaml.
+        assert (
+            evaluate_condition(
+                'deployment_mode == local and "llm_inference" not in response',
+                {"deployment_mode": "local", "response": ["kafka", "postgres"]},
+            )
+            is True
+        )
+
+
 class TestUnknownKeyErrors:
     def test_unknown_key_message_includes_key_name(self) -> None:
         with pytest.raises(ConditionEvaluationError, match="my_missing_key"):

--- a/tests/unit/onboarding/test_interactive_onboarding_policy.py
+++ b/tests/unit/onboarding/test_interactive_onboarding_policy.py
@@ -345,7 +345,8 @@ class TestHybridPath:
             b
             for b in t3["on_submit"]
             if "deployment_mode == hybrid" in b.get("condition", "")
-            and "llm_inference in" in b.get("condition", "")
+            and "llm_inference" in b.get("condition", "")
+            and "not in" not in b.get("condition", "")
         )
         assert hybrid_llm["next"] == "configure_llm_endpoint"
 


### PR DESCRIPTION
Evidence-Source: OCC#904
Evidence-Ticket: OMN-10797

## Summary

OMN-10779 followup. The interactive onboarding policy in `interactive_onboarding.yaml` writes branch conditions like:

```
deployment_mode == local and llm_inference not in response
```

where `llm_inference` is intended as a **literal value** to test for membership in `response` — not a state key to resolve. The OMN-10779 evaluator parsed every LHS as a state key and raised `ConditionEvaluationError: Unknown state key: 'llm_inference'`, breaking two integration tests in `test_condition_evaluator_policy_integration.py` and the `Tests (Split 2/15)` CI job. This blocks merge of OMN-10790 (#1554).

## Fix

- Extend the LHS grammar in `condition_evaluator.py` to accept either a bareword (state key — existing behavior) or a single/double-quoted literal.
- Quote `"llm_inference"` literals in `interactive_onboarding.yaml` so the policy expresses the intended semantics with the new grammar.
- Update one substring assertion in `test_interactive_onboarding_policy.py` that depended on the bareword form.
- Add `TestQuotedLiteralLhs` unit tests covering the new behavior.

## Evidence

- 49 condition_evaluator tests pass: `uv run pytest tests/ -v -k test_condition_evaluator`
- 243 onboarding tests pass: `uv run pytest tests/unit/onboarding/ tests/integration/onboarding/`
- Pre-commit clean.

## Why this is non-deployable

Pure compute module (no I/O, no event bus, no DB) plus a static policy YAML. No runtime artifact changes; deploy gate handled by `dod-deploy` evidence in `contracts/OMN-10797.yaml`.

## Files

- `src/omnibase_infra/onboarding/condition_evaluator.py`
- `src/omnibase_infra/onboarding/policies/interactive_onboarding.yaml`
- `tests/unit/onboarding/test_condition_evaluator.py`
- `tests/unit/onboarding/test_interactive_onboarding_policy.py`
- `contracts/OMN-10797.yaml`
