### PR TITLE
chore(OMN-9529): remove stale ONEX_OUTPUT/INPUT_TOPIC comment references

### DIFF
--- a/.secretresolver_allowlist
+++ b/.secretresolver_allowlist
@@ -40,8 +40,6 @@ src/omnibase_infra/runtime/protocol_domain_plugin.py:239 # OMN-764 OMNIBASE_INFR
 # Runtime - Service Kernel
 # ==============================================================================
 src/omnibase_infra/runtime/service_kernel.py:157 # OMN-764 ONEX_CONTRACTS_DIR
-src/omnibase_infra/runtime/service_kernel.py:333 # OMN-764 ONEX_INPUT_TOPIC
-src/omnibase_infra/runtime/service_kernel.py:334 # OMN-764 ONEX_OUTPUT_TOPIC
 src/omnibase_infra/runtime/service_kernel.py:335 # OMN-764 ONEX_GROUP_ID
 src/omnibase_infra/runtime/service_kernel.py:464 # OMN-764 ONEX_ENVIRONMENT
 src/omnibase_infra/runtime/service_kernel.py:465 # OMN-764 KAFKA_BOOTSTRAP_SERVERS

--- a/contracts/OMN-9529.yaml
+++ b/contracts/OMN-9529.yaml
@@ -21,7 +21,7 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "grep -rn 'ONEX_GROUP_ID' docker/docker-compose.infra.yml | grep -v 'OMN-8840' | wc -l"
+        check_value: "! grep -RInE 'ONEX_(OUTPUT|INPUT)_TOPIC' docker/docker-compose.infra.yml docker/docker-compose.e2e.yml docker/catalog/services docker/Dockerfile.runtime .secretresolver_allowlist"
   - id: dod-tests-pass
     description: Stale topic env var enforcement tests continue to pass
     source: manual

--- a/contracts/OMN-9529.yaml
+++ b/contracts/OMN-9529.yaml
@@ -1,0 +1,38 @@
+# OMN-9529 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control
+# (contracts/OMN-9529.yaml in OmniNode-ai/onex_change_control).
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: OMN-9529
+title: "Runtime Config Topic Var Cleanup (ONEX_OUTPUT/INPUT_TOPIC)"
+summary: >
+  Removes all stale comment references to banned env vars ONEX_OUTPUT_TOPIC and ONEX_INPUT_TOPIC from compose files, catalog service YAMLs, Dockerfile.runtime, and .secretresolver_allowlist. Comment-only change — no runtime behavior change.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-stale-refs-removed
+    description: All stale ONEX_OUTPUT/INPUT_TOPIC comment blocks removed
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "grep -rn 'ONEX_GROUP_ID' docker/docker-compose.infra.yml | grep -v 'OMN-8840' | wc -l"
+  - id: dod-tests-pass
+    description: Stale topic env var enforcement tests continue to pass
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_stale_topic_env_var_docs_removal.py tests/unit/runtime/test_kernel_topic_env_var_removal.py -v"
+  - id: dod-deploy
+    description: >
+      Comment-only change — no env vars added, removed, or modified. No runtime restart required. Compose files validated by Compose Required-Env Coverage CI gate.
+
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: comment-only cleanup, no runtime behavior change; docker compose files validated by Compose Required-Env Coverage CI gate"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -30,8 +30,6 @@
 #   ONEX_LOG_LEVEL    - Logging level (default: INFO)
 #   ONEX_ENVIRONMENT  - Environment name (default: local)
 #   ONEX_GROUP_ID     - Consumer group ID (default: onex-runtime)
-#   Note: ONEX_INPUT_TOPIC and ONEX_OUTPUT_TOPIC were removed (OMN-8784).
-#         Topics must be declared in node contract event_bus.subscribe_topics / publish_topics.
 #
 # =============================================================================
 # PERFORMANCE OPTIMIZATION TIPS

--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -41,8 +41,6 @@ operational_defaults:
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
   OTEL_SERVICE_NAME: omninode-runtime-main
-  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-main
 ports:
   external: 8085

--- a/docker/catalog/services/runtime-canary.yaml
+++ b/docker/catalog/services/runtime-canary.yaml
@@ -40,8 +40,6 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-canary
 ports:
   external: 8088

--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -40,8 +40,6 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-effects
 ports:
   external: 8086

--- a/docker/catalog/services/runtime-worker.yaml
+++ b/docker/catalog/services/runtime-worker.yaml
@@ -34,8 +34,6 @@ operational_defaults:
   KEYCLOAK_ADMIN_CLIENT_ID: onex-admin
   KEYCLOAK_ISSUER: http://localhost:28080/realms/omninode
   ONEX_SERVICE_CLIENT_ID: onex-service
-  # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-  # Topics come from each node's contract.yaml event_bus declaration.
   ONEX_GROUP_ID: onex-runtime-workers
 ports: null
 healthcheck:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -289,8 +289,6 @@ services:
       # Runtime configuration
       ONEX_ENVIRONMENT: test
       ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-DEBUG}
-      # OMN-8840/OMN-8784: ONEX_INPUT_TOPIC / ONEX_OUTPUT_TOPIC removed (banned env vars).
-      # e2e runtime derives topics from node contracts mounted at /app/contracts.
       ONEX_GROUP_ID: onex-runtime-e2e
       ONEX_CONTRACTS_DIR: /app/contracts
     ports:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -623,9 +623,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-omninode-runtime-main}
       RUNTIME_PROFILE: main
-      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-      # Topics come from each node's contract.yaml event_bus declaration;
-      # setting this var raises ProtocolConfigurationError at kernel bootstrap.
       ONEX_GROUP_ID: ${ONEX_GROUP_ID:-onex-runtime-main}
       KAFKA_INSTANCE_ID: runtime-main
       # OMN-9060: HandlerRegistrationStoragePostgres reads POSTGRES_HOST directly
@@ -681,8 +678,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-effects
       RUNTIME_PROFILE: effects
-      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-      # Topics come from each node's contract.yaml event_bus declaration.
       ONEX_GROUP_ID: ${ONEX_EFFECTS_GROUP_ID:-onex-runtime-effects}
       KAFKA_INSTANCE_ID: runtime-effects
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)
@@ -736,8 +731,6 @@ services:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-runtime-worker
       RUNTIME_PROFILE: workers
-      # OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var).
-      # Topics come from each node's contract.yaml event_bus declaration.
       ONEX_GROUP_ID: ${ONEX_WORKER_GROUP_ID:-onex-runtime-workers}
       KAFKA_INSTANCE_ID: runtime-worker
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)


### PR DESCRIPTION
Evidence-Ticket: OMN-9529
Evidence-Source: c3b14fd6b92b068e805b86e00dd30fe2446e067e

## Summary

Removes all stale `# OMN-8840/OMN-8784: ONEX_OUTPUT_TOPIC removed (banned env var)` comment blocks from compose files, catalog service YAMLs, Dockerfile.runtime, and two stale secretresolver_allowlist line-number entries.

Ticket: OMN-9529

## Files changed

- `docker/docker-compose.infra.yml` — 3 stale comment blocks removed (main, effects, worker sections)
- `docker/docker-compose.e2e.yml` — 1 stale comment block removed
- `docker/catalog/services/omninode-runtime.yaml` — 1 stale comment block removed
- `docker/catalog/services/runtime-worker.yaml` — 1 stale comment block removed
- `docker/catalog/services/runtime-effects.yaml` — 1 stale comment block removed
- `docker/catalog/services/runtime-canary.yaml` — 1 stale comment block removed
- `docker/Dockerfile.runtime` — 1 stale note removed
- `.secretresolver_allowlist` — 2 stale entries removed (lines 333/334 that no longer correspond to ONEX_INPUT/OUTPUT_TOPIC)

## Verification

- All 6 stale-topic-var enforcement tests pass
- Pre-existing infrastructure-connectivity test failures only (need 192.168.86.201); no regressions
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed deprecated environment variable references and cleaned up related inline comments across deployment and compose configs.
  * Updated runtime service configurations with observability and profiling defaults for main, effects, and worker profiles.
* **Documentation**
  * Added a deploy-evidence contract documenting the comment-only cleanup and verification checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1575)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->