### PR TITLE
fix(OMN-11095): prevent delegation intent terminal topic fallback

### DIFF
--- a/contracts/OMN-11095.yaml
+++ b/contracts/OMN-11095.yaml
@@ -1,0 +1,33 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11095
+title: "Prevent delegation intent terminal topic fallback"
+summary: "Route intermediate delegation intent payloads (routing, inference, quality-gate, baseline, remote-agent invocation) to their per-class command topics so the terminal delegation-completed topic only carries terminal ModelDelegationResult envelopes."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Focused unit + integration tests cover dispatch-result topic selection for routing, inference, quality-gate, baseline, and terminal delegation events."
+    command: "uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/integration/runtime/test_delegation_intent_topic_routing_integration.py -q"
+  - kind: manual
+    description: "Deploy-gate proof: after merge and approved runtime restart, the .201 delegation smoke shows exactly one terminal ModelDelegationResult envelope on onex.evt.omnibase-infra.delegation-completed.v1 for the test correlation, with no intermediate intent payloads."
+    command: >-
+      deploy: set -euo pipefail; CORR_ID=$(python3 -c 'import uuid; print(uuid.uuid4())'); printf '{"command_name":"delegate_skill","requester":"deploy-gate","payload":{"skill_id":"smoke","prompt":"OMN-11095 verification"},"correlation_id":"%s","response_topic":"onex.evt.omnimarket.delegate-skill-completed.v1","timeout_seconds":30}\n' "$CORR_ID" | docker exec -i omnibase-infra-redpanda rpk topic produce onex.cmd.omnimarket.delegate-skill.v1; timeout 30s docker exec omnibase-infra-redpanda rpk topic consume onex.evt.omnibase-infra.delegation-completed.v1 --offset start 2>/dev/null | grep "$CORR_ID" | wc -l | awk '{exit ($1 == 1 ? 0 : 1)}'
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-focused-tests
+    description: "Focused unit + integration tests prove the dispatch result applier routes intermediate delegation intents to their per-class command topics and reserves the terminal completed topic for ModelDelegationResult payloads."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/integration/runtime/test_delegation_intent_topic_routing_integration.py -q"
+  - id: dod-deploy-proof
+    description: "Post-merge deploy proof: rpk topic consume on the infra terminal completed topic returns exactly one terminal envelope (the ModelDelegationResult) for a fresh smoke correlation, with zero intermediate intent payloads."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: >-
+          deploy: set -euo pipefail; CORR_ID=$(python3 -c 'import uuid; print(uuid.uuid4())'); printf '{"command_name":"delegate_skill","requester":"deploy-gate","payload":{"skill_id":"smoke","prompt":"OMN-11095 verification"},"correlation_id":"%s","response_topic":"onex.evt.omnimarket.delegate-skill-completed.v1","timeout_seconds":30}\n' "$CORR_ID" | docker exec -i omnibase-infra-redpanda rpk topic produce onex.cmd.omnimarket.delegate-skill.v1; timeout 30s docker exec omnibase-infra-redpanda rpk topic consume onex.evt.omnibase-infra.delegation-completed.v1 --offset start 2>/dev/null | grep "$CORR_ID" | wc -l | awk '{exit ($1 == 1 ? 0 : 1)}'

--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -52,8 +52,17 @@ from pydantic import BaseModel
 
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums import EnumDispatchStatus, EnumInfraTransportType
+from omnibase_infra.enums.generated.enum_omnibase_infra_topic import (
+    EnumOmnibaseInfraTopic,
+)
 from omnibase_infra.errors import RuntimeHostError
 from omnibase_infra.errors.error_projection import ProjectionError
+from omnibase_infra.event_bus.topic_constants import (
+    TOPIC_DELEGATION_BASELINE_COMPARISON,
+    TOPIC_DELEGATION_INFERENCE_REQUEST,
+    TOPIC_DELEGATION_QUALITY_GATE_REQUEST,
+    TOPIC_DELEGATION_ROUTING_REQUEST,
+)
 from omnibase_infra.models.errors.model_infra_error_context import (
     ModelInfraErrorContext,
 )
@@ -71,6 +80,14 @@ if TYPE_CHECKING:
     from omnibase_infra.runtime.service_intent_executor import IntentExecutor
 
 logger = logging.getLogger(__name__)
+
+_DELEGATION_INTENT_TOPIC_BY_CLASS: dict[str, str] = {
+    "ModelBaselineIntent": TOPIC_DELEGATION_BASELINE_COMPARISON,
+    "ModelInferenceIntent": TOPIC_DELEGATION_INFERENCE_REQUEST,
+    "ModelInvocationCommand": EnumOmnibaseInfraTopic.CMD_REMOTE_AGENT_INVOKE_V1.value,
+    "ModelQualityGateIntent": TOPIC_DELEGATION_QUALITY_GATE_REQUEST,
+    "ModelRoutingIntent": TOPIC_DELEGATION_ROUTING_REQUEST,
+}
 
 
 class DispatchResultApplier:
@@ -256,19 +273,24 @@ class DispatchResultApplier:
 
     def _resolve_mapped_output_topic(self, event: BaseModel) -> str:
         """Resolve output topic from configured class maps or fallback topic."""
-        if not self._output_topic_map:
-            return self._output_topic
         class_name = type(event).__name__
+        delegation_intent_topic = _DELEGATION_INTENT_TOPIC_BY_CLASS.get(class_name)
+        if not self._output_topic_map:
+            return delegation_intent_topic or self._output_topic
         short_name = class_name.removeprefix("Model")
         return self._output_topic_map.get(
             short_name,
-            self._output_topic_map.get(class_name, self._output_topic),
+            self._output_topic_map.get(
+                class_name,
+                delegation_intent_topic or self._output_topic,
+            ),
         )
 
     def _allowed_output_topics(self) -> set[str]:
         """Return contract-derived topics the applier may publish to."""
         return {
             self._output_topic,
+            *_DELEGATION_INTENT_TOPIC_BY_CLASS.values(),
             *self._output_topic_map.values(),
             *self._topic_router.values(),
             *self._allowed_output_topic_set,

--- a/tests/integration/runtime/test_delegation_intent_topic_routing_integration.py
+++ b/tests/integration/runtime/test_delegation_intent_topic_routing_integration.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OMN-11095 delegation intent topic routing.
+
+End-to-end regression coverage that intermediate delegation intent payloads
+(routing, inference, quality-gate, baseline, remote-agent invocation) are
+published to their per-class command topics rather than the terminal
+delegation-completed fallback topic.
+
+Acceptance criteria (from OMN-11095):
+
+* Intermediate intents are not published to ``onex.evt.omnibase-infra.delegation-completed.v1``.
+* The delegation-completed topic contains only the terminal
+  ``ModelDelegationResult`` envelope for the correlation.
+* Focused tests cover dispatch-result topic selection for routing, inference,
+  quality, baseline, and terminal delegation events.
+
+These tests exercise the full DispatchResultApplier publish path with an
+in-memory capturing event bus to assert the resolved topic per output event.
+
+Related:
+    - OMN-11095: Fix delegation-completed topic contamination.
+    - src/omnibase_infra/runtime/service_dispatch_result_applier.py
+    - tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.enums.generated.enum_omnibase_infra_topic import (
+    EnumOmnibaseInfraTopic,
+)
+from omnibase_infra.event_bus.topic_constants import (
+    TOPIC_DELEGATION_BASELINE_COMPARISON,
+    TOPIC_DELEGATION_INFERENCE_REQUEST,
+    TOPIC_DELEGATION_QUALITY_GATE_REQUEST,
+    TOPIC_DELEGATION_ROUTING_REQUEST,
+)
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.service_dispatch_result_applier import (
+    DispatchResultApplier,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Stand-in payload models
+# ---------------------------------------------------------------------------
+
+
+class ModelRoutingIntent(BaseModel):
+    """Stand-in matching the omnimarket reducer routing intent class name."""
+
+    intent: str = "routing_reducer"
+    correlation_id: UUID
+
+
+class ModelInferenceIntent(BaseModel):
+    intent: str = "llm_inference"
+    correlation_id: UUID
+
+
+class ModelInvocationCommand(BaseModel):
+    intent: str = "remote_agent_invoke"
+    correlation_id: UUID
+
+
+class ModelQualityGateIntent(BaseModel):
+    intent: str = "quality_gate"
+    correlation_id: UUID
+
+
+class ModelBaselineIntent(BaseModel):
+    intent: str = "baseline_comparison"
+    correlation_id: UUID
+
+
+class ModelDelegationResult(BaseModel):
+    """Stand-in for the terminal delegation result payload."""
+
+    correlation_id: UUID
+    status: str = "completed"
+    quality_score: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# In-memory capturing event bus
+# ---------------------------------------------------------------------------
+
+
+class _CapturingEventBus:
+    """Captures every publish_envelope call for later assertions."""
+
+    def __init__(self) -> None:
+        self.published: list[dict[str, Any]] = []
+
+    async def publish_envelope(
+        self,
+        *,
+        envelope: ModelEventEnvelope[Any],
+        topic: str,
+        key: bytes | None = None,
+    ) -> None:
+        self.published.append(
+            {
+                "envelope": envelope,
+                "topic": topic,
+                "key": key,
+                "captured_at": datetime.now(UTC),
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    correlation_id: UUID,
+    output_events: list[BaseModel],
+) -> ModelDispatchResult:
+    return ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="test.topic",
+        started_at=datetime.now(UTC),
+        correlation_id=correlation_id,
+        dispatcher_id="integration-test-dispatcher",
+        output_events=output_events,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationIntentTopicRoutingIntegration:
+    """OMN-11095 regression: intermediate intents do not contaminate terminal topic."""
+
+    @pytest.mark.asyncio
+    async def test_intermediate_delegation_intents_route_to_command_topics(
+        self,
+    ) -> None:
+        """All intermediate intent classes publish to their per-class command topics.
+
+        The applier is configured with the terminal completed topic as
+        ``output_topic`` (mirroring production wiring). Each intermediate
+        intent must select its own command topic from
+        ``_DELEGATION_INTENT_TOPIC_BY_CLASS`` rather than falling back to the
+        completed terminal topic.
+        """
+        bus = _CapturingEventBus()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=bus,
+            output_topic=completed_topic,
+        )
+
+        correlation_id = uuid4()
+        result = _make_result(
+            correlation_id=correlation_id,
+            output_events=[
+                ModelRoutingIntent(correlation_id=correlation_id),
+                ModelInvocationCommand(correlation_id=correlation_id),
+                ModelInferenceIntent(correlation_id=correlation_id),
+                ModelQualityGateIntent(correlation_id=correlation_id),
+                ModelBaselineIntent(correlation_id=correlation_id),
+            ],
+        )
+
+        await applier.apply(result)
+
+        topics = [record["topic"] for record in bus.published]
+        assert topics == [
+            TOPIC_DELEGATION_ROUTING_REQUEST,
+            EnumOmnibaseInfraTopic.CMD_REMOTE_AGENT_INVOKE_V1.value,
+            TOPIC_DELEGATION_INFERENCE_REQUEST,
+            TOPIC_DELEGATION_QUALITY_GATE_REQUEST,
+            TOPIC_DELEGATION_BASELINE_COMPARISON,
+        ]
+        # The terminal topic must not appear for any intermediate intent.
+        assert completed_topic not in topics
+
+    @pytest.mark.asyncio
+    async def test_terminal_delegation_result_publishes_to_completed_topic(
+        self,
+    ) -> None:
+        """Terminal ``ModelDelegationResult`` payloads still flow through the
+        configured fallback topic."""
+        bus = _CapturingEventBus()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=bus,
+            output_topic=completed_topic,
+        )
+
+        correlation_id = uuid4()
+        result = _make_result(
+            correlation_id=correlation_id,
+            output_events=[ModelDelegationResult(correlation_id=correlation_id)],
+        )
+
+        await applier.apply(result)
+
+        assert len(bus.published) == 1
+        published = bus.published[0]
+        assert published["topic"] == completed_topic
+        assert isinstance(published["envelope"].payload, ModelDelegationResult)
+        assert published["envelope"].correlation_id == correlation_id
+
+    @pytest.mark.asyncio
+    async def test_mixed_intermediate_and_terminal_payloads_route_independently(
+        self,
+    ) -> None:
+        """A single dispatch result mixing intermediate + terminal payloads
+        routes each to its own topic without contamination."""
+        bus = _CapturingEventBus()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=bus,
+            output_topic=completed_topic,
+        )
+
+        correlation_id = uuid4()
+        result = _make_result(
+            correlation_id=correlation_id,
+            output_events=[
+                ModelRoutingIntent(correlation_id=correlation_id),
+                ModelDelegationResult(correlation_id=correlation_id),
+            ],
+        )
+
+        await applier.apply(result)
+
+        topics = [record["topic"] for record in bus.published]
+        assert topics == [
+            TOPIC_DELEGATION_ROUTING_REQUEST,
+            completed_topic,
+        ]
+        # The intermediate intent must not appear on the completed topic.
+        terminal_records = [
+            record for record in bus.published if record["topic"] == completed_topic
+        ]
+        assert len(terminal_records) == 1
+        assert isinstance(
+            terminal_records[0]["envelope"].payload, ModelDelegationResult
+        )

--- a/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
+++ b/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
@@ -58,6 +58,42 @@ class TopicCarryingEvent(BaseModel):
     value: str = "x"
 
 
+class ModelRoutingIntent(BaseModel):
+    """Stub delegation routing intent from omnimarket."""
+
+    intent: str = "routing_reducer"
+
+
+class ModelInferenceIntent(BaseModel):
+    """Stub delegation inference intent from omnimarket."""
+
+    intent: str = "llm_inference"
+
+
+class ModelInvocationCommand(BaseModel):
+    """Stub delegation remote-agent invocation command from omnibase_core."""
+
+    intent: str = "remote_agent_invoke"
+
+
+class ModelQualityGateIntent(BaseModel):
+    """Stub delegation quality-gate intent from omnimarket."""
+
+    intent: str = "quality_gate"
+
+
+class ModelBaselineIntent(BaseModel):
+    """Stub delegation baseline intent from omnimarket."""
+
+    intent: str = "baseline_comparison"
+
+
+class ModelDelegationResult(BaseModel):
+    """Stub terminal delegation result payload."""
+
+    content: str = "done"
+
+
 def _make_result(**overrides: object) -> ModelDispatchResult:
     defaults: dict[str, object] = {
         "status": EnumDispatchStatus.SUCCESS,
@@ -305,6 +341,59 @@ class TestPublishPathTopicRouting:
         assert mock_bus.publish_envelope.call_count == 2
         topics = [c.kwargs["topic"] for c in mock_bus.publish_envelope.call_args_list]
         assert topics == ["active-topic", "accepted-topic"]
+
+
+class TestDelegationIntentTopicRouting:
+    """Regression coverage for OMN-11095 delegation terminal contamination."""
+
+    @pytest.mark.asyncio
+    async def test_delegation_intermediate_intents_do_not_fall_back_to_completed_topic(
+        self,
+    ) -> None:
+        mock_bus = AsyncMock()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=completed_topic,
+        )
+        result = _make_result(
+            output_events=[
+                ModelRoutingIntent(),
+                ModelInvocationCommand(),
+                ModelInferenceIntent(),
+                ModelQualityGateIntent(),
+                ModelBaselineIntent(),
+            ],
+        )
+
+        await applier.apply(result)
+
+        topics = [c.kwargs["topic"] for c in mock_bus.publish_envelope.call_args_list]
+        assert topics == [
+            "onex.cmd.omnibase-infra.delegation-routing-request.v1",
+            "onex.cmd.omnibase-infra.remote-agent-invoke.v1",
+            "onex.cmd.omnibase-infra.delegation-inference-request.v1",
+            "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1",
+            "onex.cmd.omnibase-infra.baseline-comparison-request.v1",
+        ]
+        assert completed_topic not in topics
+
+    @pytest.mark.asyncio
+    async def test_delegation_terminal_topic_keeps_terminal_payload_only(self) -> None:
+        mock_bus = AsyncMock()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=completed_topic,
+        )
+        result = _make_result(output_events=[ModelDelegationResult()])
+
+        await applier.apply(result)
+
+        mock_bus.publish_envelope.assert_called_once()
+        call_kwargs = mock_bus.publish_envelope.call_args.kwargs
+        assert call_kwargs["topic"] == completed_topic
+        assert isinstance(call_kwargs["envelope"].payload, ModelDelegationResult)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add infra-side fallback routing for delegation intermediate intent models so they publish to their command topics instead of the delegation-completed terminal topic.
- Preserve terminal fallback behavior for actual terminal delegation result payloads.
- Add OMN-11095 regression coverage (unit + integration) for routing / baseline / inference / quality-gate / remote-agent-invocation intent contamination.

## Verification
- uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/integration/runtime/test_delegation_intent_topic_routing_integration.py -q
- uv run ruff check src/omnibase_infra/runtime/service_dispatch_result_applier.py tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/integration/runtime/test_delegation_intent_topic_routing_integration.py
- uv run mypy --strict src/omnibase_infra/runtime/service_dispatch_result_applier.py
- pre-commit run --files <changed files>
- Commit hooks passed
- Push hooks passed

## DoD evidence
- contracts/OMN-11095.yaml carries focused-tests + deploy-proof dod_evidence entries.

Linear: OMN-11095
Evidence-Source: OCC#1053
Evidence-Ticket: OMN-11095