### PR TITLE
feat(OMN-10937): wire reviewdog caller workflow

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,17 @@
+name: reviewdog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+jobs:
+  reviewdog:
+    uses: OmniNode-ai/omniclaude/.github/workflows/reviewdog-review.yml@main
+    with:
+      src-dir: "src/"
+      ruff-enabled: true
+      mypy-enabled: true
+      security-enabled: true
+      fail-level: "error"
+    secrets:
+      REVIEWDOG_PAT: ${{ secrets.REVIEWDOG_PAT }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   reviewdog:
-    uses: OmniNode-ai/omniclaude/.github/workflows/reviewdog-review.yml@main
+    uses: OmniNode-ai/omniclaude/.github/workflows/reviewdog-review.yml@f0892d9cb908b0eaa44a0c5a89dc4b37b27a8b19
     with:
       src-dir: "src/"
       ruff-enabled: true


### PR DESCRIPTION
## Summary
- Adds reviewdog caller workflow consuming reusable workflow from omniclaude
- Triggers on pull_request and merge_group
- Python linters (ruff, mypy) + security scanners enabled

## Test plan
- [ ] YAML syntax validates
- [ ] CI green (reviewdog check will activate after omniclaude PR #1575 merges)

Fixes OMN-10937 (child of OMN-10928)

Evidence-Source: OCC#991

Evidence-Ticket: OMN-10937