### PR TITLE
feat(OMN-11069): add OverlayFileLoader with error taxonomy

### DIFF
--- a/contracts/OMN-11069.yaml
+++ b/contracts/OMN-11069.yaml
@@ -1,0 +1,33 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11069
+title: "Add OverlayFileLoader with error taxonomy for overlay YAML parsing"
+summary: "Introduces OverlayFileLoader and 6 overlay-specific error types in omnibase_infra.runtime.overlay. All overlay YAML parsing goes through this loader — no direct yaml.safe_load elsewhere."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Unit and integration tests for OverlayFileLoader covering all error paths and permission modes."
+    command: "uv run pytest tests/unit/runtime/overlay/ tests/integration/runtime/test_overlay_file_loader_integration.py -v"
+  - kind: manual
+    description: "Deploy-gate proof: OverlayFileLoader importable from the deployed runtime image."
+    command: >-
+      deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay import OverlayFileLoader, OverlayNotFoundError, OverlaySchemaInvalidError, OverlayPermissionError; print('overlay module OK')"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-unit-tests
+    description: "Unit tests cover all 8 loader paths including permission modes and error types."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/overlay/ tests/integration/runtime/test_overlay_file_loader_integration.py -v"
+  - id: dod-deploy-proof
+    description: "Post-merge deploy proof: OverlayFileLoader and error types importable from runtime container."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay import OverlayFileLoader, OverlayNotFoundError, OverlaySchemaInvalidError, OverlayPermissionError; print('overlay module OK')"

--- a/src/omnibase_infra/runtime/overlay/__init__.py
+++ b/src/omnibase_infra/runtime/overlay/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay configuration loading and error types."""
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayMergeConflictError,
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+    RequiredConfigMissingError,
+    UnsupportedOverlayVersionError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+__all__ = [
+    "OverlayFileLoader",
+    "OverlayMergeConflictError",
+    "OverlayNotFoundError",
+    "OverlayPermissionError",
+    "OverlaySchemaInvalidError",
+    "RequiredConfigMissingError",
+    "UnsupportedOverlayVersionError",
+]

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay-specific error classes for OverlayFileLoader and related components."""
+
+from __future__ import annotations
+
+from omnibase_infra.errors import RuntimeHostError
+
+
+class OverlayNotFoundError(RuntimeHostError):
+    """Overlay file is missing; user must run onboarding to generate one."""
+
+
+class OverlaySchemaInvalidError(RuntimeHostError):
+    """Overlay file is malformed YAML or fails Pydantic schema validation."""
+
+
+class UnsupportedOverlayVersionError(RuntimeHostError):
+    """Overlay file declares a version not in the supported set."""
+
+
+class OverlayPermissionError(RuntimeHostError):
+    """Overlay file permissions are too open for a secret-containing file."""
+
+
+class OverlayMergeConflictError(RuntimeHostError):
+    """Irreconcilable conflict detected in the overlay stack."""
+
+
+class RequiredConfigMissingError(RuntimeHostError):
+    """A contract-required config key has no value in the overlay."""

--- a/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OverlayFileLoader: loads and validates overlay YAML files."""
+
+from __future__ import annotations
+
+import logging
+import stat
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+
+logger = logging.getLogger(__name__)
+
+_ONBOARDING_MSG = (
+    "Overlay file not found at '{path}'. "
+    "Run onboarding to generate your overlay file: `onex-infra onboard`."
+)
+
+# group-read, group-write, other-read, other-write
+_OPEN_PERMISSION_MASK = stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
+
+
+class OverlayFileLoader:
+    """Loads and validates overlay YAML files into typed ModelOverlayFile instances.
+
+    All overlay parsing goes through this loader — no direct yaml.safe_load elsewhere.
+    """
+
+    def __init__(self, *, require_restricted_permissions: bool = False) -> None:
+        self._require_restricted_permissions = require_restricted_permissions
+
+    def load(self, overlay_path: Path) -> object:
+        """Load and validate an overlay YAML file.
+
+        Args:
+            overlay_path: Path to the overlay YAML file.
+
+        Returns:
+            Validated ModelOverlayFile instance.
+
+        Raises:
+            OverlayNotFoundError: File does not exist.
+            OverlayPermissionError: File permissions too open (when require_restricted_permissions=True).
+            OverlaySchemaInvalidError: YAML parse error or Pydantic validation failure.
+        """
+        # Import here to allow pytest.importorskip to handle missing core models
+        try:
+            from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
+        except ImportError as exc:
+            raise ImportError(
+                "omnibase_core.models.overlay.model_overlay_file is not available. "
+                "Ensure omnibase_core PR #1082 has been merged and installed."
+            ) from exc
+
+        if not overlay_path.exists():
+            raise OverlayNotFoundError(_ONBOARDING_MSG.format(path=overlay_path))
+
+        self._check_permissions(overlay_path)
+
+        try:
+            raw = yaml.safe_load(overlay_path.read_text())
+        except yaml.YAMLError as exc:
+            raise OverlaySchemaInvalidError(
+                f"Failed to parse overlay YAML at '{overlay_path}': {exc}"
+            ) from exc
+
+        if not isinstance(raw, dict):
+            raise OverlaySchemaInvalidError(
+                f"Overlay file at '{overlay_path}' must be a YAML mapping, got {type(raw).__name__}"
+            )
+
+        try:
+            return ModelOverlayFile.model_validate(raw)
+        except ValidationError as exc:
+            raise OverlaySchemaInvalidError(
+                f"Overlay schema validation failed for '{overlay_path}': {exc}"
+            ) from exc
+
+    def _check_permissions(self, path: Path) -> None:
+        mode = path.stat().st_mode
+        is_open = bool(mode & _OPEN_PERMISSION_MASK)
+        if not is_open:
+            return
+        if self._require_restricted_permissions:
+            raise OverlayPermissionError(
+                f"Overlay file '{path}' has permissions too open for a secret-containing file. "
+                f"Run: chmod 600 '{path}'"
+            )
+        logger.warning(
+            "Overlay file '%s' has open permissions (mode=%s). "
+            "Run `chmod 600 '%s'` to restrict access.",
+            path,
+            oct(mode & 0o777),
+            path,
+        )

--- a/tests/integration/runtime/test_overlay_file_loader_integration.py
+++ b/tests/integration/runtime/test_overlay_file_loader_integration.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OverlayFileLoader.
+
+These tests verify the full parse-and-validate path end-to-end using real
+YAML fixtures on disk, without mocking the model or YAML parser.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("omnibase_core.models.overlay.model_overlay_file")
+
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import (
+    OverlayFileLoader,
+)
+
+_FULL_OVERLAY = """\
+overlay_version: '1.0.0'
+environment: dev
+scope: env
+transports:
+  database:
+    POSTGRES_HOST: db.test.local
+    POSTGRES_PORT: '5436'
+  kafka:
+    KAFKA_BOOTSTRAP_SERVERS: kafka.test.local:9092
+secrets:
+  INFISICAL_ADDR: 'http://infisical.test.local:8880'
+services:
+  omniclaude:
+    ENABLE_POSTGRES: 'true'
+llm:
+  coder:
+    url: 'http://llm.test.local:8000'
+"""
+
+
+@pytest.mark.integration
+class TestOverlayFileLoaderIntegration:
+    def test_full_overlay_round_trip(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_FULL_OVERLAY)
+        result = OverlayFileLoader().load(p)
+
+        assert str(result.overlay_version) == "1.0.0"
+        assert result.environment == "dev"
+        assert result.transports["database"]["POSTGRES_HOST"] == "db.test.local"
+        assert (
+            result.transports["kafka"]["KAFKA_BOOTSTRAP_SERVERS"]
+            == "kafka.test.local:9092"
+        )
+        assert result.secrets["INFISICAL_ADDR"] == "http://infisical.test.local:8880"
+        assert result.services["omniclaude"]["ENABLE_POSTGRES"] == "true"
+        assert result.llm["coder"]["url"] == "http://llm.test.local:8000"
+
+    def test_content_hash_stable_on_reload(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_FULL_OVERLAY)
+        loader = OverlayFileLoader()
+        r1 = loader.load(p)
+        r2 = loader.load(p)
+        assert r1.content_hash() == r2.content_hash()
+
+    def test_missing_overlay_gives_onboarding_instructions(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(OverlayNotFoundError, match="onboarding"):
+            OverlayFileLoader().load(tmp_path / "does_not_exist.yaml")
+
+    def test_invalid_yaml_content_raises_schema_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("not_a_mapping: [1, 2\n  broken yaml {{")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_permission_enforcement_on_600(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\nenvironment: dev\nscope: env\n")
+        p.chmod(0o600)
+        result = OverlayFileLoader(require_restricted_permissions=True).load(p)
+        assert result is not None
+
+    def test_permission_enforcement_rejects_644(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\nenvironment: dev\nscope: env\n")
+        p.chmod(0o644)
+        with pytest.raises(OverlayPermissionError):
+            OverlayFileLoader(require_restricted_permissions=True).load(p)

--- a/tests/unit/runtime/overlay/__init__.py
+++ b/tests/unit/runtime/overlay/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/overlay/test_overlay_file_loader.py
+++ b/tests/unit/runtime/overlay/test_overlay_file_loader.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OverlayFileLoader."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("omnibase_core.models.overlay.model_overlay_file")
+
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import (
+    OverlayFileLoader,
+)
+
+_VALID_OVERLAY = (
+    "overlay_version: '1.0.0'\n"
+    "environment: dev\n"
+    "scope: env\n"
+    "transports:\n"
+    "  database:\n"
+    "    POSTGRES_HOST: localhost\n"
+)
+
+
+@pytest.mark.unit
+class TestOverlayFileLoader:
+    def test_loads_valid_overlay(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        result = OverlayFileLoader().load(p)
+        assert result.environment == "dev"
+        assert result.transports["database"]["POSTGRES_HOST"] == "localhost"
+
+    def test_not_found_raises_with_onboarding_message(self, tmp_path: Path) -> None:
+        with pytest.raises(OverlayNotFoundError, match="onboarding"):
+            OverlayFileLoader().load(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("{{invalid yaml")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_missing_required_fields_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\n")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_unsupported_version_rejected_by_model(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '99.0.0'\nenvironment: dev\nscope: env\n")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_warn_open_permissions_logs_only(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o644)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = OverlayFileLoader(require_restricted_permissions=False).load(p)
+        assert result is not None
+        assert any(
+            "permission" in r.message.lower() or "chmod" in r.message
+            for r in caplog.records
+        )
+
+    def test_require_restricted_permissions_raises_on_open(
+        self, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o644)
+        with pytest.raises(OverlayPermissionError, match="chmod 600"):
+            OverlayFileLoader(require_restricted_permissions=True).load(p)
+
+    def test_restricted_permissions_passes_on_600(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o600)
+        result = OverlayFileLoader(require_restricted_permissions=True).load(p)
+        assert result is not None


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_infra/runtime/overlay/errors.py` with 6 error types inheriting from `RuntimeHostError`: `OverlayNotFoundError`, `OverlaySchemaInvalidError`, `UnsupportedOverlayVersionError`, `OverlayPermissionError`, `OverlayMergeConflictError`, `RequiredConfigMissingError`
- Adds `OverlayFileLoader` with configurable permission enforcement, YAML parse error handling, and Pydantic validation wrapping — all overlay YAML parsing goes through this loader
- Integration test covers round-trip, hash stability, missing file, invalid YAML, and permission modes
- Adds `contracts/OMN-11069.yaml` with deploy DoD evidence

## Ticket

OMN-11069

Evidence-Ticket: OMN-11069
Evidence-Source: OCC#1049

## Test plan

- 8 unit tests pass (with omnibase_core PR #1082 on PYTHONPATH)
- 6 integration tests pass
- All pre-commit hooks pass