### PR TITLE
feat(OMN-10926): delegation env scanner — enforce mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
       - name: Check no localhost env fallbacks in src/ (OMN-10732)
         run: uv run python scripts/validate_no_env_fallbacks.py
 
+      # SYNC: OMN-10926 — delegation env read scanner in enforce mode (Wave 2)
+      # Fails CI if any delegation/LLM/bifrost module adds a new bare os.environ/os.getenv read.
+      - name: Delegation env read scanner (enforce)
+        run: python scripts/ci/check_delegation_env_reads.py --mode enforce
+
       - name: Check topic suffix exports (F56)
         run: python scripts/validation/check_topic_suffix_exports.py
 

--- a/scripts/ci/check_delegation_env_reads.py
+++ b/scripts/ci/check_delegation_env_reads.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CI scanner for os.environ/os.getenv reads in delegation-owned modules.
+
+Detects direct environment variable access in delegation modules. Report mode
+(warn only) is used in Wave 0. Enforce mode (exit 1) is reserved for Wave 2
+after contract-driven config is landed.
+
+Module scope: nodes matching delegation/LLM-inference/bifrost patterns.
+
+Exit codes:
+    0: Scan completed (report mode always returns 0)
+    1: Violations found (enforce mode only)
+
+Usage:
+    python scripts/ci/check_delegation_env_reads.py
+    python scripts/ci/check_delegation_env_reads.py --mode enforce
+    python scripts/ci/check_delegation_env_reads.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DELEGATION_MODULE_PATTERNS = [
+    "nodes/node_delegation_",
+    "nodes/node_delegate_skill_",
+    "nodes/node_delegation_routing_",
+    "nodes/node_llm_inference_",
+    "nodes/node_llm_completion_",
+    "nodes/node_llm_embedding_",
+    "nodes/node_delegation_quality_gate_",
+    "nodes/node_projection_delegation",
+    "delegation/",
+    "adapters/llm/",
+]
+
+ALLOWLISTED_PATH_SEGMENTS = [
+    "tests/",
+    "fixtures/",
+    "conftest.py",
+    "__pycache__/",
+]
+
+# Inline skip token: # ONEX_FLAG_EXEMPT or # ONEX_EXCLUDE allows a line
+SKIP_TOKENS = ["ONEX_FLAG_EXEMPT", "ONEX_EXCLUDE"]
+
+
+@dataclass
+class ScanResult:
+    scanned_files: int = 0
+    violations: list[str] = field(default_factory=list)
+    report_generated: bool = False
+
+
+def _is_allowlisted(rel_path: str) -> bool:
+    return any(segment in rel_path for segment in ALLOWLISTED_PATH_SEGMENTS)
+
+
+def _is_delegation_module(rel_path: str) -> bool:
+    return any(pattern in rel_path for pattern in DELEGATION_MODULE_PATTERNS)
+
+
+def _has_skip_token(line: str) -> bool:
+    return any(token in line for token in SKIP_TOKENS)
+
+
+def _find_env_calls_in_source(source: str, filepath: str) -> list[str]:
+    """Return list of violation strings for env calls in the given source.
+
+    Deduplicates by line number, keeping the most specific match
+    (os.environ.get > os.environ > os.getenv).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+
+    # Map lineno -> (call_repr, specificity, end_lineno) — higher specificity wins
+    # Walk ast.Call (not ast.Attribute) so end_lineno covers the closing ) and any
+    # inline ONEX_EXCLUDE comment on the same line as the closing paren.
+    # specificity: os.environ.get=2, os.environ[...]=1, os.getenv=1
+    best_per_line: dict[int, tuple[str, int, int]] = {}
+
+    for node in ast.walk(tree):
+        lineno: int | None = None
+        call_repr: str | None = None
+        specificity: int = 1
+        end_lineno: int
+
+        # os.getenv(...) or os.environ[...] (Subscript, not a Call)
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+            and node.attr in ("environ", "getenv")
+        ):
+            lineno = node.lineno
+            call_repr = f"os.{node.attr}"
+            end_lineno = getattr(node, "end_lineno", node.lineno)
+
+        # os.environ.get(...) or os.getenv(...) — prefer Call for accurate end_lineno
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "getenv"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            ):
+                lineno = node.lineno
+                call_repr = "os.getenv"
+                end_lineno = getattr(node, "end_lineno", node.lineno)
+            elif (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "environ"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id == "os"
+            ):
+                lineno = node.lineno
+                call_repr = "os.environ.get"
+                specificity = 2
+                end_lineno = getattr(node, "end_lineno", node.lineno)
+
+        if lineno is not None and call_repr is not None:
+            existing = best_per_line.get(lineno)
+            if existing is None or specificity > existing[1]:
+                best_per_line[lineno] = (call_repr, specificity, end_lineno)
+
+    violations: list[str] = []
+    for lineno in sorted(best_per_line):
+        call_repr, _, end_lineno = best_per_line[lineno]
+        line_text = lines[lineno - 1] if lineno <= len(lines) else ""
+        # Check all lines of a multi-line call for skip tokens (handles formatter-wrapped calls)
+        call_lines = (
+            lines[lineno - 1 : end_lineno] if end_lineno > lineno else [line_text]
+        )
+        if any(_has_skip_token(ln) for ln in call_lines):
+            continue
+        violations.append(f"{filepath}:{lineno}: {call_repr} — {line_text.strip()}")
+
+    return violations
+
+
+def scan_delegation_modules(
+    repo_root: Path | None = None,
+    mode: str = "report",
+) -> ScanResult:
+    if repo_root is None:
+        # Walk up from this file to find the repo root (.git dir)
+        candidate = Path(__file__).parent
+        while candidate != candidate.parent:
+            if (candidate / ".git").exists():
+                repo_root = candidate
+                break
+            candidate = candidate.parent
+        else:
+            repo_root = Path.cwd()
+
+    result = ScanResult()
+
+    src_root = repo_root / "src"
+    if not src_root.exists():
+        result.report_generated = True
+        return result
+
+    for py_file in src_root.rglob("*.py"):
+        rel = str(py_file.relative_to(repo_root))
+        rel_forward = rel.replace("\\", "/")
+
+        if _is_allowlisted(rel_forward):
+            continue
+        if not _is_delegation_module(rel_forward):
+            continue
+
+        result.scanned_files += 1
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        violations = _find_env_calls_in_source(source, rel_forward)
+        result.violations.extend(violations)
+
+    result.report_generated = True
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan delegation modules for direct os.environ/os.getenv usage"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["report", "enforce"],
+        default="report",
+        help="report: warn only (default). enforce: exit 1 on violations.",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    # Locate repo root from CWD
+    candidate = Path.cwd()
+    repo_root: Path = candidate
+    while candidate != candidate.parent:
+        if (candidate / ".git").exists():
+            repo_root = candidate
+            break
+        candidate = candidate.parent
+
+    result = scan_delegation_modules(repo_root=repo_root, mode=args.mode)
+
+    if result.violations:
+        print(
+            f"[delegation-env-scanner] Found {len(result.violations)} env read(s) "
+            f"in delegation modules ({args.mode} mode)"
+        )
+        for v in sorted(result.violations):
+            print(f"  {v}")
+        if args.mode == "enforce":
+            print(
+                "\nFix: replace os.environ/os.getenv with contract-driven config "
+                "resolution (OMN-10915 Wave 2)."
+            )
+            return 1
+        print(
+            "\n[report mode] These will become blocking violations in Wave 2 "
+            "(OMN-10917 → OMN-10915)."
+        )
+    elif args.verbose:
+        print(
+            f"[delegation-env-scanner] OK — scanned {result.scanned_files} files, "
+            "no violations."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/tests/test_delegation_env_scanner.py
+++ b/scripts/ci/tests/test_delegation_env_scanner.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the delegation env read scanner (OMN-10926).
+
+Verifies enforce mode catches new violations and respects ONEX_FLAG_EXEMPT /
+ONEX_EXCLUDE annotations, including on the closing ) of formatter-wrapped calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_CI = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_CI))
+
+from check_delegation_env_reads import (
+    ScanResult,
+    _find_env_calls_in_source,
+    _is_allowlisted,
+    _is_delegation_module,
+    scan_delegation_modules,
+)
+
+
+class TestIsDelegationModule:
+    def test_adapters_llm(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py"
+        )
+
+    def test_node_llm_inference(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config_loader_bifrost.py"
+        )
+
+    def test_delegation_orchestrator(self) -> None:
+        assert _is_delegation_module(
+            "src/omnibase_infra/nodes/node_delegation_orchestrator/handlers/h.py"
+        )
+
+    def test_non_delegation_excluded(self) -> None:
+        assert not _is_delegation_module("src/omnibase_infra/runtime/service_kernel.py")
+
+
+class TestIsAllowlisted:
+    def test_test_file_allowlisted(self) -> None:
+        assert _is_allowlisted("tests/unit/delegation/test_foo.py")
+
+    def test_conftest_allowlisted(self) -> None:
+        assert _is_allowlisted("tests/conftest.py")
+
+    def test_handler_not_allowlisted(self) -> None:
+        assert not _is_allowlisted(
+            "src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py"
+        )
+
+
+class TestFindEnvCallsInSource:
+    def test_detects_os_environ_get(self) -> None:
+        source = 'import os\nvalue = os.environ.get("KEY", "")\n'
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 1
+        assert "os.environ.get" in violations[0]
+
+    def test_skips_onex_flag_exempt_same_line(self) -> None:
+        source = (
+            'import os\nvalue = os.environ.get("KEY", "")  # ONEX_FLAG_EXEMPT: test\n'
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+    def test_skips_onex_exclude_on_closing_paren(self) -> None:
+        source = (
+            "import os\n"
+            "value = os.environ.get(\n"
+            '    "KEY", ""\n'
+            ")  # ONEX_EXCLUDE: migration tracked\n"
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+    def test_skips_onex_flag_exempt_on_closing_paren(self) -> None:
+        source = (
+            "import os\n"
+            "value = os.environ.get(\n"
+            '    "KEY", ""\n'
+            ")  # ONEX_FLAG_EXEMPT: Wave 3 migration (OMN-10915)\n"
+        )
+        violations = _find_env_calls_in_source(source, "test.py")
+        assert len(violations) == 0
+
+
+@pytest.mark.unit
+class TestScanDelegationModules:
+    def test_scanner_clean_in_enforce_mode(self) -> None:
+        """After OMN-10926, enforce mode must return zero violations on current code."""
+        repo_root = Path(__file__).parent.parent.parent
+        result = scan_delegation_modules(repo_root=repo_root, mode="enforce")
+        assert len(result.violations) == 0, (
+            "Unexpected env reads in delegation modules — add ONEX_FLAG_EXEMPT or "
+            "replace with contract-driven config (OMN-10915):\n"
+            + "\n".join(result.violations)
+        )
+
+    def test_report_mode_does_not_fail(self) -> None:
+        repo_root = Path(__file__).parent.parent.parent
+        result = scan_delegation_modules(repo_root=repo_root, mode="report")
+        assert result.report_generated
+
+    def test_scan_result_dataclass(self) -> None:
+        result = ScanResult()
+        assert result.scanned_files == 0
+        assert result.violations == []
+        assert result.report_generated is False
+
+    def test_enforce_mode_catches_new_violation(self, tmp_path: Path) -> None:
+        """Enforce mode exits non-zero when a bare env read appears in a delegation module."""
+        src = tmp_path / "src" / "omnibase_infra" / "adapters" / "llm"
+        src.mkdir(parents=True)
+        (src / "new_adapter.py").write_text(
+            'import os\nendpoint = os.environ.get("LLM_URL", "")\n'
+        )
+        (tmp_path / ".git").mkdir()
+
+        result = scan_delegation_modules(repo_root=tmp_path, mode="enforce")
+        assert len(result.violations) == 1
+        assert "os.environ.get" in result.violations[0]
+
+    def test_enforce_mode_passes_when_exempt(self, tmp_path: Path) -> None:
+        """Enforce mode passes when ONEX_FLAG_EXEMPT is on the violation line."""
+        src = tmp_path / "src" / "omnibase_infra" / "adapters" / "llm"
+        src.mkdir(parents=True)
+        (src / "new_adapter.py").write_text(
+            "import os\n"
+            'endpoint = os.environ.get("LLM_URL", "")  # ONEX_FLAG_EXEMPT: Wave 3\n'
+        )
+        (tmp_path / ".git").mkdir()
+
+        result = scan_delegation_modules(repo_root=tmp_path, mode="enforce")
+        assert len(result.violations) == 0
+
+    def test_scanner_ignores_non_llm_adapters(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "omnibase_infra" / "runtime"
+        src.mkdir(parents=True)
+        (src / "service_kernel.py").write_text('import os\nos.environ.get("KEY")\n')
+        (tmp_path / ".git").mkdir()
+
+        result = scan_delegation_modules(repo_root=tmp_path, mode="enforce")
+        assert result.scanned_files == 0
+        assert result.violations == []

--- a/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
@@ -156,8 +156,11 @@ class AdapterCodeAnalysisEnrichment:
             temperature: Sampling temperature (lower = more deterministic).
             api_key: Optional Bearer token for authenticated endpoints.
         """
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_CODER_URL", "http://localhost:8000"
+        self._base_url: str = (
+            base_url
+            or os.environ.get(  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
+                "LLM_CODER_URL", "http://localhost:8000"
+            )
         )
         self._model: str = model
         self._max_tokens: int = max_tokens

--- a/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
@@ -255,8 +255,11 @@ class AdapterCodeReviewAnalysis:
                 "Provide a valid URL or set the LLM_CODER_FAST_URL environment variable.",
                 context=context,
             )
-        resolved_base_url: str = base_url or os.environ.get(
-            "LLM_CODER_FAST_URL", "http://localhost:8001"
+        resolved_base_url: str = (
+            base_url
+            or os.environ.get(  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
+                "LLM_CODER_FAST_URL", "http://localhost:8001"
+            )
         )
         if not resolved_base_url.strip():
             context = ModelInfraErrorContext.with_correlation(

--- a/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
@@ -246,8 +246,11 @@ class AdapterDocumentationGeneration:
                 "Provide a valid URL or set the LLM_DEEPSEEK_R1_URL environment variable.",
                 context=context,
             )
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_DEEPSEEK_R1_URL", "http://localhost:8001"
+        self._base_url: str = (
+            base_url
+            or os.environ.get(  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
+                "LLM_DEEPSEEK_R1_URL", "http://localhost:8001"
+            )
         )
         self._model: str = model
         self._max_tokens: int = max_tokens

--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -216,7 +216,7 @@ class AdapterLlmProviderOpenai:
         self._provider_type_value = provider_type
         self._base_url = base_url or os.environ.get(
             "LLM_CODER_URL", "http://localhost:8000"
-        )
+        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         self._default_model = default_model
         self._api_key = api_key
         self._is_available = True

--- a/src/omnibase_infra/adapters/llm/adapter_similarity_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_similarity_enrichment.py
@@ -134,7 +134,9 @@ class AdapterSimilarityEnrichment:
                 by Qdrant before results are returned.  ``None`` disables the
                 threshold (all results up to ``top_k`` are returned).
         """
-        _embedding_base_url = embedding_base_url or os.environ.get("LLM_EMBEDDING_URL")
+        _embedding_base_url = embedding_base_url or os.environ.get(
+            "LLM_EMBEDDING_URL"
+        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         if not _embedding_base_url:
             raise ProtocolConfigurationError(
                 "embedding_base_url is required. Set LLM_EMBEDDING_URL environment variable.",
@@ -145,7 +147,9 @@ class AdapterSimilarityEnrichment:
             )
         self._embedding_base_url: str = _embedding_base_url
         self._embedding_model: str = embedding_model
-        _qdrant_url = qdrant_url or os.environ.get("QDRANT_URL")
+        _qdrant_url = qdrant_url or os.environ.get(
+            "QDRANT_URL"
+        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         if not _qdrant_url:
             raise ProtocolConfigurationError(
                 "qdrant_url is required. Set QDRANT_URL environment variable.",

--- a/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
@@ -194,7 +194,7 @@ class AdapterSummarizationEnrichment:
 
         self._base_url: str = base_url or os.environ.get(
             "LLM_QWEN_72B_URL", "http://localhost:8100"
-        )
+        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         self._model: str = model
         self._token_threshold: int = token_threshold
         self._summary_max_tokens: int = summary_max_tokens

--- a/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
@@ -266,7 +266,7 @@ class AdapterTestBoilerplateGeneration:
             )
         self._base_url: str = base_url or os.environ.get(
             "LLM_CODER_FAST_URL", "http://localhost:8001"
-        )
+        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         if not self._base_url.strip():
             context = ModelInfraErrorContext.with_correlation(
                 transport_type=EnumInfraTransportType.HTTP,

--- a/src/omnibase_infra/adapters/llm/consumer_llm_inference.py
+++ b/src/omnibase_infra/adapters/llm/consumer_llm_inference.py
@@ -134,8 +134,15 @@ async def start_llm_inference_consumer(
                 # Route by model name heuristics
                 model_lower = model_name.lower()
                 if "glm" in model_lower:
-                    base_url = os.environ.get("LLM_GLM_URL", "")
-                    api_key = api_key or os.environ.get("LLM_GLM_API_KEY", "")
+                    base_url = os.environ.get(
+                        "LLM_GLM_URL", ""
+                    )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
+                    api_key = (
+                        api_key
+                        or os.environ.get(
+                            "LLM_GLM_API_KEY", ""
+                        )  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
+                    )
                 elif "deepseek" in model_lower:
                     base_url = endpoints.get("LLM_DEEPSEEK_R1_URL", "")
                 elif "coder" in model_lower or "qwen" in model_lower:

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config_loader_bifrost.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config_loader_bifrost.py
@@ -77,7 +77,9 @@ def load_bifrost_config_from_env() -> ModelBifrostConfig:
     # External backends (only added when API key is configured)
     _add_backend_if_set(backends, "glm", "GLM_BASE_URL")
     # Gemini uses a well-known base URL; only add when API key is present
-    if os.environ.get("GEMINI_API_KEY", "").strip():
+    if os.environ.get(
+        "GEMINI_API_KEY", ""
+    ).strip():  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
         _add_backend_if_set(
             backends,
             "gemini",
@@ -118,7 +120,9 @@ def _add_backend_if_set(
     default_url: str | None = None,
 ) -> None:
     """Add a backend entry if the env var is set and non-empty."""
-    url = os.environ.get(env_var, "").strip()
+    url = os.environ.get(
+        env_var, ""
+    ).strip()  # ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)
     if not url and default_url:
         url = default_url
     if not url:

--- a/tests/integration/test_delegation_contract_bootstrap.py
+++ b/tests/integration/test_delegation_contract_bootstrap.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Prove delegation runtime boots from contract config with zero delegation env vars."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+FIXTURE = (
+    Path(__file__).parent.parent / "fixtures" / "delegation-runtime-profile-test.yaml"
+)
+
+DELEGATION_ENV_VARS = [
+    "KAFKA_BOOTSTRAP_SERVERS",
+    "KAFKA_BROKER_ALLOWLIST",
+    "LLM_CODER_URL",
+    "LLM_CODER_FAST_URL",
+    "LLM_CODER_MODEL_NAME",
+    "LLM_CODER_FAST_MODEL_NAME",
+    "BIFROST_CONTRACT_PATH",
+    "TASK_CLASS_CONTRACT_PATH",
+    "LLM_ENDPOINT_CIDR_ALLOWLIST",
+    "LOCAL_LLM_SHARED_SECRET",
+]
+
+
+@pytest.fixture
+def clean_delegation_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in DELEGATION_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.integration
+def test_fixture_exists() -> None:
+    assert FIXTURE.exists(), f"Test fixture not found: {FIXTURE}"
+
+
+@pytest.mark.integration
+def test_contract_loads_with_no_delegation_env_vars(clean_delegation_env: None) -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    profile = loader.load()
+    assert profile.name == "delegation-runtime-profile"
+    assert profile.version == 1
+
+
+@pytest.mark.integration
+def test_event_bus_config_accessor(clean_delegation_env: None) -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    bus = loader.event_bus_config()
+    assert bus.provider == "kafka"
+    assert len(bus.bootstrap_servers) > 0
+
+
+@pytest.mark.integration
+def test_llm_backend_config_accessor(clean_delegation_env: None) -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    llm = loader.llm_backend_config()
+    assert llm is not None
+
+
+@pytest.mark.integration
+def test_security_config_accessor(clean_delegation_env: None) -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    security = loader.security_config()
+    assert security is not None
+
+
+@pytest.mark.integration
+def test_no_delegation_env_reads_during_load(
+    clean_delegation_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Critical: prove the loader does not read any delegation env vars."""
+    env_reads: list[str] = []
+    original_getenv = os.getenv
+
+    def tracking_getenv(key: str, default: str | None = None) -> str | None:
+        env_reads.append(key)
+        return original_getenv(key, default)
+
+    monkeypatch.setattr(os, "getenv", tracking_getenv)
+
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    loader.load()
+
+    delegation_reads = [k for k in env_reads if k in DELEGATION_ENV_VARS]
+    assert delegation_reads == [], (
+        f"Loader read delegation env vars: {delegation_reads}"
+    )
+
+
+@pytest.mark.integration
+def test_missing_file_raises_not_found_error() -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+        DelegationProfileNotFoundError,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=Path("/nonexistent/path.yaml"))
+    with pytest.raises(DelegationProfileNotFoundError):
+        loader.load()
+
+
+@pytest.mark.integration
+def test_loader_caches_after_first_load(clean_delegation_env: None) -> None:
+    from omnibase_infra.runtime.delegation_profile_config_loader import (
+        DelegationProfileConfigLoader,
+    )
+
+    loader = DelegationProfileConfigLoader(contract_path=FIXTURE)
+    profile1 = loader.load()
+    profile2 = loader.load()
+    assert profile1 is profile2


### PR DESCRIPTION
## Summary
- Add `scripts/ci/check_delegation_env_reads.py` (ported from omnimarket with `ast.Call` fix for accurate `end_lineno` on multi-line calls)
- Wire scanner as `--mode enforce` in CI lint job — CI now fails if any bare `os.environ`/`os.getenv` read is added to delegation/LLM/bifrost modules
- Annotate 12 remaining LLM adapter env reads with `# ONEX_FLAG_EXEMPT: Wave 3 migration to contract config (OMN-10915)` — these are tracked for the next migration wave
- Add 17 scanner tests: enforce mode catches new violation, exempt annotations suppress correctly, multi-line closing-`) ONEX_FLAG_EXEMPT is honored

**Key scanner fix:** `ast.Attribute.end_lineno` only covers the attribute token, not call arguments. By walking `ast.Call` nodes instead, `end_lineno` covers the full call including the closing `)`, so skip tokens placed there by the ruff formatter are correctly detected.

**Depends on:** OMN-10925 (PR #1582) must merge first (provides the base branch).

## Test plan
- [ ] `python scripts/ci/check_delegation_env_reads.py --mode enforce --verbose` exits 0
- [ ] 17 scanner tests pass in `scripts/ci/tests/test_delegation_env_scanner.py`
- [ ] CI `Delegation env read scanner (enforce)` step blocks PRs that add bare env reads

OMN-10926