### PR TITLE
feat(OMN-11207): add evidence bundle writer utility

### DIFF
--- a/src/omnibase_infra/utils/util_evidence_bundle_writer.py
+++ b/src/omnibase_infra/utils/util_evidence_bundle_writer.py
@@ -274,6 +274,7 @@ class DictBundleAdapter:
 
 __all__: list[str] = [
     "DictBundleAdapter",
+    "JsonPayload",
     "ProtocolEvidenceBundle",
     "write_evidence_bundle",
 ]

--- a/src/omnibase_infra/utils/util_evidence_bundle_writer.py
+++ b/src/omnibase_infra/utils/util_evidence_bundle_writer.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Evidence bundle writer utility.
+
+Writes a standard evidence bundle to disk in a tamper-evident, atomicity-sentinel
+layout. The proof_summary.md file is written LAST and serves as the completeness
+sentinel: a bundle is complete if and only if the sentinel exists AND all declared
+artifact hashes in artifact_manifest.json match recomputation.
+
+Write order is encoded in artifact_manifest.json as monotonically increasing
+``write_order`` integers. Never use filesystem timestamps for ordering proof —
+mtime is unreliable across FSes and NFS.
+
+Evidence root convention: ``docs/evidence/<plan-slug>/<correlation-id>/``
+
+Ticket: OMN-11207
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Protocol, cast, runtime_checkable
+
+from omnibase_core.types import JsonType
+
+logger = logging.getLogger(__name__)
+
+_ARTIFACT_MANIFEST_FILENAME = "artifact_manifest.json"
+_PROOF_SUMMARY_FILENAME = "proof_summary.md"
+_RUN_MANIFEST_FILENAME = "run_manifest.json"
+_CONTRACT_SNAPSHOT_FILENAME = "contract_snapshot.json"
+_INPUT_FILENAME = "input.json"
+_OUTPUT_FILENAME = "output.json"
+_VERIFIER_RESULT_FILENAME = "verifier_result.json"
+
+JsonPayload = dict[str, JsonType]
+
+
+@runtime_checkable
+class ProtocolEvidenceBundle(Protocol):
+    """Structural protocol for evidence bundles accepted by the writer.
+
+    Implementations may be Pydantic models or plain dicts. The writer
+    uses duck typing so it works before and after the canonical
+    omnibase_core.models.evidence_bundle PR lands.
+    """
+
+    @property
+    def correlation_id(self) -> str:
+        """Unique correlation ID for this run; used as the bundle directory name."""
+        ...
+
+    @property
+    def run_manifest(self) -> JsonPayload:
+        """Run-level metadata (node, version, timestamps, plan slug, etc.)."""
+        ...
+
+    @property
+    def contract_snapshot(self) -> JsonPayload | None:
+        """Snapshot of the contract YAML at execution time, or None."""
+        ...
+
+    @property
+    def input(self) -> JsonPayload | None:
+        """Node input payload, or None."""
+        ...
+
+    @property
+    def output(self) -> JsonPayload | None:
+        """Node output payload, or None."""
+        ...
+
+    @property
+    def verifier_result(self) -> JsonPayload | None:
+        """Optional verifier / DoD check result, or None."""
+        ...
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the hex-encoded SHA-256 digest of a file's contents."""
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _write_json(path: Path, data: JsonPayload) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=True))
+
+
+def write_evidence_bundle(evidence_root: Path, bundle: object) -> Path:
+    """Write a standard evidence bundle to disk.
+
+    Accepts any object that exposes the ProtocolEvidenceBundle interface
+    (including plain dataclasses or dicts with matching attributes).
+
+    Write sequence:
+    1. run_manifest.json
+    2. contract_snapshot.json (if present)
+    3. input.json (if present)
+    4. output.json (if present)
+    5. verifier_result.json (if present)
+    6. artifact_manifest.json  (hashes + write_order for every preceding file)
+    7. proof_summary.md        (atomicity sentinel — LAST)
+
+    Completeness invariant: bundle is complete iff proof_summary.md exists AND
+    all hashes in artifact_manifest.json match recomputation.
+
+    Args:
+        evidence_root: Root directory under which the bundle directory is created.
+        bundle: Any object satisfying ProtocolEvidenceBundle, or a dict with
+            equivalent keys.
+
+    Returns:
+        Path to the created bundle directory.
+
+    Raises:
+        ValueError: If the bundle has no correlation_id.
+        OSError: On filesystem failures.
+    """
+    adapted: ProtocolEvidenceBundle
+    if isinstance(bundle, dict):
+        adapted = DictBundleAdapter(bundle)
+    elif isinstance(bundle, ProtocolEvidenceBundle):
+        adapted = bundle
+    else:
+        adapted = DictBundleAdapter({})
+
+    correlation_id: str = adapted.correlation_id
+    if not correlation_id:
+        raise ValueError("bundle.correlation_id must be non-empty")
+
+    bundle_dir = evidence_root / correlation_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact_entries: list[JsonPayload] = []
+    write_counter = 0
+
+    def _write_artifact(filename: str, data: JsonPayload) -> None:
+        nonlocal write_counter
+        path = bundle_dir / filename
+        _write_json(path, data)
+        sha256 = _sha256_file(path)
+        artifact_entries.append(
+            {
+                "filename": filename,
+                "sha256": sha256,
+                "write_order": write_counter,
+            }
+        )
+        write_counter += 1
+        logger.debug("Wrote artifact %s (sha256=%s)", filename, sha256[:12])
+
+    # 1. run_manifest.json — always present
+    _write_artifact(_RUN_MANIFEST_FILENAME, adapted.run_manifest)
+
+    # 2-5. Optional artifacts — written only when present
+    optional_artifacts: list[tuple[str, JsonPayload | None]] = [
+        (_CONTRACT_SNAPSHOT_FILENAME, adapted.contract_snapshot),
+        (_INPUT_FILENAME, adapted.input),
+        (_OUTPUT_FILENAME, adapted.output),
+        (_VERIFIER_RESULT_FILENAME, adapted.verifier_result),
+    ]
+    for filename, payload in optional_artifacts:
+        if payload is not None:
+            _write_artifact(filename, payload)
+
+    # 6. artifact_manifest.json — records all preceding files with hashes
+    # cast: list[JsonPayload] is list[JsonType] but mypy can't see through the PEP 695
+    # recursive type alias, so we cast to satisfy the dict[str, JsonType] value constraint.
+    manifest_path = bundle_dir / _ARTIFACT_MANIFEST_FILENAME
+    _write_json(
+        manifest_path,
+        {
+            "correlation_id": correlation_id,
+            "artifact_count": len(artifact_entries),
+            "artifacts": cast("list[JsonType]", artifact_entries),
+        },
+    )
+    manifest_sha256 = _sha256_file(manifest_path)
+    logger.debug("Wrote artifact_manifest.json (sha256=%s)", manifest_sha256[:12])
+
+    # 7. proof_summary.md — atomicity sentinel, written LAST
+    proof_path = bundle_dir / _PROOF_SUMMARY_FILENAME
+    proof_lines = [
+        "# Evidence Bundle — Proof Summary",
+        "",
+        f"**correlation_id**: `{correlation_id}`",
+        f"**artifact_count**: {len(artifact_entries)}",
+        f"**artifact_manifest_sha256**: `{manifest_sha256}`",
+        "",
+        "## Artifacts",
+        "",
+    ]
+    for entry in artifact_entries:
+        proof_lines.append(
+            f"- `{entry['filename']}` (write_order={entry['write_order']}, "
+            f"sha256=`{entry['sha256']}`)"
+        )
+    proof_lines += [
+        "",
+        "## Completeness",
+        "",
+        "This file is the atomicity sentinel. Its presence means all declared "
+        "artifacts were written. Verify by recomputing SHA-256 for each file "
+        "listed above and comparing against artifact_manifest.json entries.",
+        "",
+    ]
+    proof_path.write_text("\n".join(proof_lines))
+    logger.info(
+        "Evidence bundle complete: %s (%d artifacts)", bundle_dir, len(artifact_entries)
+    )
+
+    return bundle_dir
+
+
+class DictBundleAdapter:
+    """Wraps a plain dict to expose the ProtocolEvidenceBundle interface."""
+
+    def __init__(self, data: dict[str, JsonType]) -> None:
+        self._data = data
+
+    @property
+    def correlation_id(self) -> str:
+        value = self._data.get("correlation_id", "")
+        return str(value) if value is not None else ""
+
+    @property
+    def run_manifest(self) -> JsonPayload:
+        value = self._data.get("run_manifest", {})
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def contract_snapshot(self) -> JsonPayload | None:
+        value = self._data.get("contract_snapshot")
+        return value if isinstance(value, dict) else None
+
+    @property
+    def input(self) -> JsonPayload | None:
+        value = self._data.get("input")
+        return value if isinstance(value, dict) else None
+
+    @property
+    def output(self) -> JsonPayload | None:
+        value = self._data.get("output")
+        return value if isinstance(value, dict) else None
+
+    @property
+    def verifier_result(self) -> JsonPayload | None:
+        value = self._data.get("verifier_result")
+        return value if isinstance(value, dict) else None
+
+
+__all__: list[str] = [
+    "DictBundleAdapter",
+    "ProtocolEvidenceBundle",
+    "write_evidence_bundle",
+]

--- a/src/omnibase_infra/utils/util_evidence_bundle_writer.py
+++ b/src/omnibase_infra/utils/util_evidence_bundle_writer.py
@@ -51,32 +51,26 @@ class ProtocolEvidenceBundle(Protocol):
     @property
     def correlation_id(self) -> str:
         """Unique correlation ID for this run; used as the bundle directory name."""
-        ...
 
     @property
     def run_manifest(self) -> JsonPayload:
         """Run-level metadata (node, version, timestamps, plan slug, etc.)."""
-        ...
 
     @property
     def contract_snapshot(self) -> JsonPayload | None:
         """Snapshot of the contract YAML at execution time, or None."""
-        ...
 
     @property
     def input(self) -> JsonPayload | None:
         """Node input payload, or None."""
-        ...
 
     @property
     def output(self) -> JsonPayload | None:
         """Node output payload, or None."""
-        ...
 
     @property
     def verifier_result(self) -> JsonPayload | None:
         """Optional verifier / DoD check result, or None."""
-        ...
 
 
 def _sha256_file(path: Path) -> str:
@@ -216,13 +210,16 @@ def write_evidence_bundle(evidence_root: Path, bundle: object) -> Path:
             f"- `{entry['filename']}` (write_order={entry['write_order']}, "
             f"sha256=`{entry['sha256']}`)"
         )
+    completeness_text = (
+        "This file is the atomicity sentinel. Its presence means all declared "
+        "artifacts were written. Verify by recomputing SHA-256 for each file "
+        "listed above and comparing against artifact_manifest.json entries."
+    )
     proof_lines += [
         "",
         "## Completeness",
         "",
-        "This file is the atomicity sentinel. Its presence means all declared "
-        "artifacts were written. Verify by recomputing SHA-256 for each file "
-        "listed above and comparing against artifact_manifest.json entries.",
+        completeness_text,
         "",
     ]
     proof_path.write_text("\n".join(proof_lines))

--- a/src/omnibase_infra/utils/util_evidence_bundle_writer.py
+++ b/src/omnibase_infra/utils/util_evidence_bundle_writer.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Protocol, cast, runtime_checkable
 
 from omnibase_core.types import JsonType
@@ -131,9 +131,26 @@ def write_evidence_bundle(evidence_root: Path, bundle: object) -> Path:
     correlation_id: str = adapted.correlation_id
     if not correlation_id:
         raise ValueError("bundle.correlation_id must be non-empty")
+    if (
+        "/" in correlation_id
+        or "\\" in correlation_id
+        or correlation_id in {".", ".."}
+        or correlation_id.startswith(".")
+        or PurePosixPath(correlation_id).is_absolute()
+        or PureWindowsPath(correlation_id).is_absolute()
+    ):
+        raise ValueError(
+            "bundle.correlation_id must be a single path segment without "
+            f"separators or traversal markers; got: {correlation_id!r}",
+        )
 
     bundle_dir = evidence_root / correlation_id
-    bundle_dir.mkdir(parents=True, exist_ok=True)
+    if bundle_dir.exists():
+        raise FileExistsError(
+            f"Evidence bundle already exists at {bundle_dir}; refusing to "
+            "overwrite a previously written bundle for this correlation_id",
+        )
+    bundle_dir.mkdir(parents=True)
 
     artifact_entries: list[JsonPayload] = []
     write_counter = 0

--- a/src/omnibase_infra/utils/util_evidence_bundle_writer.py
+++ b/src/omnibase_infra/utils/util_evidence_bundle_writer.py
@@ -51,26 +51,32 @@ class ProtocolEvidenceBundle(Protocol):
     @property
     def correlation_id(self) -> str:
         """Unique correlation ID for this run; used as the bundle directory name."""
+        ...
 
     @property
     def run_manifest(self) -> JsonPayload:
         """Run-level metadata (node, version, timestamps, plan slug, etc.)."""
+        ...
 
     @property
     def contract_snapshot(self) -> JsonPayload | None:
         """Snapshot of the contract YAML at execution time, or None."""
+        ...
 
     @property
     def input(self) -> JsonPayload | None:
         """Node input payload, or None."""
+        ...
 
     @property
     def output(self) -> JsonPayload | None:
         """Node output payload, or None."""
+        ...
 
     @property
     def verifier_result(self) -> JsonPayload | None:
         """Optional verifier / DoD check result, or None."""
+        ...
 
 
 def _sha256_file(path: Path) -> str:
@@ -207,8 +213,7 @@ def write_evidence_bundle(evidence_root: Path, bundle: object) -> Path:
     ]
     for entry in artifact_entries:
         proof_lines.append(
-            f"- `{entry['filename']}` (write_order={entry['write_order']}, "
-            f"sha256=`{entry['sha256']}`)"
+            f"- `{entry['filename']}` (write_order={entry['write_order']}, sha256=`{entry['sha256']}`)"
         )
     completeness_text = (
         "This file is the atomicity sentinel. Its presence means all declared "

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/integration/utils/test_evidence_bundle_writer_integration.py
+++ b/tests/integration/utils/test_evidence_bundle_writer_integration.py
@@ -80,7 +80,9 @@ def test_artifact_manifest_hash_is_deterministic_across_writes(
     a = _hashes_by_name("corr-a")
     b = _hashes_by_name("corr-b")
     shared = set(a) & set(b)
-    for name in shared - {"run_manifest.json"}:
+    comparable = shared - {"run_manifest.json"}
+    assert comparable, "no comparable artifacts found across bundles"
+    for name in comparable:
         assert a[name] == b[name], f"{name} hash drifted between identical bundles"
 
 

--- a/tests/integration/utils/test_evidence_bundle_writer_integration.py
+++ b/tests/integration/utils/test_evidence_bundle_writer_integration.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for util_evidence_bundle_writer (OMN-11207).
+
+Exercises `write_evidence_bundle` against the real filesystem with a real
+tmp_path and asserts:
+- Sentinel ordering: proof_summary.md has the highest write_order even
+  when concurrent disk timestamps would suggest otherwise.
+- Manifest hash stability across two independent writes of the same
+  payload to different correlation_ids.
+- Disk-level layout: every declared artifact lands in
+  evidence_root/<correlation_id>/ and no stray files appear.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnibase_infra.utils.util_evidence_bundle_writer import write_evidence_bundle
+
+pytestmark = pytest.mark.integration
+
+
+def _full_bundle(correlation_id: str) -> dict[str, Any]:
+    return {
+        "correlation_id": correlation_id,
+        "run_manifest": {"node": "node_integration_compute", "version": "1.0.0"},
+        "contract_snapshot": {
+            "name": "node_integration_compute",
+            "node_type": "COMPUTE_GENERIC",
+        },
+        "input": {"payload": "integration-input"},
+        "output": {"result": "integration-output"},
+        "verifier_result": {"passed": True, "checks": []},
+    }
+
+
+def test_proof_summary_is_the_completeness_sentinel(tmp_path: Path) -> None:
+    """proof_summary.md is written LAST on disk after the manifest is sealed.
+
+    The artifact_manifest.json captures write_order for every pre-sentinel
+    artifact. proof_summary.md itself is the atomicity sentinel — it must
+    exist on disk for the bundle to be considered complete, and it is
+    deliberately not listed in the manifest's artifacts array (its presence
+    is the proof, not a member of the index it follows).
+    """
+    write_evidence_bundle(tmp_path, _full_bundle("corr-sentinel"))
+    bundle_dir = tmp_path / "corr-sentinel"
+    manifest = json.loads((bundle_dir / "artifact_manifest.json").read_text())
+    write_orders = [a["write_order"] for a in manifest["artifacts"]]
+    assert write_orders == sorted(write_orders), "write_order is not monotonic"
+    assert len(set(write_orders)) == len(write_orders), "write_order has duplicates"
+    assert (bundle_dir / "proof_summary.md").is_file(), (
+        "proof_summary.md sentinel missing — bundle not complete"
+    )
+
+
+def test_artifact_manifest_hash_is_deterministic_across_writes(
+    tmp_path: Path,
+) -> None:
+    """Same logical bundle, two correlation_ids, identical artifact hashes per file.
+
+    Asserts the writer hashes file content (not paths or timestamps), so
+    two structurally identical bundles produce per-file SHA-256 digests
+    that match. Bundle-level paths differ by correlation_id; per-file
+    hashes do not.
+    """
+    write_evidence_bundle(tmp_path, _full_bundle("corr-a"))
+    write_evidence_bundle(tmp_path, _full_bundle("corr-b"))
+
+    def _hashes_by_name(corr: str) -> dict[str, str]:
+        manifest = json.loads((tmp_path / corr / "artifact_manifest.json").read_text())
+        return {a["filename"]: a["sha256"] for a in manifest["artifacts"]}
+
+    a = _hashes_by_name("corr-a")
+    b = _hashes_by_name("corr-b")
+    shared = set(a) & set(b)
+    for name in shared - {"run_manifest.json"}:
+        assert a[name] == b[name], f"{name} hash drifted between identical bundles"
+
+
+def test_no_stray_files_under_correlation_dir(tmp_path: Path) -> None:
+    """Only the declared artifacts appear in the bundle directory on disk."""
+    write_evidence_bundle(tmp_path, _full_bundle("corr-no-stray"))
+    bundle_dir = tmp_path / "corr-no-stray"
+    files_on_disk = {p.name for p in bundle_dir.iterdir() if p.is_file()}
+    manifest = json.loads((bundle_dir / "artifact_manifest.json").read_text())
+    declared = {a["filename"] for a in manifest["artifacts"]} | {
+        "artifact_manifest.json",
+        "proof_summary.md",
+    }
+    assert files_on_disk == declared, (
+        f"on-disk files diverge from declared artifacts: "
+        f"{files_on_disk.symmetric_difference(declared)}"
+    )
+
+
+def test_artifact_sha256_matches_recomputation_for_each_file(tmp_path: Path) -> None:
+    """Per-artifact SHA-256 in the manifest matches a fresh disk recomputation."""
+    write_evidence_bundle(tmp_path, _full_bundle("corr-recompute"))
+    bundle_dir = tmp_path / "corr-recompute"
+    manifest = json.loads((bundle_dir / "artifact_manifest.json").read_text())
+    for artifact in manifest["artifacts"]:
+        on_disk = hashlib.sha256(
+            (bundle_dir / artifact["filename"]).read_bytes()
+        ).hexdigest()
+        assert on_disk == artifact["sha256"], (
+            f"{artifact['filename']} disk hash != manifest hash"
+        )

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -155,6 +155,8 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolKafkaReplayConsumer": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py",
     "ProtocolOffsetAndTimestamp": "nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py",
     "ProtocolTopicPartition": "nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py",
+    # [NODE] OMN-11207 structural protocol for evidence bundles accepted by the writer
+    "ProtocolEvidenceBundle": "utils/util_evidence_bundle_writer.py",
 }
 
 # Duplicate protocol names that appear in multiple files (node-internal

--- a/tests/unit/utils/test_evidence_bundle_writer.py
+++ b/tests/unit/utils/test_evidence_bundle_writer.py
@@ -189,15 +189,12 @@ class TestArtifactManifest:
         bundle = _make_full_bundle("corr-recompute")
         bundle_dir = write_evidence_bundle(tmp_path, bundle)
         proof_text = (bundle_dir / _PROOF_SUMMARY).read_text()
-        # Extract sha256 from proof_summary.md
-        recorded_sha: str | None = None
+        recorded_sha = ""
         for line in proof_text.splitlines():
             if "artifact_manifest_sha256" in line:
-                # line: **artifact_manifest_sha256**: `<hex>`
                 recorded_sha = line.split("`")[1]
                 break
-        if recorded_sha is None:
-            pytest.fail("artifact_manifest_sha256 not found in proof_summary.md")
+        assert recorded_sha, "artifact_manifest_sha256 not found in proof_summary.md"
 
         actual_sha = _sha256(bundle_dir / _ARTIFACT_MANIFEST)
         assert actual_sha == recorded_sha

--- a/tests/unit/utils/test_evidence_bundle_writer.py
+++ b/tests/unit/utils/test_evidence_bundle_writer.py
@@ -190,12 +190,13 @@ class TestArtifactManifest:
         bundle_dir = write_evidence_bundle(tmp_path, bundle)
         proof_text = (bundle_dir / _PROOF_SUMMARY).read_text()
         # Extract sha256 from proof_summary.md
+        recorded_sha: str | None = None
         for line in proof_text.splitlines():
             if "artifact_manifest_sha256" in line:
                 # line: **artifact_manifest_sha256**: `<hex>`
                 recorded_sha = line.split("`")[1]
                 break
-        else:
+        if recorded_sha is None:
             pytest.fail("artifact_manifest_sha256 not found in proof_summary.md")
 
         actual_sha = _sha256(bundle_dir / _ARTIFACT_MANIFEST)

--- a/tests/unit/utils/test_evidence_bundle_writer.py
+++ b/tests/unit/utils/test_evidence_bundle_writer.py
@@ -81,6 +81,31 @@ class TestEvidenceBundleDirectoryCreation:
         with pytest.raises(ValueError, match="correlation_id"):
             write_evidence_bundle(tmp_path, bundle)
 
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../escape",
+            "nested/path",
+            "back\\slash",
+            ".",
+            "..",
+            ".hidden",
+            "/absolute",
+        ],
+    )
+    def test_correlation_id_path_traversal_rejected(
+        self, tmp_path: Path, bad_id: str
+    ) -> None:
+        bundle = {"correlation_id": bad_id, "run_manifest": {}}
+        with pytest.raises(ValueError, match="single path segment"):
+            write_evidence_bundle(tmp_path, bundle)
+
+    def test_existing_bundle_dir_raises_file_exists(self, tmp_path: Path) -> None:
+        bundle = _make_minimal_bundle("corr-replay")
+        write_evidence_bundle(tmp_path, bundle)
+        with pytest.raises(FileExistsError, match="already exists"):
+            write_evidence_bundle(tmp_path, bundle)
+
 
 @pytest.mark.unit
 class TestEvidenceBundleArtifactsWritten:

--- a/tests/unit/utils/test_evidence_bundle_writer.py
+++ b/tests/unit/utils/test_evidence_bundle_writer.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for util_evidence_bundle_writer module.
+
+Covers:
+- Bundle directory is created under evidence_root/correlation_id/
+- All declared artifacts are written to disk
+- artifact_manifest.json has correct hashes and monotonically increasing write_order
+- proof_summary.md is written LAST (highest write_order, NOT by mtime)
+- Bundle hash (artifact_manifest sha256) matches recomputation
+- Optional artifacts are omitted when None
+- Dict-style bundles are accepted
+- Empty correlation_id raises ValueError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnibase_infra.utils.util_evidence_bundle_writer import write_evidence_bundle
+
+_PROOF_SUMMARY = "proof_summary.md"
+_ARTIFACT_MANIFEST = "artifact_manifest.json"
+_RUN_MANIFEST = "run_manifest.json"
+_CONTRACT_SNAPSHOT = "contract_snapshot.json"
+_INPUT = "input.json"
+_OUTPUT = "output.json"
+_VERIFIER_RESULT = "verifier_result.json"
+
+
+def _make_full_bundle(correlation_id: str = "test-corr-001") -> dict[str, Any]:
+    return {
+        "correlation_id": correlation_id,
+        "run_manifest": {"node": "node_test_compute", "version": "1.0.0"},
+        "contract_snapshot": {
+            "name": "node_test_compute",
+            "node_type": "COMPUTE_GENERIC",
+        },
+        "input": {"payload": "hello"},
+        "output": {"result": "world"},
+        "verifier_result": {"passed": True, "checks": []},
+    }
+
+
+def _make_minimal_bundle(correlation_id: str = "test-corr-min") -> dict[str, Any]:
+    return {
+        "correlation_id": correlation_id,
+        "run_manifest": {"node": "node_minimal", "version": "0.1.0"},
+        "contract_snapshot": None,
+        "input": None,
+        "output": None,
+        "verifier_result": None,
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.mark.unit
+class TestEvidenceBundleDirectoryCreation:
+    def test_creates_bundle_dir_under_evidence_root(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-dir-test")
+        result = write_evidence_bundle(tmp_path, bundle)
+        assert result == tmp_path / "corr-dir-test"
+        assert result.is_dir()
+
+    def test_creates_nested_evidence_root_if_missing(self, tmp_path: Path) -> None:
+        deep_root = tmp_path / "docs" / "evidence" / "plan-alpha"
+        bundle = _make_minimal_bundle("corr-nested")
+        result = write_evidence_bundle(deep_root, bundle)
+        assert result.is_dir()
+
+    def test_empty_correlation_id_raises(self, tmp_path: Path) -> None:
+        bundle = {"correlation_id": "", "run_manifest": {}}
+        with pytest.raises(ValueError, match="correlation_id"):
+            write_evidence_bundle(tmp_path, bundle)
+
+
+@pytest.mark.unit
+class TestEvidenceBundleArtifactsWritten:
+    def test_full_bundle_writes_all_artifacts(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-full")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        for filename in [
+            _RUN_MANIFEST,
+            _CONTRACT_SNAPSHOT,
+            _INPUT,
+            _OUTPUT,
+            _VERIFIER_RESULT,
+            _ARTIFACT_MANIFEST,
+            _PROOF_SUMMARY,
+        ]:
+            assert (bundle_dir / filename).exists(), f"Missing: {filename}"
+
+    def test_minimal_bundle_omits_optional_artifacts(self, tmp_path: Path) -> None:
+        bundle = _make_minimal_bundle("corr-min")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        assert (bundle_dir / _RUN_MANIFEST).exists()
+        assert (bundle_dir / _ARTIFACT_MANIFEST).exists()
+        assert (bundle_dir / _PROOF_SUMMARY).exists()
+        for optional in [_CONTRACT_SNAPSHOT, _INPUT, _OUTPUT, _VERIFIER_RESULT]:
+            assert not (bundle_dir / optional).exists(), f"Should be absent: {optional}"
+
+    def test_run_manifest_contents_match(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-content")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        data = json.loads((bundle_dir / _RUN_MANIFEST).read_text())
+        assert data["node"] == "node_test_compute"
+        assert data["version"] == "1.0.0"
+
+
+@pytest.mark.unit
+class TestArtifactManifest:
+    def test_artifact_manifest_has_correct_hashes(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-hash")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        for entry in manifest["artifacts"]:
+            actual = _sha256(bundle_dir / entry["filename"])
+            assert actual == entry["sha256"], (
+                f"Hash mismatch for {entry['filename']}: "
+                f"expected {entry['sha256']}, got {actual}"
+            )
+
+    def test_artifact_manifest_write_order_is_monotonic(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-order")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        orders = [e["write_order"] for e in manifest["artifacts"]]
+        assert orders == list(range(len(orders))), (
+            f"Write order not monotonic: {orders}"
+        )
+
+    def test_artifact_manifest_correlation_id_matches(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-id-check")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        assert manifest["correlation_id"] == "corr-id-check"
+
+    def test_artifact_manifest_artifact_count_matches_entries(
+        self, tmp_path: Path
+    ) -> None:
+        bundle = _make_full_bundle("corr-count")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        assert manifest["artifact_count"] == len(manifest["artifacts"])
+
+    def test_minimal_bundle_manifest_artifact_count(self, tmp_path: Path) -> None:
+        bundle = _make_minimal_bundle("corr-min-count")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        # Only run_manifest is written for minimal bundle
+        assert manifest["artifact_count"] == 1
+
+    def test_artifact_manifest_sha256_matches_recomputation(
+        self, tmp_path: Path
+    ) -> None:
+        bundle = _make_full_bundle("corr-recompute")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        proof_text = (bundle_dir / _PROOF_SUMMARY).read_text()
+        # Extract sha256 from proof_summary.md
+        for line in proof_text.splitlines():
+            if "artifact_manifest_sha256" in line:
+                # line: **artifact_manifest_sha256**: `<hex>`
+                recorded_sha = line.split("`")[1]
+                break
+        else:
+            pytest.fail("artifact_manifest_sha256 not found in proof_summary.md")
+
+        actual_sha = _sha256(bundle_dir / _ARTIFACT_MANIFEST)
+        assert actual_sha == recorded_sha
+
+
+@pytest.mark.unit
+class TestProofSummarySentinel:
+    def test_proof_summary_is_last_by_write_order(self, tmp_path: Path) -> None:
+        """proof_summary.md must be written LAST — verified via write_order, not mtime."""
+        bundle = _make_full_bundle("corr-sentinel")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        artifact_filenames = {e["filename"] for e in manifest["artifacts"]}
+        # proof_summary.md is NOT in the manifest — it is the sentinel written after
+        assert _PROOF_SUMMARY not in artifact_filenames
+
+    def test_proof_summary_exists_after_write(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-sentinel-exists")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        assert (bundle_dir / _PROOF_SUMMARY).exists()
+
+    def test_proof_summary_lists_all_manifest_artifacts(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-sentinel-list")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        manifest = json.loads((bundle_dir / _ARTIFACT_MANIFEST).read_text())
+        proof_text = (bundle_dir / _PROOF_SUMMARY).read_text()
+        for entry in manifest["artifacts"]:
+            assert entry["filename"] in proof_text, (
+                f"Artifact {entry['filename']} missing from proof_summary.md"
+            )
+
+    def test_proof_summary_references_correlation_id(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-sentinel-id")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        proof_text = (bundle_dir / _PROOF_SUMMARY).read_text()
+        assert "corr-sentinel-id" in proof_text
+
+
+@pytest.mark.unit
+class TestDictStyleBundle:
+    def test_dict_bundle_with_all_fields(self, tmp_path: Path) -> None:
+        bundle = _make_full_bundle("corr-dict-full")
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        assert (bundle_dir / _RUN_MANIFEST).exists()
+        assert (bundle_dir / _PROOF_SUMMARY).exists()
+
+    def test_dict_bundle_minimal_keys(self, tmp_path: Path) -> None:
+        bundle = {"correlation_id": "corr-dict-min", "run_manifest": {"v": 1}}
+        bundle_dir = write_evidence_bundle(tmp_path, bundle)
+        assert (bundle_dir / _RUN_MANIFEST).exists()
+        assert (bundle_dir / _PROOF_SUMMARY).exists()
+        # Optional artifacts absent
+        for optional in [_CONTRACT_SNAPSHOT, _INPUT, _OUTPUT, _VERIFIER_RESULT]:
+            assert not (bundle_dir / optional).exists()


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_infra/utils/util_evidence_bundle_writer.py` with `write_evidence_bundle()`: a reusable utility that writes tamper-evident evidence bundles to disk with a defined write sequence and atomicity sentinel.
- Artifacts written in order: `run_manifest.json` → optional artifacts → `artifact_manifest.json` (SHA-256 + monotonic `write_order`) → `proof_summary.md` LAST as the completeness sentinel.
- Never uses filesystem timestamps for ordering proof — `write_order` integers are the canonical sequence.
- Introduces `ProtocolEvidenceBundle` (structural Protocol) and `DictBundleAdapter` for dict-style bundles, decoupled from the pending omnibase_core PR #1099.
- 18 unit tests covering: directory creation, all artifact writes, hash correctness, `write_order` monotonicity, sentinel semantics, dict-style bundles, and recomputed manifest SHA-256 verification.

## Ticket

OMN-11207 (epic OMN-11188)

## Test plan

- [x] `uv run pytest tests/unit/utils/test_evidence_bundle_writer.py -v` — 18/18 passed
- [x] `uv run mypy src/omnibase_infra/utils/util_evidence_bundle_writer.py --strict` — 0 errors
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] `pre-commit run --files ...` — all hooks passed

Evidence-Source: OCC#1121
Evidence-Ticket: OMN-11207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tamper‑evident evidence bundle export: deterministic JSON artifacts, per‑artifact SHA‑256 hashes, an artifact manifest, and a final proof‑summary sentinel for atomicity and verifiability.
  * Validation of bundle IDs to reject invalid/empty IDs and refuse overwrites; accepts dict-style bundle inputs.

* **Tests**
  * Unit and integration tests validating artifact ordering, hash determinism, manifest integrity, sentinel behavior, and absence of stray files.

* **Chores**
  * Minor license/header additions to tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->