### PR TITLE
fix(OMN-9877): add LLM adapter timeout contract

### DIFF
--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -747,6 +747,7 @@ class AdapterLlmProviderOpenai:
             max_tokens=request.max_tokens,
             temperature=request.temperature,
             api_key=self._api_key,
+            timeout_seconds=request.timeout_seconds,
         )
 
 

--- a/src/omnibase_infra/adapters/llm/model_llm_adapter_request.py
+++ b/src/omnibase_infra/adapters/llm/model_llm_adapter_request.py
@@ -32,6 +32,7 @@ class ModelLlmAdapterRequest(BaseModel):
         parameters: Generation parameters as a JSON-compatible dictionary.
         max_tokens: Maximum tokens to generate, or None for default.
         temperature: Sampling temperature, or None for default.
+        timeout_seconds: HTTP request timeout in seconds.
 
     Warning:
         Dict fields (``parameters``) are shallowly mutable despite
@@ -76,6 +77,12 @@ class ModelLlmAdapterRequest(BaseModel):
         ge=0.0,
         le=2.0,
         description="Temperature for generation.",
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        le=600.0,
+        description="HTTP request timeout in seconds.",
     )
 
 

--- a/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
@@ -184,6 +184,7 @@ class TestAdapterLlmProviderOpenaiTranslation:
             model_name="qwen2.5-coder-14b",
             temperature=0.7,
             max_tokens=500,
+            timeout_seconds=120.0,
         )
         infra_request = adapter._translate_request(spi_request)
 
@@ -191,6 +192,7 @@ class TestAdapterLlmProviderOpenaiTranslation:
         assert infra_request.model == "qwen2.5-coder-14b"
         assert infra_request.temperature == 0.7
         assert infra_request.max_tokens == 500
+        assert infra_request.timeout_seconds == 120.0
         assert len(infra_request.messages) == 1
         assert infra_request.messages[0]["role"] == "user"
         assert infra_request.messages[0]["content"] == "Explain ONEX"

--- a/tests/unit/adapters/llm/test_model_llm_adapter_request.py
+++ b/tests/unit/adapters/llm/test_model_llm_adapter_request.py
@@ -29,6 +29,7 @@ class TestModelLlmAdapterRequest:
         assert req.parameters == {}
         assert req.max_tokens is None
         assert req.temperature is None
+        assert req.timeout_seconds == 30.0
 
     def test_request_with_parameters(self) -> None:
         """Request with all optional fields."""
@@ -38,9 +39,11 @@ class TestModelLlmAdapterRequest:
             parameters={"top_p": 0.9},
             max_tokens=500,
             temperature=0.7,
+            timeout_seconds=120.0,
         )
         assert req.max_tokens == 500
         assert req.temperature == 0.7
+        assert req.timeout_seconds == 120.0
         assert req.parameters == {"top_p": 0.9}
 
     def test_frozen_model(self) -> None:
@@ -90,6 +93,21 @@ class TestModelLlmAdapterRequest:
         """temperature defaults to None (provider default)."""
         req = ModelLlmAdapterRequest(prompt="Hello", model_name="test")
         assert req.temperature is None
+
+    def test_timeout_seconds_bounds(self) -> None:
+        """timeout_seconds must match infra request bounds."""
+        with pytest.raises(ValidationError):
+            ModelLlmAdapterRequest(
+                prompt="Hello",
+                model_name="test",
+                timeout_seconds=0.5,
+            )
+        with pytest.raises(ValidationError):
+            ModelLlmAdapterRequest(
+                prompt="Hello",
+                model_name="test",
+                timeout_seconds=601.0,
+            )
 
     def test_satisfies_protocol(self) -> None:
         """Verify structural compatibility with ProtocolLLMRequest."""


### PR DESCRIPTION
## Summary
- Salvages the small stale runtime LLM timeout contract worktree under OMN-9877.
- Adds timeout_seconds to LLM adapter requests and passes it into the OpenAI-compatible provider call path.
- Adds unit coverage for request defaults and provider timeout propagation.

## Verification
- pre-commit hooks ran during commit and passed.
- pre-push hooks ran during push and passed.

## Notes
- This branch had no direct numeric ticket name; I attached it to OMN-9877 because the local audit identifies it as runtime contract work and OMN-9877 remains Backlog.