### PR TITLE
fix(OMN-9211): rename onex.snapshot.* topic to valid onex.evt.* grammar

### DIFF
--- a/contracts/OMN-9211.yaml
+++ b/contracts/OMN-9211.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.0.0"
+ticket_id: OMN-9211
+title: "Fix invalid topic names: replace onex.snapshot.* with onex.evt.* grammar"
+summary: "Renames onex.snapshot.* topic references to valid onex.evt.* grammar. Pure contract fix."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: manual
+    description: No live deploy required; pure topic grammar fix.
+    command: "echo 'no deploy required for OMN-9211'"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-deploy
+    description: No live deploy required; topic rename is a pure contract fix.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy gate evidence: OMN-9211 is a topic grammar fix; no live deploy required"

--- a/contracts/OMN-9532.yaml
+++ b/contracts/OMN-9532.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.0.0"
+ticket_id: OMN-9532
+title: "Contract-First Topic & Node-Type Enforcement epic"
+summary: "Epic for contract enforcement work. No runtime behavior changes."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: manual
+    description: No live deploy required; pure contract metadata changes.
+    command: "echo 'no deploy required for OMN-9532'"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-deploy
+    description: No live deploy required; all changes are pure contract metadata fixes.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy gate evidence: OMN-9532 is a pure contract metadata epic; no live deploy required"

--- a/src/omnibase_infra/cli/infra_test/verify.py
+++ b/src/omnibase_infra/cli/infra_test/verify.py
@@ -21,7 +21,10 @@ from omnibase_infra.cli.infra_test._helpers import (
     get_broker,
     get_postgres_dsn,
 )
-from omnibase_infra.topics.platform_topic_suffixes import SUFFIX_REGISTRATION_SNAPSHOTS
+from omnibase_infra.topics.platform_topic_suffixes import (
+    SUFFIX_NODE_INTROSPECTION,
+    SUFFIX_REGISTRATION_SNAPSHOTS,
+)
 
 console = Console()
 
@@ -199,7 +202,7 @@ def verify_snapshots(topic: str) -> None:
 @verify.command("idempotency")
 @click.option(
     "--topic",
-    default="onex.evt.platform.node-introspection.v1",  # onex-topic-allow: pending contract auto-wiring
+    default=SUFFIX_NODE_INTROSPECTION,
     help="Introspection topic.",
     show_default=True,
 )

--- a/src/omnibase_infra/cli/infra_test/verify.py
+++ b/src/omnibase_infra/cli/infra_test/verify.py
@@ -131,7 +131,7 @@ def verify_topics() -> None:
 @verify.command("snapshots")
 @click.option(
     "--topic",
-    default="onex.snapshot.platform.registration-snapshots.v1",
+    default="onex.evt.platform.registration-snapshots.v1",
     help="Snapshot topic to verify.",
     show_default=True,
 )

--- a/src/omnibase_infra/cli/infra_test/verify.py
+++ b/src/omnibase_infra/cli/infra_test/verify.py
@@ -21,6 +21,7 @@ from omnibase_infra.cli.infra_test._helpers import (
     get_broker,
     get_postgres_dsn,
 )
+from omnibase_infra.topics.platform_topic_suffixes import SUFFIX_REGISTRATION_SNAPSHOTS
 
 console = Console()
 
@@ -131,7 +132,7 @@ def verify_topics() -> None:
 @verify.command("snapshots")
 @click.option(
     "--topic",
-    default="onex.evt.platform.registration-snapshots.v1",
+    default=SUFFIX_REGISTRATION_SNAPSHOTS,
     help="Snapshot topic to verify.",
     show_default=True,
 )

--- a/src/omnibase_infra/enums/generated/enum_platform_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_platform_topic.py
@@ -41,6 +41,7 @@ class EnumPlatformTopic(str, Enum):
     EVT_NODE_REGISTRATION_INITIATED_V1 = "onex.evt.platform.node-registration-initiated.v1"  # onex.evt.platform.node-registration-initiated.v1
     EVT_NODE_REGISTRATION_REJECTED_V1 = "onex.evt.platform.node-registration-rejected.v1"  # onex.evt.platform.node-registration-rejected.v1
     EVT_NODE_REGISTRATION_RESULT_V1 = "onex.evt.platform.node-registration-result.v1"  # onex.evt.platform.node-registration-result.v1
+    EVT_REGISTRATION_SNAPSHOTS_V1 = "onex.evt.platform.registration-snapshots.v1"  # onex.evt.platform.registration-snapshots.v1
     EVT_REGISTRY_REQUEST_INTROSPECTION_V1 = "onex.evt.platform.registry-request-introspection.v1"  # onex.evt.platform.registry-request-introspection.v1
     EVT_TOPIC_CATALOG_CHANGED_V1 = "onex.evt.platform.topic-catalog-changed.v1"  # onex.evt.platform.topic-catalog-changed.v1
     EVT_TOPIC_CATALOG_RESPONSE_V1 = "onex.evt.platform.topic-catalog-response.v1"  # onex.evt.platform.topic-catalog-response.v1

--- a/src/omnibase_infra/nodes/node_ledger_projection_compute/__init__.py
+++ b/src/omnibase_infra/nodes/node_ledger_projection_compute/__init__.py
@@ -25,7 +25,7 @@ Subscribed Topics:
     - onex.cmd.platform.request-introspection.v1
     - onex.evt.platform.fsm-state-transitions.v1
     - onex.intent.platform.runtime-tick.v1
-    - onex.snapshot.platform.registration-snapshots.v1
+    - onex.evt.platform.registration-snapshots.v1
 
 Consumer Configuration:
     - consumer_purpose: "audit" (non-processing, read-only)

--- a/src/omnibase_infra/nodes/node_ledger_projection_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_ledger_projection_compute/contract.yaml
@@ -51,7 +51,7 @@ event_bus:
     # Runtime coordination
     - "onex.intent.platform.runtime-tick.v1"
     # State snapshots
-    - "onex.snapshot.platform.registration-snapshots.v1"
+    - "onex.evt.platform.registration-snapshots.v1"
   # Audit consumer - read-only, non-processing consumption for ledger persistence
   consumer_purpose: "audit"
   # Start from earliest offset to capture all historical events

--- a/src/omnibase_infra/nodes/node_ledger_projection_compute/node.py
+++ b/src/omnibase_infra/nodes/node_ledger_projection_compute/node.py
@@ -21,7 +21,7 @@ Subscribed Topics (via contract.yaml):
     - onex.cmd.platform.request-introspection.v1
     - onex.evt.platform.fsm-state-transitions.v1
     - onex.intent.platform.runtime-tick.v1
-    - onex.snapshot.platform.registration-snapshots.v1
+    - onex.evt.platform.registration-snapshots.v1
 
 Ticket: OMN-1648, OMN-1726
 """

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -91,7 +91,7 @@ event_bus:
     - "onex.cmd.platform.node-registration-acked.v1"
     - "onex.cmd.platform.topic-catalog-query.v1"
     - "onex.cmd.platform.request-introspection.v1"
-    - "onex.snapshot.platform.registration-snapshots.v1"
+    - "onex.evt.platform.registration-snapshots.v1"
 # Feature Flags [OMN-5584]
 # Platform-housed flags: multiple services depend on these, so they live in
 # the central registration orchestrator contract.

--- a/src/omnibase_infra/topics/platform_topic_suffixes.py
+++ b/src/omnibase_infra/topics/platform_topic_suffixes.py
@@ -127,7 +127,7 @@ heartbeat collection, health checks, and scheduled workflows.
 """
 
 # Registration snapshots
-SUFFIX_REGISTRATION_SNAPSHOTS: str = "onex.snapshot.platform.registration-snapshots.v1"
+SUFFIX_REGISTRATION_SNAPSHOTS: str = "onex.evt.platform.registration-snapshots.v1"
 """Topic suffix for registration snapshot events.
 
 Published periodically with aggregated registration state. Used for

--- a/tests/integration/test_topic_suffix_exports.py
+++ b/tests/integration/test_topic_suffix_exports.py
@@ -40,3 +40,22 @@ def test_all_suffix_constants_importable_from_topics() -> None:
             assert hasattr(topics_pkg, name), (
                 f"{name} listed in __all__ but not importable"
             )
+
+
+@pytest.mark.integration
+def test_registration_snapshots_topic_follows_onex_grammar() -> None:
+    """SUFFIX_REGISTRATION_SNAPSHOTS must use onex.evt.* grammar, not onex.snapshot.* (OMN-9211)."""
+    from omnibase_infra.topics.platform_topic_suffixes import (
+        SUFFIX_REGISTRATION_SNAPSHOTS,
+    )
+
+    assert SUFFIX_REGISTRATION_SNAPSHOTS.startswith("onex.evt."), (
+        f"Registration snapshots topic must use onex.evt.* kind, got: {SUFFIX_REGISTRATION_SNAPSHOTS}"
+    )
+    parts = SUFFIX_REGISTRATION_SNAPSHOTS.split(".")
+    assert len(parts) == 5, (
+        f"Topic must have 5 segments (onex.<kind>.<producer>.<event>.v<N>), got: {SUFFIX_REGISTRATION_SNAPSHOTS}"
+    )
+    assert (
+        SUFFIX_REGISTRATION_SNAPSHOTS == "onex.evt.platform.registration-snapshots.v1"
+    ), f"Unexpected topic value: {SUFFIX_REGISTRATION_SNAPSHOTS}"

--- a/tests/unit/test_cli_registry_commands.py
+++ b/tests/unit/test_cli_registry_commands.py
@@ -54,12 +54,12 @@ class TestCLIRegistryCommands:
         assert "onex" in result.output.lower()
 
     def test_list_topics_shows_all_kinds(self) -> None:
-        """list-topics shows Event, Command, Intent, Snapshot kinds."""
+        """list-topics shows Event and Command kinds."""
         runner = CliRunner()
         result = runner.invoke(cli, ["registry", "list-topics"])
         assert result.exit_code == 0
         assert "Event" in result.output
-        assert "Snapshot" in result.output
+        assert "Command" in result.output
 
     def test_validate_group_still_works(self) -> None:
         """Existing validate commands still work."""

--- a/tests/unit/topics/test_platform_topic_suffixes.py
+++ b/tests/unit/topics/test_platform_topic_suffixes.py
@@ -160,7 +160,7 @@ class TestPlatformTopicSuffixes:
         """Registration snapshots suffix should have correct format."""
         assert (
             SUFFIX_REGISTRATION_SNAPSHOTS
-            == "onex.snapshot.platform.registration-snapshots.v1"
+            == "onex.evt.platform.registration-snapshots.v1"
         )
 
     def test_node_registration_acked_suffix_format(self) -> None:


### PR DESCRIPTION
Evidence-Source: OCC#1093
Evidence-Ticket: OMN-9211

## Summary

Fixes `invalid_topic_name` violation from contract sweep (OMN-9532 epic).

**OMN-9211 — invalid_topic_name**

The topic `onex.snapshot.platform.registration-snapshots.v1` uses a non-standard `snapshot` kind segment. Renamed to `onex.evt.platform.registration-snapshots.v1` to comply with the 5-segment `onex.{cmd|evt|intent}.{producer}.{event}.v{N}` grammar.

**Changes:**
- `node_ledger_projection_compute/contract.yaml` — subscribe_topics
- `node_registration_orchestrator/contract.yaml` — publish_topics
- `topics/platform_topic_suffixes.py` — `SUFFIX_REGISTRATION_SNAPSHOTS` constant
- `cli/infra_test/verify.py` — CLI default value
- `enums/generated/enum_platform_topic.py` — regenerated via `generate_topic_enums.py`
- Node docstrings updated in `__init__.py` and `node.py`

## Test plan
- [x] `pre-commit run --files <changed-files>` — all hooks pass including Topic Naming Lint, Topic Enum Drift Check, Topic Contract Parity Gate
- [x] Topic enum regenerated: `EVT_REGISTRATION_SNAPSHOTS_V1 = "onex.evt.platform.registration-snapshots.v1"`
- [x] Violation sweep: 0 `invalid_topic_name` violations remaining

## Related tickets
- OMN-9211, OMN-9532 (parent epic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized registration-snapshot topic names to the canonical platform event form across the infra and updated CLI defaults to use the canonical topic values.
  * Added contract metadata entries for tickets OMN-9211 and OMN-9532 documenting the topic-grammar change.

* **Tests**
  * Added an integration test enforcing the registration-snapshots topic naming and format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->