### PR TITLE
feat(OMN-10712/10713/10714): declare bare env var reads in contract.yaml

### DIFF
--- a/contracts/OMN-10712.yaml
+++ b/contracts/OMN-10712.yaml
@@ -1,0 +1,26 @@
+# OMN-10712 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control
+# (contracts/OMN-10712.yaml in OmniNode-ai/onex_change_control).
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: OMN-10712
+title: Declare bare env var reads in omnibase_infra node contracts
+summary: >
+  Adds env_dependencies blocks to three omnibase_infra node contracts (node_intent_storage_effect, node_rrh_emit_effect, node_runtime_orchestrator) to formally declare bare os.environ/os.getenv reads that existed in handler source but had no contract declaration.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-deploy
+    description: >
+      Deploy verification: changes are contract schema declarations only — no handler code changes, no migration, no new runtime service. env_dependencies declarations are metadata; they do not alter runtime behaviour at deploy time. No restart required. The existing running runtime on .201 continues to operate identically.
+
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: no-op — env_dependencies are schema metadata, not runtime wiring; existing runtime unaffected"

--- a/src/omnibase_infra/nodes/node_intent_storage_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_intent_storage_effect/contract.yaml
@@ -191,6 +191,19 @@ health_check:
     - name: "graph_backend"
       type: "connection"
       critical: true
+env_dependencies:
+  GRAPH_BOLT_URI:
+    required: false
+    description: "Bolt protocol URI for the graph database (e.g. 'bolt://192.168.86.201:7687'); used by HandlerGraph as the primary connection URI"
+  MEMGRAPH_BOLT_URI:
+    required: false
+    description: "Bolt URI for the Memgraph instance; checked before GRAPH_BOLT_URI when both are set"
+  OMNIMEMORY_MEMGRAPH_HOST:
+    required: false
+    description: "Hostname or IP for Memgraph; used by ModelConfigGraphProjector when GRAPH_BOLT_URI/MEMGRAPH_BOLT_URI are not set"
+  OMNIMEMORY_MEMGRAPH_PORT:
+    required: false
+    description: "Port for Memgraph Bolt connection; used alongside OMNIMEMORY_MEMGRAPH_HOST by ModelConfigGraphProjector"
 # Metadata
 metadata:
   description: "Capability-oriented effect node for intent storage operations. Handles storing classified intents in Memgraph graph database and querying intents by session or distribution statistics."

--- a/src/omnibase_infra/nodes/node_rrh_emit_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_rrh_emit_effect/contract.yaml
@@ -48,6 +48,10 @@ handler_routing:
       supported_operations:
         - "rrh.collect.toolchain"
       description: "Collect build-tool versions (pre-commit, ruff, pytest, mypy)."
+env_dependencies:
+  ONEX_ENVIRONMENT:
+    required: false
+    description: "Environment label (e.g. 'production', 'staging', 'local') passed to runtime target collection; defaults to 'local'"
 capabilities:
   - name: "rrh.collect"
     description: "Collect environment data for RRH validation"

--- a/src/omnibase_infra/nodes/node_runtime_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_runtime_orchestrator/contract.yaml
@@ -462,6 +462,13 @@ handlers:
   optional:
     - type: ProtocolLogger
       version: {major: 1, minor: 0, patch: 0}
+env_dependencies:
+  ONEX_ENVIRONMENT:
+    required: false
+    description: "Environment label (e.g. 'production', 'staging', 'local') used by runtime health monitor and contract publisher for environment-tagged events; defaults to 'local'"
+  KAFKA_ENVIRONMENT:
+    required: false
+    description: "Kafka environment label passed to the service kernel bootstrap; propagated to runtime event envelopes; defaults to reading ONEX_ENVIRONMENT fallback"
 profile_tags:
   - runtime
   - orchestrator


### PR DESCRIPTION
Evidence-Ticket: OMN-10712
Evidence-Source: OCC#964

## Summary

Declares bare `os.environ` / `os.getenv` reads in infra handler source code as `env_dependencies` blocks in the corresponding node's `contract.yaml`. Part of the same batch as omnimarket PR covering OMN-10712/10713/10714.

**Nodes updated (3):**
- `node_intent_storage_effect`: `GRAPH_BOLT_URI`, `MEMGRAPH_BOLT_URI`, `OMNIMEMORY_MEMGRAPH_HOST`, `OMNIMEMORY_MEMGRAPH_PORT` (read by `HandlerGraph` and `ModelConfigGraphProjector`)
- `node_rrh_emit_effect`: `ONEX_ENVIRONMENT` (read by `HandlerRuntimeTargetCollect`)
- `node_runtime_orchestrator`: `ONEX_ENVIRONMENT`, `KAFKA_ENVIRONMENT` (read by runtime-level services `service_kernel.py` and `service_runtime_host_process.py`)

All declarations are `required: false` — all have documented defaults or graceful fallback paths in the handler code.

## Test plan

- [x] Pre-commit passes on all changed contracts (`pre-commit run --all-files`)
- [x] `ONEX Contract Validation` hook green
- [x] `yamlfmt` hook green (contract files well-formed)