### PR TITLE
fix(OMN-11130): provide runtime GitHub auth for merge sweep

### DIFF
--- a/contracts/OMN-11130.yaml
+++ b/contracts/OMN-11130.yaml
@@ -1,0 +1,38 @@
+# OMN-11130 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-11130
+title: "Provide GitHub CLI auth to runtime PR lifecycle sweep"
+summary: "Runtime containers install the GitHub CLI and receive GITHUB_TOKEN/GH_TOKEN so skill-based PR lifecycle inventory and merge gates can run through the Pattern-B runtime path."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Runtime env anchor and env parity checks prove GitHub token passthrough is declared and treated as secret."
+    command: "uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q"
+  - kind: manual
+    description: "Deploy proof requires runtime image rebuild, container recreation, gh auth inside runtime containers, and a pr_lifecycle_orchestrator dry-run inventory through the runtime broker."
+    command: "deploy: docker build -f docker/Dockerfile.runtime -t runtime:latest . && docker compose -f docker/docker-compose.generated.yml up -d omninode-runtime runtime-effects && docker exec omninode-runtime gh auth status && runtime broker inventory returns open PRs"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-env-tests
+    description: "Runtime env anchor, env parity, and required-env coverage tests pass with GITHUB_TOKEN/GH_TOKEN included."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py -q"
+  - id: dod-compose-config
+    description: "Docker compose config validates with the protected runtime env file loaded."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "docker compose -f docker/docker-compose.generated.yml config --quiet"
+  - id: dod-deploy-gate
+    description: "Deployable runtime change — rolling rebuild/recreate of omninode-runtime and runtime-effects is required so the final image contains gh and the containers receive GH_TOKEN."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: docker exec omninode-runtime gh auth status && runtime broker pr_lifecycle_orchestrator inventory reports open PRs"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -384,6 +384,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libpq5 \
     # Curl for health checks
     curl \
+    # GitHub CLI for runtime-owned PR lifecycle inventory and merge gates
+    gh \
     # CA certificates for HTTPS connections
     ca-certificates \
     # Tini - minimal init system for proper signal handling as PID 1

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -158,6 +158,11 @@ x-runtime-env: &runtime-env
   ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS: ${ONEX_TOPIC_PROVISIONER_MAX_PARTITIONS:-0}
   # Linear API for build loop ticket fetching
   LINEAR_API_KEY: ${LINEAR_API_KEY:?LINEAR_API_KEY must be set}
+  # GitHub API/CLI auth for runtime-owned PR lifecycle inventory and merge gates.
+  # gh reads GH_TOKEN in non-interactive containers; handlers using HTTP clients
+  # read GITHUB_TOKEN.
+  GITHUB_TOKEN: ${GITHUB_TOKEN:?GITHUB_TOKEN must be set}
+  GH_TOKEN: ${GITHUB_TOKEN:?GITHUB_TOKEN must be set}
   # --- Infisical config (OMN-5382: removed from base env — injected per-bundle) ---
   # Infisical vars are only present when the secrets bundle is selected.
   # --- Container-internal service addresses (OMN-5381: same invariant as OMN-3431 for Kafka) ---

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -116,6 +116,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: prod
+      KAFKA_ENVIRONMENT: prod
       ONEX_STATE_ROOT: /app/data/.onex_state_prod
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: prod-main
@@ -144,6 +145,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: prod
+      KAFKA_ENVIRONMENT: prod
       ONEX_STATE_ROOT: /app/data/.onex_state_prod
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: prod-effects
@@ -172,6 +174,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: prod
+      KAFKA_ENVIRONMENT: prod
       ONEX_STATE_ROOT: /app/data/.onex_state_prod
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: prod-worker

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -100,6 +100,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: stability-test
+      KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: stability-test-main
@@ -130,6 +131,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: stability-test
+      KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: stability-test-effects
@@ -160,6 +162,7 @@ services:
       OMNIMEMORY_ENABLED: ""
       OMNIMEMORY_MEMGRAPH_HOST: ""
       ONEX_ENVIRONMENT: stability-test
+      KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
       ONEX_RUNTIME_ID: stability-test-worker

--- a/tests/ci/test_env_parity.py
+++ b/tests/ci/test_env_parity.py
@@ -94,6 +94,9 @@ SECRET_KEYS: frozenset[str] = frozenset(
         "ONEX_SERVICE_CLIENT_SECRET",
         # Linear API — injected via Infisical at runtime
         "LINEAR_API_KEY",
+        # GitHub API/CLI auth — injected via Infisical at runtime
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
         # Qdrant vector store API key — credential, sourced from Infisical
         "QDRANT_API_KEY",
     }

--- a/tests/ci/test_runtime_env_anchor.py
+++ b/tests/ci/test_runtime_env_anchor.py
@@ -46,6 +46,8 @@ REQUIRED_RUNTIME_KEYS: frozenset[str] = frozenset(
         "ONEX_LOG_LEVEL",
         "ONEX_ENVIRONMENT",
         "USE_EVENT_ROUTING",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
         "VALKEY_HOST",
         "VALKEY_PORT",
     }

--- a/tests/integration/docker/test_docker_integration.py
+++ b/tests/integration/docker/test_docker_integration.py
@@ -1093,6 +1093,7 @@ class TestDockerComposeProfiles:
                 "ONEX_REGISTRATION_AUTO_ACK": "true",
                 "ONEX_SERVICE_CLIENT_SECRET": "test-service-secret",
                 "LINEAR_API_KEY": "test-linear-api-key",
+                "GITHUB_TOKEN": "test-github-token",
                 # OMN-7979: LLM endpoint URLs added with :? fail-fast to
                 # activate PluginLlm in runtime containers.
                 "LLM_CODER_URL": "http://llm-coder.test:8000",

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -107,6 +107,7 @@ COMPOSE_RENDER_ENV = {
     "INFISICAL_DB_CONNECTION_URI": "postgresql://postgres:postgres@postgres:5432/infisical",
     "INFISICAL_ENCRYPTION_KEY": "render-only-infisical-encryption-key-32",
     "INFISICAL_REDIS_URL": "redis://valkey:6379",
+    "GITHUB_TOKEN": "render-only-github-token",
     "LINEAR_API_KEY": "render-only-linear-api-key",
     "LLM_CODER_FAST_URL": _http_url("llm-coder-fast.invalid"),
     "LLM_CODER_URL": _http_url("llm-coder.invalid"),
@@ -236,6 +237,7 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
         assert environment["OMNIMEMORY_ENABLED"] == ""
         assert environment["OMNIMEMORY_MEMGRAPH_HOST"] == ""
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
+        assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
         assert "image" not in services[service_name]
         assert services[service_name]["restart"] == "unless-stopped"

--- a/tests/unit/infra/test_runtime_lane_kafka_environment.py
+++ b/tests/unit/infra/test_runtime_lane_kafka_environment.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Static checks for runtime-lane Kafka environment isolation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_SERVICES = ("omninode-runtime", "runtime-effects", "runtime-worker")
+
+
+def _construct_compose_value(
+    loader: yaml.SafeLoader,
+    node: yaml.Node,
+) -> object:
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_scalar(node)
+
+
+class _TestSafeLoader(yaml.SafeLoader):
+    """Test-local YAML loader with Docker Compose tag support."""
+
+
+_TestSafeLoader.add_constructor("!override", _construct_compose_value)
+
+
+def _load_compose_yaml(path: Path) -> dict:
+    compose = yaml.load(path.read_text(encoding="utf-8"), Loader=_TestSafeLoader)  # noqa: S506
+    assert isinstance(compose, dict)
+    return compose
+
+
+@pytest.mark.parametrize(
+    ("overlay_name", "expected_environment"),
+    [
+        ("docker-compose.prod.yml", "prod"),
+        ("docker-compose.stability-test.yml", "stability-test"),
+    ],
+)
+def test_non_local_runtime_lanes_set_kafka_environment(
+    overlay_name: str,
+    expected_environment: str,
+) -> None:
+    overlay_path = REPO_ROOT / "docker" / overlay_name
+    overlay = _load_compose_yaml(overlay_path)
+
+    for service_name in RUNTIME_SERVICES:
+        environment = overlay["services"][service_name]["environment"]
+        assert environment["ONEX_ENVIRONMENT"] == expected_environment
+        assert environment["KAFKA_ENVIRONMENT"] == expected_environment

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -129,6 +129,7 @@ def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
         assert "BUILD_SOURCE" not in environment
         assert "EXPECTED_BUILD_SOURCE" not in environment
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
+        assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
         assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
 


### PR DESCRIPTION
Evidence-Ticket: OMN-11130
Evidence-Source: a3fd6c465a0a7c9cbcdc4f82a26293043333764d

## Summary
- Install GitHub CLI in the final runtime image so Pattern-B PR lifecycle handlers can run `gh` inside runtime containers.
- Pass GitHub auth through the runtime env anchor as `GITHUB_TOKEN` and `GH_TOKEN`.
- Isolate prod/stability Kafka consumer groups by setting `KAFKA_ENVIRONMENT` in non-local runtime lanes.
- Add OMN-11130 deploy-gate contract and regression coverage for runtime env and lane isolation.

## Verification
- `uv run pytest tests/unit/infra/test_runtime_lane_kafka_environment.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q` -> 21 passed
- `uv run pytest tests/ci/test_runtime_env_anchor.py tests/ci/test_env_parity.py tests/ci/test_compose_required_env_coverage.py tests/ci/test_validate_pr_contracts.py -q` -> 19 passed, 1 skipped
- `uv run ruff check tests/unit/infra/test_runtime_lane_kafka_environment.py tests/integration/infra/test_stability_test_runtime_compose_render.py tests/unit/infra/test_stability_test_runtime_lane.py tests/ci/test_env_parity.py tests/ci/test_runtime_env_anchor.py tests/integration/docker/test_docker_integration.py` -> passed
- `uv run pytest tests/integration/docker/test_docker_integration.py::TestDockerComposeProfiles::test_compose_config_valid -q` -> skipped locally, Docker daemon unavailable
- Live .201 runtime rebuild/recreate completed for local/prod/stability runtime/effects containers; all six active runtime containers healthy.
- Live Pattern-B `pr_lifecycle_orchestrator` dry-run inventory for `omnibase_infra,omnidash` returned `prs_inventoried: 4`.

## Operational Notes
- Local cadence LaunchAgent PATH/env was repaired and reload succeeded; inventory now reaches GitHub.
- Host-side cadence dispatch still cannot reach Kafka at `localhost:19092` from this Mac session, but direct runtime broker dispatch is working and inventories open PRs.