### PR TITLE
feat(OMN-10959): add catalog ulimit rendering

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -49,6 +49,7 @@ runs:
       uses: astral-sh/setup-uv@v7
       with:
         version: ${{ inputs.uv-version }}
+        enable-cache: ${{ inputs.cache-enabled != 'false' }}
     - name: Load cached uv
       if: inputs.cache-enabled != 'false'
       uses: actions/cache@v4

--- a/docker/catalog/services/redpanda.yaml
+++ b/docker/catalog/services/redpanda.yaml
@@ -20,6 +20,11 @@ volumes:
 depends_on: []
 restart: unless-stopped
 resources: null
+ulimits:
+  # OMN-10959: keep broker file descriptor capacity aligned with live compose.
+  nofile:
+    soft: 65535
+    hard: 65535
 command:
   - redpanda
   - start

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -103,6 +103,13 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
                 }
             }
 
+        # Ulimits
+        if manifest.ulimits:
+            svc["ulimits"] = {
+                name: {"soft": limit.soft, "hard": limit.hard}
+                for name, limit in sorted(manifest.ulimits.items())
+            }
+
         # Labels
         if manifest.labels:
             svc["labels"] = manifest.labels

--- a/src/omnibase_infra/docker/catalog/manifest_schema.py
+++ b/src/omnibase_infra/docker/catalog/manifest_schema.py
@@ -62,6 +62,14 @@ class ResourceLimits:
 
 
 @dataclass(frozen=True)
+class ULimit:
+    """Container ulimit soft/hard pair for docker compose."""
+
+    soft: int
+    hard: int
+
+
+@dataclass(frozen=True)
 class CatalogManifest:
     """Declaration of a single deployable catalog entry.
 
@@ -86,6 +94,7 @@ class CatalogManifest:
     restart: str = "unless-stopped"
     labels: dict[str, str] = field(default_factory=dict)
     resources: ResourceLimits | None = None
+    ulimits: dict[str, ULimit] = field(default_factory=dict)
     stop_grace_period: str | None = None
     # Per-entry env overrides (e.g., per-entry OTEL name)
     catalog_env: dict[str, str] = field(default_factory=dict)

--- a/src/omnibase_infra/docker/catalog/resolver.py
+++ b/src/omnibase_infra/docker/catalog/resolver.py
@@ -20,6 +20,7 @@ from omnibase_infra.docker.catalog.manifest_schema import (
     HealthCheck,
     PortMapping,
     ResourceLimits,
+    ULimit,
 )
 
 
@@ -82,6 +83,13 @@ def _load_manifest(path: Path) -> CatalogManifest:
             memory_reservation=str(r.get("memory_reservation", "128M")),
         )
 
+    ulimits: dict[str, ULimit] = {}
+    for name, limit in (raw.get("ulimits") or {}).items():
+        ulimits[str(name)] = ULimit(
+            soft=int(limit["soft"]),
+            hard=int(limit["hard"]),
+        )
+
     return CatalogManifest(
         name=raw["name"],
         description=raw.get("description", ""),
@@ -99,6 +107,7 @@ def _load_manifest(path: Path) -> CatalogManifest:
         restart=raw.get("restart", "unless-stopped"),
         labels=raw.get("labels", {}),
         resources=resources,
+        ulimits=ulimits,
         stop_grace_period=raw.get("stop_grace_period"),
         catalog_env=raw.get("catalog_env", {}),
         extra_networks=raw.get("extra_networks", []),

--- a/tests/integration/docker/test_catalog_ulimits_render.py
+++ b/tests/integration/docker/test_catalog_ulimits_render.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for catalog ulimit rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.docker.catalog.generator import generate_compose
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+
+CATALOG_DIR = str(Path(__file__).resolve().parents[3] / "docker" / "catalog")
+
+
+@pytest.mark.integration
+def test_redpanda_catalog_ulimits_render_to_compose() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["core"])
+    compose = generate_compose(resolved)
+
+    assert compose["services"]["redpanda"]["ulimits"] == {
+        "nofile": {"soft": 65535, "hard": 65535}
+    }

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -46,6 +46,16 @@ def test_generated_compose_preserves_depends_on_conditions() -> None:
 
 
 @pytest.mark.unit
+def test_generated_compose_preserves_redpanda_ulimits() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["core"])
+    compose = generate_compose(resolved)
+    redpanda = compose["services"]["redpanda"]
+
+    assert redpanda["ulimits"] == {"nofile": {"soft": 65535, "hard": 65535}}
+
+
+@pytest.mark.unit
 def test_generated_compose_preserves_one_shot_semantics() -> None:
     resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
     resolved = resolver.resolve(bundles=["runtime"])

--- a/tests/unit/infra/test_manifest_schema.py
+++ b/tests/unit/infra/test_manifest_schema.py
@@ -14,6 +14,7 @@ from omnibase_infra.docker.catalog.manifest_schema import (
     PortMapping,
     ServiceLayer,
     ServiceManifest,
+    ULimit,
 )
 
 
@@ -75,6 +76,27 @@ def test_depends_on_with_conditions() -> None:
         condition=DependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY,
     )
     assert dep_completed.condition == DependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY
+
+
+@pytest.mark.unit
+def test_service_manifest_accepts_typed_ulimits() -> None:
+    manifest = ServiceManifest(
+        name="redpanda",
+        description="Kafka-compatible event streaming",
+        image="redpandadata/redpanda:v24.2.7",
+        layer=ServiceLayer.INFRASTRUCTURE,
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=PortMapping(external=19092, internal=19092),
+        healthcheck=HealthCheck(test="rpk cluster health"),
+        volumes=["redpanda_data:/var/lib/redpanda/data"],
+        depends_on=[],
+        ulimits={"nofile": ULimit(soft=65535, hard=65535)},
+    )
+
+    assert manifest.ulimits["nofile"].soft == 65535
+    assert manifest.ulimits["nofile"].hard == 65535
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add typed CatalogManifest ulimit support with soft/hard pairs.
- Load ulimits from catalog service YAML and render them into generated compose services.
- Add Redpanda nofile ulimit to the catalog manifest to match live compose and prevent broker FD exhaustion.

Evidence-Ticket: OMN-10959
Evidence-Source: OCC#1026

## Verification
- uv run pytest tests/unit/infra/test_manifest_schema.py tests/unit/infra/test_catalog_generator.py -q
- uv run ruff check src/omnibase_infra/docker/catalog/manifest_schema.py src/omnibase_infra/docker/catalog/resolver.py src/omnibase_infra/docker/catalog/generator.py tests/unit/infra/test_manifest_schema.py tests/unit/infra/test_catalog_generator.py tests/integration/docker/test_catalog_ulimits_render.py
- uv run pytest tests/unit/infra/test_manifest_schema.py tests/unit/infra/test_catalog_generator.py tests/unit/infra/test_catalog_resolver.py tests/unit/infra/test_catalog_validator.py -q
- uv run pytest tests/integration/docker/test_catalog_ulimits_render.py tests/unit/infra/test_manifest_schema.py tests/unit/infra/test_catalog_generator.py -q
- uv run pytest tests/unit/infra tests/integration/docker/test_catalog_ulimits_render.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker services now support configurable ulimits for managing system resource limits.
  * Redpanda service updated with file descriptor ulimits set to 65535.

* **Tests**
  * Added comprehensive tests for ulimits configuration parsing and Docker Compose generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1594)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->