### PR TITLE
feat(OMN-10794): wire HandlerComplianceLoop into HandlerDelegationWorkflow

### DIFF
--- a/contracts/OMN-10794.yaml
+++ b/contracts/OMN-10794.yaml
@@ -1,0 +1,38 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10794"
+title: "feat(OMN-10794): wire HandlerComplianceLoop into HandlerDelegationWorkflow"
+summary: >
+  Wave 3 / Task 5 of the tokens-to-compliance epic. Adds output_schema_key and compliance_budget to ModelDelegationRequest, threads the schema-compliance loop into HandlerDelegationWorkflow.handle_inference_response, allows the ROUTED -> ROUTED self-loop for repair re-prompts, and accumulates tokens_to_compliance + compliance_attempts onto the terminal ModelDelegationResult and ModelTaskDelegatedEvent. Backwards compatible: legacy callers that omit output_schema_key get the single-attempt path with compliance_attempts=1 and tokens_to_compliance equal to the single attempt's total_tokens. Bumps node_delegation_orchestrator contract to 0.3.0 and updates the FSM transition table.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: 9 new unit tests prove the compliance-loop wiring — first-try compliance, repair-on-failure, two-attempt token accumulation, budget ABORT, and FSM ROUTED-to-ROUTED self-loop legality.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/nodes/node_delegation_orchestrator/test_compliance_loop_wiring.py -v'
+  - id: dod-002
+    description: Existing 32 orchestrator tests pass — legacy single-attempt path semantics are preserved.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/delegation/test_delegation_orchestrator.py -v'
+  - id: dod-003
+    description: Pyright/mypy strict pass for the modified handler and request model.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run mypy src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py --strict'
+  - id: dod-deploy
+    description: Deployable runtime change — the orchestrator's behavior is contract-driven, the new code path is opt-in via output_schema_key, and downstream consumers (HandlerProjectionDelegation, sqlite_adapter) are already wired for the new fields. Rolling restart is the only deploy step required.
+    source: manual
+    checks:
+      - check_type: behavior_proven
+        check_value: 'opt-in compliance-loop wiring; legacy callers unchanged; downstream projection already accepts the new fields with safe defaults — deploy gate compat'

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
@@ -18,15 +18,15 @@ contract_name: "node_delegation_orchestrator"
 node_name: "node_delegation_orchestrator"
 contract_version:
   major: 0
-  minor: 2
+  minor: 3
   patch: 0
 node_version:
   major: 0
-  minor: 2
+  minor: 3
   patch: 0
 node_type: "ORCHESTRATOR_GENERIC"
 description: >
-  Orchestrator node that coordinates delegation through a correlation_id-keyed FSM: receive delegation request, invoke routing reducer, dispatch typed invocation commands to the selected effect lane, react to remote agent lifecycle events or the legacy inference and quality-gate path, then emit delegation-completed or delegation-failed. As of 0.2.0 (OMN-10792), exposes HandlerComplianceLoop as an in-process helper that the workflow handler can invoke per inference attempt to enforce schema-compliance of LLM outputs and emit tokens_to_compliance + compliance_attempts metrics on the terminal event.
+  Orchestrator node that coordinates delegation through a correlation_id-keyed FSM: receive delegation request, invoke routing reducer, dispatch typed invocation commands to the selected effect lane, react to remote agent lifecycle events or the legacy inference and quality-gate path, then emit delegation-completed or delegation-failed. As of 0.2.0 (OMN-10792), exposes HandlerComplianceLoop as an in-process helper. As of 0.3.0 (OMN-10794), HandlerDelegationWorkflow invokes the loop per inference attempt when ModelDelegationRequest sets ``output_schema_key`` + ``compliance_budget``: validation failure with budget CONTINUE emits a fresh repair-prompt ModelInferenceIntent and stays in ROUTED (self-loop); compliant or budget ABORT forwards to the quality gate. tokens_to_compliance + compliance_attempts are accumulated across attempts and forwarded onto the terminal ModelDelegationResult and ModelTaskDelegatedEvent.
 
 input_model:
   name: "ModelDelegationRequest"
@@ -97,11 +97,14 @@ fsm:
       to: ROUTED
       trigger: "invocation command accepted"
     - from: ROUTED
+      to: ROUTED
+      trigger: "schema-compliance loop emits repair re-prompt (OMN-10794)"
+    - from: ROUTED
       to: EXECUTING
       trigger: "agent lifecycle progress received"
     - from: ROUTED
       to: INFERENCE_COMPLETED
-      trigger: "inference response received"
+      trigger: "inference response received (loop accepted or budget aborted)"
     - from: EXECUTING
       to: COMPLETED
       trigger: "agent lifecycle completed"

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from uuid import UUID
@@ -98,10 +99,15 @@ _CLAUDE_INPUT_PRICE_PER_TOKEN: float = 3.0 / 1_000_000
 _CLAUDE_OUTPUT_PRICE_PER_TOKEN: float = 15.0 / 1_000_000
 
 # Valid state transitions: from_state -> set of valid to_states
+# Note: ROUTED -> ROUTED self-loop (OMN-10794) supports the schema-compliance
+# loop's repair re-prompts — when an inference response fails validation and
+# the budget allows another attempt, the orchestrator stays in ROUTED while
+# emitting a fresh ModelInferenceIntent carrying the repair prompt.
 _VALID_TRANSITIONS: dict[EnumDelegationState, frozenset[EnumDelegationState]] = {
     EnumDelegationState.RECEIVED: frozenset({EnumDelegationState.ROUTED}),
     EnumDelegationState.ROUTED: frozenset(
         {
+            EnumDelegationState.ROUTED,  # OMN-10794 — schema-repair re-prompt
             EnumDelegationState.EXECUTING,
             EnumDelegationState.INFERENCE_COMPLETED,
             EnumDelegationState.COMPLETED,
@@ -122,6 +128,87 @@ _VALID_TRANSITIONS: dict[EnumDelegationState, frozenset[EnumDelegationState]] = 
 }
 
 
+def _record_inference_response(
+    workflow: DelegationWorkflowState,
+    response: ModelInferenceResponseData,
+) -> None:
+    """Persist a single inference attempt's data onto the workflow."""
+    workflow.inference_content = response.content
+    workflow.inference_model_used = response.model_used
+    workflow.inference_latency_ms = response.latency_ms
+    workflow.inference_prompt_tokens = response.prompt_tokens
+    workflow.inference_completion_tokens = response.completion_tokens
+    workflow.inference_total_tokens = response.total_tokens
+    workflow.inference_llm_call_id = response.llm_call_id
+
+
+def _evaluate_compliance(
+    workflow: DelegationWorkflowState,
+    response: ModelInferenceResponseData,
+    transition: Callable[[DelegationWorkflowState, EnumDelegationState], None],
+) -> list[BaseModel]:
+    """Run one compliance-loop iteration; emit repair intent or accept (OMN-10794).
+
+    Pre: workflow.state == ROUTED and workflow.request.output_schema_key
+    is not None and workflow.request.compliance_budget is not None.
+    """
+    # Local import to keep the cold path off the legacy boot path.
+    from omnibase_infra.nodes.node_delegation_orchestrator.handlers.handler_compliance_loop import (
+        HandlerComplianceLoop,
+    )
+
+    assert workflow.request is not None
+    assert workflow.request.output_schema_key is not None
+    assert workflow.request.compliance_budget is not None
+    assert workflow.routing_decision is not None
+
+    loop = HandlerComplianceLoop()
+    result = loop.evaluate(
+        candidate_output=response.content,
+        schema_key=workflow.request.output_schema_key,
+        original_prompt=workflow.request.prompt,
+        attempt_number=workflow.compliance_attempts,
+        cumulative_tokens=workflow.accumulated_tokens,
+        attempt_tokens=response.total_tokens,
+        budget_limits=workflow.request.compliance_budget,
+        run_id=str(workflow.correlation_id),
+    )
+
+    # Always update the running token total.
+    workflow.accumulated_tokens = result.tokens_to_compliance
+
+    if result.compliant or result.repair_prompt == "":
+        # Compliant or budget ABORT — record this attempt and forward to gate.
+        transition(workflow, EnumDelegationState.INFERENCE_COMPLETED)
+        _record_inference_response(workflow, response)
+        return [
+            ModelQualityGateIntent(
+                payload=ModelQualityGateInput(
+                    correlation_id=response.correlation_id,
+                    task_type=workflow.request.task_type,
+                    llm_response_content=response.content,
+                )
+            )
+        ]
+
+    # Non-compliant, budget allows another attempt — emit repair prompt.
+    # ROUTED -> ROUTED self-loop: stay in ROUTED, increment attempt counter.
+    transition(workflow, EnumDelegationState.ROUTED)
+    workflow.compliance_attempts += 1
+    temperature = _TASK_TEMPERATURE.get(workflow.request.task_type, 0.3)
+    return [
+        ModelInferenceIntent(
+            base_url=workflow.routing_decision.endpoint_url,
+            model=workflow.routing_decision.selected_model,
+            system_prompt=workflow.routing_decision.system_prompt,
+            prompt=result.repair_prompt,
+            max_tokens=workflow.request.max_tokens,
+            temperature=temperature,
+            correlation_id=workflow.correlation_id,
+        )
+    ]
+
+
 @dataclass
 class DelegationWorkflowState:
     """Mutable workflow state for a single delegation correlation_id."""
@@ -140,6 +227,13 @@ class DelegationWorkflowState:
     inference_llm_call_id: str = ""
     gate_result: ModelQualityGateResult | None = None
     started_at_ns: int = field(default_factory=time.monotonic_ns)
+    # Compliance-loop counters (OMN-10794). The orchestrator owns the loop,
+    # ``compliance_attempts`` counts the inference attempts it has issued so
+    # far (1 = first attempt) and ``accumulated_tokens`` is the running sum
+    # of tokens across all attempts. Both are forwarded onto the terminal
+    # ModelDelegationResult / ModelTaskDelegatedEvent.
+    compliance_attempts: int = 0
+    accumulated_tokens: int = 0
 
 
 class HandlerDelegationWorkflow:
@@ -217,6 +311,7 @@ class HandlerDelegationWorkflow:
         """Handle routing decision from the routing reducer.
 
         Transitions RECEIVED -> ROUTED, then emits intent to LLM inference.
+        This is attempt #1 of the compliance loop (OMN-10794).
         """
         cid = decision.correlation_id
         workflow = self._workflows.get(cid)
@@ -228,6 +323,7 @@ class HandlerDelegationWorkflow:
 
         self._transition(workflow, EnumDelegationState.ROUTED)
         workflow.routing_decision = decision
+        workflow.compliance_attempts = 1
 
         assert workflow.request is not None
         temperature = _TASK_TEMPERATURE.get(workflow.request.task_type, 0.3)
@@ -246,11 +342,21 @@ class HandlerDelegationWorkflow:
     def handle_inference_response(
         self,
         response: ModelInferenceResponseData,
-    ) -> list[ModelQualityGateIntent]:
+    ) -> list[BaseModel]:
         """Handle LLM inference response.
 
-        Transitions ROUTED -> INFERENCE_COMPLETED, then emits intent to
-        the quality gate reducer.
+        Two paths:
+
+        1. **Legacy** (request.output_schema_key is None) — accept the response
+           on the first attempt and forward to the quality gate. Transitions
+           ROUTED -> INFERENCE_COMPLETED.
+
+        2. **Compliance loop** (request.output_schema_key is set, OMN-10794) —
+           validate the response against the registered schema. On success or
+           budget-abort, accumulate tokens and forward to the quality gate
+           (ROUTED -> INFERENCE_COMPLETED). On non-compliant + budget CONTINUE,
+           emit a fresh ModelInferenceIntent with the repair prompt and stay
+           in ROUTED (self-loop).
         """
         workflow = self._workflows.get(response.correlation_id)
         if workflow is None:
@@ -259,23 +365,26 @@ class HandlerDelegationWorkflow:
         if workflow.state != EnumDelegationState.ROUTED:
             return []
 
-        self._transition(workflow, EnumDelegationState.INFERENCE_COMPLETED)
-        workflow.inference_content = response.content
-        workflow.inference_model_used = response.model_used
-        workflow.inference_latency_ms = response.latency_ms
-        workflow.inference_prompt_tokens = response.prompt_tokens
-        workflow.inference_completion_tokens = response.completion_tokens
-        workflow.inference_total_tokens = response.total_tokens
-        workflow.inference_llm_call_id = response.llm_call_id
-
         assert workflow.request is not None
-        gate_input = ModelQualityGateInput(
-            correlation_id=response.correlation_id,
-            task_type=workflow.request.task_type,
-            llm_response_content=response.content,
-        )
+        assert workflow.routing_decision is not None
 
-        return [ModelQualityGateIntent(payload=gate_input)]
+        # Legacy path: no compliance loop, single attempt.
+        if workflow.request.output_schema_key is None:
+            self._transition(workflow, EnumDelegationState.INFERENCE_COMPLETED)
+            _record_inference_response(workflow, response)
+            workflow.accumulated_tokens = response.total_tokens
+            return [
+                ModelQualityGateIntent(
+                    payload=ModelQualityGateInput(
+                        correlation_id=response.correlation_id,
+                        task_type=workflow.request.task_type,
+                        llm_response_content=response.content,
+                    )
+                )
+            ]
+
+        # Compliance-loop path.
+        return _evaluate_compliance(workflow, response, self._transition)
 
     def handle_gate_result(
         self,
@@ -307,6 +416,14 @@ class HandlerDelegationWorkflow:
 
         elapsed_ms = (time.monotonic_ns() - workflow.started_at_ns) // 1_000_000
 
+        # Compliance counters (OMN-10794): defaults preserve legacy single-attempt
+        # semantics (1 attempt, total_tokens of that attempt) when the request
+        # didn't opt into the compliance loop.
+        compliance_attempts = workflow.compliance_attempts or 1
+        tokens_to_compliance = (
+            workflow.accumulated_tokens or workflow.inference_total_tokens
+        )
+
         delegation_result = ModelDelegationResult(
             correlation_id=cid,
             task_type=workflow.request.task_type,
@@ -323,6 +440,8 @@ class HandlerDelegationWorkflow:
             failure_reason="; ".join(result.failure_reasons)
             if not result.passed
             else "",
+            tokens_to_compliance=tokens_to_compliance,
+            compliance_attempts=compliance_attempts,
         )
 
         # Estimate Claude cost for savings comparison (Task 11)
@@ -346,6 +465,8 @@ class HandlerDelegationWorkflow:
             cost_savings_usd=round(estimated_claude_cost, 6),
             delegation_latency_ms=elapsed_ms,
             llm_call_id=workflow.inference_llm_call_id,
+            tokens_to_compliance=tokens_to_compliance,
+            compliance_attempts=compliance_attempts,
         )
 
         events: list[BaseModel] = []

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py
@@ -14,6 +14,9 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
+from omnimarket.nodes.node_budget_policy_compute.models.model_budget_limits import (
+    ModelBudgetLimits,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -28,6 +31,13 @@ class ModelDelegationRequest(BaseModel):
         correlation_id: Unique identifier for tracking through the pipeline.
         max_tokens: Maximum tokens for the LLM response.
         emitted_at: Timestamp when the request was created.
+        output_schema_key: When set, activates the compliance loop — the
+            orchestrator validates each LLM response against the schema
+            registered under this key in omnimarket's output schema registry
+            and emits repair prompts on failure (OMN-10794).
+        compliance_budget: Token / cost / time ceilings the compliance loop
+            enforces between attempts. Required when ``output_schema_key`` is
+            set, ignored otherwise.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
@@ -59,6 +69,23 @@ class ModelDelegationRequest(BaseModel):
     emitted_at: datetime = Field(
         ...,
         description="Timestamp when the request was created.",
+    )
+    output_schema_key: str | None = Field(
+        default=None,
+        description=(
+            "When set, the orchestrator runs the schema-compliance loop: it "
+            "validates each inference response against the registry-resolved "
+            "schema and emits repair prompts on validation failure. None = "
+            "legacy single-attempt path."
+        ),
+    )
+    compliance_budget: ModelBudgetLimits | None = Field(
+        default=None,
+        description=(
+            "Budget ceilings (tokens, cost, elapsed time) the compliance loop "
+            "enforces between repair attempts. Required when "
+            "``output_schema_key`` is set."
+        ),
     )
 
 

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py
@@ -11,13 +11,13 @@ to a local LLM via the ONEX runtime event bus.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Self
 from uuid import UUID
 
 from omnimarket.nodes.node_budget_policy_compute.models.model_budget_limits import (
     ModelBudgetLimits,
 )
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelDelegationRequest(BaseModel):
@@ -87,6 +87,23 @@ class ModelDelegationRequest(BaseModel):
             "``output_schema_key`` is set."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_compliance_loop_config(self) -> Self:
+        """Reject ``output_schema_key`` set without ``compliance_budget``.
+
+        The compliance loop's evaluator requires both. Catching this at model
+        construction time prevents a runtime assertion in the workflow handler
+        when the orchestrator first sees the inference response.
+        """
+        if self.output_schema_key is not None and self.compliance_budget is None:
+            msg = (
+                "compliance_budget is required when output_schema_key is set "
+                "(the compliance loop has nothing to evaluate against without "
+                "token / cost / time ceilings)"
+            )
+            raise ValueError(msg)
+        return self
 
 
 __all__: list[str] = ["ModelDelegationRequest"]

--- a/tests/integration/delegation/test_compliance_loop_wiring_integration.py
+++ b/tests/integration/delegation/test_compliance_loop_wiring_integration.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration test for compliance-loop wiring in HandlerDelegationWorkflow — OMN-10794.
+
+The OMN-10792 unit tests for HandlerComplianceLoop and the OMN-10794 unit tests
+for HandlerDelegationWorkflow each cover their own surface, but neither exercises
+the full path from a real ModelDelegationRequest through the workflow handler,
+into the real omnimarket compute nodes (schema-registry, schema-repair,
+budget-policy), and back out as repair intent or terminal event.
+
+This test wires the orchestrator handler against unmocked omnimarket handlers
+and asserts the cross-package contract holds end-to-end:
+
+* request -> routing decision -> compliance-eligible response triggers
+  HandlerComplianceLoop.evaluate against the registered `delegation_result`
+  schema and emits a fresh ModelInferenceIntent carrying the repair prompt
+  (workflow remains in ROUTED for the self-loop).
+* the second-attempt compliant response transitions ROUTED -> INFERENCE_COMPLETED
+  with accumulated tokens equal to attempt 1 + attempt 2.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import NAMESPACE_DNS, uuid4, uuid5
+
+import pytest
+from omnimarket.nodes.node_budget_policy_compute.models.model_budget_limits import (
+    ModelBudgetLimits,
+)
+from omnimarket.nodes.node_output_schema_registry_compute.handlers.handler_output_schema_registry import (
+    known_schema_keys,
+)
+
+from omnibase_infra.nodes.node_delegation_orchestrator.enums import EnumDelegationState
+from omnibase_infra.nodes.node_delegation_orchestrator.handlers.handler_delegation_workflow import (
+    HandlerDelegationWorkflow,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_request import (
+    ModelDelegationRequest,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_intent import (
+    ModelInferenceIntent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_response_data import (
+    ModelInferenceResponseData,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_quality_gate_intent import (
+    ModelQualityGateIntent,
+)
+from omnibase_infra.nodes.node_delegation_routing_reducer.models.model_routing_decision import (
+    ModelRoutingDecision,
+)
+
+pytestmark = pytest.mark.integration
+
+
+_GENEROUS_LIMITS = ModelBudgetLimits(
+    max_tokens=10_000, max_cost_usd=10.0, max_time_s=600.0
+)
+
+
+def _valid_delegation_payload() -> str:
+    return json.dumps(
+        {
+            "correlation_id": "00000000-0000-0000-0000-000000000000",
+            "task_type": "test",
+            "model_used": "qwen3-coder-30b",
+            "endpoint_url": "http://192.168.86.201:8000",
+            "content": "def test_compliance_wiring(): assert True",
+            "quality_passed": True,
+            "quality_score": 0.95,
+            "latency_ms": 100,
+            "prompt_tokens": 110,
+            "completion_tokens": 110,
+            "total_tokens": 220,
+            "fallback_to_claude": False,
+            "failure_reason": "",
+            "tokens_to_compliance": 220,
+            "compliance_attempts": 1,
+        }
+    )
+
+
+def _routing(cid: object) -> ModelRoutingDecision:
+    return ModelRoutingDecision(
+        correlation_id=cid,
+        task_type="test",
+        selected_model="qwen3-coder-30b",
+        selected_backend_id=uuid5(
+            NAMESPACE_DNS, "omninode.ai/backends/qwen3-coder-30b"
+        ),
+        endpoint_url="http://192.168.86.201:8000",
+        cost_tier="low",
+        max_context_tokens=65536,
+        system_prompt="You are a test generation assistant.",
+        rationale="qwen3-coder-30b for task=test",
+    )
+
+
+def _response(
+    cid: object, content: str, *, total_tokens: int
+) -> ModelInferenceResponseData:
+    prompt_tokens = total_tokens // 2
+    completion_tokens = total_tokens - prompt_tokens
+    return ModelInferenceResponseData(
+        correlation_id=cid,
+        content=content,
+        model_used="qwen3-coder-30b",
+        latency_ms=100,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+class TestComplianceLoopWiringEndToEnd:
+    """End-to-end: orchestrator handler + unmocked omnimarket compute nodes."""
+
+    def test_delegation_result_schema_is_registered(self) -> None:
+        """Wiring requires the omnimarket schema registry to know
+        `delegation_result` — if this regresses the workflow can never opt into
+        the compliance loop with a meaningful schema_key."""
+        assert "delegation_result" in known_schema_keys()
+
+    def test_first_attempt_invalid_emits_repair_intent_and_stays_routed(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = ModelDelegationRequest(
+            prompt="Generate a unit test for foo()",
+            task_type="test",
+            correlation_id=uuid4(),
+            emitted_at=datetime.now(UTC),
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid = request.correlation_id
+        wf.handle_delegation_request(request)
+        wf.handle_routing_decision(_routing(cid))
+
+        # Attempt 1: missing required fields. Real schema-registry rejects this,
+        # real schema-repair builds a repair prompt, real budget-policy says CONTINUE.
+        out = wf.handle_inference_response(
+            _response(cid, json.dumps({"task_type": "summarize"}), total_tokens=180)
+        )
+
+        assert len(out) == 1, f"expected exactly one repair intent, got: {out!r}"
+        assert isinstance(out[0], ModelInferenceIntent)
+        # Workflow stays in ROUTED (self-loop) so the next inference response
+        # for the same correlation_id can re-enter the compliance evaluator.
+        assert wf.workflows[cid].state == EnumDelegationState.ROUTED
+        # compliance_attempts is incremented for the next attempt, so after
+        # attempt 1 fires the counter reads 2.
+        assert wf.workflows[cid].compliance_attempts == 2
+        assert wf.workflows[cid].accumulated_tokens == 180
+
+    def test_two_attempt_success_transitions_to_completed_with_accumulated_tokens(
+        self,
+    ) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = ModelDelegationRequest(
+            prompt="Generate a unit test for foo()",
+            task_type="test",
+            correlation_id=uuid4(),
+            emitted_at=datetime.now(UTC),
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid = request.correlation_id
+        wf.handle_delegation_request(request)
+        wf.handle_routing_decision(_routing(cid))
+
+        # Attempt 1: invalid -> repair intent.
+        wf.handle_inference_response(
+            _response(cid, json.dumps({"task_type": "summarize"}), total_tokens=180)
+        )
+
+        # Attempt 2: valid -> quality gate intent, INFERENCE_COMPLETED, total=400.
+        out = wf.handle_inference_response(
+            _response(cid, _valid_delegation_payload(), total_tokens=220)
+        )
+
+        assert len(out) == 1
+        assert isinstance(out[0], ModelQualityGateIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.INFERENCE_COMPLETED
+        assert wf.workflows[cid].compliance_attempts == 2
+        assert wf.workflows[cid].accumulated_tokens == 400

--- a/tests/unit/nodes/node_delegation_orchestrator/test_compliance_loop_wiring.py
+++ b/tests/unit/nodes/node_delegation_orchestrator/test_compliance_loop_wiring.py
@@ -1,0 +1,375 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for compliance-loop wiring in HandlerDelegationWorkflow — OMN-10794.
+
+These tests cover the new orchestrator behavior: when a delegation request
+opts into the compliance loop via ``output_schema_key``, the workflow
+validates each inference attempt, emits repair prompts on validation failure,
+and accumulates ``tokens_to_compliance`` + ``compliance_attempts`` onto the
+terminal result and event.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5
+
+import pytest
+from omnimarket.nodes.node_budget_policy_compute.models.model_budget_limits import (
+    ModelBudgetLimits,
+)
+
+from omnibase_infra.nodes.node_delegation_orchestrator.enums import EnumDelegationState
+from omnibase_infra.nodes.node_delegation_orchestrator.handlers.handler_delegation_workflow import (
+    HandlerDelegationWorkflow,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_event import (
+    ModelDelegationEvent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_request import (
+    ModelDelegationRequest,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_intent import (
+    ModelInferenceIntent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_inference_response_data import (
+    ModelInferenceResponseData,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_quality_gate_intent import (
+    ModelQualityGateIntent,
+)
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+    ModelTaskDelegatedEvent,
+)
+from omnibase_infra.nodes.node_delegation_quality_gate_reducer.models.model_quality_gate_result import (
+    ModelQualityGateResult,
+)
+from omnibase_infra.nodes.node_delegation_routing_reducer.models.model_routing_decision import (
+    ModelRoutingDecision,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_GENEROUS_LIMITS = ModelBudgetLimits(
+    max_tokens=10_000, max_cost_usd=10.0, max_time_s=600.0
+)
+_TIGHT_LIMITS = ModelBudgetLimits(max_tokens=300, max_cost_usd=10.0, max_time_s=600.0)
+
+
+def _valid_delegation_payload() -> str:
+    payload: dict[str, Any] = {
+        "correlation_id": "00000000-0000-0000-0000-000000000000",
+        "task_type": "test",
+        "model_used": "qwen3-coder",
+        "endpoint_url": "http://192.168.86.201:8000",
+        "content": "def test_x(): pass",
+        "quality_passed": True,
+        "quality_score": 0.95,
+        "latency_ms": 100,
+        "prompt_tokens": 50,
+        "completion_tokens": 20,
+        "total_tokens": 70,
+        "fallback_to_claude": False,
+        "failure_reason": "",
+        "tokens_to_compliance": 70,
+        "compliance_attempts": 1,
+    }
+    return json.dumps(payload)
+
+
+def _make_request(
+    *,
+    correlation_id: UUID | None = None,
+    output_schema_key: str | None = None,
+    compliance_budget: ModelBudgetLimits | None = None,
+) -> ModelDelegationRequest:
+    return ModelDelegationRequest(
+        prompt="Generate a unit test for foo()",
+        task_type="test",
+        correlation_id=correlation_id or uuid4(),
+        emitted_at=datetime.now(UTC),
+        output_schema_key=output_schema_key,
+        compliance_budget=compliance_budget,
+    )
+
+
+def _make_routing(cid: UUID) -> ModelRoutingDecision:
+    return ModelRoutingDecision(
+        correlation_id=cid,
+        task_type="test",
+        selected_model="qwen3-coder-30b",
+        selected_backend_id=uuid5(
+            NAMESPACE_DNS, "omninode.ai/backends/qwen3-coder-30b"
+        ),
+        endpoint_url="http://192.168.86.201:8000",
+        cost_tier="low",
+        max_context_tokens=65536,
+        system_prompt="You are a test generation assistant.",
+        rationale="qwen3-coder-30b for task=test",
+    )
+
+
+def _make_inference_response(
+    cid: UUID, content: str, *, total_tokens: int = 100
+) -> ModelInferenceResponseData:
+    # Split tokens into prompt/completion arbitrarily; the loop only consumes total.
+    prompt_tokens = total_tokens // 2
+    completion_tokens = total_tokens - prompt_tokens
+    return ModelInferenceResponseData(
+        correlation_id=cid,
+        content=content,
+        model_used="qwen3-coder-30b",
+        latency_ms=100,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _drive_to_routed(
+    workflow: HandlerDelegationWorkflow,
+    request: ModelDelegationRequest,
+) -> tuple[UUID, list[ModelInferenceIntent]]:
+    workflow.handle_delegation_request(request)
+    intents = workflow.handle_routing_decision(_make_routing(request.correlation_id))
+    return request.correlation_id, intents  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Legacy path — output_schema_key unset, behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyPathUnchanged:
+    """Without output_schema_key, the workflow takes the single-attempt path."""
+
+    def test_legacy_request_skips_compliance_loop(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request()  # output_schema_key=None
+        cid, _ = _drive_to_routed(wf, request)
+
+        out = wf.handle_inference_response(
+            _make_inference_response(cid, "any content", total_tokens=120)
+        )
+        assert len(out) == 1
+        assert isinstance(out[0], ModelQualityGateIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.INFERENCE_COMPLETED
+
+    def test_legacy_terminal_event_carries_default_compliance_counters(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request()
+        cid, _ = _drive_to_routed(wf, request)
+
+        wf.handle_inference_response(
+            _make_inference_response(cid, "x", total_tokens=120)
+        )
+        events = wf.handle_gate_result(
+            ModelQualityGateResult(
+                correlation_id=cid,
+                passed=True,
+                quality_score=0.9,
+                failure_reasons=[],
+                fallback_recommended=False,
+            )
+        )
+        compat = next(e for e in events if isinstance(e, ModelTaskDelegatedEvent))
+        delegation = next(e for e in events if isinstance(e, ModelDelegationEvent))
+        # Legacy path: compliance_attempts=1, tokens_to_compliance=total of single attempt.
+        assert compat.compliance_attempts == 1
+        assert compat.tokens_to_compliance == 120
+        from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_result import (
+            ModelDelegationResult,
+        )
+
+        assert isinstance(delegation.payload, ModelDelegationResult)
+        assert delegation.payload.compliance_attempts == 1
+        assert delegation.payload.tokens_to_compliance == 120
+
+
+# ---------------------------------------------------------------------------
+# Compliance-loop path — output_schema_key set, retry on validation failure
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceLoopFirstTrySuccess:
+    """When the first inference response validates against the schema, the
+    workflow accepts immediately and forwards to the quality gate."""
+
+    def test_first_try_compliant_emits_quality_gate_intent(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        out = wf.handle_inference_response(
+            _make_inference_response(cid, _valid_delegation_payload(), total_tokens=200)
+        )
+        assert len(out) == 1
+        assert isinstance(out[0], ModelQualityGateIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.INFERENCE_COMPLETED
+        assert wf.workflows[cid].compliance_attempts == 1
+        assert wf.workflows[cid].accumulated_tokens == 200
+
+
+class TestComplianceLoopRetry:
+    """Validation failure with budget CONTINUE emits a repair-prompt
+    ModelInferenceIntent and stays in ROUTED (self-loop)."""
+
+    def test_first_attempt_failure_emits_repair_intent(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid, initial = _drive_to_routed(wf, request)
+        assert len(initial) == 1
+
+        # Malformed JSON → schema repair triggers
+        out = wf.handle_inference_response(
+            _make_inference_response(cid, "not valid json {{{", total_tokens=100)
+        )
+        assert len(out) == 1
+        assert isinstance(out[0], ModelInferenceIntent)
+        # Repair prompt carries the schema-repair instructions
+        assert "schema" in out[0].prompt.lower()
+        assert wf.workflows[cid].state == EnumDelegationState.ROUTED  # self-loop
+        assert (
+            wf.workflows[cid].compliance_attempts == 2
+        )  # incremented for next attempt
+        assert wf.workflows[cid].accumulated_tokens == 100
+
+    def test_two_attempt_success_accumulates_tokens(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        # Attempt 1: fail (100 tokens) → repair issued
+        attempt1 = wf.handle_inference_response(
+            _make_inference_response(cid, "garbage", total_tokens=100)
+        )
+        assert isinstance(attempt1[0], ModelInferenceIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.ROUTED
+
+        # Attempt 2: pass (150 tokens) → accept, forward to gate, total=250
+        attempt2 = wf.handle_inference_response(
+            _make_inference_response(cid, _valid_delegation_payload(), total_tokens=150)
+        )
+        assert len(attempt2) == 1
+        assert isinstance(attempt2[0], ModelQualityGateIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.INFERENCE_COMPLETED
+        assert wf.workflows[cid].compliance_attempts == 2
+        assert wf.workflows[cid].accumulated_tokens == 250
+
+    def test_two_attempt_terminal_event_carries_running_total(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        wf.handle_inference_response(
+            _make_inference_response(cid, "garbage", total_tokens=100)
+        )
+        wf.handle_inference_response(
+            _make_inference_response(cid, _valid_delegation_payload(), total_tokens=150)
+        )
+        events = wf.handle_gate_result(
+            ModelQualityGateResult(
+                correlation_id=cid,
+                passed=True,
+                quality_score=0.9,
+                failure_reasons=[],
+                fallback_recommended=False,
+            )
+        )
+        compat = next(e for e in events if isinstance(e, ModelTaskDelegatedEvent))
+        assert compat.compliance_attempts == 2
+        assert compat.tokens_to_compliance == 250
+
+
+class TestComplianceLoopBudgetAbort:
+    """Budget ABORT terminates the loop without further inference attempts;
+    the orchestrator forwards the (non-compliant) attempt to the quality
+    gate so the failure reason surfaces in the terminal event."""
+
+    def test_budget_abort_forwards_to_gate(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_TIGHT_LIMITS,  # 300-token ceiling
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        # First attempt: 400 tokens. Ratio 400/300=1.33 > 1.0 → ABORT.
+        out = wf.handle_inference_response(
+            _make_inference_response(cid, "garbage", total_tokens=400)
+        )
+        assert len(out) == 1
+        # ABORT path forwards to gate, NOT another inference intent.
+        assert isinstance(out[0], ModelQualityGateIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.INFERENCE_COMPLETED
+        # Attempt counter not incremented (no retry happened); tokens recorded.
+        assert wf.workflows[cid].compliance_attempts == 1
+        assert wf.workflows[cid].accumulated_tokens == 400
+
+    def test_budget_abort_terminal_event_carries_actual_attempts(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_TIGHT_LIMITS,
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        wf.handle_inference_response(
+            _make_inference_response(cid, "garbage", total_tokens=400)
+        )
+        events = wf.handle_gate_result(
+            ModelQualityGateResult(
+                correlation_id=cid,
+                passed=False,
+                quality_score=0.1,
+                failure_reasons=["malformed json"],
+                fallback_recommended=True,
+            )
+        )
+        compat = next(e for e in events if isinstance(e, ModelTaskDelegatedEvent))
+        assert compat.compliance_attempts == 1
+        assert compat.tokens_to_compliance == 400
+        assert compat.quality_gate_passed is False
+
+
+class TestFsmSelfLoopAllowed:
+    """The ROUTED -> ROUTED self-loop must be a legal FSM transition (OMN-10794)."""
+
+    def test_self_loop_does_not_raise(self) -> None:
+        wf = HandlerDelegationWorkflow()
+        request = _make_request(
+            output_schema_key="delegation_result",
+            compliance_budget=_GENEROUS_LIMITS,
+        )
+        cid, _ = _drive_to_routed(wf, request)
+
+        # First failed attempt → self-loop. Must not raise.
+        out = wf.handle_inference_response(
+            _make_inference_response(cid, "garbage", total_tokens=50)
+        )
+        assert isinstance(out[0], ModelInferenceIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.ROUTED
+
+        # Second failed attempt → another self-loop, also legal.
+        out2 = wf.handle_inference_response(
+            _make_inference_response(cid, "still garbage", total_tokens=60)
+        )
+        assert isinstance(out2[0], ModelInferenceIntent)
+        assert wf.workflows[cid].state == EnumDelegationState.ROUTED
+        assert wf.workflows[cid].compliance_attempts == 3


### PR DESCRIPTION
Evidence-Source: OCC#907
Evidence-Ticket: OMN-10794

## Summary

Wave 3 / Task 5 of the tokens-to-compliance epic. Wires the OMN-10792 `HandlerComplianceLoop` into the delegation orchestrator so that delegations opting in via `output_schema_key` get per-attempt schema validation, repair-prompt re-issue, and accumulated `tokens_to_compliance` / `compliance_attempts` on the terminal event.

## Changes

### `ModelDelegationRequest` (additive, optional)

- `output_schema_key: str | None` — when set, activates the loop. Resolves to a schema in omnimarket's output schema registry.
- `compliance_budget: ModelBudgetLimits | None` — token / cost / time ceilings the loop enforces between attempts.

### `HandlerDelegationWorkflow.handle_inference_response` (split paths)

Two paths inside the same handler:

1. **Legacy** (`output_schema_key is None`) — accept the response on the first attempt and forward to the quality gate. Behavior unchanged.
2. **Compliance loop** (`output_schema_key is set`) — call `HandlerComplianceLoop.evaluate(...)`:
   - **compliant** → forward to quality gate, accumulate tokens
   - **budget ABORT** → forward to quality gate (the failure surfaces in the terminal event)
   - **non-compliant + budget CONTINUE** → emit a fresh `ModelInferenceIntent` carrying the repair prompt and stay in `ROUTED` (self-loop), increment `compliance_attempts` for the next iteration

### `DelegationWorkflowState`

New fields: `compliance_attempts: int = 0`, `accumulated_tokens: int = 0`. The orchestrator owns the loop counters; the loop handler is per-attempt-stateless.

### FSM `ROUTED → ROUTED` self-loop

Added to `_VALID_TRANSITIONS` and `contract.yaml` transition table. Triggered by repair re-prompts from the loop.

### Terminal event population

`handle_gate_result` now populates `tokens_to_compliance` and `compliance_attempts` on both `ModelDelegationResult` and the backwards-compatible `ModelTaskDelegatedEvent`. Defaults preserve legacy semantics: 1 attempt, total tokens of that single attempt.

### Contract bump

`node_delegation_orchestrator/contract.yaml` → 0.3.0 (was 0.2.0 from OMN-10792). Updated description documents the new opt-in loop wiring; FSM section adds the self-loop transition.

## Tests

- 9 new unit tests in `tests/unit/nodes/node_delegation_orchestrator/test_compliance_loop_wiring.py`:
  - Legacy path unchanged (2 tests)
  - First-try compliance accepts immediately (1 test)
  - Repair-on-failure with self-loop (1 test)
  - Two-attempt success accumulates tokens (1 test)
  - Two-attempt terminal event carries running total (1 test)
  - Budget ABORT forwards to gate (1 test)
  - Budget ABORT terminal event carries actual attempts (1 test)
  - FSM self-loop is a legal transition (1 test)
- All 32 existing orchestrator tests still pass.
- mypy `--strict` clean.
- pre-commit clean.

## Why this is a runtime change (not pure-compute)

The wiring runs in the orchestrator's hot path. Downstream consumers (`HandlerProjectionDelegation` from OMN-10793, `sqlite_adapter` from OMN-10789) are already wired for `tokens_to_compliance` + `compliance_attempts` with safe defaults, so a rolling restart is the only deploy step. No schema migration, no data migration.

## Files

- `src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py`
- `src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_delegation_request.py`
- `src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml`
- `tests/unit/nodes/node_delegation_orchestrator/test_compliance_loop_wiring.py`
- `contracts/OMN-10794.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional compliance-loop controls for delegation requests (activate schema validation and repair re-prompts), automated retries until acceptance or budget exhaustion, and terminal metrics for tokens-to-compliance and compliance attempts; legacy requests remain unchanged.
* **Documentation**
  * Contract/interface docs updated to describe the compliance-loop behavior and version bump.
* **Tests**
  * New unit and end-to-end tests validating legacy and compliance-loop flows, retries, budget aborts, and accumulated metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1560)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
