### PR TITLE
fix(OMN-10940): reconcile delegation runtime live patches

### DIFF
--- a/contracts/OMN-10940.yaml
+++ b/contracts/OMN-10940.yaml
@@ -1,0 +1,32 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10940"
+title: "Reconcile delegation runtime live patches"
+summary: "Reconcile delegation workflow live patches, terminal task-delegated fields, bridge output handling, and schema migration fingerprint evidence."
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "events"
+  - "runtime"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-integration-pipeline"
+    description: "Integration coverage proves the delegation pipeline live-patch reconciliation path."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/nodes/test_delegation_pipeline_e2e.py -q"
+  - id: "dod-schema-fingerprint"
+    description: "Migration schema fingerprint is stamped for the added delegation and service-registry migrations."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python scripts/check_schema_fingerprint.py verify"
+  - id: "dod-deploy"
+    description: "Deploy validation plan for delegation runtime reconciliation; no live runtime restart was performed in this PR."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: after merge, verify the runtime container imports PluginDelegation, applies DispatchResultApplier output events, and can publish a task-delegated event with prompt_text and response_text"

--- a/contracts/OMN-10940.yaml
+++ b/contracts/OMN-10940.yaml
@@ -6,7 +6,7 @@ is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "events"
-  - "runtime"
+  - "protocols"
 emergency_bypass:
   enabled: false
   justification: ""

--- a/docker/migrations/forward/078_create_delegation_events.sql
+++ b/docker/migrations/forward/078_create_delegation_events.sql
@@ -1,0 +1,70 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Migration 078: create delegation_events projection table (OMN-10526).
+-- Consumed by HandlerProjectionDelegation from onex.evt.omniclaude.task-delegated.v1.
+
+CREATE TABLE IF NOT EXISTS delegation_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id TEXT UNIQUE NOT NULL,
+    session_id TEXT,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    task_type TEXT NOT NULL,
+    delegated_to TEXT NOT NULL,
+    model_name TEXT DEFAULT '',
+    delegated_by TEXT,
+    quality_gate_passed BOOLEAN DEFAULT false,
+    quality_gates_checked JSONB,
+    quality_gates_failed JSONB,
+    cost_usd NUMERIC(18, 9) DEFAULT 0,
+    cost_savings_usd NUMERIC(18, 9) DEFAULT 0,
+    delegation_latency_ms INT,
+    repo TEXT,
+    is_shadow BOOLEAN DEFAULT false,
+    llm_call_id TEXT,
+    prompt_text TEXT,
+    response_text TEXT,
+    tokens_to_compliance INT NOT NULL DEFAULT 0,
+    compliance_attempts INT NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS delegation_shadow_comparisons (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id TEXT UNIQUE NOT NULL,
+    session_id TEXT,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    task_type TEXT NOT NULL,
+    primary_agent TEXT NOT NULL,
+    shadow_agent TEXT NOT NULL,
+    divergence_detected BOOLEAN DEFAULT false,
+    divergence_score NUMERIC(18, 9),
+    primary_latency_ms INT,
+    shadow_latency_ms INT,
+    primary_cost_usd NUMERIC(18, 9),
+    shadow_cost_usd NUMERIC(18, 9),
+    divergence_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_session_id
+    ON delegation_events (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_timestamp
+    ON delegation_events (timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_delegated_to
+    ON delegation_events (delegated_to);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_shadow_comparisons_session_id
+    ON delegation_shadow_comparisons (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_shadow_comparisons_timestamp
+    ON delegation_shadow_comparisons (timestamp DESC);
+
+COMMENT ON TABLE delegation_events IS
+    'Projection of task-delegated events from onex.evt.omniclaude.task-delegated.v1. OMN-10526.';
+
+UPDATE db_metadata
+    SET schema_version = '078', updated_at = NOW()
+    WHERE id = TRUE AND owner_service = 'omnibase_infra';

--- a/docker/migrations/forward/079_create_node_service_registry.sql
+++ b/docker/migrations/forward/079_create_node_service_registry.sql
@@ -1,0 +1,30 @@
+-- Create the dashboard-compatible node service registry projection table.
+-- Runtime projection handlers upsert node introspection and heartbeat events here.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS node_service_registry (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    service_name TEXT UNIQUE NOT NULL,
+    service_url TEXT NOT NULL DEFAULT '',
+    service_type TEXT NOT NULL DEFAULT 'api',
+    health_status TEXT NOT NULL DEFAULT 'unknown',
+    last_health_check TIMESTAMPTZ,
+    last_heartbeat_at TIMESTAMPTZ,
+    uptime_seconds BIGINT NOT NULL DEFAULT 0,
+    health_check_interval_seconds INTEGER NOT NULL DEFAULT 60,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_health_status
+    ON node_service_registry (health_status);
+
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_service_type
+    ON node_service_registry (service_type);
+
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_last_heartbeat
+    ON node_service_registry (last_heartbeat_at DESC);

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:c573b449b412b6b9d62c875664dd88e8b4c76673faf19c21374084ec041f2699
-generated_at: 2026-05-02T00:36:33Z
-migration_file_count: 63
+sha256:ddb6c970c2e22533f7db84b2656f6d651847758113d34ec075610b60ddb751cd
+generated_at: 2026-05-13T17:02:49Z
+migration_file_count: 65

--- a/scripts/validate-pr-contract-sync.sh
+++ b/scripts/validate-pr-contract-sync.sh
@@ -61,16 +61,16 @@ trap 'rm -rf "$tmpdir"' EXIT
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    # Node handler pattern: .../nodes/<node>/handlers/*.py
-    if echo "$file" | grep -qE '.*/nodes/([^/]+)/handlers/[^/]+\.py$'; then
-        node="$(echo "$file" | sed -E 's|.*/nodes/([^/]+)/handlers/[^/]+\.py$|\1|')"
+    # Node handler pattern: src/<package>/nodes/<node>/handlers/*.py
+    if echo "$file" | grep -qE '^src/[^/]+/nodes/([^/]+)/handlers/[^/]+\.py$'; then
+        node="$(echo "$file" | sed -E 's|^src/[^/]+/nodes/([^/]+)/handlers/[^/]+\.py$|\1|')"
         touch "$tmpdir/node_handler_${node}"
         continue
     fi
 
-    # Node contract pattern: .../nodes/<node>/contract.yaml
-    if echo "$file" | grep -qE '.*/nodes/([^/]+)/contract\.yaml$'; then
-        node="$(echo "$file" | sed -E 's|.*/nodes/([^/]+)/contract\.yaml$|\1|')"
+    # Node contract pattern: src/<package>/nodes/<node>/contract.yaml
+    if echo "$file" | grep -qE '^src/[^/]+/nodes/([^/]+)/contract\.yaml$'; then
+        node="$(echo "$file" | sed -E 's|^src/[^/]+/nodes/([^/]+)/contract\.yaml$|\1|')"
         touch "$tmpdir/node_contract_${node}"
         continue
     fi

--- a/src/omnibase_infra/adapters/llm/plugin_llm.py
+++ b/src/omnibase_infra/adapters/llm/plugin_llm.py
@@ -197,6 +197,9 @@ class PluginLlm:
             from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
                 DelegationIntentBridge,
             )
+            from omnibase_infra.nodes.node_delegation_orchestrator.protocol_delegation_intent_bridge import (
+                ProtocolDelegationIntentBridge,
+            )
 
             bridge = DelegationIntentBridge(
                 event_bus=event_bus,
@@ -204,7 +207,7 @@ class PluginLlm:
             )
             if config.container.service_registry is not None:
                 await config.container.service_registry.register_instance(
-                    interface=DelegationIntentBridge,
+                    interface=ProtocolDelegationIntentBridge,  # type: ignore[type-abstract]
                     instance=bridge,
                     scope=EnumInjectionScope.GLOBAL,
                     metadata={

--- a/src/omnibase_infra/configs/routing_tiers.yaml
+++ b/src/omnibase_infra/configs/routing_tiers.yaml
@@ -29,18 +29,17 @@ tiers:
           - code_review
           - refactor
           - test
+          - document
           - research
+        fast_path_threshold_tokens: 65536
       - id: deepseek-r1-14b
         backend_id: local-deepseek-r1-14b
         max_context_tokens: 24576
         use_for:
-          - test
           - research
           - reasoning
           - planning
           - review
-          - document
-        fast_path_threshold_tokens: 24576
     eval_before_accept: true
     eval_model: deepseek-r1-14b
     max_retries: 2

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/contract.yaml
@@ -19,15 +19,15 @@ node_name: "node_delegation_orchestrator"
 contract_version:
   major: 0
   minor: 3
-  patch: 0
+  patch: 1
 node_version:
   major: 0
   minor: 3
-  patch: 0
+  patch: 1
 node_type: "ORCHESTRATOR_GENERIC"
 terminal_event: "onex.evt.omnibase-infra.delegation-completed.v1"
 description: >
-  Orchestrator node that coordinates delegation through a correlation_id-keyed FSM: receive delegation request, invoke routing reducer, dispatch typed invocation commands to the selected effect lane, react to remote agent lifecycle events or the legacy inference and quality-gate path, then emit delegation-completed or delegation-failed. As of 0.2.0 (OMN-10792), exposes HandlerComplianceLoop as an in-process helper. As of 0.3.0 (OMN-10794), HandlerDelegationWorkflow invokes the loop per inference attempt when ModelDelegationRequest sets ``output_schema_key`` + ``compliance_budget``: validation failure with budget CONTINUE emits a fresh repair-prompt ModelInferenceIntent and stays in ROUTED (self-loop); compliant or budget ABORT forwards to the quality gate. tokens_to_compliance + compliance_attempts are accumulated across attempts and forwarded onto the terminal ModelDelegationResult and ModelTaskDelegatedEvent.
+  Orchestrator node that coordinates delegation through a correlation_id-keyed FSM: receive delegation request, invoke routing reducer, dispatch typed invocation commands to the selected effect lane, react to remote agent lifecycle events or the legacy inference and quality-gate path, then emit delegation-completed or delegation-failed. As of 0.2.0 (OMN-10792), exposes HandlerComplianceLoop as an in-process helper. As of 0.3.0 (OMN-10794), HandlerDelegationWorkflow invokes the loop per inference attempt when ModelDelegationRequest sets ``output_schema_key`` + ``compliance_budget``: validation failure with budget CONTINUE emits a fresh repair-prompt ModelInferenceIntent and stays in ROUTED (self-loop); compliant or budget ABORT forwards to the quality gate. tokens_to_compliance + compliance_attempts are accumulated across attempts and forwarded onto the terminal ModelDelegationResult and ModelTaskDelegatedEvent. As of 0.3.1 (OMN-10940), ModelTaskDelegatedEvent also carries prompt_text and response_text for live patch reconciliation, and PluginDelegation wires DelegationIntentBridge as the DispatchResultApplier in-process output handler so inference output events are applied before terminal publication.
 
 input_model:
   name: "ModelDelegationRequest"
@@ -77,7 +77,7 @@ published_events:
     description: "Delegation pipeline terminal event (completed or failed, topic set per-instance)."
   - event_type: "TaskDelegatedEvent"
     topic: "onex.evt.omniclaude.task-delegated.v1"
-    description: "Backward-compatible task-delegated event for omnidash projection."
+    description: "Backward-compatible task-delegated event for omnidash projection, including prompt_text and response_text when available from the delegation workflow."
   - event_type: "BaselineIntent"
     topic: "onex.cmd.omnibase-infra.baseline-comparison-request.v1"
     description: "Intent to trigger baseline cost comparison for savings tracking."

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/handler_delegation_workflow.py
@@ -467,6 +467,8 @@ class HandlerDelegationWorkflow:
             llm_call_id=workflow.inference_llm_call_id,
             tokens_to_compliance=tokens_to_compliance,
             compliance_attempts=compliance_attempts,
+            prompt_text=workflow.request.prompt,
+            response_text=workflow.inference_content,
         )
 
         events: list[BaseModel] = []

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -83,6 +83,14 @@ class ModelTaskDelegatedEvent(BaseModel):
         ge=1,
         description="Number of LLM invocations to reach compliance.",
     )
+    prompt_text: str | None = Field(
+        default=None,
+        description="Raw prompt sent to the delegated model.",
+    )
+    response_text: str | None = Field(
+        default=None,
+        description="Raw response received from the delegated model.",
+    )
 
 
 __all__: list[str] = ["ModelTaskDelegatedEvent"]

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
@@ -339,6 +339,9 @@ class PluginDelegation:
             from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
                 DelegationIntentBridge,
             )
+            from omnibase_infra.nodes.node_delegation_orchestrator.protocol_delegation_intent_bridge import (
+                ProtocolDelegationIntentBridge,
+            )
 
             # Resolve the bridge registered by PluginLlm (has real LlmCallerDelegation).
             # Fall back to None so routing/quality-gate intents still work without LLM.
@@ -347,7 +350,7 @@ class PluginDelegation:
                 try:
                     existing_bridge = (
                         await config.container.service_registry.resolve_service(
-                            DelegationIntentBridge
+                            ProtocolDelegationIntentBridge  # type: ignore[type-abstract]
                         )
                     )
                     llm_caller = existing_bridge.llm_caller

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/plugin.py
@@ -336,6 +336,38 @@ class PluginDelegation:
                 len(published_events_map),
             )
 
+            from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
+                DelegationIntentBridge,
+            )
+
+            # Resolve the bridge registered by PluginLlm (has real LlmCallerDelegation).
+            # Fall back to None so routing/quality-gate intents still work without LLM.
+            llm_caller = None
+            if config.container.service_registry is not None:
+                try:
+                    existing_bridge = (
+                        await config.container.service_registry.resolve_service(
+                            DelegationIntentBridge
+                        )
+                    )
+                    llm_caller = existing_bridge.llm_caller
+                    logger.info(
+                        "PluginDelegation: resolved LlmCallerDelegation from container "
+                        "(correlation_id=%s)",
+                        correlation_id,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "PluginDelegation: DelegationIntentBridge not in container — "
+                        "inference intents will be disabled (correlation_id=%s)",
+                        correlation_id,
+                    )
+
+            delegation_bridge = DelegationIntentBridge(
+                event_bus=config.event_bus,
+                llm_caller=llm_caller,
+            )
+
             # DispatchResultApplier uses config.event_bus for publish_envelope
             # (publisher-only path, compatible with ProtocolEventBusPublisher).
             result_applier = DispatchResultApplier(
@@ -343,6 +375,7 @@ class PluginDelegation:
                 output_topic=config.output_topic,
                 topic_router=_TOPIC_ROUTER,
                 output_topic_map=published_events_map,
+                output_event_handler=delegation_bridge.handle_output_event,
             )
 
             if config.container.service_registry is not None:
@@ -371,46 +404,11 @@ class PluginDelegation:
                 subcontract=subcontract,
                 node_name="delegation-orchestrator",
             )
-
-            from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
-                DelegationIntentBridge,
-            )
-            from omnibase_infra.nodes.node_delegation_orchestrator.wiring import (
-                wire_delegation_bridge,
-            )
-
-            # Resolve the bridge registered by PluginLlm (has real LlmCallerDelegation).
-            # Fall back to None so routing/quality-gate intents still work without LLM.
-            llm_caller = None
-            if config.container.service_registry is not None:
-                try:
-                    existing_bridge = (
-                        await config.container.service_registry.resolve_service(
-                            DelegationIntentBridge
-                        )
-                    )
-                    llm_caller = existing_bridge.llm_caller
-                    logger.info(
-                        "PluginDelegation: resolved LlmCallerDelegation from container "
-                        "(correlation_id=%s)",
-                        correlation_id,
-                    )
-                except Exception:  # noqa: BLE001
-                    logger.debug(
-                        "PluginDelegation: DelegationIntentBridge not in container — "
-                        "inference intents will be disabled (correlation_id=%s)",
-                        correlation_id,
-                    )
-
-            bridge_result = await wire_delegation_bridge(
-                event_bus=config.event_bus,
-                llm_caller=llm_caller,
-            )
             logger.info(
-                "DelegationIntentBridge wired llm_caller=%s (correlation_id=%s): %s",
+                "DelegationIntentBridge wired in-process llm_caller=%s "
+                "(correlation_id=%s)",
                 type(llm_caller).__name__ if llm_caller else "None",
                 correlation_id,
-                bridge_result,
             )
 
             self._wiring = wiring

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/protocol_delegation_intent_bridge.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/protocol_delegation_intent_bridge.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Protocol key for delegation intent bridge dependency injection."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from omnibase_infra.nodes.node_delegation_orchestrator.delegation_intent_bridge import (
+    ProtocolLlmCaller,
+)
+
+
+class ProtocolDelegationIntentBridge(Protocol):
+    """Protocol key for delegation intent bridge DI lookup."""
+
+    @property
+    def llm_caller(self) -> ProtocolLlmCaller | None: ...
+
+
+__all__ = ["ProtocolDelegationIntentBridge"]

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/protocol_delegation_intent_bridge.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/protocol_delegation_intent_bridge.py
@@ -15,7 +15,8 @@ class ProtocolDelegationIntentBridge(Protocol):
     """Protocol key for delegation intent bridge DI lookup."""
 
     @property
-    def llm_caller(self) -> ProtocolLlmCaller | None: ...
+    def llm_caller(self) -> ProtocolLlmCaller | None:
+        pass  # Protocol stub — implementation provided by concrete class
 
 
 __all__ = ["ProtocolDelegationIntentBridge"]

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -473,9 +473,11 @@ _DB_URL_ENV_MAP: dict[str, str] = {
 }
 
 _TOPIC_TO_EVENT_TYPE: dict[str, str] = {
+    "delegation-shadow-comparison": "delegation_shadow_comparison",
     "node-heartbeat": "heartbeat",
     "node-introspection": "introspection",
     "node-state-change": "state_change",
+    "task-delegated": "task_delegated",
 }
 
 

--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -43,7 +43,7 @@ Related:
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4, uuid5
@@ -133,6 +133,8 @@ class DispatchResultApplier:
         projection_effect: ProtocolProjectionEffect | None = None,
         topic_router: dict[str, str] | None = None,
         output_topic_map: dict[str, str] | None = None,
+        output_event_handler: Callable[[BaseModel], Awaitable[BaseModel | None]]
+        | None = None,
     ) -> None:
         """Initialize the dispatch result applier.
 
@@ -160,6 +162,9 @@ class DispatchResultApplier:
                 ``published_events``) to their declared Kafka topics. Uses short
                 names (``Model`` prefix stripped) with full class name fallback.
                 Build with ``load_published_events_map()`` (OMN-5132).
+            output_event_handler: Optional async hook for output events that are
+                executed in-process instead of being published. If it returns a
+                non-None model, the original output event is considered handled.
         """
         self._event_bus = event_bus
         self._output_topic = output_topic
@@ -168,6 +173,7 @@ class DispatchResultApplier:
         self._projection_effect = projection_effect
         self._topic_router: dict[str, str] = topic_router or {}
         self._output_topic_map: dict[str, str] = output_topic_map or {}
+        self._output_event_handler = output_event_handler
 
     @property
     def published_events_map(self) -> dict[str, str]:
@@ -440,6 +446,25 @@ class DispatchResultApplier:
         if result.output_events:
             for idx, output_event in enumerate(result.output_events):
                 try:
+                    if self._output_event_handler is not None:
+                        handled_result = await self._output_event_handler(output_event)
+                        if handled_result is not None:
+                            logger.info(
+                                "Handled output event in-process "
+                                "(event_type=%s, result_type=%s, correlation_id=%s)",
+                                type(output_event).__name__,
+                                type(handled_result).__name__,
+                                str(effective_correlation_id),
+                                extra={
+                                    "output_event_type": type(output_event).__name__,
+                                    "handled_result_type": type(
+                                        handled_result
+                                    ).__name__,
+                                    "dispatcher_id": result.dispatcher_id,
+                                },
+                            )
+                            continue
+
                     # Deterministic envelope_id: uuid5(correlation_id, "type:index")
                     # ensures redeliveries produce identical IDs, enabling
                     # downstream consumers to deduplicate at-least-once events.

--- a/tests/integration/nodes/test_delegation_pipeline_e2e.py
+++ b/tests/integration/nodes/test_delegation_pipeline_e2e.py
@@ -211,8 +211,8 @@ class TestDelegationPipelineHappyPath:
         assert final_events[2].delegated_by == "delegation-pipeline"
         assert final_events[2].cost_savings_usd > 0
 
-    def test_happy_path_document_task_routes_to_deepseek(self) -> None:
-        """Verify document tasks route to DeepSeek and use temperature 0.5."""
+    def test_happy_path_document_task_routes_to_qwen(self) -> None:
+        """Verify document tasks route to Qwen and use temperature 0.5."""
         cid = uuid4()
         request = ModelDelegationRequest(
             prompt="Write docstrings for the ConfigPrefetcher class",
@@ -222,12 +222,12 @@ class TestDelegationPipelineHappyPath:
         )
 
         routing_decision = routing_delta(request)
-        # document tasks route to the deployed DeepSeek model in the local tier
+        # document tasks route to Qwen in the local tier for bounded demo output.
         assert (
             routing_decision.selected_model
-            == "Corianas/DeepSeek-R1-Distill-Qwen-14B-AWQ"
+            == "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"
         )
-        assert routing_decision.endpoint_url == "http://192.168.86.201:8001"
+        assert routing_decision.endpoint_url == "http://192.168.86.201:8000"
 
         orchestrator = HandlerDelegationWorkflow()
         orchestrator.handle_delegation_request(request)

--- a/tests/scripts/test_validate_pr_contract_sync.py
+++ b/tests/scripts/test_validate_pr_contract_sync.py
@@ -80,6 +80,19 @@ def test_handler_change_without_contract_change_fails():
 
 
 @pytest.mark.unit
+def test_node_handler_named_test_file_does_not_trigger_contract_sync():
+    """Test files under tests/unit/nodes are not production node handlers."""
+    result = run_script(
+        [
+            "tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing.py",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"Expected PASS for test-only handler path.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.unit
 def test_skill_prompt_change_with_skill_md_passes():
     """Skill prompt.md change accompanied by SKILL.md change must PASS."""
     result = run_script(

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -156,6 +156,9 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolKafkaReplayConsumer": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py",
     "ProtocolOffsetAndTimestamp": "nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py",
     "ProtocolTopicPartition": "nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py",
+    # [NODE] DI boundary for delegation intent bridge — narrows the LLM caller surface
+    # so the delegation orchestrator handler can be tested without driving the real caller (OMN-10940).
+    "ProtocolDelegationIntentBridge": "nodes/node_delegation_orchestrator/protocol_delegation_intent_bridge.py",
 }
 
 # Duplicate protocol names that appear in multiple files (node-internal

--- a/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing.py
+++ b/tests/unit/nodes/node_delegation_routing_reducer/handlers/test_handler_delegation_routing.py
@@ -131,22 +131,22 @@ class TestRoutingByTaskType:
             decision.endpoint_url == "http://192.168.86.201:8000"
         )  # onex-allow-internal-ip
 
-    def test_document_routes_to_deepseek(
+    def test_document_routes_to_coder(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Document tasks go to deepseek-r1-14b via local-deepseek backend."""
+        """Document tasks go to qwen3-coder-30b via the local coder backend."""
         bifrost = _write_bifrost(
             tmp_path,
             {
-                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
             },  # onex-allow-internal-ip
         )
         monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document")
         decision = delta(req)
-        assert decision.selected_model == "deepseek-r1-14b"
+        assert decision.selected_model == "qwen3-coder-30b"
         assert (
-            decision.endpoint_url == "http://192.168.86.201:8001"
+            decision.endpoint_url == "http://192.168.86.201:8000"
         )  # onex-allow-internal-ip
 
 
@@ -166,11 +166,11 @@ class TestFastPathRouting:
         monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="test", prompt="Write tests for auth.py")
         decision = delta(req)
-        assert decision.selected_model == "deepseek-r1-14b"
+        assert decision.selected_model == "qwen3-coder-30b"
         assert (
-            decision.endpoint_url == "http://192.168.86.201:8001"
+            decision.endpoint_url == "http://192.168.86.201:8000"
         )  # onex-allow-internal-ip
-        assert decision.max_context_tokens == 24576
+        assert decision.max_context_tokens == 65536
 
     def test_long_prompt_skips_fast_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -202,20 +202,20 @@ class TestFastPathRouting:
         decision = delta(req)
         assert decision.selected_model == "qwen3-coder-30b"
 
-    def test_document_uses_deepseek_fast_path(
+    def test_document_uses_coder_fast_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Document tasks use deepseek-r1-14b (fast path in local tier)."""
+        """Document tasks use qwen3-coder-30b (fast path in local tier)."""
         bifrost = _write_bifrost(
             tmp_path,
             {
-                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
             },  # onex-allow-internal-ip
         )
         monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)
         req = _request(task_type="document", prompt="short prompt")
         decision = delta(req)
-        assert decision.selected_model == "deepseek-r1-14b"
+        assert decision.selected_model == "qwen3-coder-30b"
 
 
 class TestMissingEndpoint:
@@ -284,7 +284,7 @@ class TestSystemPrompts:
         bifrost = _write_bifrost(
             tmp_path,
             {
-                "local-deepseek-r1-14b": "http://192.168.86.201:8001"
+                "local-qwen-coder-30b": "http://192.168.86.201:8000"
             },  # onex-allow-internal-ip
         )
         monkeypatch.setenv("BIFROST_CONTRACT_PATH", bifrost)

--- a/uv.lock
+++ b/uv.lock
@@ -2324,7 +2324,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.148.7,<7.0.0" },
     { name = "kafka-python", specifier = ">=2.0.2,<3.0.0" },
     { name = "locust", specifier = ">=2.31.8,<3.0.0" },
-    { name = "mypy", specifier = ">=1.13.0,<2.0.0" },
+    { name = "mypy", specifier = ">=1.13.0,<3.0.0" },
     { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
     { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
     { name = "pytest", specifier = ">=8.4.0,<10.0.0" },


### PR DESCRIPTION
## Summary
- preserves the canonical-clone delegation runtime live-patch work in a ticket branch
- wires delegation output events through an in-process bridge and carries prompt/response text into task-delegated events
- adds projection migrations for delegation_events and node_service_registry

## Verification
- uv run pytest tests/integration/nodes/test_delegation_pipeline_e2e.py -q
- pre-commit hooks passed during commit and push

## Runtime impact
- No deploy performed
- No runtime restart performed
- No .201 mutation performed

Evidence-Source: OCC#990
Evidence-Ticket: OMN-10940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegation events now include prompt and response text for better traceability.
  * Document tasks now route to the Qwen coder backend for improved handling.

* **Infrastructure Updates**
  * Added delegation event storage with shadow-comparison and analysis capabilities.
  * Added a node service registry for health and activity tracking.
  * Projections now recognize delegation shadow-comparison events.

* **Testing / QA**
  * Updated integration/unit tests and CI gate logic to reflect routing and contract sync changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1580)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->