### PR TITLE
fix(OMN-11058): add dep_health_allowlist for consumer-restart topic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: 8d7e85bc00e7f1b1306d1cb40949be1ab6e7e91a # pragma: allowlist secret
     hooks:
       - id: no-hardcoded-topics
-        exclude: ^(src/omnibase_infra/(enums/generated|cli|tui|models/registration/model_event_bus_topic_entry\.py|nodes/.*/handlers|nodes/.*/services|nodes/.*/contracts|runtime/contract_registration_event_router\.py|services/observability|services/service_timeout_emitter\.py|topics/service_topic_registry\.py|event_bus/topic_constants\.py|validation|contracts/)|scripts/|tests/|contracts/)
+        exclude: ^(src/omnibase_infra/(enums/generated|cli|tui|models/registration/model_event_bus_topic_entry\.py|nodes/.*/handlers|nodes/.*/services|nodes/.*/contracts|runtime/contract_registration_event_router\.py|services/observability|services/service_timeout_emitter\.py|topics/service_topic_registry\.py|event_bus/topic_constants\.py|validation|contracts/)|scripts/|tests/|contracts/|src/dep_health_allowlist\.yaml)
       - id: no-bare-feature-flags
         # YAML formatting (standard across ecosystem)
       - id: no-untracked-todos

--- a/src/dep_health_allowlist.yaml
+++ b/src/dep_health_allowlist.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Dependency Health Sweep — omnibase_infra allowlist
+# OMN-11058: CRITICAL topic triage — runtime ownership verification (2026-05-15)
+#
+# Format: each entry must have a `topic` key (used as literal match by the sweep engine).
+# Optional keys: reason, owner_repo, planned_subscriber, expires_at (all informational).
+#
+# Topics on this list are SUPPRESSED from MISSING_TOPIC_EDGE findings when
+# scanning this repo root. Only use for genuinely unwired topics with a clear plan.
+#
+# Review this list quarterly. Remove entries when the subscriber is wired.
+allowlist:
+  # --- consumer-restart ---
+  # Published by: node_consumer_health_triage_effect (omnibase_infra)
+  # Intended consumer: runtime-level consumer watchdog / supervisor process
+  # Status: genuinely_unwired — the restart command is designed to trigger
+  #         OS/process-level consumer restarts. The receiving component is the
+  #         runtime-worker service, which currently uses process-level restart
+  #         logic (util_consumer_restart), not a Kafka-subscribed ONEX node.
+  #         No node contract declares subscription to this topic.
+  # Expires: 2026-08-15 — either wire a dedicated node_consumer_restart_effect
+  #           or convert the runtime-worker to subscribe via Kafka.
+  - topic: "onex.cmd.omnibase-infra.consumer-restart.v1"
+    reason: "Consumer restart command targets runtime-worker process; no ONEX node subscriber exists yet — runtime-level watchdog planned."
+    owner_repo: omnibase_infra
+    planned_subscriber: node_consumer_restart_effect
+    expires_at: "2026-08-15"


### PR DESCRIPTION
## Summary

OMN-11058: Suppress false-positive CRITICAL MISSING_TOPIC_EDGE finding for `onex.cmd.omnibase-infra.consumer-restart.v1`.

**Classification:** `genuinely_unwired` — `node_consumer_health_triage_effect` publishes restart commands but no ONEX node subscribes. The restart mechanism is implemented at the process level via `util_consumer_restart` imported by observability consumer services. A proper `node_consumer_restart_effect` subscriber is planned.

Evidence-Source: OCC#1034
Evidence-Ticket: OMN-11058

## Changes

- `src/dep_health_allowlist.yaml` — created with `consumer-restart.v1` entry (reason, planned_subscriber, expires_at 2026-08-15)
- `.pre-commit-config.yaml` — added `dep_health_allowlist.yaml` to `no-hardcoded-topics` exclude

## Companion PR

omnimarket `jonah/omn-11058-critical-topic-triage` — handles 8 of the 9 CRITICAL findings.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] Sweep re-run with both worktree paths returns `{"status": "clean", "findings": [], "summary": {}}`