### PR TITLE
feat(OMN-11069): wire overlay config into runtime boot

### DIFF
--- a/src/omnibase_infra/runtime/overlay/__init__.py
+++ b/src/omnibase_infra/runtime/overlay/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_infra/runtime/overlay/boot_overlay.py
+++ b/src/omnibase_infra/runtime/overlay/boot_overlay.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Extracted, unit-testable helper for overlay config loading at runtime boot.
+
+Once Tasks 1-4 PRs merge, replace the local stub imports with:
+  - ModelOverlayFile: omnibase_core.models.overlay.model_overlay_file
+  - ModelOverlayResolutionManifest: omnibase_core.models.overlay.model_overlay_resolution_manifest
+  - OverlayFileLoader: omnibase_infra.runtime.overlay.overlay_file_loader (real impl)
+  - OverlayConfigResolver: omnibase_infra.runtime.overlay.overlay_config_resolver (real impl)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
+from omnibase_infra.runtime.overlay.model_overlay_resolution_result import (
+    ModelOverlayResolutionResult,
+)
+from omnibase_infra.runtime.overlay.overlay_config_resolver import OverlayConfigResolver
+from omnibase_infra.runtime.overlay.overlay_file_loader import (
+    LEGACY_ENV_SENTINEL_KEYS,
+    OverlayFileLoader,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _legacy_env_vars_present() -> bool:
+    return any(os.environ.get(k) for k in LEGACY_ENV_SENTINEL_KEYS)
+
+
+def load_overlay_config(
+    *,
+    overlay_path: Path,
+    contracts_dir: Path,
+    require_overlay: bool = False,
+) -> ModelOverlayResolutionResult | None:
+    """Load and resolve overlay config for runtime boot.
+
+    Returns a resolved result ready for env injection, or None when running
+    in legacy env-var compat mode (overlay absent but legacy vars present).
+
+    Raises OverlayNotFoundError when:
+    - require_overlay=True and overlay file is missing (regardless of env vars)
+    - overlay file is missing AND no legacy env vars detected (cold-start)
+    """
+    try:
+        overlay = OverlayFileLoader().load(overlay_path)
+    except OverlayNotFoundError:
+        if require_overlay:
+            raise OverlayNotFoundError(
+                f"Overlay file required but not found at {overlay_path}. "
+                "ONEX_REQUIRE_OVERLAY=true enforces overlay-only boot. "
+                "Run onboarding to generate an overlay file: `onex onboard`"
+            )
+        if _legacy_env_vars_present():
+            logger.warning(
+                "No overlay file found at %s but legacy env vars detected. "
+                "Running in env-var compatibility mode. "
+                "Migrate by running: `onex onboard --generate-overlay`. "
+                "This fallback will be removed in a future release.",
+                overlay_path,
+            )
+            return None
+        raise OverlayNotFoundError(
+            f"No overlay file found at {overlay_path} and no legacy env vars detected. "
+            "This appears to be a fresh install. "
+            "Run onboarding to configure the runtime: `onex onboard`"
+        )
+
+    return OverlayConfigResolver().resolve(overlay, contracts_dir)

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay-specific error types for runtime boot."""
+
+from __future__ import annotations
+
+from omnibase_infra.errors.error_infra import RuntimeHostError
+
+
+class OverlayNotFoundError(RuntimeHostError):
+    """Raised when the overlay file is missing and no fallback is available."""
+
+
+class OverlaySchemaInvalidError(RuntimeHostError):
+    """Raised when the overlay file fails YAML parsing or Pydantic validation."""
+
+
+class OverlayPermissionError(RuntimeHostError):
+    """Overlay file permissions too open for a secret-containing file."""
+
+
+class RequiredConfigMissingError(RuntimeHostError):
+    """One or more required config keys declared in contracts are absent from the overlay."""

--- a/src/omnibase_infra/runtime/overlay/model_overlay_env_injection_result.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_env_injection_result.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Result model for overlay environment injection."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelOverlayEnvInjectionResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    injected_keys: tuple[str, ...] = Field(default_factory=tuple)
+    skipped_existing_keys: tuple[str, ...] = Field(default_factory=tuple)

--- a/src/omnibase_infra/runtime/overlay/model_overlay_file.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_file.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Stub ModelOverlayFile — replaced by omnibase_core.models.overlay.model_overlay_file once Task 1 merges."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_SUPPORTED_VERSIONS = frozenset({"1.0.0"})
+
+
+class ModelOverlayFile(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    overlay_version: str = Field(..., min_length=1)
+    environment: str = Field(..., min_length=1)
+    scope: str = Field(...)
+    transports: dict[str, dict[str, str]] = Field(default_factory=dict)
+    secrets: dict[str, str] = Field(default_factory=dict)
+    services: dict[str, dict[str, str]] = Field(default_factory=dict)
+    llm: dict[str, dict[str, str]] = Field(default_factory=dict)
+
+    @field_validator("overlay_version")
+    @classmethod
+    def _check_version(cls, v: str) -> str:
+        if v not in _SUPPORTED_VERSIONS:
+            msg = f"overlay_version '{v}' not supported; supported: {sorted(_SUPPORTED_VERSIONS)}"
+            raise ValueError(msg)
+        return v
+
+    def content_hash(self) -> str:
+        canonical = json.dumps(self.model_dump(mode="json"), sort_keys=True)
+        return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+    def all_env_pairs(self) -> dict[str, str]:
+        pairs: dict[str, str] = {}
+        for section_vals in self.transports.values():
+            pairs.update(section_vals)
+        pairs.update(self.secrets)
+        for section_vals in self.services.values():
+            pairs.update(section_vals)
+        for section_vals in self.llm.values():
+            pairs.update(section_vals)
+        return pairs

--- a/src/omnibase_infra/runtime/overlay/model_overlay_resolution_manifest.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_resolution_manifest.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Stub ModelOverlayResolutionManifest — replaced by omnibase_core.models.overlay once Task 2 merges."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelOverlayResolutionManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    overlay_file_hash: str = Field(...)
+    overlay_version: str = Field(...)
+    overlay_scope_stack: tuple[str, ...] = Field(...)
+    contract_requirements_hash: str = Field(...)
+    resolved_config_hash: str = Field(...)
+    resolved_transports: tuple[str, ...] = Field(...)
+    required_transports: tuple[str, ...] = Field(...)
+    runtime_version: str = Field(...)
+    timestamp: datetime = Field(...)
+    config_source: str = Field(...)
+
+    def stable_identity_hash(self) -> str:
+        stable = {
+            "overlay_file_hash": self.overlay_file_hash,
+            "contract_requirements_hash": self.contract_requirements_hash,
+            "resolved_config_hash": self.resolved_config_hash,
+            "resolved_transports": sorted(self.resolved_transports),
+        }
+        return f"sha256:{hashlib.sha256(json.dumps(stable, sort_keys=True).encode()).hexdigest()}"
+
+    def model_dump_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.model_dump(mode="json"), indent=indent)

--- a/src/omnibase_infra/runtime/overlay/model_overlay_resolution_manifest.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_resolution_manifest.py
@@ -34,5 +34,5 @@ class ModelOverlayResolutionManifest(BaseModel):
         }
         return f"sha256:{hashlib.sha256(json.dumps(stable, sort_keys=True).encode()).hexdigest()}"
 
-    def model_dump_json(self, *, indent: int = 2) -> str:
+    def to_json(self, *, indent: int = 2) -> str:
         return json.dumps(self.model_dump(mode="json"), indent=indent)

--- a/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Resolution result model for overlay config resolver."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.runtime.overlay.model_overlay_env_injection_result import (
+    ModelOverlayEnvInjectionResult,
+)
+from omnibase_infra.runtime.overlay.model_overlay_resolution_manifest import (
+    ModelOverlayResolutionManifest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ModelOverlayResolutionResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    resolved: dict[str, str] = Field(default_factory=dict)
+    missing: tuple[str, ...] = Field(default_factory=tuple)
+    manifest: ModelOverlayResolutionManifest
+
+    def apply_to_environment(self) -> ModelOverlayEnvInjectionResult:
+        injected: list[str] = []
+        skipped: list[str] = []
+        for key, value in self.resolved.items():
+            if key in os.environ:
+                logger.warning(
+                    "Overlay key %s already set in environment (existing=%s); skipping",
+                    key,
+                    os.environ[key],
+                )
+                skipped.append(key)
+            else:
+                os.environ[key] = value
+                injected.append(key)
+        return ModelOverlayEnvInjectionResult(
+            injected_keys=tuple(injected),
+            skipped_existing_keys=tuple(skipped),
+        )

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay config resolver — resolves overlay values against contract requirements."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.model_overlay_file import ModelOverlayFile
+from omnibase_infra.runtime.overlay.model_overlay_resolution_manifest import (
+    ModelOverlayResolutionManifest,
+)
+from omnibase_infra.runtime.overlay.model_overlay_resolution_result import (
+    ModelOverlayResolutionResult,
+)
+
+
+class OverlayConfigResolver:
+    """Resolves a loaded ModelOverlayFile against contract requirements.
+
+    When the real Tasks 3/4 implementations merge, this class is replaced by
+    omnibase_infra.runtime.overlay.overlay_config_resolver from that PR.
+    Until then, this stub resolves all overlay key/value pairs without
+    requirement-level filtering.
+    """
+
+    def resolve(
+        self,
+        overlay: ModelOverlayFile,
+        requirements: object | None = None,
+    ) -> ModelOverlayResolutionResult:
+        all_pairs = overlay.all_env_pairs()
+        resolved_hash = f"sha256:{hashlib.sha256(json.dumps(all_pairs, sort_keys=True).encode()).hexdigest()}"
+        manifest = ModelOverlayResolutionManifest(
+            overlay_file_hash=overlay.content_hash(),
+            overlay_version=overlay.overlay_version,
+            overlay_scope_stack=(overlay.scope,),
+            contract_requirements_hash=_requirements_hash(requirements),
+            resolved_config_hash=resolved_hash,
+            resolved_transports=tuple(overlay.transports.keys()),
+            required_transports=tuple(overlay.transports.keys()),
+            runtime_version="stub",
+            timestamp=datetime.now(tz=UTC),
+            config_source="overlay",
+        )
+        return ModelOverlayResolutionResult(
+            resolved=all_pairs,
+            missing=(),
+            manifest=manifest,
+        )
+
+
+def _requirements_hash(requirements: object | None) -> str:
+    if requirements is None:
+        return "sha256:no-requirements"
+    try:
+        canonical = json.dumps({"contracts_dir": str(requirements)}, sort_keys=True)
+        return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+    except (TypeError, ValueError):
+        return "sha256:unserializable-requirements"

--- a/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay file loader — parses and validates overlay YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlaySchemaInvalidError,
+)
+from omnibase_infra.runtime.overlay.model_overlay_file import ModelOverlayFile
+
+# Legacy env vars that indicate the operator has a .env-style setup.
+LEGACY_ENV_SENTINEL_KEYS: tuple[str, ...] = (
+    "POSTGRES_HOST",
+    "KAFKA_BOOTSTRAP_SERVERS",
+    "VALKEY_HOST",
+    "POSTGRES_PASSWORD",
+)
+
+
+class OverlayFileLoader:
+    """Loads and validates overlay YAML files into typed ModelOverlayFile instances."""
+
+    def __init__(self, *, require_restricted_permissions: bool = False) -> None:
+        self._require_restricted_permissions = require_restricted_permissions
+
+    def load(self, path: Path) -> ModelOverlayFile:
+        if not path.exists():
+            raise OverlayNotFoundError(
+                f"Overlay file not found at {path}. "
+                "Run onboarding to generate an overlay file: `onex onboard`"
+            )
+        if self._require_restricted_permissions:
+            mode = path.stat().st_mode
+            if mode & 0o044:
+                from omnibase_infra.runtime.overlay.errors import OverlayPermissionError
+
+                raise OverlayPermissionError(
+                    f"Overlay file {path} has group/other read permissions. "
+                    "Restrict with: chmod 600 {path}"
+                )
+        try:
+            raw = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            raise OverlaySchemaInvalidError(
+                f"YAML parse error in {path}: {exc}"
+            ) from exc
+        try:
+            return ModelOverlayFile.model_validate(raw or {})
+        except Exception as exc:
+            raise OverlaySchemaInvalidError(
+                f"Schema validation failed for {path}: {exc}"
+            ) from exc

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -872,9 +872,7 @@ async def bootstrap() -> int:
                 )
                 _manifest_dir.mkdir(parents=True, exist_ok=True)
                 _manifest_path = _manifest_dir / "overlay_resolution_manifest.json"
-                _manifest_path.write_text(
-                    _overlay_result.manifest.model_dump_json(indent=2)
-                )
+                _manifest_path.write_text(_overlay_result.manifest.to_json(indent=2))
         except _OverlayNotFoundError:
             raise
         except (OSError, ValueError, ImportError) as _overlay_exc:

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -834,6 +834,56 @@ async def bootstrap() -> int:
                     parameter="event_bus.type",
                 )
 
+        # 2c. Load overlay config (OMN-11069)
+        # Overlay is the primary config path. Falls back to legacy env vars with
+        # a deprecation warning when overlay file is absent but env vars are present.
+        # Raises OverlayNotFoundError on cold-start (no overlay, no env vars).
+        _overlay_path = Path(
+            os.environ.get(
+                "ONEX_OVERLAY_PATH",
+                str(Path.home() / ".omnibase" / "overlay.yaml"),
+            )
+        )
+        _require_overlay = os.environ.get("ONEX_REQUIRE_OVERLAY", "").lower() == "true"
+        try:
+            from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+            from omnibase_infra.runtime.overlay.errors import (
+                OverlayNotFoundError as _OverlayNotFoundError,
+            )
+
+            _overlay_result = load_overlay_config(
+                overlay_path=_overlay_path,
+                contracts_dir=contracts_dir,
+                require_overlay=_require_overlay,
+            )
+            if _overlay_result is not None:
+                _injection = _overlay_result.apply_to_environment()
+                logger.info(
+                    "Overlay config loaded: source=%s injected=%d skipped=%d (correlation_id=%s)",
+                    _overlay_result.manifest.config_source,
+                    len(_injection.injected_keys),
+                    len(_injection.skipped_existing_keys),
+                    correlation_id,
+                )
+                import tempfile
+
+                _manifest_dir = Path(
+                    os.environ.get("ONEX_MANIFEST_DIR", tempfile.gettempdir())
+                )
+                _manifest_dir.mkdir(parents=True, exist_ok=True)
+                _manifest_path = _manifest_dir / "overlay_resolution_manifest.json"
+                _manifest_path.write_text(
+                    _overlay_result.manifest.model_dump_json(indent=2)
+                )
+        except _OverlayNotFoundError:
+            raise
+        except (OSError, ValueError, ImportError) as _overlay_exc:
+            logger.warning(
+                "Overlay config load failed (non-fatal, continuing with env vars): %s (correlation_id=%s)",
+                _overlay_exc,
+                correlation_id,
+            )
+
         # 3. Create event bus
         # Dispatch based on configuration or environment variable:
         # - ONEX_EVENT_BUS_TYPE env var overrides config.event_bus.type

--- a/tests/unit/runtime/overlay/__init__.py
+++ b/tests/unit/runtime/overlay/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/overlay/test_boot_overlay.py
+++ b/tests/unit/runtime/overlay/test_boot_overlay.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for load_overlay_config() boot helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
+
+_VALID_OVERLAY = (
+    "overlay_version: '1.0.0'\n"
+    "environment: dev\n"
+    "scope: env\n"
+    "transports:\n"
+    "  database:\n"
+    "    POSTGRES_HOST: overlay-host\n"
+)
+
+
+@pytest.mark.unit
+class TestBootOverlay:
+    def test_overlay_present_resolves_and_returns_manifest(self, tmp_path):
+        overlay_path = tmp_path / "overlay.yaml"
+        overlay_path.write_text(_VALID_OVERLAY)
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+
+        result = load_overlay_config(
+            overlay_path=overlay_path,
+            contracts_dir=contracts_dir,
+            require_overlay=False,
+        )
+
+        assert result is not None
+        assert result.manifest.config_source == "overlay"
+
+    def test_overlay_missing_env_present_returns_none_with_warning(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("POSTGRES_HOST", "legacy-host")
+
+        result = load_overlay_config(
+            overlay_path=tmp_path / "missing.yaml",
+            contracts_dir=tmp_path,
+            require_overlay=False,
+        )
+
+        assert result is None
+
+    def test_overlay_missing_no_env_raises_with_onboarding_message(
+        self, tmp_path, monkeypatch
+    ):
+        for key in (
+            "POSTGRES_HOST",
+            "KAFKA_BOOTSTRAP_SERVERS",
+            "VALKEY_HOST",
+            "POSTGRES_PASSWORD",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        with pytest.raises(OverlayNotFoundError, match="onboarding"):
+            load_overlay_config(
+                overlay_path=tmp_path / "missing.yaml",
+                contracts_dir=tmp_path,
+                require_overlay=False,
+            )
+
+    def test_require_overlay_true_fails_even_with_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("POSTGRES_HOST", "legacy")
+
+        with pytest.raises(OverlayNotFoundError):
+            load_overlay_config(
+                overlay_path=tmp_path / "missing.yaml",
+                contracts_dir=tmp_path,
+                require_overlay=True,
+            )
+
+    def test_overlay_present_resolved_keys_accessible(self, tmp_path):
+        overlay_path = tmp_path / "overlay.yaml"
+        overlay_path.write_text(_VALID_OVERLAY)
+
+        result = load_overlay_config(
+            overlay_path=overlay_path,
+            contracts_dir=tmp_path,
+            require_overlay=False,
+        )
+
+        assert result is not None
+        assert result.resolved.get("POSTGRES_HOST") == "overlay-host"


### PR DESCRIPTION
## Summary

- Adds `load_overlay_config()` helper in `runtime/overlay/boot_overlay.py` covering all 4 boot paths: overlay present (resolve+inject+manifest), legacy env compat (return None + WARN), cold-start (OverlayNotFoundError with onboarding message), and `ONEX_REQUIRE_OVERLAY=true` hard-fail
- Wires the helper into `service_kernel.py` `bootstrap()` between Step 2 (config load) and Step 3 (event bus) using `ONEX_OVERLAY_PATH` / `ONEX_REQUIRE_OVERLAY` env vars; writes manifest JSON to `ONEX_MANIFEST_DIR/overlay_resolution_manifest.json`
- Ships stub implementations for `ModelOverlayFile`, `OverlayFileLoader`, `OverlayConfigResolver`, and result/manifest models as single-class files; these will be replaced by the canonical omnibase_core/omnibase_infra implementations once Tasks 1-4 PRs merge

## Test plan

- [ ] `uv run pytest tests/unit/runtime/overlay/ -v` - 5 unit tests cover all 4 `load_overlay_config()` paths
- [ ] Pre-commit hooks: all pass (architecture validation, mypy, SPDX, ruff)
- [ ] Push hooks: mypy + architecture layer validation pass
- [ ] CI green

## Ticket

OMN-11069

Evidence-Source: OCC#OMN-11069

## Notes

The stub models are intentionally minimal and will be superseded by the real implementations from Tasks 1-4 workers.