### PR TITLE
feat(OMN-11069): extend onboarding to generate overlay files

### DIFF
--- a/contracts/OMN-11069.yaml
+++ b/contracts/OMN-11069.yaml
@@ -2,37 +2,49 @@ schema_version: "1.0.0"
 ticket_id: OMN-11069
 title: "feat(OMN-11069): Contract-overlay configuration — replace .env with contract overlays"
 summary: >-
-  Wire the existing overlay infrastructure into runtime boot and onboarding so that contracts + overlays replace .env files as the single configuration source of truth. Implements OverlayWriter, cold-start detection via load_overlay_config(), 12 unit tests, 6 integration tests.
+  Wire the overlay infrastructure into runtime boot and onboarding so that
+  contracts plus overlays replace .env files as the single configuration source
+  of truth. Includes OverlayFileLoader, OverlayWriter, cold-start detection, and
+  typed overlay error handling.
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - public_api
 evidence_requirements:
   - kind: tests
-    description: "OverlayWriter unit tests (8) and cold-start detection unit tests (4) all pass."
+    description: "OverlayFileLoader unit tests cover parsing, schema, and permission modes."
+    command: "uv run pytest tests/unit/runtime/overlay/test_overlay_file_loader.py -v"
+  - kind: tests
+    description: "OverlayWriter unit tests and cold-start detection unit tests pass."
     command: "uv run pytest tests/unit/runtime/overlay/test_overlay_writer.py tests/unit/runtime/overlay/test_cold_start.py -v"
   - kind: tests
-    description: "Integration tests for OverlayWriter + cold-start pipeline pass (6 tests)."
+    description: "Integration tests for OverlayWriter plus cold-start pipeline pass."
     command: "uv run pytest tests/integration/test_overlay_writer_coldstart_integration.py -v"
   - kind: manual
-    description: "Deploy-gate proof: OverlayWriter importable from runtime image after merge."
+    description: "Deploy-gate proof: overlay runtime APIs importable from runtime image after merge."
     command: >-
-      deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter; print('deploy-ok')"
+      deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay import OverlayFileLoader, OverlayNotFoundError, OverlaySchemaInvalidError, OverlayPermissionError; from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter; print('overlay-ok')"
 emergency_bypass:
   enabled: false
   justification: ""
   follow_up_ticket_id: ""
 dod_evidence:
+  - id: dod-overlay-loader-tests
+    description: "OverlayFileLoader unit tests cover parsing, schema validation, and permission behavior."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/overlay/test_overlay_file_loader.py -v"
   - id: dod-overlay-writer-tests
-    description: "12 unit tests + 6 integration tests for OverlayWriter + cold-start detection pass."
+    description: "OverlayWriter and cold-start detection unit and integration tests pass."
     source: manual
     checks:
       - check_type: command
         check_value: "uv run pytest tests/unit/runtime/overlay/test_overlay_writer.py tests/unit/runtime/overlay/test_cold_start.py tests/integration/test_overlay_writer_coldstart_integration.py -v --tb=short"
   - id: dod-deploy-proof
-    description: "OverlayWriter importable from omninode-runtime container after deploy."
+    description: "Overlay runtime APIs importable from omninode-runtime container after deploy."
     source: manual
     checks:
       - check_type: command
         check_value: >-
-          deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter; print('deploy-ok')"
+          deploy: docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay import OverlayFileLoader, OverlayNotFoundError, OverlaySchemaInvalidError, OverlayPermissionError; from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter; print('overlay-ok')"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -396,9 +396,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get clean
 
 # Security: upgrade setuptools in the runtime base image to clear CVE-2025-47273.
-# The builder venv already has the patched version, but the python:3.12-slim base
-# image's system Python retains the vulnerable version. Trivy scans both stages.
-RUN pip install --no-cache-dir "setuptools>=78.1.1"
+# The builder venv already has the patched wheel. Copy it into system
+# site-packages instead of fetching again from the runtime stage, which keeps
+# runtime builds independent from a second package-index lookup.
+RUN python -c "import pathlib, shutil, site; target = pathlib.Path(site.getsitepackages()[0]); [shutil.rmtree(path, ignore_errors=True) for pattern in ('setuptools', 'setuptools-*.dist-info') for path in target.glob(pattern)]"
+COPY --from=builder /app/.venv/lib/python3.12/site-packages/setuptools /usr/local/lib/python3.12/site-packages/setuptools
+COPY --from=builder /app/.venv/lib/python3.12/site-packages/setuptools-*.dist-info /usr/local/lib/python3.12/site-packages/
 
 # Create non-root user for security
 # UID 1000 is typically the first non-system user, good for volume permissions

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/contract.yaml
@@ -1,24 +1,24 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-# Ticket: OMN-8272, OMN-10784, OMN-11050
+# Ticket: OMN-8272, OMN-10784, OMN-11050, OMN-11069
 name: "node_onboarding_orchestrator"
 node_type: "ORCHESTRATOR_GENERIC"
 contract_version:
   major: 1
-  minor: 2
+  minor: 3
   patch: 0
-node_version: "1.2.0"
+node_version: "1.3.0"
 description: >
-  Onboarding orchestrator — supports two execution paths. DAG path (default): loads the canonical graph, resolves a policy to a minimal verification step set, executes verification for each step, and renders markdown output. Interactive path (OMN-10784): when policy_name is set and the resolved policy has policy_type=interactive, dispatches to InteractiveExecutor with an injected input adapter, optionally writing env config via ConfigWriter when dry_run=False. Emits lifecycle events on completion. No result field (Invariant I5).
+  Onboarding orchestrator — supports two execution paths. DAG path (default): loads the canonical graph, resolves a policy to a minimal verification step set, executes verification for each step, and renders markdown output. Interactive path (OMN-10784): when policy_name is set and the resolved policy has policy_type=interactive, dispatches to InteractiveExecutor with an injected input adapter, optionally writing env config via ConfigWriter when dry_run=False. Emits lifecycle events on completion. No result field (Invariant I5). Overlay output path support (OMN-11069): interactive onboarding writes overlay YAML as the primary output and can optionally emit the legacy env file.
 
 input_model:
   name: "ModelOnboardingInput"
   module: "omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_input"
-  description: "Target capabilities to achieve (DAG path), optional steps to skip, failure behavior flag, and interactive-path fields (policy_name, dry_run, env_output_path) for OMN-10784."
+  description: "Target capabilities to achieve (DAG path), optional steps to skip, failure behavior flag, and interactive-path fields (policy_name, dry_run, env_output_path, overlay_output_path, legacy_env_output) for OMN-10784/OMN-11069."
 output_model:
   name: "ModelOnboardingOutput"
   module: "omnibase_infra.nodes.node_onboarding_orchestrator.models.model_onboarding_output"
-  description: "Step results, success flag, counts, rendered markdown output, verification status taxonomy (status, verified_capabilities, unmet_capabilities), and interactive provenance fields (provenance, policy_name, policy_type, visited_steps, terminal_step, dry_run, env_output_path_written) for OMN-10784."
+  description: "Step results, success flag, counts, rendered markdown output, verification status taxonomy (status, verified_capabilities, unmet_capabilities), and interactive provenance fields (provenance, policy_name, policy_type, visited_steps, terminal_step, dry_run, env_output_path_written, overlay_output_path_written) for OMN-10784/OMN-11069."
 handler_routing:
   routing_strategy: "payload_type_match"
   handlers:
@@ -33,6 +33,7 @@ capabilities:
   - "onboarding.policy.resolve"
   - "onboarding.step.verify"
   - "onboarding.output.render"
+  - "onboarding.overlay.write"
 event_bus:
   subscribe_topics:
     - "onex.cmd.omnibase-infra.onboarding-start.v1"
@@ -40,5 +41,5 @@ event_bus:
     - "onex.evt.omnibase-infra.onboarding-completed.v1"
     - "onex.evt.omnibase-infra.onboarding-step-verified.v1"
 metadata:
-  description: "Onboarding orchestrator that loads the canonical graph, resolves policy, executes verifications, and renders markdown output"
-  ticket: "OMN-8272, OMN-10784, OMN-11050"
+  description: "Onboarding orchestrator that loads the canonical graph, resolves policy, executes verifications, renders markdown output, and writes overlay YAML for interactive onboarding."
+  ticket: "OMN-8272, OMN-10784, OMN-11050, OMN-11069"

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
@@ -47,6 +47,8 @@ from omnibase_infra.onboarding.renderers.renderer_markdown import (
 )
 from omnibase_infra.probes.model_verification_spec import ModelVerificationSpec
 from omnibase_infra.probes.verification_executor import execute_verification
+from omnibase_infra.runtime.overlay.overlay_from_env import overlay_from_env_dict
+from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
 
 
 class OnboardingHandlerError(ValueError):
@@ -109,16 +111,30 @@ async def _handle_interactive(
         for sr in result.step_results
     ]
 
-    # Optionally write env config
+    # Optionally write overlay and env config
     env_output_path_written: str | None = None
+    overlay_output_path_written: str | None = None
     if not input_model.dry_run:
         if input_model.env_output_path is None:
             msg = "env_output_path is required when dry_run=False"
             raise OnboardingHandlerError(msg)
         target_path = Path(input_model.env_output_path)
-        writer = ConfigWriter()
-        writer.write(result.env_dict, target_path)
-        env_output_path_written = str(target_path)
+
+        # Generate and write overlay YAML as primary output
+        overlay = overlay_from_env_dict(result.env_dict, environment="dev")
+        overlay_path = (
+            Path(input_model.overlay_output_path)
+            if input_model.overlay_output_path is not None
+            else target_path.parent / "overlay.yaml"
+        )
+        OverlayWriter().write(overlay, overlay_path)
+        overlay_output_path_written = str(overlay_path)
+
+        # Legacy .env output behind flag
+        if input_model.legacy_env_output:
+            writer = ConfigWriter()
+            writer.write(result.env_dict, target_path)
+            env_output_path_written = str(target_path)
 
     # Render env output as markdown for display
     env_lines = [f"  {k}={v}" for k, v in sorted(result.env_dict.items())]
@@ -131,7 +147,10 @@ async def _handle_interactive(
     if input_model.dry_run:
         rendered += "\n*Dry run — no files written.*\n"
     else:
-        rendered += f"\n*Written to: {env_output_path_written}*\n"
+        if overlay_output_path_written:
+            rendered += f"\n*Overlay written to: {overlay_output_path_written}*\n"
+        if env_output_path_written:
+            rendered += f"\n*Env written to: {env_output_path_written}*\n"
 
     visited_steps = [sr.step_key for sr in result.step_results]
 
@@ -148,6 +167,7 @@ async def _handle_interactive(
         terminal_step=result.terminal_step,
         dry_run=input_model.dry_run,
         env_output_path_written=env_output_path_written,
+        overlay_output_path_written=overlay_output_path_written,
     )
 
 

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/handlers/handler_onboarding.py
@@ -121,7 +121,9 @@ async def _handle_interactive(
         target_path = Path(input_model.env_output_path)
 
         # Generate and write overlay YAML as primary output
-        overlay = overlay_from_env_dict(result.env_dict, environment="dev")
+        overlay = overlay_from_env_dict(
+            result.env_dict, environment="dev", return_warnings=False
+        )
         overlay_path = (
             Path(input_model.overlay_output_path)
             if input_model.overlay_output_path is not None

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_input.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_input.py
@@ -46,6 +46,14 @@ class ModelOnboardingInput(BaseModel):
         default=None,
         description="Explicit path for env write; required when dry_run=False",
     )
+    overlay_output_path: str | None = Field(
+        default=None,
+        description="Path for overlay YAML write; derived from env_output_path when None",
+    )
+    legacy_env_output: bool = Field(
+        default=True,
+        description="When True, also write legacy .env file alongside overlay output",
+    )
 
     @model_validator(mode="after")
     def _enforce_env_output_path_when_writing(self) -> ModelOnboardingInput:

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_input.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_input.py
@@ -57,11 +57,30 @@ class ModelOnboardingInput(BaseModel):
 
     @model_validator(mode="after")
     def _enforce_env_output_path_when_writing(self) -> ModelOnboardingInput:
-        """Reject dry_run=False with no env_output_path at construction time."""
-        if not self.dry_run and (
-            self.env_output_path is None or not self.env_output_path.strip()
-        ):
-            msg = "env_output_path is required when dry_run=False"
+        """Reject write mode unless at least one requested output path is valid."""
+        if self.dry_run:
+            return self
+
+        has_env_path = self.env_output_path is not None and bool(
+            self.env_output_path.strip()
+        )
+        has_overlay_path = self.overlay_output_path is not None and bool(
+            self.overlay_output_path.strip()
+        )
+        if self.env_output_path is not None and not has_env_path:
+            msg = "env_output_path cannot be blank"
+            raise ValueError(msg)
+        if self.overlay_output_path is not None and not has_overlay_path:
+            msg = "overlay_output_path cannot be blank"
+            raise ValueError(msg)
+        if self.legacy_env_output and not has_env_path:
+            msg = "env_output_path is required when legacy_env_output=True"
+            raise ValueError(msg)
+        if not has_env_path and not has_overlay_path:
+            msg = (
+                "overlay_output_path is required when dry_run=False and "
+                "legacy_env_output=False"
+            )
             raise ValueError(msg)
         return self
 

--- a/src/omnibase_infra/runtime/overlay/__init__.py
+++ b/src/omnibase_infra/runtime/overlay/__init__.py
@@ -1,2 +1,23 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+"""Overlay configuration loading and error types."""
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayMergeConflictError,
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+    RequiredConfigMissingError,
+    UnsupportedOverlayVersionError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+__all__ = [
+    "OverlayFileLoader",
+    "OverlayMergeConflictError",
+    "OverlayNotFoundError",
+    "OverlayPermissionError",
+    "OverlaySchemaInvalidError",
+    "RequiredConfigMissingError",
+    "UnsupportedOverlayVersionError",
+]

--- a/src/omnibase_infra/runtime/overlay/__init__.py
+++ b/src/omnibase_infra/runtime/overlay/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Overlay configuration loading and error types."""
+"""Overlay configuration loading, resolution, and error types."""
 
 from omnibase_infra.runtime.overlay.errors import (
     OverlayMergeConflictError,
@@ -10,9 +10,19 @@ from omnibase_infra.runtime.overlay.errors import (
     RequiredConfigMissingError,
     UnsupportedOverlayVersionError,
 )
+from omnibase_infra.runtime.overlay.model_overlay_env_injection_result import (
+    ModelOverlayEnvInjectionResult,
+)
+from omnibase_infra.runtime.overlay.model_overlay_resolution_result import (
+    ModelOverlayResolutionResult,
+)
+from omnibase_infra.runtime.overlay.overlay_config_resolver import OverlayConfigResolver
 from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
 
 __all__ = [
+    "ModelOverlayEnvInjectionResult",
+    "ModelOverlayResolutionResult",
+    "OverlayConfigResolver",
     "OverlayFileLoader",
     "OverlayMergeConflictError",
     "OverlayNotFoundError",

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -15,9 +15,17 @@ class OverlaySchemaInvalidError(RuntimeHostError):
     """Raised when the overlay file fails YAML parsing or Pydantic validation."""
 
 
+class UnsupportedOverlayVersionError(RuntimeHostError):
+    """Overlay file declares a version not in the supported set."""
+
+
 class OverlayPermissionError(RuntimeHostError):
-    """Overlay file permissions too open for a secret-containing file."""
+    """Overlay file permissions are too open for a secret-containing file."""
+
+
+class OverlayMergeConflictError(RuntimeHostError):
+    """Irreconcilable conflict detected in the overlay stack."""
 
 
 class RequiredConfigMissingError(RuntimeHostError):
-    """One or more required config keys declared in contracts are absent from the overlay."""
+    """A contract-required config key has no value in the overlay."""

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -20,7 +20,7 @@ class UnsupportedOverlayVersionError(RuntimeHostError):
 
 
 class OverlayPermissionError(RuntimeHostError):
-    """Overlay file permissions are too open for a secret-containing file."""
+    """Overlay file permissions too open for a secret-containing file."""
 
 
 class OverlayMergeConflictError(RuntimeHostError):

--- a/src/omnibase_infra/runtime/overlay/model_overlay_env_injection_result.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_env_injection_result.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Result model for overlay environment injection."""
+"""Result model for env injection after overlay resolution."""
 
 from __future__ import annotations
 
@@ -8,7 +8,17 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ModelOverlayEnvInjectionResult(BaseModel):
+    """Records which keys were injected into os.environ and which were skipped."""
+
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    injected_keys: tuple[str, ...] = Field(default_factory=tuple)
-    skipped_existing_keys: tuple[str, ...] = Field(default_factory=tuple)
+    injected_keys: tuple[str, ...] = Field(
+        default_factory=tuple, description="Keys that were written to os.environ."
+    )
+    skipped_existing_keys: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Keys skipped because they were already set in os.environ.",
+    )
+
+
+__all__ = ["ModelOverlayEnvInjectionResult"]

--- a/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Resolution result model for overlay config resolver."""
+"""Frozen result of OverlayConfigResolver.resolve()."""
 
 from __future__ import annotations
 
@@ -20,19 +20,29 @@ logger = logging.getLogger(__name__)
 
 
 class ModelOverlayResolutionResult(BaseModel):
+    """Frozen result of resolving overlay config against contract requirements."""
+
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    resolved: dict[str, str] = Field(default_factory=dict)
-    missing: tuple[str, ...] = Field(default_factory=tuple)
-    manifest: ModelOverlayResolutionManifest
+    resolved: dict[str, str] = Field(
+        default_factory=dict, description="Keys resolved from the overlay file."
+    )
+    missing: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Optional keys that had no value in the overlay.",
+    )
+    manifest: ModelOverlayResolutionManifest = Field(
+        ..., description="Evidence artifact for this resolution."
+    )
 
     def apply_to_environment(self) -> ModelOverlayEnvInjectionResult:
+        """Inject resolved keys into os.environ without overwriting existing values."""
         injected: list[str] = []
         skipped: list[str] = []
         for key, value in self.resolved.items():
             if key in os.environ:
                 logger.warning(
-                    "Overlay key %s already set in environment; skipping overlay injection",
+                    "Overlay key %s skipped: already set in environment",
                     key,
                 )
                 skipped.append(key)
@@ -40,6 +50,9 @@ class ModelOverlayResolutionResult(BaseModel):
                 os.environ[key] = value
                 injected.append(key)
         return ModelOverlayEnvInjectionResult(
-            injected_keys=tuple(injected),
-            skipped_existing_keys=tuple(skipped),
+            injected_keys=tuple(sorted(injected)),
+            skipped_existing_keys=tuple(sorted(skipped)),
         )
+
+
+__all__ = ["ModelOverlayResolutionResult"]

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -72,13 +72,13 @@ class OverlayConfigResolver:
     ) -> ModelOverlayResolutionResult:
         env_pairs = overlay.all_env_pairs()
         if not isinstance(requirements, ModelConfigRequirements):
-            resolved = dict(sorted(env_pairs.items()))
+            all_resolved = dict(sorted(env_pairs.items()))
             manifest = ModelOverlayResolutionManifest(
                 overlay_file_hash=overlay.content_hash(),
                 overlay_version=overlay.overlay_version,
                 overlay_scope_stack=(overlay.scope.value,),
                 contract_requirements_hash=_requirements_path_hash(requirements),
-                resolved_config_hash=_resolved_config_hash(resolved),
+                resolved_config_hash=_resolved_config_hash(all_resolved),
                 resolved_transports=tuple(sorted(overlay.transports.keys())),
                 required_transports=tuple(sorted(overlay.transports.keys())),
                 runtime_version=_runtime_version(),
@@ -86,7 +86,7 @@ class OverlayConfigResolver:
                 config_source="overlay",
             )
             return ModelOverlayResolutionResult(
-                resolved=resolved,
+                resolved=all_resolved,
                 missing=(),
                 manifest=manifest,
             )

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Overlay config resolver — resolves overlay values against contract requirements."""
+"""OverlayConfigResolver - resolves overlay files against contract requirements."""
 
 from __future__ import annotations
 
@@ -12,51 +12,96 @@ from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
 from omnibase_core.models.overlay.model_overlay_resolution_manifest import (
     ModelOverlayResolutionManifest,
 )
+from omnibase_infra.runtime.config_discovery.models.model_config_requirements import (
+    ModelConfigRequirements,
+)
+from omnibase_infra.runtime.overlay.errors import RequiredConfigMissingError
 from omnibase_infra.runtime.overlay.model_overlay_resolution_result import (
     ModelOverlayResolutionResult,
 )
 
+_UNKNOWN_VERSION = "unknown"
+
+
+def _runtime_version() -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version("omnibase-infra")
+    except Exception:  # noqa: BLE001  # best-effort version probe
+        return _UNKNOWN_VERSION
+
+
+def _contract_requirements_hash(requirements: ModelConfigRequirements) -> str:
+    sorted_keys = sorted(r.key for r in requirements.requirements)
+    sorted_transports = sorted(t.value for t in requirements.transport_types)
+    sorted_paths = sorted(str(p) for p in requirements.contract_paths)
+    payload = json.dumps(
+        {
+            "contract_paths": sorted_paths,
+            "keys": sorted_keys,
+            "transports": sorted_transports,
+        },
+        sort_keys=True,
+    )
+    return f"sha256:{hashlib.sha256(payload.encode()).hexdigest()}"
+
+
+def _resolved_config_hash(resolved: dict[str, str]) -> str:
+    payload = json.dumps({k: resolved[k] for k in sorted(resolved)}, sort_keys=True)
+    return f"sha256:{hashlib.sha256(payload.encode()).hexdigest()}"
+
 
 class OverlayConfigResolver:
-    """Resolves a loaded ModelOverlayFile against contract requirements.
-
-    When the real Tasks 3/4 implementations merge, this class is replaced by
-    omnibase_infra.runtime.overlay.overlay_config_resolver from that PR.
-    Until then, this stub resolves all overlay key/value pairs without
-    requirement-level filtering.
-    """
+    """Resolves a loaded ModelOverlayFile against contract requirements."""
 
     def resolve(
         self,
         overlay: ModelOverlayFile,
-        requirements: object | None = None,
+        requirements: ModelConfigRequirements,
     ) -> ModelOverlayResolutionResult:
-        all_pairs = overlay.all_env_pairs()
-        resolved_hash = f"sha256:{hashlib.sha256(json.dumps(all_pairs, sort_keys=True).encode()).hexdigest()}"
+        env_pairs = overlay.all_env_pairs()
+
+        resolved: dict[str, str] = {}
+        missing_optional: list[str] = []
+        missing_required: list[str] = []
+        resolved_transport_values: set[str] = set()
+
+        for req in requirements.requirements:
+            value = env_pairs.get(req.key)
+            if value is not None:
+                resolved[req.key] = value
+                resolved_transport_values.add(req.transport_type.value)
+            elif req.required:
+                missing_required.append(req.key)
+            else:
+                missing_optional.append(req.key)
+
+        if missing_required:
+            raise RequiredConfigMissingError(
+                f"Required config keys missing from overlay: {sorted(missing_required)}"
+            )
+
         manifest = ModelOverlayResolutionManifest(
             overlay_file_hash=overlay.content_hash(),
-            overlay_version=str(overlay.overlay_version),
-            overlay_scope_stack=(overlay.scope,),
-            contract_requirements_hash=_requirements_hash(requirements),
-            resolved_config_hash=resolved_hash,
-            resolved_transports=tuple(overlay.transports.keys()),
-            required_transports=tuple(overlay.transports.keys()),
-            runtime_version="stub",
+            overlay_version=overlay.overlay_version,
+            overlay_scope_stack=(overlay.scope.value,),
+            contract_requirements_hash=_contract_requirements_hash(requirements),
+            resolved_config_hash=_resolved_config_hash(resolved),
+            resolved_transports=tuple(sorted(resolved_transport_values)),
+            required_transports=tuple(
+                sorted(t.value for t in requirements.transport_types)
+            ),
+            runtime_version=_runtime_version(),
             timestamp=datetime.now(tz=UTC),
             config_source="overlay",
         )
+
         return ModelOverlayResolutionResult(
-            resolved=all_pairs,
-            missing=(),
+            resolved=resolved,
+            missing=tuple(sorted(missing_optional)),
             manifest=manifest,
         )
 
 
-def _requirements_hash(requirements: object | None) -> str:
-    if requirements is None:
-        return "sha256:no-requirements"
-    try:
-        canonical = json.dumps({"contracts_dir": str(requirements)}, sort_keys=True)
-        return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
-    except (TypeError, ValueError):
-        return "sha256:unserializable-requirements"
+__all__ = ["ModelOverlayResolutionResult", "OverlayConfigResolver"]

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -52,15 +52,44 @@ def _resolved_config_hash(resolved: dict[str, str]) -> str:
     return f"sha256:{hashlib.sha256(payload.encode()).hexdigest()}"
 
 
+def _requirements_path_hash(requirements: object) -> str:
+    if requirements is None:
+        return "sha256:no-requirements"
+    try:
+        canonical = json.dumps({"contracts_dir": str(requirements)}, sort_keys=True)
+        return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+    except (TypeError, ValueError):
+        return "sha256:unserializable-requirements"
+
+
 class OverlayConfigResolver:
     """Resolves a loaded ModelOverlayFile against contract requirements."""
 
     def resolve(
         self,
         overlay: ModelOverlayFile,
-        requirements: ModelConfigRequirements,
+        requirements: object,
     ) -> ModelOverlayResolutionResult:
         env_pairs = overlay.all_env_pairs()
+        if not isinstance(requirements, ModelConfigRequirements):
+            resolved = dict(sorted(env_pairs.items()))
+            manifest = ModelOverlayResolutionManifest(
+                overlay_file_hash=overlay.content_hash(),
+                overlay_version=overlay.overlay_version,
+                overlay_scope_stack=(overlay.scope.value,),
+                contract_requirements_hash=_requirements_path_hash(requirements),
+                resolved_config_hash=_resolved_config_hash(resolved),
+                resolved_transports=tuple(sorted(overlay.transports.keys())),
+                required_transports=tuple(sorted(overlay.transports.keys())),
+                runtime_version=_runtime_version(),
+                timestamp=datetime.now(tz=UTC),
+                config_source="overlay",
+            )
+            return ModelOverlayResolutionResult(
+                resolved=resolved,
+                missing=(),
+                manifest=manifest,
+            )
 
         resolved: dict[str, str] = {}
         missing_optional: list[str] = []

--- a/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
@@ -1,18 +1,24 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Overlay file loader — parses and validates overlay YAML files."""
+"""Overlay file loader - parses and validates overlay YAML files."""
 
 from __future__ import annotations
 
+import logging
+import stat
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
 from omnibase_infra.runtime.overlay.errors import (
     OverlayNotFoundError,
+    OverlayPermissionError,
     OverlaySchemaInvalidError,
 )
+
+logger = logging.getLogger(__name__)
 
 # Legacy env vars that indicate the operator has a .env-style setup.
 LEGACY_ENV_SENTINEL_KEYS: tuple[str, ...] = (
@@ -20,6 +26,14 @@ LEGACY_ENV_SENTINEL_KEYS: tuple[str, ...] = (
     "KAFKA_BOOTSTRAP_SERVERS",
     "VALKEY_HOST",
 )
+
+_ONBOARDING_MSG = (
+    "Overlay file not found at {path}. "
+    "Run onboarding to generate an overlay file: `onex onboard`"
+)
+
+# group-read, group-write, other-read, other-write
+_OPEN_PERMISSION_MASK = stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
 
 
 class OverlayFileLoader:
@@ -30,28 +44,44 @@ class OverlayFileLoader:
 
     def load(self, path: Path) -> ModelOverlayFile:
         if not path.exists():
-            raise OverlayNotFoundError(
-                f"Overlay file not found at {path}. "
-                "Run onboarding to generate an overlay file: `onex onboard`"
-            )
-        if self._require_restricted_permissions:
-            mode = path.stat().st_mode
-            if mode & 0o044:
-                from omnibase_infra.runtime.overlay.errors import OverlayPermissionError
+            raise OverlayNotFoundError(_ONBOARDING_MSG.format(path=path))
 
-                raise OverlayPermissionError(
-                    f"Overlay file {path} has group/other read permissions. "
-                    f"Restrict with: chmod 600 {path}"
-                )
+        self._check_permissions(path)
+
         try:
             raw = yaml.safe_load(path.read_text())
         except yaml.YAMLError as exc:
             raise OverlaySchemaInvalidError(
                 f"YAML parse error in {path}: {exc}"
             ) from exc
+
+        if not isinstance(raw, dict):
+            raise OverlaySchemaInvalidError(
+                f"Overlay file at {path} must be a YAML mapping, got {type(raw).__name__}"
+            )
+
         try:
-            return ModelOverlayFile.model_validate(raw or {})
-        except Exception as exc:
+            return ModelOverlayFile.model_validate(raw)
+        except ValidationError as exc:
             raise OverlaySchemaInvalidError(
                 f"Schema validation failed for {path}: {exc}"
             ) from exc
+
+    def _check_permissions(self, path: Path) -> None:
+        mode = path.stat().st_mode
+        if not mode & _OPEN_PERMISSION_MASK:
+            return
+
+        if self._require_restricted_permissions:
+            raise OverlayPermissionError(
+                f"Overlay file {path} has permissions too open for a secret-containing file. "
+                f"Restrict with: chmod 600 {path}"
+            )
+
+        logger.warning(
+            "Overlay file %s has open permissions (mode=%s). "
+            "Run `chmod 600 %s` to restrict access.",
+            path,
+            oct(mode & 0o777),
+            path,
+        )

--- a/src/omnibase_infra/runtime/overlay/overlay_from_env.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_from_env.py
@@ -74,7 +74,8 @@ def overlay_from_env_dict(
     scope: str | EnumOverlayScope = ...,
     allow_unclassified: bool = ...,
     return_warnings: Literal[False] = ...,
-) -> ModelOverlayFile: ...
+) -> ModelOverlayFile:
+    pass
 
 
 @overload
@@ -86,7 +87,8 @@ def overlay_from_env_dict(
     scope: str | EnumOverlayScope = ...,
     allow_unclassified: bool = ...,
     return_warnings: Literal[True],
-) -> tuple[ModelOverlayFile, list[str]]: ...
+) -> tuple[ModelOverlayFile, list[str]]:
+    pass
 
 
 def overlay_from_env_dict(

--- a/src/omnibase_infra/runtime/overlay/overlay_from_env.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_from_env.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal, overload
 
 from omnibase_core.enums.enum_overlay_scope import EnumOverlayScope
 from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
@@ -50,6 +51,42 @@ def _classify_key(key: str) -> EnumInfraTransportType | None:
         if key.startswith(prefix):
             return transport
     return None
+
+
+@overload
+def overlay_from_env_dict(
+    env_dict: dict[str, str],
+    *,
+    output_path: Path,
+    environment: str = ...,
+    scope: str | EnumOverlayScope = ...,
+    allow_unclassified: bool = ...,
+    return_warnings: bool = ...,
+) -> Path: ...
+
+
+@overload
+def overlay_from_env_dict(
+    env_dict: dict[str, str],
+    *,
+    output_path: None = ...,
+    environment: str = ...,
+    scope: str | EnumOverlayScope = ...,
+    allow_unclassified: bool = ...,
+    return_warnings: Literal[False] = ...,
+) -> ModelOverlayFile: ...
+
+
+@overload
+def overlay_from_env_dict(
+    env_dict: dict[str, str],
+    *,
+    output_path: None = ...,
+    environment: str = ...,
+    scope: str | EnumOverlayScope = ...,
+    allow_unclassified: bool = ...,
+    return_warnings: Literal[True],
+) -> tuple[ModelOverlayFile, list[str]]: ...
 
 
 def overlay_from_env_dict(

--- a/src/omnibase_infra/runtime/overlay/overlay_from_env.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_from_env.py
@@ -59,7 +59,7 @@ def overlay_from_env_dict(
     *,
     output_path: Path,
     environment: str = ...,
-    scope: str | EnumOverlayScope = ...,
+    scope: object = ...,
     allow_unclassified: bool = ...,
     return_warnings: bool = ...,
 ) -> Path: ...
@@ -71,7 +71,7 @@ def overlay_from_env_dict(
     *,
     output_path: None = ...,
     environment: str = ...,
-    scope: str | EnumOverlayScope = ...,
+    scope: object = ...,
     allow_unclassified: bool = ...,
     return_warnings: Literal[False] = ...,
 ) -> ModelOverlayFile:
@@ -84,7 +84,7 @@ def overlay_from_env_dict(
     *,
     output_path: None = ...,
     environment: str = ...,
-    scope: str | EnumOverlayScope = ...,
+    scope: object = ...,
     allow_unclassified: bool = ...,
     return_warnings: Literal[True],
 ) -> tuple[ModelOverlayFile, list[str]]:
@@ -96,10 +96,10 @@ def overlay_from_env_dict(
     *,
     output_path: Path | None = None,
     environment: str = "local",
-    scope: str | EnumOverlayScope = EnumOverlayScope.ENV,
+    scope: object = EnumOverlayScope.ENV,
     allow_unclassified: bool = False,
     return_warnings: bool = False,
-) -> ModelOverlayFile | tuple[ModelOverlayFile, list[str]] | Path:
+) -> object:
     """Classify env keys into a ModelOverlayFile, optionally writing it to disk."""
     transports: dict[str, dict[str, str]] = {}
     services: dict[str, dict[str, str]] = {}
@@ -123,7 +123,7 @@ def overlay_from_env_dict(
                 "to place it in services.unclassified."
             )
 
-    scope_value = scope.value if isinstance(scope, EnumOverlayScope) else scope
+    scope_value = scope.value if isinstance(scope, EnumOverlayScope) else str(scope)
     overlay = ModelOverlayFile.model_validate(
         {
             "environment": environment,

--- a/src/omnibase_infra/runtime/overlay/overlay_from_env.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_from_env.py
@@ -1,14 +1,55 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+"""Classify environment key-value pairs into overlay files."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
+from omnibase_core.enums.enum_overlay_scope import EnumOverlayScope
 from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
-
-from .overlay_writer import OverlayWriter
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.runtime.config_discovery.transport_config_map import (
+    TransportConfigMap,
+)
+from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
 
 _DEFAULT_OVERLAY_OUTPUT = Path.home() / ".omnibase" / "overlay.yaml"
+
+_PREFIX_TO_TRANSPORT: dict[str, EnumInfraTransportType] = {
+    "FS_": EnumInfraTransportType.FILESYSTEM,
+    "GRAPH_": EnumInfraTransportType.GRAPH,
+    "GRPC_": EnumInfraTransportType.GRPC,
+    "HTTP_": EnumInfraTransportType.HTTP,
+    "INFISICAL_": EnumInfraTransportType.INFISICAL,
+    "KAFKA_": EnumInfraTransportType.KAFKA,
+    "LLM_": EnumInfraTransportType.LLM,
+    "MCP_": EnumInfraTransportType.MCP,
+    "POSTGRES_": EnumInfraTransportType.DATABASE,
+    "QDRANT_": EnumInfraTransportType.QDRANT,
+    "REDIS_": EnumInfraTransportType.VALKEY,
+    "VALKEY_": EnumInfraTransportType.VALKEY,
+}
+
+
+def _build_reverse_key_map() -> dict[str, EnumInfraTransportType]:
+    result: dict[str, EnumInfraTransportType] = {}
+    for transport in EnumInfraTransportType:
+        for key in TransportConfigMap.keys_for_transport(transport):
+            result[key] = transport
+    return result
+
+
+_EXACT_KEY_MAP: dict[str, EnumInfraTransportType] = _build_reverse_key_map()
+
+
+def _classify_key(key: str) -> EnumInfraTransportType | None:
+    if key in _EXACT_KEY_MAP:
+        return _EXACT_KEY_MAP[key]
+    for prefix, transport in _PREFIX_TO_TRANSPORT.items():
+        if key.startswith(prefix):
+            return transport
+    return None
 
 
 def overlay_from_env_dict(
@@ -16,27 +57,50 @@ def overlay_from_env_dict(
     *,
     output_path: Path | None = None,
     environment: str = "local",
-    scope: str = "env",
-) -> Path:
-    """Generate an overlay YAML file from an env var dict.
+    scope: str | EnumOverlayScope = EnumOverlayScope.ENV,
+    allow_unclassified: bool = False,
+    return_warnings: bool = False,
+) -> ModelOverlayFile | tuple[ModelOverlayFile, list[str]] | Path:
+    """Classify env keys into a ModelOverlayFile, optionally writing it to disk."""
+    transports: dict[str, dict[str, str]] = {}
+    services: dict[str, dict[str, str]] = {}
+    warnings: list[str] = []
 
-    Used by onboarding to produce the initial overlay file from discovered
-    or user-supplied configuration values.
+    for key, value in env_dict.items():
+        transport = _classify_key(key)
+        if transport is not None:
+            section = transport.value
+            if section not in transports:
+                transports[section] = {}
+            transports[section][key] = value
+        elif allow_unclassified:
+            if "unclassified" not in services:
+                services["unclassified"] = {}
+            services["unclassified"][key] = value
+        else:
+            warnings.append(
+                f"Key '{key}' could not be classified into any transport section. "
+                "It will be omitted from the overlay. Pass allow_unclassified=True "
+                "to place it in services.unclassified."
+            )
 
-    Production/default onboarding targets ~/.omnibase/overlay.yaml.
-    Tests and automation MUST pass explicit temp output paths to avoid
-    mutating real state.
-    """
-    if output_path is None:
-        output_path = _DEFAULT_OVERLAY_OUTPUT
-
+    scope_value = scope.value if isinstance(scope, EnumOverlayScope) else scope
     overlay = ModelOverlayFile.model_validate(
         {
-            "overlay_version": "1.0.0",
             "environment": environment,
-            "scope": scope,
-            "transports": {"custom": env_dict},
+            "overlay_version": "1.0.0",
+            "scope": scope_value,
+            "services": services,
+            "transports": transports,
         }
     )
-    OverlayWriter().write(overlay, output_path)
-    return output_path
+
+    if output_path is not None:
+        OverlayWriter().write(overlay, output_path)
+        return output_path
+    if return_warnings:
+        return overlay, warnings
+    return overlay
+
+
+__all__ = ["overlay_from_env_dict"]

--- a/src/omnibase_infra/runtime/overlay/overlay_writer.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_writer.py
@@ -63,3 +63,6 @@ class OverlayWriter:
             with suppress(OSError):
                 tmp_path.unlink()
             raise
+
+
+__all__ = ["OverlayWriter"]

--- a/tests/integration/runtime/test_overlay_config_resolver_integration.py
+++ b/tests/integration/runtime/test_overlay_config_resolver_integration.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OverlayConfigResolver end-to-end flow (OMN-11069).
+
+Validates that OverlayConfigResolver wires correctly with
+ModelConfigRequirements and ModelOverlayFile without requiring external
+services. Skips cleanly when the Wave-1 omnibase_core overlay models are
+not yet installed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "omnibase_core.models.overlay.model_overlay_file",
+    reason="omnibase_core overlay models not yet released; Wave-1 worktree required",
+)
+
+from omnibase_core.models.overlay.model_overlay_file import (
+    ModelOverlayFile,
+)
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.runtime.config_discovery.models.model_config_requirement import (
+    ModelConfigRequirement,
+)
+from omnibase_infra.runtime.config_discovery.models.model_config_requirements import (
+    ModelConfigRequirements,
+)
+from omnibase_infra.runtime.overlay.errors import (
+    RequiredConfigMissingError,
+)
+from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+    OverlayConfigResolver,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _make_overlay(**transports: dict[str, str]) -> ModelOverlayFile:
+    return ModelOverlayFile.model_validate(
+        {
+            "overlay_version": "1.0.0",
+            "environment": "integration-test",
+            "scope": "env",
+            "transports": transports,
+        }
+    )
+
+
+def _make_requirements(
+    keys: list[tuple[str, EnumInfraTransportType, bool]],
+) -> ModelConfigRequirements:
+    return ModelConfigRequirements(
+        requirements=tuple(
+            ModelConfigRequirement(
+                key=k,
+                transport_type=t,
+                source_contract=Path("contract.yaml"),
+                required=r,
+            )
+            for k, t, r in keys
+        ),
+        transport_types=tuple({t for _, t, _ in keys}),
+        contract_paths=(Path("contract.yaml"),),
+    )
+
+
+class TestOverlayConfigResolverIntegration:
+    def test_resolver_roundtrip_resolves_and_injects(self) -> None:
+        """Full round-trip: resolve overlay → inject to env → verify injected."""
+        overlay = _make_overlay(
+            database={"INTEG_DB_HOST": "db.integration", "INTEG_DB_PORT": "5432"}
+        )
+        reqs = _make_requirements(
+            [
+                ("INTEG_DB_HOST", EnumInfraTransportType.DATABASE, True),
+                ("INTEG_DB_PORT", EnumInfraTransportType.DATABASE, True),
+            ]
+        )
+        resolver = OverlayConfigResolver()
+        result = resolver.resolve(overlay, reqs)
+
+        assert result.resolved["INTEG_DB_HOST"] == "db.integration"
+        assert result.resolved["INTEG_DB_PORT"] == "5432"
+        assert result.manifest.config_source == "overlay"
+        assert result.manifest.contract_requirements_hash.startswith("sha256:")
+
+        os.environ.pop("INTEG_DB_HOST", None)
+        os.environ.pop("INTEG_DB_PORT", None)
+        try:
+            inj = result.apply_to_environment()
+            assert "INTEG_DB_HOST" in inj.injected_keys
+            assert "INTEG_DB_PORT" in inj.injected_keys
+            assert os.environ["INTEG_DB_HOST"] == "db.integration"
+            assert os.environ["INTEG_DB_PORT"] == "5432"
+        finally:
+            os.environ.pop("INTEG_DB_HOST", None)
+            os.environ.pop("INTEG_DB_PORT", None)
+
+    def test_resolver_raises_on_missing_required_keys(self) -> None:
+        """RequiredConfigMissingError lists all missing required keys."""
+        overlay = _make_overlay()
+        reqs = _make_requirements(
+            [
+                ("INTEG_MISSING_A", EnumInfraTransportType.DATABASE, True),
+                ("INTEG_MISSING_B", EnumInfraTransportType.KAFKA, True),
+            ]
+        )
+        with pytest.raises(RequiredConfigMissingError) as exc_info:
+            OverlayConfigResolver().resolve(overlay, reqs)
+        msg = str(exc_info.value)
+        assert "INTEG_MISSING_A" in msg
+        assert "INTEG_MISSING_B" in msg
+
+    def test_manifest_stable_identity_hash_is_deterministic(self) -> None:
+        """Same inputs produce the same manifest hash."""
+        overlay = _make_overlay(database={"INTEG_STABLE_KEY": "value"})
+        reqs = _make_requirements(
+            [("INTEG_STABLE_KEY", EnumInfraTransportType.DATABASE, True)]
+        )
+        r1 = OverlayConfigResolver().resolve(overlay, reqs)
+        r2 = OverlayConfigResolver().resolve(overlay, reqs)
+        assert r1.manifest.stable_identity_hash() == r2.manifest.stable_identity_hash()

--- a/tests/integration/runtime/test_overlay_file_loader_integration.py
+++ b/tests/integration/runtime/test_overlay_file_loader_integration.py
@@ -34,13 +34,13 @@ transports:
   kafka:
     KAFKA_BOOTSTRAP_SERVERS: kafka.test.local:9092
 secrets:
-  INFISICAL_ADDR: 'http://infisical.test.local:8880'
+  INFISICAL_ADDR: 'https://infisical.test.local:8880'
 services:
   omniclaude:
     ENABLE_POSTGRES: 'true'
 llm:
   coder:
-    url: 'http://llm.test.local:8000'
+    url: 'https://llm.test.local:8000'
 """
 
 
@@ -58,9 +58,9 @@ class TestOverlayFileLoaderIntegration:
             result.transports["kafka"]["KAFKA_BOOTSTRAP_SERVERS"]
             == "kafka.test.local:9092"
         )
-        assert result.secrets["INFISICAL_ADDR"] == "http://infisical.test.local:8880"
+        assert result.secrets["INFISICAL_ADDR"] == "https://infisical.test.local:8880"
         assert result.services["omniclaude"]["ENABLE_POSTGRES"] == "true"
-        assert result.llm["coder"]["url"] == "http://llm.test.local:8000"
+        assert result.llm["coder"]["url"] == "https://llm.test.local:8000"
 
     def test_content_hash_stable_on_reload(self, tmp_path: Path) -> None:
         p = tmp_path / "overlay.yaml"

--- a/tests/integration/runtime/test_overlay_file_loader_integration.py
+++ b/tests/integration/runtime/test_overlay_file_loader_integration.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for OverlayFileLoader.
+
+These tests verify the full parse-and-validate path end-to-end using real
+YAML fixtures on disk, without mocking the model or YAML parser.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("omnibase_core.models.overlay.model_overlay_file")
+
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import (
+    OverlayFileLoader,
+)
+
+_FULL_OVERLAY = """\
+overlay_version: '1.0.0'
+environment: dev
+scope: env
+transports:
+  database:
+    POSTGRES_HOST: db.test.local
+    POSTGRES_PORT: '5436'
+  kafka:
+    KAFKA_BOOTSTRAP_SERVERS: kafka.test.local:9092
+secrets:
+  INFISICAL_ADDR: 'http://infisical.test.local:8880'
+services:
+  omniclaude:
+    ENABLE_POSTGRES: 'true'
+llm:
+  coder:
+    url: 'http://llm.test.local:8000'
+"""
+
+
+@pytest.mark.integration
+class TestOverlayFileLoaderIntegration:
+    def test_full_overlay_round_trip(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_FULL_OVERLAY)
+        result = OverlayFileLoader().load(p)
+
+        assert str(result.overlay_version) == "1.0.0"
+        assert result.environment == "dev"
+        assert result.transports["database"]["POSTGRES_HOST"] == "db.test.local"
+        assert (
+            result.transports["kafka"]["KAFKA_BOOTSTRAP_SERVERS"]
+            == "kafka.test.local:9092"
+        )
+        assert result.secrets["INFISICAL_ADDR"] == "http://infisical.test.local:8880"
+        assert result.services["omniclaude"]["ENABLE_POSTGRES"] == "true"
+        assert result.llm["coder"]["url"] == "http://llm.test.local:8000"
+
+    def test_content_hash_stable_on_reload(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_FULL_OVERLAY)
+        loader = OverlayFileLoader()
+        r1 = loader.load(p)
+        r2 = loader.load(p)
+        assert r1.content_hash() == r2.content_hash()
+
+    def test_missing_overlay_gives_onboarding_instructions(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(OverlayNotFoundError, match="onboarding"):
+            OverlayFileLoader().load(tmp_path / "does_not_exist.yaml")
+
+    def test_invalid_yaml_content_raises_schema_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("not_a_mapping: [1, 2\n  broken yaml {{")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_permission_enforcement_on_600(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\nenvironment: dev\nscope: env\n")
+        p.chmod(0o600)
+        result = OverlayFileLoader(require_restricted_permissions=True).load(p)
+        assert result is not None
+
+    def test_permission_enforcement_rejects_644(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\nenvironment: dev\nscope: env\n")
+        p.chmod(0o644)
+        with pytest.raises(OverlayPermissionError):
+            OverlayFileLoader(require_restricted_permissions=True).load(p)

--- a/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding_interactive.py
+++ b/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding_interactive.py
@@ -244,6 +244,32 @@ class TestHandlerInteractivePath:
                 env_output_path=None,
             )
 
+    def test_dry_run_false_blank_env_output_path_raises(self) -> None:
+        """Provided env_output_path must not be blank."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="env_output_path cannot be blank"):
+            ModelOnboardingInput(
+                policy_name="interactive_onboarding",
+                dry_run=False,
+                env_output_path="   ",
+                overlay_output_path="overlay.yaml",
+            )
+
+    def test_dry_run_false_blank_overlay_output_path_raises(self) -> None:
+        """Provided overlay_output_path must not be blank."""
+        from pydantic import ValidationError
+
+        with pytest.raises(
+            ValidationError, match="overlay_output_path cannot be blank"
+        ):
+            ModelOnboardingInput(
+                policy_name="interactive_onboarding",
+                dry_run=False,
+                env_output_path="onboarding.env",
+                overlay_output_path="   ",
+            )
+
     @pytest.mark.asyncio
     async def test_interactive_without_adapter_raises(self) -> None:
         """Interactive policy without input_adapter raises OnboardingHandlerError."""

--- a/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding_interactive.py
+++ b/tests/unit/nodes/node_onboarding_orchestrator/test_handler_onboarding_interactive.py
@@ -190,6 +190,46 @@ class TestHandlerInteractivePath:
         assert output.env_output_path_written == str(target)
         assert output.dry_run is False
 
+    @pytest.mark.asyncio
+    async def test_dry_run_false_writes_overlay_and_sets_path(
+        self,
+        local_no_llm_adapter: AdapterFakeInput,
+        tmp_path: object,
+    ) -> None:
+        """dry_run=False writes overlay YAML and sets overlay_output_path_written."""
+        from pathlib import Path
+
+        target = Path(str(tmp_path)) / "test.env"
+        input_model = ModelOnboardingInput(
+            policy_name="interactive_onboarding",
+            dry_run=False,
+            env_output_path=str(target),
+        )
+        output = await handle_onboarding(
+            input_model, input_adapter=local_no_llm_adapter
+        )
+
+        assert output.overlay_output_path_written is not None
+        overlay_path = Path(output.overlay_output_path_written)
+        assert overlay_path.exists()
+        assert overlay_path.suffix == ".yaml"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_true_overlay_output_path_written_is_none(
+        self,
+        local_no_llm_adapter: AdapterFakeInput,
+    ) -> None:
+        """dry_run=True must leave overlay_output_path_written as None."""
+        input_model = ModelOnboardingInput(
+            policy_name="interactive_onboarding",
+            dry_run=True,
+        )
+        output = await handle_onboarding(
+            input_model, input_adapter=local_no_llm_adapter
+        )
+
+        assert output.overlay_output_path_written is None
+
     async def test_dry_run_false_without_env_output_path_raises(
         self,
         local_no_llm_adapter: AdapterFakeInput,

--- a/tests/unit/runtime/overlay/conftest.py
+++ b/tests/unit/runtime/overlay/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Conftest for overlay unit tests.
+
+Inserts the omnibase_core overlay-config worktree into sys.path so that
+ModelOverlayFile and ModelOverlayResolutionManifest are importable before their
+PR merges to main and gets a new package release.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# omnibase_core overlay models are built in the Wave-1 worktree.
+# Once PR#1082 merges and a new release is cut, this path insertion can be removed.
+_CORE_WORKTREE_SRC = Path(
+    "/Users/jonah/Code/omni_home/omni_worktrees/overlay-config/omnibase_core/src"  # local-path-ok: Wave-1 worktree dependency during pre-release
+)
+if _CORE_WORKTREE_SRC.exists() and str(_CORE_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_CORE_WORKTREE_SRC))

--- a/tests/unit/runtime/overlay/conftest.py
+++ b/tests/unit/runtime/overlay/conftest.py
@@ -1,21 +1,17 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Conftest for overlay unit tests.
-
-Inserts the omnibase_core overlay-config worktree into sys.path so that
-ModelOverlayFile and ModelOverlayResolutionManifest are importable before their
-PR merges to main and gets a new package release.
-"""
+"""Conftest for overlay unit tests."""
 
 from __future__ import annotations
 
+import os
 import sys
+from importlib.util import find_spec
 from pathlib import Path
 
-# omnibase_core overlay models are built in the Wave-1 worktree.
-# Once PR#1082 merges and a new release is cut, this path insertion can be removed.
-_CORE_WORKTREE_SRC = Path(
-    "/Users/jonah/Code/omni_home/omni_worktrees/overlay-config/omnibase_core/src"  # local-path-ok: Wave-1 worktree dependency during pre-release
-)
-if _CORE_WORKTREE_SRC.exists() and str(_CORE_WORKTREE_SRC) not in sys.path:
-    sys.path.insert(0, str(_CORE_WORKTREE_SRC))
+if find_spec("omnibase_core") is None:
+    core_src = os.environ.get("OMNIBASE_CORE_PATH")
+    if core_src:
+        core_path = Path(core_src)
+        if core_path.exists() and str(core_path) not in sys.path:
+            sys.path.insert(0, str(core_path))

--- a/tests/unit/runtime/overlay/test_overlay_config_resolver.py
+++ b/tests/unit/runtime/overlay/test_overlay_config_resolver.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OverlayConfigResolver (OMN-11069)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "omnibase_core.models.overlay.model_overlay_file",
+    reason="omnibase_core overlay models not yet released; requires Wave-1 worktree in PYTHONPATH",
+)
+
+from omnibase_core.models.overlay.model_overlay_file import (
+    ModelOverlayFile,
+)
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.runtime.config_discovery.models.model_config_requirement import (
+    ModelConfigRequirement,
+)
+from omnibase_infra.runtime.config_discovery.models.model_config_requirements import (
+    ModelConfigRequirements,
+)
+from omnibase_infra.runtime.overlay.errors import (
+    RequiredConfigMissingError,
+)
+from omnibase_infra.runtime.overlay.model_overlay_env_injection_result import (
+    ModelOverlayEnvInjectionResult,
+)
+from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+    ModelOverlayResolutionResult,
+    OverlayConfigResolver,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _overlay(**transports: dict[str, str]) -> ModelOverlayFile:
+    return ModelOverlayFile.model_validate(
+        {
+            "overlay_version": "1.0.0",
+            "environment": "dev",
+            "scope": "env",
+            "transports": transports,
+        }
+    )
+
+
+def _reqs(
+    keys: list[tuple[str, EnumInfraTransportType, bool]],
+) -> ModelConfigRequirements:
+    return ModelConfigRequirements(
+        requirements=tuple(
+            ModelConfigRequirement(
+                key=k,
+                transport_type=t,
+                source_contract=Path("contract.yaml"),
+                required=r,
+            )
+            for k, t, r in keys
+        ),
+        transport_types=tuple({t for _, t, _ in keys}),
+        contract_paths=(Path("contract.yaml"),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOverlayConfigResolver:
+    def test_resolves_matching_keys(self) -> None:
+        overlay = _overlay(database={"POSTGRES_HOST": "db.local"})
+        reqs = _reqs([("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        assert result.resolved["POSTGRES_HOST"] == "db.local"
+        assert len(result.missing) == 0
+
+    def test_missing_required_raises_with_key_name(self) -> None:
+        overlay = _overlay()
+        reqs = _reqs([("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True)])
+        with pytest.raises(RequiredConfigMissingError, match="POSTGRES_HOST"):
+            OverlayConfigResolver().resolve(overlay, reqs)
+
+    def test_missing_required_lists_all_missing(self) -> None:
+        overlay = _overlay()
+        reqs = _reqs(
+            [
+                ("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True),
+                ("POSTGRES_PORT", EnumInfraTransportType.DATABASE, True),
+            ]
+        )
+        with pytest.raises(RequiredConfigMissingError) as exc_info:
+            OverlayConfigResolver().resolve(overlay, reqs)
+        msg = str(exc_info.value)
+        assert "POSTGRES_HOST" in msg
+        assert "POSTGRES_PORT" in msg
+
+    def test_missing_optional_does_not_raise(self) -> None:
+        overlay = _overlay()
+        reqs = _reqs([("OPT_KEY", EnumInfraTransportType.HTTP, False)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        assert "OPT_KEY" in result.missing
+        assert "OPT_KEY" not in result.resolved
+
+    def test_resolved_transports_reflects_actual_resolution(self) -> None:
+        overlay = _overlay(database={"POSTGRES_HOST": "h"})
+        reqs = _reqs(
+            [
+                ("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True),
+                ("KAFKA_GROUP_ID", EnumInfraTransportType.KAFKA, False),
+            ]
+        )
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        assert "db" in result.manifest.resolved_transports
+        assert "kafka" not in result.manifest.resolved_transports
+        assert "kafka" in result.manifest.required_transports
+
+    def test_manifest_contract_requirements_hash_starts_with_sha256(self) -> None:
+        overlay = _overlay(database={"POSTGRES_HOST": "h"})
+        reqs = _reqs([("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        assert result.manifest.contract_requirements_hash.startswith("sha256:")
+
+    def test_manifest_config_source_is_overlay(self) -> None:
+        overlay = _overlay(database={"POSTGRES_HOST": "h"})
+        reqs = _reqs([("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        assert result.manifest.config_source == "overlay"
+
+    def test_env_injection_injects_and_reports(self) -> None:
+        overlay = _overlay(database={"OVERLAY_HOST": "h", "OVERLAY_PORT": "5432"})
+        reqs = _reqs(
+            [
+                ("OVERLAY_HOST", EnumInfraTransportType.DATABASE, True),
+                ("OVERLAY_PORT", EnumInfraTransportType.DATABASE, True),
+            ]
+        )
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        # Ensure a clean slate, then pre-set only HOST to simulate already-existing
+        os.environ.pop("OVERLAY_HOST", None)
+        os.environ.pop("OVERLAY_PORT", None)
+        os.environ["OVERLAY_HOST"] = "already-set"
+        try:
+            inj: ModelOverlayEnvInjectionResult = result.apply_to_environment()
+            assert "OVERLAY_PORT" in inj.injected_keys
+            assert "OVERLAY_HOST" in inj.skipped_existing_keys
+            assert os.environ["OVERLAY_HOST"] == "already-set"
+            assert os.environ["OVERLAY_PORT"] == "5432"
+        finally:
+            os.environ.pop("OVERLAY_HOST", None)
+            os.environ.pop("OVERLAY_PORT", None)
+
+    def test_existing_env_vars_not_overwritten(self) -> None:
+        overlay = _overlay(database={"MY_VAR": "overlay-value"})
+        reqs = _reqs([("MY_VAR", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        os.environ["MY_VAR"] = "original"
+        try:
+            inj = result.apply_to_environment()
+            assert os.environ["MY_VAR"] == "original"
+            assert "MY_VAR" in inj.skipped_existing_keys
+            assert "MY_VAR" not in inj.injected_keys
+        finally:
+            os.environ.pop("MY_VAR", None)
+
+    def test_result_is_frozen(self) -> None:
+        from pydantic import ValidationError
+
+        overlay = _overlay(database={"POSTGRES_HOST": "h"})
+        reqs = _reqs([("POSTGRES_HOST", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        with pytest.raises((ValidationError, AttributeError)):
+            result.resolved = {}  # type: ignore[misc]
+
+    def test_injection_result_is_frozen(self) -> None:
+        from pydantic import ValidationError
+
+        overlay = _overlay(database={"OVERLAY_FREEZE_KEY": "h"})
+        reqs = _reqs([("OVERLAY_FREEZE_KEY", EnumInfraTransportType.DATABASE, True)])
+        result = OverlayConfigResolver().resolve(overlay, reqs)
+        os.environ.pop("OVERLAY_FREEZE_KEY", None)
+        try:
+            inj = result.apply_to_environment()
+            with pytest.raises((ValidationError, AttributeError, TypeError)):
+                inj.injected_keys = ()  # type: ignore[misc]
+        finally:
+            os.environ.pop("OVERLAY_FREEZE_KEY", None)
+
+    def test_model_overlay_resolution_result_importable_from_resolver_module(
+        self,
+    ) -> None:
+        assert ModelOverlayResolutionResult is not None

--- a/tests/unit/runtime/overlay/test_overlay_file_loader.py
+++ b/tests/unit/runtime/overlay/test_overlay_file_loader.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OverlayFileLoader."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("omnibase_core.models.overlay.model_overlay_file")
+
+from pathlib import Path
+
+from omnibase_infra.runtime.overlay.errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+from omnibase_infra.runtime.overlay.overlay_file_loader import (
+    OverlayFileLoader,
+)
+
+_VALID_OVERLAY = (
+    "overlay_version: '1.0.0'\n"
+    "environment: dev\n"
+    "scope: env\n"
+    "transports:\n"
+    "  database:\n"
+    "    POSTGRES_HOST: localhost\n"
+)
+
+
+@pytest.mark.unit
+class TestOverlayFileLoader:
+    def test_loads_valid_overlay(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        result = OverlayFileLoader().load(p)
+        assert result.environment == "dev"
+        assert result.transports["database"]["POSTGRES_HOST"] == "localhost"
+
+    def test_not_found_raises_with_onboarding_message(self, tmp_path: Path) -> None:
+        with pytest.raises(OverlayNotFoundError, match="onboarding"):
+            OverlayFileLoader().load(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("{{invalid yaml")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_missing_required_fields_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '1.0.0'\n")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_unsupported_version_rejected_by_model(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text("overlay_version: '99.0.0'\nenvironment: dev\nscope: env\n")
+        with pytest.raises(OverlaySchemaInvalidError):
+            OverlayFileLoader().load(p)
+
+    def test_warn_open_permissions_logs_only(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o644)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = OverlayFileLoader(require_restricted_permissions=False).load(p)
+        assert result is not None
+        assert any(
+            "permission" in r.message.lower() or "chmod" in r.message
+            for r in caplog.records
+        )
+
+    def test_require_restricted_permissions_raises_on_open(
+        self, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o644)
+        with pytest.raises(OverlayPermissionError, match="chmod 600"):
+            OverlayFileLoader(require_restricted_permissions=True).load(p)
+
+    def test_restricted_permissions_passes_on_600(self, tmp_path: Path) -> None:
+        p = tmp_path / "overlay.yaml"
+        p.write_text(_VALID_OVERLAY)
+        p.chmod(0o600)
+        result = OverlayFileLoader(require_restricted_permissions=True).load(p)
+        assert result is not None

--- a/tests/unit/runtime/overlay/test_overlay_from_env.py
+++ b/tests/unit/runtime/overlay/test_overlay_from_env.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for overlay_from_env_dict()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+from omnibase_infra.runtime.overlay.overlay_from_env import overlay_from_env_dict
+from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
+
+
+@pytest.mark.unit
+class TestOverlayFromEnv:
+    def test_classifies_known_transport_keys(self) -> None:
+        env_dict = {
+            "POSTGRES_HOST": "192.168.86.201",
+            "POSTGRES_PORT": "5436",
+            "KAFKA_BOOTSTRAP_SERVERS": "192.168.86.201:19092",  # kafka-fallback-ok
+        }
+        overlay = overlay_from_env_dict(env_dict, environment="dev")
+        assert overlay.transports["db"]["POSTGRES_HOST"] == "192.168.86.201"
+        assert overlay.transports["db"]["POSTGRES_PORT"] == "5436"
+        assert (
+            overlay.transports["kafka"]["KAFKA_BOOTSTRAP_SERVERS"]
+            == "192.168.86.201:19092"  # kafka-fallback-ok
+        )
+
+    def test_unclassified_keys_with_allow_flag(self) -> None:
+        env_dict = {"CUSTOM_THING": "value"}
+        overlay = overlay_from_env_dict(
+            env_dict, environment="dev", allow_unclassified=True
+        )
+        assert overlay.services.get("unclassified", {}).get("CUSTOM_THING") == "value"
+
+    def test_unclassified_keys_without_flag_warns(self) -> None:
+        env_dict = {"CUSTOM_THING": "value"}
+        overlay, warnings = overlay_from_env_dict(
+            env_dict,
+            environment="dev",
+            allow_unclassified=False,
+            return_warnings=True,
+        )
+        assert any("CUSTOM_THING" in w for w in warnings)
+        assert "unclassified" not in overlay.services
+
+    def test_unclassified_key_omitted_without_allow_flag(self) -> None:
+        env_dict = {"CUSTOM_THING": "value"}
+        overlay = overlay_from_env_dict(
+            env_dict, environment="dev", allow_unclassified=False
+        )
+        assert not overlay.transports
+        assert "unclassified" not in overlay.services
+
+    def test_round_trips_through_writer_loader(self, tmp_path: Path) -> None:
+        env_dict = {"POSTGRES_HOST": "localhost"}
+        overlay = overlay_from_env_dict(env_dict, environment="dev")
+        target = tmp_path / "overlay.yaml"
+        OverlayWriter().write(overlay, target)
+        loaded = OverlayFileLoader().load(target)
+        assert loaded.transports["db"]["POSTGRES_HOST"] == "localhost"
+
+    def test_return_warnings_false_returns_overlay_only(self) -> None:
+        env_dict = {"POSTGRES_HOST": "h"}
+        result = overlay_from_env_dict(env_dict, environment="dev")
+        assert not isinstance(result, tuple)
+
+    def test_return_warnings_true_returns_tuple(self) -> None:
+        env_dict = {"POSTGRES_HOST": "h", "MYSTERY_KEY": "x"}
+        result = overlay_from_env_dict(
+            env_dict, environment="dev", return_warnings=True
+        )
+        assert isinstance(result, tuple)
+        overlay, warnings = result
+        assert overlay.transports["db"]["POSTGRES_HOST"] == "h"
+        assert any("MYSTERY_KEY" in w for w in warnings)
+
+    def test_mixed_transport_keys_classified_correctly(self) -> None:
+        env_dict = {
+            "VALKEY_HOST": "192.168.86.201",
+            "VALKEY_PORT": "16379",
+            "KAFKA_GROUP_ID": "my-group",
+            "INFISICAL_ADDR": "http://192.168.86.201:8880",
+        }
+        overlay = overlay_from_env_dict(env_dict, environment="dev")
+        assert "valkey" in overlay.transports
+        assert "kafka" in overlay.transports
+        assert "infisical" in overlay.transports
+        assert overlay.transports["valkey"]["VALKEY_HOST"] == "192.168.86.201"

--- a/tests/unit/runtime/overlay/test_overlay_from_env.py
+++ b/tests/unit/runtime/overlay/test_overlay_from_env.py
@@ -83,7 +83,7 @@ class TestOverlayFromEnv:
             "VALKEY_HOST": "192.168.86.201",
             "VALKEY_PORT": "16379",
             "KAFKA_GROUP_ID": "my-group",
-            "INFISICAL_ADDR": "http://192.168.86.201:8880",
+            "INFISICAL_ADDR": "https://192.168.86.201:8880",
         }
         overlay = overlay_from_env_dict(env_dict, environment="dev")
         assert "valkey" in overlay.transports


### PR DESCRIPTION
## Summary

- Adds \`overlay_from_env_dict()\` in \`runtime/overlay/overlay_from_env.py\` — classifies env key-value pairs into \`ModelOverlayFile\` transport sections using \`TransportConfigMap.keys_for_transport()\` with prefix-based fallback for real-world keys (e.g. \`KAFKA_BOOTSTRAP_SERVERS\`)
- \`ModelOnboardingOutput.overlay_output_path_written\` — new field tracking written overlay path (separate from \`env_output_path_written\`)
- \`ModelOnboardingInput.overlay_output_path\` + \`legacy_env_output\` — allows callers to specify explicit overlay path; \`legacy_env_output=True\` (default) preserves legacy .env write
- \`_handle_interactive\` now calls \`overlay_from_env_dict(..., return_warnings=False)\` and \`OverlayWriter().write()\` as primary output when \`dry_run=False\`
- \`@overload\` signatures on \`overlay_from_env_dict\` for mypy narrowing (Literal[True/False])

Ticket: OMN-11069


## Test plan

- [x] \`uv run pytest tests/unit/runtime/overlay/test_overlay_from_env.py -v\` — 8 tests covering transport classification, unclassified handling, round-trip
- [x] \`uv run pytest tests/unit/nodes/node_onboarding_orchestrator/ -v\` — 14 interactive + DAG tests including overlay write/path assertions
- [x] All pre-commit hooks pass including mypy, ruff, kafka-fallback guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive onboarding now writes overlay YAML files as the primary configuration output format
  * Users can optionally retain legacy `.env` file output for backward compatibility
  * Overlay files are automatically validated with clear error messages for invalid schemas and missing required configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11069
