### PR TITLE
feat(OMN-10951): add delegation projection consumer to runtime-observability bundle

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -51,6 +51,7 @@ runtime-observability-projections:
     - llm-cost-aggregation-consumer
     - consumer-health-projection
     - decision-store-consumer
+    - omnimarket-projection-delegation
   includes: []
   inject_env: {}
   inject_required_env:


### PR DESCRIPTION
## Summary

- Add `omnimarket-projection-delegation` to the `runtime-observability-projections` bundle
- The service was defined in `docker/catalog/services/omnimarket-projection-delegation.yaml` but never added to a bundle, so it was never deployed

**Ticket:** OMN-10951
**Epic:** OMN-10939

## What this enables

After merge + `onex up runtime`, the delegation projection consumer will start alongside other projection consumers. It reads from `onex.evt.omniclaude.task-delegated.v1` Kafka topic and writes to `omnidash_analytics.delegation_events` Postgres table.

## Test plan

- [ ] `uv run python -m omnibase_infra.docker.catalog.cli validate runtime-observability-projections` passes
- [ ] Bundle includes the new service in generated compose
- [ ] After deploy: consumer group visible via `rpk group list`
- [ ] After deploy: delegation events appear in Postgres `delegation_events` table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated runtime observability configuration to expand monitoring and projection capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1593)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1007
Evidence-Ticket: OMN-10951