### PR TITLE
feat(OMN-10860): add /skill HTTP endpoint to runtime ServiceHealth

### DIFF
--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -2327,6 +2327,13 @@ class RuntimeHostProcess:
             self._pattern_b_broker_config.enabled_profiles
         )
 
+    async def dispatch_local_ingress_request(
+        self,
+        request: ModelLocalRuntimeIngressRequest,
+    ) -> ModelLocalRuntimeIngressResponse:
+        """Public entry point for local ingress dispatch (used by HTTP /skill handler)."""
+        return await self._dispatch_local_ingress_request(request)
+
     async def _dispatch_local_ingress_request(
         self,
         request: ModelLocalRuntimeIngressRequest,

--- a/src/omnibase_infra/services/service_health.py
+++ b/src/omnibase_infra/services/service_health.py
@@ -65,6 +65,15 @@ from uuid import UUID
 
 from aiohttp import web
 
+from omnibase_core.models.runtime.model_runtime_skill_error import (
+    ModelRuntimeSkillError,
+)
+from omnibase_core.models.runtime.model_runtime_skill_request import (
+    ModelRuntimeSkillRequest,
+)
+from omnibase_core.models.runtime.model_runtime_skill_response import (
+    ModelRuntimeSkillResponse,
+)
 from omnibase_core.types import JsonType
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import (
@@ -78,6 +87,9 @@ from omnibase_infra.runtime.models.model_detailed_health_response import (
 )
 from omnibase_infra.runtime.models.model_health_check_response import (
     ModelHealthCheckResponse,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_request import (
+    ModelLocalRuntimeIngressRequest,
 )
 from omnibase_infra.utils.correlation import generate_correlation_id
 
@@ -629,6 +641,8 @@ class ServiceHealth:
             self._app.router.add_get("/ready", self._handle_readiness)
             # OMN-519: Detailed diagnostics endpoint
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
+            # OMN-10860: Skill dispatch endpoint
+            self._app.router.add_post("/skill", self._handle_skill)
 
             # Create and start runner
             self._runner = web.AppRunner(self._app)
@@ -650,7 +664,7 @@ class ServiceHealth:
                 extra={
                     "host": self._host,
                     "port": self._port,
-                    "endpoints": ["/health", "/ready", "/health/detailed"],
+                    "endpoints": ["/health", "/ready", "/health/detailed", "/skill"],
                     "version": self._version,
                 },
             )
@@ -1132,6 +1146,134 @@ class ServiceHealth:
                 status=503,
                 content_type="application/json",
             )
+
+    async def _handle_skill(self, request: web.Request) -> web.Response:
+        """Handle POST /skill requests — dispatch to local runtime ingress.
+
+        Accepts a JSON body matching ModelRuntimeSkillRequest, dispatches through
+        the runtime's local ingress path, and returns a ModelRuntimeSkillResponse.
+
+        HTTP Status Codes:
+            - 200: Dispatch completed (check response.ok for execution result)
+            - 400: Request body failed validation
+            - 500: Unexpected server error
+        """
+        raw_correlation = request.headers.get("X-Correlation-ID")
+        try:
+            correlation_id: UUID = (
+                UUID(raw_correlation) if raw_correlation else generate_correlation_id()
+            )
+        except ValueError:
+            correlation_id = generate_correlation_id()
+
+        try:
+            body = await request.json()
+        except Exception as exc:  # noqa: BLE001 — boundary: aiohttp json() raises various types
+            skill_response = ModelRuntimeSkillResponse(
+                ok=False,
+                command_name="unknown",
+                correlation_id=correlation_id,
+                error=ModelRuntimeSkillError(
+                    code="validation_error",
+                    message=f"Invalid JSON body: {exc}",
+                ),
+            )
+            return web.Response(
+                text=skill_response.model_dump_json(exclude_none=True),
+                status=400,
+                content_type="application/json",
+            )
+
+        try:
+            skill_request = ModelRuntimeSkillRequest.model_validate(body, strict=False)
+        except Exception as exc:  # noqa: BLE001 — boundary: Pydantic ValidationError + others
+            skill_response = ModelRuntimeSkillResponse(
+                ok=False,
+                command_name=body.get("command_name", "unknown")
+                if isinstance(body, dict)
+                else "unknown",
+                correlation_id=correlation_id,
+                error=ModelRuntimeSkillError(
+                    code="validation_error",
+                    message=f"Invalid skill request: {exc}",
+                ),
+            )
+            return web.Response(
+                text=skill_response.model_dump_json(exclude_none=True),
+                status=400,
+                content_type="application/json",
+            )
+
+        ingress_request = ModelLocalRuntimeIngressRequest(
+            command_name=skill_request.command_name,
+            payload=skill_request.payload,
+            correlation_id=skill_request.correlation_id or correlation_id,
+            timeout_ms=min(skill_request.timeout_ms, 600_000),
+        )
+
+        try:
+            ingress_response = await self.runtime.dispatch_local_ingress_request(
+                ingress_request
+            )
+        except Exception as exc:
+            logger.exception(
+                "Skill dispatch failed with exception (correlation_id=%s)",
+                correlation_id,
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            skill_response = ModelRuntimeSkillResponse(
+                ok=False,
+                command_name=skill_request.command_name,
+                correlation_id=correlation_id,
+                error=ModelRuntimeSkillError(
+                    code="dispatch_error",
+                    message=f"Skill dispatch failed: {exc}",
+                ),
+            )
+            return web.Response(
+                text=skill_response.model_dump_json(exclude_none=True),
+                status=500,
+                content_type="application/json",
+            )
+
+        if ingress_response.ok and ingress_response.dispatch_result is not None:
+            skill_response = ModelRuntimeSkillResponse(
+                ok=True,
+                command_name=ingress_response.command_name,
+                node_alias=ingress_response.node_alias,
+                resolved_node_name=ingress_response.resolved_node_name,
+                contract_name=ingress_response.contract_name,
+                command_topic=ingress_response.command_topic,
+                terminal_event=ingress_response.terminal_event,
+                correlation_id=ingress_response.correlation_id,
+                dispatch_result=ingress_response.dispatch_result,
+                output_payloads=ingress_response.output_payloads,
+            )
+        else:
+            ingress_err = ingress_response.error
+            skill_response = ModelRuntimeSkillResponse(
+                ok=False,
+                command_name=ingress_response.command_name,
+                correlation_id=ingress_response.correlation_id,
+                error=ModelRuntimeSkillError(
+                    code=ingress_err.code
+                    if ingress_err is not None
+                    else "dispatch_error",
+                    message=ingress_err.message
+                    if ingress_err is not None
+                    else "dispatch failed",
+                    retryable=ingress_err.retryable
+                    if ingress_err is not None
+                    else False,
+                    details=ingress_err.details if ingress_err is not None else None,
+                ),
+            )
+
+        return web.Response(
+            text=skill_response.model_dump_json(exclude_none=True),
+            status=200,
+            content_type="application/json",
+        )
 
     def _build_component_health(
         self,

--- a/tests/integration/runtime/test_service_health_skill_endpoint_integration.py
+++ b/tests/integration/runtime/test_service_health_skill_endpoint_integration.py
@@ -106,8 +106,9 @@ class TestServiceHealthSkillEndpointIntegration:
 
             runtime.dispatch_local_ingress_request = AsyncMock(return_value=ingress_ok)  # type: ignore[method-assign]
 
-            health_server, port = await self._boot_health_server(runtime)
+            health_server: ServiceHealth | None = None
             try:
+                health_server, port = await self._boot_health_server(runtime)
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
                         f"http://127.0.0.1:{port}/skill",
@@ -125,7 +126,8 @@ class TestServiceHealthSkillEndpointIntegration:
                 assert data["command_name"] == "test_command"
                 runtime.dispatch_local_ingress_request.assert_awaited_once()
             finally:
-                await health_server.stop()
+                if health_server is not None:
+                    await health_server.stop()
                 await runtime.stop()
 
     @pytest.mark.asyncio
@@ -141,8 +143,9 @@ class TestServiceHealthSkillEndpointIntegration:
             seed_mock_handlers(runtime)
             await runtime.start()
 
-            health_server, port = await self._boot_health_server(runtime)
+            health_server: ServiceHealth | None = None
             try:
+                health_server, port = await self._boot_health_server(runtime)
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
                         f"http://127.0.0.1:{port}/skill",
@@ -155,7 +158,8 @@ class TestServiceHealthSkillEndpointIntegration:
                 assert data["ok"] is False
                 assert data["error"]["code"] == "validation_error"
             finally:
-                await health_server.stop()
+                if health_server is not None:
+                    await health_server.stop()
                 await runtime.stop()
 
     @pytest.mark.asyncio
@@ -175,8 +179,9 @@ class TestServiceHealthSkillEndpointIntegration:
 
             runtime.dispatch_local_ingress_request = AsyncMock(return_value=ingress_ok)  # type: ignore[method-assign]
 
-            health_server, port = await self._boot_health_server(runtime)
+            health_server: ServiceHealth | None = None
             try:
+                health_server, port = await self._boot_health_server(runtime)
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
                         f"http://127.0.0.1:{port}/skill",
@@ -190,5 +195,6 @@ class TestServiceHealthSkillEndpointIntegration:
                 ingress_req = call_args[0][0]
                 assert ingress_req.correlation_id == corr_id
             finally:
-                await health_server.stop()
+                if health_server is not None:
+                    await health_server.stop()
                 await runtime.stop()

--- a/tests/integration/runtime/test_service_health_skill_endpoint_integration.py
+++ b/tests/integration/runtime/test_service_health_skill_endpoint_integration.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for POST /skill endpoint on ServiceHealth (OMN-10860).
+
+Boots a real ServiceHealth HTTP server with a mocked RuntimeHostProcess and
+verifies that the /skill endpoint correctly routes requests through the
+dispatch_local_ingress_request path end-to-end over a real HTTP connection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import aiohttp
+import pytest
+
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
+)
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from omnibase_infra.services.service_health import ServiceHealth
+from tests.helpers.runtime_helpers import make_runtime_config, seed_mock_handlers
+
+pytestmark = pytest.mark.integration
+
+_CORR_ID = UUID("aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb")
+
+_SKILL_TEST_CONFIG: dict[str, object] = {
+    "service_name": "skill-endpoint-test",
+    "node_name": "test-node",
+    "env": "test",
+    "version": "v1",
+}
+
+
+def _ok_ingress_response(
+    command_name: str = "test_command",
+) -> ModelLocalRuntimeIngressResponse:
+    from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+        ModelDispatchBusTerminalResult,
+    )
+
+    return ModelLocalRuntimeIngressResponse(
+        ok=True,
+        command_name=command_name,
+        correlation_id=_CORR_ID,
+        dispatch_result=ModelDispatchBusTerminalResult(
+            correlation_id=_CORR_ID,
+            status="completed",
+            payload={"result": "ok"},
+            error_message=None,
+        ),
+        output_payloads=[{"result": "ok"}],
+    )
+
+
+def _error_ingress_response(
+    command_name: str = "bad_command",
+) -> ModelLocalRuntimeIngressResponse:
+    return ModelLocalRuntimeIngressResponse(
+        ok=False,
+        command_name=command_name,
+        error=ModelLocalRuntimeIngressError(
+            code="unknown_command", message="Unknown command"
+        ),  # type: ignore[arg-type]
+    )
+
+
+class TestServiceHealthSkillEndpointIntegration:
+    """Integration tests for the POST /skill HTTP endpoint."""
+
+    async def _boot_health_server(
+        self,
+        runtime: RuntimeHostProcess,
+    ) -> tuple[ServiceHealth, int]:
+        """Start a ServiceHealth server and return it + its bound port."""
+        health_server = ServiceHealth(runtime=runtime, port=0, version="test-1.0.0")
+        await health_server.start()
+        site = health_server._site
+        assert site is not None
+        internal_server = site._server
+        assert internal_server is not None
+        sockets = getattr(internal_server, "sockets", None)
+        assert sockets and len(sockets) > 0
+        port: int = sockets[0].getsockname()[1]
+        return health_server, port
+
+    @pytest.mark.asyncio
+    async def test_skill_endpoint_dispatches_and_returns_ok(self) -> None:
+        """POST /skill with a valid request reaches dispatch and returns ok=True."""
+        event_bus = EventBusInmemory()
+        runtime = RuntimeHostProcess(event_bus=event_bus, config=_SKILL_TEST_CONFIG)
+        ingress_ok = _ok_ingress_response("test_command")
+
+        async def noop_populate() -> None:
+            pass
+
+        with patch.object(runtime, "_populate_handlers_from_registry", noop_populate):
+            seed_mock_handlers(runtime)
+            await runtime.start()
+
+            runtime.dispatch_local_ingress_request = AsyncMock(return_value=ingress_ok)  # type: ignore[method-assign]
+
+            health_server, port = await self._boot_health_server(runtime)
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"http://127.0.0.1:{port}/skill",
+                        json={
+                            "command_name": "test_command",
+                            "payload": {"dry_run": True},
+                            "correlation_id": str(_CORR_ID),
+                            "timeout_ms": 5000,
+                        },
+                    ) as resp:
+                        assert resp.status == 200
+                        data = await resp.json()
+
+                assert data["ok"] is True
+                assert data["command_name"] == "test_command"
+                runtime.dispatch_local_ingress_request.assert_awaited_once()
+            finally:
+                await health_server.stop()
+                await runtime.stop()
+
+    @pytest.mark.asyncio
+    async def test_skill_endpoint_returns_400_on_invalid_json(self) -> None:
+        """POST /skill with malformed JSON returns 400 with validation_error."""
+        event_bus = EventBusInmemory()
+        runtime = RuntimeHostProcess(event_bus=event_bus, config=_SKILL_TEST_CONFIG)
+
+        async def noop_populate() -> None:
+            pass
+
+        with patch.object(runtime, "_populate_handlers_from_registry", noop_populate):
+            seed_mock_handlers(runtime)
+            await runtime.start()
+
+            health_server, port = await self._boot_health_server(runtime)
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"http://127.0.0.1:{port}/skill",
+                        data=b"not-json{{{",
+                        headers={"Content-Type": "application/json"},
+                    ) as resp:
+                        assert resp.status == 400
+                        data = await resp.json()
+
+                assert data["ok"] is False
+                assert data["error"]["code"] == "validation_error"
+            finally:
+                await health_server.stop()
+                await runtime.stop()
+
+    @pytest.mark.asyncio
+    async def test_skill_endpoint_propagates_correlation_id_from_header(self) -> None:
+        """X-Correlation-ID header is propagated into the ingress request."""
+        event_bus = EventBusInmemory()
+        runtime = RuntimeHostProcess(event_bus=event_bus, config=_SKILL_TEST_CONFIG)
+        corr_id = uuid4()
+        ingress_ok = _ok_ingress_response("session_orchestrator")
+
+        async def noop_populate() -> None:
+            pass
+
+        with patch.object(runtime, "_populate_handlers_from_registry", noop_populate):
+            seed_mock_handlers(runtime)
+            await runtime.start()
+
+            runtime.dispatch_local_ingress_request = AsyncMock(return_value=ingress_ok)  # type: ignore[method-assign]
+
+            health_server, port = await self._boot_health_server(runtime)
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"http://127.0.0.1:{port}/skill",
+                        json={"command_name": "session_orchestrator", "payload": {}},
+                        headers={"X-Correlation-ID": str(corr_id)},
+                    ) as resp:
+                        assert resp.status == 200
+
+                call_args = runtime.dispatch_local_ingress_request.call_args
+                assert call_args is not None
+                ingress_req = call_args[0][0]
+                assert ingress_req.correlation_id == corr_id
+            finally:
+                await health_server.stop()
+                await runtime.stop()

--- a/tests/unit/runtime/test_service_health_skill_endpoint.py
+++ b/tests/unit/runtime/test_service_health_skill_endpoint.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the POST /skill endpoint on ServiceHealth (OMN-10860)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from aiohttp import web
+
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_error import (
+    ModelLocalRuntimeIngressError,
+)
+from omnibase_infra.runtime.models.model_local_runtime_ingress_response import (
+    ModelLocalRuntimeIngressResponse,
+)
+from omnibase_infra.services.service_health import ServiceHealth
+
+_CORR_ID = UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _make_dispatch_result() -> ModelDispatchBusTerminalResult:
+    return ModelDispatchBusTerminalResult(
+        correlation_id=_CORR_ID,
+        status="completed",
+        payload={"result": "ok"},
+        error_message=None,
+    )
+
+
+def _make_ok_ingress_response(
+    command_name: str = "test_command",
+) -> ModelLocalRuntimeIngressResponse:
+    return ModelLocalRuntimeIngressResponse(
+        ok=True,
+        command_name=command_name,
+        correlation_id=_CORR_ID,
+        dispatch_result=_make_dispatch_result(),
+        output_payloads=[{"result": "ok"}],
+    )
+
+
+def _make_error_ingress_response(
+    code: str = "unknown_command",
+    message: str = "Unknown command",
+    command_name: str = "bad_command",
+) -> ModelLocalRuntimeIngressResponse:
+    return ModelLocalRuntimeIngressResponse(
+        ok=False,
+        command_name=command_name,
+        error=ModelLocalRuntimeIngressError(code=code, message=message),  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture
+def mock_runtime() -> MagicMock:
+    runtime = MagicMock()
+    runtime.dispatch_local_ingress_request = AsyncMock(
+        return_value=_make_ok_ingress_response()
+    )
+    return runtime
+
+
+@pytest.mark.unit
+class TestServiceHealthSkillEndpoint:
+    """Tests for the POST /skill endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_skill_success(self, mock_runtime: MagicMock) -> None:
+        """Successful dispatch returns 200 with ok=True."""
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        with patch(
+            "omnibase_infra.services.service_health.web.Application"
+        ) as mock_app_cls:
+            with patch(
+                "omnibase_infra.services.service_health.web.AppRunner"
+            ) as mock_runner_cls:
+                with patch(
+                    "omnibase_infra.services.service_health.web.TCPSite"
+                ) as mock_site_cls:
+                    app_instance = MagicMock()
+                    routes: list[tuple[str, str, object]] = []
+
+                    def _add_post(path: str, handler: object) -> None:
+                        routes.append(("POST", path, handler))
+
+                    app_instance.router = MagicMock()
+                    app_instance.router.add_get = MagicMock()
+                    app_instance.router.add_post = MagicMock(side_effect=_add_post)
+                    mock_app_cls.return_value = app_instance
+
+                    runner_instance = MagicMock()
+                    runner_instance.setup = AsyncMock()
+                    mock_runner_cls.return_value = runner_instance
+
+                    site_instance = MagicMock()
+                    site_instance.start = AsyncMock()
+                    mock_site_cls.return_value = site_instance
+
+                    await server.start()
+
+        # POST /skill should be registered
+        assert app_instance.router.add_post.called
+        call_args = app_instance.router.add_post.call_args_list
+        paths = [c.args[0] for c in call_args]
+        assert "/skill" in paths
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_ok_response(self, mock_runtime: MagicMock) -> None:
+        """_handle_skill returns 200 with ok=True for a successful ingress response."""
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(return_value={"command_name": "test_command"})
+
+        response = await server._handle_skill(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+        assert body["command_name"] == "test_command"
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_invalid_json(self, mock_runtime: MagicMock) -> None:
+        """_handle_skill returns 400 when request body is not valid JSON."""
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(side_effect=ValueError("bad json"))
+
+        response = await server._handle_skill(mock_request)
+
+        assert response.status == 400
+        body = json.loads(response.text)
+        assert body["ok"] is False
+        assert body["error"]["code"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_validation_error(self, mock_runtime: MagicMock) -> None:
+        """_handle_skill returns 400 when body fails ModelRuntimeSkillRequest validation."""
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        # command_name is required; empty dict should fail
+        mock_request.json = AsyncMock(return_value={})
+
+        response = await server._handle_skill(mock_request)
+
+        assert response.status == 400
+        body = json.loads(response.text)
+        assert body["ok"] is False
+        assert body["error"]["code"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_unknown_command(self, mock_runtime: MagicMock) -> None:
+        """_handle_skill returns 200 with ok=False for unknown_command ingress error."""
+        mock_runtime.dispatch_local_ingress_request = AsyncMock(
+            return_value=_make_error_ingress_response(
+                code="unknown_command", message="Unknown command 'bogus'"
+            )
+        )
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(return_value={"command_name": "bogus"})
+
+        response = await server._handle_skill(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is False
+        assert body["error"]["code"] == "unknown_command"
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_dispatch_exception(
+        self, mock_runtime: MagicMock
+    ) -> None:
+        """_handle_skill returns 500 when dispatch_local_ingress_request raises."""
+        mock_runtime.dispatch_local_ingress_request = AsyncMock(
+            side_effect=RuntimeError("broker down")
+        )
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(return_value={"command_name": "test_command"})
+
+        response = await server._handle_skill(mock_request)
+
+        assert response.status == 500
+        body = json.loads(response.text)
+        assert body["ok"] is False
+        assert body["error"]["code"] == "dispatch_error"
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_correlation_id_propagated(
+        self, mock_runtime: MagicMock
+    ) -> None:
+        """Caller-supplied X-Correlation-ID is forwarded into the ingress request."""
+        caller_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Correlation-ID": caller_id}
+        mock_request.json = AsyncMock(return_value={"command_name": "test_command"})
+
+        await server._handle_skill(mock_request)
+
+        call_args = mock_runtime.dispatch_local_ingress_request.call_args
+        ingress_req = call_args.args[0]
+        assert str(ingress_req.correlation_id) == caller_id
+
+    @pytest.mark.asyncio
+    async def test_handle_skill_timeout_clamped(self, mock_runtime: MagicMock) -> None:
+        """timeout_ms is clamped to 600_000 (ModelLocalRuntimeIngressRequest upper bound)."""
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(
+            return_value={"command_name": "test_command", "timeout_ms": 900_000}
+        )
+
+        await server._handle_skill(mock_request)
+
+        call_args = mock_runtime.dispatch_local_ingress_request.call_args
+        ingress_req = call_args.args[0]
+        assert ingress_req.timeout_ms == 600_000


### PR DESCRIPTION
## Summary

- Adds `POST /skill` endpoint to `ServiceHealth` (aiohttp) that accepts `ModelRuntimeSkillRequest` JSON, dispatches through `RuntimeHostProcess.dispatch_local_ingress_request`, and returns `ModelRuntimeSkillResponse`
- Exposes `dispatch_local_ingress_request` as a public method on `RuntimeHostProcess` (thin wrapper over the existing private `_dispatch_local_ingress_request`)
- Delegate skills can now set `ONEX_RUNTIME_URL=http://192.168.86.201:18085` and POST to `/skill` with zero Kafka transport code in the skill layer

## Test plan

- [ ] `uv run pytest tests/unit/runtime/test_service_health_skill_endpoint.py -v` — 8 unit tests covering: success path, invalid JSON body, validation error, unknown command, dispatch exception (500), correlation ID propagation, timeout clamp
- [ ] `uv run pytest tests/unit/runtime/test_service_health.py` — 46 existing health tests, all pass (no regressions)
- [ ] `pre-commit run --files ...` — all hooks pass on changed files
- [ ] `uv run mypy src/omnibase_infra/services/service_health.py src/omnibase_infra/runtime/service_runtime_host_process.py --strict` — clean

Closes OMN-10860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /skill to accept skill requests with JSON validation, correlation ID propagation, timeout clamping, and structured success/error responses.

* **Public API**
  * Added a public runtime entry point to dispatch local ingress requests.

* **Tests**
  * Added unit and integration tests covering success, malformed/validation errors, unknown-command results, dispatch failures, correlation ID forwarding, and timeout clamping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1566)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#944
Evidence-Ticket: OMN-10860