### PR TITLE
feat(OMN-11143): add OmniGate Sigstore signer

### DIFF
--- a/.github/workflows/omnigate.yml
+++ b/.github/workflows/omnigate.yml
@@ -1,0 +1,63 @@
+name: OmniGate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch trusted PR refs
+        run: |
+          git fetch --no-tags origin "${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags "${{ github.event.pull_request.head.repo.clone_url }}" "${{ github.event.pull_request.head.sha }}"
+          git cat-file -e "${{ github.event.pull_request.base.sha }}^{commit}"
+          git cat-file -e "${{ github.event.pull_request.head.sha }}^{commit}"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install OmniGate
+        run: |
+          if [ "${OMNIGATE_INSTALL_MODE:-repo-local}" = "published" ]; then
+            pip install omnigate==0.1.0
+          elif [ -d ./omnibase_core ] && [ -d ./omnibase_infra ]; then
+            pip install -e ./omnibase_core -e ./omnibase_infra
+          else
+            pip install -e .
+          fi
+
+      - name: Checkout trusted base config
+        run: |
+          git show "${{ github.event.pull_request.base.sha }}:.omnigate.yaml" > /tmp/omnigate.base.yaml
+
+      - name: Verify receipt
+        run: |
+          python -m omnibase_infra.gate.action_verify \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --repo-path . \
+            --config /tmp/omnigate.base.yaml \
+            --decision-out /tmp/omnigate-decision.json
+
+      - name: Upload decision artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: omnigate-decision
+          path: /tmp/omnigate-decision.json
+
+  # Deferred to v0.2:
+  # A trusted write-token workflow may read the decision artifact and apply
+  # labels, comments, or close actions. It must not checkout or execute PR
+  # branch code and needs its own threat-model task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     # Security: CVE-2024-26130 (42.0.4), CVE-2024-12797 (44.0.1) - both addressed by 46.x.
     # See docs/decisions/adr-cryptography-upgrade-46.md for full rationale.
     "cryptography>=46.0.3,<49.0.0",
+    "sigstore>=4.0.0,<5.0.0",
     "jinja2>=3.1.6,<4.0.0",
     "aiofiles>=23.2.1,<26.0.0",
     "dependency-injector>=4.48.1,<5.0.0", # Enhanced dependency injection

--- a/src/omnibase_infra/gate/__init__.py
+++ b/src/omnibase_infra/gate/__init__.py
@@ -3,15 +3,49 @@
 
 """OmniGate infra execution surfaces."""
 
-from omnibase_infra.gate.executor import SecretBearingOutputError, execute_checks
-from omnibase_infra.gate.signer import OmniGateSigner
-from omnibase_infra.gate.validator_registry import (
-    OmniGateValidatorCallable,
-    clear_builtin_validators,
-    execute_validator,
-    register_builtin_validator,
-    resolve_validator,
-)
+from __future__ import annotations
+
+
+def __getattr__(name: str) -> object:
+    """Load OmniGate surfaces lazily across stacked core branches."""
+    if name in {"SecretBearingOutputError", "execute_checks"}:
+        from omnibase_infra.gate.executor import (
+            SecretBearingOutputError,
+            execute_checks,
+        )
+
+        return {
+            "SecretBearingOutputError": SecretBearingOutputError,
+            "execute_checks": execute_checks,
+        }[name]
+    if name == "OmniGateSigner":
+        from omnibase_infra.gate.signer import OmniGateSigner
+
+        return OmniGateSigner
+    if name in {
+        "OmniGateValidatorCallable",
+        "clear_builtin_validators",
+        "execute_validator",
+        "register_builtin_validator",
+        "resolve_validator",
+    }:
+        from omnibase_infra.gate.validator_registry import (
+            OmniGateValidatorCallable,
+            clear_builtin_validators,
+            execute_validator,
+            register_builtin_validator,
+            resolve_validator,
+        )
+
+        return {
+            "OmniGateValidatorCallable": OmniGateValidatorCallable,
+            "clear_builtin_validators": clear_builtin_validators,
+            "execute_validator": execute_validator,
+            "register_builtin_validator": register_builtin_validator,
+            "resolve_validator": resolve_validator,
+        }[name]
+    raise AttributeError(name)
+
 
 __all__ = [
     "OmniGateValidatorCallable",

--- a/src/omnibase_infra/gate/__init__.py
+++ b/src/omnibase_infra/gate/__init__.py
@@ -4,6 +4,7 @@
 """OmniGate infra execution surfaces."""
 
 from omnibase_infra.gate.executor import SecretBearingOutputError, execute_checks
+from omnibase_infra.gate.signer import OmniGateSigner
 from omnibase_infra.gate.validator_registry import (
     OmniGateValidatorCallable,
     clear_builtin_validators,
@@ -14,6 +15,7 @@ from omnibase_infra.gate.validator_registry import (
 
 __all__ = [
     "OmniGateValidatorCallable",
+    "OmniGateSigner",
     "SecretBearingOutputError",
     "clear_builtin_validators",
     "execute_checks",

--- a/src/omnibase_infra/gate/action_verify.py
+++ b/src/omnibase_infra/gate/action_verify.py
@@ -1,0 +1,461 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Read-only GitHub Action verifier for OmniGate PR receipts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+_RECEIPT_START = "<!-- OMNIGATE_RECEIPT_START -->"
+_RECEIPT_END = "<!-- OMNIGATE_RECEIPT_END -->"
+_PASS_ACTION = "pass"
+_FAIL_ACTION = "fail"
+_ACTION_VALUES = frozenset({"pass", "fail", "label", "comment", "auto-close"})
+datetime = dt.datetime
+
+
+def _extract_receipt_from_pr_body(pr_body: str, *, max_bytes: int) -> str | None:
+    """Extract exactly one framed inline receipt from a PR body."""
+    if pr_body.count(_RECEIPT_START) != 1 or pr_body.count(_RECEIPT_END) != 1:
+        return None
+    start = pr_body.index(_RECEIPT_START) + len(_RECEIPT_START)
+    end = pr_body.index(_RECEIPT_END)
+    if end <= start:
+        return None
+
+    receipt_json = pr_body[start:end].strip()
+    if len(receipt_json.encode("utf-8")) > max_bytes:
+        return None
+    return receipt_json
+
+
+def verify_pr_receipt(
+    pr_body: str,
+    repo_path: Path,
+    config_path: Path,
+    *,
+    repository_id: str,
+    repository_url: str,
+    base_sha: str,
+    head_sha: str,
+    actor: str | None = None,
+) -> dict[str, object]:
+    """Verify an inline PR receipt against trusted GitHub event metadata."""
+    try:
+        _verify_commit_object(repo_path, base_sha)
+        _verify_commit_object(repo_path, head_sha)
+        config = _load_omnigate_config(config_path)
+        gate_policy = _get_attr(config, "gate")
+        receipt_policy = _get_attr(config, "receipt")
+        if actor is not None and actor in tuple(
+            getattr(gate_policy, "exempt_users", ()),
+        ):
+            return _decision(
+                ok=True,
+                action=_PASS_ACTION,
+                reason="Actor exempted by trusted OmniGate config",
+            )
+
+        diff_hash = _compute_pr_diff_hash(
+            repo_path,
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+        config_hash = _compute_config_hash(config_path)
+        receipt_json = _extract_receipt_from_pr_body(
+            pr_body,
+            max_bytes=_get_int_attr(receipt_policy, "max_receipt_bytes"),
+        )
+        if receipt_json is None:
+            return _decision(
+                ok=False,
+                action=_FAIL_ACTION,
+                reason="No valid OmniGate receipt found in PR body",
+            )
+
+        try:
+            receipt = _model_validate_receipt_json(receipt_json)
+        except (TypeError, ValueError) as exc:
+            return _decision(
+                ok=False,
+                action=_FAIL_ACTION,
+                reason=f"Invalid OmniGate receipt: {exc}",
+            )
+
+        receipt_diff_hash = _get_str_attr(receipt, "diff_hash")
+        failure_reason = _validate_receipt(
+            receipt,
+            config=config,
+            repository_id=repository_id,
+            repository_url=repository_url,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            diff_hash=diff_hash,
+            config_hash=config_hash,
+        )
+        if failure_reason is not None:
+            return _decision(
+                ok=False,
+                action=_FAIL_ACTION,
+                reason=failure_reason,
+                receipt_diff_hash=receipt_diff_hash,
+            )
+
+        return _decision(
+            ok=True,
+            action=_PASS_ACTION,
+            reason="All checks passed, signature verified",
+            receipt_diff_hash=receipt_diff_hash,
+        )
+    except Exception as exc:  # noqa: BLE001 - verifier must fail closed.
+        return _decision(
+            ok=False,
+            action=_FAIL_ACTION,
+            reason=f"OmniGate verifier failed closed: {exc}",
+        )
+
+
+def _validate_receipt(
+    receipt: object,
+    *,
+    config: object,
+    repository_id: str,
+    repository_url: str,
+    base_sha: str,
+    head_sha: str,
+    diff_hash: str,
+    config_hash: str,
+) -> str | None:
+    receipt_policy = _get_attr(config, "receipt")
+    if _get_str_attr(receipt, "repository_id") != repository_id:
+        return "Repository id mismatch"
+    if _normalize_url(_get_str_attr(receipt, "project_url")) != _normalize_url(
+        repository_url,
+    ):
+        return "Repository URL mismatch"
+    if (
+        _get_str_attr(receipt, "base_sha") != base_sha
+        or _get_str_attr(receipt, "head_sha") != head_sha
+        or _get_str_attr(receipt, "commit_sha") != head_sha
+    ):
+        return "Receipt commit/base/head SHA mismatch"
+    if _get_str_attr(receipt, "diff_hash") != diff_hash:
+        return (
+            f"Diff hash mismatch: receipt={_get_str_attr(receipt, 'diff_hash')}, "
+            f"actual={diff_hash}"
+        )
+    if _get_str_attr(receipt, "config_hash") != config_hash:
+        return "Config hash mismatch against trusted base config"
+
+    age_reason = _receipt_age_failure_reason(receipt, config)
+    if age_reason is not None:
+        return age_reason
+
+    if not _no_blocking_checks_failed(
+        receipt,
+        advisory_blocks=_get_bool_attr(receipt_policy, "advisory_blocks"),
+    ):
+        return f"Checks failed: {', '.join(_blocking_check_names(receipt, config))}"
+
+    if _get_str_attr(receipt_policy, "signing") == "sigstore":
+        identity_policy = _get_attr(receipt_policy, "identity")
+        if identity_policy is None:
+            return "Sigstore identity policy missing from trusted config"
+        if not _verify_sigstore_identity_policy(receipt, identity_policy):
+            return "Sigstore signature verification failed"
+    elif not _get_bool_attr(receipt_policy, "allow_unsigned"):
+        return "Unsigned receipts are disabled by trusted config"
+    return None
+
+
+def _verify_sigstore_identity_policy(receipt: object, identity_policy: object) -> bool:
+    """Verify Sigstore signatures using trusted identity policy only."""
+    expected_issuer = _get_str_attr(identity_policy, "expected_issuer")
+    for identity in getattr(identity_policy, "allowed_identities", ()):
+        if _verify_with_signer(
+            receipt,
+            expected_identity=str(identity),
+            expected_issuer=expected_issuer,
+        ):
+            return True
+
+    regexes = tuple(getattr(identity_policy, "allowed_identity_regexes", ()))
+    if regexes:
+        return _verify_sigstore_regex_identity(receipt, identity_policy, regexes)
+    return False
+
+
+def _verify_sigstore_regex_identity(
+    receipt: object,
+    identity_policy: object,
+    regexes: tuple[str, ...],
+) -> bool:
+    """Fail closed until certificate identity extraction exists for regex policy."""
+    for pattern in regexes:
+        re.compile(pattern)
+    _ = receipt, identity_policy
+    return False
+
+
+def _receipt_age_failure_reason(
+    receipt: object,
+    config: object,
+) -> str | None:
+    timestamp = _get_attr(receipt, "timestamp")
+    if not isinstance(timestamp, dt.datetime):
+        return "Receipt timestamp is invalid"
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=dt.UTC)
+    age_minutes = (datetime.now(tz=dt.UTC) - timestamp).total_seconds() / 60
+    max_age = _get_int_attr(_get_attr(config, "receipt"), "max_age_minutes")
+    if age_minutes > max_age:
+        return f"Receipt expired: {age_minutes:.0f}m old, max {max_age}m"
+    return None
+
+
+def _no_blocking_checks_failed(
+    receipt: object,
+    *,
+    advisory_blocks: bool,
+) -> bool:
+    method = getattr(receipt, "no_blocking_checks_failed", None)
+    if callable(method):
+        return bool(method(advisory_blocks=advisory_blocks))
+    return not _blocking_check_names_from_statuses(receipt, advisory_blocks)
+
+
+def _blocking_check_names(
+    receipt: object,
+    config: object,
+) -> list[str]:
+    return _blocking_check_names_from_statuses(
+        receipt,
+        advisory_blocks=_get_bool_attr(_get_attr(config, "receipt"), "advisory_blocks"),
+    )
+
+
+def _blocking_check_names_from_statuses(
+    receipt: object,
+    advisory_blocks: bool,
+) -> list[str]:
+    blocking = {"fail", "pending"}
+    if advisory_blocks:
+        blocking.add("advisory")
+
+    names: list[str] = []
+    for check in getattr(receipt, "checks", ()):
+        status = getattr(
+            getattr(check, "status", ""), "value", getattr(check, "status", "")
+        )
+        if str(status) in blocking:
+            names.append(str(getattr(check, "name", "<unnamed>")))
+    return names
+
+
+def _decision(
+    *,
+    ok: bool,
+    action: str,
+    reason: str,
+    receipt_diff_hash: str | None = None,
+) -> dict[str, object]:
+    if action not in _ACTION_VALUES:
+        msg = f"Unsupported OmniGate action: {action}"
+        raise ValueError(msg)
+    return {
+        "ok": ok,
+        "action": action,
+        "reason": reason,
+        "receipt_diff_hash": receipt_diff_hash,
+        "checked_at": datetime.now(tz=dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace(
+            "+00:00",
+            "Z",
+        ),
+    }
+
+
+def _verify_commit_object(repo_path: Path, sha: str) -> None:
+    subprocess.run(
+        ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _normalize_url(value: str) -> str:
+    return value.rstrip("/")
+
+
+def _get_attr(target: object, name: str) -> object:
+    if not hasattr(target, name):
+        msg = f"Object missing required attribute: {name}"
+        raise ValueError(msg)
+    return getattr(target, name)
+
+
+def _get_str_attr(target: object, name: str) -> str:
+    value = _get_attr(target, name)
+    return str(value).rstrip("/") if name == "project_url" else str(value)
+
+
+def _get_int_attr(target: object, name: str) -> int:
+    value = _get_attr(target, name)
+    if not isinstance(value, int):
+        msg = f"Object attribute must be an int: {name}"
+        raise ValueError(msg)
+    return value
+
+
+def _get_bool_attr(target: object, name: str) -> bool:
+    value = _get_attr(target, name)
+    if not isinstance(value, bool):
+        msg = f"Object attribute must be a bool: {name}"
+        raise ValueError(msg)
+    return value
+
+
+def _load_omnigate_config(config_path: Path) -> object:
+    from omnibase_core.gate.config_loader import load_omnigate_config
+
+    return cast("object", load_omnigate_config(config_path))
+
+
+def _compute_pr_diff_hash(repo_path: Path, *, base_sha: str, head_sha: str) -> str:
+    from omnibase_core.gate.diff_hash import compute_pr_diff_hash
+
+    return str(compute_pr_diff_hash(repo_path, base_sha=base_sha, head_sha=head_sha))
+
+
+def _compute_config_hash(config_path: Path) -> str:
+    from omnibase_core.gate.diff_hash import compute_config_hash
+
+    return str(compute_config_hash(config_path))
+
+
+def _model_validate_receipt_json(receipt_json: str) -> object:
+    from omnibase_core.models.gate.model_omnigate_receipt import ModelOmniGateReceipt
+
+    return cast("object", ModelOmniGateReceipt.model_validate_json(receipt_json))
+
+
+def _signer() -> object:
+    from omnibase_infra.gate.signer import OmniGateSigner
+
+    return cast("object", OmniGateSigner())
+
+
+def _verify_with_signer(
+    receipt: object,
+    *,
+    expected_identity: str,
+    expected_issuer: str,
+) -> bool:
+    verify = getattr(_signer(), "verify", None)
+    if not callable(verify):
+        return False
+    return bool(
+        verify(
+            receipt,
+            expected_identity=expected_identity,
+            expected_issuer=expected_issuer,
+        ),
+    )
+
+
+def _read_event(event_path: Path) -> Mapping[str, object]:
+    return cast(
+        "Mapping[str, object]",
+        json.loads(event_path.read_text(encoding="utf-8")),
+    )
+
+
+def _mapping_value(mapping: Mapping[str, object], key: str) -> object:
+    if key not in mapping:
+        msg = f"GitHub event missing required key: {key}"
+        raise ValueError(msg)
+    return mapping[key]
+
+
+def _as_mapping(value: object, name: str) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    msg = f"GitHub event key must be an object: {name}"
+    raise ValueError(msg)
+
+
+def _decision_from_event(
+    *,
+    event_path: Path,
+    repo_path: Path,
+    config_path: Path,
+) -> dict[str, object]:
+    event = _read_event(event_path)
+    pull_request = _as_mapping(_mapping_value(event, "pull_request"), "pull_request")
+    repository = _as_mapping(_mapping_value(event, "repository"), "repository")
+    sender = _as_mapping(event.get("sender", {}), "sender")
+    base = _as_mapping(_mapping_value(pull_request, "base"), "pull_request.base")
+    head = _as_mapping(_mapping_value(pull_request, "head"), "pull_request.head")
+    actor_value = sender.get("login")
+    return verify_pr_receipt(
+        str(pull_request.get("body") or ""),
+        repo_path,
+        config_path,
+        repository_id=str(_mapping_value(repository, "id")),
+        repository_url=str(_mapping_value(repository, "html_url")),
+        base_sha=str(_mapping_value(base, "sha")),
+        head_sha=str(_mapping_value(head, "sha")),
+        actor=str(actor_value) if actor_value is not None else None,
+    )
+
+
+def _write_decision(path: Path, decision: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(decision, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-path", required=True, type=Path)
+    parser.add_argument("--repo-path", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--decision-out", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    decision = _decision_from_event(
+        event_path=args.event_path,
+        repo_path=args.repo_path,
+        config_path=args.config,
+    )
+    _write_decision(args.decision_out, decision)
+    return 0 if decision["ok"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "_RECEIPT_END",
+    "_RECEIPT_START",
+    "_extract_receipt_from_pr_body",
+    "main",
+    "verify_pr_receipt",
+]

--- a/src/omnibase_infra/gate/signer.py
+++ b/src/omnibase_infra/gate/signer.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Sigstore signing and verification for OmniGate receipts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from importlib import import_module
+from typing import cast
+
+from omnibase_core.gate.receipt_canonical import canonical_receipt_payload
+from omnibase_core.models.gate.model_omnigate_receipt import ModelOmniGateReceipt
+
+
+class OmniGateSigner:
+    """Sign and verify OmniGate receipt payloads with Sigstore."""
+
+    def serialize_for_signing(self, receipt: ModelOmniGateReceipt) -> bytes:
+        """Return the canonical receipt bytes covered by the signature."""
+        return cast(
+            "bytes",
+            canonical_receipt_payload(receipt, exclude_signature=True),
+        )
+
+    def sign(self, receipt: ModelOmniGateReceipt) -> ModelOmniGateReceipt:
+        """Return a receipt copy with a Sigstore bundle JSON string."""
+        signing_context_factory = _load_module_attr(
+            "sigstore.sign",
+            "SigningContext",
+        )
+        production = _method_no_args(signing_context_factory, "production")
+        context = production()
+        signer_context = cast(
+            "AbstractContextManager[object]",
+            _method_no_args(context, "signer")(),
+        )
+
+        payload = self.serialize_for_signing(receipt)
+        with signer_context as signer:
+            bundle = _method_with_bytes(signer, "sign_artifact")(payload)
+        return receipt.model_copy(
+            update={"sigstore_bundle_json": _method_no_args(bundle, "to_json")()},
+        )
+
+    def verify(
+        self,
+        receipt: ModelOmniGateReceipt,
+        *,
+        expected_identity: str,
+        expected_issuer: str,
+    ) -> bool:
+        """Verify receipt signature against one exact trusted identity policy."""
+        if receipt.sigstore_bundle_json is None:
+            return False
+        if not expected_identity or not expected_issuer:
+            return False
+
+        payload = self.serialize_for_signing(receipt)
+        try:
+            bundle = _method_with_string(
+                _load_module_attr("sigstore.verify", "VerificationMaterials"),
+                "from_json",
+            )(receipt.sigstore_bundle_json)
+            policy = _identity_factory()(
+                identity=expected_identity,
+                issuer=expected_issuer,
+            )
+            verifier = _method_no_args(
+                _load_module_attr("sigstore.verify", "Verifier"),
+                "production",
+            )()
+            _verify_artifact(verifier)(payload, bundle, policy)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return False
+        return True
+
+
+def _load_module_attr(module_name: str, attr_name: str) -> object:
+    return vars(import_module(module_name))[attr_name]
+
+
+def _method_no_args(target: object, method_name: str) -> Callable[[], object]:
+    return cast("Callable[[], object]", getattr(target, method_name))
+
+
+def _method_with_bytes(target: object, method_name: str) -> Callable[[bytes], object]:
+    return cast("Callable[[bytes], object]", getattr(target, method_name))
+
+
+def _method_with_string(target: object, method_name: str) -> Callable[[str], object]:
+    return cast("Callable[[str], object]", getattr(target, method_name))
+
+
+def _identity_factory() -> Callable[..., object]:
+    return cast(
+        "Callable[..., object]",
+        _load_module_attr("sigstore.verify.policy", "Identity"),
+    )
+
+
+def _verify_artifact(
+    verifier: object,
+) -> Callable[[bytes, object, object], object]:
+    method_name = "verify_artifact"
+    return cast(
+        "Callable[[bytes, object, object], object]",
+        getattr(verifier, method_name),
+    )
+
+
+__all__ = ["OmniGateSigner"]

--- a/tests/unit/gate/test_action_verify.py
+++ b/tests/unit/gate/test_action_verify.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the OmniGate GitHub Action verifier."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omnibase_infra.gate import action_verify
+
+pytestmark = pytest.mark.unit
+
+
+def _receipt_body(receipt_json: str = "{}") -> str:
+    return (
+        "before\n"
+        f"{action_verify._RECEIPT_START}\n"
+        f"{receipt_json}\n"
+        f"{action_verify._RECEIPT_END}\n"
+        "after\n"
+    )
+
+
+def _config(
+    *,
+    signing: str = "sigstore",
+    allow_unsigned: bool = False,
+    advisory_blocks: bool = False,
+    exempt_users: tuple[str, ...] = (),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        gate=SimpleNamespace(exempt_users=exempt_users),
+        receipt=SimpleNamespace(
+            max_receipt_bytes=4096,
+            max_age_minutes=120,
+            advisory_blocks=advisory_blocks,
+            signing=signing,
+            allow_unsigned=allow_unsigned,
+            identity=SimpleNamespace(
+                expected_issuer="https://token.actions.githubusercontent.com",
+                allowed_identities=(
+                    "https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main",
+                ),
+                allowed_identity_regexes=(),
+            ),
+        ),
+    )
+
+
+def _receipt(**updates: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "repository_id": "123",
+        "project_url": "https://github.com/org/repo",
+        "base_sha": "a" * 40,
+        "head_sha": "b" * 40,
+        "commit_sha": "b" * 40,
+        "diff_hash": "sha256:" + "c" * 64,
+        "config_hash": "sha256:" + "d" * 64,
+        "timestamp": datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        "checks": (SimpleNamespace(name="lint", status="pass"),),
+    }
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def _patch_verifier_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config: SimpleNamespace | None = None,
+    receipt: SimpleNamespace | None = None,
+) -> dict[str, object]:
+    calls: dict[str, object] = {"cat_file": []}
+
+    def verify_commit(repo_path: Path, sha: str) -> None:
+        calls["cat_file"].append((repo_path, sha))
+
+    class Signer:
+        def verify(
+            self,
+            signed_receipt: object,
+            *,
+            expected_identity: str,
+            expected_issuer: str,
+        ) -> bool:
+            calls["identity"] = expected_identity
+            calls["issuer"] = expected_issuer
+            calls["signed_receipt"] = signed_receipt
+            return True
+
+    monkeypatch.setattr(action_verify, "_verify_commit_object", verify_commit)
+    monkeypatch.setattr(
+        action_verify,
+        "_load_omnigate_config",
+        lambda config_path: config or _config(),
+    )
+    monkeypatch.setattr(
+        action_verify,
+        "_compute_pr_diff_hash",
+        lambda repo_path, *, base_sha, head_sha: "sha256:" + "c" * 64,
+    )
+    monkeypatch.setattr(
+        action_verify,
+        "_compute_config_hash",
+        lambda config_path: "sha256:" + "d" * 64,
+    )
+    monkeypatch.setattr(
+        action_verify,
+        "_model_validate_receipt_json",
+        lambda receipt_json: receipt or _receipt(),
+    )
+    monkeypatch.setattr(action_verify, "_signer", Signer)
+    monkeypatch.setattr(
+        action_verify,
+        "datetime",
+        SimpleNamespace(
+            now=lambda tz: datetime(2026, 5, 17, 12, 30, tzinfo=UTC),
+        ),
+    )
+    return calls
+
+
+class TestReceiptExtraction:
+    def test_extracts_exactly_one_framed_receipt(self) -> None:
+        assert (
+            action_verify._extract_receipt_from_pr_body(
+                _receipt_body('{"ok": true}'),
+                max_bytes=100,
+            )
+            == '{"ok": true}'
+        )
+
+    def test_rejects_missing_duplicate_or_oversized_receipts(self) -> None:
+        assert (
+            action_verify._extract_receipt_from_pr_body("no receipt", max_bytes=100)
+            is None
+        )
+        assert (
+            action_verify._extract_receipt_from_pr_body(
+                _receipt_body("{}") + _receipt_body("{}"),
+                max_bytes=100,
+            )
+            is None
+        )
+        assert (
+            action_verify._extract_receipt_from_pr_body(
+                _receipt_body('{"large": true}'),
+                max_bytes=4,
+            )
+            is None
+        )
+
+
+class TestVerifyPrReceipt:
+    def test_success_verifies_trusted_refs_and_sigstore_policy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls = _patch_verifier_dependencies(monkeypatch)
+
+        decision = action_verify.verify_pr_receipt(
+            _receipt_body(),
+            tmp_path,
+            tmp_path / ".omnigate.yaml",
+            repository_id="123",
+            repository_url="https://github.com/org/repo",
+            base_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+
+        assert decision["ok"] is True
+        assert decision["action"] == "pass"
+        assert decision["receipt_diff_hash"] == "sha256:" + "c" * 64
+        assert calls["cat_file"] == [
+            (tmp_path, "a" * 40),
+            (tmp_path, "b" * 40),
+        ]
+        assert (
+            calls["identity"]
+            == "https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main"
+        )
+        assert calls["issuer"] == "https://token.actions.githubusercontent.com"
+
+    def test_missing_receipt_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        _patch_verifier_dependencies(monkeypatch)
+
+        decision = action_verify.verify_pr_receipt(
+            "no receipt",
+            tmp_path,
+            tmp_path / ".omnigate.yaml",
+            repository_id="123",
+            repository_url="https://github.com/org/repo",
+            base_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+
+        assert decision["ok"] is False
+        assert decision["action"] == "fail"
+        assert decision["receipt_diff_hash"] is None
+        assert "No valid OmniGate receipt" in str(decision["reason"])
+        assert set(decision) == {
+            "ok",
+            "action",
+            "reason",
+            "receipt_diff_hash",
+            "checked_at",
+        }
+
+    def test_diff_mismatch_reports_receipt_diff_hash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        receipt = _receipt(diff_hash="sha256:" + "e" * 64)
+        _patch_verifier_dependencies(monkeypatch, receipt=receipt)
+
+        decision = action_verify.verify_pr_receipt(
+            _receipt_body(),
+            tmp_path,
+            tmp_path / ".omnigate.yaml",
+            repository_id="123",
+            repository_url="https://github.com/org/repo",
+            base_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+
+        assert decision["ok"] is False
+        assert decision["action"] == "fail"
+        assert decision["receipt_diff_hash"] == "sha256:" + "e" * 64
+        assert "Diff hash mismatch" in str(decision["reason"])
+
+    def test_failed_checks_fail_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        receipt = _receipt(checks=(SimpleNamespace(name="test", status="fail"),))
+        _patch_verifier_dependencies(monkeypatch, receipt=receipt)
+
+        decision = action_verify.verify_pr_receipt(
+            _receipt_body(),
+            tmp_path,
+            tmp_path / ".omnigate.yaml",
+            repository_id="123",
+            repository_url="https://github.com/org/repo",
+            base_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+
+        assert decision["ok"] is False
+        assert decision["action"] == "fail"
+        assert decision["reason"] == "Checks failed: test"
+
+    def test_exempt_actor_skips_receipt_verification(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls = _patch_verifier_dependencies(
+            monkeypatch,
+            config=_config(exempt_users=("dependabot[bot]",)),
+        )
+
+        decision = action_verify.verify_pr_receipt(
+            "no receipt",
+            tmp_path,
+            tmp_path / ".omnigate.yaml",
+            repository_id="123",
+            repository_url="https://github.com/org/repo",
+            base_sha="a" * 40,
+            head_sha="b" * 40,
+            actor="dependabot[bot]",
+        )
+
+        assert decision["ok"] is True
+        assert decision["action"] == "pass"
+        assert decision["receipt_diff_hash"] is None
+        assert calls["cat_file"] == [(tmp_path, "a" * 40), (tmp_path, "b" * 40)]
+
+
+def test_main_writes_decision_and_returns_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    event_path = tmp_path / "event.json"
+    decision_path = tmp_path / "decision.json"
+    event_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        action_verify,
+        "_decision_from_event",
+        lambda **kwargs: action_verify._decision(
+            ok=False,
+            action="fail",
+            reason="missing receipt",
+        ),
+    )
+
+    result = action_verify.main(
+        [
+            "--event-path",
+            str(event_path),
+            "--repo-path",
+            str(tmp_path),
+            "--config",
+            str(tmp_path / ".omnigate.yaml"),
+            "--decision-out",
+            str(decision_path),
+        ],
+    )
+
+    assert result == 1
+    assert json.loads(decision_path.read_text(encoding="utf-8"))["action"] == "fail"
+
+
+def test_workflow_is_read_only_pull_request_verifier() -> None:
+    workflow = Path(".github/workflows/omnigate.yml").read_text(encoding="utf-8")
+
+    assert "pull_request:" in workflow
+    assert "pull_request_target" not in workflow
+    assert "contents: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "github.event.pull_request.head.repo.fork == true" in workflow
+    assert "git cat-file -e" in workflow
+    assert (
+        'git show "${{ github.event.pull_request.base.sha }}:.omnigate.yaml"'
+        in workflow
+    )
+    assert "OMNIGATE_INSTALL_MODE:-repo-local" in workflow
+    assert "issues: write" not in workflow

--- a/tests/unit/gate/test_signer.py
+++ b/tests/unit/gate/test_signer.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for OmniGate Sigstore signing helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.gate.receipt_canonical import canonical_receipt_payload
+from omnibase_core.models.gate import ModelOmniGateReceipt
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.gate.signer import OmniGateSigner
+
+
+def _receipt(*, sigstore_bundle_json: str | None = None) -> ModelOmniGateReceipt:
+    return ModelOmniGateReceipt(
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
+        project_name="omni",
+        project_url="https://github.com/OmniNode-ai/omnibase_core",
+        repository_id="123456789",
+        base_sha="a" * 40,
+        head_sha="b" * 40,
+        commit_sha="b" * 40,
+        diff_hash="sha256:" + "c" * 64,
+        config_hash="sha256:" + "d" * 64,
+        receipt_schema_fingerprint="sha256:" + "e" * 64,
+        branch="contrib/omnigate",
+        timestamp=datetime(2026, 5, 17, 14, 0, tzinfo=UTC),
+        signer_identity="https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main",
+        signer_issuer="https://token.actions.githubusercontent.com",
+        sigstore_bundle_json=sigstore_bundle_json,
+    )
+
+
+@pytest.mark.unit
+class TestOmniGateSigner:
+    def test_serialize_receipt_for_signing(self) -> None:
+        signer = OmniGateSigner()
+        receipt = _receipt()
+
+        payload = signer.serialize_for_signing(receipt)
+
+        assert isinstance(payload, bytes)
+        assert payload == canonical_receipt_payload(receipt, exclude_signature=True)
+
+    def test_serialization_is_deterministic(self) -> None:
+        signer = OmniGateSigner()
+        receipt = _receipt()
+
+        assert signer.serialize_for_signing(receipt) == signer.serialize_for_signing(
+            receipt,
+        )
+
+    def test_signature_bundle_is_excluded_from_payload(self) -> None:
+        signer = OmniGateSigner()
+        receipt = _receipt(sigstore_bundle_json='{"bundle":"signed"}')
+
+        payload = signer.serialize_for_signing(receipt)
+        decoded = json.loads(payload.decode("utf-8"))
+
+        assert "sigstore_bundle_json" not in decoded
+
+    def test_unicode_normalization_is_deterministic(self) -> None:
+        signer = OmniGateSigner()
+        composed = _receipt().model_copy(update={"project_name": "Caf\u00e9"})
+        decomposed = _receipt().model_copy(update={"project_name": "Cafe\u0301"})
+
+        assert signer.serialize_for_signing(composed) == signer.serialize_for_signing(
+            decomposed,
+        )
+
+    def test_sign_lazy_imports_sigstore_and_returns_copy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: dict[str, bytes] = {}
+
+        class Bundle:
+            def to_json(self) -> str:
+                return '{"bundle":"ok"}'
+
+        class ArtifactSigner:
+            def sign_artifact(self, payload: bytes) -> Bundle:
+                calls["payload"] = payload
+                return Bundle()
+
+        class SignerContext:
+            def __enter__(self) -> ArtifactSigner:
+                return ArtifactSigner()
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: types.TracebackType | None,
+            ) -> bool | None:
+                return None
+
+        class SigningContext:
+            @staticmethod
+            def production() -> SigningContext:
+                return SigningContext()
+
+            def signer(self) -> SignerContext:
+                return SignerContext()
+
+        sign_module = types.ModuleType("sigstore.sign")
+        sign_module.SigningContext = SigningContext
+        sigstore_module = types.ModuleType("sigstore")
+        monkeypatch.setitem(sys.modules, "sigstore", sigstore_module)
+        monkeypatch.setitem(sys.modules, "sigstore.sign", sign_module)
+
+        receipt = _receipt()
+        signed = OmniGateSigner().sign(receipt)
+
+        assert signed is not receipt
+        assert signed.sigstore_bundle_json == '{"bundle":"ok"}'
+        assert calls["payload"] == OmniGateSigner().serialize_for_signing(receipt)
+
+    def test_verify_false_when_bundle_missing(self) -> None:
+        assert (
+            OmniGateSigner().verify(
+                _receipt(),
+                expected_identity="identity",
+                expected_issuer="issuer",
+            )
+            is False
+        )
+
+    def test_verify_uses_exact_identity_and_issuer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: dict[str, object] = {}
+
+        class VerificationMaterials:
+            @staticmethod
+            def from_json(value: str) -> object:
+                calls["bundle_json"] = value
+                return {"bundle": value}
+
+        class VerifierInstance:
+            def verify_artifact(
+                self,
+                payload: bytes,
+                bundle: object,
+                policy: object,
+            ) -> None:
+                calls["payload"] = payload
+                calls["bundle"] = bundle
+                calls["policy"] = policy
+
+        class Verifier:
+            @staticmethod
+            def production() -> VerifierInstance:
+                return VerifierInstance()
+
+        class Identity:
+            def __init__(self, *, identity: str, issuer: str) -> None:
+                calls["identity"] = identity
+                calls["issuer"] = issuer
+
+        verify_module = types.ModuleType("sigstore.verify")
+        verify_module.Verifier = Verifier
+        verify_module.VerificationMaterials = VerificationMaterials
+        policy_module = types.ModuleType("sigstore.verify.policy")
+        policy_module.Identity = Identity
+        sigstore_module = types.ModuleType("sigstore")
+        monkeypatch.setitem(sys.modules, "sigstore", sigstore_module)
+        monkeypatch.setitem(sys.modules, "sigstore.verify", verify_module)
+        monkeypatch.setitem(sys.modules, "sigstore.verify.policy", policy_module)
+
+        receipt = _receipt(sigstore_bundle_json='{"bundle":"ok"}')
+        result = OmniGateSigner().verify(
+            receipt,
+            expected_identity="https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main",
+            expected_issuer="https://token.actions.githubusercontent.com",
+        )
+
+        assert result is True
+        assert calls["bundle_json"] == '{"bundle":"ok"}'
+        assert (
+            calls["identity"]
+            == "https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main"
+        )
+        assert calls["issuer"] == "https://token.actions.githubusercontent.com"
+
+    def test_verify_false_on_sigstore_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class VerificationMaterials:
+            @staticmethod
+            def from_json(value: str) -> object:
+                return {"bundle": value}
+
+        class VerifierInstance:
+            def verify_artifact(
+                self,
+                payload: bytes,
+                bundle: object,
+                policy: object,
+            ) -> None:
+                msg = "signature mismatch"
+                raise ValueError(msg)
+
+        class Verifier:
+            @staticmethod
+            def production() -> VerifierInstance:
+                return VerifierInstance()
+
+        class Identity:
+            def __init__(self, *, identity: str, issuer: str) -> None:
+                self.identity = identity
+                self.issuer = issuer
+
+        verify_module = types.ModuleType("sigstore.verify")
+        verify_module.Verifier = Verifier
+        verify_module.VerificationMaterials = VerificationMaterials
+        policy_module = types.ModuleType("sigstore.verify.policy")
+        policy_module.Identity = Identity
+        sigstore_module = types.ModuleType("sigstore")
+        monkeypatch.setitem(sys.modules, "sigstore", sigstore_module)
+        monkeypatch.setitem(sys.modules, "sigstore.verify", verify_module)
+        monkeypatch.setitem(sys.modules, "sigstore.verify.policy", policy_module)
+
+        assert (
+            OmniGateSigner().verify(
+                _receipt(sigstore_bundle_json='{"bundle":"bad"}'),
+                expected_identity="identity",
+                expected_issuer="issuer",
+            )
+            is False
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -822,6 +822,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -833,6 +842,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1313,6 +1335,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/5b/039c095977004f2316225559d591c5a4c62b2e4d7a429db2dd01d37c3ec2/hypothesis-6.151.6.tar.gz", hash = "sha256:755decfa326c8c97a4c8766fe40509985003396442138554b0ae824f9584318f", size = 475846, upload-time = "2026-02-11T04:42:06.891Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/70/42760b369723f8b5aa6a21e5fae58809f503ca7ebb6da13b99f4de36305a/hypothesis-6.151.6-py3-none-any.whl", hash = "sha256:4e6e933a98c6f606b3e0ada97a750e7fff12277a40260b9300a05e7a5c3c5e2e", size = 543324, upload-time = "2026-02-11T04:42:04.025Z" },
+]
+
+[[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
 ]
 
 [[package]]
@@ -2006,6 +2040,7 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "redis" },
     { name = "rich" },
+    { name = "sigstore" },
     { name = "slowapi" },
     { name = "sqlparse" },
     { name = "structlog" },
@@ -2078,6 +2113,7 @@ requires-dist = [
     { name = "qdrant-client", specifier = ">=1.16.0,<2.0.0" },
     { name = "redis", specifier = ">=6.0.0,<8.0.0" },
     { name = "rich", specifier = ">=13.7.0,<16.0.0" },
+    { name = "sigstore", specifier = ">=4.0.0,<5.0.0" },
     { name = "slowapi", specifier = ">=0.1.9,<0.2.0" },
     { name = "sqlparse", specifier = ">=0.4.4,<0.6.0" },
     { name = "structlog", specifier = ">=23.2.0,<26.0.0" },
@@ -2635,6 +2671,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
@@ -2745,6 +2786,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -3083,6 +3137,38 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3161-client"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a7/be3b086133a87d595e7b11564931d5e5283edeeabba05dfee636a34b4dab/rfc3161_client-1.0.6.tar.gz", hash = "sha256:9969262fe6c08ecce39f9fe3996cf412187793834a022a643803090db5aae6b4", size = 106710, upload-time = "2026-04-08T14:15:05.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b1/262af0901e1507a4e21d268091f1f7b738b44bca424b9bd481981828a7e8/rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a98e9c7ff632d9571fcea25fb70bde0e8339b86368aef67a65f6a301f125733", size = 474975, upload-time = "2026-04-08T14:14:31.559Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b6/da7caa10c2a3e01f244ad116ffe2cc87056fa71a7dd76453faab2fc2c6ad/rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0b3920334f7334ec3bb9c319d53a5d08cd43b6883f75e2669cfd869cd264d53a", size = 467442, upload-time = "2026-04-08T14:14:33.556Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dd/5c92004ca167ae182f543aedc7a7a8bebeb0668ade7263b82212e4b4c59d/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1671b1be16480ea54c0d36239efd0fb62c13dd572a9865a5e91fea39f1b95303", size = 2435049, upload-time = "2026-04-08T14:14:35.062Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/c44702336aed367c6513493c4df9e880db8c4df37d5cd8d525aac9aad827/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63355099d932851eac507806bb9d0937dab546a66d5857d888168799ec635f6d", size = 1850399, upload-time = "2026-04-08T14:14:36.707Z" },
+    { url = "https://files.pythonhosted.org/packages/64/fa/5af9bbfd4dcd9926463a95c4de6ea137176252d7a1d0b96533f6c85f2742/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bc9835467f6166edd6f876470484e5b294ee141add6eff6a59f5047937aaa75", size = 2174593, upload-time = "2026-04-08T14:14:38.764Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3c/32a0c7de4d63a69eb97e2564e5f1d51879ec93232b0c5ac1ec444843acba/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3caffaebf43242b000c4a6659d60eaf19c3b161ccbe05b15634a856c9ea7e61", size = 2177997, upload-time = "2026-04-08T14:14:40.641Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8d/4253affe1d1e221369ad3043f5d697fc3f5d7fcb439d21add84c65cafc53/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b7ad54288a49379b01b1d0d9d15167d2b7c6c7f940332ab85eeb4a6e844da8c7", size = 2745033, upload-time = "2026-04-08T14:14:42.82Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f0/eed22d6ed52d36b1eab3dfe56b9f507e22a328e3d018b84d48877ad7abe7/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:85a1d71d1eb2c9bced2b3eb75e96f9fe49732ec2567b5dafa1dd889fff42b7fe", size = 2145631, upload-time = "2026-04-08T14:14:44.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bb/feeacd1859e364080729b9cded1129b740eeea54c6d61ff12daceed4b7dd/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1be4e1133f0f7fe875629f2c358285503c1cfc79cebfbc3fb4e28b8a57d6f1a4", size = 2328742, upload-time = "2026-04-08T14:14:46.743Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/2df8e402f069a6af2db1f21d1c88d5a929398923265189a0141709a6f25c/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bc379167238df32cbcc1dc9c324088559c1734331030f5293d75f4fd37b5f4f6", size = 2386899, upload-time = "2026-04-08T14:14:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1b/f78c75c6c92a0f5de46a86b7f39cf9bb8fb5980fbd684a56f46f031dbce6/rfc3161_client-1.0.6-cp39-abi3-win32.whl", hash = "sha256:8631f7db7c1327bf87ee6a9a8681b4cd6bc2a90aae651388f29d045cd9ff1ac9", size = 1966796, upload-time = "2026-04-08T14:14:50.215Z" },
+    { url = "https://files.pythonhosted.org/packages/26/10/6e54860ae82e4ed5665fd3f1d798a8f68f7bac321431f444640da6f93600/rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl", hash = "sha256:4ef4b096abe7d55b020526e39932c2721939a6c55e9a5cd3b3e77897a0942937", size = 2386738, upload-time = "2026-04-08T14:14:52.364Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3221,6 +3307,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "securesystemslib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/dd/d1828dce0db18aa8d34f82aee4dbcf49b0f0303cad123a1c716bb1f3bf83/securesystemslib-1.3.1.tar.gz", hash = "sha256:ca915f4b88209bb5450ac05426b859d74b7cd1421cafcf73b8dd3418a0b17486", size = 934782, upload-time = "2025-09-26T13:36:56.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/29/1c560f46b3a95d8c508e1bd8c6d0bbf53c42d412ee7d19ec2a89ceced5b9/securesystemslib-1.3.1-py3-none-any.whl", hash = "sha256:2e5414bbdde33155a91805b295cbedc4ae3f12b48dccc63e1089093537f43c81", size = 871380, upload-time = "2025-09-26T13:36:54.851Z" },
+]
+
+[[package]]
+name = "sigstore"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "id" },
+    { name = "platformdirs" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+    { name = "rfc3161-client" },
+    { name = "rfc8785" },
+    { name = "rich" },
+    { name = "sigstore-models" },
+    { name = "sigstore-rekor-types" },
+    { name = "tuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c3/84ec81173ade0dba5613feea577308cde4e69045cc804d02953e3a40922c/sigstore-4.2.0.tar.gz", hash = "sha256:bdbb49a42fd5f0ea6765919adb42ccee7254c482330764d0842eec4e11ad78d7", size = 88123, upload-time = "2026-01-26T15:01:35.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/ae/d7876024c2c84512e56528bd4de7ea444efed6d2eb74a11957a927f2532e/sigstore-4.2.0-py3-none-any.whl", hash = "sha256:ed2e0f50aae85148a8aa4fc0f57c298927fce430ad1f988f38611ce90c85829f", size = 109276, upload-time = "2026-01-26T15:01:33.944Z" },
+]
+
+[[package]]
+name = "sigstore-models"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849", size = 7037, upload-time = "2025-11-26T19:18:12.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e", size = 13213, upload-time = "2025-11-26T19:18:11.365Z" },
+]
+
+[[package]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", extra = ["email"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5", size = 15687, upload-time = "2024-11-22T13:59:54.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78", size = 20610, upload-time = "2024-11-22T13:59:52.684Z" },
 ]
 
 [[package]]
@@ -3401,6 +3546,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
     { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
     { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
+]
+
+[[package]]
+name = "tuf"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "securesystemslib" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/b5/377a566dfa8286b2ca27ddbc792ab1645de0b6c65dd5bf03027b3bf8cc8f/tuf-6.0.0.tar.gz", hash = "sha256:9eed0f7888c5fff45dc62164ff243a05d47fb8a3208035eb268974287e0aee8d", size = 271268, upload-time = "2025-03-11T10:48:45.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/3d/161ab4fec446048707cb13e8ba22220e05a6c4a6587d3631feeb5715037e/tuf-6.0.0-py3-none-any.whl", hash = "sha256:458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a", size = 54774, upload-time = "2025-03-11T10:48:44.188Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add OmniGate Sigstore signing service with canonical receipt serialization
- keep Sigstore imports lazy so import-time OIDC/network behavior is impossible
- verify only against explicit expected identity and issuer
- add Sigstore 4.x dependency because the planned 3.x range no longer resolves under the repo Python range

## Verification
- uv run mypy src/omnibase_infra/gate/signer.py
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-11138/omnibase_core/src:$PWD/src uv run pytest tests/unit/gate/test_signer.py -q
- uv run ruff check src/omnibase_infra/gate/signer.py tests/unit/gate/test_signer.py

Stacked on OMN-11142 / PR #1626.