### PR TITLE
fix(OMN-10713): declare graph config env dependencies

### DIFF
--- a/src/omnibase_infra/contracts/handlers/graph/handler_contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/graph/handler_contract.yaml
@@ -119,6 +119,27 @@ activation:
   optional: true
   required_env:
     - OMNIMEMORY_MEMGRAPH_HOST
+dependencies:
+  - name: "graph_bolt_uri"
+    type: "environment"
+    env_var: "GRAPH_BOLT_URI"
+    required: false
+    description: "Primary Bolt URI for graph database connections."
+  - name: "memgraph_bolt_uri"
+    type: "environment"
+    env_var: "MEMGRAPH_BOLT_URI"
+    required: false
+    description: "Legacy Memgraph Bolt URI used before GRAPH_BOLT_URI."
+  - name: "omnimemory_memgraph_host"
+    type: "environment"
+    env_var: "OMNIMEMORY_MEMGRAPH_HOST"
+    required: false
+    description: "Compose-aligned Memgraph host for OmniMemory graph connections."
+  - name: "omnimemory_memgraph_port"
+    type: "environment"
+    env_var: "OMNIMEMORY_MEMGRAPH_PORT"
+    required: false
+    description: "Compose-aligned Memgraph Bolt port for OmniMemory graph connections."
 metadata:
   handler_type: "infra_handler"
   handler_category: "effect"


### PR DESCRIPTION
## Summary
- Declare GRAPH_BOLT_URI and MEMGRAPH_BOLT_URI as typed environment dependencies in the graph handler contract
- Declare OMNIMEMORY_MEMGRAPH_HOST and OMNIMEMORY_MEMGRAPH_PORT as typed environment dependencies for compose-aligned graph connections

## Verification
- git diff --check
- uv run python - <<'PY' ... ContractConfigExtractor graph dependency check ... PY
- uv run pytest tests/unit/runtime/config_discovery/test_contract_config_extractor.py -q

Evidence-Ticket: OMN-10713
Evidence-Source: OCC#1035
Linear: OMN-10713