### PR TITLE
fix(OMN-11064): use env var interpolation for onboarding verification targets

### DIFF
--- a/src/omnibase_infra/onboarding/graphs/canonical.yaml
+++ b/src/omnibase_infra/onboarding/graphs/canonical.yaml
@@ -96,7 +96,7 @@ steps:
     estimated_duration_seconds: 120
     verification:
       check_type: "tcp_probe"
-      target: "localhost:5436"
+      target: "${POSTGRES_HOST}:${POSTGRES_PORT}"
       timeout_seconds: 30
       description: "PostgreSQL is accepting connections on external port"
   - step_key: "check_event_bus"
@@ -110,7 +110,7 @@ steps:
     estimated_duration_seconds: 30
     verification:
       check_type: "tcp_probe"
-      target: "localhost:19092"
+      target: "${REDPANDA_HOST}:${REDPANDA_PORT}"
       timeout_seconds: 15
       description: "Redpanda is accepting connections on external port"
   - step_key: "check_node_bus_connection"
@@ -152,7 +152,7 @@ steps:
     estimated_duration_seconds: 60
     verification:
       check_type: "http_health"
-      target: "http://localhost:3000"
+      target: "http://${OMNIDASH_HOST}:${OMNIDASH_PORT}"
       timeout_seconds: 30
       description: "Omnidash is serving on port 3000"
   - step_key: "install_omnimarket"

--- a/src/omnibase_infra/probes/verification_executor.py
+++ b/src/omnibase_infra/probes/verification_executor.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -18,6 +20,22 @@ from pathlib import Path
 from omnibase_infra.probes.capability_probe import http_health_check, socket_check
 from omnibase_infra.probes.model_verification_result import ModelVerificationResult
 from omnibase_infra.probes.protocol_verification_spec import VerificationSpec
+
+_ENV_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _interpolate_env(target: str) -> str:
+    """Expand ${VAR} references in target from environment.
+
+    Raises:
+        KeyError: If a referenced variable is not set in the environment.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        return os.environ[var]
+
+    return _ENV_VAR_RE.sub(_replace, target)
 
 
 async def _check_command_exit_0(target: str, timeout: int) -> tuple[bool, str]:
@@ -113,8 +131,10 @@ async def execute_verification(spec: VerificationSpec) -> ModelVerificationResul
         msg = f"Unknown check_type: {spec.check_type}"
         raise ValueError(msg)
 
+    target = _interpolate_env(spec.target)
+
     start = time.monotonic()
-    passed, message = await handler(spec.target, spec.timeout_seconds)
+    passed, message = await handler(target, spec.timeout_seconds)
     elapsed_ms = int((time.monotonic() - start) * 1000)
 
     return ModelVerificationResult(
@@ -126,4 +146,4 @@ async def execute_verification(spec: VerificationSpec) -> ModelVerificationResul
     )
 
 
-__all__ = ["execute_verification"]
+__all__ = ["_interpolate_env", "execute_verification"]

--- a/tests/unit/probes/test_verification_executor.py
+++ b/tests/unit/probes/test_verification_executor.py
@@ -15,7 +15,10 @@ import pytest
 
 from omnibase_infra.probes.model_verification_result import ModelVerificationResult
 from omnibase_infra.probes.model_verification_spec import ModelVerificationSpec
-from omnibase_infra.probes.verification_executor import execute_verification
+from omnibase_infra.probes.verification_executor import (
+    _interpolate_env,
+    execute_verification,
+)
 
 
 class TestCommandExit0:
@@ -210,3 +213,53 @@ class TestUnknownCheckType:
         )
         with pytest.raises(ValueError, match="Unknown check_type"):
             await execute_verification(spec)
+
+
+class TestInterpolateEnv:
+    """Tests for _interpolate_env (OMN-11064)."""
+
+    def test_no_vars_unchanged(self) -> None:
+        assert _interpolate_env("localhost:5432") == "localhost:5432"
+
+    def test_single_var_expanded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("POSTGRES_HOST", "192.168.86.201")
+        assert _interpolate_env("${POSTGRES_HOST}") == "192.168.86.201"
+
+    def test_two_vars_expanded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("POSTGRES_HOST", "192.168.86.201")
+        monkeypatch.setenv("POSTGRES_PORT", "5436")
+        assert (
+            _interpolate_env("${POSTGRES_HOST}:${POSTGRES_PORT}")
+            == "192.168.86.201:5436"
+        )
+
+    def test_var_in_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNIDASH_HOST", "192.168.86.201")
+        monkeypatch.setenv("OMNIDASH_PORT", "3000")
+        assert (
+            _interpolate_env("http://${OMNIDASH_HOST}:${OMNIDASH_PORT}")
+            == "http://192.168.86.201:3000"
+        )
+
+    def test_missing_var_raises_key_error(self) -> None:
+        with pytest.raises(KeyError):
+            _interpolate_env("${NONEXISTENT_VAR_XYZ_12345}")
+
+    @pytest.mark.asyncio
+    async def test_execute_verification_interpolates_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """execute_verification expands ${VAR} in target before probing."""
+        monkeypatch.setenv("POSTGRES_HOST", "192.168.86.201")
+        monkeypatch.setenv("POSTGRES_PORT", "5436")
+        spec = ModelVerificationSpec(
+            check_type="tcp_probe",
+            target="${POSTGRES_HOST}:${POSTGRES_PORT}",
+        )
+        with patch(
+            "omnibase_infra.probes.verification_executor.socket_check",
+            return_value=True,
+        ) as mock_socket:
+            result = await execute_verification(spec)
+        assert result.passed is True
+        mock_socket.assert_called_once_with("192.168.86.201", 5436, timeout=10.0)


### PR DESCRIPTION
## Summary
- Adds `_interpolate_env()` to verification executor — expands `${VAR}` references from env before probing
- Updates `canonical.yaml` to use env var refs instead of hardcoded localhost addresses
- Fail-fast `KeyError` on missing env vars (no silent fallback)
- 6 new tests for interpolation (single var, multi var, URL, missing var, integration with execute_verification)

### Targets changed
| Step | Old | New |
|------|-----|-----|
| check_docker_infra | `localhost:5436` | `${POSTGRES_HOST}:${POSTGRES_PORT}` |
| check_event_bus | `localhost:19092` | `${REDPANDA_HOST}:${REDPANDA_PORT}` |
| check_omnidash | `http://localhost:3000` | `http://${OMNIDASH_HOST}:${OMNIDASH_PORT}` |

Closes OMN-11064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service verification now supports configurable host and port for PostgreSQL, Redpanda, and Omnidash through environment variables instead of hardcoded values.

* **Tests**
  * Added comprehensive test coverage for environment variable interpolation in service verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1605)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1052
Evidence-Ticket: OMN-11064