### PR TITLE
fix(OMN-10864): gate RuntimeHostProcess subscription path on plugin_managed

### DIFF
--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -642,6 +642,16 @@ async def _wire_package_node_subscriptions(
             )
             continue
 
+        # plugin_managed: domain plugin owns Kafka subscription (OMN-10864).
+        if event_bus_section.get("plugin_managed"):
+            skipped_no_topics += 1
+            logger.info(
+                "RuntimeHostProcess: skipping Kafka subscription for "
+                "plugin-managed contract node=%s (OMN-10864)",
+                node_name,
+            )
+            continue
+
         if node_name in already_wired_names:
             skipped_existing += 1
             continue
@@ -5569,14 +5579,24 @@ class RuntimeHostProcess:
                 raw_contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
             except Exception:  # noqa: BLE001 - loader below reports malformed contracts
                 raw_contract = None
-            if _requires_raw_event_projection_wiring(
+            raw_event_bus = (
                 raw_contract.get("event_bus")
                 if isinstance(raw_contract, dict)
                 else None
-            ):
+            )
+            if _requires_raw_event_projection_wiring(raw_event_bus):
                 logger.info(
                     "Skipping event_bus subcontract wiring for raw projection consumer: "
                     "handler=%s",
+                    descriptor.name or handler_type,
+                )
+                continue
+
+            # plugin_managed: domain plugin owns Kafka subscription (OMN-10864).
+            if isinstance(raw_event_bus, dict) and raw_event_bus.get("plugin_managed"):
+                logger.info(
+                    "RuntimeHostProcess: skipping Kafka subscription for "
+                    "plugin-managed contract handler=%s (OMN-10864)",
                     descriptor.name or handler_type,
                 )
                 continue

--- a/tests/integration/test_runtime_host_plugin_managed_gate.py
+++ b/tests/integration/test_runtime_host_plugin_managed_gate.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests: RuntimeHostProcess._wire_event_bus_subscriptions skips plugin_managed.
+
+OMN-10864 second fix: the RuntimeHostProcess subscription wiring path must not create
+Kafka consumer groups for contracts flagged plugin_managed=true.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _write_contract(path: Path, name: str, *, plugin_managed: bool = False) -> None:
+    pm_line = f"  plugin_managed: {'true' if plugin_managed else 'false'}\n"
+    path.write_text(
+        textwrap.dedent(f"""\
+        name: "{name}"
+        node_type: "ORCHESTRATOR_GENERIC"
+        event_bus:
+          version:
+            major: 1
+            minor: 0
+            patch: 0
+          subscribe_topics:
+            - "onex.cmd.omnibase-infra.{name}-request.v1"
+        """)
+        + pm_line
+    )
+
+
+pytestmark = pytest.mark.integration
+
+
+class TestRuntimeHostProcessPluginManagedGate:
+    """_wire_event_bus_subscriptions must honour plugin_managed=true (OMN-10864 v2)."""
+
+    def _make_descriptor(self, contract_path: Path, name: str) -> Any:
+        d = MagicMock()
+        d.contract_path = str(contract_path)
+        d.name = name
+        return d
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_handler_skipped(self, tmp_path: Path) -> None:
+        """Handler whose contract.yaml has plugin_managed=true is not subscribed."""
+        contract_path = tmp_path / "contract.yaml"
+        _write_contract(
+            contract_path, "node_delegation_orchestrator", plugin_managed=True
+        )
+
+        mock_event_bus = MagicMock()
+        mock_event_bus.subscribe = AsyncMock(return_value=MagicMock())
+        mock_dispatch = MagicMock()
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            RuntimeHostProcess,
+        )
+
+        process = RuntimeHostProcess.__new__(RuntimeHostProcess)
+        process._event_bus = mock_event_bus
+        process._dispatch_engine = mock_dispatch
+        process._handler_descriptors = {
+            "TestHandler": self._make_descriptor(
+                contract_path, "node_delegation_orchestrator"
+            )
+        }
+        process._runtime_node_graph_config = None
+        process._node_identity = MagicMock()
+        process._node_identity.service = "test"
+        process._node_identity.version = "0.0.1"
+
+        mock_wiring = MagicMock()
+        mock_wiring.wire_subscriptions = AsyncMock()
+
+        with (
+            patch(
+                "omnibase_infra.runtime.service_runtime_host_process.EventBusSubcontractWiring",
+                return_value=mock_wiring,
+            ),
+            patch.object(
+                type(process),
+                "_get_environment_from_config",
+                return_value="test",
+            ),
+        ):
+            await process._wire_event_bus_subscriptions()
+
+        mock_wiring.wire_subscriptions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_plugin_managed_handler_wired(self, tmp_path: Path) -> None:
+        """Handler with plugin_managed=false is subscribed normally."""
+        contract_path = tmp_path / "contract.yaml"
+        _write_contract(contract_path, "node_normal_worker", plugin_managed=False)
+
+        mock_event_bus = MagicMock()
+        mock_dispatch = MagicMock()
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            RuntimeHostProcess,
+        )
+
+        process = RuntimeHostProcess.__new__(RuntimeHostProcess)
+        process._event_bus = mock_event_bus
+        process._dispatch_engine = mock_dispatch
+        process._handler_descriptors = {
+            "NormalHandler": self._make_descriptor(contract_path, "node_normal_worker")
+        }
+        process._runtime_node_graph_config = None
+        process._node_identity = MagicMock()
+        process._node_identity.service = "test"
+        process._node_identity.version = "0.0.1"
+
+        mock_wiring = MagicMock()
+        mock_wiring.wire_subscriptions = AsyncMock()
+
+        with (
+            patch(
+                "omnibase_infra.runtime.service_runtime_host_process.EventBusSubcontractWiring",
+                return_value=mock_wiring,
+            ),
+            patch.object(
+                type(process),
+                "_get_environment_from_config",
+                return_value="test",
+            ),
+            patch(
+                "omnibase_infra.runtime.service_runtime_host_process.load_event_bus_subcontract",
+            ) as mock_load,
+        ):
+            mock_subcontract = MagicMock()
+            mock_subcontract.subscribe_topics = (
+                "onex.cmd.omnibase-infra.node-normal-worker-request.v1",
+            )
+            mock_load.return_value = mock_subcontract
+
+            await process._wire_event_bus_subscriptions()
+
+        mock_wiring.wire_subscriptions.assert_called_once()

--- a/tests/unit/runtime/test_node_subscription_wiring.py
+++ b/tests/unit/runtime/test_node_subscription_wiring.py
@@ -277,6 +277,145 @@ class TestPackageNodeSubscriptionWiring:
         assert wired2 == 0  # all already wired
 
 
+class TestPluginManagedSkipsRuntimeHostSubscription:
+    """plugin_managed=true in contract.yaml prevents runtime-host from subscribing [OMN-10864 v2]."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_contract_skipped_in_package_wiring(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """_wire_package_node_subscriptions skips plugin_managed=true contracts."""
+        node = tmp_path / "nodes" / "node_delegation_orchestrator" / "contract.yaml"
+        node.parent.mkdir(parents=True)
+        node.write_text(
+            textwrap.dedent("""\
+            name: "node_delegation_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.delegation-request.v1"
+              plugin_managed: true
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        (
+            wired,
+            _skipped_existing,
+            skipped_no_topics,
+        ) = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 0
+        assert skipped_no_topics == 1
+        mock_event_bus_wiring.wire_subscriptions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_managed_false_still_wired_in_package_wiring(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """Contracts with plugin_managed=false (or absent) are still subscribed."""
+        node = tmp_path / "nodes" / "node_normal_worker" / "contract.yaml"
+        node.parent.mkdir(parents=True)
+        node.write_text(
+            textwrap.dedent("""\
+            name: "node_normal_worker"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnimarket.normal-work.v1"
+              plugin_managed: false
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        wired, _, _ = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 1
+        mock_event_bus_wiring.wire_subscriptions.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mixed_contracts_only_non_plugin_managed_wired(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """In a mix of contracts, only non-plugin-managed ones get subscriptions."""
+        managed = tmp_path / "nodes" / "node_delegation_orchestrator" / "contract.yaml"
+        managed.parent.mkdir(parents=True)
+        managed.write_text(
+            textwrap.dedent("""\
+            name: "node_delegation_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.delegation-request.v1"
+              plugin_managed: true
+            """)
+        )
+
+        normal = tmp_path / "nodes" / "node_normal_worker" / "contract.yaml"
+        normal.parent.mkdir(parents=True)
+        normal.write_text(
+            textwrap.dedent("""\
+            name: "node_normal_worker"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnimarket.normal-work.v1"
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        wired, _, skipped_no_topics = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 1
+        assert skipped_no_topics == 1
+        wired_names = {c["node_name"] for c in mock_event_bus_wiring._wire_calls}
+        assert "node_delegation_orchestrator" not in wired_names
+        assert "node_normal_worker" in wired_names
+
+
 class TestDiscoverPackageNodeContracts:
     """Tests for _discover_package_node_contracts."""
 


### PR DESCRIPTION
## Summary

- `_wire_event_bus_subscriptions` and `_wire_package_node_subscriptions` in `service_runtime_host_process.py` now check `event_bus.plugin_managed` from the raw contract YAML and skip Kafka subscription creation when it is `true`
- This closes the second duplicate-consumer path that PR #1568 missed — the `runtime-host` consumer group was processing `delegation-request` messages without a `result_applier`, causing delegation chains to stall
- 3 new unit tests added to `test_node_subscription_wiring.py` covering plugin-managed skip, non-plugin-managed still wired, and mixed-contract scenarios

## Context

Fixes OMN-10864 second fix attempt. After PR #1568 gated auto-wiring, runtime logs still showed TWO consumers:
- `node=runtime_config` (PluginDelegation — correct, has result_applier)
- `node=runtime-host` (RuntimeHostProcess — wrong, no result_applier)

This PR gates the `RuntimeHostProcess` subscription wiring paths using the same `plugin_managed` raw-dict check pattern.

## Test plan

- [ ] `uv run pytest tests/unit/runtime/test_node_subscription_wiring.py -v` -- all 10 pass
- [ ] Pre-commit hooks all pass
- [ ] 28 pre-existing kernel/infra test failures are infra connectivity failures (Postgres not running locally), confirmed identical on `main`

Evidence-Ticket: OMN-10864
Evidence-Source: OCC#961