### PR TITLE
feat(OMN-11198): add /v1/introspection/manifest endpoint (internal only)

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2255,6 +2255,7 @@ async def bootstrap() -> int:
         auto_wiring_report = None
         claimed_topic_patterns: set[str] = set()
         auto_wiring_manifest_for_subscriptions = None
+        auto_wiring_manifest_discovered = None  # OMN-11198: full discovery result
         lifecycle_executor = None
         try:
             from omnibase_infra.runtime.auto_wiring import (
@@ -2268,6 +2269,9 @@ async def bootstrap() -> int:
             # 1. Discover all contracts from installed packages
             auto_wiring_start = time.time()
             manifest = discover_contracts()
+            auto_wiring_manifest_discovered = (
+                manifest  # OMN-11198: captured for introspection
+            )
             logger.info(
                 "Auto-wiring discovery: %d contracts found, %d errors "
                 "(correlation_id=%s)",
@@ -2823,6 +2827,17 @@ async def bootstrap() -> int:
                     exc_info=True,
                 )
         health_server.attach_runtime(runtime)
+
+        # OMN-11198: Expose the auto-wiring manifest on /v1/introspection/manifest.
+        # Prefer the filtered manifest (actual subscriptions); fall back to the full
+        # discovery result when filtering was skipped.
+        _introspection_manifest = (
+            auto_wiring_manifest_for_subscriptions
+            if auto_wiring_manifest_for_subscriptions is not None
+            else auto_wiring_manifest_discovered
+        )
+        if _introspection_manifest is not None:
+            health_server.attach_manifest(_introspection_manifest)
 
         # 7. Setup graceful shutdown
         shutdown_event = asyncio.Event()

--- a/src/omnibase_infra/services/service_health.py
+++ b/src/omnibase_infra/services/service_health.py
@@ -12,6 +12,7 @@ The service exposes:
     - GET /health: Returns runtime liveness status as JSON (process alive)
     - GET /ready: Returns runtime readiness status as JSON (can serve traffic)
     - GET /health/detailed: Returns verbose per-component diagnostics (OMN-519)
+    - GET /v1/introspection/manifest: Returns auto-wiring manifest JSON (OMN-11198)
 
 Configuration:
     ONEX_HTTP_PORT: Port to listen on (default: 8085)
@@ -96,6 +97,9 @@ from omnibase_infra.utils.correlation import generate_correlation_id
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
+    from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+        ModelAutoWiringManifest,
+    )
     from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
 
 logger = logging.getLogger(__name__)
@@ -304,6 +308,9 @@ class ServiceHealth:
         self._site: web.TCPSite | None = None
         self._is_running: bool = False
 
+        # OMN-11198: Manifest attached after startup for introspection endpoint
+        self._manifest: ModelAutoWiringManifest | None = None
+
         # OMN-519: Track last successful health check timestamps per component
         self._last_healthy_timestamps: dict[str, str] = {}
         # Track health phase transitions so frequent probes do not flood logs.
@@ -418,6 +425,15 @@ class ServiceHealth:
         self._runtime = runtime
         logger.info(
             "ServiceHealth attached runtime after early startup",
+            extra={"port": self._port, "host": self._host},
+        )
+
+    def attach_manifest(self, manifest: ModelAutoWiringManifest) -> None:
+        """Attach the auto-wiring manifest for the introspection endpoint (OMN-11198)."""
+        self._manifest = manifest
+        logger.info(
+            "ServiceHealth attached manifest (%d contracts)",
+            manifest.total_discovered,
             extra={"port": self._port, "host": self._host},
         )
 
@@ -679,6 +695,10 @@ class ServiceHealth:
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             # OMN-10860: Skill dispatch endpoint
             self._app.router.add_post("/skill", self._handle_skill)
+            # OMN-11198: Manifest introspection endpoint (internal only)
+            self._app.router.add_get(
+                "/v1/introspection/manifest", self._handle_introspection_manifest
+            )
 
             # Create and start runner
             self._runner = web.AppRunner(self._app)
@@ -700,7 +720,13 @@ class ServiceHealth:
                 extra={
                     "host": self._host,
                     "port": self._port,
-                    "endpoints": ["/health", "/ready", "/health/detailed", "/skill"],
+                    "endpoints": [
+                        "/health",
+                        "/ready",
+                        "/health/detailed",
+                        "/skill",
+                        "/v1/introspection/manifest",
+                    ],
                     "version": self._version,
                 },
             )
@@ -1512,6 +1538,33 @@ class ServiceHealth:
                 status=503,
                 content_type="application/json",
             )
+
+    async def _handle_introspection_manifest(
+        self, request: web.Request
+    ) -> web.Response:
+        """Handle GET /v1/introspection/manifest (internal only, OMN-11198).
+
+        Returns the auto-wiring manifest as JSON so operators can inspect which
+        contracts were discovered at startup without SSHing into the container.
+
+        HTTP Status Codes:
+            - 200: Manifest is available; body is the full manifest JSON.
+            - 503: Manifest not yet built (startup not complete).
+        """
+        _ = request
+
+        if self._manifest is None:
+            return web.Response(
+                text='{"error": "manifest not yet built", "status": "starting"}',
+                status=503,
+                content_type="application/json",
+            )
+
+        return web.Response(
+            text=self._manifest.model_dump_json(),
+            status=200,
+            content_type="application/json",
+        )
 
 
 __all__: list[str] = ["DEFAULT_HTTP_HOST", "DEFAULT_HTTP_PORT", "ServiceHealth"]

--- a/tests/integration/services/test_introspection_endpoint_integration.py
+++ b/tests/integration/services/test_introspection_endpoint_integration.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for /v1/introspection/manifest (OMN-11198).
+
+The unit suite covers the in-process handler with a mocked runtime; this
+integration test boots a real aiohttp web.Application against the
+ServiceHealth router with a real ModelAutoWiringManifest attached and
+exercises the HTTP surface end-to-end. The goal is to prove that attach
++ route registration + JSON serialization wire together without crash
+and that the 503 -> 200 transition matches the contract described in
+the OMN-11198 ticket.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+    ModelAutoWiringManifest,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
+    ModelContractVersion,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_discovered_contract import (
+    ModelDiscoveredContract,
+)
+from omnibase_infra.services.service_health import ServiceHealth
+
+pytestmark = pytest.mark.integration
+
+
+def _make_manifest(contract_count: int = 2) -> ModelAutoWiringManifest:
+    contracts = tuple(
+        ModelDiscoveredContract(
+            name=f"integration_contract_{i}",
+            node_type="EFFECT_GENERIC",
+            contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+            contract_path=Path(f"/fake/integration/{i}/contract.yaml"),
+            entry_point_name=f"integration_contract_{i}",
+            package_name=f"integration_pkg_{i}",
+        )
+        for i in range(contract_count)
+    )
+    return ModelAutoWiringManifest(contracts=contracts)
+
+
+def _build_service(manifest: ModelAutoWiringManifest | None) -> ServiceHealth:
+    runtime = MagicMock()
+    service = ServiceHealth(runtime=runtime, port=0)
+    if manifest is not None:
+        service.attach_manifest(manifest)
+    return service
+
+
+def _build_app(service: ServiceHealth) -> web.Application:
+    app = web.Application()
+    app.router.add_get(
+        "/v1/introspection/manifest",
+        service._handle_introspection_manifest,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_introspection_returns_503_before_attach_manifest() -> None:
+    service = _build_service(manifest=None)
+    app = _build_app(service)
+    async with TestServer(app) as server, TestClient(server) as client:
+        response = await client.get("/v1/introspection/manifest")
+        assert response.status == 503
+        body = json.loads(await response.text())
+        assert body["status"] == "starting"
+
+
+@pytest.mark.asyncio
+async def test_introspection_returns_200_after_attach_manifest() -> None:
+    service = _build_service(manifest=_make_manifest(contract_count=2))
+    app = _build_app(service)
+    async with TestServer(app) as server, TestClient(server) as client:
+        response = await client.get("/v1/introspection/manifest")
+        assert response.status == 200
+        body = json.loads(await response.text())
+        names = {c["name"] for c in body["contracts"]}
+        assert names == {"integration_contract_0", "integration_contract_1"}
+
+
+@pytest.mark.asyncio
+async def test_introspection_serves_attached_manifest_contents() -> None:
+    """The JSON body must exactly mirror the attached manifest."""
+    manifest = _make_manifest(contract_count=3)
+    service = _build_service(manifest=manifest)
+    app = _build_app(service)
+    async with TestServer(app) as server, TestClient(server) as client:
+        response = await client.get("/v1/introspection/manifest")
+        assert response.status == 200
+        body = json.loads(await response.text())
+        expected = json.loads(manifest.model_dump_json())
+        assert body == expected

--- a/tests/unit/runtime/test_introspection_router.py
+++ b/tests/unit/runtime/test_introspection_router.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for GET /v1/introspection/manifest endpoint (OMN-11198)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.models.model_auto_wiring_manifest import (
+    ModelAutoWiringManifest,
+)
+from omnibase_infra.services.service_health import ServiceHealth
+
+
+def _make_manifest(contract_count: int = 2) -> ModelAutoWiringManifest:
+    """Build a minimal ModelAutoWiringManifest for testing."""
+    from pathlib import Path
+
+    from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
+        ModelContractVersion,
+    )
+    from omnibase_infra.runtime.auto_wiring.models.model_discovered_contract import (
+        ModelDiscoveredContract,
+    )
+
+    contracts = tuple(
+        ModelDiscoveredContract(
+            name=f"test_contract_{i}",
+            node_type="EFFECT_GENERIC",
+            contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+            contract_path=Path(f"/fake/path/{i}/contract.yaml"),
+            entry_point_name=f"test_contract_{i}",
+            package_name=f"pkg_{i}",
+        )
+        for i in range(contract_count)
+    )
+    return ModelAutoWiringManifest(contracts=contracts)
+
+
+@pytest.mark.unit
+class TestIntrospectionManifestEndpoint:
+    """Tests for GET /v1/introspection/manifest on ServiceHealth."""
+
+    @pytest.mark.asyncio
+    async def test_returns_503_when_manifest_not_attached(self) -> None:
+        """Returns 503 if attach_manifest() was never called (startup not complete)."""
+        mock_runtime = MagicMock()
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        mock_request = MagicMock()
+        response = await server._handle_introspection_manifest(mock_request)
+
+        assert response.status == 503
+        body = json.loads(response.text)
+        assert body["status"] == "starting"
+
+    @pytest.mark.asyncio
+    async def test_returns_200_with_manifest_json_when_attached(self) -> None:
+        """Returns 200 with full manifest JSON after attach_manifest() is called."""
+        mock_runtime = MagicMock()
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        manifest = _make_manifest(contract_count=2)
+        server.attach_manifest(manifest)
+
+        mock_request = MagicMock()
+        response = await server._handle_introspection_manifest(mock_request)
+
+        assert response.status == 200
+        assert response.content_type == "application/json"
+        body = json.loads(response.text)
+        assert "contracts" in body
+        assert len(body["contracts"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_manifest_json_contains_contract_names(self) -> None:
+        """Returned JSON includes the contract names from the attached manifest."""
+        mock_runtime = MagicMock()
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        manifest = _make_manifest(contract_count=1)
+        server.attach_manifest(manifest)
+
+        mock_request = MagicMock()
+        response = await server._handle_introspection_manifest(mock_request)
+
+        body = json.loads(response.text)
+        contract_names = [c["name"] for c in body["contracts"]]
+        assert "test_contract_0" in contract_names
+
+    @pytest.mark.asyncio
+    async def test_attach_manifest_replaces_previous(self) -> None:
+        """Calling attach_manifest() a second time replaces the prior manifest."""
+        mock_runtime = MagicMock()
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        server.attach_manifest(_make_manifest(contract_count=1))
+        server.attach_manifest(_make_manifest(contract_count=3))
+
+        mock_request = MagicMock()
+        response = await server._handle_introspection_manifest(mock_request)
+
+        body = json.loads(response.text)
+        assert len(body["contracts"]) == 3
+
+    def test_attach_manifest_stores_reference(self) -> None:
+        """attach_manifest() stores the manifest on _manifest attribute."""
+        mock_runtime = MagicMock()
+        server = ServiceHealth(runtime=mock_runtime, port=0)
+
+        assert server._manifest is None
+        manifest = _make_manifest()
+        server.attach_manifest(manifest)
+        assert server._manifest is manifest


### PR DESCRIPTION
## Summary

- Adds `GET /v1/introspection/manifest` on the internal health port (:8085)
- Returns the auto-wiring manifest (discovered contracts) as JSON after startup completes
- Returns 503 with `{"status": "starting"}` if the manifest has not yet been built
- Wired via `attach_manifest()` on `ServiceHealth`, called from `service_kernel.py` after contract discovery finishes; falls back to raw discovery result if the filtered manifest was not produced
- Endpoint is on the internal port only — not exposed through the public gateway

Closes OMN-11198

## Test plan

- [x] `test_returns_503_when_manifest_not_attached` — 503 before attach_manifest()
- [x] `test_returns_200_with_manifest_json_when_attached` — 200 with full manifest JSON
- [x] `test_manifest_json_contains_contract_names` — contract names present in response
- [x] `test_attach_manifest_replaces_previous` — second attach replaces first
- [x] `test_attach_manifest_stores_reference` — attribute stored correctly
- [x] All pre-commit hooks pass; mypy passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/v1/introspection/manifest` endpoint to expose service contract discovery information during runtime.
  * Health server now preserves and serves auto-wiring contract manifests.

* **Tests**
  * Added comprehensive unit tests for the new introspection endpoint, covering manifest availability scenarios and data integrity validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11198
