### PR TITLE
fix(OMN-11066): mark pattern-b-dispatch topic as plugin_managed to prevent DLQ routing

### DIFF
--- a/src/omnibase_infra/nodes/node_runtime_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_runtime_orchestrator/contract.yaml
@@ -69,6 +69,7 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
+  plugin_managed: true
   subscribe_topics:
     - "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
   publish_topics:

--- a/tests/unit/runtime/test_node_subscription_wiring.py
+++ b/tests/unit/runtime/test_node_subscription_wiring.py
@@ -467,6 +467,145 @@ class TestPluginManagedSkipsRuntimeHostSubscription:
         assert "node_normal_worker" in wired_names
 
 
+class TestPatternBDispatchTopicNotConsumedByGenericDispatcher:
+    """OMN-11066: Pattern B dispatch topic must not be consumed by the generic dispatcher.
+
+    The node_runtime_orchestrator contract declares
+    ``onex.cmd.omnibase-infra.pattern-b-dispatch.v1`` as a subscribe_topic
+    owned by RuntimePatternBBroker (plugin_managed).  If plugin_managed is
+    absent or False, _wire_package_node_subscriptions routes the topic through
+    the generic dispatch engine, which has no dispatcher registered for it and
+    DLQs every message.
+    """
+
+    def test_node_runtime_orchestrator_contract_has_plugin_managed(self) -> None:
+        """node_runtime_orchestrator/contract.yaml must declare plugin_managed: true."""
+        import yaml
+
+        import omnibase_infra as _pkg
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+        )
+
+        package_root = Path(_pkg.__file__).parent
+        contracts = _discover_package_node_contracts(package_root)
+
+        orchestrator = next(
+            (c for c in contracts if c.get("name") == "node_runtime_orchestrator"),
+            None,
+        )
+        assert orchestrator is not None, (
+            "node_runtime_orchestrator contract not found in package"
+        )
+        event_bus = orchestrator.get("event_bus")
+        assert isinstance(event_bus, dict), (
+            "node_runtime_orchestrator must have an event_bus section"
+        )
+        assert event_bus.get("plugin_managed") is True, (
+            "node_runtime_orchestrator event_bus must set plugin_managed: true "
+            "so RuntimePatternBBroker is the sole consumer of "
+            "onex.cmd.omnibase-infra.pattern-b-dispatch.v1 (OMN-11066)"
+        )
+        assert "onex.cmd.omnibase-infra.pattern-b-dispatch.v1" in (
+            event_bus.get("subscribe_topics") or []
+        ), "pattern-b-dispatch topic must remain declared in subscribe_topics"
+
+    @pytest.mark.asyncio
+    async def test_pattern_b_dispatch_topic_skipped_when_plugin_managed(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """When plugin_managed=true, generic dispatcher does not subscribe to Pattern B topic.
+
+        Reproduces the no-dispatcher DLQ path from OMN-11066: without
+        plugin_managed the generic runtime route subscribes to
+        onex.cmd.omnibase-infra.pattern-b-dispatch.v1, finds no dispatcher,
+        and routes to DLQ.  With plugin_managed=true the contract is skipped.
+        """
+        node = tmp_path / "nodes" / "node_runtime_orchestrator" / "contract.yaml"
+        node.parent.mkdir(parents=True)
+        node.write_text(
+            textwrap.dedent("""\
+            name: "node_runtime_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              plugin_managed: true
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+              publish_topics:
+                - "onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1"
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        (
+            wired,
+            _skipped_existing,
+            skipped_no_topics,
+        ) = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 0, "Pattern B dispatch topic must not be wired via generic path"
+        assert skipped_no_topics == 1
+        mock_event_bus_wiring.wire_subscriptions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pattern_b_dispatch_topic_consumed_by_generic_without_plugin_managed(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """Without plugin_managed, generic dispatcher would subscribe — reproduces DLQ root cause."""
+        node = tmp_path / "nodes" / "node_runtime_orchestrator" / "contract.yaml"
+        node.parent.mkdir(parents=True)
+        node.write_text(
+            textwrap.dedent("""\
+            name: "node_runtime_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+              publish_topics:
+                - "onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1"
+            """)
+        )
+
+        from omnibase_infra.runtime.service_runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        (
+            wired,
+            _skipped_existing,
+            _skipped_no_topics,
+        ) = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+        )
+
+        assert wired == 1, (
+            "Without plugin_managed, generic path subscribes — "
+            "this is the pre-fix DLQ root cause"
+        )
+        mock_event_bus_wiring.wire_subscriptions.assert_called_once()
+
+
 class TestDiscoverPackageNodeContracts:
     """Tests for _discover_package_node_contracts."""
 


### PR DESCRIPTION
## Summary

Fixes OMN-11066: Pattern B dispatch commands on `.201` were being consumed by the generic runtime dispatcher instead of `RuntimePatternBBroker`, resulting in every command being routed to DLQ (`onex.dlq.onex.v1`).

**Root cause:** `node_runtime_orchestrator/contract.yaml` declared `onex.cmd.omnibase-infra.pattern-b-dispatch.v1` as a `subscribe_topic` without `plugin_managed: true`. At startup, `_wire_package_node_subscriptions` and `_wire_event_bus_subscriptions` both scanned this contract and subscribed to the topic via the generic dispatch engine. The dispatch engine had no dispatcher registered for `command` category + `omnibase-infra.pattern-b-dispatch` message type, so it emitted: _"No dispatcher found for category 'command' and message type 'onex.cmd.omnibase-infra.pattern-b-dispatch.v1'; routing to DLQ topic 'onex.dlq.onex.v1'"_.

**Fix:** Add `plugin_managed: true` to the `event_bus` section of `node_runtime_orchestrator/contract.yaml`. This is the established OMN-10864 mechanism — it tells both `_wire_package_node_subscriptions` (line 675) and `_wire_event_bus_subscriptions` (line 5688) to skip this contract's subscription, leaving `RuntimePatternBBroker` as the sole consumer of the Pattern B dispatch topic.

`RuntimePatternBBroker` subscribes to the same topic independently via its `start()` method, which is correct — `plugin_managed` simply prevents the generic path from also consuming it.

## Files changed

- `src/omnibase_infra/nodes/node_runtime_orchestrator/contract.yaml` — add `plugin_managed: true`
- `tests/unit/runtime/test_node_subscription_wiring.py` — add `TestPatternBDispatchTopicNotConsumedByGenericDispatcher` with 3 tests

## Tests

Three new tests in `TestPatternBDispatchTopicNotConsumedByGenericDispatcher`:
1. `test_node_runtime_orchestrator_contract_has_plugin_managed` — asserts the live contract has `plugin_managed: true`
2. `test_pattern_b_dispatch_topic_skipped_when_plugin_managed` — verifies generic path skips it with plugin_managed
3. `test_pattern_b_dispatch_topic_consumed_by_generic_without_plugin_managed` — proves the pre-fix DLQ root cause (generic path subscribes without plugin_managed)

All 50 unit tests in the runtime test suite pass. Pre-commit clean.

## Ticket

OMN-11066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `plugin_managed` configuration option to event bus settings, controlling dispatch topic consumption behavior.

* **Tests**
  * Added test coverage validating the plugin-managed configuration and its effect on topic dispatch handling based on configuration state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11066
