### PR TITLE
fix(OMN-10705): Remove bus bypass handler imports from onex-setup.py

### DIFF
--- a/scripts/onex-setup.py
+++ b/scripts/onex-setup.py
@@ -238,19 +238,19 @@ async def _run_orchestrator(
     # Import effect node implementations lazily to avoid import-time side-effects.
     # Build a minimal stub container (no services required for CLI invocation).
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.nodes.node_setup_infisical_effect.handlers.handler_infisical_full_setup import (
+    from omnibase_infra.nodes.node_setup_infisical_effect.handlers import (
         HandlerInfisicalFullSetup,
     )
-    from omnibase_infra.nodes.node_setup_local_provision_effect.handlers.handler_local_provision import (
+    from omnibase_infra.nodes.node_setup_local_provision_effect.handlers import (
         HandlerLocalProvision,
     )
-    from omnibase_infra.nodes.node_setup_orchestrator.handlers.handler_setup_orchestrator import (
+    from omnibase_infra.nodes.node_setup_orchestrator.handlers import (
         HandlerSetupOrchestrator,
     )
-    from omnibase_infra.nodes.node_setup_preflight_effect.handlers.handler_preflight_check import (
+    from omnibase_infra.nodes.node_setup_preflight_effect.handlers import (
         HandlerPreflightCheck,
     )
-    from omnibase_infra.nodes.node_setup_validate_effect.handlers.handler_service_validate import (
+    from omnibase_infra.nodes.node_setup_validate_effect.handlers import (
         HandlerServiceValidate,
     )
 

--- a/src/omnibase_infra/nodes/node_setup_infisical_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_infisical_effect/contract.yaml
@@ -7,8 +7,12 @@ node_type: "EFFECT_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
+changelog:
+  - version: "1.0.1"
+    ticket: "OMN-10705"
+    change: "Export HandlerInfisicalFullSetup via handlers/__init__.py public API"
 description: >
   EFFECT node that bootstraps the Infisical secret store by running provision-infisical.py (identity setup) and seed-infisical.py (secret population) in sequence. Part of the setup orchestration workflow.
 

--- a/src/omnibase_infra/nodes/node_setup_infisical_effect/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_setup_infisical_effect/handlers/__init__.py
@@ -7,4 +7,8 @@
 Ticket: OMN-3494
 """
 
-__all__: list[str] = []
+from omnibase_infra.nodes.node_setup_infisical_effect.handlers.handler_infisical_full_setup import (
+    HandlerInfisicalFullSetup,
+)
+
+__all__: list[str] = ["HandlerInfisicalFullSetup"]

--- a/src/omnibase_infra/nodes/node_setup_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_orchestrator/contract.yaml
@@ -7,8 +7,12 @@ node_type: "ORCHESTRATOR_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
+changelog:
+  - version: "1.0.1"
+    ticket: "OMN-10705"
+    change: "Export HandlerSetupOrchestrator via handlers/__init__.py public API"
 description: >
   ORCHESTRATOR node that coordinates the full platform setup workflow: cloud gate check (I8) → preflight validation → local Docker Compose provisioning → Infisical bootstrap → post-provision health validation. Emits a structured sequence of lifecycle events (SETUP_EVENT_TYPES). No result field — orchestrators emit events only (Invariant I5).
 

--- a/src/omnibase_infra/nodes/node_setup_orchestrator/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_setup_orchestrator/handlers/__init__.py
@@ -7,4 +7,8 @@
 Ticket: OMN-3495
 """
 
-__all__: list[str] = []
+from omnibase_infra.nodes.node_setup_orchestrator.handlers.handler_setup_orchestrator import (
+    HandlerSetupOrchestrator,
+)
+
+__all__: list[str] = ["HandlerSetupOrchestrator"]

--- a/src/omnibase_infra/nodes/node_setup_validate_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_validate_effect/contract.yaml
@@ -7,8 +7,12 @@ node_type: "EFFECT_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
+changelog:
+  - version: "1.0.1"
+    ticket: "OMN-10705"
+    change: "Export HandlerServiceValidate via handlers/__init__.py public API"
 description: >
   EFFECT node that validates TCP/HTTP health for all LOCAL-mode services in the deployment topology after provisioning is complete. Services with a health_check_path use HTTP GET; others use TCP connect.
 

--- a/src/omnibase_infra/nodes/node_setup_validate_effect/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_setup_validate_effect/handlers/__init__.py
@@ -7,4 +7,8 @@
 Ticket: OMN-3494
 """
 
-__all__: list[str] = []
+from omnibase_infra.nodes.node_setup_validate_effect.handlers.handler_service_validate import (
+    HandlerServiceValidate,
+)
+
+__all__: list[str] = ["HandlerServiceValidate"]

--- a/tests/integration/test_setup_handlers_public_api.py
+++ b/tests/integration/test_setup_handlers_public_api.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Integration test: setup node handlers are accessible via public __init__.py API.
+
+Verifies that OMN-10705 correctly exposes each setup handler through its node's
+handlers/__init__.py public surface, replacing direct sub-module imports in
+scripts/onex-setup.py. This is the observable side-effect the ticket targets.
+
+Ticket: OMN-10705
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+class TestSetupHandlersPublicApi:
+    """Verify that setup handlers are reachable from the public handlers package."""
+
+    def test_handler_infisical_full_setup_importable_via_init(self) -> None:
+        from omnibase_infra.nodes.node_setup_infisical_effect.handlers import (
+            HandlerInfisicalFullSetup,
+        )
+
+        assert HandlerInfisicalFullSetup is not None
+
+    def test_handler_setup_orchestrator_importable_via_init(self) -> None:
+        from omnibase_infra.nodes.node_setup_orchestrator.handlers import (
+            HandlerSetupOrchestrator,
+        )
+
+        assert HandlerSetupOrchestrator is not None
+
+    def test_handler_service_validate_importable_via_init(self) -> None:
+        from omnibase_infra.nodes.node_setup_validate_effect.handlers import (
+            HandlerServiceValidate,
+        )
+
+        assert HandlerServiceValidate is not None
+
+    def test_handler_infisical_full_setup_in_all(self) -> None:
+        import omnibase_infra.nodes.node_setup_infisical_effect.handlers as pkg
+
+        assert "HandlerInfisicalFullSetup" in pkg.__all__
+
+    def test_handler_setup_orchestrator_in_all(self) -> None:
+        import omnibase_infra.nodes.node_setup_orchestrator.handlers as pkg
+
+        assert "HandlerSetupOrchestrator" in pkg.__all__
+
+    def test_handler_service_validate_in_all(self) -> None:
+        import omnibase_infra.nodes.node_setup_validate_effect.handlers as pkg
+
+        assert "HandlerServiceValidate" in pkg.__all__
+
+    def test_public_import_matches_direct_import_infisical(self) -> None:
+        from omnibase_infra.nodes.node_setup_infisical_effect.handlers import (
+            HandlerInfisicalFullSetup as PublicHandler,
+        )
+        from omnibase_infra.nodes.node_setup_infisical_effect.handlers.handler_infisical_full_setup import (
+            HandlerInfisicalFullSetup as DirectHandler,
+        )
+
+        assert PublicHandler is DirectHandler
+
+    def test_public_import_matches_direct_import_orchestrator(self) -> None:
+        from omnibase_infra.nodes.node_setup_orchestrator.handlers import (
+            HandlerSetupOrchestrator as PublicHandler,
+        )
+        from omnibase_infra.nodes.node_setup_orchestrator.handlers.handler_setup_orchestrator import (
+            HandlerSetupOrchestrator as DirectHandler,
+        )
+
+        assert PublicHandler is DirectHandler
+
+    def test_public_import_matches_direct_import_validate(self) -> None:
+        from omnibase_infra.nodes.node_setup_validate_effect.handlers import (
+            HandlerServiceValidate as PublicHandler,
+        )
+        from omnibase_infra.nodes.node_setup_validate_effect.handlers.handler_service_validate import (
+            HandlerServiceValidate as DirectHandler,
+        )
+
+        assert PublicHandler is DirectHandler


### PR DESCRIPTION
## Summary

- Replaces 5 direct `nodes.*.handlers.<module>` imports in `scripts/onex-setup.py` with imports from each node's `handlers/__init__.py` public API layer
- Adds `HandlerSetupOrchestrator`, `HandlerInfisicalFullSetup`, and `HandlerServiceValidate` to their respective `handlers/__init__.py` `__all__` exports (the other two nodes already exported their handlers)
- Bumps `contract_version` patch from 1.0.0 → 1.0.1 for the 3 affected nodes (required by Contract Sync Gate)
- Adds integration test `test_setup_handlers_public_api.py` (9 tests) verifying all 3 handlers are importable via public API
- No behavior change — same handler classes are used, now accessed via the package public surface

## Ticket

OMN-10705

Evidence-Ticket: OMN-10705
Evidence-Source: OCC#935

## Test plan

- [x] Unit tests: 33 passed across 5 node test suites
- [x] Integration tests: 9 passed in test_setup_handlers_public_api.py
- [x] `pre-commit run --all-files` — all hooks passed
- [x] `uv run ruff format && ruff check` — clean
- [ ] CI green