### PR TITLE
feat(OMN-10917): delegation env read scanner in report mode

### DIFF
--- a/scripts/ci/check_delegation_env_reads.py
+++ b/scripts/ci/check_delegation_env_reads.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CI scanner for os.environ/os.getenv reads in delegation-owned modules.
+
+Detects direct environment variable access in delegation modules. Report mode
+(warn only) is used in Wave 0. Enforce mode (exit 1) is reserved for Wave 2
+after contract-driven config is landed.
+
+Module scope: nodes matching delegation/LLM-inference/bifrost patterns.
+
+Exit codes:
+    0: Scan completed (report mode always returns 0)
+    1: Violations found (enforce mode only)
+
+Usage:
+    python scripts/ci/check_delegation_env_reads.py
+    python scripts/ci/check_delegation_env_reads.py --mode enforce
+    python scripts/ci/check_delegation_env_reads.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DELEGATION_MODULE_PATTERNS = [
+    "nodes/node_delegation_",
+    "nodes/node_delegate_skill_",
+    "nodes/node_delegation_routing_",
+    "nodes/node_llm_inference_",
+    "nodes/node_llm_completion_",
+    "nodes/node_llm_embedding_",
+    "nodes/node_delegation_quality_gate_",
+    "nodes/node_projection_delegation",
+    "delegation/",
+    "adapters/llm/",
+]
+
+ALLOWLISTED_PATH_SEGMENTS = [
+    "tests/",
+    "fixtures/",
+    "conftest.py",
+    "__pycache__/",
+]
+
+# Inline skip token: # ONEX_FLAG_EXEMPT or # ONEX_EXCLUDE allows a line
+SKIP_TOKENS = ["ONEX_FLAG_EXEMPT", "ONEX_EXCLUDE"]
+
+
+@dataclass
+class ScanResult:
+    scanned_files: int = 0
+    violations: list[str] = field(default_factory=list)
+    report_generated: bool = False
+
+
+def _is_allowlisted(rel_path: str) -> bool:
+    for segment in ALLOWLISTED_PATH_SEGMENTS:
+        if segment in rel_path:
+            return True
+    return False
+
+
+def _is_delegation_module(rel_path: str) -> bool:
+    for pattern in DELEGATION_MODULE_PATTERNS:
+        if pattern in rel_path:
+            return True
+    return False
+
+
+def _has_skip_token(line: str) -> bool:
+    for token in SKIP_TOKENS:
+        if token in line:
+            return True
+    return False
+
+
+def _find_env_calls_in_source(source: str, filepath: str) -> list[str]:
+    """Return list of violation strings for env calls in the given source.
+
+    Deduplicates by line number, keeping the most specific match
+    (os.environ.get > os.environ > os.getenv).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+
+    # Map lineno -> (call_repr, specificity) — higher specificity wins
+    # specificity: os.environ.get=2, os.environ=1, os.getenv=1
+    best_per_line: dict[int, tuple[str, int]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+
+        lineno: int | None = None
+        call_repr: str | None = None
+        specificity: int = 1
+
+        if isinstance(node.value, ast.Name) and node.value.id == "os":
+            if node.attr in ("environ", "getenv"):
+                lineno = node.lineno
+                call_repr = f"os.{node.attr}"
+        elif (
+            isinstance(node.value, ast.Attribute)
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "os"
+            and node.value.attr == "environ"
+            and node.attr == "get"
+        ):
+            lineno = node.lineno
+            call_repr = "os.environ.get"
+            specificity = 2
+
+        if lineno is not None and call_repr is not None:
+            existing = best_per_line.get(lineno)
+            if existing is None or specificity > existing[1]:
+                best_per_line[lineno] = (call_repr, specificity)
+
+    violations: list[str] = []
+    for lineno in sorted(best_per_line):
+        call_repr, _ = best_per_line[lineno]
+        line_text = lines[lineno - 1] if lineno <= len(lines) else ""
+        if _has_skip_token(line_text):
+            continue
+        violations.append(f"{filepath}:{lineno}: {call_repr} — {line_text.strip()}")
+
+    return violations
+
+
+def scan_delegation_modules(
+    repo_root: Path | None = None,
+    mode: str = "report",
+) -> ScanResult:
+    if repo_root is None:
+        # Walk up from this file to find the repo root (.git dir)
+        candidate = Path(__file__).parent
+        while candidate != candidate.parent:
+            if (candidate / ".git").exists():
+                repo_root = candidate
+                break
+            candidate = candidate.parent
+        else:
+            repo_root = Path.cwd()
+
+    result = ScanResult()
+
+    src_root = repo_root / "src"
+    if not src_root.exists():
+        result.report_generated = True
+        return result
+
+    for py_file in src_root.rglob("*.py"):
+        rel = str(py_file.relative_to(repo_root))
+        rel_forward = rel.replace("\\", "/")
+
+        if _is_allowlisted(rel_forward):
+            continue
+        if not _is_delegation_module(rel_forward):
+            continue
+
+        result.scanned_files += 1
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        violations = _find_env_calls_in_source(source, rel_forward)
+        result.violations.extend(violations)
+
+    result.report_generated = True
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan delegation modules for direct os.environ/os.getenv usage"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["report", "enforce"],
+        default="report",
+        help="report: warn only (default). enforce: exit 1 on violations.",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    # Locate repo root from CWD
+    candidate = Path.cwd()
+    repo_root: Path = candidate
+    while candidate != candidate.parent:
+        if (candidate / ".git").exists():
+            repo_root = candidate
+            break
+        candidate = candidate.parent
+
+    result = scan_delegation_modules(repo_root=repo_root, mode=args.mode)
+
+    if result.violations:
+        print(
+            f"[delegation-env-scanner] Found {len(result.violations)} env read(s) "
+            f"in delegation modules ({args.mode} mode)"
+        )
+        for v in sorted(result.violations):
+            print(f"  {v}")
+        if args.mode == "enforce":
+            print(
+                "\nFix: replace os.environ/os.getenv with contract-driven config "
+                "resolution (OMN-10915 Wave 2)."
+            )
+            return 1
+        print(
+            "\n[report mode] These will become blocking violations in Wave 2 "
+            "(OMN-10917 → OMN-10915)."
+        )
+    elif args.verbose:
+        print(
+            f"[delegation-env-scanner] OK — scanned {result.scanned_files} files, "
+            "no violations."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_delegation_env_scanner.py
+++ b/tests/ci/test_delegation_env_scanner.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the delegation env read scanner.
+
+Verifies that the scanner:
+- finds known os.environ/os.getenv violations in delegation modules
+- ignores test fixtures and non-delegation modules
+- operates in report mode without failing CI
+
+Ticket: OMN-10917
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+scripts_ci_dir = Path(__file__).parent.parent.parent / "scripts" / "ci"
+sys.path.insert(0, str(scripts_ci_dir))
+
+from check_delegation_env_reads import (
+    ScanResult,
+    _find_env_calls_in_source,
+    _is_allowlisted,
+    _is_delegation_module,
+    scan_delegation_modules,
+)
+
+
+class TestIsDelegationModule:
+    def test_delegation_orchestrator(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/h.py"
+        )
+
+    def test_delegation_routing_reducer(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_delegation_routing_reducer/handlers/h.py"
+        )
+
+    def test_delegate_skill_orchestrator(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_delegate_skill_orchestrator/node.py"
+        )
+
+    def test_llm_inference_effect(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/cfg.py"
+        )
+
+    def test_llm_completion_effect(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_llm_completion_effect/handlers/h.py"
+        )
+
+    def test_adapters_llm(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py"
+        )
+
+    def test_non_delegation_module_excluded(self) -> None:
+        assert not _is_delegation_module(
+            "src/omnibase_infra/nodes/node_registration_orchestrator/node.py"
+        )
+
+    def test_event_bus_excluded(self) -> None:
+        assert not _is_delegation_module(
+            "src/omnibase_infra/event_bus/kafka_consumer.py"
+        )
+
+
+class TestIsAllowlisted:
+    def test_test_file_allowlisted(self) -> None:
+        assert _is_allowlisted(
+            "src/omnibase_infra/nodes/node_delegation_orchestrator/tests/test_foo.py"
+        )
+
+    def test_fixtures_allowlisted(self) -> None:
+        assert _is_allowlisted("tests/fixtures/delegation_fixture.py")
+
+    def test_conftest_allowlisted(self) -> None:
+        assert _is_allowlisted("tests/ci/conftest.py")
+
+    def test_regular_handler_not_allowlisted(self) -> None:
+        assert not _is_allowlisted(
+            "src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py"
+        )
+
+
+class TestFindEnvCallsInSource:
+    def test_detects_os_environ_get(self) -> None:
+        source = 'import os\nvalue = os.environ.get("KEY", "")\n'
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 1
+        assert "os.environ.get" in violations[0]
+        assert "test.py:2" in violations[0]
+
+    def test_detects_os_getenv(self) -> None:
+        source = 'import os\nvalue = os.getenv("KEY")\n'
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 1
+        assert "os.getenv" in violations[0]
+
+    def test_detects_os_environ_subscript(self) -> None:
+        source = 'import os\nvalue = os.environ["KEY"]\n'
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 1
+        assert "os.environ" in violations[0]
+
+    def test_skips_onex_flag_exempt(self) -> None:
+        source = (
+            'import os\nvalue = os.getenv("KEY")  # ONEX_FLAG_EXEMPT: activation gate\n'
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+    def test_skips_onex_exclude(self) -> None:
+        source = (
+            'import os\nvalue = os.environ.get("KEY")  # ONEX_EXCLUDE: archive port\n'
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+    def test_no_false_positive_on_attribute_not_os(self) -> None:
+        source = 'value = config.environ.get("KEY")\n'
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+    def test_multiple_violations_detected(self) -> None:
+        source = (
+            "import os\n"
+            'url = os.environ.get("LLM_URL", "")\n'
+            'key = os.getenv("API_KEY")\n'
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 2
+
+
+@pytest.mark.unit
+class TestScanDelegationModules:
+    def test_scanner_finds_known_violations(self) -> None:
+        repo_root = Path(__file__).parent.parent.parent
+        result = scan_delegation_modules(repo_root=repo_root, mode="report")
+        assert result.scanned_files > 0
+        assert result.report_generated
+
+    def test_scanner_finds_violations_in_repo(self) -> None:
+        """Known env reads exist in delegation modules — scanner must detect them."""
+        repo_root = Path(__file__).parent.parent.parent
+        result = scan_delegation_modules(repo_root=repo_root, mode="report")
+        assert len(result.violations) > 0, (
+            "Expected known env reads in delegation modules — "
+            "check node_delegation_routing_reducer and adapters/llm/"
+        )
+
+    def test_report_mode_does_not_fail(self) -> None:
+        repo_root = Path(__file__).parent.parent.parent
+        result = scan_delegation_modules(repo_root=repo_root, mode="report")
+        # report mode must always set report_generated = True regardless of violations
+        assert result.report_generated
+
+    def test_scan_result_is_dataclass(self) -> None:
+        result = ScanResult()
+        assert result.scanned_files == 0
+        assert result.violations == []
+        assert result.report_generated is False
+
+    def test_scanner_ignores_non_delegation_files(self, tmp_path: Path) -> None:
+        """Files outside delegation module patterns must not appear in violations."""
+        # Write a file with env reads in a non-delegation path
+        src = (
+            tmp_path / "src" / "mypackage" / "nodes" / "node_registration_orchestrator"
+        )
+        src.mkdir(parents=True)
+        (src / "handler.py").write_text('import os\nos.getenv("KEY")\n')
+        # Also create a .git dir so repo_root detection works
+        (tmp_path / ".git").mkdir()
+
+        result = scan_delegation_modules(repo_root=tmp_path, mode="report")
+        assert result.scanned_files == 0
+        assert result.violations == []
+        assert result.report_generated
+
+    def test_scanner_ignores_test_files_in_delegation_paths(
+        self, tmp_path: Path
+    ) -> None:
+        """Test files inside delegation module directories must be skipped."""
+        src = (
+            tmp_path
+            / "src"
+            / "mypackage"
+            / "nodes"
+            / "node_delegation_orchestrator"
+            / "tests"
+        )
+        src.mkdir(parents=True)
+        (src / "test_handler.py").write_text('import os\nos.getenv("KEY")\n')
+        (tmp_path / ".git").mkdir()
+
+        result = scan_delegation_modules(repo_root=tmp_path, mode="report")
+        assert result.scanned_files == 0
+        assert result.violations == []


### PR DESCRIPTION
## Summary
- AST-based scanner for `os.environ`/`os.getenv` in delegation-owned modules
- Report mode (warn only) — enforce mode available for Wave 2 (OMN-10915)
- Covers delegation orchestrator, routing reducer, delegate-skill orchestrator, LLM inference/completion/embedding effects, projection delegation, and adapters/llm/ paths
- Deduplicates per-line violations with specificity preference (`os.environ.get` > `os.environ`)
- Honors `ONEX_FLAG_EXEMPT` and `ONEX_EXCLUDE` inline skip tokens

## Test plan
- [x] Scanner finds known violations in delegation modules (routing reducer, bifrost config loader, LLM adapters)
- [x] Scanner ignores test fixtures and non-delegation modules
- [x] Report mode does not exit non-zero
- [x] 25/25 unit tests passing

OMN-10917

Evidence-Source: OCC#982
Evidence-Ticket: OMN-10917