### PR TITLE
fix(OMN-10714): declare miscellaneous handler config

### DIFF
--- a/contracts/OMN-10714.yaml
+++ b/contracts/OMN-10714.yaml
@@ -1,0 +1,32 @@
+# OMN-10714 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control
+# (contracts/OMN-10714.yaml in OmniNode-ai/onex_change_control).
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: OMN-10714
+title: "Declare miscellaneous handler config in contract.yaml"
+summary: >
+  Declares miscellaneous omnibase_infra handler environment variables as typed contract dependencies so contract-config discovery can resolve filesystem, setup preflight, Slack, Gmail, and shared handler configuration.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-contract-config-deps
+    description: Miscellaneous omnibase_infra handler config keys are declared in contract YAML.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/config_discovery/test_contract_config_extractor.py tests/unit/runtime/test_runtime_contract_config_loader.py -q"
+  - id: dod-deploy
+    description: >
+      Contract-only config declaration change. No migration, new topic, or runtime restart was performed pre-merge; the declarations ship with the next normal runtime deploy.
+
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: no live deploy or restart performed for OMN-10714; contract-only configuration declarations ship with the next normal runtime rollout"

--- a/src/omnibase_infra/contracts/handlers/filesystem/handler_contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/filesystem/handler_contract.yaml
@@ -64,6 +64,12 @@ capability_outputs:
   - filesystem.list
   - filesystem.delete
   - filesystem.mkdir
+dependencies:
+  - name: "fs_allowed_paths"
+    type: "environment"
+    env_var: "FS_ALLOWED_PATHS"
+    required: false
+    description: "Comma-separated filesystem path allowlist used when handler config omits allowed_paths"
 # NOTE: Models defined in OMN-1160 (FileSystemHandler Contract)
 input_model: omnibase_infra.handlers.filesystem.ModelFileSystemRequest
 output_model: omnibase_infra.handlers.filesystem.ModelFileSystemResult

--- a/src/omnibase_infra/handlers/contract.yaml
+++ b/src/omnibase_infra/handlers/contract.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+handler_id: shared.infra.handlers
+name: shared_infra_handlers
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+description: >
+  Shared infra handler configuration surface for handlers that live directly under omnibase_infra.handlers rather than inside a node package.
+
+dependencies:
+  - name: "fs_allowed_paths"
+    type: "environment"
+    env_var: "FS_ALLOWED_PATHS"
+    required: false
+    description: "Comma-separated filesystem path allowlist used when HandlerFileSystem config omits allowed_paths"
+  - name: "slack_bot_token"
+    type: "environment"
+    env_var: "SLACK_BOT_TOKEN"
+    required: true
+    description: "Slack Bot Token used by HandlerSlackWebhook for Web API posts"
+  - name: "slack_channel_id"
+    type: "environment"
+    env_var: "SLACK_CHANNEL_ID"
+    required: false
+    description: "Default Slack channel ID used by HandlerSlackWebhook"
+  - name: "gmail_client_id"
+    type: "environment"
+    env_var: "GMAIL_CLIENT_ID"
+    required: true
+    description: "Gmail OAuth2 client ID used by HandlerGmailApi"
+  - name: "gmail_client_secret"
+    type: "environment"
+    env_var: "GMAIL_CLIENT_SECRET"
+    required: true
+    description: "Gmail OAuth2 client secret used by HandlerGmailApi"
+  - name: "gmail_refresh_token"
+    type: "environment"
+    env_var: "GMAIL_REFRESH_TOKEN"
+    required: true
+    description: "Gmail OAuth2 refresh token used by HandlerGmailApi"
+metadata:
+  handler_category: "shared"
+  transport_types:
+    - filesystem
+    - http

--- a/src/omnibase_infra/nodes/node_setup_preflight_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_preflight_effect/contract.yaml
@@ -32,6 +32,12 @@ handler_routing:
       handler:
         name: "HandlerPreflightCheck"
         module: "omnibase_infra.nodes.node_setup_preflight_effect.handlers.handler_preflight_check"
+dependencies:
+  - name: "omnibase_dir"
+    type: "environment"
+    env_var: "OMNIBASE_DIR"
+    required: false
+    description: "Override path for the local omnibase directory used by setup preflight checks"
 capabilities:
   - "preflight.check"
 metadata:


### PR DESCRIPTION
## Summary
- Adds an adjacent shared handler `contract.yaml` under `src/omnibase_infra/handlers/` for shared handler environment config (`FS_ALLOWED_PATHS`, Slack, Gmail).
- Adds typed dependencies for setup preflight `OMNIBASE_DIR` and filesystem handler `FS_ALLOWED_PATHS`.
- Adds repo-local `contracts/OMN-10714.yaml` deploy-gate evidence for the runtime-owned contract path touch.
- Confirms existing Gmail, Slack, and merge-gate node contracts expose the credential/team dependencies to the extractor.

## Verification
- `uv run python` YAML parse check for 7 relevant omnibase_infra contracts
- `uv run validate-yaml contracts/OMN-10714.yaml`
- `uv run python -m omnibase_core.validators.contract_config_compliance --rule missing_contract_config ...` for touched/listed handler paths: 0 findings
- `ContractConfigExtractor` found all 8 target omnibase_infra keys
- `uv run pytest tests/unit/runtime/config_discovery/test_contract_config_extractor.py tests/unit/runtime/test_runtime_contract_config_loader.py -q` -> 84 passed
- `git diff --check`

## Evidence
Evidence-Ticket: OMN-10714
Evidence-Source: OCC#1037

## Ticket
OMN-10714
