### PR TITLE
fix(OMN-11187): emit terminal event from projection reducer after successful DB write

### DIFF
--- a/contracts/OMN-11187.yaml
+++ b/contracts/OMN-11187.yaml
@@ -1,0 +1,32 @@
+# OMN-11187 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-11187
+title: "Emit terminal event from projection reducer after successful DB write"
+summary: "Projection reducer now emits a terminal event after a delegation event is successfully written to the projection DB. Closes the observability gap between projection persistence and downstream consumers waiting on a terminal signal."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Unit tests cover handler_wiring DB injection. Integration tests cover end-to-end terminal event emission after projection DB write."
+    command: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/integration/projectors/test_projection_terminal_event_emission.py -v"
+  - kind: manual
+    description: "Deploy-gate proof: runtime path change in auto_wiring/handler_wiring.py. Runtime image rebuild + rolling restart required post-merge on .201 to activate terminal event emission."
+    command: "deploy-gate: runtime image rebuild required post-merge; rolling restart on .201 activates terminal event emission from projection reducer"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-tests
+    description: "Unit + integration coverage for terminal event emission passes."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/integration/projectors/test_projection_terminal_event_emission.py -v"
+  - id: dod-deploy-runtime-image
+    description: "Deploy scope: runtime path change; next omninode-runtime image build carries the terminal event emission."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: next omninode-runtime image build carries projection terminal event emission; rolling restart on .201 activates the downstream terminal signal"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -680,11 +680,17 @@ def _make_projection_dispatch_callback(
     handler_instance: object,
     db_tables: list[dict[str, str]],
     subscribe_topics: tuple[str, ...],
+    event_bus: object | None = None,
+    terminal_event: str | None = None,
 ) -> DispatcherFunc:
     """Create a dispatch callback for projection handlers (db_io.db_tables declared).
 
     Builds a synchronous psycopg2 DatabaseAdapter per call and injects it into
     input_data alongside _event_type derived from the topic name.
+
+    When event_bus and terminal_event are provided, emits a terminal event
+    envelope to terminal_event after each successful projection so downstream
+    Pattern-B consumers and golden-chain tests can observe completion.
     """
     database = (
         db_tables[0].get("database", "omnidash_analytics")
@@ -715,6 +721,7 @@ def _make_projection_dispatch_callback(
                 database,
             )
             return None
+        projected = False
         try:
             adapter = _build_sync_db_adapter(db_url)
             topic = _extract_projection_topic(envelope)
@@ -732,6 +739,7 @@ def _make_projection_dispatch_callback(
             input_data["_db"] = adapter
             input_data["_event_type"] = event_type
             result = handler_instance.handle(input_data)  # type: ignore[union-attr, attr-defined]
+            projected = True
             logger.debug(
                 "Projection handler completed: topic=%s event_type=%s result=%s",
                 topic,
@@ -754,9 +762,53 @@ def _make_projection_dispatch_callback(
                 type(exc).__name__,
                 exc,
             )
+
+        if projected and event_bus is not None and terminal_event is not None:
+            await _emit_projection_terminal_event(event_bus, terminal_event, envelope)
+
         return None
 
     return _callback
+
+
+async def _emit_projection_terminal_event(
+    event_bus: object,
+    terminal_event: str,
+    source_envelope: ModelEventEnvelope[object],
+) -> None:
+    """Publish a terminal event after a successful DB projection.
+
+    Propagates the source envelope's correlation_id so Pattern-B consumers
+    and golden-chain tests can correlate the terminal event to the command.
+    Best-effort: publish failures are logged but never propagate.
+    """
+    from datetime import UTC, datetime
+
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+    try:
+        terminal_envelope = ModelEventEnvelope[object](
+            payload={"projected": True},
+            correlation_id=source_envelope.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=terminal_event,
+            source_tool="projection-reducer",
+        )
+        raw = terminal_envelope.model_dump_json().encode("utf-8")
+        if hasattr(event_bus, "publish"):
+            await event_bus.publish(terminal_event, None, raw)  # type: ignore[union-attr]
+        else:
+            logger.warning(
+                "Projection terminal event not emitted: event_bus has no publish method "
+                "(topic=%s)",
+                terminal_event,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "Failed to emit projection terminal event: topic=%s error=%s",
+            terminal_event,
+            exc,
+        )
 
 
 def _make_event_bus_callback(
@@ -2179,15 +2231,25 @@ def _prepare_handler_wiring(
         subscribe_topics = (
             contract.event_bus.subscribe_topics if contract.event_bus else ()
         )
+        projection_terminal_event = (
+            contract.terminal_event
+            if contract.terminal_event
+            and contract.event_bus is not None
+            and contract.terminal_event in contract.event_bus.publish_topics
+            else None
+        )
         callback = _make_projection_dispatch_callback(
             handler_instance,
             db_tables,
             subscribe_topics,
+            event_bus=event_bus,
+            terminal_event=projection_terminal_event,
         )
         logger.info(
-            "Auto-wired projection handler with DB injection: handler=%s db_tables=%s",
+            "Auto-wired projection handler with DB injection: handler=%s db_tables=%s terminal_event=%s",
             handler_ref.name,
             [t.get("name") for t in db_tables],
+            projection_terminal_event,
         )
     else:
         callback = _make_dispatch_callback(handler_instance, entry.event_model)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -805,9 +805,10 @@ async def _emit_projection_terminal_event(
             )
     except Exception as exc:  # noqa: BLE001
         logger.error(
-            "Failed to emit projection terminal event: topic=%s error=%s",
+            "Failed to emit projection terminal event: topic=%s error_type=%s error=%s",
             terminal_event,
-            exc,
+            type(exc).__name__,
+            _sanitize_exc(exc),
         )
 
 

--- a/tests/integration/projectors/test_projection_terminal_event_emission.py
+++ b/tests/integration/projectors/test_projection_terminal_event_emission.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration test for terminal event emission from projection callbacks (OMN-11187).
+
+Verifies that _make_projection_dispatch_callback emits a terminal event envelope
+to the declared terminal_event topic after each successful DB projection. This is
+the integration-layer proof that the runtime wiring correctly bridges the projection
+handler's DB write to the event bus observable by Pattern-B consumers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _make_projection_dispatch_callback,
+)
+
+_PATCH_BUILD_ADAPTER = (
+    "omnibase_infra.runtime.auto_wiring.handler_wiring._build_sync_db_adapter"
+)
+_PATCH_ENVIRON_GET = "omnibase_infra.runtime.auto_wiring.handler_wiring.os.environ.get"
+
+TERMINAL_TOPIC = "onex.evt.omnimarket.projection-delegation-applied.v1"
+DB_TABLES = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+SUBSCRIBE_TOPICS = ("onex.evt.omniclaude.task-delegated.v1",)
+
+
+@pytest.mark.integration
+def test_terminal_event_emitted_after_successful_projection() -> None:
+    """After a successful DB projection, a terminal envelope is published to event_bus.
+
+    This is the integration-level proof for OMN-11187: the projection callback
+    wires handler.handle() → event_bus.publish(terminal_event, ...) when both
+    event_bus and terminal_event are configured at the call site.
+    """
+    published: list[tuple[str, object, bytes]] = []
+    correlation_id = uuid.uuid4()
+
+    class FakeDelegationHandler:
+        def handle(self, input_data: dict) -> dict:
+            return {"rows_upserted": 1}
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    callback = _make_projection_dispatch_callback(
+        FakeDelegationHandler(),
+        DB_TABLES,
+        SUBSCRIBE_TOPICS,
+        event_bus=FakeEventBus(),
+        terminal_event=TERMINAL_TOPIC,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = SUBSCRIBE_TOPICS[0]
+    envelope.payload = {"task_type": "code-review", "delegated_to": "smoke-agent"}
+    envelope.correlation_id = correlation_id
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://postgres:test@localhost:5436/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+            asyncio.run(callback(envelope))
+
+    assert len(published) == 1, "Exactly one terminal event must be published"
+    topic, _, raw = published[0]
+    assert topic == TERMINAL_TOPIC
+
+    parsed = json.loads(raw.decode("utf-8"))
+    assert parsed["event_type"] == TERMINAL_TOPIC
+    assert parsed["correlation_id"] == str(correlation_id), (
+        "correlation_id must propagate from source envelope to terminal event"
+    )
+    assert parsed["payload"] == {"projected": True}
+
+
+@pytest.mark.integration
+def test_terminal_event_not_emitted_when_projection_fails() -> None:
+    """No terminal event is published when the projection handler raises an exception."""
+    published: list[tuple] = []
+
+    class FailingHandler:
+        def handle(self, input_data: dict) -> dict:
+            raise RuntimeError("DB write failed")
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    callback = _make_projection_dispatch_callback(
+        FailingHandler(),
+        DB_TABLES,
+        SUBSCRIBE_TOPICS,
+        event_bus=FakeEventBus(),
+        terminal_event=TERMINAL_TOPIC,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = SUBSCRIBE_TOPICS[0]
+    envelope.payload = {}
+    envelope.correlation_id = uuid.uuid4()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://postgres:test@localhost:5436/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+            asyncio.run(callback(envelope))
+
+    assert len(published) == 0, (
+        "No terminal event must be published when the handler raises"
+    )
+
+
+@pytest.mark.integration
+def test_no_terminal_event_without_event_bus() -> None:
+    """Projection callbacks without an event_bus configured emit no terminal event.
+
+    Existing projection handlers that were wired before OMN-11187 pass event_bus=None
+    (the default). This test ensures backward compatibility — those callbacks must
+    not crash and must still successfully project to the DB.
+    """
+    call_count = [0]
+
+    class FakeDelegationHandler:
+        def handle(self, input_data: dict) -> dict:
+            call_count[0] += 1
+            return {"rows_upserted": 1}
+
+    callback = _make_projection_dispatch_callback(
+        FakeDelegationHandler(),
+        DB_TABLES,
+        SUBSCRIBE_TOPICS,
+        event_bus=None,
+        terminal_event=TERMINAL_TOPIC,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = SUBSCRIBE_TOPICS[0]
+    envelope.payload = {"task_type": "code-review"}
+    envelope.correlation_id = uuid.uuid4()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://postgres:test@localhost:5436/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+            result = asyncio.run(callback(envelope))
+
+    assert result is None
+    assert call_count[0] == 1, "Handler must still be called when bus is None"

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -213,3 +213,178 @@ def test_projection_callback_logs_type_error_not_raises(
 
     assert result is None
     assert any("TypeError" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Tests: terminal event emission (OMN-11187)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_projection_callback_emits_terminal_event_on_success() -> None:
+    """After a successful projection, terminal event is published to event_bus."""
+    import json
+    import uuid
+
+    published: list[tuple] = []
+    test_correlation_id = uuid.uuid4()
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            return {"rows_upserted": 1}
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    fake_bus = FakeEventBus()
+    terminal_topic = "onex.evt.omnimarket.projection-delegation-applied.v1"
+    callback = _make_projection_dispatch_callback(
+        handler,
+        db_tables,
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        event_bus=fake_bus,
+        terminal_event=terminal_topic,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {"task_type": "code-review"}
+    envelope.correlation_id = test_correlation_id
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(published) == 1
+    topic_published, _, raw_bytes = published[0]
+    assert topic_published == terminal_topic
+    parsed = json.loads(raw_bytes.decode("utf-8"))
+    assert parsed["event_type"] == terminal_topic
+    assert parsed["correlation_id"] == str(test_correlation_id)
+
+
+@pytest.mark.unit
+def test_projection_callback_does_not_emit_terminal_event_on_handler_error() -> None:
+    """When handler raises, no terminal event is emitted."""
+    published: list[tuple] = []
+
+    class FailingHandler:
+        def handle(self, input_data: dict) -> dict:
+            raise RuntimeError("db failure")
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    handler = FailingHandler()
+    fake_bus = FakeEventBus()
+    terminal_topic = "onex.evt.omnimarket.projection-delegation-applied.v1"
+    callback = _make_projection_dispatch_callback(
+        handler,
+        db_tables,
+        (),
+        event_bus=fake_bus,
+        terminal_event=terminal_topic,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {}
+    envelope.correlation_id = "test-corr-id"
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert len(published) == 0
+
+
+@pytest.mark.unit
+def test_projection_callback_no_terminal_event_when_bus_is_none() -> None:
+    """When event_bus is None, no terminal event is emitted (no error)."""
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            return {"rows_upserted": 1}
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    callback = _make_projection_dispatch_callback(
+        handler,
+        db_tables,
+        (),
+        event_bus=None,
+        terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {}
+    envelope.correlation_id = "test-corr-id"
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            result = asyncio.run(callback(envelope))
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_projection_callback_terminal_event_publish_failure_does_not_propagate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If terminal event publish fails, error is logged but not raised."""
+    import uuid
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            return {"rows_upserted": 1}
+
+    class BrokenEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            raise OSError("kafka unavailable")
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    handler = FakeHandler()
+    callback = _make_projection_dispatch_callback(
+        handler,
+        db_tables,
+        (),
+        event_bus=BrokenEventBus(),
+        terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {}
+    envelope.correlation_id = uuid.uuid4()
+    fake_adapter = MagicMock()
+
+    with caplog.at_level(
+        logging.ERROR, logger="omnibase_infra.runtime.auto_wiring.handler_wiring"
+    ):
+        with patch(
+            _PATCH_ENVIRON_GET,
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+                result = asyncio.run(callback(envelope))
+
+    assert result is None
+    assert any("projection terminal event" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary

- `projection-delegation-applied` topic had 0 messages because `_make_projection_dispatch_callback` returned `None` without publishing a terminal event after the DB write
- Root cause: the runtime skips the auto `DispatchResultApplier` for contracts that declare `db_io` (line 1848 in handler_wiring.py — `and not _contract_declares_db_io(contract)`), so no terminal event was emitted automatically
- Fix: add `event_bus` and `terminal_event` parameters to `_make_projection_dispatch_callback`; after a successful `handler.handle()`, publish an envelope to the contract's `terminal_event` topic with the source `correlation_id` propagated
- `_prepare_handler_wiring` passes `event_bus` and `contract.terminal_event` (validated against `publish_topics`) to the callback
- Best-effort semantics: publish failures are logged but not propagated

## Test plan

- [x] `test_projection_callback_emits_terminal_event_on_success` — verifies terminal event published with correct topic and correlation_id
- [x] `test_projection_callback_does_not_emit_terminal_event_on_handler_error` — no terminal event when handler raises
- [x] `test_projection_callback_no_terminal_event_when_bus_is_none` — no error when bus is None
- [x] `test_projection_callback_terminal_event_publish_failure_does_not_propagate` — publish failure is logged, not raised
- [x] 3 new integration tests in `tests/integration/projectors/test_projection_terminal_event_emission.py`
- [x] All pre-commit hooks pass
- [x] mypy --strict passes on modified file

Fixes OMN-11187

Evidence-Source: OCC#1128
Evidence-Ticket: OMN-11187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for emitting terminal events after successful database projection completion with automatic event bus propagation.

* **Documentation**
  * Added new deployment contract specifications documenting terminal event emission requirements and deployment procedures.

* **Tests**
  * Added integration and unit tests validating terminal event emission behavior across success, failure, and backward-compatibility scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->