### PR TITLE
fix(OMN-10814): add config injection path for LINEAR_API_KEY in node_merge_gate_effect

### DIFF
--- a/contracts/OMN-10814.yaml
+++ b/contracts/OMN-10814.yaml
@@ -1,0 +1,20 @@
+# OMN-10814 contract file for omnibase_infra deploy-gate.
+# This repo-local contract carries deploy-gate evidence only.
+schema_version: "1.0.0"
+ticket_id: "OMN-10814"
+title: "Add config injection path for LINEAR_API_KEY in node_merge_gate_effect"
+summary: "HandlerUpsertMergeGate now consumes Linear credentials from typed constructor injection backed by node_merge_gate_effect/contract.yaml config declarations, instead of reading LINEAR_API_KEY or LINEAR_TEAM_ID directly from os.environ. The change is runtime library behavior only; no live deploy or restart is performed pre-merge."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-deploy"
+    description: "Deploy validation plan for the merge-gate Linear config injection path. No runtime deploy, restart, or .201 mutation was performed pre-merge."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omninode-runtime after merge during the normal rollout, then verify the deployed image imports HandlerUpsertMergeGate and that node_merge_gate_effect/contract.yaml declares linear_api_key and linear_team_id config entries; pre-merge proof is local unit and integration coverage only."

--- a/src/omnibase_infra/nodes/node_merge_gate_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_merge_gate_effect/contract.yaml
@@ -179,6 +179,16 @@ io_operations:
       - duration_ms
       - correlation_id
       - backend_id
+# =============================================================================
+# CONFIG (injectable via DI / secret resolver)
+# =============================================================================
+config:
+  linear_api_key:
+    default: null
+    description: "Linear API key for quarantine ticket creation (optional; when null, QUARANTINE tickets are skipped)"
+  linear_team_id:
+    default: null
+    description: "Linear team ID for quarantine ticket creation (optional; when null, QUARANTINE tickets are skipped)"
 # Dependencies (protocols this node requires)
 dependencies:
   - name: "protocol_postgres_adapter"

--- a/src/omnibase_infra/nodes/node_merge_gate_effect/handlers/handler_upsert_merge_gate.py
+++ b/src/omnibase_infra/nodes/node_merge_gate_effect/handlers/handler_upsert_merge_gate.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -137,14 +136,25 @@ class HandlerUpsertMergeGate(MixinPostgresOpExecutor):
         True
     """
 
-    def __init__(self, pool: asyncpg.Pool | None = None) -> None:
-        """Initialise handler with asyncpg connection pool.
+    def __init__(
+        self,
+        pool: asyncpg.Pool | None = None,
+        linear_api_key: str | None = None,
+        linear_team_id: str | None = None,
+    ) -> None:
+        """Initialise handler with asyncpg connection pool and optional Linear config.
 
         Args:
             pool: asyncpg connection pool. Should be pre-configured and ready.
                 When None (auto-wired path), handle() returns a failure result.
+            linear_api_key: Linear API key for quarantine ticket creation.
+                When None, quarantine tickets are skipped with a warning.
+            linear_team_id: Linear team ID for quarantine ticket creation.
+                When None, quarantine tickets are skipped with a warning.
         """
         self._pool = pool
+        self._linear_api_key = linear_api_key
+        self._linear_team_id = linear_team_id
 
     @property
     def handler_type(self) -> EnumHandlerType:
@@ -266,12 +276,8 @@ class HandlerUpsertMergeGate(MixinPostgresOpExecutor):
             payload: Merge gate decision payload.
             correlation_id: Correlation ID for tracing.
         """
-        api_key = os.environ.get(
-            "LINEAR_API_KEY"
-        )  # ONEX_EXCLUDE: Linear API key has no config injection path
-        team_id = os.environ.get(
-            "LINEAR_TEAM_ID"
-        )  # ONEX_EXCLUDE: Linear team ID has no config injection path
+        api_key = self._linear_api_key
+        team_id = self._linear_team_id
 
         if not api_key or not team_id:
             logger.warning(

--- a/tests/integration/nodes/test_node_merge_gate_effect_config_injection_integration.py
+++ b/tests/integration/nodes/test_node_merge_gate_effect_config_injection_integration.py
@@ -30,7 +30,7 @@ from omnibase_infra.nodes.node_merge_gate_effect.models.model_merge_gate_result 
 pytestmark = [pytest.mark.integration]
 
 CONTRACT = (
-    Path(__file__).resolve().parents[3]
+    Path(__file__).parents[3]
     / "src"
     / "omnibase_infra"
     / "nodes"

--- a/tests/integration/nodes/test_node_merge_gate_effect_config_injection_integration.py
+++ b/tests/integration/nodes/test_node_merge_gate_effect_config_injection_integration.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for node_merge_gate_effect Linear config injection (OMN-10814).
+
+Proves the contract-to-handler wiring for the LINEAR_API_KEY config injection
+path: the contract.yaml declares the two config keys the DI/secret resolver is
+expected to supply, and the handler consumes those injected values rather than
+reading os.environ directly. The regression this guards against is the original
+``os.environ.get("LINEAR_API_KEY")`` read, which had no contract declaration and
+no injection path, so the resolver could never supply the credential.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import yaml
+
+from omnibase_infra.nodes.node_merge_gate_effect.handlers.handler_upsert_merge_gate import (
+    HandlerUpsertMergeGate,
+)
+from omnibase_infra.nodes.node_merge_gate_effect.models.model_merge_gate_result import (
+    ModelMergeGateResult,
+    ModelMergeGateViolation,
+)
+
+pytestmark = [pytest.mark.integration]
+
+CONTRACT = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "omnibase_infra"
+    / "nodes"
+    / "node_merge_gate_effect"
+    / "contract.yaml"
+)
+
+
+def _make_quarantine_payload() -> ModelMergeGateResult:
+    from datetime import UTC, datetime
+
+    return ModelMergeGateResult(
+        gate_id=uuid4(),
+        pr_ref="OmniNode-ai/omnibase_infra#42",
+        head_sha="abc123def456",
+        base_sha="000111222333",
+        decision="QUARANTINE",
+        tier="tier-a",
+        violations=[
+            ModelMergeGateViolation(
+                rule_code="RRH-1001",
+                severity="FAIL",
+                message="Working tree is dirty",
+            ),
+        ],
+        run_id=uuid4(),
+        correlation_id=uuid4(),
+        run_fingerprint="fp-test-12345",
+        decided_at=datetime.now(tz=UTC),
+    )
+
+
+def _make_pool() -> MagicMock:
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"was_insert": True})
+    pool = MagicMock()
+    acquire = AsyncMock()
+    acquire.__aenter__ = AsyncMock(return_value=conn)
+    acquire.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire = MagicMock(return_value=acquire)
+    return pool
+
+
+def test_contract_declares_linear_config_keys() -> None:
+    """The contract declares the config keys the resolver injects into the handler."""
+    contract = yaml.safe_load(CONTRACT.read_text(encoding="utf-8"))
+    config = contract["config"]
+
+    assert "linear_api_key" in config
+    assert "linear_team_id" in config
+    # Optional credentials: default null so the resolver may legitimately omit
+    # them, in which case QUARANTINE ticket creation is skipped.
+    assert config["linear_api_key"]["default"] is None
+    assert config["linear_team_id"]["default"] is None
+
+
+@pytest.mark.asyncio
+async def test_injected_credential_reaches_linear_request_not_env() -> None:
+    """The injected key flows to the Linear request even when env vars are unset.
+
+    With os.environ cleared of LINEAR_API_KEY/LINEAR_TEAM_ID, the handler still
+    creates the ticket using the constructor-injected credential — proving the
+    DI path is the source of truth, not the removed os.environ read.
+    """
+    payload = _make_quarantine_payload()
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json = MagicMock(
+        return_value={
+            "data": {
+                "issueCreate": {
+                    "success": True,
+                    "issue": {
+                        "id": "i1",
+                        "identifier": "OMN-1",
+                        "url": "https://linear.app/omninode/issue/OMN-1",
+                    },
+                }
+            }
+        }
+    )
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"LINEAR_API_KEY": "", "LINEAR_TEAM_ID": ""},
+            clear=False,
+        ),
+        patch(
+            "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+            "handler_upsert_merge_gate.httpx.AsyncClient"
+        ) as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        handler = HandlerUpsertMergeGate(
+            _make_pool(),
+            linear_api_key="resolver-injected-key",
+            linear_team_id="resolver-injected-team",
+        )
+        result = await handler.handle(payload, uuid4())
+
+    assert result.success is True
+    mock_client.post.assert_called_once()
+    post_kwargs = mock_client.post.call_args[1]
+    assert post_kwargs["headers"]["Authorization"] == "resolver-injected-key"
+    assert post_kwargs["json"]["variables"]["teamId"] == "resolver-injected-team"
+
+
+@pytest.mark.asyncio
+async def test_missing_injected_credential_skips_linear_call() -> None:
+    """Without injected credentials the upsert succeeds and no Linear call is made."""
+    payload = _make_quarantine_payload()
+
+    with patch(
+        "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+        "handler_upsert_merge_gate.httpx.AsyncClient"
+    ) as mock_client_cls:
+        handler = HandlerUpsertMergeGate(_make_pool())
+        result = await handler.handle(payload, uuid4())
+
+    assert result.success is True
+    mock_client_cls.assert_not_called()

--- a/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
+++ b/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
@@ -188,23 +188,21 @@ class TestHandlerUpsertMergeGateQuarantine:
             }
         )
 
-        with (
-            patch.dict(
-                "os.environ",
-                {"LINEAR_API_KEY": "test-key", "LINEAR_TEAM_ID": "team-123"},
-            ),
-            patch(
-                "omnibase_infra.nodes.node_merge_gate_effect.handlers."
-                "handler_upsert_merge_gate.httpx.AsyncClient"
-            ) as mock_client_cls,
-        ):
+        with patch(
+            "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+            "handler_upsert_merge_gate.httpx.AsyncClient"
+        ) as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client.post = AsyncMock(return_value=mock_resp)
             mock_client_cls.return_value = mock_client
 
-            handler = HandlerUpsertMergeGate(pool)
+            handler = HandlerUpsertMergeGate(
+                pool,
+                linear_api_key="test-key",
+                linear_team_id="team-123",
+            )
             result = await handler.handle(payload, uuid4())
 
         assert result.success is True
@@ -255,20 +253,15 @@ class TestHandlerUpsertMergeGateQuarantine:
 
     @pytest.mark.asyncio
     async def test_quarantine_without_linear_config_still_succeeds(self) -> None:
-        """QUARANTINE without LINEAR_API_KEY skips ticket, upsert still succeeds."""
+        """QUARANTINE without injected Linear config skips ticket, upsert still succeeds."""
         conn = AsyncMock()
         conn.fetchrow = AsyncMock(return_value={"was_insert": True})
         pool = create_mock_pool_with_conn(conn)
 
         payload = make_gate_payload(decision="QUARANTINE")
 
-        with patch.dict(
-            "os.environ",
-            {"LINEAR_API_KEY": "", "LINEAR_TEAM_ID": ""},
-            clear=False,
-        ):
-            handler = HandlerUpsertMergeGate(pool)
-            result = await handler.handle(payload, uuid4())
+        handler = HandlerUpsertMergeGate(pool)
+        result = await handler.handle(payload, uuid4())
 
         assert result.success is True
 
@@ -281,23 +274,21 @@ class TestHandlerUpsertMergeGateQuarantine:
 
         payload = make_gate_payload(decision="QUARANTINE")
 
-        with (
-            patch.dict(
-                "os.environ",
-                {"LINEAR_API_KEY": "test-key", "LINEAR_TEAM_ID": "team-123"},
-            ),
-            patch(
-                "omnibase_infra.nodes.node_merge_gate_effect.handlers."
-                "handler_upsert_merge_gate.httpx.AsyncClient"
-            ) as mock_client_cls,
-        ):
+        with patch(
+            "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+            "handler_upsert_merge_gate.httpx.AsyncClient"
+        ) as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
             mock_client_cls.return_value = mock_client
 
-            handler = HandlerUpsertMergeGate(pool)
+            handler = HandlerUpsertMergeGate(
+                pool,
+                linear_api_key="test-key",
+                linear_team_id="team-123",
+            )
             result = await handler.handle(payload, uuid4())
 
         # Upsert succeeded even though Linear failed
@@ -432,10 +423,93 @@ class TestTierAContractGateProfile:
         assert len(profile.rules) == 13
 
 
+# =============================================================================
+# Tests: injected Linear config (OMN-10814)
+# =============================================================================
+
+
+class TestHandlerUpsertMergeGateInjectedConfig:
+    """Test that injected linear_api_key/linear_team_id take precedence over env vars."""
+
+    @pytest.mark.asyncio
+    async def test_injected_api_key_used_over_env_var(self) -> None:
+        """Constructor-injected linear_api_key is used; env var is not read."""
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value={"was_insert": True})
+        pool = create_mock_pool_with_conn(conn)
+
+        violations = [
+            ModelMergeGateViolation(
+                rule_code="RRH-1001",
+                severity="FAIL",
+                message="Working tree is dirty",
+            ),
+        ]
+        payload = make_gate_payload(decision="QUARANTINE", violations=violations)
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={
+                "data": {
+                    "issueCreate": {
+                        "success": True,
+                        "issue": {"id": "i1", "identifier": "OMN-1", "url": "http://x"},
+                    }
+                }
+            }
+        )
+
+        with (
+            patch.dict("os.environ", {}, clear=False),
+            patch(
+                "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+                "handler_upsert_merge_gate.httpx.AsyncClient"
+            ) as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            handler = HandlerUpsertMergeGate(
+                pool,
+                linear_api_key="injected-key",
+                linear_team_id="injected-team",
+            )
+            result = await handler.handle(payload, uuid4())
+
+        assert result.success is True
+        mock_client.post.assert_called_once()
+        post_kwargs = mock_client.post.call_args[1]
+        assert post_kwargs["headers"]["Authorization"] == "injected-key"
+
+    @pytest.mark.asyncio
+    async def test_no_injected_config_skips_linear_ticket(self) -> None:
+        """Without injected linear config, QUARANTINE upsert succeeds but Linear is skipped."""
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value={"was_insert": True})
+        pool = create_mock_pool_with_conn(conn)
+
+        payload = make_gate_payload(decision="QUARANTINE")
+
+        with patch(
+            "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+            "handler_upsert_merge_gate.httpx.AsyncClient"
+        ) as mock_client_cls:
+            handler = HandlerUpsertMergeGate(pool)
+            result = await handler.handle(payload, uuid4())
+
+        assert result.success is True
+        mock_client_cls.assert_not_called()
+
+
 __all__: list[str] = [
     "TestHandlerUpsertMergeGateSuccess",
     "TestHandlerUpsertMergeGateQuarantine",
     "TestHandlerUpsertMergeGateErrors",
     "TestModelMergeGateResult",
     "TestTierAContractGateProfile",
+    "TestHandlerUpsertMergeGateInjectedConfig",
 ]

--- a/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
+++ b/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
@@ -465,7 +465,11 @@ class TestHandlerUpsertMergeGateInjectedConfig:
         )
 
         with (
-            patch.dict("os.environ", {}, clear=False),
+            patch.dict(
+                "os.environ",
+                {"LINEAR_API_KEY": "env-key", "LINEAR_TEAM_ID": "env-team"},
+                clear=False,
+            ),
             patch(
                 "omnibase_infra.nodes.node_merge_gate_effect.handlers."
                 "handler_upsert_merge_gate.httpx.AsyncClient"
@@ -488,6 +492,7 @@ class TestHandlerUpsertMergeGateInjectedConfig:
         mock_client.post.assert_called_once()
         post_kwargs = mock_client.post.call_args[1]
         assert post_kwargs["headers"]["Authorization"] == "injected-key"
+        assert post_kwargs["json"]["variables"]["teamId"] == "injected-team"
 
     @pytest.mark.asyncio
     async def test_no_injected_config_skips_linear_ticket(self) -> None:
@@ -498,10 +503,17 @@ class TestHandlerUpsertMergeGateInjectedConfig:
 
         payload = make_gate_payload(decision="QUARANTINE")
 
-        with patch(
-            "omnibase_infra.nodes.node_merge_gate_effect.handlers."
-            "handler_upsert_merge_gate.httpx.AsyncClient"
-        ) as mock_client_cls:
+        with (
+            patch.dict(
+                "os.environ",
+                {"LINEAR_API_KEY": "env-key", "LINEAR_TEAM_ID": "env-team"},
+                clear=False,
+            ),
+            patch(
+                "omnibase_infra.nodes.node_merge_gate_effect.handlers."
+                "handler_upsert_merge_gate.httpx.AsyncClient"
+            ) as mock_client_cls,
+        ):
             handler = HandlerUpsertMergeGate(pool)
             result = await handler.handle(payload, uuid4())
 

--- a/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
+++ b/tests/unit/nodes/node_merge_gate_effect/handlers/test_handler_upsert_merge_gate.py
@@ -454,7 +454,11 @@ class TestHandlerUpsertMergeGateInjectedConfig:
                 "data": {
                     "issueCreate": {
                         "success": True,
-                        "issue": {"id": "i1", "identifier": "OMN-1", "url": "http://x"},
+                        "issue": {
+                            "id": "i1",
+                            "identifier": "OMN-1",
+                            "url": "https://linear.app/omninode/issue/OMN-1",
+                        },
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adds `linear_api_key` and `linear_team_id` as optional constructor parameters to `HandlerUpsertMergeGate` — callers inject credentials via DI instead of relying on bare `os.environ` reads
- Adds a `config:` section to `node_merge_gate_effect/contract.yaml` documenting the injection contract for both values
- Removes the two `ONEX_EXCLUDE: Linear API key has no config injection path` annotations and the `os.environ` reads entirely — the injection path now exists
- When `linear_api_key` or `linear_team_id` are not injected (`None`), QUARANTINE ticket creation is skipped with a warning log (same graceful-degradation behavior as before)
- Migrates existing tests from `patch.dict("os.environ", ...)` mocks to constructor injection
- Adds 2 new unit tests: injected key used over env, no-config path skips Linear

## Test plan

- [x] `uv run pytest tests/unit/nodes/node_merge_gate_effect/ -v` — 19/19 passed
- [x] `uv run ruff check` — clean
- [x] `pre-commit run --files ...` — all hooks pass including `check-env-reads`

Closes OMN-10814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored Linear integration configuration management for more flexible credential handling; system now gracefully skips quarantine ticket creation when Linear credentials are unavailable.

* **Tests**
  * Added integration and unit tests validating credential injection and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1229
Evidence-Ticket: OMN-10814