### PR TITLE
fix(OMN-10706): replace direct handler import with node package public API

### DIFF
--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -43,10 +43,8 @@ import asyncpg
 from aiokafka import AIOKafkaProducer
 from aiokafka.errors import KafkaError
 
-from omnibase_infra.nodes.node_baselines_batch_compute.handlers.handler_baselines_batch_compute import (
+from omnibase_infra.nodes.node_baselines_batch_compute import (
     HandlerBaselinesBatchCompute,
-)
-from omnibase_infra.nodes.node_baselines_batch_compute.models.model_baselines_batch_compute_command import (
     ModelBaselinesBatchComputeCommand,
 )
 


### PR DESCRIPTION
Evidence-Ticket: OMN-10706
Evidence-Source: OCC#970

## Summary

Fixes OMN-10706 (child of OMN-10704).

`scripts/run_baselines_batch_compute.py` was importing directly from `omnibase_infra.nodes.node_baselines_batch_compute.handlers.handler_baselines_batch_compute`, bypassing the node package's public API.

Changed to import `HandlerBaselinesBatchCompute` and `ModelBaselinesBatchComputeCommand` from `omnibase_infra.nodes.node_baselines_batch_compute` (the package `__init__` already exported both).

## Test plan
- [ ] `uv run pytest tests/ -k "baselines"` — 96 passed
- [ ] All pre-commit hooks passed