### PR TITLE
feat(OMN-11200): add projection freshness SLA monitor

### DIFF
--- a/contracts/OMN-11200.yaml
+++ b/contracts/OMN-11200.yaml
@@ -1,0 +1,28 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11200"
+title: "Projection freshness SLA monitor"
+summary: >
+  Add ServiceFreshnessMonitor that periodically checks each declared ModelProjectionContract against MAX(freshness_field) FROM freshness_source_table and emits ModelProjectionDegradedEvent / ModelProjectionRecoveredEvent as freshness state transitions occur. Includes projection contract registry for contract_registry, topic_registry, and registration projections.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "All 15 unit tests pass covering detection, degradation, recovery, dedup, skip, and lifecycle."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_freshness_monitor.py -v"
+  - id: "dod-deploy"
+    description: >
+      Runtime deploy: after merging, rebuild omninode-runtime image on 192.168.86.201. ServiceFreshnessMonitor imports cleanly and freshness topics resolve.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-runtime python -c 'from omnibase_infra.runtime.freshness_monitor import ServiceFreshnessMonitor; print(\"freshness monitor available\")'"

--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -327,6 +327,8 @@ _LEGACY_ALLOWLIST: dict[str, str] = {
     # --- omnibase-infra service-level topics (emitted by services, not nodes) ---
     "onex.evt.omnibase-infra.wiring-health-snapshot.v1": "emitted by WiringHealthChecker service; no contract.yaml node needed — service-level emission | owner: jonah | expiry: 2026-09-01",
     "onex.evt.omnibase-infra.runtime-health-check.v1": "emitted by ServiceRuntimeHealthMonitor; no contract.yaml node needed — service-level emission | owner: jonah | expiry: 2026-09-01",
+    "onex.evt.omnibase-infra.projection-freshness-degraded.v1": "OMN-11200; emitted by ServiceFreshnessMonitor; no contract.yaml node needed — service-level emission | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omnibase-infra.projection-freshness-recovered.v1": "OMN-11200; emitted by ServiceFreshnessMonitor; no contract.yaml node needed — service-level emission | owner: jonah | expiry: 2026-12-01",
     # --- platform/cross-cutting topics ---
     "onex.evt.omnibase-infra.circuit-breaker.v1": "new topic (OMN-5293); publisher-only, no node contract.yaml yet | owner: jonah | expiry: 2026-09-01",
     "onex.evt.omnibase-infra.runtime-error.v1": "new topic (OMN-5649); emitted by monitor_logs.py RuntimeErrorEmitter; contract.yaml added in OMN-5650 | owner: jonah | expiry: 2026-09-01",

--- a/src/omnibase_infra/models/health/model_projection_degraded_event.py
+++ b/src/omnibase_infra/models/health/model_projection_degraded_event.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelProjectionDegradedEvent — emitted when a projection breaches its freshness SLA."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelProjectionDegradedEvent(BaseModel):
+    """Emitted when a projection's staleness exceeds its declared SLA."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_name: str = Field(..., min_length=1)
+    sla_seconds: int = Field(..., gt=0)
+    actual_staleness_seconds: float = Field(..., ge=0)
+    degraded_behavior: str = Field(..., min_length=1)
+    observed_at: datetime = Field(...)
+    source_contract_hash: str = Field(..., min_length=1)
+
+
+__all__: list[str] = ["ModelProjectionDegradedEvent"]

--- a/src/omnibase_infra/models/health/model_projection_recovered_event.py
+++ b/src/omnibase_infra/models/health/model_projection_recovered_event.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelProjectionRecoveredEvent — emitted when a degraded projection returns within SLA."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelProjectionRecoveredEvent(BaseModel):
+    """Emitted when a previously-degraded projection returns within its SLA."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_name: str = Field(..., min_length=1)
+    sla_seconds: int = Field(..., gt=0)
+    actual_staleness_seconds: float = Field(..., ge=0)
+    observed_at: datetime = Field(...)
+    source_contract_hash: str = Field(..., min_length=1)
+
+
+__all__: list[str] = ["ModelProjectionRecoveredEvent"]

--- a/src/omnibase_infra/runtime/freshness_monitor.py
+++ b/src/omnibase_infra/runtime/freshness_monitor.py
@@ -27,14 +27,14 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
-from omnibase_core.models.projection.model_projection_contract import (
-    ModelProjectionContract,
-)
 from omnibase_infra.models.health.model_projection_degraded_event import (
     ModelProjectionDegradedEvent,
 )
 from omnibase_infra.models.health.model_projection_recovered_event import (
     ModelProjectionRecoveredEvent,
+)
+from omnibase_infra.models.projection.model_projection_contract import (
+    ModelProjectionContract,
 )
 from omnibase_infra.topics import topic_keys
 from omnibase_infra.utils.correlation import generate_correlation_id
@@ -200,7 +200,7 @@ class ServiceFreshnessMonitor:
                     projection_name=contract.projection_name,
                     sla_seconds=contract.freshness_sla_seconds,
                     actual_staleness_seconds=staleness,
-                    degraded_behavior=str(contract.degraded_semantics),
+                    degraded_behavior=contract.degraded_semantics.value,
                     observed_at=now,
                     source_contract_hash=contract_hash,
                 )

--- a/src/omnibase_infra/runtime/freshness_monitor.py
+++ b/src/omnibase_infra/runtime/freshness_monitor.py
@@ -141,10 +141,7 @@ class ServiceFreshnessMonitor:
         self._running = False
         if self._task is not None:
             self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
+            await asyncio.gather(self._task, return_exceptions=True)
             self._task = None
         logger.info("ServiceFreshnessMonitor stopped")
 
@@ -244,8 +241,6 @@ class ServiceFreshnessMonitor:
             try:
                 await asyncio.sleep(self._check_interval)
                 await self.run_once()
-            except asyncio.CancelledError:
-                break
             except Exception:  # noqa: BLE001 — never crash the loop
                 logger.warning(
                     "ServiceFreshnessMonitor loop iteration failed (will retry in %ds)",

--- a/src/omnibase_infra/runtime/freshness_monitor.py
+++ b/src/omnibase_infra/runtime/freshness_monitor.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Projection freshness SLA monitor (OMN-11200).
+
+Periodically checks each declared ModelProjectionContract against a database
+clock and emits ModelProjectionDegradedEvent or ModelProjectionRecoveredEvent
+as freshness state transitions occur.
+
+Rules:
+- Freshness is determined solely by querying MAX({freshness_field}) FROM
+  {freshness_source_table}. Never infer from arbitrary timestamp columns.
+- If freshness_field or freshness_source_table is absent: state is UNKNOWN,
+  skip the contract.
+- Degraded → Recovered transitions emit a recovery event.
+- Duplicate events are suppressed: one degraded event per breach, one recovery
+  per resolution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.projection.model_projection_contract import (
+    ModelProjectionContract,
+)
+from omnibase_infra.models.health.model_projection_degraded_event import (
+    ModelProjectionDegradedEvent,
+)
+from omnibase_infra.models.health.model_projection_recovered_event import (
+    ModelProjectionRecoveredEvent,
+)
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.utils.correlation import generate_correlation_id
+
+if TYPE_CHECKING:
+    from omnibase_infra.protocols.protocol_event_bus_like import ProtocolEventBusLike
+    from omnibase_infra.protocols.protocol_topic_registry import ProtocolTopicRegistry
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL: float = 60.0
+
+_FreshnessPayload = ModelProjectionDegradedEvent | ModelProjectionRecoveredEvent
+
+# Type alias for the async DB query callable injected by callers / tests.
+# Signature: (table, field) -> datetime | None
+QueryFn = Callable[[str, str], Coroutine[None, None, datetime | None]]
+
+
+def _contract_hash(contract: ModelProjectionContract) -> str:
+    """Return a short deterministic hash of the contract's identity fields."""
+    payload = json.dumps(
+        {
+            "name": contract.projection_name,
+            "table": contract.freshness_source_table,
+            "field": contract.freshness_field,
+            "sla": contract.freshness_sla_seconds,
+        },
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+class ServiceFreshnessMonitor:
+    """Periodic projection freshness SLA monitor.
+
+    Usage::
+
+        async def query(table: str, field: str) -> datetime | None:
+            row = await db.fetchrow(f"SELECT MAX({field}) FROM {table}")
+            return row[0] if row else None
+
+        monitor = ServiceFreshnessMonitor(
+            contracts=PROJECTION_CONTRACTS,
+            query_fn=query,
+            event_bus=bus,
+        )
+        await monitor.start()
+        ...
+        await monitor.stop()
+    """
+
+    def __init__(
+        self,
+        contracts: tuple[ModelProjectionContract, ...],
+        query_fn: QueryFn,
+        event_bus: ProtocolEventBusLike | None = None,
+        check_interval_seconds: float = _DEFAULT_INTERVAL,
+        topic_registry: ProtocolTopicRegistry | None = None,
+    ) -> None:
+        if check_interval_seconds <= 0:
+            raise ValueError(
+                f"check_interval_seconds must be positive, got {check_interval_seconds}"
+            )
+
+        self._contracts = contracts
+        self._query_fn = query_fn
+        self._event_bus = event_bus
+        self._check_interval = check_interval_seconds
+        self._degraded: set[str] = set()
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+        if topic_registry is None:
+            from omnibase_infra.topics.service_topic_registry import (
+                ServiceTopicRegistry,
+            )
+
+            topic_registry = ServiceTopicRegistry.from_defaults()
+
+        self._topic_degraded = topic_registry.resolve(
+            topic_keys.PROJECTION_FRESHNESS_DEGRADED
+        )
+        self._topic_recovered = topic_registry.resolve(
+            topic_keys.PROJECTION_FRESHNESS_RECOVERED
+        )
+
+    async def start(self) -> None:
+        """Start the background check loop. Idempotent."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop(), name="freshness-monitor")
+        logger.info(
+            "ServiceFreshnessMonitor started (contracts=%d interval=%ds)",
+            len(self._contracts),
+            int(self._check_interval),
+        )
+
+    async def stop(self) -> None:
+        """Stop the background check loop. Idempotent."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("ServiceFreshnessMonitor stopped")
+
+    async def run_once(
+        self,
+    ) -> list[_FreshnessPayload]:
+        """Run a single check cycle across all contracts.
+
+        Returns:
+            All events emitted during this cycle (degraded + recovered), in
+            the order they were produced.
+        """
+        now = datetime.now(UTC)
+        emitted: list[_FreshnessPayload] = []
+
+        for contract in self._contracts:
+            if not contract.freshness_field or not contract.freshness_source_table:
+                logger.debug(
+                    "Freshness monitor: skipping %s (no freshness_field or "
+                    "freshness_source_table declared)",
+                    contract.projection_name,
+                )
+                continue
+
+            contract_hash = _contract_hash(contract)
+            try:
+                max_ts = await self._query_fn(
+                    contract.freshness_source_table, contract.freshness_field
+                )
+            except Exception:  # noqa: BLE001 — boundary; never crash the loop
+                logger.warning(
+                    "Freshness monitor: query failed for %s (will retry next cycle)",
+                    contract.projection_name,
+                    exc_info=True,
+                )
+                continue
+
+            if max_ts is None:
+                logger.debug(
+                    "Freshness monitor: %s returned NULL — no rows yet, skipping",
+                    contract.projection_name,
+                )
+                continue
+
+            # Ensure max_ts is timezone-aware for arithmetic.
+            if max_ts.tzinfo is None:
+                max_ts = max_ts.replace(tzinfo=UTC)
+
+            staleness = (now - max_ts).total_seconds()
+            is_stale = staleness > contract.freshness_sla_seconds
+            was_degraded = contract.projection_name in self._degraded
+
+            if is_stale and not was_degraded:
+                self._degraded.add(contract.projection_name)
+                event: _FreshnessPayload = ModelProjectionDegradedEvent(
+                    projection_name=contract.projection_name,
+                    sla_seconds=contract.freshness_sla_seconds,
+                    actual_staleness_seconds=staleness,
+                    degraded_behavior=str(contract.degraded_semantics),
+                    observed_at=now,
+                    source_contract_hash=contract_hash,
+                )
+                logger.warning(
+                    "Projection %s is stale: staleness=%.1fs sla=%ds behavior=%s",
+                    contract.projection_name,
+                    staleness,
+                    contract.freshness_sla_seconds,
+                    contract.degraded_semantics,
+                )
+                await self._emit(event, self._topic_degraded)
+                emitted.append(event)
+
+            elif not is_stale and was_degraded:
+                self._degraded.discard(contract.projection_name)
+                recovered_event = ModelProjectionRecoveredEvent(
+                    projection_name=contract.projection_name,
+                    sla_seconds=contract.freshness_sla_seconds,
+                    actual_staleness_seconds=staleness,
+                    observed_at=now,
+                    source_contract_hash=contract_hash,
+                )
+                logger.info(
+                    "Projection %s recovered: staleness=%.1fs sla=%ds",
+                    contract.projection_name,
+                    staleness,
+                    contract.freshness_sla_seconds,
+                )
+                await self._emit(recovered_event, self._topic_recovered)
+                emitted.append(recovered_event)
+
+        return emitted
+
+    # -- Internal ----------------------------------------------------------------
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await asyncio.sleep(self._check_interval)
+                await self.run_once()
+            except asyncio.CancelledError:
+                break
+            except Exception:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "ServiceFreshnessMonitor loop iteration failed (will retry in %ds)",
+                    int(self._check_interval),
+                    exc_info=True,
+                )
+
+    async def _emit(
+        self,
+        event: _FreshnessPayload,
+        topic: str,
+    ) -> None:
+        if self._event_bus is None:
+            return
+        event_type = (
+            "projection-freshness-degraded"
+            if isinstance(event, ModelProjectionDegradedEvent)
+            else "projection-freshness-recovered"
+        )
+        envelope: ModelEventEnvelope[_FreshnessPayload] = ModelEventEnvelope(
+            payload=event,
+            correlation_id=generate_correlation_id(),
+            event_type=event_type,
+            source_tool="ServiceFreshnessMonitor",
+        )
+        try:
+            await self._event_bus.publish_envelope(envelope=envelope, topic=topic)
+        except Exception:
+            logger.exception(
+                "ServiceFreshnessMonitor: failed to emit %s for %s",
+                event_type,
+                event.projection_name,
+            )
+
+
+__all__: list[str] = ["ServiceFreshnessMonitor"]

--- a/src/omnibase_infra/topics/service_topic_registry.py
+++ b/src/omnibase_infra/topics/service_topic_registry.py
@@ -150,6 +150,13 @@ class ServiceTopicRegistry:
             topic_keys.RUNTIME_HEALTH_CHECK: (
                 "onex.evt.omnibase-infra.runtime-health-check.v1"
             ),
+            # Projection freshness SLA monitoring
+            topic_keys.PROJECTION_FRESHNESS_DEGRADED: (
+                "onex.evt.omnibase-infra.projection-freshness-degraded.v1"
+            ),
+            topic_keys.PROJECTION_FRESHNESS_RECOVERED: (
+                "onex.evt.omnibase-infra.projection-freshness-recovered.v1"
+            ),
             # Runtime error
             topic_keys.RUNTIME_ERROR: ("onex.evt.omnibase-infra.runtime-error.v1"),
             topic_keys.ERROR_TRIAGED: ("onex.evt.omnibase-infra.error-triaged.v1"),

--- a/src/omnibase_infra/topics/topic_keys.py
+++ b/src/omnibase_infra/topics/topic_keys.py
@@ -165,6 +165,12 @@ CONSUMER_RESTART_CMD: Final[str] = "CONSUMER_RESTART_CMD"
 RUNTIME_HEALTH_CHECK: Final[str] = "RUNTIME_HEALTH_CHECK"
 """Runtime health check events from ServiceRuntimeHealthMonitor."""
 
+PROJECTION_FRESHNESS_DEGRADED: Final[str] = "PROJECTION_FRESHNESS_DEGRADED"
+"""Projection freshness SLA breach events from ServiceFreshnessMonitor."""
+
+PROJECTION_FRESHNESS_RECOVERED: Final[str] = "PROJECTION_FRESHNESS_RECOVERED"
+"""Projection freshness recovery events from ServiceFreshnessMonitor."""
+
 # ==============================================================================
 # Runtime Error Topics
 # ==============================================================================
@@ -266,6 +272,8 @@ __all__: list[str] = [
     "CONSUMER_HEALTH",
     "CONSUMER_RESTART_CMD",
     "DISPATCH_OUTCOME_EVALUATED",
+    "PROJECTION_FRESHNESS_DEGRADED",
+    "PROJECTION_FRESHNESS_RECOVERED",
     "EFFECTIVENESS_INVALIDATION",
     "ERROR_TRIAGED",
     "EVAL_COMPLETED",

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -754,6 +754,33 @@ pattern_exemptions:
     documentation:
       - CLAUDE.md (File & Class Naming - Service convention)
     ticket: OMN-1135
+  - file_pattern: 'freshness_monitor\.py'
+    class_pattern: "Class name 'ServiceFreshnessMonitor'"
+    violation_pattern: "contains anti-pattern 'Service'"
+    reason: >
+      Follows CLAUDE.md Service<Name> naming convention for service classes. Service files use service_<name>.py with Service<Name> class names.
+
+    documentation:
+      - CLAUDE.md (File & Class Naming - Service convention)
+    ticket: OMN-11200
+  - file_pattern: 'model_projection_degraded_event\.py'
+    field_pattern: "Field 'projection_name'"
+    violation_pattern: "might reference an entity"
+    reason: >
+      projection_name is the canonical name of a projection contract (e.g. "contract_registry"), not an entity reference. It identifies the projection by name, not by a database entity ID.
+
+    documentation:
+      - OMN-11199 (projection contract registry)
+    ticket: OMN-11200
+  - file_pattern: 'model_projection_recovered_event\.py'
+    field_pattern: "Field 'projection_name'"
+    violation_pattern: "might reference an entity"
+    reason: >
+      projection_name is the canonical name of a projection contract (e.g. "contract_registry"), not an entity reference. It identifies the projection by name, not by a database entity ID.
+
+    documentation:
+      - OMN-11199 (projection contract registry)
+    ticket: OMN-11200
   - file_pattern: 'service_snapshot\.py'
     class_pattern: "Class name 'ServiceSnapshot'"
     violation_pattern: "contains anti-pattern 'Service'"

--- a/tests/integration/runtime/test_freshness_monitor_integration.py
+++ b/tests/integration/runtime/test_freshness_monitor_integration.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for ServiceFreshnessMonitor (OMN-11200).
+
+Validates the monitor wires correctly with:
+- Projection contract registry contracts
+- Topic registry resolution
+- Event bus envelope publishing
+- Start/stop lifecycle with the async loop
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.models.health.model_projection_degraded_event import (
+    ModelProjectionDegradedEvent,
+)
+from omnibase_infra.models.health.model_projection_recovered_event import (
+    ModelProjectionRecoveredEvent,
+)
+from omnibase_infra.models.projection.projection_contract_registry import (
+    PROJECTION_CONTRACTS,
+)
+from omnibase_infra.runtime.freshness_monitor import ServiceFreshnessMonitor
+
+
+def _make_stub_registry() -> MagicMock:
+    registry = MagicMock()
+    registry.resolve.side_effect = lambda key: (
+        "onex.evt.omnibase-infra.projection-freshness-degraded.v1"
+        if "DEGRADED" in key
+        else "onex.evt.omnibase-infra.projection-freshness-recovered.v1"
+    )
+    return registry
+
+
+@pytest.mark.integration
+class TestFreshnessMonitorIntegration:
+    @pytest.mark.asyncio
+    async def test_registry_contracts_produce_degraded_events(self) -> None:
+        """All PROJECTION_CONTRACTS produce degraded events when stale."""
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=120)
+
+        async def query(table: str, field: str) -> datetime:
+            return stale_ts
+
+        bus = MagicMock()
+        bus.publish_envelope = AsyncMock()
+
+        monitor = ServiceFreshnessMonitor(
+            contracts=PROJECTION_CONTRACTS,
+            query_fn=query,
+            event_bus=bus,
+            check_interval_seconds=60.0,
+            topic_registry=_make_stub_registry(),
+        )
+        events = await monitor.run_once()
+
+        assert len(events) == len(PROJECTION_CONTRACTS)
+        for event in events:
+            assert isinstance(event, ModelProjectionDegradedEvent)
+        assert bus.publish_envelope.await_count == len(PROJECTION_CONTRACTS)
+
+    @pytest.mark.asyncio
+    async def test_full_degrade_recover_cycle_with_bus(self) -> None:
+        """Full degradation → recovery cycle emits correct envelopes."""
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=120)
+        fresh_ts = now - timedelta(seconds=5)
+        contracts = PROJECTION_CONTRACTS[:1]
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return stale_ts if call_count <= 1 else fresh_ts
+
+        bus = MagicMock()
+        bus.publish_envelope = AsyncMock()
+
+        monitor = ServiceFreshnessMonitor(
+            contracts=contracts,
+            query_fn=query,
+            event_bus=bus,
+            check_interval_seconds=60.0,
+            topic_registry=_make_stub_registry(),
+        )
+
+        degraded = await monitor.run_once()
+        recovered = await monitor.run_once()
+
+        assert len(degraded) == 1
+        assert isinstance(degraded[0], ModelProjectionDegradedEvent)
+        assert len(recovered) == 1
+        assert isinstance(recovered[0], ModelProjectionRecoveredEvent)
+
+        assert bus.publish_envelope.await_count == 2
+        degraded_topic = bus.publish_envelope.call_args_list[0].kwargs["topic"]
+        recovered_topic = bus.publish_envelope.call_args_list[1].kwargs["topic"]
+        assert "degraded" in degraded_topic
+        assert "recovered" in recovered_topic
+
+    @pytest.mark.asyncio
+    async def test_start_stop_lifecycle(self) -> None:
+        """Monitor starts and stops cleanly without hanging."""
+
+        async def query(table: str, field: str) -> datetime:
+            return datetime.now(UTC)
+
+        monitor = ServiceFreshnessMonitor(
+            contracts=PROJECTION_CONTRACTS,
+            query_fn=query,
+            check_interval_seconds=60.0,
+            topic_registry=_make_stub_registry(),
+        )
+
+        await monitor.start()
+        assert monitor._running is True
+        assert monitor._task is not None
+
+        await monitor.stop()
+        assert monitor._running is False
+        assert monitor._task is None

--- a/tests/unit/runtime/test_freshness_monitor.py
+++ b/tests/unit/runtime/test_freshness_monitor.py
@@ -45,7 +45,7 @@ def _make_contract(
     sla_seconds: int = 30,
     freshness_field: str = "last_seen_at",
     freshness_source_table: str = "test_table",
-    behavior: EnumDegradedBehavior = EnumDegradedBehavior.SERVE_STALE,
+    behavior: EnumDegradedBehavior = EnumDegradedBehavior.SERVE_STALE_WITH_WARNING,
 ) -> ModelProjectionContract:
     return ModelProjectionContract(
         projection_name=name,
@@ -135,7 +135,7 @@ class TestDegradationEvent:
         contract = _make_contract(
             name="my_proj",
             sla_seconds=30,
-            behavior=EnumDegradedBehavior.SERVE_STALE,
+            behavior=EnumDegradedBehavior.SERVE_STALE_WITH_WARNING,
         )
 
         async def query(table: str, field: str) -> datetime:
@@ -150,7 +150,7 @@ class TestDegradationEvent:
         assert evt.projection_name == "my_proj"
         assert evt.sla_seconds == 30
         assert evt.actual_staleness_seconds > 30
-        assert evt.degraded_behavior == "serve_stale"
+        assert evt.degraded_behavior == "serve_stale_with_warning"
         assert evt.source_contract_hash  # non-empty string
         assert isinstance(evt.observed_at, datetime)
 

--- a/tests/unit/runtime/test_freshness_monitor.py
+++ b/tests/unit/runtime/test_freshness_monitor.py
@@ -1,0 +1,408 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ServiceFreshnessMonitor (OMN-11200).
+
+Validates:
+- Staleness detection against SLA
+- Degradation event emitted with correct fields
+- Recovery event emitted on resolution
+- No duplicate degradation events per breach
+- Contracts without freshness fields are skipped
+- NULL query result is skipped without event
+- Query failure is swallowed (loop continues)
+- start/stop lifecycle is idempotent
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
+from omnibase_core.models.projection.model_cursor_contract import ModelCursorContract
+from omnibase_core.models.projection.model_projection_contract import (
+    ModelProjectionContract,
+)
+from omnibase_infra.models.health.model_projection_degraded_event import (
+    ModelProjectionDegradedEvent,
+)
+from omnibase_infra.models.health.model_projection_recovered_event import (
+    ModelProjectionRecoveredEvent,
+)
+from omnibase_infra.runtime.freshness_monitor import ServiceFreshnessMonitor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CURSOR = ModelCursorContract(cursor_type="kafka_offset", supports_replay=True)
+
+
+def _make_contract(
+    name: str = "test_projection",
+    sla_seconds: int = 30,
+    freshness_field: str = "last_seen_at",
+    freshness_source_table: str = "test_table",
+    behavior: EnumDegradedBehavior = EnumDegradedBehavior.SERVE_STALE,
+) -> ModelProjectionContract:
+    return ModelProjectionContract(
+        projection_name=name,
+        source_topics=("onex.evt.test.event.v1",),
+        schema_model="omnibase_infra.models.test.ModelTest",
+        freshness_sla_seconds=sla_seconds,
+        freshness_field=freshness_field,
+        freshness_source_table=freshness_source_table,
+        degraded_semantics=behavior,
+        cursor=_CURSOR,
+        ordering_contract_ref=None,
+    )
+
+
+def _make_stub_registry(
+    degraded_topic: str = "onex.evt.omnibase-infra.projection-freshness-degraded.v1",
+    recovered_topic: str = "onex.evt.omnibase-infra.projection-freshness-recovered.v1",
+) -> MagicMock:
+    registry = MagicMock()
+    registry.resolve.side_effect = lambda key: (
+        degraded_topic if "DEGRADED" in key else recovered_topic
+    )
+    return registry
+
+
+def _make_monitor(
+    contracts: tuple[ModelProjectionContract, ...],
+    query_fn: object,
+    event_bus: object | None = None,
+) -> ServiceFreshnessMonitor:
+    return ServiceFreshnessMonitor(
+        contracts=contracts,
+        query_fn=query_fn,  # type: ignore[arg-type]
+        event_bus=event_bus,
+        check_interval_seconds=60.0,
+        topic_registry=_make_stub_registry(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessDetection:
+    @pytest.mark.asyncio
+    async def test_detects_staleness_correctly(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> datetime:
+            return stale_ts
+
+        monitor = _make_monitor((contract,), query)
+        events = await monitor.run_once()
+
+        assert len(events) == 1
+        assert isinstance(events[0], ModelProjectionDegradedEvent)
+        assert events[0].actual_staleness_seconds > 30
+
+    @pytest.mark.asyncio
+    async def test_healthy_projection_emits_no_event(self) -> None:
+        now = datetime.now(UTC)
+        fresh_ts = now - timedelta(seconds=10)
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> datetime:
+            return fresh_ts
+
+        monitor = _make_monitor((contract,), query)
+        events = await monitor.run_once()
+
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Degradation event fields
+# ---------------------------------------------------------------------------
+
+
+class TestDegradationEvent:
+    @pytest.mark.asyncio
+    async def test_degradation_event_fields(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=90)
+        contract = _make_contract(
+            name="my_proj",
+            sla_seconds=30,
+            behavior=EnumDegradedBehavior.SERVE_STALE,
+        )
+
+        async def query(table: str, field: str) -> datetime:
+            return stale_ts
+
+        monitor = _make_monitor((contract,), query)
+        events = await monitor.run_once()
+
+        assert len(events) == 1
+        evt = events[0]
+        assert isinstance(evt, ModelProjectionDegradedEvent)
+        assert evt.projection_name == "my_proj"
+        assert evt.sla_seconds == 30
+        assert evt.actual_staleness_seconds > 30
+        assert evt.degraded_behavior == "serve_stale"
+        assert evt.source_contract_hash  # non-empty string
+        assert isinstance(evt.observed_at, datetime)
+
+    @pytest.mark.asyncio
+    async def test_degradation_event_emitted_to_bus(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> datetime:
+            return stale_ts
+
+        bus = MagicMock()
+        bus.publish_envelope = AsyncMock()
+        monitor = _make_monitor((contract,), query, event_bus=bus)
+        await monitor.run_once()
+
+        bus.publish_envelope.assert_awaited_once()
+        call_kwargs = bus.publish_envelope.call_args.kwargs
+        assert "projection-freshness-degraded" in call_kwargs["topic"]
+
+
+# ---------------------------------------------------------------------------
+# Recovery event
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryEvent:
+    @pytest.mark.asyncio
+    async def test_emits_recovery_after_degradation(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        fresh_ts = now - timedelta(seconds=5)
+        contract = _make_contract(sla_seconds=30)
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return stale_ts if call_count == 1 else fresh_ts
+
+        monitor = _make_monitor((contract,), query)
+
+        first_events = await monitor.run_once()
+        assert len(first_events) == 1
+        assert isinstance(first_events[0], ModelProjectionDegradedEvent)
+
+        second_events = await monitor.run_once()
+        assert len(second_events) == 1
+        assert isinstance(second_events[0], ModelProjectionRecoveredEvent)
+        assert second_events[0].projection_name == contract.projection_name
+        assert second_events[0].sla_seconds == 30
+
+    @pytest.mark.asyncio
+    async def test_recovery_event_emitted_to_bus(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        fresh_ts = now - timedelta(seconds=5)
+        contract = _make_contract(sla_seconds=30)
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return stale_ts if call_count == 1 else fresh_ts
+
+        bus = MagicMock()
+        bus.publish_envelope = AsyncMock()
+        monitor = _make_monitor((contract,), query, event_bus=bus)
+
+        await monitor.run_once()
+        await monitor.run_once()
+
+        assert bus.publish_envelope.await_count == 2
+        recovery_call = bus.publish_envelope.call_args_list[1]
+        assert "projection-freshness-recovered" in recovery_call.kwargs["topic"]
+
+
+# ---------------------------------------------------------------------------
+# No duplicate events
+# ---------------------------------------------------------------------------
+
+
+class TestNoDuplicates:
+    @pytest.mark.asyncio
+    async def test_no_duplicate_degradation_events(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> datetime:
+            return stale_ts
+
+        monitor = _make_monitor((contract,), query)
+
+        first = await monitor.run_once()
+        second = await monitor.run_once()
+        third = await monitor.run_once()
+
+        assert len(first) == 1
+        assert len(second) == 0
+        assert len(third) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_recovery_events(self) -> None:
+        now = datetime.now(UTC)
+        stale_ts = now - timedelta(seconds=60)
+        fresh_ts = now - timedelta(seconds=5)
+        contract = _make_contract(sla_seconds=30)
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return stale_ts if call_count <= 1 else fresh_ts
+
+        monitor = _make_monitor((contract,), query)
+
+        await monitor.run_once()
+        recovery = await monitor.run_once()
+        no_event = await monitor.run_once()
+
+        assert len(recovery) == 1
+        assert isinstance(recovery[0], ModelProjectionRecoveredEvent)
+        assert len(no_event) == 0
+
+
+# ---------------------------------------------------------------------------
+# Skip contracts without freshness fields
+# ---------------------------------------------------------------------------
+
+
+class TestSkipWithoutFreshnessFields:
+    @pytest.mark.asyncio
+    async def test_skips_contract_without_freshness_field(self) -> None:
+        # ModelProjectionContract requires min_length=1 for freshness_field,
+        # so we mock the field being empty via a contract with a real field
+        # but patch the attribute at runtime to simulate the absent-field path.
+        contract = _make_contract()
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return datetime.now(UTC)
+
+        monitor = _make_monitor((contract,), query)
+
+        # Temporarily override freshness_field to empty string via object.__setattr__
+        # since the model is frozen.
+        object.__setattr__(contract, "freshness_field", "")
+        events = await monitor.run_once()
+
+        assert events == []
+        assert call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_contract_without_source_table(self) -> None:
+        contract = _make_contract()
+        call_count = 0
+
+        async def query(table: str, field: str) -> datetime:
+            nonlocal call_count
+            call_count += 1
+            return datetime.now(UTC)
+
+        monitor = _make_monitor((contract,), query)
+
+        object.__setattr__(contract, "freshness_source_table", "")
+        events = await monitor.run_once()
+
+        assert events == []
+        assert call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# NULL / error query paths
+# ---------------------------------------------------------------------------
+
+
+class TestQueryEdgeCases:
+    @pytest.mark.asyncio
+    async def test_null_query_result_skipped(self) -> None:
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> None:
+            return None
+
+        monitor = _make_monitor((contract,), query)
+        events = await monitor.run_once()
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_query_failure_swallowed_loop_continues(self) -> None:
+        contract_bad = _make_contract(
+            name="bad", sla_seconds=30, freshness_source_table="bad_table"
+        )
+        now = datetime.now(UTC)
+        good_ts = now - timedelta(seconds=60)
+        contract_good = _make_contract(
+            name="good", sla_seconds=30, freshness_source_table="good_table"
+        )
+
+        async def query(table: str, field: str) -> datetime:
+            if table == "bad_table":
+                raise RuntimeError("DB exploded")
+            return good_ts
+
+        monitor = _make_monitor((contract_bad, contract_good), query)
+        events = await monitor.run_once()
+
+        # bad projection query failed → skipped; good projection is stale → degraded
+        assert len(events) == 1
+        assert events[0].projection_name == "good"
+
+    @pytest.mark.asyncio
+    async def test_naive_timestamp_handled_without_error(self) -> None:
+        now = datetime.now(UTC)
+        naive_ts = (now - timedelta(seconds=60)).replace(tzinfo=None)
+        contract = _make_contract(sla_seconds=30)
+
+        async def query(table: str, field: str) -> datetime:
+            return naive_ts
+
+        monitor = _make_monitor((contract,), query)
+        events = await monitor.run_once()
+
+        assert len(events) == 1
+        assert isinstance(events[0], ModelProjectionDegradedEvent)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_invalid_interval_raises(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            ServiceFreshnessMonitor(
+                contracts=(),
+                query_fn=AsyncMock(),
+                check_interval_seconds=0,
+                topic_registry=_make_stub_registry(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_stop_idempotent(self) -> None:
+        monitor = _make_monitor((), AsyncMock())
+        await monitor.start()
+        await monitor.start()
+        await monitor.stop()
+        await monitor.stop()

--- a/tests/unit/runtime/test_freshness_monitor.py
+++ b/tests/unit/runtime/test_freshness_monitor.py
@@ -20,16 +20,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
-from omnibase_core.models.projection.model_cursor_contract import ModelCursorContract
-from omnibase_core.models.projection.model_projection_contract import (
-    ModelProjectionContract,
-)
+from omnibase_infra.enums.enum_degraded_behavior import EnumDegradedBehavior
 from omnibase_infra.models.health.model_projection_degraded_event import (
     ModelProjectionDegradedEvent,
 )
 from omnibase_infra.models.health.model_projection_recovered_event import (
     ModelProjectionRecoveredEvent,
+)
+from omnibase_infra.models.projection.model_cursor_contract import ModelCursorContract
+from omnibase_infra.models.projection.model_projection_contract import (
+    ModelProjectionContract,
 )
 from omnibase_infra.runtime.freshness_monitor import ServiceFreshnessMonitor
 


### PR DESCRIPTION
## Summary

- Adds `ServiceFreshnessMonitor` in `src/omnibase_infra/runtime/freshness_monitor.py` that periodically queries `MAX({freshness_field}) FROM {freshness_source_table}` for each declared `ModelProjectionContract` and emits typed events on SLA breach / recovery
- Adds `ModelProjectionDegradedEvent` and `ModelProjectionRecoveredEvent` in `models/health/`
- Adds `PROJECTION_FRESHNESS_DEGRADED` and `PROJECTION_FRESHNESS_RECOVERED` topic keys + canonical Kafka topic strings in `ServiceTopicRegistry`
- Adds `projection_contract_registry.py` with the three infra projection contracts (local copy of OMN-11199 PR, pending merge of that branch)
- Pins `omnibase-core` to OMN-11192 PR SHA for `ModelProjectionContract` / `EnumDegradedBehavior`
- 15 unit tests: staleness detection, degraded/recovery event fields and bus emission, no-duplicate guarantees, skip paths (no freshness fields, NULL result, query failure), naive datetime handling, and start/stop lifecycle
- Fixes pre-existing duplicate key in `scripts/check_contract_topic_parity.py` (ruff F601)

## Dependencies

- Requires OMN-11192 (omnibase_core `ModelProjectionContract`) — pinned via git SHA
- Requires OMN-11199 (projection contract registry) — contracts duplicated locally pending merge

## Test plan

- [x] `uv run pytest tests/unit/runtime/test_freshness_monitor.py -v` — 15/15 pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Full unit suite (`pytest tests/ -m unit`) — only pre-existing `test_full_bootstrap_with_real_event_bus` failure (tmpdir in /var, unrelated to this PR)

OMN-11200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added projection freshness SLA monitoring: background service that detects breaches and emits degraded/recovered events, new event models, projection contract registry, and topic keys/mappings.

* **Tests**
  * Added unit and integration tests covering detection, event payloads, publishing, deduplication, lifecycle, and error/edge cases.

* **Chores**
  * Clarified dependency pin guidance, extended CI allowlist exemptions, updated validation exemptions, and added an operational contract for rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11200
