### PR TITLE
fix(OMN-11067): stabilize runtime ingress startup

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -66,6 +66,8 @@ runs:
         CACHE_ENABLED: ${{ inputs.cache-enabled }}
         INSTALL_ARGS: ${{ inputs.install-args }}
       run: |
+        export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+        git config --global http.version HTTP/1.1
         read -r -a install_args <<< "$INSTALL_ARGS"
         if [ "$CACHE_ENABLED" = "false" ]; then
           uv sync --no-cache "${install_args[@]}"

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -38,6 +38,14 @@ inputs:
     description: 'Set to "false" to skip uv cache restore/save for short timeout-sensitive jobs'
     required: false
     default: 'true'
+  sync-attempts:
+    description: 'Maximum uv sync attempts before failing'
+    required: false
+    default: '3'
+  sync-retry-delay-seconds:
+    description: 'Base delay in seconds between uv sync retries'
+    required: false
+    default: '10'
 runs:
   using: 'composite'
   steps:
@@ -65,12 +73,50 @@ runs:
       env:
         CACHE_ENABLED: ${{ inputs.cache-enabled }}
         INSTALL_ARGS: ${{ inputs.install-args }}
+        UV_SYNC_ATTEMPTS: ${{ inputs.sync-attempts }}
+        UV_SYNC_RETRY_DELAY_SECONDS: ${{ inputs.sync-retry-delay-seconds }}
       run: |
         export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
         git config --global http.version HTTP/1.1
         read -r -a install_args <<< "$INSTALL_ARGS"
-        if [ "$CACHE_ENABLED" = "false" ]; then
-          uv sync --no-cache "${install_args[@]}"
-        else
-          uv sync "${install_args[@]}"
+        sync_attempts="${UV_SYNC_ATTEMPTS}"
+        retry_delay_seconds="${UV_SYNC_RETRY_DELAY_SECONDS}"
+
+        if ! [[ "$sync_attempts" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::sync-attempts must be a positive integer (got: ${sync_attempts})"
+          exit 2
         fi
+
+        if ! [[ "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
+          echo "::error::sync-retry-delay-seconds must be a non-negative integer (got: ${retry_delay_seconds})"
+          exit 2
+        fi
+
+        echo "uv version: $(uv --version)"
+        echo "uv sync attempts: ${sync_attempts}"
+        echo "uv sync retry delay seconds: ${retry_delay_seconds}"
+        echo "UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-<unset>}"
+        echo "UV_CONCURRENT_DOWNLOADS=${UV_CONCURRENT_DOWNLOADS:-<unset>}"
+        echo "UV_CONCURRENT_BUILDS=${UV_CONCURRENT_BUILDS:-<unset>}"
+        echo "UV_NO_CACHE=${UV_NO_CACHE:-<unset>}"
+
+        sync_cmd=(uv sync)
+        if [ "$CACHE_ENABLED" = "false" ]; then
+          sync_cmd+=(--no-cache)
+        fi
+
+        sync_cmd+=("${install_args[@]}")
+
+        attempt=1
+        until "${sync_cmd[@]}"; do
+          status=$?
+          if [ "$attempt" -ge "$sync_attempts" ]; then
+            echo "::error::uv sync failed after ${attempt} attempt(s)"
+            exit "$status"
+          fi
+
+          sleep_seconds=$((retry_delay_seconds * attempt))
+          echo "::warning::uv sync attempt ${attempt}/${sync_attempts} failed with exit ${status}; retrying in ${sleep_seconds}s"
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ env:
   UV_VERSION: "0.6.14"
   PYTHON_VERSION: "3.12"
   CACHE_VERSION: "0.6.0"
+  # uv resolves several pinned git dependencies during CI.  The self-hosted
+  # runner pool has intermittent HTTP/2 stream resets against GitHub; force git
+  # subprocesses spawned by uv onto HTTP/1.1 so dependency installs are stable.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: "http.version"
+  GIT_CONFIG_VALUE_0: "HTTP/1.1"
   # Large transitive wheels such as torch and CUDA packages can exceed uv's
   # default timeout on self-hosted runners during sibling-boundary jobs.
   UV_HTTP_TIMEOUT: "600"

--- a/contracts/OMN-10207.yaml
+++ b/contracts/OMN-10207.yaml
@@ -36,7 +36,7 @@ dod_evidence:
       - check_type: command
         check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run python -c \"from pathlib import Path; from omnibase_infra.runtime.service_kernel import load_runtime_config; c=load_runtime_config(Path('contracts')); print(c.local_ingress.model_dump(mode='json')); print(c.pattern_b_broker.model_dump(mode='json'))\""
   - id: dod-compose-config
-    description: "Stability compose render includes the host-visible local runtime socket mount on the main runtime service."
+    description: "Stability compose render includes the runtime-owned local runtime socket tmpfs on the main runtime service."
     source: manual
     checks:
       - check_type: command

--- a/contracts/OMN-11067.yaml
+++ b/contracts/OMN-11067.yaml
@@ -1,0 +1,39 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11067
+title: "Stabilize stability-test runtime ingress startup"
+summary: "Fix the stability-test main runtime startup crash by making the local ingress socket path runtime-owned and cleaning up partially-started resources."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Focused local ingress, Pattern B, runtime startup cleanup, and compose render checks pass."
+    command: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/integration/test_runtime_pattern_b_ingress_config.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_runtime_socket_uses_owned_tmpfs -q"
+  - kind: manual
+    description: "Deploy-gate proof: after merge and approved runtime restart, the stability runtime reports local ingress running and accepts an OmniMarket Pattern B command."
+    command: >-
+      deploy: set -euo pipefail; CORR_ID=$(python3 -c 'import uuid; print(uuid.uuid4())'); docker exec omninode-stability-test-runtime python -c "import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); d=h['details']; assert d['runtime_attached'] is True; assert d['local_ingress']['running'] is True; print({'runtime_attached': d['runtime_attached'], 'local_ingress': d['local_ingress']})"; printf '{"command_name":"runtime_sweep","requester":"deploy-gate","payload":{"dry_run":true},"correlation_id":"%s","response_topic":"onex.evt.omnimarket.pattern-b-dispatch-completed.v1","timeout_seconds":5}\n' "$CORR_ID" | docker exec -i omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1; timeout 20s docker exec omnibase-infra-stability-test-redpanda rpk topic consume onex.evt.omnimarket.pattern-b-dispatch-completed.v1 --offset start 2>/dev/null | grep -m1 "$CORR_ID"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-focused-tests
+    description: "Focused tests prove local ingress and Pattern B config plus startup cleanup behavior."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/integration/test_runtime_pattern_b_ingress_config.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_runtime_socket_uses_owned_tmpfs -q"
+  - id: dod-compose-render
+    description: "Rendered stability compose uses runtime-owned tmpfs for the socket path."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "POSTGRES_PASSWORD=postgres LINEAR_API_KEY=dummy docker compose --profile runtime -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml config --format json | jq -e '.services[\"omninode-runtime\"] as $s | (($s.tmpfs // []) | index(\"/run/onex-runtime:uid=1000,gid=1000,mode=0770\") != null) and ((((($s.volumes // []) | map(tostring) | join(\"\\n\")) | contains(\"/run/onex-runtime\")) | not))' >/dev/null"
+  - id: dod-deploy-proof
+    description: "Post-merge deploy proof must show local ingress running and the OmniMarket Pattern B topic accepting commands."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          deploy: set -euo pipefail; CORR_ID=$(python3 -c 'import uuid; print(uuid.uuid4())'); docker exec omninode-stability-test-runtime python -c "import json, urllib.request; h=json.loads(urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5).read()); d=h['details']; assert d['runtime_attached'] is True; assert d['local_ingress']['running'] is True; print({'runtime_attached': d['runtime_attached'], 'local_ingress': d['local_ingress']})"; printf '{"command_name":"runtime_sweep","requester":"deploy-gate","payload":{"dry_run":true},"correlation_id":"%s","response_topic":"onex.evt.omnimarket.pattern-b-dispatch-completed.v1","timeout_seconds":5}\n' "$CORR_ID" | docker exec -i omnibase-infra-stability-test-redpanda rpk topic produce onex.cmd.omnimarket.pattern-b-dispatch.v1; timeout 20s docker exec omnibase-infra-stability-test-redpanda rpk topic consume onex.evt.omnimarket.pattern-b-dispatch-completed.v1 --offset start 2>/dev/null | grep -m1 "$CORR_ID"

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -648,7 +648,8 @@ services:
       - runtime_data:/app/data
       - ../contracts:/app/contracts:ro
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
-      - ${ONEX_LOCAL_RUNTIME_SOCKET_DIR:-/data/omninode/runtime-local-ingress}:/run/onex-runtime
+    tmpfs:
+      - /run/onex-runtime:uid=1000,gid=1000,mode=0770
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8085/health"]
       interval: 30s

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -114,7 +114,6 @@ services:
       - runtime_logs:/app/logs
       - runtime_data:/app/data
       - ${OMNICLAUDE_SKILLS_DIR:-./skills}:/app/skills:ro
-      - ${ONEX_LOCAL_RUNTIME_SOCKET_DIR:-/data/omninode/runtime-local-ingress}:/run/onex-runtime
     labels:
       - "com.omninode.lane=stability-test"
       - "com.omninode.ticket=OMN-10281"

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -1519,6 +1519,7 @@ class EventBusKafka(
         # immediately so callers get a clear error.
         stripped_group_id = group_id.strip()
         if not stripped_group_id:
+            self._pending_consumer_keys.discard(consumer_key)
             context = ModelInfraErrorContext.with_correlation(
                 correlation_id=correlation_id,
                 transport_type=EnumInfraTransportType.KAFKA,
@@ -1698,6 +1699,19 @@ class EventBusKafka(
                     logger.debug(
                         "Failed to emit consumer started health event", exc_info=True
                     )
+
+        except asyncio.CancelledError:
+            self._pending_consumer_keys.discard(consumer_key)
+            try:
+                await consumer.stop()
+            except Exception as cleanup_err:  # noqa: BLE001 — boundary: logs warning and degrades
+                logger.warning(
+                    "Cleanup failed for cancelled Kafka consumer start (topic=%s): %s",
+                    topic,
+                    cleanup_err,
+                    exc_info=True,
+                )
+            raise
 
         except TimeoutError as e:
             self._pending_consumer_keys.discard(consumer_key)

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1715,14 +1715,26 @@ class RuntimeHostProcess:
             if self._shutdown_requested.is_set():
                 logger.info("RuntimeHostProcess startup cancelled by shutdown")
                 return
+            await self._cleanup_after_startup_failure()
             raise
         except Exception:
             self._is_running = False
+            await self._cleanup_after_startup_failure()
             raise
         finally:
             if self._startup_task is startup_task:
                 self._startup_task = None
             self._is_starting = False
+
+    async def _cleanup_after_startup_failure(self) -> None:
+        """Release partially-started resources after start() fails."""
+        try:
+            await self.stop()
+        except Exception as cleanup_error:  # noqa: BLE001 - preserve startup failure
+            logger.warning(
+                "RuntimeHostProcess cleanup after startup failure failed: %s",
+                sanitize_error_message(cleanup_error),
+            )
 
     async def _start_runtime(self) -> None:
         """Start the runtime host.

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -182,3 +182,38 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
     )
     assert docker_cache_step["if"] == "${{ false }}"
     assert docker_cache_step["uses"] == "actions/cache/restore@v5"
+
+
+def test_setup_python_uv_retries_uv_sync_and_logs_transport_settings() -> None:
+    action = _load_yaml(SETUP_PYTHON_UV_ACTION)
+
+    assert action["inputs"]["sync-attempts"]["default"] == "3"
+    assert action["inputs"]["sync-retry-delay-seconds"]["default"] == "10"
+
+    install_step = next(
+        step
+        for step in action["runs"]["steps"]
+        if step.get("name") == "Install dependencies"
+    )
+    assert install_step["env"]["UV_SYNC_ATTEMPTS"] == "${{ inputs.sync-attempts }}"
+    assert (
+        install_step["env"]["UV_SYNC_RETRY_DELAY_SECONDS"]
+        == "${{ inputs.sync-retry-delay-seconds }}"
+    )
+
+    run_script = install_step["run"]
+    assert 'export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"' in run_script
+    assert "git config --global http.version HTTP/1.1" in run_script
+    assert "sync_cmd=(uv sync)" in run_script
+    assert "sync_cmd+=(--no-cache)" in run_script
+    assert 'until "${sync_cmd[@]}"; do' in run_script
+    assert (
+        'echo "::warning::uv sync attempt ${attempt}/${sync_attempts} failed'
+        in run_script
+    )
+    assert 'echo "::error::uv sync failed after ${attempt} attempt(s)"' in run_script
+    assert 'echo "UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-<unset>}"' in run_script
+    assert (
+        'echo "UV_CONCURRENT_DOWNLOADS=${UV_CONCURRENT_DOWNLOADS:-<unset>}"'
+        in run_script
+    )

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -303,6 +303,20 @@ def test_stability_lane_render_inherits_release_build_source() -> None:
 
 
 @pytest.mark.integration
+def test_stability_lane_runtime_socket_uses_owned_tmpfs() -> None:
+    rendered_config = _compose_config_json()
+    runtime_service = rendered_config["services"]["omninode-runtime"]
+
+    assert runtime_service["tmpfs"] == ["/run/onex-runtime:uid=1000,gid=1000,mode=0770"]
+    volume_targets = {
+        volume["target"]
+        for volume in runtime_service.get("volumes", [])
+        if isinstance(volume, dict) and "target" in volume
+    }
+    assert "/run/onex-runtime" not in volume_targets
+
+
+@pytest.mark.integration
 def test_stability_lane_render_does_not_expose_production_ports_or_services() -> None:
     rendered_config = _compose_config_json()
     services = rendered_config["services"]

--- a/tests/unit/docker/test_docker_security.py
+++ b/tests/unit/docker/test_docker_security.py
@@ -539,6 +539,16 @@ class TestDockerComposeSecurity:
                 f"Unsafe restart policy: {policy} (use unless-stopped or on-failure)"
             )
 
+    def test_runtime_socket_uses_owned_tmpfs(self) -> None:
+        """Runtime socket mount must not depend on host directory ownership."""
+        compose_file = COMPOSE_FILE_PATH
+        content = compose_file.read_text()
+
+        assert "/data/omninode/runtime-local-ingress" not in content
+        assert "${ONEX_LOCAL_RUNTIME_SOCKET_DIR" not in content
+        assert "tmpfs:" in content
+        assert "/run/onex-runtime:uid=1000,gid=1000,mode=0770" in content
+
 
 @pytest.mark.unit
 class TestDockerNetworkSecurity:

--- a/tests/unit/event_bus/test_kafka_event_bus.py
+++ b/tests/unit/event_bus/test_kafka_event_bus.py
@@ -1364,6 +1364,7 @@ class TestKafkaEventBusConsumerGroupId:
                 match="Consumer group ID is required",
             ):
                 await event_bus._start_consumer_for_topic("test-topic", "   ")
+            assert event_bus._pending_consumer_keys == set()
 
     @pytest.mark.asyncio
     async def test_empty_group_id_raises_error(self, mock_producer: AsyncMock) -> None:
@@ -1381,6 +1382,35 @@ class TestKafkaEventBusConsumerGroupId:
                 match="Consumer group ID is required",
             ):
                 await event_bus._start_consumer_for_topic("test-topic", "")
+            assert event_bus._pending_consumer_keys == set()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_consumer_start_stops_consumer(
+        self, mock_producer: AsyncMock, mock_consumer: AsyncMock
+    ) -> None:
+        """Cancelled consumer startup must not leave an AIOKafkaConsumer open."""
+        mock_consumer.start = AsyncMock(side_effect=asyncio.CancelledError())
+        consumer_cls = MagicMock(return_value=mock_consumer)
+
+        with (
+            patch(
+                "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+                return_value=mock_producer,
+            ),
+            patch(
+                "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+                consumer_cls,
+            ),
+        ):
+            config = ModelKafkaEventBusConfig(bootstrap_servers=TEST_BOOTSTRAP_SERVERS)
+            event_bus = EventBusKafka(config=config)
+
+            with pytest.raises(asyncio.CancelledError):
+                await event_bus._start_consumer_for_topic("test-topic", "test-group")
+
+        mock_consumer.stop.assert_awaited_once()
+        assert event_bus._pending_consumer_keys == set()
+        assert event_bus._group_consumers == {}
 
     @pytest.mark.asyncio
     async def test_group_id_not_double_suffixed(

--- a/tests/unit/runtime/test_runtime_host_process.py
+++ b/tests/unit/runtime/test_runtime_host_process.py
@@ -818,6 +818,53 @@ class TestRuntimeHostProcessLifecycle:
         assert process._is_starting is False
         assert process.is_running is False
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_startup_failure_runs_shutdown_cleanup(self) -> None:
+        """Failed startup must release resources created before the error."""
+
+        process = RuntimeHostProcess(config=make_runtime_config())
+        startup_error = RuntimeError("startup boom")
+        cleanup = AsyncMock()
+
+        async def failing_start_runtime() -> None:
+            raise startup_error
+
+        with (
+            patch.object(process, "_start_runtime", failing_start_runtime),
+            patch.object(process, "stop", cleanup),
+        ):
+            with pytest.raises(RuntimeError, match="startup boom"):
+                await process.start()
+
+        cleanup.assert_awaited_once()
+        assert process._startup_task is None
+        assert process._is_starting is False
+        assert process.is_running is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_startup_cleanup_error_preserves_original_failure(self) -> None:
+        """Cleanup errors after failed startup must not mask the root cause."""
+
+        process = RuntimeHostProcess(config=make_runtime_config())
+        cleanup = AsyncMock(side_effect=RuntimeError("cleanup boom"))
+
+        async def failing_start_runtime() -> None:
+            raise RuntimeError("startup boom")
+
+        with (
+            patch.object(process, "_start_runtime", failing_start_runtime),
+            patch.object(process, "stop", cleanup),
+        ):
+            with pytest.raises(RuntimeError, match="startup boom"):
+                await process.start()
+
+        cleanup.assert_awaited_once()
+        assert process._startup_task is None
+        assert process._is_starting is False
+        assert process.is_running is False
+
     @pytest.mark.asyncio
     async def test_stop_calls_shutdown_on_all_handlers(self) -> None:
         """Test that stop() calls shutdown() on all registered handlers.


### PR DESCRIPTION
Evidence-Ticket: OMN-11067
Evidence-Source: f6cb14f2c2b63c85c4520985285a053c1ac70cb4

## Summary
- replace the runtime socket host bind mount with a runtime-owned tmpfs at /run/onex-runtime
- keep the typed local ingress contract path unchanged
- clean up partially started runtime resources and cancelled Kafka consumers after startup failure
- harden uv dependency installs in CI against transient GitHub/PyPI transport failures seen while validating this PR

## Verification
- uv run pytest tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_runtime_socket_uses_owned_tmpfs tests/unit/runtime/test_runtime_host_process.py::TestRuntimeHostProcessLifecycle tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/event_bus/test_kafka_event_bus.py::TestKafkaEventBusConsumerGroupId -q
- PYTHONPATH=$PWD/src:$PYTHONPATH uv run pytest tests/integration/test_runtime_pattern_b_ingress_config.py tests/unit/runtime/test_runtime_local_ingress.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/runtime/test_kernel.py::TestLoadRuntimeConfig::test_repo_runtime_config_enables_main_profile_ingress tests/unit/models/test_model_serialization_roundtrip.py tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_lane_runtime_socket_uses_owned_tmpfs -q
- uv run ruff check src/omnibase_infra/runtime/service_runtime_host_process.py src/omnibase_infra/event_bus/event_bus_kafka.py tests/unit/runtime/test_runtime_host_process.py tests/unit/event_bus/test_kafka_event_bus.py tests/unit/docker/test_docker_security.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- git diff --check
- uv run pytest tests/ci/test_ci_workflow_resilience.py -q
- uv run ruff check tests/ci/test_ci_workflow_resilience.py
- uv run python - <<'EOF'
from pathlib import Path
import yaml
for p in ['.github/workflows/ci.yml', '.github/actions/setup-python-uv/action.yml']:
    yaml.safe_load(Path(p).read_text())
    print(f'{p} parsed')
EOF

## Live validation
Not run yet: no .201 deploy or restart performed. After merge/deploy, validate that omninode-stability-test-runtime stops restarting, /health reports runtime_attached, and the OmniMarket Pattern B broker group is active.