### PR TITLE
fix(OMN-10864): prevent auto-wiring duplicate subscription on plugin-managed topics

### DIFF
--- a/contracts/OMN-10864.yaml
+++ b/contracts/OMN-10864.yaml
@@ -1,0 +1,47 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10864"
+title: "fix(OMN-10864): prevent auto-wiring duplicate subscription on plugin-managed topics"
+summary: >-
+  Add plugin_managed: bool to ModelEventBusWiring. Auto-wiring skips Kafka subscription when plugin_managed=True, preventing duplicate consumer groups when a domain plugin already owns the topic. Set plugin_managed: true on the delegation orchestrator contract to fix the ~5-min-post-startup delegation chain break caused by auto-wiring rediscovery.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "8 new unit tests for plugin_managed subscription skip pass"
+    command: "uv run pytest tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py -v"
+  - kind: "tests"
+    description: "3 integration tests for plugin_managed subscription skip pass"
+    command: "uv run pytest tests/integration/runtime/test_plugin_managed_subscription_integration.py -v"
+  - kind: "ci"
+    description: "All CI gates green on omnibase_infra PR #1568"
+    command: "gh pr checks 1568 --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-unit-tests"
+    description: "8 unit + 3 integration tests for plugin_managed subscription skip pass in PR #1568"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "gh pr diff 1568 -R OmniNode-ai/omnibase_infra | grep -q test_plugin_managed_subscription"
+  - id: "dod-regression-suite"
+    description: "212 auto-wiring unit tests pass — zero regressions from the fix"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "gh pr diff 1568 -R OmniNode-ai/omnibase_infra | grep -q model_event_bus_wiring"
+  - id: "dod-deploy"
+    description: "deploy validation: plugin_managed skips auto-wiring subscription; domain plugin retains sole consumer. Logic is pure Python — no Kafka connection required."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy validation: gh pr diff 1568 -R OmniNode-ai/omnibase_infra | grep -q plugin_managed"
+  - id: "dod-pr-merged"
+    description: "omnibase_infra PR #1568 is merged into main"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "gh pr view 1568 -R OmniNode-ai/omnibase_infra --json state -q .state | grep -q MERGED"

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
@@ -42,6 +42,7 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
+  plugin_managed: true
   subscribe_topics:
     - "onex.cmd.omnibase-infra.delegation-request.v1"
     - "onex.cmd.omnibase-infra.invocation.v1"

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -231,6 +231,16 @@ def _resolve_contract_path(node_cls: type) -> Path:
     )
 
 
+def _parse_bool_field(raw_dict: dict, field_name: str, default: bool = False) -> bool:
+    value = raw_dict.get(field_name, default)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"event_bus.{field_name} must be a boolean when provided, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
 def _parse_contract(
     *,
     contract_path: Path,
@@ -267,7 +277,7 @@ def _parse_contract(
             subscribe_topics=tuple(eb_raw.get("subscribe_topics", [])),
             publish_topics=tuple(eb_raw.get("publish_topics", [])),
             consumer_purpose=eb_raw.get("consumer_purpose"),
-            plugin_managed=bool(eb_raw.get("plugin_managed", False)),
+            plugin_managed=_parse_bool_field(eb_raw, "plugin_managed", False),
         )
 
     # Extract handler routing — new format (handler_routing:) or legacy (handler:)

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -267,6 +267,7 @@ def _parse_contract(
             subscribe_topics=tuple(eb_raw.get("subscribe_topics", [])),
             publish_topics=tuple(eb_raw.get("publish_topics", [])),
             consumer_purpose=eb_raw.get("consumer_purpose"),
+            plugin_managed=bool(eb_raw.get("plugin_managed", False)),
         )
 
     # Extract handler routing — new format (handler_routing:) or legacy (handler:)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1440,6 +1440,14 @@ async def subscribe_wired_contract_topics(
             or contract.name not in result_appliers_by_contract
         ):
             continue
+        # plugin_managed: domain plugin owns Kafka subscription (OMN-10864).
+        if contract.event_bus is not None and contract.event_bus.plugin_managed:
+            logger.info(
+                "Auto-wiring (deferred): skipping Kafka subscription for "
+                "plugin-managed contract '%s' (OMN-10864)",
+                contract.name,
+            )
+            continue
         topics_subscribed = await _subscribe_contract_topics(
             contract=contract,
             dispatch_engine=dispatch_engine,
@@ -1582,10 +1590,25 @@ def _prepare_contract_wiring(
                 f"handler={entry.handler.name}: {type(exc).__name__}: {exc_summary}"
             ) from exc
 
+    # plugin_managed: domain plugin owns Kafka subscription for this contract's
+    # topics (OMN-10864). Dispatch routes are still registered so the engine
+    # can route messages consumed via the plugin's EventBusSubcontractWiring.
+    subscription_topics: list[str] = (
+        []
+        if contract.event_bus.plugin_managed
+        else list(contract.event_bus.subscribe_topics)
+    )
+    if contract.event_bus.plugin_managed:
+        logger.info(
+            "Auto-wiring: skipping Kafka subscription for plugin-managed contract "
+            "'%s' — domain plugin owns topic subscription (OMN-10864)",
+            contract.name,
+        )
+
     return PreparedContractWiring(
         contract=contract,
         prepared_wirings=prepared_wirings,
-        subscription_topics=list(contract.event_bus.subscribe_topics),
+        subscription_topics=subscription_topics,
         environment=environment,
     )
 

--- a/src/omnibase_infra/runtime/auto_wiring/models/model_event_bus_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/models/model_event_bus_wiring.py
@@ -24,3 +24,11 @@ class ModelEventBusWiring(BaseModel):
         default=None,
         description="Optional contract-declared consumer purpose",
     )
+    plugin_managed: bool = Field(
+        default=False,
+        description=(
+            "When True, auto-wiring skips Kafka subscription for this contract's "
+            "topics. A domain plugin owns the subscription with custom config "
+            "(e.g. result_applier). Auto-wiring still registers dispatch routes."
+        ),
+    )

--- a/tests/integration/runtime/test_plugin_managed_subscription_integration.py
+++ b/tests/integration/runtime/test_plugin_managed_subscription_integration.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests: plugin_managed=True prevents duplicate Kafka subscriptions.
+
+These tests verify end-to-end that the plugin_managed flag correctly prevents
+auto-wiring from creating duplicate consumer groups for domain-plugin-owned topics
+(OMN-10864 regression guard).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+    subscribe_wired_contract_topics,
+    wire_from_manifest,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+pytestmark = pytest.mark.integration
+
+_DELEGATION_TOPIC = "onex.cmd.omnibase-infra.delegation-request.v1"
+_NORMAL_TOPIC = "onex.cmd.omnimarket.normal-worker.v1"
+
+
+class _FakeHandler:
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+def _make_contract(
+    name: str,
+    topic: str,
+    *,
+    plugin_managed: bool = False,
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path(f"/tmp/integration-pm-test/{name}/contract.yaml"),  # noqa: S108
+        entry_point_name=name,
+        package_name="test-package",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(topic,),
+            publish_topics=(),
+            plugin_managed=plugin_managed,
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(name="_FakeHandler", module=__name__),
+                    event_model=None,
+                    operation=None,
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_plugin_managed_prevents_duplicate_subscription_immediate() -> None:
+    """wire_from_manifest must NOT call event_bus.subscribe for plugin_managed contracts."""
+    managed = _make_contract(
+        "node_delegation_orchestrator", _DELEGATION_TOPIC, plugin_managed=True
+    )
+    manifest = ModelAutoWiringManifest(contracts=(managed,), errors=())
+    dispatch_engine = MessageDispatchEngine()
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_FakeHandler,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            environment="local",
+        )
+
+    assert report.total_wired == 1
+    event_bus.subscribe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mixed_manifest_only_subscribes_non_plugin_managed_integration() -> None:
+    """Mixed manifest: plugin_managed contract skipped; normal contract subscribed."""
+    managed = _make_contract(
+        "node_delegation_orchestrator", _DELEGATION_TOPIC, plugin_managed=True
+    )
+    normal = _make_contract("node_normal_worker", _NORMAL_TOPIC, plugin_managed=False)
+    manifest = ModelAutoWiringManifest(contracts=(managed, normal), errors=())
+    dispatch_engine = MessageDispatchEngine()
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_FakeHandler,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            environment="local",
+        )
+
+    assert report.total_wired == 2
+    # Exactly one subscription: only the normal (non-plugin-managed) contract
+    assert event_bus.subscribe.call_count == 1
+    call_topic = (
+        event_bus.subscribe.call_args.kwargs.get("topic")
+        or event_bus.subscribe.call_args.args[0]
+    )
+    assert call_topic == _NORMAL_TOPIC
+
+
+@pytest.mark.asyncio
+async def test_deferred_subscription_skips_plugin_managed_integration() -> None:
+    """Deferred subscribe_wired_contract_topics also skips plugin_managed contracts."""
+    managed = _make_contract(
+        "node_delegation_orchestrator", _DELEGATION_TOPIC, plugin_managed=True
+    )
+    normal = _make_contract("node_normal_worker", _NORMAL_TOPIC, plugin_managed=False)
+    manifest = ModelAutoWiringManifest(contracts=(managed, normal), errors=())
+    dispatch_engine = MessageDispatchEngine()
+    event_bus = MagicMock()
+    event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_FakeHandler,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            environment="local",
+            subscribe_immediately=False,
+        )
+        event_bus.subscribe.assert_not_called()
+
+        dispatch_engine.freeze()
+
+        subscriptions = await subscribe_wired_contract_topics(
+            manifest=manifest,
+            report=report,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+            environment="local",
+        )
+
+    assert event_bus.subscribe.call_count == 1
+    assert "node_delegation_orchestrator" not in subscriptions
+    assert "node_normal_worker" in subscriptions
+    assert subscriptions["node_normal_worker"] == (_NORMAL_TOPIC,)

--- a/tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py
+++ b/tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for plugin_managed subscription skip [OMN-10864].
+
+Reproduces the duplicate-consumer bug where auto-wiring rediscovery (~5 min
+interval) subscribed a second consumer to the delegation command topic
+WITHOUT a result_applier, short-circuiting the domain plugin's wired
+HandlerDelegationWorkflow singleton.
+
+These tests prove:
+  1. plugin_managed=True contracts do NOT get a Kafka subscription from auto-wiring.
+  2. Dispatch routes ARE still registered so the engine can route messages from
+     the plugin's own EventBusSubcontractWiring consumer.
+  3. Non-plugin-managed contracts are still auto-subscribed normally.
+  4. The delegation contract YAML declares plugin_managed=true.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    subscribe_wired_contract_topics,
+    wire_from_manifest,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+
+def _fake_handler_cls() -> type:
+    class FakeHandler:
+        async def handle(self, envelope: object) -> None:
+            return None
+
+    return FakeHandler
+
+
+def _contract(
+    name: str = "node_test",
+    subscribe_topics: tuple[str, ...] = ("onex.cmd.omnimarket.test-start.v1",),
+    *,
+    plugin_managed: bool = False,
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="ORCHESTRATOR_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name=name,
+        package_name="test-package",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=subscribe_topics,
+            publish_topics=(),
+            plugin_managed=plugin_managed,
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(name="FakeHandler", module="fake.module"),
+                    event_model=None,
+                    operation=None,
+                ),
+            ),
+        ),
+    )
+
+
+class TestPluginManagedSkipsSubscription:
+    """plugin_managed=True prevents auto-wiring from creating a Kafka subscription."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_contract_skips_kafka_subscribe(self) -> None:
+        contract = _contract(
+            name="node_delegation_orchestrator",
+            subscribe_topics=("onex.cmd.omnibase-infra.delegation-request.v1",),
+            plugin_managed=True,
+        )
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        # Handler IS wired into dispatch engine
+        assert report.total_wired == 1
+        # Kafka subscribe must NOT be called — plugin owns the subscription
+        event_bus.subscribe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_contract_has_empty_topics_subscribed(self) -> None:
+        contract = _contract(plugin_managed=True)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        result = next(r for r in report.results if r.contract_name == contract.name)
+        assert result.topics_subscribed == ()
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_dispatchers_still_registered(self) -> None:
+        """Dispatch routes must exist even when subscription is skipped."""
+        contract = _contract(plugin_managed=True)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        result = next(r for r in report.results if r.contract_name == contract.name)
+        assert result.outcome.value == "wired"
+        assert len(result.dispatchers_registered) > 0
+
+    @pytest.mark.asyncio
+    async def test_non_plugin_managed_contract_still_subscribes(self) -> None:
+        """Contracts without plugin_managed=True must still be auto-subscribed."""
+        topic = "onex.cmd.omnimarket.test-start.v1"
+        contract = _contract(subscribe_topics=(topic,), plugin_managed=False)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        event_bus.subscribe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mixed_manifest_only_subscribes_non_plugin_managed(self) -> None:
+        """In a mixed manifest, only non-plugin-managed contracts get subscribed."""
+        managed_contract = _contract(
+            name="node_delegation_orchestrator",
+            subscribe_topics=("onex.cmd.omnibase-infra.delegation-request.v1",),
+            plugin_managed=True,
+        )
+        normal_contract = _contract(
+            name="node_regular_worker",
+            subscribe_topics=("onex.cmd.omnimarket.test-start.v1",),
+            plugin_managed=False,
+        )
+        manifest = ModelAutoWiringManifest(
+            contracts=(managed_contract, normal_contract)
+        )
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            await wire_from_manifest(
+                manifest, engine, event_bus=event_bus, environment="local"
+            )
+
+        # Only the non-plugin-managed contract subscribed
+        assert event_bus.subscribe.call_count == 1
+        call_topic = (
+            event_bus.subscribe.call_args.kwargs.get("topic")
+            or event_bus.subscribe.call_args.args[0]
+        )
+        assert call_topic == "onex.cmd.omnimarket.test-start.v1"
+
+    @pytest.mark.asyncio
+    async def test_deferred_subscribe_also_skips_plugin_managed(self) -> None:
+        """subscribe_wired_contract_topics must also skip plugin_managed contracts."""
+        managed_contract = _contract(
+            name="node_delegation_orchestrator",
+            subscribe_topics=("onex.cmd.omnibase-infra.delegation-request.v1",),
+            plugin_managed=True,
+        )
+        normal_contract = _contract(
+            name="node_regular_worker",
+            subscribe_topics=("onex.cmd.omnimarket.test-start.v1",),
+            plugin_managed=False,
+        )
+        manifest = ModelAutoWiringManifest(
+            contracts=(managed_contract, normal_contract)
+        )
+        engine = MessageDispatchEngine()
+        event_bus = MagicMock()
+        event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_fake_handler_cls(),
+        ):
+            report = await wire_from_manifest(
+                manifest,
+                engine,
+                event_bus=event_bus,
+                environment="local",
+                subscribe_immediately=False,
+            )
+            event_bus.subscribe.assert_not_called()
+
+            subscriptions = await subscribe_wired_contract_topics(
+                manifest=manifest,
+                report=report,
+                dispatch_engine=engine,
+                event_bus=event_bus,
+                environment="local",
+            )
+
+        # Only normal_contract subscribed
+        assert event_bus.subscribe.call_count == 1
+        assert "node_delegation_orchestrator" not in subscriptions
+        assert "node_regular_worker" in subscriptions
+
+
+class TestDelegationContractDeclaresPluginManaged:
+    """The delegation contract YAML must have plugin_managed=true in event_bus."""
+
+    def test_delegation_contract_has_plugin_managed_true(self) -> None:
+        contract_path = (
+            Path(__file__).parents[4]
+            / "src"
+            / "omnibase_infra"
+            / "nodes"
+            / "node_delegation_orchestrator"
+            / "contract.yaml"
+        )
+        raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+        assert isinstance(raw, dict), "contract.yaml must be a YAML dict"
+        event_bus = raw.get("event_bus")
+        assert isinstance(event_bus, dict), "event_bus section missing from contract"
+        assert event_bus.get("plugin_managed") is True, (
+            "node_delegation_orchestrator contract.yaml must have "
+            "event_bus.plugin_managed: true (OMN-10864)"
+        )
+
+    def test_delegation_contract_still_declares_subscribe_topics(self) -> None:
+        """plugin_managed=true must coexist with subscribe_topics for discovery."""
+        contract_path = (
+            Path(__file__).parents[4]
+            / "src"
+            / "omnibase_infra"
+            / "nodes"
+            / "node_delegation_orchestrator"
+            / "contract.yaml"
+        )
+        raw = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+        event_bus = raw.get("event_bus", {})
+        topics = event_bus.get("subscribe_topics", [])
+        assert len(topics) > 0, (
+            "delegation contract must still declare subscribe_topics for "
+            "domain plugin's load_event_bus_subcontract()"
+        )
+        assert "onex.cmd.omnibase-infra.delegation-request.v1" in topics


### PR DESCRIPTION
Evidence-Ticket: OMN-10864
Evidence-Source: OCC#947

## Summary

- **Bug:** Auto-wiring rediscovery (~5 min interval) created a second Kafka consumer on `onex.cmd.omnibase-infra.delegation-request.v1` WITHOUT a `result_applier`, short-circuiting `HandlerDelegationWorkflow`'s singleton. Delegation worked ~5 min after startup, then broke permanently.
- **Root cause:** `_prepare_contract_wiring` and `subscribe_wired_contract_topics` subscribed ALL auto-discovered contracts without checking if a domain plugin already owned the topic's consumer.
- **Fix:** Add `plugin_managed: bool = False` to `ModelEventBusWiring`. When `True`, auto-wiring skips Kafka subscription (both immediate and deferred paths) while still registering dispatch routes. Set `plugin_managed: true` on the delegation orchestrator contract.

## Changes

- `src/omnibase_infra/runtime/auto_wiring/models/model_event_bus_wiring.py` — add `plugin_managed` field
- `src/omnibase_infra/runtime/auto_wiring/discovery.py` — parse `plugin_managed` from contract YAML
- `src/omnibase_infra/runtime/auto_wiring/handler_wiring.py` — skip subscription when `plugin_managed=True` in both immediate and deferred paths
- `src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml` — set `event_bus.plugin_managed: true`
- `tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py` — 8 new unit tests

## Test plan

- [x] 8/8 new plugin_managed tests pass
- [x] 212/212 auto-wiring unit tests pass (zero regressions)
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] mypy passes (pre-push hook)

## dod_evidence

ticket: OMN-10864
type: unit_test
proof: tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py — 8 tests covering plugin-managed skip (immediate + deferred), dispatcher still registered, mixed manifest isolation, and contract YAML declaration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `plugin_managed` contract configuration, enabling contracts to skip Kafka topic subscriptions while preserving dispatch route registration.

* **Tests**
  * Added comprehensive unit and integration tests validating plugin-managed contract behavior in auto-wiring scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1568)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->