### PR TITLE
fix(OMN-10967): remove free-text skip bypass from integration-test-check.yml

### DIFF
--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -12,9 +12,8 @@
 # OMN-8732: Test removal gate
 #
 # Hard-blocks merge when a PR deletes a tests/integration/*.py file
-# without adding a replacement. Override: include
-# [skip-test-removal-gate: <reason>] in the PR body for legitimate
-# test consolidation.
+# without adding a replacement. No override mechanism — consolidation
+# requires a replacement test to be added in the same PR.
 
 name: Integration Test Check
 
@@ -126,16 +125,8 @@ jobs:
           fetch-depth: 0
 
       - name: Detect integration test deletions without replacements
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
-
-          # Allow legitimate test consolidation via override token
-          if echo "${PR_BODY:-}" | grep -qF '[skip-test-removal-gate:'; then
-            echo "skip-test-removal-gate token found — bypassing test removal check"
-            exit 0
-          fi
 
           # Counting logic lives in a Python script so it can be unit-tested
           # against synthetic git diff outputs. See


### PR DESCRIPTION
Evidence-Ticket: OMN-10967
Evidence-Source: OCC#1005

## Summary

- Removes the free-text test-removal-gate override from the check-test-removal job in integration-test-check.yml
- PRs that delete integration tests without adding a replacement must now include the replacement test — no bypass mechanism exists
- Updates the header comment to reflect the no-override policy

## Ticket

OMN-10967

## Test plan

- [ ] Verify CI Integration Test Removal Gate job runs on this PR (no bypass available)
- [ ] Confirm the validate_test_removal_gate.py script is still invoked (unchanged)

dod_evidence:
- type: no_deployable_artifact
  description: CI workflow change only — no runtime code modified
- type: tests_passing
  description: Gate script still passes for PRs with proper replacement tests
