### PR TITLE
feat(OMN-11196): build and emit runtime manifest at startup

### DIFF
--- a/contracts/OMN-11196.yaml
+++ b/contracts/OMN-11196.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11196"
+title: "Build and emit runtime manifest at startup"
+summary: >
+  Adds manifest_builder.py that converts ModelAutoWiringReport + ModelAutoWiringManifest into a ModelRuntimeManifest. Wires the builder into service_kernel.bootstrap() to publish the manifest once per startup on onex.evt.omnibase-infra.runtime-manifest-published.v1.
+
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "topics"
+  - "events"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "Unit tests for manifest builder pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_manifest_builder.py -v"
+  - id: "dod-deploy"
+    description: >
+      Runtime deploy required: rebuild omninode-runtime image on 192.168.86.201 after merge. Rolling restart of omninode-runtime. Verify manifest event published on startup via rpk topic consume.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-runtime python -c 'from omnibase_infra.runtime.manifest_builder import build_runtime_manifest; print(\"ok\")' && rpk topic produce onex.evt.omnibase-infra.runtime-manifest-published.v1 --dry-run"

--- a/src/omnibase_infra/runtime/manifest_builder.py
+++ b/src/omnibase_infra/runtime/manifest_builder.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Build a ModelRuntimeManifest from auto-wiring results (OMN-11196).
+
+Called once at the end of the bootstrap sequence, after all startup phases:
+contract discovery, ownership validation, handler registration, and topic
+ownership. Produces a deterministic, hash-stable snapshot of the runtime
+topology for observability and drift detection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timezone
+
+from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+    ModelAutoWiringManifest,
+)
+from omnibase_infra.runtime.auto_wiring.report import (
+    EnumWiringOutcome,
+    ModelAutoWiringReport,
+    ModelContractWiringResult,
+)
+
+
+def build_runtime_manifest(
+    report: ModelAutoWiringReport,
+    manifest: ModelAutoWiringManifest,
+    runtime_profile: str,
+    image_digest: str | None = None,
+) -> object:
+    """Build a ModelRuntimeManifest from auto-wiring results.
+
+    Extracts wired/skipped/failed contracts, topics, and handlers from the
+    wiring report and discovered manifest, then returns a frozen
+    ModelRuntimeManifest ready for publication on the event bus.
+
+    The import of ModelRuntimeManifest is deferred so that this module can be
+    imported before omnibase_core PR #1098 lands (the model is gated behind a
+    try/import in service_kernel.py as well).
+
+    Args:
+        report: The wiring report produced by wire_from_manifest().
+        manifest: The filtered auto-wiring manifest (post-quarantine).
+        runtime_profile: The RUNTIME_PROFILE value (e.g. "main").
+        image_digest: Optional OCI image digest for the running container.
+
+    Returns:
+        A ModelRuntimeManifest instance (typed as object to allow graceful
+        fallback when the model is not yet available in omnibase_core).
+
+    Raises:
+        ImportError: If omnibase_core.models.runtime_manifest is not installed.
+    """
+    from omnibase_core.models.runtime_manifest.model_manifest_contract import (
+        ModelManifestContract,
+    )
+    from omnibase_core.models.runtime_manifest.model_manifest_handler import (
+        ModelManifestHandler,
+    )
+    from omnibase_core.models.runtime_manifest.model_runtime_manifest import (
+        ModelRuntimeManifest,
+    )
+
+    results_by_outcome: dict[str, list[ModelContractWiringResult]] = {
+        EnumWiringOutcome.WIRED: [],
+        EnumWiringOutcome.SKIPPED: [],
+        EnumWiringOutcome.FAILED: [],
+    }
+    for result in report.results:
+        results_by_outcome[result.outcome].append(result)
+
+    # Build a lookup from contract name → discovered contract for metadata
+    contract_by_name = {c.name: c for c in manifest.contracts}
+
+    def _to_manifest_contract(
+        result: ModelContractWiringResult,
+    ) -> ModelManifestContract:
+        discovered = contract_by_name.get(result.contract_name)
+        version = str(discovered.contract_version) if discovered else "unknown"
+        node_type = discovered.node_type if discovered else "unknown"
+        # Stable hash: SHA-256 of "{name}:{version}"
+        import hashlib
+
+        contract_hash = hashlib.sha256(
+            f"{result.contract_name}:{version}".encode()
+        ).hexdigest()
+        return ModelManifestContract(
+            name=result.contract_name,
+            version=version,
+            node_type=node_type,
+            contract_hash=contract_hash,
+        )
+
+    wired_contracts = tuple(
+        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.WIRED]
+    )
+    skipped_contracts = tuple(
+        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.SKIPPED]
+    )
+    failed_contracts = tuple(
+        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.FAILED]
+    )
+
+    # Collect all publish topics from wired results
+    owned_command_topics: set[str] = set()
+    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+        discovered = contract_by_name.get(result.contract_name)
+        if discovered and discovered.event_bus:
+            owned_command_topics.update(discovered.event_bus.publish_topics)
+
+    # Collect all subscribe topics from wired results
+    subscribed_event_topics: set[str] = set()
+    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+        subscribed_event_topics.update(result.topics_subscribed)
+
+    # Collect all wired handlers from wired results
+    handlers: list[ModelManifestHandler] = []
+    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+        discovered = contract_by_name.get(result.contract_name)
+        if not discovered or not discovered.handler_routing:
+            continue
+        routing_strategy = discovered.handler_routing.routing_strategy or "unknown"
+        for wiring_outcome in result.wirings:
+            handlers.append(
+                ModelManifestHandler(
+                    name=wiring_outcome.handler_name,
+                    module_path=result.contract_name,
+                    routing_strategy=routing_strategy,
+                )
+            )
+
+    return ModelRuntimeManifest(
+        runtime_profile=runtime_profile,
+        contracts=wired_contracts,
+        owned_command_topics=frozenset(owned_command_topics),
+        subscribed_event_topics=frozenset(subscribed_event_topics),
+        handlers=tuple(handlers),
+        skipped_contracts=skipped_contracts,
+        failed_contracts=failed_contracts,
+        ownership_violations=(),
+        image_digest=image_digest,
+        started_at=datetime.now(tz=UTC),
+    )

--- a/src/omnibase_infra/runtime/manifest_builder.py
+++ b/src/omnibase_infra/runtime/manifest_builder.py
@@ -10,7 +10,7 @@ topology for observability and drift detection.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
     ModelAutoWiringManifest,
@@ -91,31 +91,35 @@ def build_runtime_manifest(
             contract_hash=contract_hash,
         )
 
-    wired_contracts = tuple(
-        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.WIRED]
+    wired_results = sorted(
+        results_by_outcome[EnumWiringOutcome.WIRED],
+        key=lambda r: (r.contract_name, r.package_name),
     )
-    skipped_contracts = tuple(
-        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.SKIPPED]
+    skipped_results = sorted(
+        results_by_outcome[EnumWiringOutcome.SKIPPED],
+        key=lambda r: (r.contract_name, r.package_name),
     )
-    failed_contracts = tuple(
-        _to_manifest_contract(r) for r in results_by_outcome[EnumWiringOutcome.FAILED]
+    failed_results = sorted(
+        results_by_outcome[EnumWiringOutcome.FAILED],
+        key=lambda r: (r.contract_name, r.package_name),
     )
 
-    # Collect all publish topics from wired results
+    wired_contracts = tuple(_to_manifest_contract(r) for r in wired_results)
+    skipped_contracts = tuple(_to_manifest_contract(r) for r in skipped_results)
+    failed_contracts = tuple(_to_manifest_contract(r) for r in failed_results)
+
     owned_command_topics: set[str] = set()
-    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+    for result in wired_results:
         discovered = contract_by_name.get(result.contract_name)
         if discovered and discovered.event_bus:
             owned_command_topics.update(discovered.event_bus.publish_topics)
 
-    # Collect all subscribe topics from wired results
     subscribed_event_topics: set[str] = set()
-    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+    for result in wired_results:
         subscribed_event_topics.update(result.topics_subscribed)
 
-    # Collect all wired handlers from wired results
     handlers: list[ModelManifestHandler] = []
-    for result in results_by_outcome[EnumWiringOutcome.WIRED]:
+    for result in wired_results:
         discovered = contract_by_name.get(result.contract_name)
         if not discovered or not discovered.handler_routing:
             continue

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -3234,6 +3234,62 @@ async def bootstrap() -> int:
         for handler in logging.root.handlers:
             handler.flush()
 
+        # 9.8. Emit runtime manifest snapshot (OMN-11196).
+        # Published once per startup after all phases complete.
+        # Non-fatal: failures are logged and the kernel continues.
+        if (
+            auto_wiring_report is not None
+            and auto_wiring_manifest_for_subscriptions is not None
+        ):
+            try:
+                from omnibase_core.models.events.model_event_envelope import (
+                    ModelEventEnvelope,
+                )
+                from omnibase_infra.runtime.manifest_builder import (
+                    build_runtime_manifest,
+                )
+                from omnibase_infra.topics import SUFFIX_RUNTIME_MANIFEST_PUBLISHED
+
+                _manifest_topic = TopicResolver().resolve(
+                    SUFFIX_RUNTIME_MANIFEST_PUBLISHED,
+                    correlation_id=correlation_id,
+                )
+                _runtime_profile_for_manifest = os.getenv("RUNTIME_PROFILE", "main")
+                _image_digest = os.getenv("ONEX_IMAGE_DIGEST")
+                _runtime_manifest = build_runtime_manifest(
+                    report=auto_wiring_report,
+                    manifest=auto_wiring_manifest_for_subscriptions,
+                    runtime_profile=_runtime_profile_for_manifest,
+                    image_digest=_image_digest,
+                )
+                _manifest_envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+                    payload=_runtime_manifest,
+                    correlation_id=correlation_id,
+                    event_type="runtime-manifest-published",
+                    source_tool="service_kernel",
+                )
+                await event_bus.publish_envelope(
+                    envelope=_manifest_envelope,
+                    topic=_manifest_topic,
+                )
+                logger.info(
+                    "Runtime manifest published (topic=%s, correlation_id=%s)",
+                    _manifest_topic,
+                    correlation_id,
+                )
+            except ImportError:
+                logger.debug(
+                    "ModelRuntimeManifest not available in omnibase_core — "
+                    "manifest emission skipped (correlation_id=%s)",
+                    correlation_id,
+                )
+            except Exception:  # noqa: BLE001 — boundary: manifest emission is non-critical
+                logger.warning(
+                    "Failed to emit runtime manifest (correlation_id=%s)",
+                    correlation_id,
+                    exc_info=True,
+                )
+
         # Explicit run-loop entry log (OMN-3591)
         # This message confirms the kernel reached the blocking wait and did
         # not exit prematurely during bootstrap. If this message is absent

--- a/src/omnibase_infra/topics/__init__.py
+++ b/src/omnibase_infra/topics/__init__.py
@@ -144,6 +144,7 @@ from omnibase_infra.topics.platform_topic_suffixes import (
     SUFFIX_RUNNER_HEALTH_SNAPSHOT,
     SUFFIX_RUNTIME_ERROR,
     SUFFIX_RUNTIME_HEALTH_CHECK,
+    SUFFIX_RUNTIME_MANIFEST_PUBLISHED,
     SUFFIX_RUNTIME_TICK,
     SUFFIX_SERVICE_HEARTBEAT,
     SUFFIX_TOPIC_CATALOG_CHANGED,
@@ -241,6 +242,8 @@ __all__: list[str] = [
     "SUFFIX_CONSUMER_RESTART_CMD",
     "SUFFIX_RUNTIME_HEALTH_CHECK",
     "SUFFIX_RUNTIME_ERROR",
+    # Runtime manifest publication (OMN-11196)
+    "SUFFIX_RUNTIME_MANIFEST_PUBLISHED",
     # DLQ aggregation topic (OMN-6136)
     "SUFFIX_PLATFORM_DLQ_MESSAGE",
     # OmniNode routing topics (OMN-7810)

--- a/src/omnibase_infra/topics/platform_topic_suffixes.py
+++ b/src/omnibase_infra/topics/platform_topic_suffixes.py
@@ -560,6 +560,20 @@ Producer: WiringHealthChecker (OMN-5292)
 Consumer: omnidash /wiring-health dashboard
 """
 
+SUFFIX_RUNTIME_MANIFEST_PUBLISHED: str = (
+    "onex.evt.omnibase-infra.runtime-manifest-published.v1"
+)
+"""Topic suffix for runtime manifest publication events.
+
+Published once per kernel startup, after all startup phases complete:
+contract discovery, ownership validation, handler registration, and topic
+ownership. Carries a ModelRuntimeManifest payload with contract_hash and
+topology_hash for drift detection.
+
+Producer: service_kernel.bootstrap() (OMN-11196)
+Consumer: omnidash platform-registry dashboard; drift detector (future)
+"""
+
 SUFFIX_CIRCUIT_BREAKER_STATE: str = "onex.evt.omnibase-infra.circuit-breaker.v1"
 """Topic suffix for circuit breaker state transition events.
 
@@ -808,6 +822,15 @@ ALL_OMNIBASE_INFRA_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
     # Baselines ROI computation results (1 partition — low-throughput, per-cohort)
     ModelTopicSpec(
         suffix=SUFFIX_BASELINES_COMPUTED,
+        partitions=1,
+        kafka_config={
+            "retention.ms": "604800000",
+            "cleanup.policy": "delete",
+        },  # 7 days
+    ),
+    # Runtime manifest publication (1 partition — once per startup, OMN-11196)
+    ModelTopicSpec(
+        suffix=SUFFIX_RUNTIME_MANIFEST_PUBLISHED,
         partitions=1,
         kafka_config={
             "retention.ms": "604800000",

--- a/tests/unit/runtime/test_manifest_builder.py
+++ b/tests/unit/runtime/test_manifest_builder.py
@@ -94,7 +94,7 @@ def _make_wired_result(
     wirings = tuple(
         ModelWiringOutcome(
             handler_name=h,
-            resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTRACT,
+            resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
         )
         for h in handlers
     )

--- a/tests/unit/runtime/test_manifest_builder.py
+++ b/tests/unit/runtime/test_manifest_builder.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for manifest_builder.py (OMN-11196).
+
+Verifies that build_runtime_manifest() produces a valid ModelRuntimeManifest
+from mock auto-wiring results without importing any handler or node classes.
+
+These tests are skipped when omnibase_core.models.runtime_manifest is not yet
+available (PR #1098 not merged).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+    ModelAutoWiringManifest,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
+    ModelContractVersion,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_discovered_contract import (
+    ModelDiscoveredContract,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_event_bus_wiring import (
+    ModelEventBusWiring,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_handler_routing import (
+    ModelHandlerRouting,
+)
+from omnibase_infra.runtime.auto_wiring.report import (
+    EnumWiringOutcome,
+    ModelAutoWiringReport,
+    ModelContractWiringResult,
+    ModelWiringOutcome,
+)
+
+
+def _runtime_manifest_importable() -> bool:
+    try:
+        import omnibase_core.models.runtime_manifest.model_runtime_manifest
+
+        return True
+    except ImportError:
+        return False
+
+
+runtime_manifest_available = pytest.mark.skipif(
+    not _runtime_manifest_importable(),
+    reason="omnibase_core.models.runtime_manifest not yet available (PR #1098)",
+)
+
+
+def _make_discovered_contract(
+    name: str = "test-node",
+    publish_topics: tuple[str, ...] = (),
+    subscribe_topics: tuple[str, ...] = (),
+    routing_strategy: str = "payload_type_match",
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="EFFECT_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=pathlib.Path("/fake/contract.yaml"),
+        entry_point_name=f"onex.nodes.{name}",
+        package_name="test-package",
+        event_bus=ModelEventBusWiring(
+            publish_topics=list(publish_topics),
+            subscribe_topics=list(subscribe_topics),
+        )
+        if publish_topics or subscribe_topics
+        else None,
+        handler_routing=ModelHandlerRouting(
+            routing_strategy=routing_strategy,
+            handlers=[],
+        )
+        if routing_strategy
+        else None,
+    )
+
+
+def _make_wired_result(
+    contract_name: str = "test-node",
+    package_name: str = "test-package",
+    topics_subscribed: tuple[str, ...] = (),
+    handlers: tuple[str, ...] = (),
+) -> ModelContractWiringResult:
+    wirings = tuple(
+        ModelWiringOutcome(
+            handler_name=h,
+            resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTRACT,
+        )
+        for h in handlers
+    )
+    return ModelContractWiringResult(
+        contract_name=contract_name,
+        package_name=package_name,
+        outcome=EnumWiringOutcome.WIRED,
+        topics_subscribed=topics_subscribed,
+        wirings=wirings,
+    )
+
+
+def _make_skipped_result(
+    contract_name: str = "skipped-node",
+    package_name: str = "test-package",
+    reason: str = "profile mismatch",
+) -> ModelContractWiringResult:
+    return ModelContractWiringResult(
+        contract_name=contract_name,
+        package_name=package_name,
+        outcome=EnumWiringOutcome.SKIPPED,
+        reason=reason,
+    )
+
+
+def _make_failed_result(
+    contract_name: str = "failed-node",
+    package_name: str = "test-package",
+    reason: str = "handler not found",
+) -> ModelContractWiringResult:
+    return ModelContractWiringResult(
+        contract_name=contract_name,
+        package_name=package_name,
+        outcome=EnumWiringOutcome.FAILED,
+        reason=reason,
+    )
+
+
+@runtime_manifest_available
+def test_build_manifest_empty_report() -> None:
+    """build_runtime_manifest returns a valid manifest for an empty wiring report."""
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    report = ModelAutoWiringReport()
+    manifest = ModelAutoWiringManifest()
+    result = build_runtime_manifest(
+        report=report,
+        manifest=manifest,
+        runtime_profile="main",
+    )
+    assert result.runtime_profile == "main"
+    assert result.contracts == ()
+    assert result.skipped_contracts == ()
+    assert result.failed_contracts == ()
+    assert result.owned_command_topics == frozenset()
+    assert result.subscribed_event_topics == frozenset()
+    assert result.handlers == ()
+    assert result.ownership_violations == ()
+    assert result.image_digest is None
+
+
+@runtime_manifest_available
+def test_build_manifest_wired_contracts_populate_correctly() -> None:
+    """Wired contracts are projected into contracts tuple with correct metadata."""
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    discovered = _make_discovered_contract(
+        name="node-alpha",
+        publish_topics=("onex.cmd.svc.action.v1",),
+        subscribe_topics=("onex.evt.svc.event.v1",),
+    )
+    wired = _make_wired_result(
+        contract_name="node-alpha",
+        topics_subscribed=("onex.evt.svc.event.v1",),
+        handlers=("HandlerAlpha",),
+    )
+    report = ModelAutoWiringReport(results=(wired,))
+    manifest = ModelAutoWiringManifest(contracts=(discovered,))
+
+    result = build_runtime_manifest(
+        report=report, manifest=manifest, runtime_profile="main"
+    )
+
+    assert len(result.contracts) == 1
+    assert result.contracts[0].name == "node-alpha"
+    assert result.contracts[0].node_type == "EFFECT_GENERIC"
+    assert result.contracts[0].contract_hash != ""
+    assert "onex.cmd.svc.action.v1" in result.owned_command_topics
+    assert "onex.evt.svc.event.v1" in result.subscribed_event_topics
+    assert len(result.handlers) == 1
+    assert result.handlers[0].name == "HandlerAlpha"
+
+
+@runtime_manifest_available
+def test_build_manifest_skipped_and_failed_segregated() -> None:
+    """Skipped/failed contracts go to their respective tuples, not contracts."""
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    wired = _make_wired_result(contract_name="good-node")
+    skipped = _make_skipped_result(contract_name="skipped-node")
+    failed = _make_failed_result(contract_name="failed-node")
+
+    report = ModelAutoWiringReport(results=(wired, skipped, failed))
+    manifest = ModelAutoWiringManifest(
+        contracts=(
+            _make_discovered_contract("good-node"),
+            _make_discovered_contract("skipped-node"),
+            _make_discovered_contract("failed-node"),
+        )
+    )
+
+    result = build_runtime_manifest(
+        report=report, manifest=manifest, runtime_profile="test"
+    )
+
+    assert len(result.contracts) == 1
+    assert result.contracts[0].name == "good-node"
+    assert len(result.skipped_contracts) == 1
+    assert result.skipped_contracts[0].name == "skipped-node"
+    assert len(result.failed_contracts) == 1
+    assert result.failed_contracts[0].name == "failed-node"
+
+
+@runtime_manifest_available
+def test_build_manifest_image_digest_forwarded() -> None:
+    """image_digest from caller is passed through to the manifest."""
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    report = ModelAutoWiringReport()
+    manifest = ModelAutoWiringManifest()
+    result = build_runtime_manifest(
+        report=report,
+        manifest=manifest,
+        runtime_profile="production",
+        image_digest="sha256:abc123",
+    )
+    assert result.image_digest == "sha256:abc123"
+
+
+@runtime_manifest_available
+def test_build_manifest_contract_hash_deterministic() -> None:
+    """Calling build_runtime_manifest twice with identical input yields same contract_hash."""
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    discovered = _make_discovered_contract("stable-node")
+    wired = _make_wired_result("stable-node")
+    report = ModelAutoWiringReport(results=(wired,))
+    manifest = ModelAutoWiringManifest(contracts=(discovered,))
+
+    result_a = build_runtime_manifest(
+        report=report, manifest=manifest, runtime_profile="main"
+    )
+    result_b = build_runtime_manifest(
+        report=report, manifest=manifest, runtime_profile="main"
+    )
+
+    assert result_a.contract_hash == result_b.contract_hash
+    assert result_a.topology_hash == result_b.topology_hash
+
+
+def test_build_manifest_builder_importable() -> None:
+    """manifest_builder module is importable regardless of omnibase_core PR status."""
+    import importlib
+
+    mod = importlib.import_module("omnibase_infra.runtime.manifest_builder")
+    assert hasattr(mod, "build_runtime_manifest")
+
+
+def test_build_manifest_raises_on_missing_core_model() -> None:
+    """build_runtime_manifest raises ImportError when omnibase_core model is absent."""
+    import sys
+
+    from omnibase_infra.runtime.manifest_builder import build_runtime_manifest
+
+    patched = {
+        "omnibase_core.models.runtime_manifest": None,
+        "omnibase_core.models.runtime_manifest.model_runtime_manifest": None,
+        "omnibase_core.models.runtime_manifest.model_manifest_contract": None,
+        "omnibase_core.models.runtime_manifest.model_manifest_handler": None,
+    }
+    with patch.dict(sys.modules, patched):
+        report = ModelAutoWiringReport()
+        manifest = ModelAutoWiringManifest()
+        with pytest.raises((ImportError, AttributeError)):
+            build_runtime_manifest(
+                report=report, manifest=manifest, runtime_profile="main"
+            )
+
+
+def test_suffix_runtime_manifest_published_importable() -> None:
+    """SUFFIX_RUNTIME_MANIFEST_PUBLISHED is exported from topics.__init__."""
+    from omnibase_infra.topics import SUFFIX_RUNTIME_MANIFEST_PUBLISHED
+
+    assert SUFFIX_RUNTIME_MANIFEST_PUBLISHED.startswith("onex.evt.")
+    assert "runtime-manifest-published" in SUFFIX_RUNTIME_MANIFEST_PUBLISHED


### PR DESCRIPTION
## Summary

- Adds `manifest_builder.py` with `build_runtime_manifest()` that converts `ModelAutoWiringReport` + `ModelAutoWiringManifest` into a `ModelRuntimeManifest` (wired/skipped/failed contracts, publish topics, subscribe topics, handlers, deterministic SHA-256 hashes)
- Wires the builder into `service_kernel.bootstrap()` — manifest is published once per startup on `onex.evt.omnibase-infra.runtime-manifest-published.v1` after all startup phases complete (after banner log, before run-loop entry); non-fatal on failure
- Adds `SUFFIX_RUNTIME_MANIFEST_PUBLISHED` topic constant + 1-partition topic spec to `platform_topic_suffixes.py` and exports it from `topics/__init__.py`

## Dependency

Depends on omnibase_core PR #1098 (`jonah/omn-11190-runtime-manifest`) for `ModelRuntimeManifest`. The builder's import is deferred inside `build_runtime_manifest()` so the kernel boots cleanly when the model is not yet installed — the manifest section is skipped with a DEBUG log and an `ImportError` catch in `service_kernel.py`.

## Test plan

- [ ] `uv run pytest tests/unit/runtime/test_manifest_builder.py -v` — 3 pass unconditionally (importability, topic export, missing-model degradation); 5 skip until PR #1098 merges
- [ ] All pre-commit hooks pass (verified locally — 51 checks green)
- [ ] mypy passes (push hook clean)
- [ ] CI green

## Tickets

OMN-11196 (Task 8 of epic OMN-11188)

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11196


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime manifest event is now published at kernel startup, capturing the auto-wiring topology state for drift detection and monitoring.

* **Tests**
  * Added comprehensive unit tests for runtime manifest generation and event publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->