### PR TITLE
feat(OMN-11201): add data_provenance to projection tables

### DIFF
--- a/contracts/OMN-11201.yaml
+++ b/contracts/OMN-11201.yaml
@@ -6,12 +6,7 @@ summary: >
 
 is_seam_ticket: false
 interface_change: true
-interfaces_touched:
-  - "contracts table schema"
-  - "topics table schema"
-  - "registration_projections table schema"
-  - "ModelPayloadUpsertContract"
-  - "HandlerPostgresContractUpsert"
+interfaces_touched: []
 emergency_bypass:
   enabled: false
   justification: ""
@@ -30,4 +25,4 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "deploy: docker exec omninode-postgres psql -U omnibase -d omnibase_infra -c \"SELECT column_name FROM information_schema.columns WHERE table_name='contracts' AND column_name='data_provenance'\""
+        check_value: "deploy: docker exec omninode-postgres psql -U omnibase -d omnibase_infra -c \"SELECT table_name, column_name FROM information_schema.columns WHERE column_name='data_provenance' AND table_name IN ('contracts','topics','registration_projections') ORDER BY table_name\""

--- a/contracts/OMN-11201.yaml
+++ b/contracts/OMN-11201.yaml
@@ -1,0 +1,33 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11201"
+title: "Add data_provenance column to projection tables"
+summary: >
+  Add data_provenance TEXT column (default 'unknown') to contracts, topics, and registration_projections tables via migration 078. Thread the new field through ModelPayloadUpsertContract, HandlerPostgresContractUpsert, the reducer, and the projection models so projection consumers can reason about data quality origin (demo_seeded, demo_projected_shortcut, measured, estimated, unknown).
+
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "contracts table schema"
+  - "topics table schema"
+  - "registration_projections table schema"
+  - "ModelPayloadUpsertContract"
+  - "HandlerPostgresContractUpsert"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "Unit and integration tests pass for data_provenance plumbing."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/nodes/node_contract_registry_reducer/test_data_provenance_flow.py tests/integration/projections/test_data_provenance_integration.py -v"
+  - id: "dod-deploy"
+    description: >
+      Deploy: after merging, run migration 078 on 192.168.86.201 and verify the data_provenance column exists on all three projection tables.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-postgres psql -U omnibase -d omnibase_infra -c \"SELECT column_name FROM information_schema.columns WHERE table_name='contracts' AND column_name='data_provenance'\""

--- a/docker/migrations/forward/078_add_data_provenance_to_projection_tables.sql
+++ b/docker/migrations/forward/078_add_data_provenance_to_projection_tables.sql
@@ -1,0 +1,45 @@
+-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Migration 078: add data_provenance column to projection tables (OMN-11201).
+--
+-- Tracks the origin of projected data so consumers can reason about data quality.
+-- Valid values: demo_seeded, demo_projected_shortcut, measured, estimated, unknown
+
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS data_provenance TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE topics ADD COLUMN IF NOT EXISTS data_provenance TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE registration_projections ADD COLUMN IF NOT EXISTS data_provenance TEXT NOT NULL DEFAULT 'unknown';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_contracts_data_provenance'
+    ) THEN
+        ALTER TABLE contracts
+            ADD CONSTRAINT chk_contracts_data_provenance
+            CHECK (data_provenance IN ('demo_seeded', 'demo_projected_shortcut', 'measured', 'estimated', 'unknown'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_topics_data_provenance'
+    ) THEN
+        ALTER TABLE topics
+            ADD CONSTRAINT chk_topics_data_provenance
+            CHECK (data_provenance IN ('demo_seeded', 'demo_projected_shortcut', 'measured', 'estimated', 'unknown'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_registration_projections_data_provenance'
+    ) THEN
+        ALTER TABLE registration_projections
+            ADD CONSTRAINT chk_registration_projections_data_provenance
+            CHECK (data_provenance IN ('demo_seeded', 'demo_projected_shortcut', 'measured', 'estimated', 'unknown'));
+    END IF;
+END $$;
+
+COMMENT ON COLUMN contracts.data_provenance IS
+    'Origin of projected data. Values: demo_seeded, demo_projected_shortcut, measured, estimated, unknown. OMN-11201.';
+COMMENT ON COLUMN topics.data_provenance IS
+    'Origin of projected data. Values: demo_seeded, demo_projected_shortcut, measured, estimated, unknown. OMN-11201.';
+COMMENT ON COLUMN registration_projections.data_provenance IS
+    'Origin of projected data. Values: demo_seeded, demo_projected_shortcut, measured, estimated, unknown. OMN-11201.';

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:c573b449b412b6b9d62c875664dd88e8b4c76673faf19c21374084ec041f2699
-generated_at: 2026-05-02T00:36:33Z
-migration_file_count: 63
+sha256:994027b05c7bf4192923edcd9a17d32f6515c9bce70e12a051d4dcc5d33d7375
+generated_at: 2026-05-18T12:20:52Z
+migration_file_count: 64

--- a/src/omnibase_infra/models/projection/model_contract_projection.py
+++ b/src/omnibase_infra/models/projection/model_contract_projection.py
@@ -142,6 +142,15 @@ class ModelContractProjection(BaseModel):
         description="Kafka offset of last processed event (for dedupe)",
     )
 
+    # Data provenance (OMN-11201)
+    data_provenance: str = Field(
+        default="unknown",
+        description=(
+            "Origin of projected data. Valid values: "
+            "demo_seeded, demo_projected_shortcut, measured, estimated, unknown."
+        ),
+    )
+
     # Audit timestamps
     created_at: datetime | None = Field(
         default=None,

--- a/src/omnibase_infra/models/projection/model_registration_projection.py
+++ b/src/omnibase_infra/models/projection/model_registration_projection.py
@@ -277,6 +277,15 @@ class ModelRegistrationProjection(BaseModel):
         description="Timestamp of last projection update",
     )
 
+    # Data provenance (OMN-11201)
+    data_provenance: str = Field(
+        default="unknown",
+        description=(
+            "Origin of projected data. Valid values: "
+            "demo_seeded, demo_projected_shortcut, measured, estimated, unknown."
+        ),
+    )
+
     # Tracing
     correlation_id: UUID | None = Field(
         default=None,

--- a/src/omnibase_infra/models/projection/model_topic_projection.py
+++ b/src/omnibase_infra/models/projection/model_topic_projection.py
@@ -106,6 +106,15 @@ class ModelTopicProjection(BaseModel):
         description="Whether topic is currently referenced by any active contract",
     )
 
+    # Data provenance (OMN-11201)
+    data_provenance: str = Field(
+        default="unknown",
+        description=(
+            "Origin of projected data. Valid values: "
+            "demo_seeded, demo_projected_shortcut, measured, estimated, unknown."
+        ),
+    )
+
     # Audit timestamps
     created_at: datetime | None = Field(
         default=None,

--- a/src/omnibase_infra/nodes/node_contract_persistence_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_contract_persistence_effect/contract.yaml
@@ -363,6 +363,7 @@ io_operations:
       - contract_yaml
       - source_node_id
       - is_active
+      - data_provenance
       - registered_at
       - last_seen_at
     output_fields:
@@ -480,7 +481,7 @@ metadata:
   author: "OmniNode Team"
   license: "MIT"
   created: "2025-02-02"
-  updated: "2025-02-02"
+  updated: "2026-05-18"
   tags:
     - effect
     - contract-registry
@@ -491,3 +492,4 @@ metadata:
     - "OMN-1845"
     - "OMN-1653"
     - "OMN-9151"
+    - "OMN-11201"

--- a/src/omnibase_infra/nodes/node_contract_persistence_effect/handlers/handler_postgres_contract_upsert.py
+++ b/src/omnibase_infra/nodes/node_contract_persistence_effect/handlers/handler_postgres_contract_upsert.py
@@ -65,12 +65,13 @@ logger = logging.getLogger(__name__)
 SQL_UPSERT_CONTRACT = """
 INSERT INTO contracts (
     contract_id, node_name, version_major, version_minor, version_patch,
-    contract_hash, contract_yaml, is_active, registered_at, last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    contract_hash, contract_yaml, is_active, data_provenance, registered_at, last_seen_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT (contract_id) DO UPDATE SET
     contract_hash = EXCLUDED.contract_hash,
     contract_yaml = EXCLUDED.contract_yaml,
     is_active = EXCLUDED.is_active,
+    data_provenance = EXCLUDED.data_provenance,
     last_seen_at = EXCLUDED.last_seen_at,
     updated_at = NOW()
 RETURNING contract_id, (xmax = 0) AS was_insert;
@@ -201,6 +202,7 @@ class HandlerPostgresContractUpsert(MixinPostgresOpExecutor):
                 payload.contract_hash,
                 contract_yaml_str,
                 payload.is_active,
+                payload.data_provenance,
                 payload.registered_at,
                 payload.last_seen_at,
             )

--- a/src/omnibase_infra/nodes/node_contract_registry_reducer/contract_registration_event_router.py
+++ b/src/omnibase_infra/nodes/node_contract_registry_reducer/contract_registration_event_router.py
@@ -451,10 +451,28 @@ class ContractRegistrationEventRouter:
             )
 
             # Build event metadata from Kafka message
+            # Extract data_provenance from envelope metadata tags; fall back to "unknown"
+            provenance_raw = raw_envelope.metadata.tags.get(
+                "data_provenance", "unknown"
+            )
+            provenance_value = (
+                provenance_raw
+                if isinstance(provenance_raw, str)
+                and provenance_raw
+                in (
+                    "demo_seeded",
+                    "demo_projected_shortcut",
+                    "measured",
+                    "estimated",
+                    "unknown",
+                )
+                else "unknown"
+            )
             event_metadata: dict[str, JsonType] = {
                 "topic": msg.topic,
                 "partition": msg.partition or 0,
                 "offset": int(msg.offset) if msg.offset else 0,
+                "data_provenance": provenance_value,
             }
 
             # Call reducer

--- a/src/omnibase_infra/nodes/node_contract_registry_reducer/models/model_payload_upsert_contract.py
+++ b/src/omnibase_infra/nodes/node_contract_registry_reducer/models/model_payload_upsert_contract.py
@@ -84,6 +84,14 @@ class ModelPayloadUpsertContract(BaseModel):
 
     is_active: bool = Field(default=True, description="Whether contract is active.")
 
+    data_provenance: str = Field(
+        default="unknown",
+        description=(
+            "Origin of projected data. Valid values: "
+            "demo_seeded, demo_projected_shortcut, measured, estimated, unknown."
+        ),
+    )
+
     registered_at: datetime = Field(..., description="Registration timestamp.")
 
     last_seen_at: datetime = Field(..., description="Last heartbeat timestamp.")

--- a/src/omnibase_infra/nodes/node_contract_registry_reducer/reducer.py
+++ b/src/omnibase_infra/nodes/node_contract_registry_reducer/reducer.py
@@ -215,6 +215,23 @@ class ContractRegistryReducer:
         partition = int(partition_raw) if isinstance(partition_raw, (int, str)) else 0
         offset = int(offset_raw) if isinstance(offset_raw, (int, str)) else 0
 
+        # Extract data_provenance; fall back to "unknown" for absent/unrecognised values
+        _VALID_PROVENANCE = frozenset(
+            {
+                "demo_seeded",
+                "demo_projected_shortcut",
+                "measured",
+                "estimated",
+                "unknown",
+            }
+        )
+        provenance_raw = event_metadata.get("data_provenance", "unknown")
+        data_provenance = (
+            str(provenance_raw)
+            if isinstance(provenance_raw, str) and provenance_raw in _VALID_PROVENANCE
+            else "unknown"
+        )
+
         # Warn if metadata is incomplete (could cause idempotency issues)
         if not topic or partition_raw is None or offset_raw is None:
             _logger.warning(
@@ -243,7 +260,9 @@ class ContractRegistryReducer:
         # model routing where the union type is exhaustive and statically checked.
         # See: CLAUDE.md (Protocol Resolution - external type exceptions)
         if isinstance(event, ModelContractRegisteredEvent):
-            return self._on_contract_registered(state, event, topic, partition, offset)
+            return self._on_contract_registered(
+                state, event, topic, partition, offset, data_provenance
+            )
         elif isinstance(event, ModelContractDeregisteredEvent):
             return self._on_contract_deregistered(
                 state, event, topic, partition, offset
@@ -263,6 +282,7 @@ class ContractRegistryReducer:
         topic: str,
         partition: int,
         offset: int,
+        data_provenance: str = "unknown",
     ) -> ModelReducerOutput[ModelContractRegistryState]:
         """Handle contract registration - upsert contract and extract topics.
 
@@ -278,6 +298,7 @@ class ContractRegistryReducer:
             topic: Kafka topic.
             partition: Kafka partition.
             offset: Kafka offset.
+            data_provenance: Validated provenance value from event metadata.
 
         Returns:
             ModelReducerOutput with new state and PostgreSQL intents.
@@ -294,7 +315,9 @@ class ContractRegistryReducer:
         intents: list[ModelIntent] = []
 
         # Intent 1: Upsert contract record
-        upsert_intent = self._build_upsert_contract_intent(event, correlation_id)
+        upsert_intent = self._build_upsert_contract_intent(
+            event, correlation_id, data_provenance
+        )
         intents.append(upsert_intent)
 
         # Intent 2+: Extract and update topics from contract_yaml
@@ -588,12 +611,14 @@ class ContractRegistryReducer:
         self,
         event: ModelContractRegisteredEvent,
         correlation_id: UUID,
+        data_provenance: str = "unknown",
     ) -> ModelIntent:
         """Build PostgreSQL upsert intent for contract record.
 
         Args:
             event: Contract registered event with typed fields.
             correlation_id: Correlation ID for tracing.
+            data_provenance: Validated provenance value for the projection row.
 
         Returns:
             ModelIntent for postgres.upsert_contract.
@@ -612,6 +637,7 @@ class ContractRegistryReducer:
             contract_yaml=event.contract_yaml,
             source_node_id=str(event.source_node_id) if event.source_node_id else None,
             is_active=True,
+            data_provenance=data_provenance,
             registered_at=event.timestamp,
             last_seen_at=event.timestamp,
         )

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -2054,6 +2054,16 @@ pattern_exemptions:
       - docs/patterns/reducer_pattern.md
     ticket: OMN-1653
   - file_pattern: 'nodes/node_contract_registry_reducer/reducer\.py'
+    method_pattern: '_on_contract_registered'
+    violation_pattern: 'has 7 parameters'
+    reason: >
+      Extended reducer handler signature adding data_provenance (OMN-11201). The 7 parameters are: self, state (immutable input), event (typed domain event), Kafka position (topic/partition/offset) for idempotency, and data_provenance for projection tracking. This remains the canonical ONEX reducer handler pattern.
+
+    documentation:
+      - CLAUDE.md (Node Archetypes - NodeReducer)
+      - docs/patterns/reducer_pattern.md
+    ticket: OMN-11201
+  - file_pattern: 'nodes/node_contract_registry_reducer/reducer\.py'
     method_pattern: '_on_contract_deregistered'
     violation_pattern: 'has 6 parameters'
     reason: Same as _on_contract_registered - standard reducer handler signature.

--- a/tests/integration/projections/__init__.py
+++ b/tests/integration/projections/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/integration/projections/test_data_provenance_integration.py
+++ b/tests/integration/projections/test_data_provenance_integration.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for data_provenance plumbing (OMN-11201).
+
+The unit suite covers the reducer/router path with mocked deps. This
+integration test exercises the full chain that ships in PR 1639:
+
+- All three projection models (Contract, Topic, Registration) accept the
+  documented provenance vocabulary and default to "unknown".
+- The forward migration SQL declares the column with the expected vocab
+  CHECK constraint on all three target tables.
+- The migration vocab matches the model default — drift here means a
+  reducer write can succeed while a DB read rejects the row (or vice
+  versa).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.models.projection.model_contract_projection import (
+    ModelContractProjection,
+)
+from omnibase_infra.models.projection.model_registration_projection import (
+    ModelRegistrationProjection,
+)
+from omnibase_infra.models.projection.model_topic_projection import (
+    ModelTopicProjection,
+)
+
+pytestmark = pytest.mark.integration
+
+_VALID_VOCAB = (
+    "demo_seeded",
+    "demo_projected_shortcut",
+    "measured",
+    "estimated",
+    "unknown",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION_FILE = (
+    _REPO_ROOT
+    / "docker"
+    / "migrations"
+    / "forward"
+    / "078_add_data_provenance_to_projection_tables.sql"
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _contract(provenance: str = "unknown") -> ModelContractProjection:
+    return ModelContractProjection(
+        contract_id="integration-node:1.0.0",
+        node_name="integration-node",
+        version_major=1,
+        version_minor=0,
+        version_patch=0,
+        contract_hash="sha256:" + "a" * 64,
+        contract_yaml="name: integration-node\n",
+        registered_at=_now(),
+        last_seen_at=_now(),
+        is_active=True,
+        data_provenance=provenance,
+    )
+
+
+def test_contract_projection_accepts_every_documented_provenance_value() -> None:
+    for value in _VALID_VOCAB:
+        projection = _contract(provenance=value)
+        assert projection.data_provenance == value
+
+
+def test_contract_projection_defaults_to_unknown_when_provenance_omitted() -> None:
+    projection = ModelContractProjection(
+        contract_id="integration-default:1.0.0",
+        node_name="integration-default",
+        version_major=1,
+        version_minor=0,
+        version_patch=0,
+        contract_hash="sha256:" + "b" * 64,
+        contract_yaml="name: integration-default\n",
+        registered_at=_now(),
+        last_seen_at=_now(),
+        is_active=True,
+    )
+    assert projection.data_provenance == "unknown"
+
+
+def test_topic_projection_carries_provenance_field() -> None:
+    assert "data_provenance" in ModelTopicProjection.model_fields
+
+
+def test_registration_projection_carries_provenance_field() -> None:
+    assert "data_provenance" in ModelRegistrationProjection.model_fields
+
+
+def test_migration_declares_provenance_column_on_every_target_table() -> None:
+    """The forward migration must add data_provenance to all three tables."""
+    if not _MIGRATION_FILE.is_file():
+        pytest.skip(f"migration file not present at expected path: {_MIGRATION_FILE}")
+    sql = _MIGRATION_FILE.read_text(encoding="utf-8").lower()
+    for table in ("contracts", "topics", "registration_projections"):
+        assert table in sql, f"migration does not mention table {table!r}"
+    assert "data_provenance" in sql
+
+
+def test_migration_check_constraint_covers_full_vocabulary() -> None:
+    """The DB CHECK constraint must list the same vocab the model accepts."""
+    if not _MIGRATION_FILE.is_file():
+        pytest.skip(f"migration file not present at expected path: {_MIGRATION_FILE}")
+    sql = _MIGRATION_FILE.read_text(encoding="utf-8")
+    for value in _VALID_VOCAB:
+        assert value in sql, (
+            f"vocab value {value!r} missing from migration CHECK constraint; "
+            "model/DB drift will silently corrupt projection writes"
+        )

--- a/tests/unit/nodes/node_contract_registry_reducer/test_data_provenance_flow.py
+++ b/tests/unit/nodes/node_contract_registry_reducer/test_data_provenance_flow.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for data_provenance flow through contract registry reducer.
+
+Validates:
+- reducer extracts provenance from event_metadata and passes it to upsert payload
+- known provenance values are preserved; absent/unrecognised values fall back to "unknown"
+- router extracts provenance from envelope metadata tags into event_metadata
+
+Related Tickets:
+    - OMN-11201: data_provenance column migration and handler updates
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumReductionType, EnumStreamingMode
+from omnibase_core.models.events import ModelContractRegisteredEvent
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.nodes import ModelReducerOutput
+from omnibase_infra.event_bus.models.model_event_headers import ModelEventHeaders
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.nodes.node_contract_registry_reducer.contract_registration_event_router import (
+    ContractRegistrationEventRouter,
+)
+from omnibase_infra.nodes.node_contract_registry_reducer.models.model_contract_registry_state import (
+    ModelContractRegistryState,
+)
+from omnibase_infra.nodes.node_contract_registry_reducer.models.model_payload_upsert_contract import (
+    ModelPayloadUpsertContract,
+)
+from omnibase_infra.nodes.node_contract_registry_reducer.reducer import (
+    ContractRegistryReducer,
+)
+
+TEST_NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+VALID_PROVENANCE_VALUES = [
+    "demo_seeded",
+    "demo_projected_shortcut",
+    "measured",
+    "estimated",
+    "unknown",
+]
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_registered_event() -> ModelContractRegisteredEvent:
+    return ModelContractRegisteredEvent(
+        event_id=uuid4(),
+        correlation_id=uuid4(),
+        timestamp=TEST_NOW,
+        source_node_id=uuid4(),
+        node_name="test-node",
+        node_version=ModelSemVer(major=1, minor=0, patch=0),
+        contract_hash="abc123",
+        contract_yaml="name: test-node\nversion: 1.0.0",
+    )
+
+
+def _make_message(
+    event: ModelContractRegisteredEvent,
+    provenance: str | None = None,
+) -> ModelEventMessage:
+    tags: dict[str, str] = {}
+    if provenance is not None:
+        tags["data_provenance"] = provenance
+
+    envelope = ModelEventEnvelope(
+        envelope_id=uuid4(),
+        payload=event.model_dump(),
+        envelope_timestamp=TEST_NOW,
+        correlation_id=event.correlation_id,
+        source="test",
+        metadata={"tags": tags},  # type: ignore[arg-type]
+    )
+    payload_bytes = json.dumps(envelope.model_dump(mode="json")).encode("utf-8")
+    return ModelEventMessage(
+        topic="test.contract.events",
+        key=None,
+        value=payload_bytes,
+        headers=ModelEventHeaders(
+            source="test",
+            event_type="contract-registered",
+            correlation_id=envelope.correlation_id,
+            timestamp=TEST_NOW,
+        ),
+        offset="1",
+        partition=0,
+    )
+
+
+def _make_router(mock_reducer: MagicMock) -> ContractRegistrationEventRouter:
+    container = MagicMock()
+    upsert_handler = MagicMock()
+    upsert_handler.handle = AsyncMock(return_value=MagicMock(success=True))
+    return ContractRegistrationEventRouter(
+        container=container,
+        reducer=mock_reducer,
+        effect_handlers={"postgres.upsert_contract": upsert_handler},  # type: ignore[arg-type]
+        event_bus=None,
+        tick_interval_seconds=60,
+    )
+
+
+def _default_reducer_output() -> ModelReducerOutput[ModelContractRegistryState]:
+    return ModelReducerOutput(
+        result=ModelContractRegistryState(),
+        operation_id=uuid4(),
+        reduction_type=EnumReductionType.MERGE,
+        processing_time_ms=1.0,
+        items_processed=1,
+        conflicts_resolved=0,
+        streaming_mode=EnumStreamingMode.BATCH,
+        batches_processed=1,
+        intents=(),
+    )
+
+
+# =============================================================================
+# Reducer unit tests (pure function)
+# =============================================================================
+
+
+class TestReducerProvenanceExtraction:
+    """The reducer reads data_provenance from event_metadata and sets it on the upsert payload."""
+
+    def _call_on_contract_registered(
+        self,
+        reducer: ContractRegistryReducer,
+        event: ModelContractRegisteredEvent,
+        data_provenance: str,
+    ) -> Any:
+        state = ModelContractRegistryState()
+        metadata = {
+            "topic": "test.topic",
+            "partition": 0,
+            "offset": 1,
+            "data_provenance": data_provenance,
+        }
+        return reducer.reduce(state, event, metadata)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("provenance", VALID_PROVENANCE_VALUES)
+    def test_valid_provenance_preserved(self, provenance: str) -> None:
+        """All valid provenance values are propagated unchanged."""
+        reducer = ContractRegistryReducer()
+        event = _make_registered_event()
+        output = self._call_on_contract_registered(reducer, event, provenance)
+
+        upsert_intents = [
+            i
+            for i in output.intents
+            if isinstance(i.payload, ModelPayloadUpsertContract)
+        ]
+        assert len(upsert_intents) == 1
+        assert upsert_intents[0].payload.data_provenance == provenance  # type: ignore[union-attr]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["", "UNKNOWN", "random_string", "MEASURED", None],
+    )
+    def test_invalid_provenance_falls_back_to_unknown(
+        self, bad_value: str | None
+    ) -> None:
+        """Absent or unrecognised provenance values collapse to 'unknown'."""
+        reducer = ContractRegistryReducer()
+        event = _make_registered_event()
+        state = ModelContractRegistryState()
+        metadata: dict[str, Any] = {
+            "topic": "test.topic",
+            "partition": 0,
+            "offset": 1,
+        }
+        if bad_value is not None:
+            metadata["data_provenance"] = bad_value
+
+        output = reducer.reduce(state, event, metadata)
+
+        upsert_intents = [
+            i
+            for i in output.intents
+            if isinstance(i.payload, ModelPayloadUpsertContract)
+        ]
+        assert len(upsert_intents) == 1
+        assert upsert_intents[0].payload.data_provenance == "unknown"  # type: ignore[union-attr]
+
+    @pytest.mark.unit
+    def test_absent_provenance_key_falls_back_to_unknown(self) -> None:
+        """When data_provenance key is missing entirely from metadata, default is 'unknown'."""
+        reducer = ContractRegistryReducer()
+        event = _make_registered_event()
+        state = ModelContractRegistryState()
+        metadata: dict[str, Any] = {"topic": "test.topic", "partition": 0, "offset": 1}
+
+        output = reducer.reduce(state, event, metadata)
+
+        upsert_intents = [
+            i
+            for i in output.intents
+            if isinstance(i.payload, ModelPayloadUpsertContract)
+        ]
+        assert len(upsert_intents) == 1
+        assert upsert_intents[0].payload.data_provenance == "unknown"  # type: ignore[union-attr]
+
+
+# =============================================================================
+# Router unit tests — provenance extracted from envelope metadata tags
+# =============================================================================
+
+
+class TestRouterProvenanceExtraction:
+    """The router extracts data_provenance from envelope metadata tags."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.parametrize("provenance", VALID_PROVENANCE_VALUES)
+    async def test_router_passes_valid_provenance_to_reducer(
+        self, provenance: str
+    ) -> None:
+        """A valid data_provenance tag in the envelope is forwarded to reducer.reduce()."""
+        mock_reducer = MagicMock(spec=ContractRegistryReducer)
+        mock_reducer.reduce.return_value = _default_reducer_output()
+
+        router = _make_router(mock_reducer)
+        event = _make_registered_event()
+        message = _make_message(event, provenance=provenance)
+
+        await router.handle_message(message)
+
+        mock_reducer.reduce.assert_called_once()
+        _, _, event_metadata = mock_reducer.reduce.call_args[0]
+        assert event_metadata.get("data_provenance") == provenance
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_router_falls_back_to_unknown_when_tag_absent(self) -> None:
+        """When data_provenance tag is absent in the envelope, 'unknown' is forwarded."""
+        mock_reducer = MagicMock(spec=ContractRegistryReducer)
+        mock_reducer.reduce.return_value = _default_reducer_output()
+
+        router = _make_router(mock_reducer)
+        event = _make_registered_event()
+        message = _make_message(event, provenance=None)
+
+        await router.handle_message(message)
+
+        mock_reducer.reduce.assert_called_once()
+        _, _, event_metadata = mock_reducer.reduce.call_args[0]
+        assert event_metadata.get("data_provenance") == "unknown"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_router_falls_back_to_unknown_for_invalid_tag(self) -> None:
+        """An unrecognised data_provenance tag value is normalised to 'unknown'."""
+        mock_reducer = MagicMock(spec=ContractRegistryReducer)
+        mock_reducer.reduce.return_value = _default_reducer_output()
+
+        router = _make_router(mock_reducer)
+        event = _make_registered_event()
+        message = _make_message(event, provenance="INVALID_VALUE")
+
+        await router.handle_message(message)
+
+        mock_reducer.reduce.assert_called_once()
+        _, _, event_metadata = mock_reducer.reduce.call_args[0]
+        assert event_metadata.get("data_provenance") == "unknown"
+
+
+# =============================================================================
+# Projection model tests
+# =============================================================================
+
+
+class TestProjectionModelDefaults:
+    """Projection models carry data_provenance with a default of 'unknown'."""
+
+    @pytest.mark.unit
+    def test_contract_projection_default_provenance(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.models.projection.model_contract_projection import (
+            ModelContractProjection,
+        )
+
+        now = datetime.now(UTC)
+        proj = ModelContractProjection(
+            contract_id="test-node:1.0.0",
+            node_name="test-node",
+            version_major=1,
+            version_minor=0,
+            version_patch=0,
+            contract_hash="abc",
+            contract_yaml="name: test-node",
+            registered_at=now,
+            last_seen_at=now,
+            is_active=True,
+        )
+        assert proj.data_provenance == "unknown"
+
+    @pytest.mark.unit
+    def test_contract_projection_explicit_provenance(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.models.projection.model_contract_projection import (
+            ModelContractProjection,
+        )
+
+        now = datetime.now(UTC)
+        proj = ModelContractProjection(
+            contract_id="test-node:1.0.0",
+            node_name="test-node",
+            version_major=1,
+            version_minor=0,
+            version_patch=0,
+            contract_hash="abc",
+            contract_yaml="name: test-node",
+            registered_at=now,
+            last_seen_at=now,
+            is_active=True,
+            data_provenance="measured",
+        )
+        assert proj.data_provenance == "measured"
+
+    @pytest.mark.unit
+    def test_topic_projection_default_provenance(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_infra.models.projection.model_topic_projection import (
+            ModelTopicProjection,
+        )
+
+        now = datetime.now(UTC)
+        proj = ModelTopicProjection(
+            topic_suffix="onex.evt.test.v1",
+            direction="publish",
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+        assert proj.data_provenance == "unknown"
+
+    @pytest.mark.unit
+    def test_registration_projection_default_provenance(self) -> None:
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from omnibase_core.enums import EnumNodeKind
+        from omnibase_infra.enums import EnumRegistrationState
+        from omnibase_infra.models.projection.model_registration_projection import (
+            ModelRegistrationProjection,
+        )
+
+        now = datetime.now(UTC)
+        proj = ModelRegistrationProjection(
+            entity_id=uuid4(),
+            current_state=EnumRegistrationState.ACTIVE,
+            node_type=EnumNodeKind.EFFECT,
+            last_applied_event_id=uuid4(),
+            registered_at=now,
+            updated_at=now,
+        )
+        assert proj.data_provenance == "unknown"
+
+
+__all__: list[str] = [
+    "TestReducerProvenanceExtraction",
+    "TestRouterProvenanceExtraction",
+    "TestProjectionModelDefaults",
+]


### PR DESCRIPTION
## Summary

- Migration 078 adds `data_provenance TEXT NOT NULL DEFAULT 'unknown'` with CHECK constraints to `contracts`, `topics`, and `registration_projections` tables
- Valid provenance vocab: `demo_seeded`, `demo_projected_shortcut`, `measured`, `estimated`, `unknown`
- Provenance flows from Kafka envelope metadata tags → router `event_metadata` → reducer → `ModelPayloadUpsertContract` → SQL upsert handler; absent/unrecognised values normalise to `unknown`
- Three projection models (`ModelContractProjection`, `ModelTopicProjection`, `ModelRegistrationProjection`) gain `data_provenance: str = Field(default="unknown")`
- 22 unit tests cover: all valid values preserved, bad/absent values fallback, router tag extraction, projection model defaults

## Test plan

- [x] `uv run pytest tests/unit/nodes/node_contract_registry_reducer/test_data_provenance_flow.py -v` — 22/22 passed
- [x] `uv run pytest tests/unit/nodes/ -q` — 3262 passed, 0 failures
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — all checks passed
- [x] `uv run pre-commit run --all-files` — all hooks passed (pre-existing F601 violations in scripts/ are unrelated)
- [x] mypy passed on push

## Ticket

OMN-11201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projection records now include data provenance (demo_seeded, demo_projected_shortcut, measured, estimated, unknown) so projections record their origin and default to "unknown".
* **Tests**
  * Added unit and integration tests validating provenance extraction, propagation, normalization to "unknown", model defaults, and migration coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11201
