### PR TITLE
ci(OMN-11104): install aws cli for ecr workflows

### DIFF
--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -53,6 +53,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up Python for AWS CLI
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Ensure AWS CLI is available
+        shell: bash
+        run: |
+          if command -v aws >/dev/null 2>&1; then
+            aws --version
+            exit 0
+          fi
+
+          python -m pip install --user 'awscli>=1.33,<2'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/aws" --version
+
       - name: Configure AWS credentials (OIDC -> omninode-github-actions-role)
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -96,6 +96,23 @@ jobs:
             echo "::warning::Expected Buildx driver 'docker', got '${DRIVER}'"
           fi
 
+      - name: Set up Python for AWS CLI
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Ensure AWS CLI is available
+        shell: bash
+        run: |
+          if command -v aws >/dev/null 2>&1; then
+            aws --version
+            exit 0
+          fi
+
+          python -m pip install --user 'awscli>=1.33,<2'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/aws" --version
+
       - name: Configure AWS credentials (OIDC -> omninode-github-actions-role)
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/contracts/OMN-11104.yaml
+++ b/contracts/OMN-11104.yaml
@@ -9,7 +9,6 @@ is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "events"
-  - "runtime"
   - "public_api"
 evidence_requirements:
   - kind: "tests"


### PR DESCRIPTION
## Summary
- install Python and AWS CLI explicitly before ECR workflow AWS CLI calls
- apply the same hardening to runtime and migration image workflows

Evidence-Ticket: OMN-11104
Evidence-Source: ec1ea44c6e7e1f9fda43973f4033c27851cd1130

## Verification
- git diff --check
- pre-commit hooks during commit
- actionlint .github/workflows/build-and-push-runtime.yml .github/workflows/build-and-push-migrate-image.yml (reports pre-existing shellcheck warnings outside the added steps)