### PR TITLE
feat(OMN-11199): declare projection contracts for existing handlers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "296431f68a7431b9a98cd3661c6a2e05d1a18e45" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "c87e101c0d8db8b21a8f6f6a3f54c8f5d7760199" }
 # v0.36.0: spi v0.21.0 tag does not exist yet (release in flight); pin to the
 # release branch and swap to `tag = "v0.21.0"` in a follow-up once tagged.
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", tag = "v0.21.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,10 +166,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-11210: pin to omnibase_core main HEAD until EnumDataProvenance (added in
-# e2668b21, PR #1097) lands in a tagged release. The proof-of-life test
-# imports omnibase_core.enums.enum_data_provenance.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "04a2342cb9be689be6675166672facdb4406900b" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "296431f68a7431b9a98cd3661c6a2e05d1a18e45" }
 # v0.36.0: spi v0.21.0 tag does not exist yet (release in flight); pin to the
 # release branch and swap to `tag = "v0.21.0"` in a follow-up once tagged.
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", tag = "v0.21.0" }

--- a/src/omnibase_infra/models/projection/projection_contract_registry.py
+++ b/src/omnibase_infra/models/projection/projection_contract_registry.py
@@ -36,7 +36,7 @@ CONTRACT_REGISTRY_PROJECTION = ModelProjectionContract(
     freshness_sla_seconds=30,
     freshness_field="last_seen_at",
     freshness_source_table="contracts",
-    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE_WITH_WARNING,
     cursor=_KAFKA_OFFSET_CURSOR,
     ordering_contract_ref=None,
 )
@@ -53,7 +53,7 @@ TOPIC_REGISTRY_PROJECTION = ModelProjectionContract(
     freshness_sla_seconds=30,
     freshness_field="last_seen_at",
     freshness_source_table="topics",
-    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE_WITH_WARNING,
     cursor=_KAFKA_OFFSET_CURSOR,
     ordering_contract_ref=None,
 )
@@ -77,7 +77,7 @@ REGISTRATION_PROJECTION = ModelProjectionContract(
     freshness_sla_seconds=60,
     freshness_field="updated_at",
     freshness_source_table="registration_projections",
-    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE_WITH_WARNING,
     cursor=_KAFKA_OFFSET_CURSOR,
     ordering_contract_ref=None,
 )

--- a/src/omnibase_infra/models/projection/projection_contract_registry.py
+++ b/src/omnibase_infra/models/projection/projection_contract_registry.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Projection contract registry for existing CQRS projection handlers (OMN-11199).
+
+Declares ModelProjectionContract instances for every materialized projection
+maintained by omnibase_infra, providing the runtime with freshness SLAs,
+cursor mechanisms, and degraded-behaviour semantics.
+
+ModelProjectionContract is defined in omnibase_core PR #1100 (OMN-11192).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
+from omnibase_core.models.projection.model_cursor_contract import ModelCursorContract
+from omnibase_core.models.projection.model_projection_contract import (
+    ModelProjectionContract,
+)
+from omnibase_infra.enums.generated.enum_platform_topic import EnumPlatformTopic
+
+_KAFKA_OFFSET_CURSOR = ModelCursorContract(
+    cursor_type="kafka_offset",
+    supports_replay=True,
+)
+
+CONTRACT_REGISTRY_PROJECTION = ModelProjectionContract(
+    projection_name="contract_registry",
+    source_topics=(
+        EnumPlatformTopic.EVT_CONTRACT_REGISTERED_V1.value,
+        EnumPlatformTopic.EVT_CONTRACT_DEREGISTERED_V1.value,
+        EnumPlatformTopic.EVT_NODE_HEARTBEAT_V1.value,
+    ),
+    schema_model=(
+        "omnibase_infra.models.projection.model_contract_projection.ModelContractProjection"
+    ),
+    freshness_sla_seconds=30,
+    freshness_field="last_seen_at",
+    freshness_source_table="contracts",
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    cursor=_KAFKA_OFFSET_CURSOR,
+    ordering_contract_ref=None,
+)
+
+TOPIC_REGISTRY_PROJECTION = ModelProjectionContract(
+    projection_name="topic_registry",
+    source_topics=(
+        EnumPlatformTopic.EVT_CONTRACT_REGISTERED_V1.value,
+        EnumPlatformTopic.EVT_CONTRACT_DEREGISTERED_V1.value,
+    ),
+    schema_model=(
+        "omnibase_infra.models.projection.model_topic_projection.ModelTopicProjection"
+    ),
+    freshness_sla_seconds=30,
+    freshness_field="last_seen_at",
+    freshness_source_table="topics",
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    cursor=_KAFKA_OFFSET_CURSOR,
+    ordering_contract_ref=None,
+)
+
+REGISTRATION_PROJECTION = ModelProjectionContract(
+    projection_name="registration",
+    source_topics=(
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_V1.value,
+        EnumPlatformTopic.EVT_NODE_HEARTBEAT_V1.value,
+        EnumPlatformTopic.EVT_NODE_LIVENESS_EXPIRED_V1.value,
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_ACCEPTED_V1.value,
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_ACK_RECEIVED_V1.value,
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_INITIATED_V1.value,
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_REJECTED_V1.value,
+        EnumPlatformTopic.EVT_NODE_REGISTRATION_RESULT_V1.value,
+    ),
+    schema_model=(
+        "omnibase_infra.models.projection.model_registration_projection"
+        ".ModelRegistrationProjection"
+    ),
+    freshness_sla_seconds=60,
+    freshness_field="updated_at",
+    freshness_source_table="registration_projections",
+    degraded_semantics=EnumDegradedBehavior.SERVE_STALE,
+    cursor=_KAFKA_OFFSET_CURSOR,
+    ordering_contract_ref=None,
+)
+
+PROJECTION_CONTRACTS: tuple[ModelProjectionContract, ...] = (
+    CONTRACT_REGISTRY_PROJECTION,
+    TOPIC_REGISTRY_PROJECTION,
+    REGISTRATION_PROJECTION,
+)
+
+
+def get_projection_contract(name: str) -> ModelProjectionContract | None:
+    """Return the registered projection contract by name, or None if not found."""
+    for contract in PROJECTION_CONTRACTS:
+        if contract.projection_name == name:
+            return contract
+    return None
+
+
+__all__ = [
+    "CONTRACT_REGISTRY_PROJECTION",
+    "PROJECTION_CONTRACTS",
+    "REGISTRATION_PROJECTION",
+    "TOPIC_REGISTRY_PROJECTION",
+    "get_projection_contract",
+]

--- a/tests/integration/test_projection_contract_registry_integration.py
+++ b/tests/integration/test_projection_contract_registry_integration.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for projection contract registry (OMN-11199).
+
+Validates that declared projection contracts reference valid source topics
+and that all contracts are internally consistent when loaded together.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
+from omnibase_infra.enums.generated.enum_platform_topic import EnumPlatformTopic
+from omnibase_infra.models.projection.projection_contract_registry import (
+    PROJECTION_CONTRACTS,
+    get_projection_contract,
+)
+
+
+@pytest.mark.integration
+class TestProjectionContractRegistryIntegration:
+    """Verify projection contracts are consistent with the platform topic enum."""
+
+    def test_all_source_topics_are_valid_platform_topics(self) -> None:
+        """Every source_topic in a projection contract must exist in EnumPlatformTopic."""
+        valid_topics = {e.value for e in EnumPlatformTopic}
+        for contract in PROJECTION_CONTRACTS:
+            for topic in contract.source_topics:
+                assert topic in valid_topics, (
+                    f"Projection '{contract.projection_name}' references unknown topic '{topic}'"
+                )
+
+    def test_no_duplicate_projection_names(self) -> None:
+        """Each projection_name must be unique across the registry."""
+        names = [c.projection_name for c in PROJECTION_CONTRACTS]
+        assert len(names) == len(set(names)), (
+            f"Duplicate projection names: {[n for n in names if names.count(n) > 1]}"
+        )
+
+    def test_get_projection_contract_round_trips_all_entries(self) -> None:
+        """get_projection_contract must resolve every registered contract."""
+        for contract in PROJECTION_CONTRACTS:
+            resolved = get_projection_contract(contract.projection_name)
+            assert resolved is contract, (
+                f"get_projection_contract('{contract.projection_name}') returned wrong contract"
+            )
+
+    def test_degraded_semantics_are_valid_enum_values(self) -> None:
+        """All contracts must use a valid EnumDegradedBehavior variant."""
+        for contract in PROJECTION_CONTRACTS:
+            assert isinstance(contract.degraded_semantics, EnumDegradedBehavior), (
+                f"Projection '{contract.projection_name}' has invalid degraded_semantics"
+            )
+
+    def test_freshness_fields_are_non_empty(self) -> None:
+        """Freshness metadata must be fully specified."""
+        for contract in PROJECTION_CONTRACTS:
+            assert contract.freshness_field, (
+                f"Projection '{contract.projection_name}' missing freshness_field"
+            )
+            assert contract.freshness_source_table, (
+                f"Projection '{contract.projection_name}' missing freshness_source_table"
+            )

--- a/tests/unit/models/projection/test_projection_contract_registry.py
+++ b/tests/unit/models/projection/test_projection_contract_registry.py
@@ -37,7 +37,7 @@ class TestProjectionContractRegistry:
         assert c.freshness_field == "last_seen_at"
         assert c.freshness_source_table == "contracts"
         assert c.freshness_sla_seconds == 30
-        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE_WITH_WARNING
         assert c.cursor.cursor_type == "kafka_offset"
         assert c.cursor.supports_replay is True
         assert len(c.source_topics) > 0
@@ -48,7 +48,7 @@ class TestProjectionContractRegistry:
         assert c.freshness_field == "last_seen_at"
         assert c.freshness_source_table == "topics"
         assert c.freshness_sla_seconds == 30
-        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE_WITH_WARNING
         assert c.cursor.cursor_type == "kafka_offset"
         assert c.cursor.supports_replay is True
 
@@ -58,7 +58,7 @@ class TestProjectionContractRegistry:
         assert c.freshness_field == "updated_at"
         assert c.freshness_source_table == "registration_projections"
         assert c.freshness_sla_seconds == 60
-        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE_WITH_WARNING
         assert c.cursor.cursor_type == "kafka_offset"
         assert c.cursor.supports_replay is True
 

--- a/tests/unit/models/projection/test_projection_contract_registry.py
+++ b/tests/unit/models/projection/test_projection_contract_registry.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for projection_contract_registry (OMN-11199)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
+from omnibase_core.models.projection.model_projection_contract import (
+    ModelProjectionContract,
+)
+from omnibase_infra.models.projection.projection_contract_registry import (
+    CONTRACT_REGISTRY_PROJECTION,
+    PROJECTION_CONTRACTS,
+    REGISTRATION_PROJECTION,
+    TOPIC_REGISTRY_PROJECTION,
+    get_projection_contract,
+)
+
+
+@pytest.mark.unit
+class TestProjectionContractRegistry:
+    def test_all_contracts_present(self) -> None:
+        names = {c.projection_name for c in PROJECTION_CONTRACTS}
+        assert "contract_registry" in names
+        assert "topic_registry" in names
+        assert "registration" in names
+
+    def test_all_contracts_are_model_projection_contract(self) -> None:
+        for contract in PROJECTION_CONTRACTS:
+            assert isinstance(contract, ModelProjectionContract)
+
+    def test_contract_registry_fields(self) -> None:
+        c = CONTRACT_REGISTRY_PROJECTION
+        assert c.projection_name == "contract_registry"
+        assert c.freshness_field == "last_seen_at"
+        assert c.freshness_source_table == "contracts"
+        assert c.freshness_sla_seconds == 30
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.cursor.cursor_type == "kafka_offset"
+        assert c.cursor.supports_replay is True
+        assert len(c.source_topics) > 0
+
+    def test_topic_registry_fields(self) -> None:
+        c = TOPIC_REGISTRY_PROJECTION
+        assert c.projection_name == "topic_registry"
+        assert c.freshness_field == "last_seen_at"
+        assert c.freshness_source_table == "topics"
+        assert c.freshness_sla_seconds == 30
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.cursor.cursor_type == "kafka_offset"
+        assert c.cursor.supports_replay is True
+
+    def test_registration_fields(self) -> None:
+        c = REGISTRATION_PROJECTION
+        assert c.projection_name == "registration"
+        assert c.freshness_field == "updated_at"
+        assert c.freshness_source_table == "registration_projections"
+        assert c.freshness_sla_seconds == 60
+        assert c.degraded_semantics == EnumDegradedBehavior.SERVE_STALE
+        assert c.cursor.cursor_type == "kafka_offset"
+        assert c.cursor.supports_replay is True
+
+    def test_get_projection_contract_found(self) -> None:
+        assert (
+            get_projection_contract("contract_registry") is CONTRACT_REGISTRY_PROJECTION
+        )
+        assert get_projection_contract("topic_registry") is TOPIC_REGISTRY_PROJECTION
+        assert get_projection_contract("registration") is REGISTRATION_PROJECTION
+
+    def test_get_projection_contract_not_found(self) -> None:
+        assert get_projection_contract("nonexistent") is None
+
+    def test_all_contracts_have_source_topics(self) -> None:
+        for contract in PROJECTION_CONTRACTS:
+            assert len(contract.source_topics) > 0, (
+                f"{contract.projection_name} has no source_topics"
+            )
+
+    def test_all_contracts_have_schema_model(self) -> None:
+        for contract in PROJECTION_CONTRACTS:
+            assert contract.schema_model, (
+                f"{contract.projection_name} missing schema_model"
+            )
+
+    def test_all_contracts_have_positive_sla(self) -> None:
+        for contract in PROJECTION_CONTRACTS:
+            assert contract.freshness_sla_seconds > 0, (
+                f"{contract.projection_name} has non-positive SLA"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=04a2342cb9be689be6675166672facdb4406900b" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.21.0" },
 ]
 
@@ -1947,7 +1947,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.41.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=04a2342cb9be689be6675166672facdb4406900b#04a2342cb9be689be6675166672facdb4406900b" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45#296431f68a7431b9a98cd3661c6a2e05d1a18e45" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2058,7 +2058,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=04a2342cb9be689be6675166672facdb4406900b" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.21.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c87e101c0d8db8b21a8f6f6a3f54c8f5d7760199" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.21.0" },
 ]
 
@@ -1947,7 +1947,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.41.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45#296431f68a7431b9a98cd3661c6a2e05d1a18e45" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c87e101c0d8db8b21a8f6f6a3f54c8f5d7760199#c87e101c0d8db8b21a8f6f6a3f54c8f5d7760199" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2058,7 +2058,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=296431f68a7431b9a98cd3661c6a2e05d1a18e45" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c87e101c0d8db8b21a8f6f6a3f54c8f5d7760199" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.21.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary

- Adds `projection_contract_registry.py` declaring `ModelProjectionContract` for all three existing projection handlers: `contract_registry`, `topic_registry`, and `registration`
- Each contract declares freshness SLA, `kafka_offset` cursor with replay support, `SERVE_STALE` degraded semantics, source topics (via `EnumPlatformTopic` constants), schema model FQCN, and freshness source table
- Adds `PROJECTION_CONTRACTS` tuple and `get_projection_contract(name)` lookup function
- Pins `omnibase-core` to PR #1100 branch SHA (OMN-11192) to access `ModelProjectionContract`, `ModelCursorContract`, and `EnumDegradedBehavior`

Closes OMN-11199 | Epic OMN-11188

## Test plan

- [x] 10 unit tests in `test_projection_contract_registry.py` — all pass
- [x] All pre-commit hooks pass (including `no-hardcoded-topics` — uses `EnumPlatformTopic.*.value`)
- [x] mypy passes on push

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core infrastructure dependency to a newer pinned revision.

* **New Features**
  * Added a centralized projection contract registry to manage projection configurations, freshness SLAs, and degraded-serving behavior.

* **Tests**
  * Added unit and integration tests covering registry entries, topic validity, uniqueness, SLA metadata, and lookup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->