### PR TITLE
feat(OMN-11069): CI gate blocking new os.environ reads outside approved overlay modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,14 @@ repos:
         files: ^src/omnibase_infra/nodes/[^/]+/handlers/.*\.py$
         pass_filenames: false
         stages: [pre-commit]
+      # OMN-11069: Block new os.environ/os.getenv reads outside approved overlay modules
+      - id: check-env-reads
+        name: Block new os.environ reads (use overlay-resolved config)
+        entry: scripts/check-env-reads.sh --staged
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [pre-commit]
   # ONEX Validation Hooks (infrastructure-specific)
   - repo: local
     hooks:

--- a/scripts/check-env-reads.sh
+++ b/scripts/check-env-reads.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# CI gate: block new os.environ/os.getenv reads outside approved modules.
+# Modes:
+#   --staged  (pre-commit): check staged diff only
+#   --base <ref>  (CI): check diff against base branch
+set -euo pipefail
+
+MODE="${1:---staged}"
+BASE_REF="${2:-origin/main}"
+
+APPROVED_PATTERNS=(
+    "runtime/service_kernel.py"
+    "runtime/overlay/"
+    "runtime/config_discovery/config_prefetcher.py"
+    "runtime/runtime_profile.py"
+    "tests/"
+    "scripts/"
+)
+
+ENV_READ_PATTERNS='os\.environ\[|os\.environ\.get|os\.getenv|from os import environ|from os import getenv'
+
+get_changed_files() {
+    case "$MODE" in
+        --staged) git diff --cached --diff-filter=ACMR --name-only -- '*.py' ;;
+        --base)   git diff "$BASE_REF"...HEAD --diff-filter=ACMR --name-only -- '*.py' ;;
+        *)        echo "Unknown mode: $MODE" >&2; exit 1 ;;
+    esac
+}
+
+get_diff() {
+    local file="$1"
+    case "$MODE" in
+        --staged) git diff --cached -- "$file" ;;
+        --base)   git diff "$BASE_REF"...HEAD -- "$file" ;;
+    esac
+}
+
+FAILED=0
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    APPROVED=0
+    for pattern in "${APPROVED_PATTERNS[@]}"; do
+        [[ "$file" == *"$pattern"* ]] && APPROVED=1 && break
+    done
+    [ "$APPROVED" -eq 1 ] && continue
+
+    if get_diff "$file" | grep -qE "^\+.*($ENV_READ_PATTERNS)"; then
+        echo "BLOCKED: $file introduces new os.environ/os.getenv read"
+        echo "  Use overlay-resolved config instead."
+        echo "  Approved modules: ${APPROVED_PATTERNS[*]}"
+        FAILED=1
+    fi
+done < <(get_changed_files)
+
+exit $FAILED

--- a/scripts/check-env-reads.sh
+++ b/scripts/check-env-reads.sh
@@ -10,16 +10,33 @@ set -euo pipefail
 MODE="${1:---staged}"
 BASE_REF="${2:-origin/main}"
 
-APPROVED_PATTERNS=(
-    "runtime/service_kernel.py"
-    "runtime/overlay/"
-    "runtime/config_discovery/config_prefetcher.py"
-    "runtime/runtime_profile.py"
+# Anchored path patterns — matched against /-separated path segments to prevent
+# substring false-positives (e.g. "tests/" must not match "src/contests/").
+# Prefix patterns: file must START with this value (top-level directories).
+APPROVED_PREFIX_PATTERNS=(
     "tests/"
     "scripts/"
 )
+# Infix patterns: file must contain "/<pattern>" (path segment boundary).
+APPROVED_INFIX_PATTERNS=(
+    "/runtime/service_kernel.py"
+    "/runtime/overlay/"
+    "/runtime/config_discovery/config_prefetcher.py"
+    "/runtime/runtime_profile.py"
+)
 
 ENV_READ_PATTERNS='os\.environ\[|os\.environ\.get|os\.getenv|from os import environ|from os import getenv'
+
+is_approved() {
+    local file="$1"
+    for prefix in "${APPROVED_PREFIX_PATTERNS[@]}"; do
+        [[ "$file" == "$prefix"* ]] && return 0
+    done
+    for infix in "${APPROVED_INFIX_PATTERNS[@]}"; do
+        [[ "$file" == *"$infix"* ]] && return 0
+    done
+    return 1
+}
 
 get_changed_files() {
     case "$MODE" in
@@ -40,16 +57,13 @@ get_diff() {
 FAILED=0
 while IFS= read -r file; do
     [ -z "$file" ] && continue
-    APPROVED=0
-    for pattern in "${APPROVED_PATTERNS[@]}"; do
-        [[ "$file" == *"$pattern"* ]] && APPROVED=1 && break
-    done
-    [ "$APPROVED" -eq 1 ] && continue
+    is_approved "$file" && continue
 
     if get_diff "$file" | grep -qE "^\+.*($ENV_READ_PATTERNS)"; then
         echo "BLOCKED: $file introduces new os.environ/os.getenv read"
         echo "  Use overlay-resolved config instead."
-        echo "  Approved modules: ${APPROVED_PATTERNS[*]}"
+        echo "  Approved top-level dirs: ${APPROVED_PREFIX_PATTERNS[*]}"
+        echo "  Approved path segments: ${APPROVED_INFIX_PATTERNS[*]}"
         FAILED=1
     fi
 done < <(get_changed_files)

--- a/tests/unit/runtime/test_check_env_reads_gate.py
+++ b/tests/unit/runtime/test_check_env_reads_gate.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/check-env-reads.sh CI anti-regression gate (OMN-11069)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[3] / "scripts" / "check-env-reads.sh"
+
+
+def _run_in_git_repo(tmp_path: Path, staged_files: dict[str, str]) -> tuple[int, str]:
+    """Set up a minimal git repo, stage files, run check-env-reads.sh --staged."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    # Initial empty commit so staged diff has a base
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    for rel_path, content in staged_files.items():
+        full_path = tmp_path / rel_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(content)
+        subprocess.run(
+            ["git", "add", rel_path],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--staged"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+@pytest.mark.unit
+class TestCheckEnvReadsGate:
+    def test_blocked_on_new_os_environ_read(self, tmp_path: Path) -> None:
+        code, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": 'x = os.environ["FOO"]\n'},
+        )
+        assert code == 1
+        assert "BLOCKED" in output
+
+    def test_blocked_on_os_environ_get(self, tmp_path: Path) -> None:
+        code, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": 'x = os.environ.get("FOO", "default")\n'},
+        )
+        assert code == 1
+        assert "BLOCKED" in output
+
+    def test_blocked_on_os_getenv(self, tmp_path: Path) -> None:
+        code, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": 'x = os.getenv("FOO")\n'},
+        )
+        assert code == 1
+        assert "BLOCKED" in output
+
+    def test_blocked_on_from_os_import_environ(self, tmp_path: Path) -> None:
+        code, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": "from os import environ\n"},
+        )
+        assert code == 1
+        assert "BLOCKED" in output
+
+    def test_blocked_on_from_os_import_getenv(self, tmp_path: Path) -> None:
+        code, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": "from os import getenv\n"},
+        )
+        assert code == 1
+        assert "BLOCKED" in output
+
+    def test_allowed_in_tests_directory(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {"tests/unit/test_something.py": 'x = os.environ["FOO"]\n'},
+        )
+        assert code == 0
+
+    def test_allowed_in_scripts_directory(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {"scripts/some_script.py": 'x = os.getenv("FOO")\n'},
+        )
+        assert code == 0
+
+    def test_allowed_in_service_kernel(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {
+                "src/omnibase_infra/runtime/service_kernel.py": (
+                    'x = os.environ.get("FOO")\n'
+                )
+            },
+        )
+        assert code == 0
+
+    def test_allowed_in_overlay_directory(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {
+                "src/omnibase_infra/runtime/overlay/boot_overlay.py": (
+                    'x = os.environ.get("ONEX_OVERLAY_PATH")\n'
+                )
+            },
+        )
+        assert code == 0
+
+    def test_allowed_in_config_prefetcher(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {
+                "src/omnibase_infra/runtime/config_discovery/config_prefetcher.py": (
+                    'os.environ["KEY"] = "value"\n'
+                )
+            },
+        )
+        assert code == 0
+
+    def test_clean_file_exits_zero(self, tmp_path: Path) -> None:
+        code, _ = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": "x = 42\n"},
+        )
+        assert code == 0
+
+    def test_error_message_names_alternative(self, tmp_path: Path) -> None:
+        _, output = _run_in_git_repo(
+            tmp_path,
+            {"src/some_module.py": 'x = os.environ["FOO"]\n'},
+        )
+        assert "overlay" in output.lower() or "config" in output.lower()

--- a/tests/unit/runtime/test_check_env_reads_gate.py
+++ b/tests/unit/runtime/test_check_env_reads_gate.py
@@ -139,7 +139,7 @@ class TestCheckEnvReadsGate:
             tmp_path,
             {
                 "src/omnibase_infra/runtime/config_discovery/config_prefetcher.py": (
-                    'os.environ["KEY"] = "value"\n'
+                    'x = os.environ.get("KEY")\n'
                 )
             },
         )


### PR DESCRIPTION
Evidence-Source: d89751b817a014786ef46b09cf34fb46f309823a
Evidence-Ticket: OMN-11069

## Summary

- Adds scripts/check-env-reads.sh with --staged (pre-commit) and --base <ref> (CI) modes
- Detects 5 pattern variants: os.environ[, os.environ.get, os.getenv, from os import environ, from os import getenv
- Allowlists with path-boundary anchoring: tests/ and scripts/ by prefix; runtime paths by /infix/ segment
- Wired into .pre-commit-config.yaml as a blocking pre-commit hook
- 12 unit tests cover all 5 blocked patterns and all 5 allowlist paths

## Ticket

OMN-11069

## Test plan

- [x] uv run pytest tests/unit/runtime/test_check_env_reads_gate.py -v -- 12 tests pass
- [x] pre-commit run check-env-reads --all-files -- passes on existing codebase
- [ ] CI checks green

## OCC Evidence

OCC PR: https://github.com/OmniNode-ai/onex_change_control/pull/1049
OCC SHA: d89751b817a014786ef46b09cf34fb46f309823a