### PR TITLE
fix(OMN-10954): make savings consumer non-fatal + fix dsn-mode POSTGRES_HOST crash

### DIFF
--- a/src/omnibase_infra/handlers/registration_storage/handler_registration_storage_postgres.py
+++ b/src/omnibase_infra/handlers/registration_storage/handler_registration_storage_postgres.py
@@ -241,9 +241,18 @@ class HandlerRegistrationStoragePostgres(MixinAsyncCircuitBreaker):
             transport_type=cb_config.transport_type,
         )
 
-        # Store configuration — host is required via env var if not provided
+        # Store configuration — host is required via env var only when no DSN
+        # is provided (dsn-based pool creation does not consult host).
         self._dsn = dsn
-        self._host = host if host is not None else os.environ["POSTGRES_HOST"]  # ONEX_EXCLUDE: env  # fmt: skip
+        if host is not None:
+            self._host = host
+        elif dsn:
+            # DSN encodes connection target; host is unused on the dsn path.
+            # Keep a placeholder so attribute access stays valid for callers
+            # that read it for logging/diagnostics.
+            self._host = "(via-dsn)"
+        else:
+            self._host = os.environ["POSTGRES_HOST"]  # ONEX_EXCLUDE: env  # fmt: skip
         self._port = port
         self._database = database
         self._user = user

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1435,76 +1435,108 @@ async def bootstrap() -> int:
                 ]
 
                 async def _savings_consumer_loop() -> None:
-                    """Consume input events and produce savings estimates."""
+                    """Consume input events and produce savings estimates.
+
+                    Non-fatal: any failure (subscribe timeout, broker outage,
+                    missing topic on fresh broker) is logged and the task exits
+                    cleanly. Never propagates to the kernel.
+                    """
                     import json as _json
 
                     _poll_interval = 2.0
 
-                    for _input_topic in _savings_input_topics:
-                        try:
+                    try:
+                        for _input_topic in _savings_input_topics:
+                            try:
 
-                            async def _savings_on_message(
-                                msg: object,
-                                *,
-                                _topic: str = _input_topic,
-                            ) -> None:
-                                _savings_estimator.ingest_event(
-                                    _topic,
-                                    _json.loads(msg)  # type: ignore[arg-type]
-                                    if isinstance(msg, (str, bytes))
-                                    else msg,
+                                async def _savings_on_message(
+                                    msg: object,
+                                    *,
+                                    _topic: str = _input_topic,
+                                ) -> None:
+                                    _savings_estimator.ingest_event(
+                                        _topic,
+                                        _json.loads(msg)  # type: ignore[arg-type]
+                                        if isinstance(msg, (str, bytes))
+                                        else msg,
+                                    )
+
+                                await event_bus.subscribe(
+                                    _input_topic,
+                                    on_message=_savings_on_message,  # type: ignore[arg-type]
+                                    group_id=f"savings-estimator.{_input_topic}",
+                                )
+                            except asyncio.CancelledError:
+                                raise
+                            except BaseException:  # noqa: BLE001
+                                logger.warning(
+                                    "Could not subscribe to %s for savings estimation",
+                                    _input_topic,
+                                    exc_info=True,
                                 )
 
-                            await event_bus.subscribe(
-                                _input_topic,
-                                on_message=_savings_on_message,  # type: ignore[arg-type]
-                                group_id=f"savings-estimator.{_input_topic}",
-                            )
-                        except Exception:  # noqa: BLE001
-                            logger.warning(
-                                "Could not subscribe to %s for savings estimation",
-                                _input_topic,
-                                exc_info=True,
-                            )
-
-                    while True:
-                        try:
-                            await asyncio.sleep(_poll_interval)
-                            estimates = (
-                                await _savings_estimator.finalize_ready_sessions()
-                            )
-                            for estimate in estimates:
-                                try:
-                                    _envelope: ModelEventEnvelope[object] = (
-                                        ModelEventEnvelope(
-                                            payload=estimate,
-                                            correlation_id=str(
-                                                estimate.get("correlation_id", "")
-                                            ),
-                                            event_type="savings.estimated",
-                                            source="savings_estimation_consumer",
+                        while True:
+                            try:
+                                await asyncio.sleep(_poll_interval)
+                                estimates = (
+                                    await _savings_estimator.finalize_ready_sessions()
+                                )
+                                for estimate in estimates:
+                                    try:
+                                        _envelope: ModelEventEnvelope[object] = (
+                                            ModelEventEnvelope(
+                                                payload=estimate,
+                                                correlation_id=str(
+                                                    estimate.get("correlation_id", "")
+                                                ),
+                                                event_type="savings.estimated",
+                                                source="savings_estimation_consumer",
+                                            )
                                         )
-                                    )
-                                    await event_bus.publish_envelope(
-                                        _envelope,  # type: ignore[arg-type]
-                                        topic=_savings_topic,
-                                    )
-                                except Exception:  # noqa: BLE001
-                                    logger.warning(
-                                        "Failed to emit savings estimate",
-                                        exc_info=True,
-                                    )
-                        except asyncio.CancelledError:
-                            break
-                        except Exception:  # noqa: BLE001 — never crash the loop
-                            logger.warning(
-                                "Savings estimation loop iteration failed",
-                                exc_info=True,
-                            )
+                                        await event_bus.publish_envelope(
+                                            _envelope,  # type: ignore[arg-type]
+                                            topic=_savings_topic,
+                                        )
+                                    except Exception:  # noqa: BLE001
+                                        logger.warning(
+                                            "Failed to emit savings estimate",
+                                            exc_info=True,
+                                        )
+                            except asyncio.CancelledError:
+                                break
+                            except Exception:  # noqa: BLE001 — never crash the loop
+                                logger.warning(
+                                    "Savings estimation loop iteration failed",
+                                    exc_info=True,
+                                )
+                    except asyncio.CancelledError:
+                        raise
+                    except BaseException:  # noqa: BLE001 — task-level safety net
+                        logger.warning(
+                            "Savings estimation consumer terminated unexpectedly; "
+                            "pipeline will write zero rows until next runtime boot",
+                            exc_info=True,
+                        )
 
                 savings_task = asyncio.create_task(
                     _savings_consumer_loop(), name="savings-estimation-consumer"
                 )
+
+                def _savings_task_done(t: asyncio.Task[None]) -> None:
+                    """Silence unobserved task exceptions so they don't surface as kernel errors."""
+                    if t.cancelled():
+                        return
+                    exc = t.exception()
+                    if exc is not None:
+                        logger.warning(
+                            "Savings estimation consumer task exited with exception "
+                            "(correlation_id=%s): %s",
+                            correlation_id,
+                            exc,
+                            exc_info=exc,
+                        )
+
+                savings_task.add_done_callback(_savings_task_done)
                 logger.info(
                     "Savings estimation consumer started (correlation_id=%s)",
                     correlation_id,

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1440,10 +1440,16 @@ async def bootstrap() -> int:
                     Non-fatal: any failure (subscribe timeout, broker outage,
                     missing topic on fresh broker) is logged and the task exits
                     cleanly. Never propagates to the kernel.
+
+                    Subscriptions established here are tracked locally and
+                    unsubscribed in the task's finally block so the kernel
+                    does not retain orphan consumers ingesting events with no
+                    finalizer loop to drain them.
                     """
                     import json as _json
 
                     _poll_interval = 2.0
+                    _unsubscribes: list[Callable[[], Awaitable[None]]] = []
 
                     try:
                         for _input_topic in _savings_input_topics:
@@ -1461,14 +1467,15 @@ async def bootstrap() -> int:
                                         else msg,
                                     )
 
-                                await event_bus.subscribe(
+                                _unsubscribe = await event_bus.subscribe(
                                     _input_topic,
                                     on_message=_savings_on_message,  # type: ignore[arg-type]
                                     group_id=f"savings-estimator.{_input_topic}",
                                 )
+                                _unsubscribes.append(_unsubscribe)
                             except asyncio.CancelledError:
                                 raise
-                            except BaseException:  # noqa: BLE001
+                            except Exception:  # noqa: BLE001
                                 logger.warning(
                                     "Could not subscribe to %s for savings estimation",
                                     _input_topic,
@@ -1511,12 +1518,21 @@ async def bootstrap() -> int:
                                 )
                     except asyncio.CancelledError:
                         raise
-                    except BaseException:  # noqa: BLE001 — task-level safety net
+                    except Exception:  # noqa: BLE001 — task-level safety net
                         logger.warning(
                             "Savings estimation consumer terminated unexpectedly; "
                             "pipeline will write zero rows until next runtime boot",
                             exc_info=True,
                         )
+                    finally:
+                        for _unsubscribe in _unsubscribes:
+                            try:
+                                await _unsubscribe()
+                            except Exception:  # noqa: BLE001 — best-effort cleanup
+                                logger.warning(
+                                    "Failed to unsubscribe savings-estimator subscription",
+                                    exc_info=True,
+                                )
 
                 savings_task = asyncio.create_task(
                     _savings_consumer_loop(), name="savings-estimation-consumer"
@@ -1530,9 +1546,9 @@ async def bootstrap() -> int:
                     if exc is not None:
                         logger.warning(
                             "Savings estimation consumer task exited with exception "
-                            "(correlation_id=%s): %s",
+                            "(correlation_id=%s, exc_type=%s)",
                             correlation_id,
-                            exc,
+                            type(exc).__name__,
                             exc_info=exc,
                         )
 

--- a/tests/integration/handlers/test_handler_registration_storage_dsn_init.py
+++ b/tests/integration/handlers/test_handler_registration_storage_dsn_init.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration regression: dsn-constructed handler does not require POSTGRES_HOST.
+
+Context (OMN-10954):
+    Runtime boot on .201 crashed with ``KeyError('POSTGRES_HOST')`` inside
+    ``HandlerRegistrationStoragePostgres.__init__`` even when the kernel's
+    ``node_registration_orchestrator`` plugin constructed the handler with
+    ``dsn=OMNIBASE_INFRA_DB_URL``. The dsn-path of ``asyncpg.create_pool``
+    does not consult ``host``, so the env requirement was dead weight that
+    bricked container startup whenever the compose file shipped only
+    ``OMNIBASE_INFRA_DB_URL`` (the canonical seam) and omitted the legacy
+    ``POSTGRES_HOST`` var.
+
+    This integration test reproduces the boot wiring: it imports the same
+    constructor the plugin uses, calls it with the exact kwargs the plugin
+    passes, and asserts the call returns a usable handler with ``POSTGRES_HOST``
+    intentionally absent from the environment. No real Postgres pool is
+    created — the pool is lazy and only materialized on first request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.container import ModelONEXContainer
+from omnibase_infra.handlers.registration_storage.handler_registration_storage_postgres import (
+    HandlerRegistrationStoragePostgres,
+)
+
+
+@pytest.mark.integration
+def test_plugin_style_dsn_construction_without_postgres_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reproduce the boot-time call site that crashed runtime kernel on .201.
+
+    Mirrors ``node_registration_orchestrator.plugin._wire_registration_storage``:
+    constructs the handler with only ``container``, ``dsn``, and
+    ``auto_create_schema=True``. Asserts that the constructor succeeds with
+    ``POSTGRES_HOST`` cleared from the environment.
+    """
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    handler = HandlerRegistrationStoragePostgres(
+        container=ModelONEXContainer(),
+        dsn="postgresql://postgres:secret@postgres:5432/omnibase_infra",
+        auto_create_schema=True,
+    )
+
+    assert handler.handler_type == "postgresql"
+    assert handler._dsn == "postgresql://postgres:secret@postgres:5432/omnibase_infra"

--- a/tests/unit/handlers/test_handler_registration_storage_postgres_dsn_host.py
+++ b/tests/unit/handlers/test_handler_registration_storage_postgres_dsn_host.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression guard: dsn-based handler must not require POSTGRES_HOST env var.
+
+Context:
+    Runtime boot crashed with ``KeyError('POSTGRES_HOST')`` inside
+    ``HandlerRegistrationStoragePostgres.__init__`` even when constructed
+    with ``dsn=...`` set from ``OMNIBASE_INFRA_DB_URL``. The dsn-path of
+    ``asyncpg.create_pool`` does not consult ``host``, so requiring it
+    from the environment is a wiring bug.
+
+    Fix: skip the ``os.environ["POSTGRES_HOST"]`` lookup when ``dsn`` is
+    provided; keep the env requirement only for the host/port construction
+    path that asyncpg actually consumes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.container import ModelONEXContainer
+from omnibase_infra.handlers.registration_storage.handler_registration_storage_postgres import (
+    HandlerRegistrationStoragePostgres,
+)
+
+
+@pytest.mark.unit
+def test_dsn_construction_does_not_require_postgres_host_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructor with dsn must succeed even when POSTGRES_HOST is unset."""
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    handler = HandlerRegistrationStoragePostgres(
+        container=ModelONEXContainer(),
+        dsn="postgresql://postgres:secret@postgres:5432/omnibase_infra",
+    )
+
+    assert handler._dsn == "postgresql://postgres:secret@postgres:5432/omnibase_infra"
+
+
+@pytest.mark.unit
+def test_explicit_host_overrides_postgres_host_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit host argument must take precedence over env var."""
+    monkeypatch.setenv("POSTGRES_HOST", "env-host")
+
+    handler = HandlerRegistrationStoragePostgres(
+        container=ModelONEXContainer(),
+        host="explicit-host",
+    )
+
+    assert handler._host == "explicit-host"
+
+
+@pytest.mark.unit
+def test_no_dsn_no_host_falls_back_to_postgres_host_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When neither dsn nor host is provided, env var is the source of truth."""
+    monkeypatch.setenv("POSTGRES_HOST", "env-host")
+
+    handler = HandlerRegistrationStoragePostgres(container=ModelONEXContainer())
+
+    assert handler._host == "env-host"
+
+
+@pytest.mark.unit
+def test_no_dsn_no_host_no_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without dsn, host, or env var the constructor must fail loudly."""
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    with pytest.raises(KeyError):
+        HandlerRegistrationStoragePostgres(container=ModelONEXContainer())


### PR DESCRIPTION
## Summary

Unblocks the .201 runtime deploy. After auto-wiring completes successfully (0 failures, 166 handlers wired), two crash paths kill the kernel before it can serve traffic.

1. **Savings consumer crash** — `_savings_consumer_loop` surfaces an `InfraTimeoutError` when subscribing to an input topic that doesn't exist on a fresh broker. The task is wrapped in a top-level safety net (catch `BaseException` except `CancelledError`, log warning, exit cleanly) and a done-callback silences unobserved-task-exception escalation. Pattern matches the existing best-effort wiring (`ServiceRuntimeHealthMonitor`, `node_registration_orchestrator`).

2. **`HandlerRegistrationStoragePostgres` `POSTGRES_HOST` KeyError** — constructor unconditionally read `os.environ["POSTGRES_HOST"]` when `host` was `None`, even when the caller (`node_registration_orchestrator.plugin`) supplied `dsn=OMNIBASE_INFRA_DB_URL`. The dsn-path of asyncpg never consults host. Skip the env lookup when dsn is set.

OMN-10954

Evidence-Source: OCC#1002
Evidence-Ticket: OMN-10954

## Test plan

- [x] 4 new unit tests in `tests/unit/handlers/test_handler_registration_storage_postgres_dsn_host.py` cover dsn-bypass, explicit-host precedence, env-fallback, and fail-fast paths
- [x] Existing `tests/integration/runtime/test_savings_estimator_subscription_group.py` still passes (warning-log + group_id assertions)
- [x] `uv run ruff format`, `uv run ruff check`, `uv run mypy --strict` clean on changed files
- [x] `pre-commit run --files` passes on all 3 changed files
- [ ] CI green
- [ ] Runtime boots on .201 with RestartCount == 0 after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL configuration no longer requires the POSTGRES_HOST environment variable when a DSN/connection string is provided.
  * Savings estimation background task now handles cancellations and unexpected errors more robustly, always unsubscribes on shutdown, and logs task exit details to avoid silent failures.

* **Tests**
  * Added regression and integration tests covering DSN vs. env-var host construction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1590)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->