### PR TITLE
feat(OMN-11052): update standalone_quickstart to target core_installed only

### DIFF
--- a/src/omnibase_infra/onboarding/policies/standalone_quickstart.yaml
+++ b/src/omnibase_infra/onboarding/policies/standalone_quickstart.yaml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 policy_name: "standalone_quickstart"
-description: "Minimal path to running a standalone node (~5 min)"
+policy_version: "1.0"
+description: "Verify Python + uv + omnibase_core are installed (~2 min)"
 target_capabilities:
-  - "first_node_running"
-max_estimated_minutes: 5
+  - "core_installed"
+max_estimated_minutes: 2

--- a/tests/unit/onboarding/test_policy_resolver.py
+++ b/tests/unit/onboarding/test_policy_resolver.py
@@ -26,19 +26,17 @@ def canonical_graph():
 class TestResolvePolicy:
     """Tests for resolve_policy()."""
 
-    def test_standalone_quickstart_produces_5_steps(self, canonical_graph) -> None:
+    def test_standalone_quickstart_produces_3_steps(self, canonical_graph) -> None:
         steps = resolve_policy(
             canonical_graph,
-            target_capabilities=["first_node_running"],
+            target_capabilities=["core_installed"],
         )
         step_keys = [s.step_key for s in steps]
-        assert len(steps) == 5
+        assert len(steps) == 3
         assert step_keys == [
             "check_python",
             "install_uv",
             "install_core",
-            "create_first_node",
-            "run_standalone_node",
         ]
 
     def test_full_platform_produces_all_steps(self, canonical_graph) -> None:
@@ -118,7 +116,7 @@ class TestLoadBuiltinPolicies:
     def test_standalone_targets(self) -> None:
         policies = load_builtin_policies()
         standalone = policies["standalone_quickstart"]
-        assert standalone["target_capabilities"] == ["first_node_running"]
+        assert standalone["target_capabilities"] == ["core_installed"]
 
     def test_full_platform_targets(self) -> None:
         policies = load_builtin_policies()


### PR DESCRIPTION
## Summary
- Changes standalone_quickstart target from `first_node_running` to `core_installed`
- Updates test expectations for new target (3 steps: check_python, install_uv, install_core)
- Depends on #1599 (OMN-11050 step rename)

Closes OMN-11052