### PR TITLE
feat(OMN-10949): add pricing_manifest_version to ModelTaskDelegatedEvent

### DIFF
--- a/contracts/OMN-10949.yaml
+++ b/contracts/OMN-10949.yaml
@@ -15,4 +15,4 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "echo 'deploy: pricing_manifest_version is backward-compatible additive field; old events default to 0 via extra=ignore'"
+        check_value: "echo 'deploy: pricing_manifest_version is a backward-compatible additive field; old events missing this field default to 0 via model field default'"

--- a/contracts/OMN-10949.yaml
+++ b/contracts/OMN-10949.yaml
@@ -1,0 +1,18 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-10949"
+title: "feat(OMN-10949): add pricing_manifest_version to ModelTaskDelegatedEvent"
+summary: "Adds pricing_manifest_version field to ModelTaskDelegatedEvent for savings audit and recomputation."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-deploy-additive"
+    description: "pricing_manifest_version is an additive field with default=0. No deploy restart required."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy: pricing_manifest_version is backward-compatible additive field; old events default to 0 via extra=ignore'"

--- a/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
+++ b/src/omnibase_infra/nodes/node_delegation_orchestrator/models/model_task_delegated_event.py
@@ -91,6 +91,11 @@ class ModelTaskDelegatedEvent(BaseModel):
         default=None,
         description="Raw response received from the delegated model.",
     )
+    pricing_manifest_version: int = Field(
+        default=0,
+        ge=0,
+        description="Version of the pricing manifest used to compute cost_savings_usd.",
+    )
 
 
 __all__: list[str] = ["ModelTaskDelegatedEvent"]

--- a/tests/integration/delegation/test_pricing_version_wire_compat.py
+++ b/tests/integration/delegation/test_pricing_version_wire_compat.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: pricing_manifest_version wire-format compatibility (OMN-10949).
+
+Verifies that ``pricing_manifest_version`` survives the cross-model mapping
+and JSON wire roundtrip used by the delegation orchestrator and the omnidash
+projection consumer:
+
+1. ``ModelTaskDelegatedEvent`` -> Kafka JSON wire -> deserialization preserves
+   the new field so omnidash's DelegationProjection can persist it.
+2. Backward compatibility: payloads emitted before OMN-10949 lack the field
+   and must deserialize with the default of 0, so legacy events do not crash
+   the projection consumer.
+
+Unit tests in tests/unit cover individual model defaults and validation.
+This module proves the field survives the wire roundtrip that the real
+event-bus producer and consumer perform.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+    ModelTaskDelegatedEvent,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _make_event(*, pricing_manifest_version: int = 0) -> ModelTaskDelegatedEvent:
+    return ModelTaskDelegatedEvent(
+        timestamp="2026-05-13T10:00:00Z",
+        correlation_id=uuid4(),
+        task_type="code_generation",
+        delegated_to="local-qwen3",
+        quality_gate_passed=True,
+        pricing_manifest_version=pricing_manifest_version,
+    )
+
+
+class TestPricingVersionWireCompat:
+    """Prove pricing_manifest_version survives Kafka wire roundtrip."""
+
+    def test_event_json_wire_roundtrip_preserves_pricing_version(self) -> None:
+        """Event -> JSON (Kafka wire) -> deserialization preserves pricing_manifest_version."""
+        event = _make_event(pricing_manifest_version=7)
+        wire = event.model_dump(mode="json")
+
+        assert wire["pricing_manifest_version"] == 7
+
+        restored = ModelTaskDelegatedEvent.model_validate(wire)
+        assert restored.pricing_manifest_version == 7
+        assert restored.correlation_id == event.correlation_id
+
+    def test_backward_compat_legacy_payload_without_pricing_version(self) -> None:
+        """Legacy payloads emitted before OMN-10949 deserialize with default 0.
+
+        Simulates an omnidash projection consumer receiving an event produced
+        before the pricing_manifest_version field was added. The consumer must
+        not crash; the default of 0 must apply so the projection row records
+        an explicit "unknown manifest" sentinel.
+        """
+        legacy_payload = {
+            "timestamp": "2026-05-09T12:00:00Z",
+            "correlation_id": str(uuid4()),
+            "task_type": "code_generation",
+            "delegated_to": "local-qwen3",
+            "quality_gate_passed": True,
+        }
+        event = ModelTaskDelegatedEvent.model_validate(legacy_payload)
+        assert event.pricing_manifest_version == 0
+
+    def test_full_wire_roundtrip_with_nonzero_pricing_version(self) -> None:
+        """End-to-end: event with explicit pricing_manifest_version -> wire -> restore."""
+        event = _make_event(pricing_manifest_version=42)
+
+        # Producer side: serialize for Kafka publish
+        wire = event.model_dump(mode="json")
+
+        # Consumer side: omnidash projection deserialization
+        consumed = ModelTaskDelegatedEvent.model_validate(wire)
+
+        assert consumed.pricing_manifest_version == 42
+        assert consumed.task_type == "code_generation"
+        assert consumed.quality_gate_passed is True

--- a/tests/unit/nodes/node_delegation_orchestrator/models/test_pricing_version_field.py
+++ b/tests/unit/nodes/node_delegation_orchestrator/models/test_pricing_version_field.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Unit tests for pricing_manifest_version on ModelTaskDelegatedEvent.
+
+OMN-10949: Projection rows must include pricing_manifest_version so
+savings can be audited and recomputed against any manifest revision.
+Events without the field default to version 0.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.nodes.node_delegation_orchestrator.models.model_task_delegated_event import (
+    ModelTaskDelegatedEvent,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _base_event(**overrides: object) -> ModelTaskDelegatedEvent:
+    defaults: dict[str, object] = {
+        "timestamp": "2026-05-13T10:00:00Z",
+        "correlation_id": uuid4(),
+        "task_type": "code_generation",
+        "delegated_to": "local-qwen3",
+        "quality_gate_passed": True,
+    }
+    defaults.update(overrides)
+    return ModelTaskDelegatedEvent(**defaults)  # type: ignore[arg-type]
+
+
+class TestPricingManifestVersion:
+    def test_default_is_zero(self) -> None:
+        event = _base_event()
+        assert event.pricing_manifest_version == 0
+
+    def test_explicit_version_accepted(self) -> None:
+        event = _base_event(pricing_manifest_version=3)
+        assert event.pricing_manifest_version == 3
+
+    def test_serialization_roundtrip(self) -> None:
+        event = _base_event(pricing_manifest_version=7)
+        data = event.model_dump(mode="json")
+        assert data["pricing_manifest_version"] == 7
+        restored = ModelTaskDelegatedEvent.model_validate(data)
+        assert restored.pricing_manifest_version == 7
+
+    def test_extra_field_still_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            _base_event(unknown_field="bad")


### PR DESCRIPTION
## Summary

- Adds `pricing_manifest_version: int = Field(default=0, ge=0)` to `ModelTaskDelegatedEvent` so the pricing manifest version used to compute `cost_savings_usd` is included on the wire event.
- Events emitted by older producers (no field present) default to version 0.
- Includes 4 unit tests covering default, explicit value, serialization roundtrip, and extra-field rejection.

## Ticket

OMN-10949

## Test plan

- [x] `pytest tests/unit/nodes/node_delegation_orchestrator/models/test_pricing_version_field.py` — 4 passed
- [x] `pytest tests/unit/nodes/node_delegation_orchestrator/` — 63 passed, no regressions
- [x] All pre-commit hooks passed

Evidence-Source: OCC#999
Evidence-Ticket: OMN-10949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now include a pricing manifest version field to record which pricing manifest produced reported cost savings; missing values default to 0 for backward compatibility.

* **Tests**
  * Added unit and integration tests to verify the new field, JSON wire roundtrips, serialization, and legacy-deserialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1588)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->