### PR TITLE
fix(OMN-11131): allow non-platform topics in projection dispatch callback

### DIFF
--- a/contracts/OMN-11131.yaml
+++ b/contracts/OMN-11131.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11131"
+title: "Phase 2: Delegation Projection Activation"
+summary: >
+  Fix _derive_projection_event_type to allow non-platform topics (onex.evt.omniclaude.task-delegated.v1) through projection dispatch without raising ValueError. This unblocks HandlerProjectionDelegation from processing delegation events and writing rows to delegation_events table.
+
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "topics"
+  - "events"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "All 3 projection dispatch integration tests pass on the PR branch."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/projectors/test_handler_wiring_projection_dispatch.py -v"
+  - id: "dod-deploy"
+    description: >
+      Runtime deploy required: rebuild omninode-runtime image on 192.168.86.201 after PR #1625 merges. Rolling restart of omninode-runtime, omninode-runtime-effects, omninode-prod-runtime. Projection consumer local.omnimarket.projection_delegation.consume.1.0.0 re-joins and processes task-delegated events without ValueError. delegation_events table accumulates real rows.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-runtime python -c 'from omnibase_infra.runtime.auto_wiring.handler_wiring import _derive_projection_event_type; r=_derive_projection_event_type(\"\",\"onex.evt.omniclaude.task-delegated.v1\"); print(r)' && rpk group describe local.omnimarket.projection_delegation.consume.1.0.0"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -510,11 +510,10 @@ def _derive_projection_event_type(
         if segment in _TOPIC_TO_EVENT_TYPE:
             return _TOPIC_TO_EVENT_TYPE[segment]
 
-    raise ValueError(
-        "Unknown projection event type from "
-        f"topic={topic_candidate!r} event_type={envelope_event_type!r} — "
-        f"must resolve to one of {sorted(_TOPIC_TO_EVENT_TYPE)!r}"
-    )
+    # Handlers that don't use _event_type (e.g. HandlerProjectionDelegation) receive
+    # the raw segment as a passthrough. Only platform-registration projection handlers
+    # require the mapped form.
+    return segment_candidates[0] if segment_candidates else ""
 
 
 def _materialized_dispatch_trace_value(

--- a/tests/integration/projectors/test_handler_wiring_projection_dispatch.py
+++ b/tests/integration/projectors/test_handler_wiring_projection_dispatch.py
@@ -69,6 +69,56 @@ def test_projection_dispatch_bridge_injects_db_and_event_type() -> None:
 
 
 @pytest.mark.integration
+def test_projection_dispatch_bridge_non_platform_topic_passes_raw_event_type() -> None:
+    """Non-platform projection handlers (e.g. HandlerProjectionDelegation) must not
+    raise when the topic segment doesn't map to a known platform event type.
+
+    Before the fix: _derive_projection_event_type raised ValueError for
+    onex.evt.omniclaude.task-delegated.v1, blocking delegation events from
+    ever reaching the DB.
+    After the fix: the raw segment is passed as _event_type; handlers with
+    extra="ignore" (like HandlerProjectionDelegation) discard it safely.
+    """
+    received: list[dict] = []
+
+    class FakeDelegationHandler:
+        def handle(self, input_data: dict) -> dict:
+            received.append(dict(input_data))
+            return {"rows_upserted": 1}
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    handler = FakeDelegationHandler()
+    callback = _make_projection_dispatch_callback(
+        handler, db_tables, ("onex.evt.omniclaude.task-delegated.v1",)
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {
+        "correlation_id": "dc1e67e3-a267-4438-b16a-2514676f69b6",
+        "task_type": "code-review",
+        "delegated_to": "smoke-test-agent",
+    }
+    envelope.event_type = "omniclaude.task-delegated"
+
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://postgres:test@localhost:5436/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(received) == 1, "Handler should have been called exactly once"
+    assert received[0]["_db"] is fake_adapter, "_db must be injected"
+    assert received[0]["_event_type"] == "task-delegated", (
+        "raw segment passthrough for non-platform topics"
+    )
+    assert received[0].get("task_type") == "code-review", "payload preserved"
+
+
+@pytest.mark.integration
 def test_projection_dispatch_bridge_no_call_when_db_url_missing() -> None:
     """Projection handler is NOT called when OMNIDASH_ANALYTICS_DB_URL is unset.
 


### PR DESCRIPTION
## Summary

- `_derive_projection_event_type` raised `ValueError` for any topic not mapped in `_TOPIC_TO_EVENT_TYPE` (only `node-heartbeat`, `node-introspection`, `node-state-change`), blocking `HandlerProjectionDelegation` from ever processing `onex.evt.omniclaude.task-delegated.v1` events
- The `projection_delegation` consumer group joined successfully on every runtime boot but every consumed message resulted in `ValueError: Unknown projection event type` before `handle()` was ever called
- Fix: return raw topic segment as `_event_type` fallback instead of raising — handlers that don't need it use `extra="ignore"` and discard it; only `node_projection_registration` uses the mapped form

## Test plan

- [x] New integration test `test_projection_dispatch_bridge_non_platform_topic_passes_raw_event_type` verifies delegation topic dispatches with raw fallback `_event_type`
- [x] Existing platform topic tests (`node-heartbeat`) still pass unchanged
- [x] `uv run pytest tests/integration/projectors/test_handler_wiring_projection_dispatch.py -v` — all 3 pass
- [x] All pre-commit hooks pass
- [x] `mypy --strict` clean on changed file

Fixes OMN-11131 (Phase 2: Delegation Projection Activation)

Evidence-Source: OCC#1088
Evidence-Ticket: OMN-11131