### PR TITLE
feat(OMN-11208): add seed provenance enforcement (advisory)

### DIFF
--- a/.github/workflows/seed-provenance-check.yml
+++ b/.github/workflows/seed-provenance-check.yml
@@ -1,0 +1,50 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# seed-provenance-check.yml
+#
+# Advisory lint: warn when seed/demo scripts publish Kafka events without
+# setting data_provenance in the payload.
+#
+# This is ADVISORY only — the job uses continue-on-error: true and the
+# script always exits 0. It will never block a merge.
+#
+# Implements OMN-11208.
+
+name: Seed Provenance Check (Advisory)
+
+on:
+  push:
+    paths:
+      - "scripts/**/*.py"
+      - ".github/workflows/seed-provenance-check.yml"
+  pull_request:
+    paths:
+      - "scripts/**/*.py"
+      - ".github/workflows/seed-provenance-check.yml"
+
+jobs:
+  seed-provenance-check:
+    name: Seed Provenance Advisory Check
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run seed provenance check (advisory)
+        run: |
+          python scripts/check_seed_provenance.py --scripts-dir scripts/

--- a/scripts/check_seed_provenance.py
+++ b/scripts/check_seed_provenance.py
@@ -49,7 +49,7 @@ def check_scripts(scripts_dir: Path) -> list[str]:
     """Return list of warning strings for scripts missing provenance."""
     warnings: list[str] = []
 
-    candidates = sorted(scripts_dir.glob("*.py"))
+    candidates = sorted(scripts_dir.rglob("*.py"))
     for path in candidates:
         if not _is_seed_or_demo(path):
             continue

--- a/scripts/check_seed_provenance.py
+++ b/scripts/check_seed_provenance.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Advisory lint: check that seed/demo scripts set data_provenance in event payloads.
+
+Scans scripts/ for Python files that both:
+  1. Match seed/demo naming patterns (heuristic: filename contains 'seed' or 'demo'),
+  2. Publish Kafka events (heuristic: contain publish/produce/send_event/emit patterns).
+
+For each matched script, warns if the word ``data_provenance`` does not appear
+anywhere in the file content.
+
+This is ADVISORY — exit 0 always. CI uses ``continue-on-error: true``.
+
+Usage:
+    uv run python scripts/check_seed_provenance.py [--scripts-dir <path>]
+
+OMN-11208
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_EVENT_PATTERNS = re.compile(
+    r"\b(publish|produce|send_event|emit|send_and_wait|AIOKafkaProducer)\b",
+    re.MULTILINE,
+)
+_PROVENANCE_PATTERN = re.compile(r"\bdata_provenance\b", re.MULTILINE)
+_SEED_DEMO_PATTERN = re.compile(r"(seed|demo)", re.IGNORECASE)
+
+
+def _is_seed_or_demo(path: Path) -> bool:
+    return bool(_SEED_DEMO_PATTERN.search(path.stem))
+
+
+def _publishes_events(content: str) -> bool:
+    return bool(_EVENT_PATTERNS.search(content))
+
+
+def _has_provenance(content: str) -> bool:
+    return bool(_PROVENANCE_PATTERN.search(content))
+
+
+def check_scripts(scripts_dir: Path) -> list[str]:
+    """Return list of warning strings for scripts missing provenance."""
+    warnings: list[str] = []
+
+    candidates = sorted(scripts_dir.glob("*.py"))
+    for path in candidates:
+        if not _is_seed_or_demo(path):
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        if not _publishes_events(content):
+            continue
+
+        if not _has_provenance(content):
+            warnings.append(
+                f"WARNING: {path.name} publishes events but does not set "
+                "data_provenance in any payload. "
+                'Consider adding data_provenance="demo_seeded" to event payloads.'
+            )
+
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scripts-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="Directory to scan (default: scripts/)",
+    )
+    args = parser.parse_args()
+
+    warnings = check_scripts(args.scripts_dir)
+
+    if warnings:
+        print("=== Seed Provenance Advisory Check ===")
+        for w in warnings:
+            print(w)
+        print(
+            f"\n{len(warnings)} script(s) may be missing data_provenance. "
+            "This is advisory — no action required to pass CI."
+        )
+    else:
+        print("=== Seed Provenance Advisory Check: clean ===")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_seed_provenance_check.py
+++ b/tests/unit/scripts/test_seed_provenance_check.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/check_seed_provenance.py [OMN-11208]."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "check_seed_provenance.py"
+)
+
+# Import the check functions directly for unit testing
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+from check_seed_provenance import (
+    _has_provenance,
+    _is_seed_or_demo,
+    _publishes_events,
+    check_scripts,
+)
+
+
+@pytest.mark.unit
+class TestHelperFunctions:
+    def test_is_seed_or_demo_matches_seed(self) -> None:
+        assert _is_seed_or_demo(Path("seed-infisical.py"))
+
+    def test_is_seed_or_demo_matches_demo(self) -> None:
+        assert _is_seed_or_demo(Path("demo_runtime_verification.py"))
+
+    def test_is_seed_or_demo_rejects_other(self) -> None:
+        assert not _is_seed_or_demo(Path("check_topic_drift.py"))
+
+    def test_publishes_events_detects_kafka_producer(self) -> None:
+        assert _publishes_events("producer = AIOKafkaProducer(bootstrap_servers=...)")
+
+    def test_publishes_events_detects_send_and_wait(self) -> None:
+        assert _publishes_events("await producer.send_and_wait(topic, body)")
+
+    def test_publishes_events_detects_emit(self) -> None:
+        assert _publishes_events("event_bus.emit(envelope)")
+
+    def test_publishes_events_false_for_docstring_only(self) -> None:
+        # "produces" (with s) does not match \bproduce\b
+        assert not _publishes_events("re-running against a correct realm produces all")
+
+    def test_has_provenance_true(self) -> None:
+        assert _has_provenance('payload["data_provenance"] = "demo_seeded"')
+
+    def test_has_provenance_false(self) -> None:
+        assert not _has_provenance("event_type = 'baselines.computed'")
+
+
+@pytest.mark.unit
+class TestCheckScripts:
+    def test_no_warnings_when_provenance_present(self, tmp_path: Path) -> None:
+        script = tmp_path / "seed_example.py"
+        script.write_text(
+            "async def run():\n"
+            '    payload = {"data_provenance": "demo_seeded"}\n'
+            '    await producer.send_and_wait("topic", json.dumps(payload).encode())\n'
+        )
+        warnings = check_scripts(tmp_path)
+        assert warnings == []
+
+    def test_warning_when_provenance_missing(self, tmp_path: Path) -> None:
+        script = tmp_path / "seed_example.py"
+        script.write_text(
+            "async def run():\n"
+            '    payload = {"event_type": "foo"}\n'
+            '    await producer.send_and_wait("topic", json.dumps(payload).encode())\n'
+        )
+        warnings = check_scripts(tmp_path)
+        assert len(warnings) == 1
+        assert "data_provenance" in warnings[0]
+        assert "seed_example.py" in warnings[0]
+
+    def test_non_seed_demo_scripts_not_checked(self, tmp_path: Path) -> None:
+        script = tmp_path / "publish_pr_merged_event.py"
+        script.write_text(
+            'async def run():\n    await producer.send_and_wait("topic", b"data")\n'
+        )
+        warnings = check_scripts(tmp_path)
+        assert warnings == []
+
+    def test_seed_script_without_event_publish_not_warned(self, tmp_path: Path) -> None:
+        script = tmp_path / "seed_config.py"
+        script.write_text(
+            'def run():\n    client.create_secret(key="FOO", value="bar")\n'
+        )
+        warnings = check_scripts(tmp_path)
+        assert warnings == []
+
+    def test_multiple_flagged_scripts(self, tmp_path: Path) -> None:
+        for name in ("seed_a.py", "demo_b.py"):
+            (tmp_path / name).write_text(
+                'await producer.send_and_wait("topic", b"payload")\n'
+            )
+        warnings = check_scripts(tmp_path)
+        assert len(warnings) == 2
+
+
+@pytest.mark.unit
+class TestCLI:
+    def test_exits_zero_always(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0
+
+    def test_output_contains_advisory_label(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert "Seed Provenance" in result.stdout


### PR DESCRIPTION
## Summary

- Adds `scripts/check_seed_provenance.py`: heuristic advisory lint that scans seed/demo scripts for Kafka event publishing patterns and warns when `data_provenance` is absent from payloads. Always exits 0.
- Adds `.github/workflows/seed-provenance-check.yml`: runs the check on push/PR to `scripts/**/*.py`. Uses `continue-on-error: true` — ADVISORY only, never blocks merge.
- Adds `tests/unit/scripts/test_seed_provenance_check.py`: 16 unit tests covering helper predicates, `check_scripts()`, and CLI behavior.

## Ticket

OMN-11208 (epic OMN-11188)

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_seed_provenance_check.py -v` — 16/16 passed
- [x] `uv run python scripts/check_seed_provenance.py` — exits 0, outputs advisory label
- [x] `pre-commit run --files ...` — all hooks passed
- [x] Advisory nature verified: script hardcodes `return 0`; workflow has `continue-on-error: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow running advisory provenance checks on seed and demo scripts
  * Introduced automated helper script for provenance metadata verification in automation files

* **Tests**
  * Added comprehensive unit test suite covering script detection, provenance identification, and CLI behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11208
