### PR TITLE
fix(OMN-10868): wire delegation routing dispatcher in DI kernel

### DIFF
--- a/contracts/OMN-10868.yaml
+++ b/contracts/OMN-10868.yaml
@@ -41,8 +41,8 @@ dod_evidence:
       - check_type: command
         check_value: 'uv run pytest tests/integration/delegation/test_delegation_routing_dispatcher_wiring.py -v'
   - id: dod-004
-    description: deploy-compatible — pure DI wiring, no file writes, no side effects, no DB or Kafka dependencies
+    description: deploy-compatible — no migration required, no new topics, pure DI wiring ships with next runtime deploy
     source: manual
     checks:
-      - check_type: behavior_proven
-        check_value: 'dispatcher registration is pure DI wiring only — no I/O at wiring time, no runtime side effects beyond engine.register_dispatcher() and engine.register_route()'
+      - check_type: command
+        check_value: 'deploy: pure DI wiring — no DB migration, no new Kafka topics; ships automatically on next docker exec onex-runtime deploy'

--- a/contracts/OMN-10868.yaml
+++ b/contracts/OMN-10868.yaml
@@ -7,9 +7,9 @@ summary: >
 is_seam_ticket: false
 interface_change: false
 interfaces_touched:
-  - node_delegation_routing_reducer.dispatchers
-  - node_delegation_orchestrator.wiring
-  - node_delegation_orchestrator.plugin
+  - protocols
+  - topics
+  - events
 evidence_requirements:
   - kind: tests
     description: Unit and integration tests for routing dispatcher wiring

--- a/contracts/OMN-10868.yaml
+++ b/contracts/OMN-10868.yaml
@@ -1,0 +1,48 @@
+schema_version: '1.0.0'
+ticket_id: OMN-10868
+title: 'fix(OMN-10868): wire delegation routing dispatcher in DI kernel'
+summary: >
+  Registers DispatcherDelegationRoutingRequest in the MessageDispatchEngine via PluginDelegation.wire_dispatchers(), fixing the ProtocolConfigurationError that routed delegation-routing-request commands to the DLQ.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched:
+  - node_delegation_routing_reducer.dispatchers
+  - node_delegation_orchestrator.wiring
+  - node_delegation_orchestrator.plugin
+evidence_requirements:
+  - kind: tests
+    description: Unit and integration tests for routing dispatcher wiring
+    command: uv run pytest tests/unit/nodes/node_delegation_routing_reducer/dispatchers/ tests/integration/delegation/test_delegation_routing_dispatcher_wiring.py -v
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks 1571 --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Contract artifact file present in repo
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-10868.yaml'
+  - id: dod-002
+    description: Unit tests prove dispatcher routes correctly, handles invalid payload, propagates errors
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/nodes/node_delegation_routing_reducer/dispatchers/ -v'
+  - id: dod-003
+    description: Integration tests prove dispatcher registered in engine, message types match contract topic, PluginDelegation wires it
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/integration/delegation/test_delegation_routing_dispatcher_wiring.py -v'
+  - id: dod-004
+    description: deploy-compatible — pure DI wiring, no file writes, no side effects, no DB or Kafka dependencies
+    source: manual
+    checks:
+      - check_type: behavior_proven
+        check_value: 'dispatcher registration is pure DI wiring only — no I/O at wiring time, no runtime side effects beyond engine.register_dispatcher() and engine.register_route()'

--- a/contracts/OMN-10868.yaml
+++ b/contracts/OMN-10868.yaml
@@ -6,10 +6,7 @@ summary: >
 
 is_seam_ticket: false
 interface_change: false
-interfaces_touched:
-  - protocols
-  - topics
-  - events
+interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: Unit and integration tests for routing dispatcher wiring

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
@@ -191,6 +191,7 @@ class PluginDelegation:
         try:
             from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
                 wire_delegation_dispatchers,
+                wire_delegation_routing_dispatcher,
             )
 
             dispatch_summary = await wire_delegation_dispatchers(
@@ -200,13 +201,23 @@ class PluginDelegation:
                 event_bus=config.event_bus,
             )
 
+            routing_summary = await wire_delegation_routing_dispatcher(
+                engine=config.dispatch_engine,
+                correlation_id=config.correlation_id,
+            )
+
+            all_dispatchers = list(dispatch_summary.get("dispatchers", [])) + list(
+                routing_summary.get("dispatchers", [])
+            )
+
             duration = time.time() - start_time
             logger.info(
                 "Delegation dispatchers wired into engine (correlation_id=%s)",
                 config.correlation_id,
                 extra={
-                    "dispatchers": dispatch_summary.get("dispatchers", []),
-                    "routes": dispatch_summary.get("routes", []),
+                    "dispatchers": all_dispatchers,
+                    "routes": list(dispatch_summary.get("routes", []))
+                    + list(routing_summary.get("routes", [])),
                 },
             )
 
@@ -215,7 +226,7 @@ class PluginDelegation:
                 plugin_id=self.plugin_id,
                 success=True,
                 message="Delegation dispatchers wired into engine",
-                resources_created=list(dispatch_summary.get("dispatchers", [])),
+                resources_created=all_dispatchers,
                 duration_seconds=duration,
             )
 

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/wiring.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/wiring.py
@@ -38,6 +38,7 @@ ROUTE_ID_INVOCATION_COMMAND = "route.delegation.invocation"
 ROUTE_ID_ROUTING_DECISION = "route.delegation.routing-decision"
 ROUTE_ID_QUALITY_GATE_RESULT = "route.delegation.quality-gate-result"
 ROUTE_ID_AGENT_TASK_LIFECYCLE = "route.delegation.agent-task-lifecycle"
+ROUTE_ID_DELEGATION_ROUTING_REQUEST = "route.delegation.routing-request"
 
 
 class WiringResult(TypedDict):
@@ -392,5 +393,56 @@ async def wire_delegation_dispatchers(
     return {
         "dispatchers": dispatchers_registered,
         "routes": routes_registered,
+        "status": "success",
+    }
+
+
+async def wire_delegation_routing_dispatcher(
+    engine: MessageDispatchEngine,
+    correlation_id: UUID | None = None,
+) -> dict[str, list[str] | str]:
+    """Wire the delegation routing reducer dispatcher into MessageDispatchEngine.
+
+    Registers DispatcherDelegationRoutingRequest so that messages of category
+    'command' and type 'omnibase-infra.delegation-routing-request' are routed
+    to the routing reducer handler instead of the DLQ.
+
+    Args:
+        engine: MessageDispatchEngine to register the dispatcher with.
+        correlation_id: Optional correlation ID for error tracking.
+
+    Returns:
+        Summary dict with dispatchers, routes, and status.
+    """
+    from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
+    from omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request import (
+        DispatcherDelegationRoutingRequest,
+    )
+
+    dispatcher = DispatcherDelegationRoutingRequest()
+    engine.register_dispatcher(
+        dispatcher_id=dispatcher.dispatcher_id,
+        dispatcher=dispatcher.handle,
+        category=dispatcher.category,
+        message_types=dispatcher.message_types,
+    )
+
+    route = ModelDispatchRoute(
+        route_id=ROUTE_ID_DELEGATION_ROUTING_REQUEST,
+        topic_pattern="*.cmd.*.delegation-routing-request.*",
+        message_category=EnumMessageCategory.COMMAND,
+        dispatcher_id=dispatcher.dispatcher_id,
+        message_type="omnibase-infra.delegation-routing-request",
+    )
+    engine.register_route(route)
+
+    logger.info(
+        "Delegation routing dispatcher wired (correlation_id=%s)",
+        correlation_id,
+    )
+
+    return {
+        "dispatchers": [dispatcher.dispatcher_id],
+        "routes": [route.route_id],
         "status": "success",
     }

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/dispatchers/__init__.py
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/dispatchers/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/nodes/node_delegation_routing_reducer/dispatchers/dispatcher_delegation_routing_request.py
+++ b/src/omnibase_infra/nodes/node_delegation_routing_reducer/dispatchers/dispatcher_delegation_routing_request.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Dispatcher adapter for delegation routing request commands.
+
+Routes ModelDelegationRequest payloads to HandlerDelegationRouting.delta(),
+which computes the deterministic routing decision (model, endpoint, tier).
+
+Related:
+    - OMN-7040: Node-based delegation pipeline
+    - OMN-10868: Wire delegation routing dispatcher in DI kernel
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from pydantic import ValidationError
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import (
+    EnumDispatchStatus,
+    EnumInfraTransportType,
+    EnumMessageCategory,
+)
+from omnibase_infra.errors import InfraUnavailableError
+from omnibase_infra.mixins import MixinAsyncCircuitBreaker
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_delegation_request import (
+    ModelDelegationRequest,
+)
+from omnibase_infra.nodes.node_delegation_routing_reducer.handlers.handler_delegation_routing import (
+    delta,
+)
+from omnibase_infra.nodes.node_registration_orchestrator.dispatchers._util_envelope_extract import (
+    extract_envelope_fields,
+)
+from omnibase_infra.utils import sanitize_error_message
+
+__all__ = ["DispatcherDelegationRoutingRequest"]
+
+logger = logging.getLogger(__name__)
+
+TOPIC_ID_DELEGATION_ROUTING_REQUEST = "delegation.routing-request"
+
+
+class DispatcherDelegationRoutingRequest(MixinAsyncCircuitBreaker):
+    """Dispatcher for incoming delegation routing request commands."""
+
+    def __init__(self) -> None:
+        self._init_circuit_breaker(
+            threshold=3,
+            reset_timeout=20.0,
+            service_name="dispatcher.delegation.routing-request",
+            transport_type=EnumInfraTransportType.KAFKA,
+        )
+
+    @property
+    def dispatcher_id(self) -> str:
+        return "dispatcher.delegation.routing-request"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        return EnumMessageCategory.COMMAND
+
+    @property
+    def message_types(self) -> set[str]:
+        return {"ModelDelegationRequest", "omnibase-infra.delegation-routing-request"}
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        return EnumNodeKind.REDUCER
+
+    async def handle(
+        self,
+        envelope: ModelEventEnvelope[object] | dict[str, object],
+    ) -> ModelDispatchResult:
+        started_at = datetime.now(UTC)
+        correlation_id, raw_payload = extract_envelope_fields(envelope)
+
+        try:
+            async with self._circuit_breaker_lock:
+                await self._check_circuit_breaker("handle", correlation_id)
+
+            payload = raw_payload
+            if not isinstance(payload, ModelDelegationRequest):
+                if isinstance(payload, dict):
+                    payload = ModelDelegationRequest.model_validate(payload)
+                else:
+                    return ModelDispatchResult(
+                        dispatch_id=uuid4(),
+                        status=EnumDispatchStatus.INVALID_MESSAGE,
+                        topic=TOPIC_ID_DELEGATION_ROUTING_REQUEST,
+                        dispatcher_id=self.dispatcher_id,
+                        started_at=started_at,
+                        completed_at=started_at,
+                        duration_ms=0.0,
+                        error_message=f"Expected ModelDelegationRequest, got {type(payload).__name__}",
+                        correlation_id=correlation_id,
+                        output_events=[],
+                    )
+
+            assert isinstance(payload, ModelDelegationRequest)
+
+            routing_decision = delta(payload)
+
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+
+            async with self._circuit_breaker_lock:
+                await self._reset_circuit_breaker()
+
+            logger.info(
+                "DispatcherDelegationRoutingRequest processed request",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "task_type": payload.task_type,
+                    "selected_model": routing_decision.selected_model,
+                    "cost_tier": routing_decision.cost_tier,
+                    "duration_ms": duration_ms,
+                },
+            )
+
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.SUCCESS,
+                topic=TOPIC_ID_DELEGATION_ROUTING_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                correlation_id=correlation_id,
+                output_events=[routing_decision],
+            )
+
+        except InfraUnavailableError as e:
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+            logger.error(  # noqa: TRY400
+                "DispatcherDelegationRoutingRequest circuit open: %s",
+                sanitize_error_message(e),
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.HANDLER_ERROR,
+                topic=TOPIC_ID_DELEGATION_ROUTING_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                error_message=sanitize_error_message(e),
+                correlation_id=correlation_id,
+                output_events=[],
+            )
+
+        except (ValidationError, ValueError, KeyError) as e:
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+            logger.warning(
+                "DispatcherDelegationRoutingRequest validation error: %s",
+                sanitize_error_message(e),
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.INVALID_MESSAGE,
+                topic=TOPIC_ID_DELEGATION_ROUTING_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                error_message=sanitize_error_message(e),
+                correlation_id=correlation_id,
+                output_events=[],
+            )
+
+        except Exception as e:  # noqa: BLE001
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure("handle")
+            logger.error(  # noqa: TRY400
+                "DispatcherDelegationRoutingRequest failed: %s",
+                sanitize_error_message(e),
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return ModelDispatchResult(
+                dispatch_id=uuid4(),
+                status=EnumDispatchStatus.HANDLER_ERROR,
+                topic=TOPIC_ID_DELEGATION_ROUTING_REQUEST,
+                dispatcher_id=self.dispatcher_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                error_message=sanitize_error_message(e),
+                correlation_id=correlation_id,
+                output_events=[],
+            )

--- a/src/omnibase_infra/validation/infra_validators.py
+++ b/src/omnibase_infra/validation/infra_validators.py
@@ -486,7 +486,8 @@ INFRA_NODES_PATH = "src/omnibase_infra/nodes/"
 # - 150 (2026-05-09): interactive onboarding models — ModelTransition alias + ModelTransitionBranch JsonType (OMN-10771)
 #                     + StepResponse type alias in transition_reducer (OMN-10780)
 # - 152 (2026-05-10): interactive executor + result models (OMN-10782)
-INFRA_MAX_UNIONS = 152
+# - 154 (2026-05-12): delegation routing dispatcher + wiring function (OMN-10868)
+INFRA_MAX_UNIONS = 154
 
 # Maximum allowed architecture violations in infrastructure code.
 # Set to 0 (strict enforcement) to ensure one-model-per-file principle is always followed.

--- a/tests/integration/delegation/test_delegation_routing_dispatcher_wiring.py
+++ b/tests/integration/delegation/test_delegation_routing_dispatcher_wiring.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: delegation routing dispatcher is wired into the DI kernel.
+
+Verifies that wire_delegation_routing_dispatcher() registers the dispatcher
+and route in the MessageDispatchEngine such that messages of category
+'command' / type 'omnibase-infra.delegation-routing-request' are resolved
+to DispatcherDelegationRoutingRequest instead of falling through to the DLQ.
+
+This is the integration-level proof for OMN-10868 — the unit tests confirm
+individual method contracts; this test confirms end-to-end lookup succeeds.
+
+Related:
+    - OMN-10868: Wire delegation routing dispatcher in DI kernel
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.mark.asyncio
+async def test_routing_dispatcher_registered_in_engine() -> None:
+    """After wiring, the engine resolves routing-request to the correct dispatcher."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from omnibase_core.enums import EnumMessageCategory
+    from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
+        ROUTE_ID_DELEGATION_ROUTING_REQUEST,
+        wire_delegation_routing_dispatcher,
+    )
+    from omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request import (
+        DispatcherDelegationRoutingRequest,
+    )
+
+    dispatchers: dict[str, object] = {}
+    routes: list[object] = []
+
+    engine = MagicMock()
+    engine.register_dispatcher = MagicMock(
+        side_effect=lambda dispatcher_id, dispatcher, category, message_types: (
+            dispatchers.update({dispatcher_id: dispatcher})
+        )
+    )
+    engine.register_route = MagicMock(side_effect=lambda route: routes.append(route))
+
+    result = await wire_delegation_routing_dispatcher(engine)
+
+    assert result["status"] == "success"
+    assert "dispatcher.delegation.routing-request" in dispatchers
+    assert ROUTE_ID_DELEGATION_ROUTING_REQUEST in result["routes"]
+
+    route = routes[0]
+    assert route.message_type == "omnibase-infra.delegation-routing-request"
+    assert route.message_category == EnumMessageCategory.COMMAND
+
+
+@pytest.mark.asyncio
+async def test_routing_dispatcher_message_types_cover_contract_topic() -> None:
+    """DispatcherDelegationRoutingRequest declares the message type matching the contract topic."""
+    from omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request import (
+        DispatcherDelegationRoutingRequest,
+    )
+
+    dispatcher = DispatcherDelegationRoutingRequest()
+
+    assert "omnibase-infra.delegation-routing-request" in dispatcher.message_types
+    assert dispatcher.dispatcher_id == "dispatcher.delegation.routing-request"
+
+
+@pytest.mark.asyncio
+async def test_plugin_delegation_wire_dispatchers_includes_routing_reducer() -> None:
+    """PluginDelegation.wire_dispatchers() registers the routing reducer dispatcher."""
+    from unittest.mock import AsyncMock, MagicMock
+    from uuid import uuid4
+
+    from omnibase_infra.nodes.node_delegation_orchestrator.handlers.handler_delegation_workflow import (
+        HandlerDelegationWorkflow,
+    )
+    from omnibase_infra.nodes.node_delegation_orchestrator.plugin import (
+        PluginDelegation,
+    )
+    from omnibase_infra.runtime.models.model_domain_plugin_config import (
+        ModelDomainPluginConfig,
+    )
+
+    plugin = PluginDelegation()
+
+    container = MagicMock()
+    handler = HandlerDelegationWorkflow()
+    container.service_registry = MagicMock()
+    container.service_registry.resolve_service = AsyncMock(return_value=handler)
+
+    registered_dispatcher_ids: list[str] = []
+    engine = MagicMock()
+    engine.register_dispatcher = MagicMock(
+        side_effect=lambda dispatcher_id, **kwargs: registered_dispatcher_ids.append(
+            dispatcher_id
+        )
+    )
+    engine.register_route = MagicMock()
+
+    config = ModelDomainPluginConfig(
+        container=container,
+        event_bus=MagicMock(),
+        correlation_id=uuid4(),
+        input_topic="test-input",
+        output_topic="test-output",
+        consumer_group="test-group",
+        dispatch_engine=engine,
+    )
+
+    plugin._handler_wiring_succeeded = True
+    result = await plugin.wire_dispatchers(config)
+
+    assert result.success
+    assert "dispatcher.delegation.routing-request" in registered_dispatcher_ids

--- a/tests/unit/nodes/node_delegation_routing_reducer/dispatchers/__init__.py
+++ b/tests/unit/nodes/node_delegation_routing_reducer/dispatchers/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_delegation_routing_reducer/dispatchers/test_dispatcher_delegation_routing_request.py
+++ b/tests/unit/nodes/node_delegation_routing_reducer/dispatchers/test_dispatcher_delegation_routing_request.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for DispatcherDelegationRoutingRequest.
+
+Verifies that the dispatcher correctly routes delegation-routing-request
+commands to handler_delegation_routing.delta() and returns typed results.
+
+Related:
+    - OMN-10868: Wire delegation routing dispatcher in DI kernel
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.enums import EnumDispatchStatus, EnumMessageCategory
+from omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request import (
+    DispatcherDelegationRoutingRequest,
+)
+
+
+@pytest.fixture
+def dispatcher() -> DispatcherDelegationRoutingRequest:
+    return DispatcherDelegationRoutingRequest()
+
+
+@pytest.fixture
+def mock_routing_decision() -> object:
+    from omnibase_infra.nodes.node_delegation_routing_reducer.models.model_routing_decision import (
+        ModelRoutingDecision,
+    )
+
+    return ModelRoutingDecision(
+        correlation_id=uuid4(),
+        task_type="test",
+        selected_model="test-model",
+        selected_backend_id=uuid4(),
+        endpoint_url="http://localhost:8000",
+        cost_tier="local",
+        max_context_tokens=4096,
+        system_prompt="You are a test assistant.",
+        rationale="Routed to local tier.",
+    )
+
+
+@pytest.mark.unit
+class TestDispatcherDelegationRoutingRequest:
+    """DispatcherDelegationRoutingRequest unit tests."""
+
+    def test_dispatcher_id(
+        self, dispatcher: DispatcherDelegationRoutingRequest
+    ) -> None:
+        assert dispatcher.dispatcher_id == "dispatcher.delegation.routing-request"
+
+    def test_category_is_command(
+        self, dispatcher: DispatcherDelegationRoutingRequest
+    ) -> None:
+        assert dispatcher.category == EnumMessageCategory.COMMAND
+
+    def test_message_types(
+        self, dispatcher: DispatcherDelegationRoutingRequest
+    ) -> None:
+        assert "omnibase-infra.delegation-routing-request" in dispatcher.message_types
+        assert "ModelDelegationRequest" in dispatcher.message_types
+
+    @pytest.mark.asyncio
+    async def test_handle_dict_envelope_success(
+        self,
+        dispatcher: DispatcherDelegationRoutingRequest,
+        mock_routing_decision: MagicMock,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        correlation_id = uuid4()
+        envelope = {
+            "correlation_id": str(correlation_id),
+            "payload": {
+                "correlation_id": str(correlation_id),
+                "task_type": "test",
+                "prompt": "write tests for foo",
+                "emitted_at": datetime.now(UTC).isoformat(),
+            },
+        }
+
+        with patch(
+            "omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request.delta",
+            return_value=mock_routing_decision,
+        ):
+            result = await dispatcher.handle(envelope)
+
+        assert result.status == EnumDispatchStatus.SUCCESS
+        assert result.dispatcher_id == "dispatcher.delegation.routing-request"
+        assert len(result.output_events) == 1
+        assert result.output_events[0] == mock_routing_decision
+
+    @pytest.mark.asyncio
+    async def test_handle_invalid_payload_returns_invalid_message(
+        self,
+        dispatcher: DispatcherDelegationRoutingRequest,
+    ) -> None:
+        envelope = {
+            "correlation_id": str(uuid4()),
+            "payload": "not-a-dict",
+        }
+
+        result = await dispatcher.handle(envelope)
+
+        assert result.status == EnumDispatchStatus.INVALID_MESSAGE
+        assert result.dispatcher_id == "dispatcher.delegation.routing-request"
+
+    @pytest.mark.asyncio
+    async def test_handle_delta_exception_returns_handler_error(
+        self,
+        dispatcher: DispatcherDelegationRoutingRequest,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        correlation_id = uuid4()
+        envelope = {
+            "correlation_id": str(correlation_id),
+            "payload": {
+                "correlation_id": str(correlation_id),
+                "task_type": "test",
+                "prompt": "write tests",
+                "emitted_at": datetime.now(UTC).isoformat(),
+            },
+        }
+
+        with patch(
+            "omnibase_infra.nodes.node_delegation_routing_reducer.dispatchers.dispatcher_delegation_routing_request.delta",
+            side_effect=RuntimeError("routing failed"),
+        ):
+            result = await dispatcher.handle(envelope)
+
+        assert result.status == EnumDispatchStatus.HANDLER_ERROR
+        assert result.error_message is not None
+
+
+@pytest.mark.unit
+class TestWireDelegationRoutingDispatcher:
+    """wire_delegation_routing_dispatcher must register the routing reducer dispatcher."""
+
+    @pytest.mark.asyncio
+    async def test_registers_dispatcher_and_route(self) -> None:
+        from unittest.mock import MagicMock
+
+        from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
+            ROUTE_ID_DELEGATION_ROUTING_REQUEST,
+            wire_delegation_routing_dispatcher,
+        )
+
+        engine = MagicMock()
+        engine.register_dispatcher = MagicMock()
+        engine.register_route = MagicMock()
+
+        result = await wire_delegation_routing_dispatcher(engine)
+
+        assert engine.register_dispatcher.call_count == 1
+        assert engine.register_route.call_count == 1
+        assert result["status"] == "success"
+        assert "dispatcher.delegation.routing-request" in result["dispatchers"]
+        assert ROUTE_ID_DELEGATION_ROUTING_REQUEST in result["routes"]
+
+    @pytest.mark.asyncio
+    async def test_registered_dispatcher_handles_correct_message_types(self) -> None:
+        from unittest.mock import MagicMock
+
+        from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
+            wire_delegation_routing_dispatcher,
+        )
+
+        engine = MagicMock()
+        engine.register_dispatcher = MagicMock()
+        engine.register_route = MagicMock()
+
+        await wire_delegation_routing_dispatcher(engine)
+
+        call_kwargs = engine.register_dispatcher.call_args[1]
+        assert (
+            "omnibase-infra.delegation-routing-request" in call_kwargs["message_types"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_route_uses_command_category(self) -> None:
+        from unittest.mock import MagicMock
+
+        from omnibase_core.enums import EnumMessageCategory
+        from omnibase_infra.models.dispatch.model_dispatch_route import (
+            ModelDispatchRoute,
+        )
+        from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
+            wire_delegation_routing_dispatcher,
+        )
+
+        engine = MagicMock()
+        engine.register_dispatcher = MagicMock()
+        engine.register_route = MagicMock()
+
+        await wire_delegation_routing_dispatcher(engine)
+
+        route: ModelDispatchRoute = engine.register_route.call_args[0][0]
+        assert isinstance(route, ModelDispatchRoute)
+        assert route.message_category == EnumMessageCategory.COMMAND
+        assert route.message_type == "omnibase-infra.delegation-routing-request"

--- a/tests/unit/validation/test_validator_defaults.py
+++ b/tests/unit/validation/test_validator_defaults.py
@@ -129,10 +129,10 @@ class TestInfraValidatorConstants:
         - 131 (2026-03-01): OMN-3202 graph handler signature fix (+1 union)
           - HandlerGraph.initialize(): dict[str, object] | str
 
-        Current: 152 (as of interactive executor + result models OMN-10782). Target: Keep below 160 - if this grows, consider typed patterns from omnibase_core.
+        Current: 154 (as of OMN-10868 dispatcher wiring: +2 unions from DispatcherDelegationRoutingRequest). Target: Keep below 160 - if this grows, consider typed patterns from omnibase_core.
         """
-        assert INFRA_MAX_UNIONS == 152, (
-            "INFRA_MAX_UNIONS should be 152 (non-optional unions only, X | None excluded)"
+        assert INFRA_MAX_UNIONS == 154, (
+            "INFRA_MAX_UNIONS should be 154 (non-optional unions only, X | None excluded)"
         )
 
     def test_infra_max_violations_constant(self) -> None:


### PR DESCRIPTION
Evidence-Ticket: OMN-10868
Evidence-Source: OCC#958

## Summary
- Creates `DispatcherDelegationRoutingRequest` in `node_delegation_routing_reducer/dispatchers/` — handles `category='command'` / `message_type='omnibase-infra.delegation-routing-request'`
- Adds `wire_delegation_routing_dispatcher()` to `node_delegation_orchestrator/wiring.py` — registers the dispatcher and route in the `MessageDispatchEngine`
- Calls `wire_delegation_routing_dispatcher()` from `PluginDelegation.wire_dispatchers()` alongside existing orchestrator dispatcher wiring
- Bumps `INFRA_MAX_UNIONS` 152 → 154 for the 2 new non-optional unions

The root cause was that `node_delegation_routing_reducer` was subscribed to the topic via the contract's `subscribe_topics`, but the `MessageDispatchEngine` had no dispatcher registered for `category='command'` + `message_type='omnibase-infra.delegation-routing-request'`. Every message fell through to the DLQ.

## Test plan
- [x] Unit tests — dispatch success, invalid payload, handler error
- [x] wire_delegation_routing_dispatcher tests — registers dispatcher + route, correct message types
- [x] Integration tests — dispatcher wired in engine, message types match contract, PluginDelegation includes it
- [x] Existing delegation wiring tests pass (no regression)
- [x] All pre-commit hooks pass
- [x] mypy --strict passes on changed files

Fixes OMN-10868 (child of OMN-7720)