### PR TITLE
fix(OMN-11185): exempt projection consumers from ONEX_ACTIVE_RUNTIME_PACKAGES gate

### DIFF
--- a/contracts/OMN-11185.yaml
+++ b/contracts/OMN-11185.yaml
@@ -6,8 +6,7 @@ summary: >
 
 is_seam_ticket: false
 interface_change: false
-interfaces_touched:
-  - "discovery"
+interfaces_touched: []
 emergency_bypass:
   enabled: false
   justification: ""

--- a/contracts/OMN-11185.yaml
+++ b/contracts/OMN-11185.yaml
@@ -1,0 +1,29 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11185"
+title: "Remove ONEX_ACTIVE_RUNTIME_PACKAGES gate from projection consumer discovery"
+summary: >
+  Fix _contract_targets_active_runtime_packages to only check publish_topics against the ONEX_ACTIVE_RUNTIME_PACKAGES allowlist. Previously both subscribe_topics and publish_topics were checked, which incorrectly blocked projection consumers (like node_projection_delegation) that subscribe to onex.evt.omniclaude.* topics but do not publish into that domain. Subscribing is read-only; only publishing into a domain requires the producer package to be active.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched:
+  - "discovery"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "All unit and integration tests pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_discovery.py tests/integration/test_projection_consumer_discovery_gate.py -v"
+  - id: "dod-deploy"
+    description: >
+      Runtime deploy: after merging, rebuild omninode-runtime image on 192.168.86.201. node_projection_delegation consumer activates and joins the delegation consumer group without requiring omniclaude in ONEX_ACTIVE_RUNTIME_PACKAGES.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: rpk group describe local.omnimarket.projection_delegation.consume.1.0.0 && docker exec omninode-runtime python -c 'from omnibase_infra.runtime.auto_wiring.discovery import _contract_targets_active_runtime_packages; print(\"gate fixed\")'"

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -46,14 +46,21 @@ def _contract_targets_active_runtime_packages(
     contract: ModelDiscoveredContract,
     active_packages: frozenset[str] | None,
 ) -> bool:
-    """Return True when a contract's event-bus topics stay within the active runtime surface."""
+    """Return True when a contract's publish topics stay within the active runtime surface.
+
+    Only publish_topics are checked because a contract that publishes into a
+    package domain IS part of that package's producer surface and should only
+    be loaded when the package is active.  subscribe_topics are read-only
+    consumption — a projection or reducer can subscribe to topics from an
+    inactive producer package without that package needing to be active.
+    """
     if contract.event_bus is None:
         return True
 
-    all_topics = tuple(contract.event_bus.subscribe_topics) + tuple(
-        contract.event_bus.publish_topics
+    return all(
+        is_runtime_topic_active(topic, active_packages)
+        for topic in contract.event_bus.publish_topics
     )
-    return all(is_runtime_topic_active(topic, active_packages) for topic in all_topics)
 
 
 def discover_contracts() -> ModelAutoWiringManifest:

--- a/tests/integration/test_projection_consumer_discovery_gate.py
+++ b/tests/integration/test_projection_consumer_discovery_gate.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test: projection consumers must be discoverable when producer package is inactive.
+
+OMN-11185: node_projection_delegation subscribes to onex.evt.omniclaude.* topics but
+does not publish to that domain. ONEX_ACTIVE_RUNTIME_PACKAGES must not block it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts_from_paths
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+def _write_projection_contract(
+    directory: Path, name: str, subscribe_topics: list[str]
+) -> Path:
+    """Write a projection-consumer contract.yaml and return its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "contract.yaml"
+    subs_lines = "".join(f"    - {t!r}\n" for t in subscribe_topics)
+    path.write_text(
+        f'name: "{name}"\n'
+        'node_type: "REDUCER_GENERIC"\n'
+        "contract_version:\n"
+        "  major: 1\n"
+        "  minor: 0\n"
+        "  patch: 0\n"
+        'node_version: "1.0.0"\n'
+        'description: "Projection consumer - read-only subscriber"\n'
+        "event_bus:\n"
+        "  subscribe_topics:\n"
+        f"{subs_lines}"
+        "  publish_topics: []\n"
+        '  consumer_purpose: "projection"\n'
+    )
+    return path
+
+
+class TestProjectionConsumerDiscoveryGate:
+    """OMN-11185: verify projection consumers load regardless of ONEX_ACTIVE_RUNTIME_PACKAGES."""
+
+    @pytest.mark.integration
+    def test_projection_consumer_subscribing_to_omniclaude_loads_when_omniclaude_inactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """node_projection_delegation (subscribes to omniclaude topics) must be discoverable
+        even when ONEX_ACTIVE_RUNTIME_PACKAGES does not include omniclaude."""
+        monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+
+        path = _write_projection_contract(
+            tmp_path / "node_projection_delegation",
+            name="node_projection_delegation",
+            subscribe_topics=[
+                "onex.evt.omniclaude.task-delegated.v1",
+                "onex.evt.omniclaude.delegation-completed.v1",
+            ],
+        )
+
+        manifest = discover_contracts_from_paths([path])
+
+        assert manifest.total_errors == 0, f"Unexpected errors: {manifest.errors}"
+        assert manifest.total_discovered == 1, (
+            "node_projection_delegation was filtered by ONEX_ACTIVE_RUNTIME_PACKAGES "
+            "even though it only subscribes to omniclaude topics (does not publish). "
+            "OMN-11185 regression."
+        )
+        assert manifest.contracts[0].name == "node_projection_delegation"
+
+    @pytest.mark.integration
+    def test_producer_into_inactive_domain_still_filtered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A contract that PUBLISHES into an inactive package domain must still be filtered.
+
+        This verifies the gate still works for its original purpose after the OMN-11185 fix.
+        """
+        monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+
+        node_dir = tmp_path / "node_omniclaude_publisher"
+        node_dir.mkdir()
+        path = node_dir / "contract.yaml"
+        path.write_text(
+            dedent("""\
+                name: "node_omniclaude_publisher"
+                node_type: "EFFECT_GENERIC"
+                contract_version:
+                  major: 1
+                  minor: 0
+                  patch: 0
+                node_version: "1.0.0"
+                description: "Publishes into omniclaude domain"
+                event_bus:
+                  subscribe_topics:
+                    - "onex.cmd.platform.trigger.v1"
+                  publish_topics:
+                    - "onex.evt.omniclaude.agent-invoked.v1"
+                  consumer_purpose: "effects"
+            """)
+        )
+
+        manifest = discover_contracts_from_paths([path])
+
+        assert manifest.total_discovered == 0, (
+            "Contract publishing into inactive omniclaude domain should be filtered "
+            "by ONEX_ACTIVE_RUNTIME_PACKAGES gate."
+        )
+        assert manifest.total_errors == 0
+
+    @pytest.mark.integration
+    def test_no_env_filter_discovers_all_contracts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ONEX_ACTIVE_RUNTIME_PACKAGES is unset, all contracts are discovered."""
+        monkeypatch.delenv("ONEX_ACTIVE_RUNTIME_PACKAGES", raising=False)
+
+        path1 = _write_projection_contract(
+            tmp_path / "proj",
+            name="node_proj",
+            subscribe_topics=["onex.evt.omniclaude.task-delegated.v1"],
+        )
+        node_dir = tmp_path / "publisher"
+        node_dir.mkdir()
+        path2 = node_dir / "contract.yaml"
+        path2.write_text(
+            dedent("""\
+                name: "node_publisher"
+                node_type: "EFFECT_GENERIC"
+                contract_version:
+                  major: 1
+                  minor: 0
+                  patch: 0
+                node_version: "1.0.0"
+                description: "Publisher"
+                event_bus:
+                  subscribe_topics: []
+                  publish_topics:
+                    - "onex.evt.omniclaude.agent-invoked.v1"
+            """)
+        )
+
+        manifest = discover_contracts_from_paths([path1, path2])
+
+        assert manifest.total_errors == 0
+        assert manifest.total_discovered == 2

--- a/tests/unit/runtime/auto_wiring/test_discovery.py
+++ b/tests/unit/runtime/auto_wiring/test_discovery.py
@@ -434,6 +434,91 @@ class TestDiscoverContractsFromPaths:
         assert manifest.total_discovered == 0
         assert manifest.total_errors == 0
 
+    @pytest.mark.unit
+    def test_projection_consumer_subscribing_to_inactive_package_domain_is_included(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Projection consumers that subscribe to topics from inactive packages must load.
+
+        OMN-11185: node_projection_delegation subscribes to onex.evt.omniclaude.*
+        to materialize views but does NOT publish to omniclaude.  The env var gate
+        must not block read-only consumers — only producers targeting inactive domains
+        should be filtered.
+        """
+        monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+        node_dir = tmp_path / "projection_delegation"
+        node_dir.mkdir()
+        path = node_dir / "contract.yaml"
+        path.write_text(
+            dedent("""\
+                name: "node_projection_delegation"
+                node_type: "REDUCER_GENERIC"
+                contract_version:
+                  major: 1
+                  minor: 0
+                  patch: 0
+                node_version: "1.0.0"
+                description: "Projection consumer for delegation events from omniclaude"
+                event_bus:
+                  subscribe_topics:
+                    - "onex.evt.omniclaude.delegation-dispatched.v1"
+                    - "onex.evt.omniclaude.delegation-completed.v1"
+                  publish_topics: []
+                  consumer_purpose: "projection"
+            """)
+        )
+
+        manifest = discover_contracts_from_paths([path])
+
+        assert manifest.total_discovered == 1
+        assert manifest.total_errors == 0
+        assert manifest.contracts[0].name == "node_projection_delegation"
+
+    @pytest.mark.unit
+    def test_discover_contracts_includes_projection_consumer_for_inactive_package(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entry-point discovery must include projection consumers from inactive package domains.
+
+        OMN-11185: package is omnimarket (active), contract subscribes to omniclaude
+        topics (inactive) but publishes nothing — must not be filtered.
+        """
+        monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+        (tmp_path / "contract.yaml").write_text(
+            dedent("""\
+                name: "node_projection_delegation"
+                node_type: "REDUCER_GENERIC"
+                contract_version:
+                  major: 1
+                  minor: 0
+                  patch: 0
+                node_version: "1.0.0"
+                description: "Projection consumer for delegation events"
+                event_bus:
+                  subscribe_topics:
+                    - "onex.evt.omniclaude.delegation-dispatched.v1"
+                  publish_topics: []
+                  consumer_purpose: "projection"
+            """)
+        )
+        module_file = tmp_path / "node.py"
+        module_file.write_text("")
+
+        cls = type("NodeProjectionDelegation", (), {"process": lambda self: None})
+        ep = _make_entry_point(
+            "node_projection_delegation", node_cls=cls, dist_name="omnimarket"
+        )
+
+        with (
+            patch(_EP_MODULE, return_value=[ep]),
+            patch("inspect.getfile", return_value=str(module_file)),
+        ):
+            manifest = discover_contracts()
+
+        assert manifest.total_discovered == 1
+        assert manifest.total_errors == 0
+        assert manifest.contracts[0].name == "node_projection_delegation"
+
 
 class TestModelAutoWiringManifest:
     """Tests for manifest query methods."""


### PR DESCRIPTION
## Summary

- `_contract_targets_active_runtime_packages` previously checked both `subscribe_topics` and `publish_topics` against the active-packages allowlist, incorrectly blocking projection consumers (like `node_projection_delegation`) that subscribe to `onex.evt.omniclaude.*` topics but do not produce them.
- Fix: only check `publish_topics` — subscribing to a topic domain does not require the producer package to be active; only publishing into a domain does.
- Integration tests (3) + unit tests (2 new, 24 total) prove the fix and verify the gate still works for producers.

## Root cause

`node_projection_delegation` subscribes to `onex.evt.omniclaude.*` topics to materialize delegation views. Because `omniclaude` was not in `ONEX_ACTIVE_RUNTIME_PACKAGES`, the filter excluded the contract entirely.

## Test plan

- [x] `tests/unit/runtime/auto_wiring/test_discovery.py` — 24 tests pass (2 new)
- [x] `tests/integration/test_projection_consumer_discovery_gate.py` — 3 new integration tests pass
- [x] Pre-commit all hooks pass (both commits)
- [x] mypy passes on push

Evidence-Source: OCC#1108
Evidence-Ticket: OMN-11185

OMN-11185