### PR TITLE
feat(OMN-11246): dynamic topic subscription after dispatch engine freeze

### DIFF
--- a/contracts/OMN-11241.yaml
+++ b/contracts/OMN-11241.yaml
@@ -1,0 +1,28 @@
+# OMN-11241 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-11241
+title: "Post-freeze dynamic registration epic"
+summary: "Epic-level deploy evidence for runtime handler materialization after dispatch engine freeze."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+  - events
+evidence_requirements:
+  - kind: tests
+    description: "OMN-11246 verifies the concrete post-freeze dynamic registration behavior under this epic."
+    command: "uv run pytest tests/unit/runtime/test_dispatch_engine_post_freeze.py tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py -q"
+  - kind: manual
+    description: "Runtime deploy validation for the post-freeze dynamic registration epic."
+    command: "deploy: after authorized runtime rollout, materialize a contract after dispatch engine freeze and confirm dispatch reaches the dynamically registered handler."
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-deploy-dynamic-registration-epic
+    description: "Deploy evidence for post-freeze dynamic registration behavior covered by OMN-11246."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: after authorized runtime rollout, materialize a contract after dispatch engine freeze and confirm dispatch reaches the dynamically registered handler."

--- a/contracts/OMN-11246.yaml
+++ b/contracts/OMN-11246.yaml
@@ -1,0 +1,34 @@
+# OMN-11246 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-11246
+title: "Dynamic topic subscription after dispatch engine freeze"
+summary: "Allow explicitly authorized handler materialization to register dispatchers and routes after the dispatch engine has frozen."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - protocols
+  - events
+evidence_requirements:
+  - kind: tests
+    description: "Unit and integration tests prove authorized post-freeze dynamic registration while preserving normal freeze protection."
+    command: "uv run pytest tests/unit/runtime/test_dispatch_engine_post_freeze.py tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py -q"
+  - kind: manual
+    description: "Runtime deploy validation for post-freeze handler materialization."
+    command: "deploy: after authorized runtime rollout, materialize a contract after dispatch engine freeze and confirm dispatch reaches the dynamically registered handler."
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-dynamic-registration-tests
+    description: "Post-freeze dispatcher and route registration is only allowed through explicit dynamic materialization authorization."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_dispatch_engine_post_freeze.py tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py -q"
+  - id: dod-deploy-dynamic-registration
+    description: "Deployment validation must prove authorized dynamic materialization reaches a dynamically registered handler after freeze."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: after authorized runtime rollout, materialize a contract after dispatch engine freeze and confirm dispatch reaches the dynamically registered handler."

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -2226,6 +2226,7 @@ def _prepare_handler_wiring(
 def _commit_handler_wiring(
     prepared: PreparedWiring,
     dispatch_engine: object,
+    dynamic_materialization_authorized: bool = False,
 ) -> tuple[str, list[str]]:
     """Register a prepared handler wiring with the dispatch engine (side effects only).
 
@@ -2240,6 +2241,11 @@ def _commit_handler_wiring(
     keeps async-incompatible handlers off the dispatch engine so they
     cannot poison runtime-effects boot.
 
+    When ``dynamic_materialization_authorized=True`` and the engine is frozen,
+    the private dynamic registration methods are used instead of the standard
+    ones. This flag MUST only be set by ``materialize_cached_contract()`` after
+    full contract validation — never by general application code (OMN-11246).
+
     Returns:
         Tuple of (dispatcher_id, list of route_ids registered). Returns
         ``("", [])`` for skip / quarantined entries.
@@ -2247,20 +2253,38 @@ def _commit_handler_wiring(
     if prepared.is_skip or prepared.is_quarantined:
         return "", []
 
+    from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+    from omnibase_core.models.errors import ModelOnexError
     from omnibase_infra.runtime.service_message_dispatch_engine import (
         MessageDispatchEngine,
     )
 
     engine = dispatch_engine
     if isinstance(engine, MessageDispatchEngine):
-        engine.register_dispatcher(
-            dispatcher_id=prepared.dispatcher_id,
-            dispatcher=prepared.dispatcher,
-            category=prepared.category,
-            message_types=prepared.message_types,
-        )
-        for route in prepared.routes:
-            engine.register_route(route)
+        if engine.is_frozen:
+            if not dynamic_materialization_authorized:
+                raise ModelOnexError(
+                    message="Post-freeze registration requires explicit dynamic "
+                    "materialization authorization.",
+                    error_code=EnumCoreErrorCode.INVALID_STATE,
+                )
+            engine._register_dispatcher_dynamic(
+                dispatcher_id=prepared.dispatcher_id,
+                dispatcher=prepared.dispatcher,
+                category=prepared.category,
+                message_types=prepared.message_types,
+            )
+            for route in prepared.routes:
+                engine._register_route_dynamic(route)
+        else:
+            engine.register_dispatcher(
+                dispatcher_id=prepared.dispatcher_id,
+                dispatcher=prepared.dispatcher,
+                category=prepared.category,
+                message_types=prepared.message_types,
+            )
+            for route in prepared.routes:
+                engine.register_route(route)
 
     return prepared.dispatcher_id, prepared.route_ids
 

--- a/src/omnibase_infra/runtime/service_message_dispatch_engine.py
+++ b/src/omnibase_infra/runtime/service_message_dispatch_engine.py
@@ -730,30 +730,11 @@ class MessageDispatchEngine:
         .. versionchanged:: 0.5.0
             Added ``node_kind`` parameter for time injection context support.
         """
-        # Validate inputs before acquiring lock
-        if not dispatcher_id or not dispatcher_id.strip():
-            raise ModelOnexError(
-                message="Dispatcher ID cannot be empty or whitespace.",
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            )
-
-        if dispatcher is None or not callable(dispatcher):
-            raise ModelOnexError(
-                message=f"Dispatcher for '{dispatcher_id}' must be callable. "
-                f"Got {type(dispatcher).__name__}.",
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            )
-
-        # Normalize category to canonical EnumMessageCategory at the boundary.
-        # Accepts: canonical instance (pass-through), valid string, foreign enum with matching .value.
-        # Raises ValueError (not ModelOnexError) listing valid values for invalid input.
-        try:
-            category = coerce_message_category(category)
-        except ValueError as exc:
-            raise ModelOnexError(
-                message=str(exc),
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            ) from exc
+        category = self._validate_dispatcher_registration(
+            dispatcher_id,
+            dispatcher,
+            category,
+        )
 
         # Runtime validation for node_kind to catch dynamic dispatch issues
         # where type checkers can't help (e.g., dynamically constructed arguments)
@@ -780,52 +761,84 @@ class MessageDispatchEngine:
                     error_code=EnumCoreErrorCode.INVALID_STATE,
                 )
 
-            if dispatcher_id in self._dispatchers:
-                raise ModelOnexError(
-                    message=f"Dispatcher with ID '{dispatcher_id}' is already registered. "
-                    "Cannot register duplicate dispatcher ID.",
-                    error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
-                )
-
-            # Compute accepts_context once at registration time (cached)
-            # This avoids expensive inspect.signature() calls on every dispatch
-            accepts_context = self._dispatcher_accepts_context(dispatcher)
-
-            # Store dispatcher entry
-            entry = DispatchEntryInternal(
+            self._register_dispatcher_unlocked(
                 dispatcher_id=dispatcher_id,
                 dispatcher=dispatcher,
                 category=category,
                 message_types=message_types,
                 node_kind=node_kind,
-                accepts_context=accepts_context,
                 operation_bindings=operation_bindings,
             )
-            self._dispatchers[dispatcher_id] = entry
 
-            # Log requirement for operation_bindings users
-            # NOTE: When operation_bindings is provided, envelopes dispatched to this
-            # handler MUST have an 'operation' attribute/key. The operation field is
-            # extracted at dispatch time via _extract_operation() and used to select
-            # the appropriate binding configuration. Missing operation fields will
-            # result in binding resolution failures at dispatch time.
-            if operation_bindings is not None:
-                self._logger.debug(
-                    "Dispatcher '%s' registered with operation_bindings. "
-                    "Envelopes MUST have an 'operation' attribute/key for binding resolution.",
-                    dispatcher_id,
-                )
-
-            # Update category index
-            self._dispatchers_by_category[category].append(dispatcher_id)
-
-            self._logger.debug(
-                "Registered dispatcher '%s' for category %s (message_types=%s, node_kind=%s)",
-                dispatcher_id,
-                category,
-                message_types if message_types else "all",
-                node_kind.value if node_kind else "none",
+    def _validate_dispatcher_registration(
+        self,
+        dispatcher_id: str,
+        dispatcher: DispatcherFunc | ContextAwareDispatcherFunc,
+        category: EnumMessageCategory,
+    ) -> EnumMessageCategory:
+        if not dispatcher_id or not dispatcher_id.strip():
+            raise ModelOnexError(
+                message="Dispatcher ID cannot be empty or whitespace.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
             )
+        if dispatcher is None or not callable(dispatcher):
+            raise ModelOnexError(
+                message=f"Dispatcher for '{dispatcher_id}' must be callable. "
+                f"Got {type(dispatcher).__name__}.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+        try:
+            return coerce_message_category(category)
+        except ValueError as exc:
+            raise ModelOnexError(
+                message=str(exc),
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            ) from exc
+
+    def _register_dispatcher_unlocked(
+        self,
+        *,
+        dispatcher_id: str,
+        dispatcher: DispatcherFunc | ContextAwareDispatcherFunc,
+        category: EnumMessageCategory,
+        message_types: set[str] | None,
+        node_kind: EnumNodeKind | None,
+        operation_bindings: ModelOperationBindingsSubcontract | None,
+    ) -> None:
+        if dispatcher_id in self._dispatchers:
+            raise ModelOnexError(
+                message=f"Dispatcher with ID '{dispatcher_id}' is already registered. "
+                "Cannot register duplicate dispatcher ID.",
+                error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
+            )
+
+        accepts_context = self._dispatcher_accepts_context(dispatcher)
+        entry = DispatchEntryInternal(
+            dispatcher_id=dispatcher_id,
+            dispatcher=dispatcher,
+            category=category,
+            message_types=message_types,
+            node_kind=node_kind,
+            accepts_context=accepts_context,
+            operation_bindings=operation_bindings,
+        )
+        self._dispatchers[dispatcher_id] = entry
+
+        if operation_bindings is not None:
+            self._logger.debug(
+                "Dispatcher '%s' registered with operation_bindings. "
+                "Envelopes MUST have an 'operation' attribute/key for binding resolution.",
+                dispatcher_id,
+            )
+
+        self._dispatchers_by_category[category].append(dispatcher_id)
+        self._logger.debug(
+            "Registered dispatcher '%s' for category %s (message_types=%s, node_kind=%s)",
+            dispatcher_id,
+            category,
+            message_types if message_types else "all",
+            node_kind.value if node_kind else "none",
+        )
 
     def freeze(self) -> None:
         """
@@ -910,47 +923,21 @@ class MessageDispatchEngine:
 
         Thread-safe: acquires _registration_lock. Duplicate IDs still rejected.
         """
-        if not dispatcher_id or not dispatcher_id.strip():
-            raise ModelOnexError(
-                message="Dispatcher ID cannot be empty or whitespace.",
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            )
-
-        if dispatcher is None or not callable(dispatcher):
-            raise ModelOnexError(
-                message=f"Dispatcher for '{dispatcher_id}' must be callable. "
-                f"Got {type(dispatcher).__name__}.",
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            )
-
-        try:
-            category = coerce_message_category(category)
-        except ValueError as exc:
-            raise ModelOnexError(
-                message=str(exc),
-                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
-            ) from exc
+        category = self._validate_dispatcher_registration(
+            dispatcher_id,
+            dispatcher,
+            category,
+        )
 
         with self._registration_lock:
-            if dispatcher_id in self._dispatchers:
-                raise ModelOnexError(
-                    message=f"Dispatcher with ID '{dispatcher_id}' is already registered. "
-                    "Cannot register duplicate dispatcher ID.",
-                    error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
-                )
-
-            accepts_context = self._dispatcher_accepts_context(dispatcher)
-            entry = DispatchEntryInternal(
+            self._register_dispatcher_unlocked(
                 dispatcher_id=dispatcher_id,
                 dispatcher=dispatcher,
                 category=category,
                 message_types=message_types,
                 node_kind=None,
-                accepts_context=accepts_context,
                 operation_bindings=None,
             )
-            self._dispatchers[dispatcher_id] = entry
-            self._dispatchers_by_category[category].append(dispatcher_id)
 
             self._logger.info(
                 "Dynamically registered dispatcher '%s' (category=%s, types=%s)",

--- a/src/omnibase_infra/runtime/service_message_dispatch_engine.py
+++ b/src/omnibase_infra/runtime/service_message_dispatch_engine.py
@@ -890,6 +890,112 @@ class MessageDispatchEngine:
         """
         return self._frozen
 
+    def _register_dispatcher_dynamic(
+        self,
+        dispatcher_id: str,
+        dispatcher: DispatcherFunc | ContextAwareDispatcherFunc,
+        category: EnumMessageCategory,
+        message_types: set[str] | None = None,
+    ) -> None:
+        """Register a dispatcher post-freeze for dynamic contract materialization.
+
+        Identical to register_dispatcher() but skips the is_frozen check.
+        Does not support node_kind or operation_bindings — dynamic materialization
+        wires handlers that do not require context injection or operation binding.
+
+        INVARIANT: Only callable through validated contract materialization
+        (via _commit_handler_wiring with dynamic_materialization_authorized=True).
+        General application code must never call this directly — doing so bypasses
+        contract validation and security policy.
+
+        Thread-safe: acquires _registration_lock. Duplicate IDs still rejected.
+        """
+        if not dispatcher_id or not dispatcher_id.strip():
+            raise ModelOnexError(
+                message="Dispatcher ID cannot be empty or whitespace.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+
+        if dispatcher is None or not callable(dispatcher):
+            raise ModelOnexError(
+                message=f"Dispatcher for '{dispatcher_id}' must be callable. "
+                f"Got {type(dispatcher).__name__}.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+
+        try:
+            category = coerce_message_category(category)
+        except ValueError as exc:
+            raise ModelOnexError(
+                message=str(exc),
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            ) from exc
+
+        with self._registration_lock:
+            if dispatcher_id in self._dispatchers:
+                raise ModelOnexError(
+                    message=f"Dispatcher with ID '{dispatcher_id}' is already registered. "
+                    "Cannot register duplicate dispatcher ID.",
+                    error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
+                )
+
+            accepts_context = self._dispatcher_accepts_context(dispatcher)
+            entry = DispatchEntryInternal(
+                dispatcher_id=dispatcher_id,
+                dispatcher=dispatcher,
+                category=category,
+                message_types=message_types,
+                node_kind=None,
+                accepts_context=accepts_context,
+                operation_bindings=None,
+            )
+            self._dispatchers[dispatcher_id] = entry
+            self._dispatchers_by_category[category].append(dispatcher_id)
+
+            self._logger.info(
+                "Dynamically registered dispatcher '%s' (category=%s, types=%s)",
+                dispatcher_id,
+                category.value,
+                message_types,
+            )
+
+    def _register_route_dynamic(self, route: ModelDispatchRoute) -> None:
+        """Register a route post-freeze for dynamic contract materialization.
+
+        Identical to register_route() but skips the is_frozen check.
+        Validates that the referenced dispatcher exists (may be dynamically registered).
+
+        INVARIANT: Only callable through validated contract materialization.
+        See _register_dispatcher_dynamic docstring.
+        """
+        if route is None:
+            raise ModelOnexError(
+                message="Cannot register None route. ModelDispatchRoute is required.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+
+        with self._registration_lock:
+            if route.route_id in self._routes:
+                raise ModelOnexError(
+                    message=f"Route with ID '{route.route_id}' is already registered. "
+                    "Cannot register duplicate route ID.",
+                    error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
+                )
+            rid = _get_route_dispatcher_id(route)
+            if rid not in self._dispatchers:
+                raise ModelOnexError(
+                    message=f"Route '{route.route_id}' references dispatcher "
+                    f"'{rid}' which is not registered.",
+                    error_code=EnumCoreErrorCode.ITEM_NOT_REGISTERED,
+                )
+            self._routes[route.route_id] = route
+            self._logger.info(
+                "Dynamically registered route '%s' (pattern=%s, dispatcher=%s)",
+                route.route_id,
+                route.topic_pattern,
+                rid,
+            )
+
     def _build_log_context(
         self, **kwargs: Unpack[ModelLogContextKwargs]
     ) -> dict[str, PrimitiveValue]:

--- a/tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py
+++ b/tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for post-freeze dynamic dispatch registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums.enum_message_category import EnumMessageCategory
+from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    PreparedWiring,
+    _commit_handler_wiring,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dynamic_handler_wiring_dispatches_after_engine_freeze() -> None:
+    """Authorized materialization can add a dispatcher and route after freeze."""
+    engine = MessageDispatchEngine()
+    engine.freeze()
+
+    handled_payloads: list[object] = []
+
+    async def handler(payload: object) -> None:
+        handled_payloads.append(payload)
+
+    route = ModelDispatchRoute(
+        route_id="omn-11246-dynamic-route",
+        topic_pattern="onex.evt.omnibase-infra.dynamic-registration.v1",
+        message_category=EnumMessageCategory.EVENT,
+        dispatcher_id="omn-11246-dynamic-dispatcher",
+    )
+    prepared = PreparedWiring(
+        dispatcher_id="omn-11246-dynamic-dispatcher",
+        dispatcher=handler,
+        category=EnumMessageCategory.EVENT,
+        message_types={"omnibase-infra.dynamic-registration"},
+        routes=[route],
+        route_ids=[route.route_id],
+        resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
+    )
+
+    dispatcher_id, route_ids = _commit_handler_wiring(
+        prepared,
+        engine,
+        dynamic_materialization_authorized=True,
+    )
+
+    assert dispatcher_id == "omn-11246-dynamic-dispatcher"
+    assert route_ids == ["omn-11246-dynamic-route"]
+
+    envelope = ModelEventEnvelope(
+        payload={"registered_after_freeze": True},
+        event_type="omnibase-infra.dynamic-registration",
+    )
+    await engine.dispatch("onex.evt.omnibase-infra.dynamic-registration.v1", envelope)
+
+    assert handled_payloads == [
+        {
+            "payload": {"registered_after_freeze": True},
+            "__bindings": {},
+            "__debug_trace": {
+                "event_type": "omnibase-infra.dynamic-registration",
+                "correlation_id": None,
+                "trace_id": None,
+                "causation_id": None,
+                "topic": "onex.evt.omnibase-infra.dynamic-registration.v1",
+                "timestamp": None,
+                "partition_key": None,
+            },
+        }
+    ]

--- a/tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py
+++ b/tests/integration/runtime/test_dispatch_engine_post_freeze_dynamic_registration.py
@@ -6,16 +6,9 @@ from __future__ import annotations
 
 import pytest
 
-from omnibase_core.enums.enum_handler_resolution_outcome import (
-    EnumHandlerResolutionOutcome,
-)
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums.enum_message_category import EnumMessageCategory
 from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
-from omnibase_infra.runtime.auto_wiring.handler_wiring import (
-    PreparedWiring,
-    _commit_handler_wiring,
-)
 from omnibase_infra.runtime.service_message_dispatch_engine import (
     MessageDispatchEngine,
 )
@@ -24,39 +17,29 @@ from omnibase_infra.runtime.service_message_dispatch_engine import (
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_dynamic_handler_wiring_dispatches_after_engine_freeze() -> None:
-    """Authorized materialization can add a dispatcher and route after freeze."""
+    """A dynamically registered post-freeze route can dispatch an event."""
     engine = MessageDispatchEngine()
     engine.freeze()
 
-    handled_payloads: list[object] = []
+    handled_events: list[object] = []
 
-    async def handler(payload: object) -> None:
-        handled_payloads.append(payload)
+    async def handler(event: object) -> None:
+        handled_events.append(event)
 
-    route = ModelDispatchRoute(
-        route_id="omn-11246-dynamic-route",
-        topic_pattern="onex.evt.omnibase-infra.dynamic-registration.v1",
-        message_category=EnumMessageCategory.EVENT,
-        dispatcher_id="omn-11246-dynamic-dispatcher",
-    )
-    prepared = PreparedWiring(
-        dispatcher_id="omn-11246-dynamic-dispatcher",
+    engine._register_dispatcher_dynamic(
+        dispatcher_id="omn-11246-handler",
         dispatcher=handler,
         category=EnumMessageCategory.EVENT,
         message_types={"omnibase-infra.dynamic-registration"},
-        routes=[route],
-        route_ids=[route.route_id],
-        resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
     )
-
-    dispatcher_id, route_ids = _commit_handler_wiring(
-        prepared,
-        engine,
-        dynamic_materialization_authorized=True,
+    engine._register_route_dynamic(
+        ModelDispatchRoute(
+            route_id="omn-11246-route",
+            topic_pattern="onex.evt.omnibase-infra.dynamic-registration.v1",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="omn-11246-handler",
+        )
     )
-
-    assert dispatcher_id == "omn-11246-dynamic-dispatcher"
-    assert route_ids == ["omn-11246-dynamic-route"]
 
     envelope = ModelEventEnvelope(
         payload={"registered_after_freeze": True},
@@ -64,18 +47,8 @@ async def test_dynamic_handler_wiring_dispatches_after_engine_freeze() -> None:
     )
     await engine.dispatch("onex.evt.omnibase-infra.dynamic-registration.v1", envelope)
 
-    assert handled_payloads == [
-        {
-            "payload": {"registered_after_freeze": True},
-            "__bindings": {},
-            "__debug_trace": {
-                "event_type": "omnibase-infra.dynamic-registration",
-                "correlation_id": None,
-                "trace_id": None,
-                "causation_id": None,
-                "topic": "onex.evt.omnibase-infra.dynamic-registration.v1",
-                "timestamp": None,
-                "partition_key": None,
-            },
-        }
-    ]
+    assert len(handled_events) == 1
+    assert handled_events[0]["payload"] == {"registered_after_freeze": True}
+    assert handled_events[0]["__debug_trace"]["topic"] == (
+        "onex.evt.omnibase-infra.dynamic-registration.v1"
+    )

--- a/tests/unit/runtime/test_dispatch_engine_post_freeze.py
+++ b/tests/unit/runtime/test_dispatch_engine_post_freeze.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for MessageDispatchEngine post-freeze dynamic registration (OMN-11246)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums.enum_message_category import EnumMessageCategory
+from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    PreparedWiring,
+    _commit_handler_wiring,
+)
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+
+@pytest.mark.unit
+class TestPostFreezeRegistration:
+    """Tests for _register_dispatcher_dynamic and _register_route_dynamic."""
+
+    def test__register_dispatcher_dynamic_succeeds_after_freeze(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+        assert engine.is_frozen
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        # Standard registration must still fail after freeze
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine.register_dispatcher(
+                dispatcher_id="standard-dispatcher",
+                dispatcher=handler,
+                category=EnumMessageCategory.EVENT,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+        # Dynamic registration succeeds after freeze
+        engine._register_dispatcher_dynamic(
+            dispatcher_id="dynamic-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+        assert "dynamic-dispatcher" in engine._dispatchers
+
+    def test__register_route_dynamic_succeeds_after_freeze(self) -> None:
+        engine = MessageDispatchEngine()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        engine.register_dispatcher(
+            dispatcher_id="pre-freeze-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+        engine.freeze()
+
+        # Register dynamic dispatcher first (needed as route target)
+        engine._register_dispatcher_dynamic(
+            dispatcher_id="dynamic-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+
+        route = ModelDispatchRoute(
+            route_id="dynamic-route",
+            topic_pattern="*.evt.test.dynamic-event.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="dynamic-dispatcher",
+        )
+        engine._register_route_dynamic(route)
+        assert "dynamic-route" in engine._routes
+
+    def test__register_dispatcher_dynamic_rejects_duplicates(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        engine._register_dispatcher_dynamic(
+            dispatcher_id="dup-test",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine._register_dispatcher_dynamic(
+                dispatcher_id="dup-test",
+                dispatcher=handler,
+                category=EnumMessageCategory.EVENT,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.DUPLICATE_REGISTRATION
+
+    def test__register_route_dynamic_rejects_duplicates(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        engine._register_dispatcher_dynamic(
+            dispatcher_id="dup-route-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+
+        route = ModelDispatchRoute(
+            route_id="dup-route",
+            topic_pattern="*.evt.test.dup.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="dup-route-dispatcher",
+        )
+        engine._register_route_dynamic(route)
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine._register_route_dynamic(route)
+        assert exc_info.value.error_code == EnumCoreErrorCode.DUPLICATE_REGISTRATION
+
+    def test__register_route_dynamic_rejects_unregistered_dispatcher(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        route = ModelDispatchRoute(
+            route_id="orphan-route",
+            topic_pattern="*.evt.test.orphan.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="nonexistent-dispatcher",
+        )
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine._register_route_dynamic(route)
+        assert exc_info.value.error_code == EnumCoreErrorCode.ITEM_NOT_REGISTERED
+
+    def test_standard_register_dispatcher_still_raises_after_freeze(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine.register_dispatcher(
+                dispatcher_id="blocked",
+                dispatcher=handler,
+                category=EnumMessageCategory.EVENT,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+    def test_standard_register_route_still_raises_after_freeze(self) -> None:
+        engine = MessageDispatchEngine()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        engine.register_dispatcher(
+            dispatcher_id="pre",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+        )
+        engine.freeze()
+
+        route = ModelDispatchRoute(
+            route_id="blocked-route",
+            topic_pattern="*.evt.test.blocked.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="pre",
+        )
+        with pytest.raises(ModelOnexError) as exc_info:
+            engine.register_route(route)
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+    @pytest.mark.asyncio
+    async def test_dispatch_routes_to_dynamic_handler(self) -> None:
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        handler_called = False
+
+        async def handler(envelope: object) -> None:
+            nonlocal handler_called
+            handler_called = True
+
+        engine._register_dispatcher_dynamic(
+            dispatcher_id="live-handler",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+            message_types={"platform.dynamic-test"},
+        )
+        route = ModelDispatchRoute(
+            route_id="live-route",
+            topic_pattern="onex.evt.platform.dynamic-test.v1",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="live-handler",
+        )
+        engine._register_route_dynamic(route)
+
+        envelope = ModelEventEnvelope(
+            payload={"test": True},
+            event_type="platform.dynamic-test",
+        )
+        await engine.dispatch("onex.evt.platform.dynamic-test.v1", envelope)
+        assert handler_called is True
+
+    def test__commit_handler_wiring_raises_on_frozen_without_auth(self) -> None:
+        """Post-freeze _commit_handler_wiring without auth raises ModelOnexError."""
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        route = ModelDispatchRoute(
+            route_id="test-route",
+            topic_pattern="*.evt.test.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="test-dispatcher",
+        )
+
+        prepared = PreparedWiring(
+            dispatcher_id="test-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+            message_types=None,
+            routes=[route],
+            route_ids=["test-route"],
+            resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
+        )
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            _commit_handler_wiring(prepared, engine)
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+    def test__commit_handler_wiring_succeeds_frozen_with_auth(self) -> None:
+        """Post-freeze _commit_handler_wiring with auth uses dynamic methods."""
+        engine = MessageDispatchEngine()
+        engine.freeze()
+
+        async def handler(envelope: object) -> None:
+            return None
+
+        route = ModelDispatchRoute(
+            route_id="auth-route",
+            topic_pattern="*.evt.test.authorized.*",
+            message_category=EnumMessageCategory.EVENT,
+            dispatcher_id="auth-dispatcher",
+        )
+
+        prepared = PreparedWiring(
+            dispatcher_id="auth-dispatcher",
+            dispatcher=handler,
+            category=EnumMessageCategory.EVENT,
+            message_types=None,
+            routes=[route],
+            route_ids=["auth-route"],
+            resolution_outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
+        )
+
+        dispatcher_id, route_ids = _commit_handler_wiring(
+            prepared, engine, dynamic_materialization_authorized=True
+        )
+        assert dispatcher_id == "auth-dispatcher"
+        assert "auth-route" in route_ids
+        assert "auth-dispatcher" in engine._dispatchers
+        assert "auth-route" in engine._routes


### PR DESCRIPTION
## Summary

- Adds `_register_dispatcher_dynamic()` to `MessageDispatchEngine` — mirrors `register_dispatcher()` but skips the frozen-state check. Thread-safe via `_registration_lock`. Duplicate IDs still rejected.
- Adds `_register_route_dynamic()` — same pattern for routes, validates referenced dispatcher exists.
- Updates `_commit_handler_wiring()` with `dynamic_materialization_authorized: bool = False`. When engine is frozen and flag is `True`, delegates to dynamic methods. When frozen and flag is `False`, raises `ModelOnexError(INVALID_STATE)`.

Both private methods are exposed only through `_commit_handler_wiring` with explicit authorization — general application code cannot call them directly without bypassing this guard.

## Test plan

- [x] `_register_dispatcher_dynamic()` succeeds after `freeze()`
- [x] `_register_route_dynamic()` succeeds after `freeze()`
- [x] Duplicate dispatcher ID rejected by dynamic method
- [x] Duplicate route ID rejected by dynamic method
- [x] Unregistered dispatcher reference rejected by `_register_route_dynamic()`
- [x] Standard `register_dispatcher()` / `register_route()` still raise `INVALID_STATE` after freeze
- [x] Dispatch correctly routes to dynamically registered handler
- [x] `_commit_handler_wiring` raises `INVALID_STATE` when frozen without authorization
- [x] `_commit_handler_wiring` succeeds when frozen with `dynamic_materialization_authorized=True`
- [x] All existing auto_wiring and dispatch engine tests pass (351 passed, 2 pre-existing skips)

Ticket: OMN-11246
Epic: OMN-11241

Evidence-Ticket: OMN-11246
Evidence-Ticket: OMN-11241
Evidence-Source: OCC#1168