### PR TITLE
feat(OMN-11108): overlay config infrastructure (Wave 2/3)

### DIFF
--- a/contracts/OMN-11108.yaml
+++ b/contracts/OMN-11108.yaml
@@ -1,0 +1,44 @@
+# OMN-11108 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-11108"
+title: "feat(OMN-11108): overlay config infrastructure (Wave 2/3)"
+summary: >-
+  Adds the overlay config infrastructure under src/omnibase_infra/runtime/overlay/: OverlayFileLoader (YAML parse + chmod 600), OverlayConfigResolver (PURE resolution against contract dependencies[], fails-closed on bad contracts), boot_overlay (sole env mutation authority), OverlayWriter (deterministic atomic write), overlay_from_env (onboarding helper), plus ModelOnboardingOutput extension.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - public_api
+evidence_requirements:
+  - kind: "tests"
+    description: "20 overlay integration tests pass on PR #1623"
+    command: >-
+      uv run pytest tests/integration/overlay/ -v
+  - kind: "ci"
+    description: "CI gates pass on omnibase_infra PR #1623"
+    command: "gh pr checks 1623 --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-contract-artifact"
+    description: "Repo-local deploy evidence contract is present for OMN-11108"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "test -f contracts/OMN-11108.yaml"
+  - id: "dod-overlay-integration-tests"
+    description: "20 overlay integration tests pass on PR #1623"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/overlay/ -v"
+  - id: "dod-deploy"
+    description: >-
+      Deploy validation: overlay infrastructure modules importable from the omninode-runtime image after deploy of PR #1623. Canonical OCC receipt at drift/dod_receipts/OMN-11108/dod-overlay-runtime-deploy in OCC#1079.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          docker exec omninode-runtime python -c "from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config; print('overlay deploy ok')"

--- a/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_output.py
+++ b/src/omnibase_infra/nodes/node_onboarding_orchestrator/models/model_onboarding_output.py
@@ -71,6 +71,10 @@ class ModelOnboardingOutput(BaseModel):
         default=None,
         description="Path written to if dry_run=False; None otherwise",
     )
+    overlay_output_path_written: str | None = Field(
+        default=None,
+        description="Path where overlay YAML was written, if generated",
+    )
 
 
 __all__ = ["ModelOnboardingOutput"]

--- a/src/omnibase_infra/runtime/overlay/__init__.py
+++ b/src/omnibase_infra/runtime/overlay/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Overlay config infrastructure — loader, resolver, writer, boot wiring."""

--- a/src/omnibase_infra/runtime/overlay/boot_overlay.py
+++ b/src/omnibase_infra/runtime/overlay/boot_overlay.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+
+from .errors import OverlayNotFoundError
+from .model_overlay_resolution_result import ModelOverlayResolutionResult
+from .overlay_config_resolver import OverlayConfigResolver
+from .overlay_file_loader import OverlayFileLoader
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OVERLAY_PATH = Path.home() / ".omnibase" / "overlay.yaml"
+
+_TRANSPORT_INDICATORS = frozenset(
+    [
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "POSTGRES_HOST",
+        "POSTGRES_PASSWORD",
+        "VALKEY_URL",
+        "INFISICAL_ADDR",
+    ]
+)
+
+
+def load_overlay_config(
+    *,
+    contracts_dir: Path,
+    overlay_path: Path | None = None,
+    manifest_path: Path | None = None,
+) -> ModelOverlayResolutionResult | None:
+    """Load overlay, resolve against contracts, inject into os.environ, write manifest.
+
+    This function is the SOLE authority for os.environ mutation during overlay bootstrap.
+    After this returns, injected values are immutable for the process lifetime.
+
+    Cold-start branching:
+    - Overlay present → load, resolve, inject, write manifest
+    - No overlay + ONEX_REQUIRE_OVERLAY=true → OverlayNotFoundError (overrides migration mode)
+    - No overlay + env vars present → None (migration compat mode, deprecation warning)
+    - No overlay + no env vars → OverlayNotFoundError with onboarding instructions
+    """
+    if overlay_path is None:
+        overlay_path = Path(
+            os.environ.get("ONEX_OVERLAY_PATH", str(_DEFAULT_OVERLAY_PATH))
+        )
+    if manifest_path is None:
+        manifest_path_str = os.environ.get("ONEX_OVERLAY_MANIFEST_PATH")
+        manifest_path = Path(manifest_path_str) if manifest_path_str else None
+
+    require_overlay = os.environ.get("ONEX_REQUIRE_OVERLAY", "").lower() == "true"
+
+    if not overlay_path.exists():
+        if require_overlay:
+            raise OverlayNotFoundError(
+                f"ONEX_REQUIRE_OVERLAY=true but overlay not found at {overlay_path}. "
+                "Environment variables alone are insufficient when overlay enforcement is enabled. "
+                "Run onboarding to generate one."
+            )
+        if _has_transport_env_vars():
+            logger.warning(
+                "No overlay file at %s but transport env vars are present. "
+                "Running in migration compatibility mode. "
+                "Generate an overlay via onboarding to silence this warning.",
+                overlay_path,
+            )
+            return None
+        raise OverlayNotFoundError(
+            f"No overlay file at {overlay_path} and no transport env vars detected. "
+            "Run onboarding to generate an overlay file."
+        )
+
+    # Load and resolve (pure — no env mutation yet)
+    loader = OverlayFileLoader()
+    overlay = loader.load(overlay_path)
+
+    resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+    result = resolver.resolve(overlay)
+
+    # ENV MUTATION BOUNDARY — this is the only place env gets written
+    _inject_resolved_pairs(result.resolved_pairs)
+
+    # Write manifest as durable evidence artifact
+    if manifest_path:
+        _write_manifest(
+            manifest_path=manifest_path,
+            overlay_path=overlay_path,
+            overlay=overlay,
+            result=result,
+        )
+
+    logger.info(
+        "Overlay config loaded: injected=%d keys, skipped=%d existing, unused=%d",
+        len(result.resolved_pairs),
+        len(result.skipped_existing_keys),
+        len(result.unused_overlay_keys),
+    )
+    return result
+
+
+def _inject_resolved_pairs(pairs: dict[str, str]) -> None:
+    """Inject resolved pairs into os.environ. Called exactly once during bootstrap."""
+    for key, value in sorted(pairs.items()):
+        os.environ[key] = value
+
+
+def _write_manifest(
+    *,
+    manifest_path: Path,
+    overlay_path: Path,
+    overlay: object,
+    result: ModelOverlayResolutionResult,
+) -> None:
+    """Write resolution manifest as JSON evidence artifact."""
+    manifest_data = {
+        "overlay_path": str(overlay_path),
+        "environment": getattr(overlay, "environment", "unknown"),
+        "scope": getattr(overlay, "scope", "unknown"),
+        "content_hash": getattr(overlay, "content_hash", lambda: "")(),
+        "resolved_pairs_hash": result.resolved_pairs_hash,
+        "injected_keys": sorted(result.resolved_pairs.keys()),
+        "skipped_existing_keys": sorted(result.skipped_existing_keys),
+        "unused_overlay_keys": sorted(result.unused_overlay_keys),
+        "required_keys": sorted(result.required_keys),
+        "stable_identity_hash": hashlib.sha256(
+            json.dumps(
+                {
+                    "content_hash": getattr(overlay, "content_hash", lambda: "")(),
+                    "resolved_pairs_hash": result.resolved_pairs_hash,
+                },
+                sort_keys=True,
+            ).encode()
+        ).hexdigest(),
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest_data, indent=2, sort_keys=True))
+    logger.info("Overlay resolution manifest written to %s", manifest_path)
+
+
+def _has_transport_env_vars() -> bool:
+    """Migration-compatibility detection only. NOT authoritative config validation.
+
+    Checks whether common transport env vars exist to distinguish "migrating from
+    env-var-based config" from "greenfield with no config at all." Future versions
+    should derive required config from contracts, not heuristics.
+    """
+    return any(key in os.environ for key in _TRANSPORT_INDICATORS)

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+
+class OverlayNotFoundError(FileNotFoundError):
+    """Overlay YAML file not found at the specified path."""
+
+
+class OverlaySchemaInvalidError(ValueError):
+    """Overlay YAML does not conform to ModelOverlayFile schema."""
+
+
+class OverlayPermissionError(PermissionError):
+    """Overlay file has overly permissive filesystem permissions."""
+
+
+class RequiredConfigMissingError(ValueError):
+    """Contract requires config keys that neither overlay nor environment provides."""

--- a/src/omnibase_infra/runtime/overlay/errors.py
+++ b/src/omnibase_infra/runtime/overlay/errors.py
@@ -17,3 +17,11 @@ class OverlayPermissionError(PermissionError):
 
 class RequiredConfigMissingError(ValueError):
     """Contract requires config keys that neither overlay nor environment provides."""
+
+
+class ContractParseError(ValueError):
+    """A contract file under contracts_dir is unreadable, unparseable, or malformed.
+
+    Resolver fails closed on this error rather than silently skipping bad contracts,
+    which would under-report required_keys and let boot succeed with missing config.
+    """

--- a/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
+++ b/src/omnibase_infra/runtime/overlay/model_overlay_resolution_result.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelOverlayResolutionResult(BaseModel):
+    """Pure resolution output — no side effects. Boot layer consumes this to mutate env."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    resolved_pairs: dict[str, str] = Field(
+        default_factory=dict,
+        description="Keys that should be injected (overlay provides, env does not have).",
+    )
+    skipped_existing_keys: frozenset[str] = Field(
+        default_factory=frozenset,
+        description="Keys the overlay provides but env already has — skip to preserve existing.",
+    )
+    unused_overlay_keys: frozenset[str] = Field(
+        default_factory=frozenset,
+        description="Keys in overlay that no contract requires — visibility into stale config.",
+    )
+    required_keys: frozenset[str] = Field(
+        default_factory=frozenset,
+        description="All keys contracts require (for audit/manifest).",
+    )
+
+    @property
+    def resolved_pairs_hash(self) -> str:
+        """Deterministic SHA-256 of resolved_pairs for replay verification."""
+        canonical = json.dumps(
+            dict(sorted(self.resolved_pairs.items())), sort_keys=True
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
+
+from .errors import RequiredConfigMissingError
+from .model_overlay_resolution_result import ModelOverlayResolutionResult
+
+logger = logging.getLogger(__name__)
+
+
+class OverlayConfigResolver:
+    """Pure resolver: computes resolution without mutating os.environ.
+
+    Uses contract dependency declarations to determine which overlay keys
+    are required, which are unused, and which are already satisfied by
+    existing env vars.
+    """
+
+    def __init__(self, *, contracts_dir: Path) -> None:
+        self._contracts_dir = contracts_dir
+
+    def resolve(self, overlay: ModelOverlayFile) -> ModelOverlayResolutionResult:
+        required_keys = self._extract_required_keys()
+        all_overlay_pairs = overlay.all_env_pairs()
+
+        resolved: dict[str, str] = {}
+        skipped: set[str] = set()
+        missing: set[str] = set()
+
+        for key in required_keys:
+            if key in os.environ:
+                skipped.add(key)
+            elif key in all_overlay_pairs:
+                resolved[key] = all_overlay_pairs[key]
+            else:
+                missing.add(key)
+
+        if missing:
+            raise RequiredConfigMissingError(
+                f"Contracts require config keys not provided by overlay or environment: "
+                f"{sorted(missing)}. Add these to your overlay YAML or set them as env vars."
+            )
+
+        unused = (
+            frozenset(all_overlay_pairs.keys()) - frozenset(resolved.keys()) - skipped
+        )
+        if unused:
+            logger.info(
+                "Overlay contains %d keys not required by any contract: %s",
+                len(unused),
+                sorted(unused),
+            )
+
+        return ModelOverlayResolutionResult(
+            resolved_pairs=resolved,
+            skipped_existing_keys=frozenset(skipped),
+            unused_overlay_keys=unused,
+            required_keys=frozenset(required_keys),
+        )
+
+    def _extract_required_keys(self) -> set[str]:
+        """Extract required env keys from contract YAML dependency declarations."""
+        required: set[str] = set()
+        for contract_path in self._contracts_dir.rglob("contract.yaml"):
+            try:
+                raw = yaml.safe_load(contract_path.read_text())
+            except (yaml.YAMLError, OSError):
+                continue
+            if not isinstance(raw, dict):
+                continue
+            deps = raw.get("dependencies", [])
+            if not isinstance(deps, list):
+                continue
+            for dep in deps:
+                if isinstance(dep, dict) and dep.get("type") == "environment":
+                    key = dep.get("key")
+                    if key:
+                        required.add(key)
+        return required

--- a/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_config_resolver.py
@@ -10,7 +10,7 @@ import yaml
 
 from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
 
-from .errors import RequiredConfigMissingError
+from .errors import ContractParseError, RequiredConfigMissingError
 from .model_overlay_resolution_result import ModelOverlayResolutionResult
 
 logger = logging.getLogger(__name__)
@@ -67,18 +67,36 @@ class OverlayConfigResolver:
         )
 
     def _extract_required_keys(self) -> set[str]:
-        """Extract required env keys from contract YAML dependency declarations."""
+        """Extract required env keys from contract YAML dependency declarations.
+
+        Fails closed: any unreadable, unparseable, or malformed contract raises
+        ContractParseError. Silently skipping bad contracts under-reports
+        required_keys and lets boot succeed with missing config (defeats the
+        purpose of the resolver).
+        """
         required: set[str] = set()
         for contract_path in self._contracts_dir.rglob("contract.yaml"):
             try:
                 raw = yaml.safe_load(contract_path.read_text())
-            except (yaml.YAMLError, OSError):
-                continue
+            except OSError as exc:
+                raise ContractParseError(
+                    f"Failed to read contract at {contract_path}: {exc}"
+                ) from exc
+            except yaml.YAMLError as exc:
+                raise ContractParseError(
+                    f"Failed to parse contract YAML at {contract_path}: {exc}"
+                ) from exc
             if not isinstance(raw, dict):
-                continue
+                raise ContractParseError(
+                    f"Contract at {contract_path} must be a YAML mapping, "
+                    f"got {type(raw).__name__}"
+                )
             deps = raw.get("dependencies", [])
             if not isinstance(deps, list):
-                continue
+                raise ContractParseError(
+                    f"Contract at {contract_path} has non-list 'dependencies' field, "
+                    f"got {type(deps).__name__}"
+                )
             for dep in deps:
                 if isinstance(dep, dict) and dep.get("type") == "environment":
                     key = dep.get("key")

--- a/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
@@ -25,28 +25,40 @@ class OverlayFileLoader:
         self._require_restricted = require_restricted_permissions
 
     def load(self, path: Path) -> ModelOverlayFile:
-        if not path.exists():
+        if not path.is_file():
+            if path.exists():
+                raise OverlaySchemaInvalidError(
+                    f"Overlay path {path} exists but is not a regular file."
+                )
             raise OverlayNotFoundError(
                 f"Overlay file not found: {path}. Run onboarding to generate one."
             )
 
         self._check_permissions(path)
 
+        # Parser/validator error text can echo overlay contents (including secret
+        # values inside YAML keys). Log the raw exception once at DEBUG and raise
+        # a sanitized message containing only the file path.
         try:
             raw = yaml.safe_load(path.read_text())
         except yaml.YAMLError as exc:
-            raise OverlaySchemaInvalidError(f"Invalid YAML in {path}: {exc}") from exc
+            logger.debug("YAML parse error for %s: %s", path, exc)
+            raise OverlaySchemaInvalidError(
+                f"Invalid YAML in {path}. See debug logs for details."
+            ) from exc
 
         if not isinstance(raw, dict):
             raise OverlaySchemaInvalidError(
-                f"Overlay must be a YAML mapping, got {type(raw).__name__}"
+                f"Overlay at {path} must be a YAML mapping, got {type(raw).__name__}"
             )
 
         try:
             return ModelOverlayFile.model_validate(raw)
         except ValidationError as exc:
+            logger.debug("Overlay schema validation failed for %s: %s", path, exc)
             raise OverlaySchemaInvalidError(
-                f"Overlay schema validation failed for {path}: {exc}"
+                f"Overlay schema validation failed for {path}. "
+                "See debug logs for details."
             ) from exc
 
     def _check_permissions(self, path: Path) -> None:

--- a/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_file_loader.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import logging
+import stat
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
+
+from .errors import (
+    OverlayNotFoundError,
+    OverlayPermissionError,
+    OverlaySchemaInvalidError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OverlayFileLoader:
+    def __init__(self, *, require_restricted_permissions: bool = True) -> None:
+        self._require_restricted = require_restricted_permissions
+
+    def load(self, path: Path) -> ModelOverlayFile:
+        if not path.exists():
+            raise OverlayNotFoundError(
+                f"Overlay file not found: {path}. Run onboarding to generate one."
+            )
+
+        self._check_permissions(path)
+
+        try:
+            raw = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            raise OverlaySchemaInvalidError(f"Invalid YAML in {path}: {exc}") from exc
+
+        if not isinstance(raw, dict):
+            raise OverlaySchemaInvalidError(
+                f"Overlay must be a YAML mapping, got {type(raw).__name__}"
+            )
+
+        try:
+            return ModelOverlayFile.model_validate(raw)
+        except ValidationError as exc:
+            raise OverlaySchemaInvalidError(
+                f"Overlay schema validation failed for {path}: {exc}"
+            ) from exc
+
+    def _check_permissions(self, path: Path) -> None:
+        file_stat = path.stat()
+        mode = stat.S_IMODE(file_stat.st_mode)
+        group_or_other = mode & (stat.S_IRWXG | stat.S_IRWXO)
+        if group_or_other:
+            msg = (
+                f"Overlay file {path} is accessible by group/other "
+                f"(mode={oct(mode)}). Expected 0600."
+            )
+            if self._require_restricted:
+                raise OverlayPermissionError(msg)
+            logger.warning(msg)

--- a/src/omnibase_infra/runtime/overlay/overlay_from_env.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_from_env.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from pathlib import Path
+
+from .overlay_writer import OverlayWriter
+
+_DEFAULT_OVERLAY_OUTPUT = Path.home() / ".omnibase" / "overlay.yaml"
+
+
+def overlay_from_env_dict(
+    env_dict: dict[str, str],
+    *,
+    output_path: Path | None = None,
+    environment: str = "local",
+    scope: str = "env",
+) -> Path:
+    """Generate an overlay YAML file from an env var dict.
+
+    Used by onboarding to produce the initial overlay file from discovered
+    or user-supplied configuration values.
+
+    Production/default onboarding targets ~/.omnibase/overlay.yaml.
+    Tests and automation MUST pass explicit temp output paths to avoid
+    mutating real state.
+    """
+    if output_path is None:
+        output_path = _DEFAULT_OVERLAY_OUTPUT
+
+    writer = OverlayWriter()
+    writer.write(
+        env_dict=env_dict,
+        output_path=output_path,
+        environment=environment,
+        scope=scope,
+    )
+    return output_path

--- a/src/omnibase_infra/runtime/overlay/overlay_writer.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_writer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import tempfile
 from pathlib import Path
 
@@ -15,8 +14,6 @@ from omnibase_infra.runtime.config_discovery.transport_config_map import (
 )
 
 logger = logging.getLogger(__name__)
-
-_SECRET_PATTERN = re.compile(r"PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL", re.IGNORECASE)
 
 
 class OverlayWriter:
@@ -33,9 +30,9 @@ class OverlayWriter:
     ) -> None:
         transports = self._classify_by_transport(env_dict)
 
-        secret_count = sum(1 for key in env_dict if _SECRET_PATTERN.search(key))
-        if secret_count:
-            logger.warning("Overlay contains %d secret-pattern keys", secret_count)
+        # Overlay legitimately stores credential-like keys (POSTGRES_PASSWORD etc.).
+        # The chmod 600 below is the protection; verbose counts of "secret-pattern keys"
+        # leak nothing useful and trip CodeQL clear-text-logging heuristics.
 
         overlay_data = {
             "overlay_version": "1.0.0",

--- a/src/omnibase_infra/runtime/overlay/overlay_writer.py
+++ b/src/omnibase_infra/runtime/overlay/overlay_writer.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.config_discovery.transport_config_map import (
+    TransportConfigMap,
+)
+
+logger = logging.getLogger(__name__)
+
+_SECRET_PATTERN = re.compile(r"PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL", re.IGNORECASE)
+
+
+class OverlayWriter:
+    def __init__(self) -> None:
+        self._transport_map = TransportConfigMap()
+
+    def write(
+        self,
+        *,
+        env_dict: dict[str, str],
+        output_path: Path,
+        environment: str,
+        scope: str,
+    ) -> None:
+        transports = self._classify_by_transport(env_dict)
+
+        secret_count = sum(1 for key in env_dict if _SECRET_PATTERN.search(key))
+        if secret_count:
+            logger.warning("Overlay contains %d secret-pattern keys", secret_count)
+
+        overlay_data = {
+            "overlay_version": "1.0.0",
+            "environment": environment,
+            "scope": scope,
+            "transports": transports,
+        }
+
+        # Atomic write: tempfile + rename
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path_str = tempfile.mkstemp(
+            dir=str(output_path.parent), suffix=".yaml.tmp"
+        )
+        tmp_path = Path(tmp_path_str)
+        try:
+            with os.fdopen(fd, "w") as f:
+                yaml.safe_dump(
+                    overlay_data, f, sort_keys=True, default_flow_style=False
+                )
+            tmp_path.chmod(0o600)
+            tmp_path.replace(output_path)
+        except BaseException:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+
+    def _classify_by_transport(
+        self, env_dict: dict[str, str]
+    ) -> dict[str, dict[str, str]]:
+        """Classify env keys into transport buckets. Sorted iteration for determinism."""
+        from omnibase_infra.enums import EnumInfraTransportType
+
+        result: dict[str, dict[str, str]] = {}
+        classified_keys: set[str] = set()
+
+        # Sorted enum iteration ensures deterministic output regardless of enum definition order
+        for transport in sorted(EnumInfraTransportType, key=lambda t: t.value):
+            transport_keys = self._transport_map.keys_for_transport(transport)
+            bucket: dict[str, str] = {}
+            for key in sorted(transport_keys):
+                if key in env_dict:
+                    bucket[key] = env_dict[key]
+                    classified_keys.add(key)
+            if bucket:
+                result[transport.value] = bucket
+
+        # Unclassified keys in sorted order
+        unclassified = {
+            k: env_dict[k] for k in sorted(env_dict.keys()) if k not in classified_keys
+        }
+        if unclassified:
+            result["custom"] = unclassified
+
+        return result

--- a/tests/integration/overlay/__init__.py
+++ b/tests/integration/overlay/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/integration/overlay/conftest.py
+++ b/tests/integration/overlay/conftest.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def overlay_dir(tmp_path: Path) -> Path:
+    """Temp directory for overlay YAML files."""
+    return tmp_path / "overlays"
+
+
+@pytest.fixture
+def sample_overlay_yaml(overlay_dir: Path) -> Path:
+    """Write a valid overlay YAML and return its path."""
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    overlay_path = overlay_dir / "overlay.yaml"
+    overlay_data = {
+        "overlay_version": "1.0.0",
+        "environment": "test",
+        "scope": "env",
+        "transports": {
+            "kafka": {
+                "KAFKA_BOOTSTRAP_SERVERS": "localhost:9092",
+            },
+            "database": {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5436",
+                "POSTGRES_PASSWORD": "test_password",
+            },
+        },
+    }
+    overlay_path.write_text(yaml.safe_dump(overlay_data, sort_keys=True))
+    overlay_path.chmod(0o600)
+    return overlay_path
+
+
+@pytest.fixture
+def contracts_dir(tmp_path: Path) -> Path:
+    """Temp directory with a minimal contract YAML requiring kafka + database."""
+    cdir = tmp_path / "contracts"
+    cdir.mkdir()
+    contract = {
+        "name": "test-node",
+        "node_type": "EFFECT_GENERIC",
+        "metadata": {"transport_type": "kafka"},
+        "dependencies": [
+            {"type": "environment", "key": "POSTGRES_HOST"},
+            {"type": "environment", "key": "KAFKA_BOOTSTRAP_SERVERS"},
+        ],
+    }
+    (cdir / "contract.yaml").write_text(yaml.safe_dump(contract))
+    return cdir

--- a/tests/integration/overlay/test_overlay_boot_integration.py
+++ b/tests/integration/overlay/test_overlay_boot_integration.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 
 class TestOverlayBootIntegration:
     """Integration tests for boot_overlay — validates that boot_overlay.py
@@ -59,6 +61,9 @@ class TestOverlayBootIntegration:
 
         monkeypatch.setenv("ONEX_OVERLAY_PATH", "/nonexistent/overlay.yaml")
         monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "existing:9092")
+        # Ensure ONEX_REQUIRE_OVERLAY does not leak from the ambient env or a
+        # prior test; if true it would override migration mode and raise.
+        monkeypatch.delenv("ONEX_REQUIRE_OVERLAY", raising=False)
         result = load_overlay_config(contracts_dir=contracts_dir)
         assert result is None
 

--- a/tests/integration/overlay/test_overlay_boot_integration.py
+++ b/tests/integration/overlay/test_overlay_boot_integration.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestOverlayBootIntegration:
+    """Integration tests for boot_overlay — validates that boot_overlay.py
+    is the SOLE authority for os.environ mutation during overlay loading."""
+
+    def test_load_overlay_config_injects_env(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", str(sample_overlay_yaml))
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        result = load_overlay_config(contracts_dir=contracts_dir)
+        assert result is not None
+        # boot_overlay is where env mutation happens
+        assert os.environ["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:9092"
+        assert os.environ["POSTGRES_HOST"] == "localhost"
+
+    def test_load_overlay_config_writes_manifest(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+
+        manifest_path = tmp_path / "overlay_resolution_manifest.json"
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", str(sample_overlay_yaml))
+        monkeypatch.setenv("ONEX_OVERLAY_MANIFEST_PATH", str(manifest_path))
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        load_overlay_config(contracts_dir=contracts_dir)
+        assert manifest_path.exists()
+        import json
+
+        manifest = json.loads(manifest_path.read_text())
+        assert "stable_identity_hash" in manifest
+        assert "resolved_pairs_hash" in manifest
+
+    def test_missing_overlay_with_env_vars_returns_none(
+        self, contracts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Migration mode: no overlay file but env vars present → returns None."""
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", "/nonexistent/overlay.yaml")
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "existing:9092")
+        result = load_overlay_config(contracts_dir=contracts_dir)
+        assert result is None
+
+    def test_missing_overlay_no_env_raises(
+        self, contracts_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Greenfield: no overlay, no env vars → error with onboarding instructions."""
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+        from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
+
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", str(tmp_path / "missing.yaml"))
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        with pytest.raises(OverlayNotFoundError):
+            load_overlay_config(contracts_dir=contracts_dir)
+
+    def test_require_overlay_overrides_migration_mode(
+        self, contracts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ONEX_REQUIRE_OVERLAY=true raises even when env vars exist."""
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+        from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
+
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", "/nonexistent/overlay.yaml")
+        monkeypatch.setenv("ONEX_REQUIRE_OVERLAY", "true")
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "exists:9092")
+        with pytest.raises(OverlayNotFoundError, match="ONEX_REQUIRE_OVERLAY=true"):
+            load_overlay_config(contracts_dir=contracts_dir)

--- a/tests/integration/overlay/test_overlay_boot_integration.py
+++ b/tests/integration/overlay/test_overlay_boot_integration.py
@@ -70,8 +70,15 @@ class TestOverlayBootIntegration:
         from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
 
         monkeypatch.setenv("ONEX_OVERLAY_PATH", str(tmp_path / "missing.yaml"))
-        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
-        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        # Clear all transport indicator vars so _has_transport_env_vars() returns False
+        for var in (
+            "KAFKA_BOOTSTRAP_SERVERS",
+            "POSTGRES_HOST",
+            "POSTGRES_PASSWORD",
+            "VALKEY_URL",
+            "INFISICAL_ADDR",
+        ):
+            monkeypatch.delenv(var, raising=False)
         with pytest.raises(OverlayNotFoundError):
             load_overlay_config(contracts_dir=contracts_dir)
 

--- a/tests/integration/overlay/test_overlay_end_to_end.py
+++ b/tests/integration/overlay/test_overlay_end_to_end.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 
 class TestOverlayEndToEnd:
     """End-to-end: generate overlay via writer → load → resolve → inject → verify manifest.

--- a/tests/integration/overlay/test_overlay_end_to_end.py
+++ b/tests/integration/overlay/test_overlay_end_to_end.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestOverlayEndToEnd:
+    """End-to-end: generate overlay via writer → load → resolve → inject → verify manifest.
+    Includes replay determinism proof."""
+
+    def test_full_pipeline_generate_load_resolve_inject(
+        self, tmp_path: Path, contracts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from omnibase_infra.runtime.overlay.boot_overlay import load_overlay_config
+        from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
+
+        env_dict = {
+            "KAFKA_BOOTSTRAP_SERVERS": "redpanda:9092",
+            "POSTGRES_HOST": "pg.internal",
+            "POSTGRES_PORT": "5436",
+            "POSTGRES_PASSWORD": "secret123",
+        }
+        writer = OverlayWriter()
+        overlay_path = tmp_path / "generated_overlay.yaml"
+        writer.write(
+            env_dict=env_dict,
+            output_path=overlay_path,
+            environment="production",
+            scope="env",
+        )
+        assert overlay_path.exists()
+        assert (overlay_path.stat().st_mode & 0o777) == 0o600
+
+        monkeypatch.setenv("ONEX_OVERLAY_PATH", str(overlay_path))
+        manifest_path = tmp_path / "manifest.json"
+        monkeypatch.setenv("ONEX_OVERLAY_MANIFEST_PATH", str(manifest_path))
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        result = load_overlay_config(contracts_dir=contracts_dir)
+        assert result is not None
+        assert os.environ["KAFKA_BOOTSTRAP_SERVERS"] == "redpanda:9092"
+        assert os.environ["POSTGRES_HOST"] == "pg.internal"
+
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["stable_identity_hash"]
+        assert manifest["environment"] == "production"
+        assert manifest["resolved_pairs_hash"]
+
+    def test_round_trip_content_hash_stable(self, tmp_path: Path) -> None:
+        """Writer output → Loader input produces identical content_hash."""
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+        from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
+
+        env_dict = {"KAFKA_BOOTSTRAP_SERVERS": "host:9092", "POSTGRES_HOST": "db"}
+        writer = OverlayWriter()
+        path = tmp_path / "overlay.yaml"
+        writer.write(
+            env_dict=env_dict, output_path=path, environment="test", scope="env"
+        )
+
+        loader = OverlayFileLoader(require_restricted_permissions=False)
+        model = loader.load(path)
+        assert model.content_hash()
+
+        path2 = tmp_path / "overlay2.yaml"
+        writer.write(
+            env_dict=env_dict, output_path=path2, environment="test", scope="env"
+        )
+        model2 = loader.load(path2)
+        assert model.content_hash() == model2.content_hash()
+
+    def test_insertion_order_independent_hash(self, tmp_path: Path) -> None:
+        """Determinism: reversed dict insertion order → identical content_hash."""
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+        from omnibase_infra.runtime.overlay.overlay_writer import OverlayWriter
+
+        env_a = {
+            "KAFKA_BOOTSTRAP_SERVERS": "host:9092",
+            "POSTGRES_HOST": "db",
+            "POSTGRES_PORT": "5436",
+        }
+        env_b = {
+            "POSTGRES_PORT": "5436",
+            "POSTGRES_HOST": "db",
+            "KAFKA_BOOTSTRAP_SERVERS": "host:9092",
+        }
+
+        writer = OverlayWriter()
+        path_a = tmp_path / "a.yaml"
+        path_b = tmp_path / "b.yaml"
+        writer.write(
+            env_dict=env_a, output_path=path_a, environment="test", scope="env"
+        )
+        writer.write(
+            env_dict=env_b, output_path=path_b, environment="test", scope="env"
+        )
+
+        # Byte-identical output regardless of insertion order
+        assert path_a.read_bytes() == path_b.read_bytes()
+
+        loader = OverlayFileLoader(require_restricted_permissions=False)
+        assert loader.load(path_a).content_hash() == loader.load(path_b).content_hash()
+
+    def test_replay_determinism_same_inputs_same_manifest(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Replay proof: same overlay + same contracts → same manifest hash across runs."""
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        loader = OverlayFileLoader()
+        overlay = loader.load(sample_overlay_yaml)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+
+        result1 = resolver.resolve(overlay)
+        result2 = resolver.resolve(overlay)
+
+        assert result1.resolved_pairs == result2.resolved_pairs
+        assert result1.resolved_pairs_hash == result2.resolved_pairs_hash
+        assert result1.unused_overlay_keys == result2.unused_overlay_keys

--- a/tests/integration/overlay/test_overlay_loader_integration.py
+++ b/tests/integration/overlay/test_overlay_loader_integration.py
@@ -8,6 +8,8 @@ import yaml
 
 from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
 
+pytestmark = pytest.mark.integration
+
 
 class TestOverlayFileLoaderIntegration:
     """Integration tests for OverlayFileLoader — validates YAML parsing,

--- a/tests/integration/overlay/test_overlay_loader_integration.py
+++ b/tests/integration/overlay/test_overlay_loader_integration.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.models.overlay.model_overlay_file import ModelOverlayFile
+
+
+class TestOverlayFileLoaderIntegration:
+    """Integration tests for OverlayFileLoader — validates YAML parsing,
+    schema validation, and permission enforcement with real files."""
+
+    def test_load_valid_overlay_returns_model(self, sample_overlay_yaml: Path) -> None:
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        loader = OverlayFileLoader()
+        result = loader.load(sample_overlay_yaml)
+        assert isinstance(result, ModelOverlayFile)
+        assert result.environment == "test"
+
+    def test_load_rejects_world_readable(self, sample_overlay_yaml: Path) -> None:
+        from omnibase_infra.runtime.overlay.errors import OverlayPermissionError
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        sample_overlay_yaml.chmod(0o644)
+        loader = OverlayFileLoader(require_restricted_permissions=True)
+        with pytest.raises(OverlayPermissionError):
+            loader.load(sample_overlay_yaml)
+
+    def test_load_missing_file_raises(self, tmp_path: Path) -> None:
+        from omnibase_infra.runtime.overlay.errors import OverlayNotFoundError
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        loader = OverlayFileLoader()
+        with pytest.raises(OverlayNotFoundError):
+            loader.load(tmp_path / "nonexistent.yaml")
+
+    def test_load_invalid_schema_raises(self, overlay_dir: Path) -> None:
+        from omnibase_infra.runtime.overlay.errors import OverlaySchemaInvalidError
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        overlay_dir.mkdir(parents=True, exist_ok=True)
+        bad = overlay_dir / "bad.yaml"
+        bad.write_text(yaml.safe_dump({"garbage": True}))
+        bad.chmod(0o600)
+        loader = OverlayFileLoader()
+        with pytest.raises(OverlaySchemaInvalidError):
+            loader.load(bad)

--- a/tests/integration/overlay/test_overlay_onboarding_integration.py
+++ b/tests/integration/overlay/test_overlay_onboarding_integration.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+class TestOverlayOnboardingIntegration:
+    def test_overlay_from_env_dict_produces_loadable_overlay(
+        self, tmp_path: Path
+    ) -> None:
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+        from omnibase_infra.runtime.overlay.overlay_from_env import (
+            overlay_from_env_dict,
+        )
+
+        env = {"KAFKA_BOOTSTRAP_SERVERS": "host:9092", "POSTGRES_HOST": "db"}
+        path = overlay_from_env_dict(env, output_path=tmp_path / "overlay.yaml")
+
+        loader = OverlayFileLoader(require_restricted_permissions=False)
+        model = loader.load(path)
+        assert model.environment == "local"
+        pairs = model.all_env_pairs()
+        assert pairs["KAFKA_BOOTSTRAP_SERVERS"] == "host:9092"
+
+    def test_overlay_from_env_dict_never_targets_default_in_tests(
+        self, tmp_path: Path
+    ) -> None:
+        """Enforce: tests always pass explicit output_path."""
+        from omnibase_infra.runtime.overlay.overlay_from_env import (
+            overlay_from_env_dict,
+        )
+
+        # This test proves the function works with explicit paths
+        path = overlay_from_env_dict(
+            {"KAFKA_BOOTSTRAP_SERVERS": "x:9092"},
+            output_path=tmp_path / "explicit.yaml",
+        )
+        assert path == tmp_path / "explicit.yaml"
+        assert path.exists()

--- a/tests/integration/overlay/test_overlay_onboarding_integration.py
+++ b/tests/integration/overlay/test_overlay_onboarding_integration.py
@@ -3,6 +3,10 @@
 
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.integration
+
 
 class TestOverlayOnboardingIntegration:
     def test_overlay_from_env_dict_produces_loadable_overlay(

--- a/tests/integration/overlay/test_overlay_resolver_integration.py
+++ b/tests/integration/overlay/test_overlay_resolver_integration.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+class TestOverlayConfigResolverIntegration:
+    """Integration tests for OverlayConfigResolver — validates that resolution
+    is PURE (no os.environ mutation), filters against contract requirements,
+    and enforces RequiredConfigMissingError."""
+
+    def test_resolve_returns_resolved_pairs_without_env_mutation(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        loader = OverlayFileLoader()
+        overlay = loader.load(sample_overlay_yaml)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+        result = resolver.resolve(overlay)
+
+        # Resolver returns resolved pairs
+        assert "KAFKA_BOOTSTRAP_SERVERS" in result.resolved_pairs
+        assert "POSTGRES_HOST" in result.resolved_pairs
+        assert result.resolved_pairs["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:9092"
+
+        # CRITICAL: resolver does NOT mutate os.environ
+        assert "KAFKA_BOOTSTRAP_SERVERS" not in os.environ
+        assert "POSTGRES_HOST" not in os.environ
+
+    def test_resolve_identifies_skipped_existing_keys(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "already-set:9092")
+        loader = OverlayFileLoader()
+        overlay = loader.load(sample_overlay_yaml)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+        result = resolver.resolve(overlay)
+
+        assert "KAFKA_BOOTSTRAP_SERVERS" in result.skipped_existing_keys
+        assert "KAFKA_BOOTSTRAP_SERVERS" not in result.resolved_pairs
+
+    def test_resolve_raises_when_required_keys_missing(
+        self, overlay_dir: Path, contracts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from omnibase_infra.runtime.overlay.errors import RequiredConfigMissingError
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+        # Overlay that only provides KAFKA, not POSTGRES_HOST (which contract requires)
+        overlay_dir.mkdir(parents=True, exist_ok=True)
+        incomplete = overlay_dir / "incomplete.yaml"
+        incomplete.write_text(
+            yaml.safe_dump(
+                {
+                    "overlay_version": "1.0.0",
+                    "environment": "test",
+                    "scope": "env",
+                    "transports": {"kafka": {"KAFKA_BOOTSTRAP_SERVERS": "host:9092"}},
+                },
+                sort_keys=True,
+            )
+        )
+        incomplete.chmod(0o600)
+
+        loader = OverlayFileLoader()
+        overlay = loader.load(incomplete)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+        with pytest.raises(RequiredConfigMissingError, match="POSTGRES_HOST"):
+            resolver.resolve(overlay)
+
+    def test_resolve_tracks_unused_overlay_keys(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        loader = OverlayFileLoader()
+        overlay = loader.load(sample_overlay_yaml)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+        result = resolver.resolve(overlay)
+
+        # POSTGRES_PORT and POSTGRES_PASSWORD are in overlay but not in contract requirements
+        assert (
+            "POSTGRES_PORT" in result.unused_overlay_keys
+            or "POSTGRES_PASSWORD" in result.unused_overlay_keys
+        )
+
+    def test_resolve_is_deterministic_for_identical_inputs(
+        self,
+        sample_overlay_yaml: Path,
+        contracts_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Replay determinism: same inputs → same resolved_pairs regardless of call order."""
+        from omnibase_infra.runtime.overlay.overlay_config_resolver import (
+            OverlayConfigResolver,
+        )
+        from omnibase_infra.runtime.overlay.overlay_file_loader import OverlayFileLoader
+
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+        loader = OverlayFileLoader()
+        overlay = loader.load(sample_overlay_yaml)
+        resolver = OverlayConfigResolver(contracts_dir=contracts_dir)
+
+        result1 = resolver.resolve(overlay)
+        result2 = resolver.resolve(overlay)
+        assert result1.resolved_pairs == result2.resolved_pairs
+        assert result1.resolved_pairs_hash == result2.resolved_pairs_hash

--- a/tests/integration/overlay/test_overlay_resolver_integration.py
+++ b/tests/integration/overlay/test_overlay_resolver_integration.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+pytestmark = pytest.mark.integration
+
 
 class TestOverlayConfigResolverIntegration:
     """Integration tests for OverlayConfigResolver — validates that resolution


### PR DESCRIPTION
## Summary

Implements the full overlay config infrastructure in omnibase_infra, TDD-first (tests written before implementation). Closes OMN-11108.

- **OverlayFileLoader**: YAML parsing, schema validation against ModelOverlayFile, chmod 600 enforcement
- **OverlayConfigResolver**: PURE resolution against contract requirements — zero os.environ mutation, filters overlay keys against contract dependencies[], raises RequiredConfigMissingError when required keys are absent
- **boot_overlay**: sole env mutation authority, 5-path cold-start branching (overlay present / ONEX_REQUIRE_OVERLAY=true / migration compat / greenfield), manifest write
- **OverlayWriter**: deterministic atomic write, sorted enum + key iteration, byte-identical output regardless of dict insertion order, chmod 600
- **overlay_from_env**: onboarding helper for initial overlay generation from env dict
- **ModelOnboardingOutput.overlay_output_path_written**: optional field recording written overlay path
- **20 integration tests**: full pipeline + all cold-start paths + replay determinism + insertion-order independence + onboarding round-trip

## Architecture decisions

- Resolver is PURE — computes without mutating. Boot layer owns injection (single authority boundary).
- Manifest uses sort_keys=True JSON for stable evidence artifacts.
- Transport enum iteration sorted by .value for deterministic classification.
- ONEX_REQUIRE_OVERLAY=true overrides migration mode unconditionally.
- _has_transport_env_vars() is explicitly marked as migration-only heuristic, NOT authoritative.
- All new modules in /runtime/overlay/ are pre-approved by check-env-reads.sh gate.

## Deviations from plan

- overlay_version must be "1.0.0" (not "1.0") per SUPPORTED_OVERLAY_VERSIONS in omnibase_core
- OverlayWriter puts KAFKA_BOOTSTRAP_SERVERS/POSTGRES_PASSWORD in "custom" bucket (not in TransportConfigMap's KAFKA/DATABASE keys); tests adapted accordingly
- Test for greenfield cold-start clears all 5 _TRANSPORT_INDICATORS (not just 2) to handle dev env vars

Evidence-Source: OCC#1079
Evidence-Ticket: OMN-11108

## Test plan

- [x] 20/20 overlay integration tests pass
- [x] Unit test suite (19187 tests) passes — 4 pre-existing failures confirmed on main, zero regressions introduced
- [x] pre-commit run --all-files: all hooks pass including check-env-reads gate
- [x] Replay determinism: same inputs → same resolved_pairs_hash across calls
- [x] Insertion-order independence: reversed dict → byte-identical YAML
- [x] Resolver confirmed pure: explicit test asserts os.environ unchanged after resolve()
- [x] RequiredConfigMissingError tested and working
- [x] boot_overlay env injection verified end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added overlay configuration infrastructure for loading, resolving, and writing configuration files from YAML
  * Enhanced onboarding output model to track overlay file paths
  * Implemented configuration validation and error handling for overlay operations

* **Tests**
  * Added comprehensive integration test suite for overlay pipeline functionality, including loading, resolution, writing, and end-to-end workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## CR Round 2 — fixes appended after first review (commit 326ff3999)

- overlay_config_resolver: fail-closed on bad contract.yaml via new ContractParseError (3253697682)
- overlay_file_loader: Path.is_file() guard against directories (3253697683); sanitize parser exception text (3253697684)
- All 5 overlay test modules: pytestmark = pytest.mark.integration (3253697685/3253697690/3253697691/3253697693)
- test_missing_overlay_with_env_vars_returns_none: monkeypatch.delenv ONEX_REQUIRE_OVERLAY (3253697688)
- overlay_writer: drop secret_count log line; resolves CodeQL py/clear-text-logging-sensitive-data alert 1175

OCC evidence: https://github.com/OmniNode-ai/onex_change_control/pull/1079