### PR TITLE
feat(OMN-11056): add EnumOnboardingStatus and capability fields to output

### DIFF
--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
@@ -20,6 +20,9 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.enum_onboarding_status import (
+    EnumOnboardingStatus,
+)
 from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_input import (
     ModelOnboardingInput,
 )
@@ -207,13 +210,33 @@ async def _handle_dag(
     renderer = RendererOnboardingMarkdown()
     rendered = renderer.render(steps, step_results, title="Onboarding Progress")
 
+    # Compute capability evidence from step results
+    verified_caps: list[str] = []
+    unmet_caps: list[str] = []
+    for step, result in zip(steps, step_results, strict=True):
+        if result.passed:
+            verified_caps.extend(step.produces_capabilities)
+        else:
+            unmet_caps.extend(step.produces_capabilities)
+
+    # Determine status
     all_passed = all(r.passed for r in step_results)
+    if all_passed:
+        status = EnumOnboardingStatus.PASSED
+    elif any(r.message == "Skipped due to previous failure" for r in step_results):
+        status = EnumOnboardingStatus.BLOCKED
+    else:
+        status = EnumOnboardingStatus.FAILED
+
     return ModelOnboardingOutput(
         success=all_passed,
         total_steps=len(steps),
         completed_steps=len(completed_steps),
         step_results=step_results,
         rendered_output=rendered,
+        status=status,
+        verified_capabilities=verified_caps,
+        unmet_capabilities=unmet_caps,
     )
 
 

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
@@ -213,8 +213,8 @@ async def _handle_dag(
     # Compute capability evidence from step results
     verified_caps: list[str] = []
     unmet_caps: list[str] = []
-    for step, result in zip(steps, step_results, strict=True):
-        if result.passed:
+    for step, step_res in zip(steps, step_results, strict=True):
+        if step_res.passed:
             verified_caps.extend(step.produces_capabilities)
         else:
             unmet_caps.extend(step.produces_capabilities)

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/enum_onboarding_status.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/enum_onboarding_status.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Onboarding result status taxonomy."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumOnboardingStatus(StrEnum):
+    """Onboarding result taxonomy."""
+
+    PASSED = "passed"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+
+
+__all__ = ["EnumOnboardingStatus"]

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_output.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_output.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.enum_onboarding_status import (
+    EnumOnboardingStatus,
+)
 from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_step_result import (
     ModelStepResult,
 )
@@ -26,6 +29,18 @@ class ModelOnboardingOutput(BaseModel):
     completed_steps: int = Field(description="Number of completed steps")
     step_results: list[ModelStepResult] = Field(description="Per-step results")
     rendered_output: str = Field(description="Rendered output string")
+    status: EnumOnboardingStatus = Field(
+        default=EnumOnboardingStatus.FAILED,
+        description="Overall onboarding result",
+    )
+    verified_capabilities: list[str] = Field(
+        default_factory=list,
+        description="Capabilities that passed verification",
+    )
+    unmet_capabilities: list[str] = Field(
+        default_factory=list,
+        description="Capabilities that failed verification",
+    )
 
     # Interactive provenance (OMN-10784 GPT #11)
     provenance: ModelInteractiveResult | None = Field(

--- a/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding.py
+++ b/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding.py
@@ -12,6 +12,9 @@ import pytest
 from omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding import (
     handle_onboarding,
 )
+from omnibase_infra.nodes.node_onboarding_orchestrator.models.enum_onboarding_status import (
+    EnumOnboardingStatus,
+)
 from omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_input import (
     ModelOnboardingInput,
 )
@@ -124,3 +127,79 @@ class TestHandleOnboarding:
         assert "<!-- GENERATED FROM" not in output.rendered_output
         # Summary line present
         assert "steps passed" in output.rendered_output
+
+
+class TestEnumOnboardingStatusFields:
+    """Tests for EnumOnboardingStatus and capability fields (OMN-11056)."""
+
+    @pytest.mark.asyncio
+    async def test_all_pass_yields_passed_status(self) -> None:
+        """All steps passing sets status=PASSED."""
+        input_model = ModelOnboardingInput(target_capabilities=["first_node_running"])
+        with patch(
+            "omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding.execute_verification",
+            new_callable=AsyncMock,
+            return_value=_make_passing_result(),
+        ):
+            output = await handle_onboarding(input_model)
+
+        assert output.status == EnumOnboardingStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_failure_without_skip_yields_failed_status(self) -> None:
+        """A failing step (no skips) sets status=FAILED."""
+        input_model = ModelOnboardingInput(
+            target_capabilities=["first_node_running"],
+            continue_on_failure=True,
+        )
+        mock = AsyncMock(
+            side_effect=[
+                _make_failing_result(),
+                _make_failing_result(),
+                _make_failing_result(),
+                _make_failing_result(),
+                _make_failing_result(),
+            ]
+        )
+        with patch(
+            "omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding.execute_verification",
+            mock,
+        ):
+            output = await handle_onboarding(input_model)
+
+        assert output.status == EnumOnboardingStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_blocked_when_steps_skipped(self) -> None:
+        """Steps skipped due to previous failure sets status=BLOCKED."""
+        input_model = ModelOnboardingInput(target_capabilities=["first_node_running"])
+        mock = AsyncMock(
+            side_effect=[
+                _make_passing_result(),
+                _make_failing_result(),
+            ]
+        )
+        with patch(
+            "omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding.execute_verification",
+            mock,
+        ):
+            output = await handle_onboarding(input_model)
+
+        assert output.status == EnumOnboardingStatus.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_verified_capabilities_populated_on_pass(self) -> None:
+        """Capabilities from passing steps appear in verified_capabilities."""
+        input_model = ModelOnboardingInput(target_capabilities=["first_node_running"])
+        with patch(
+            "omnibase_infra.nodes.node_onboarding_orchestrator.handlers.handler_onboarding.execute_verification",
+            new_callable=AsyncMock,
+            return_value=_make_passing_result(),
+        ):
+            output = await handle_onboarding(input_model)
+
+        # first_node_running graph steps produce capabilities — at least one should land
+        assert isinstance(output.verified_capabilities, list)
+        assert isinstance(output.unmet_capabilities, list)
+        # All passed so nothing should be in unmet
+        assert output.unmet_capabilities == []


### PR DESCRIPTION
## Summary
- Adds `EnumOnboardingStatus` (PASSED/PARTIAL/FAILED/BLOCKED) result taxonomy in its own `enum_onboarding_status.py` file
- Adds `verified_capabilities` and `unmet_capabilities` fields to `ModelOnboardingOutput` (both default to `[]` so existing callers are unaffected)
- Populates fields from step results in `_handle_dag` using `zip(steps, step_results, strict=True)`
- Adds 4 unit tests covering PASSED/FAILED/BLOCKED status and capability population
- Depends on #1599 (OMN-11050 step rename)

Closes OMN-11056