### PR TITLE
test(OMN-9119): add real-manifest integration test for auto-wiring

### DIFF
--- a/tests/integration/test_auto_wiring_real_manifest.py
+++ b/tests/integration/test_auto_wiring_real_manifest.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Real-manifest auto-wiring invariant test [OMN-9119].
+
+This is the integration test that would have caught the OMN-8735 regression
+(14 real handlers broke in prod) had it existed at the time.  Previous
+auto-wiring tests used fake contracts with /fake/ paths and nonexistent modules.
+None exercised the actual project tree.
+
+This file does two things:
+1. Calls discover_contracts() against the real installed onex.nodes entry points
+   and asserts total_errors == 0 (discovery phase is clean).
+2. Calls wire_from_manifest() against that manifest with a mock dispatch engine
+   (no Kafka, no DB) and asserts total_failed == 0 (wiring phase is clean).
+
+A failure here means a real handler in src/ cannot be imported or instantiated —
+the kind of breakage that OMN-8735 introduced and that must never reach prod again.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+
+
+@pytest.mark.integration
+def test_real_manifest_discovery_has_no_errors() -> None:
+    """discover_contracts() against the installed onex.nodes entry points must produce zero errors.
+
+    This is the discovery-phase gate: every entry point must load cleanly and
+    every contract.yaml must parse without errors.  A failure here means a node
+    was registered in pyproject.toml [project.entry-points."onex.nodes"] but its
+    contract.yaml is missing, malformed, or its module cannot be imported.
+    """
+    manifest = discover_contracts()
+
+    assert manifest.total_errors == 0, (
+        f"discover_contracts() reported {manifest.total_errors} error(s) against the "
+        f"real manifest — this is a wiring regression.\n"
+        + "\n".join(
+            f"  [{e.package_name}] {e.entry_point_name}: {e.error}"
+            for e in manifest.errors
+        )
+    )
+    assert manifest.total_discovered > 0, (
+        "discover_contracts() found zero contracts — entry points may not be installed"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_real_manifest_wiring_has_no_failures() -> None:
+    """wire_from_manifest() against the real onex.nodes manifest must produce zero failures.
+
+    This is the wiring-phase gate: every handler module must be importable and
+    every handler class must be instantiable with no constructor arguments.  A
+    failure here means a handler that was working before has broken — exactly the
+    OMN-8735 regression pattern (14 handlers silently broke without this gate).
+
+    The dispatch engine is mocked to avoid Kafka/DB dependencies; event_bus=None
+    skips topic subscriptions so the test runs fully offline.
+    """
+    manifest = discover_contracts()
+
+    dispatch_engine = MagicMock()
+    dispatch_engine.is_frozen = False
+
+    report = await wire_from_manifest(
+        manifest=manifest,
+        dispatch_engine=dispatch_engine,
+        event_bus=None,
+        subscribe_immediately=False,
+    )
+
+    failed_results = [r for r in report.results if str(r.outcome).endswith("FAILED")]
+    assert report.total_failed == 0, (
+        f"wire_from_manifest() reported {report.total_failed} failure(s) against the "
+        f"real manifest — this is a wiring regression (OMN-8735 pattern).\n"
+        + "\n".join(f"  {r.contract_name}: {r.reason}" for r in failed_results)
+    )
+
+    # Confirm no ModelOnexError was raised in the results
+    error_results = [
+        r for r in report.results if r.reason and "ModelOnexError" in r.reason
+    ]
+    assert not error_results, "ModelOnexError found in wiring results:\n" + "\n".join(
+        f"  {r.contract_name}: {r.reason}" for r in error_results
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_auto_wiring_real_manifest.py` with two integration tests that exercise the **real** installed `onex.nodes` entry points rather than fake contracts
- `test_real_manifest_discovery_has_no_errors`: asserts `discover_contracts()` finds >0 contracts with zero discovery errors
- `test_real_manifest_wiring_has_no_failures`: asserts `wire_from_manifest()` produces `total_failed == 0` against the real manifest (mock dispatch engine, no Kafka/DB)

## Why this matters (OMN-8735)

The OMN-8735 regression broke 14 real handlers in prod. Every existing auto-wiring test used fake `/fake/` paths and nonexistent modules — none would have caught that regression. This test closes that gap: if a handler module becomes unimportable or its class loses its zero-arg constructor, this gate fails before merge.

## Test plan

- [x] Both tests pass locally (`2 passed in 1.61s`)
- [x] All pre-commit hooks pass
- [x] Existing auto-wiring tests unaffected
- [x] Full targeted test suite (8741 tests) passes; 27 pre-existing failures in `test_kernel.py` and `test_policy_registry_performance.py` are unrelated to this change

## Ticket

OMN-9119

Evidence-Source: OCC#1196
Evidence-Ticket: OMN-9119