### PR TITLE
feat(OMN-9121): add Prometheus crash-loop alerting rules for omninode-* containers

### DIFF
--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Minimal Prometheus configuration for ONEX runtime crash-loop alerting (OMN-9121).
+#
+# Integration path:
+#   Add the observability profile services to docker-compose.infra.yml and start with:
+#     docker compose -f docker/docker-compose.infra.yml --profile observability up -d
+#
+# Metric sources:
+#   - cAdvisor (cadvisor:8080): Docker container metrics including container_restarts_total
+#   - ONEX runtime apps (:9090/metrics): App-level metrics via HandlerMetricsPrometheus
+#
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+rule_files:
+  - "rules/runtime-health.yml"
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            # Alertmanager runs at :9093 when deployed; leave empty for rules-only mode.
+            - "alertmanager:9093"
+scrape_configs:
+  # ---------------------------------------------------------------------------
+  # cAdvisor — Docker container metrics (RestartCount, CPU, memory, etc.)
+  # ---------------------------------------------------------------------------
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]
+    metrics_path: /metrics
+    scrape_interval: 15s
+  # ---------------------------------------------------------------------------
+  # ONEX runtime services — app-level Prometheus metrics (:9090/metrics)
+  # ---------------------------------------------------------------------------
+  # HandlerMetricsPrometheus binds to localhost:9090 by default (secure default).
+  # In Docker, set METRICS_HOST=0.0.0.0 and expose port 9090 per service to enable.
+  - job_name: "omninode-runtime-main"
+    static_configs:
+      - targets: ["omninode-runtime:9090"]
+    metrics_path: /metrics
+    scrape_interval: 30s
+  - job_name: "omninode-runtime-effects"
+    static_configs:
+      - targets: ["omninode-runtime-effects:9090"]
+    metrics_path: /metrics
+    scrape_interval: 30s

--- a/observability/prometheus/rules/runtime-health.yml
+++ b/observability/prometheus/rules/runtime-health.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Prometheus alerting rules for ONEX runtime crash-loop detection (OMN-9121).
+#
+# Metric source: cAdvisor (container_restarts_total)
+# cAdvisor exposes Docker container restart counts scraped from the Docker daemon.
+# Add cAdvisor to the compose stack (see observability/prometheus/prometheus.yml)
+# to enable these alerts.
+#
+# Containers targeted: any container whose name matches "omninode-*" — covers
+# omninode-runtime, omninode-runtime-effects, omninode-skill-lifecycle-consumer,
+# omninode-agent-actions-consumer, omninode-context-audit-consumer, etc.
+#
+# The 490-restart incident (OMN-9121): runtime crash-looped for 72h with zero
+# alerting. These rules close that structural gap.
+groups:
+  - name: runtime-health
+    rules:
+      # ---------------------------------------------------------------------------
+      # Critical: crash-loop storm — ≥4 restarts in 5 minutes
+      # ---------------------------------------------------------------------------
+      # Fires when a container is actively crash-looping. The 2m `for` clause
+      # absorbs one-off blips (e.g. a single OOM during a deploy) while catching
+      # sustained crash loops within 7 minutes of onset.
+      - alert: OmninodeRuntimeRestartStorm
+        expr: increase(container_restarts_total{name=~"omninode-.*"}[5m]) >= 4
+        for: 2m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "{{ $labels.name }} crash-looping ({{ $value | humanize }} restarts in 5m)"
+          description: "Container {{ $labels.name }} has restarted {{ $value | humanize }} times in the last 5 minutes and has been in this state for at least 2 minutes. Investigate immediately — this matches the 490-restart incident pattern."
+          runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/runtime-crash-loop.md"
+      # ---------------------------------------------------------------------------
+      # Warning: accumulated restart count — >10 lifetime restarts
+      # ---------------------------------------------------------------------------
+      # Fires when a container has accumulated more than 10 total restarts since
+      # the Docker daemon last started. A high accumulated count indicates repeated
+      # instability even if the current burst rate is low.
+      - alert: OmninodeRuntimeHighRestartCount
+        expr: container_restarts_total{name=~"omninode-.*"} > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "{{ $labels.name }} accumulated {{ $value | humanize }} restarts"
+          description: "Container {{ $labels.name }} has accumulated {{ $value | humanize }} total restarts since the Docker daemon started. This may indicate persistent instability. Review logs and autoheal events."
+          runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/runtime-crash-loop.md"
+      # ---------------------------------------------------------------------------
+      # Warning: runtime health endpoint absent — container running but /health dead
+      # ---------------------------------------------------------------------------
+      # Fires when the Prometheus scrape target for a runtime container drops.
+      # Complements restart-count alerting: a container can be "running" per Docker
+      # while its health endpoint is unreachable (wiring failure, port conflict, etc.).
+      - alert: OmninodeRuntimeHealthEndpointDown
+        expr: up{job=~"omninode-runtime.*"} == 0
+        for: 3m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "{{ $labels.job }} health endpoint unreachable for 3m"
+          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}. The container may be running but its /metrics or /health endpoint is not responding. Check container logs and port bindings."

--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -142,6 +142,7 @@ ALLOWED_ROOT_DIRECTORIES: frozenset[str] = frozenset(
         "tools",
         "bin",
         "deploy",
+        "observability",
         # Hidden directories (generally allowed)
         ".git",
         ".github",


### PR DESCRIPTION
Evidence-Source: OCC#1226
Evidence-Ticket: OMN-9121

## Summary

- Creates `observability/prometheus/rules/runtime-health.yml` with three alerting rules targeting the 490-restart incident gap (OMN-9121):
  - **OmninodeRuntimeRestartStorm** (critical): `increase(container_restarts_total{name=~"omninode-.*"}[5m]) >= 4` for 2m — fires ~7 minutes after a crash-loop begins
  - **OmninodeRuntimeHighRestartCount** (warning): accumulated `container_restarts_total > 10` for 5m
  - **OmninodeRuntimeHealthEndpointDown** (warning): Prometheus scrape target `up == 0` for 3m (covers containers running but with dead health endpoint)
- Creates `observability/prometheus/prometheus.yml` — minimal Prometheus config that loads the rules file and declares cAdvisor + runtime app scrape targets
- Adds `observability/` to `validate_clean_root.py` allowlist

## Integration Path

This repo has no Prometheus server or cAdvisor in docker-compose.infra.yml today. To activate these rules, add an `--profile observability` to the compose stack:

```yaml
# In docker/docker-compose.infra.yml, under services:
cadvisor:
  image: gcr.io/cadvisor/cadvisor:v0.49.1
  container_name: omnibase-infra-cadvisor
  profiles: ["observability", "full"]
  volumes:
    - /:/rootfs:ro
    - /var/run:/var/run:ro
    - /sys:/sys:ro
    - /var/lib/docker/:/var/lib/docker:ro
  networks:
    - omnibase-infra-network

prometheus:
  image: prom/prometheus:v2.53.0
  container_name: omnibase-infra-prometheus
  profiles: ["observability", "full"]
  volumes:
    - ../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
    - ../observability/prometheus/rules:/etc/prometheus/rules:ro
  ports:
    - "9090:9090"
  networks:
    - omnibase-infra-network
```

Wiring the compose services is a follow-up (OMN-9121 scope = rules file). The rules file and prometheus config are ready to consume immediately once cAdvisor is mounted.

## Why cAdvisor

Docker's `RestartCount` is available in `docker inspect` (used by the existing Python `monitor_logs.py` / `RestartWatcher`). cAdvisor exposes `container_restarts_total` as a Prometheus-native counter, enabling the `increase()` burst-rate query that the Python monitor cannot do efficiently. The two systems are complementary — cAdvisor provides Prometheus-native alerting while `monitor_logs.py` provides Slack alerting.

## Test plan

- [ ] Verify rules file passes `promtool check rules observability/prometheus/rules/runtime-health.yml` (requires promtool; not in CI yet — follow-up)
- [ ] Verify prometheus.yml passes `promtool check config observability/prometheus/prometheus.yml`
- [ ] Deploy with `--profile observability`, confirm Prometheus loads rules without error
- [ ] Simulate crash-loop by force-restarting a container repeatedly, confirm `OmninodeRuntimeRestartStorm` fires

## Ticket

OMN-9121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive observability infrastructure for monitoring runtime health and application performance metrics.
  * Configured automated alerting rules to detect runtime issues, including excessive restart patterns and unavailable metrics endpoints.
  * Enabled real-time visibility into system stability, resource utilization, and component availability.
  * Integrated container and runtime metrics collection for enhanced monitoring coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

