### PR TITLE
fix(OMN-11072): add guard test for omnibase_compat pin including delegation wire contracts

### DIFF
--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -50,8 +50,6 @@ from pathlib import Path
 # fmt: off
 _LEGACY_ALLOWLIST: dict[str, str] = {
     # --- runtime/service emitted topics pending service contract ownership split (OMN-9877) ---
-    "onex.evt.omnibase-infra.runtime-health-check.v1": "service_runtime_health_monitor emits before service contracts are represented as node contract.yaml surfaces | owner: jonah | expiry: 2026-06-15",
-    "onex.evt.platform.registration-completed.v1": "registration completion is still emitted by service/runtime registration path pending contract ownership split | owner: jonah | expiry: 2026-06-15",
     # --- omniclaude skill cmd topics (migrating via topics.yaml, OMN-4592/OMN-4594) ---
     "onex.cmd.omniclaude.action-logging.v1": "pre-migration skill topic; topics.yaml covers this once OMN-4594 wired | owner: jonah | expiry: 2026-06-01",
     "onex.cmd.omniclaude.agent-observability.v1": "pre-migration skill topic; topics.yaml covers this once OMN-4594 wired | owner: jonah | expiry: 2026-06-01",

--- a/tests/unit/docker/test_runtime_dependency_pins.py
+++ b/tests/unit/docker/test_runtime_dependency_pins.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime image dependency pin tests."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_omnibase_compat_pin_includes_delegation_wire_contracts(
+    dockerfile_path: Path,
+) -> None:
+    """Guard the runtime image against an omnimarket delegation import crash."""
+    dockerfile = dockerfile_path.read_text(encoding="utf-8")
+
+    match = re.search(
+        r'ARG OMNIBASE_COMPAT_SOURCE="https://github\.com/OmniNode-ai/'
+        r'omnibase_compat/archive/(?P<sha>[0-9a-f]{40})\.tar\.gz"',
+        dockerfile,
+    )
+
+    assert match is not None, (
+        "OMNIBASE_COMPAT_SOURCE ARG not found in Dockerfile.runtime"
+    )
+    sha = match.group("sha")
+    # Commits that contain src/omnibase_compat/contracts/delegation/wire/:
+    # 3e34ab9 feat(OMN-11024): add delegation wire DTOs
+    # c1a878f chore: release v0.4.0 (includes delegation wire, current pin)
+    delegation_commits = {
+        "3e34ab94fad0a9db1c3b59f0e100c5da659b0792",
+        "c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1",
+    }
+    assert sha in delegation_commits, (
+        f"OMNIBASE_COMPAT_SOURCE pin {sha!r} predates the delegation wire contracts. "
+        "Update the pin to a commit that includes src/omnibase_compat/contracts/delegation/wire/."
+    )


### PR DESCRIPTION
## Summary

OMN-11072 — The stability runtime was failing to boot with `ModuleNotFoundError: No module named 'omnibase_compat.contracts.delegation'` because the runtime image `OMNIBASE_COMPAT_SOURCE` was pinned to `ba32d12` which predates the delegation wire contracts added in OMN-11024.

The Dockerfile pin was already corrected to `c1a878f` (omnibase_compat v0.4.0, which includes `src/omnibase_compat/contracts/delegation/wire/`) in PR #1607. This PR adds the missing CI guard to prevent regression.

**Changes:**
- `tests/unit/docker/test_runtime_dependency_pins.py`: Unit test that parses `Dockerfile.runtime` and asserts `OMNIBASE_COMPAT_SOURCE` points to a commit that includes the delegation wire contracts. Fails immediately if the pin is rolled back to a pre-delegation SHA.
- `scripts/check_contract_topic_parity.py`: Fix two pre-existing F601 ruff violations (duplicate dictionary literal keys `onex.evt.omnibase-infra.runtime-health-check.v1` and `onex.evt.platform.registration-completed.v1`), keeping the more complete/longer-lived entries.

## Test plan

- [x] `uv run pytest tests/unit/docker/test_runtime_dependency_pins.py -v` — passes with current `c1a878f` pin
- [x] All 73 docker unit tests pass
- [x] `pre-commit run --all-files` — all hooks pass

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11072
