### PR TITLE
fix(OMN-9126): pin omnibase-core to main for multi-param resolver injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", rev = "51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" }
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "b42e6dae20f9ac02ef35a776c35ec32aae0023ed" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", rev = "51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" }
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "235c31996d20217c4270319b59dc76a0568fe078" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", branch = "main" }
 [tool.ruff]

--- a/tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py
+++ b/tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py
@@ -11,7 +11,9 @@ manifest. The fixture contains at least one handler per branch:
 
     * RESOLVED_VIA_NODE_REGISTRY       — materialized explicit dep map
     * RESOLVED_VIA_CONTAINER           — container.get_service returns instance
-    * RESOLVED_VIA_EVENT_BUS           — ``__init__(self, event_bus)``
+    * RESOLVED_VIA_KNOWN_PARAMS        — ``__init__(self, event_bus)`` (subsumes
+                                         the legacy single-param EVENT_BUS path
+                                         per OMN-10278)
     * RESOLVED_VIA_ZERO_ARG            — zero-arg constructor
     * RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP — node not hosted here
 
@@ -96,7 +98,13 @@ class HandlerContainerOwned:
 
 
 class HandlerEventBusOwned:
-    """Handler resolved via RESOLVED_VIA_EVENT_BUS (single event_bus kwarg)."""
+    """Handler resolved via RESOLVED_VIA_KNOWN_PARAMS (single event_bus kwarg).
+
+    Historically this branch resolved as RESOLVED_VIA_EVENT_BUS. With the
+    OMN-10278 multi-param resolver extension, the single-param event_bus path
+    is subsumed by the broader RESOLVED_VIA_KNOWN_PARAMS outcome — same
+    handler, same dependency, new outcome enum label.
+    """
 
     def __init__(self, event_bus: object) -> None:
         self.event_bus = event_bus
@@ -412,12 +420,12 @@ class TestFullAutoWiringExercisesResolver:
             is EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER
         )
 
-        # Event-bus branch
+        # Known-params branch (subsumes legacy EVENT_BUS path per OMN-10278)
         event_bus_contract = _find_contract(report, "node_event_bus_owned")
         assert len(event_bus_contract.wirings) == 1
         assert (
             event_bus_contract.wirings[0].resolution_outcome
-            is EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
+            is EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS
         )
 
         # Zero-arg branch
@@ -458,10 +466,12 @@ class TestFullAutoWiringExercisesResolver:
             f"precedence path; observed: {observed_outcomes!r}"
         )
         # Stronger: observed set equals expected full-branch coverage.
+        # RESOLVED_VIA_KNOWN_PARAMS subsumes the legacy single-param
+        # RESOLVED_VIA_EVENT_BUS path per OMN-10278.
         expected_outcomes = {
             EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
             EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
-            EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS,
             EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG,
             EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
         }

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=235c31996d20217c4270319b59dc76a0568fe078" },
     { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
 ]
 
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "omnibase-core"
 version = "0.40.2"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#235c31996d20217c4270319b59dc76a0568fe078" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=235c31996d20217c4270319b59dc76a0568fe078#235c31996d20217c4270319b59dc76a0568fe078" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2279,7 +2279,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
     { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=235c31996d20217c4270319b59dc76a0568fe078" },
     { name = "omnibase-spi", specifier = ">=0.20.6" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
     { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
 ]
 
@@ -2164,8 +2164,8 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.40.1"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed#b42e6dae20f9ac02ef35a776c35ec32aae0023ed" }
+version = "0.40.2"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#235c31996d20217c4270319b59dc76a0568fe078" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2279,7 +2279,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
     { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=51c39d8a743b6264ca0b72bd9efd90dcad6a6d3a" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=b42e6dae20f9ac02ef35a776c35ec32aae0023ed" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
     { name = "omnibase-spi", specifier = ">=0.20.6" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary

- Pin `omnibase-core` source to main branch (0.40.2) in `[tool.uv.sources]`
- Core 0.40.1 (PyPI) only supports single-param handler injection (event_bus). Core main extends Step 4 to multi-param injection covering event_bus, container, and ownership_query
- This fixes TypeError on 10+ handlers declaring `container: ModelONEXContainer` in `__init__` — the deploy blocker on .201 (three consecutive boot failures)

OMN-9126

Evidence-Source: OCC#1001
Evidence-Ticket: OMN-9126

## Test plan

- [ ] CI passes (Sibling Compat, Kafka gates, all test splits)
- [ ] Runtime boots on .201 with RestartCount == 0 after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the referenced omnibase-core dependency to a newer revision.

* **Tests**
  * Updated an integration test’s fixtures, assertions, and explanatory docs to expect the revised resolution outcome for a single event_bus scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1589)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->