### PR TITLE
feat(OMN-11244): event-driven contract materialization in KafkaContractSource

### DIFF
--- a/contracts/OMN-11244.yaml
+++ b/contracts/OMN-11244.yaml
@@ -1,0 +1,28 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11244"
+title: "feat(OMN-11244): event-driven contract materialization in KafkaContractSource"
+summary: >
+  Adds materialize_cached_contract() to KafkaContractSource so that a node descriptor already in the in-memory cache can be wired into the live dispatch engine post-startup without a runtime restart. Adds EnumMaterializationStatus, EnumMaterializationRejection, EnumContractSource enums and ModelDynamicMaterializationResult frozen Pydantic model. Idempotency via (node_name, sha256_hash) keyed set. Version conflict guard prevents different-hash re-wiring. Pure library addition — no Kafka subscriptions activated, no DB migration, no runtime service restart required. Part of epic OMN-11241.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "10 unit tests pass covering all materialize_cached_contract status paths."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_kafka_contract_source_materialization.py -v"
+  - id: "dod-deploy"
+    description: >
+      No live deploy required. materialize_cached_contract() is a pure library addition to KafkaContractSource — no Kafka subscriptions activated at import time, no DB migration, no runtime service restart needed. The method only executes when explicitly called by the runtime with a live dispatch_engine reference; this PR does not wire or call it. Deploy assessment: no action needed on 192.168.86.201.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: grep 'materialize_cached_contract' src/omnibase_infra/runtime/kafka_contract_source.py && echo 'No deploy action required — pure library addition, no subscriptions activated'"

--- a/src/omnibase_infra/runtime/enums/enum_contract_source.py
+++ b/src/omnibase_infra/runtime/enums/enum_contract_source.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Contract source enum for dynamic materialization (OMN-11244)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumContractSource(str, Enum):
+    """Origin of a contract that was materialized."""
+
+    FILESYSTEM = "filesystem"
+    DYNAMIC_KAFKA = "dynamic_kafka"
+    REGISTRY = "registry"
+
+
+__all__ = ["EnumContractSource"]

--- a/src/omnibase_infra/runtime/enums/enum_materialization_rejection.py
+++ b/src/omnibase_infra/runtime/enums/enum_materialization_rejection.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Materialization rejection reason enum for dynamic contract wiring (OMN-11244)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumMaterializationRejection(str, Enum):
+    """Reason a materialize_cached_contract() call was rejected."""
+
+    VERSION_CONFLICT = "version_conflict"
+    HASH_MISMATCH = "hash_mismatch"
+    PROFILE_MISMATCH = "profile_mismatch"
+    HANDLER_ALLOWLIST = "handler_allowlist"
+    PARSE_FAILURE = "parse_failure"
+
+
+__all__ = ["EnumMaterializationRejection"]

--- a/src/omnibase_infra/runtime/enums/enum_materialization_status.py
+++ b/src/omnibase_infra/runtime/enums/enum_materialization_status.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Materialization status enum for dynamic contract wiring (OMN-11244)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumMaterializationStatus(str, Enum):
+    """Outcome of a materialize_cached_contract() call."""
+
+    MATERIALIZED = "materialized"
+    ALREADY_MATERIALIZED = "already_materialized"
+    REJECTED = "rejected"
+
+
+__all__ = ["EnumMaterializationStatus"]

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -74,8 +74,9 @@ import hashlib
 import json
 import logging
 import threading
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Protocol, cast, get_args, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, get_args, runtime_checkable
 from uuid import UUID, uuid4
 
 import yaml
@@ -110,6 +111,15 @@ from omnibase_infra.runtime.enums.enum_materialization_status import (
 from omnibase_infra.runtime.models.model_dynamic_materialization import (
     ModelDynamicMaterializationResult,
 )
+
+if TYPE_CHECKING:
+    from omnibase_infra.runtime.auto_wiring.models import ModelDiscoveredContract
+    from omnibase_infra.runtime.auto_wiring.models.model_event_bus_wiring import (
+        ModelEventBusWiring,
+    )
+    from omnibase_infra.runtime.auto_wiring.models.model_handler_routing import (
+        ModelHandlerRouting,
+    )
 from omnibase_infra.runtime.protocol_contract_source import ProtocolContractSource
 from omnibase_infra.utils import sanitize_error_message
 
@@ -1015,6 +1025,158 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             )
             return False
 
+    @staticmethod
+    def _canonical_contract_hash(descriptor: ModelHandlerDescriptor) -> str:
+        content_repr = json.dumps(
+            descriptor.contract_config or {}, sort_keys=True, default=str
+        )
+        raw_bytes = content_repr.encode("utf-8")
+        return "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
+
+    def _reserve_materialization_key(
+        self, node_name: str, canon_hash: str
+    ) -> ModelDynamicMaterializationResult | tuple[str, str]:
+        with self._materialization_lock:
+            key = (node_name, canon_hash)
+            if key in self._materialized_contracts:
+                return ModelDynamicMaterializationResult(
+                    contract_name=node_name,
+                    contract_hash=canon_hash,
+                    status=EnumMaterializationStatus.ALREADY_MATERIALIZED,
+                )
+
+            existing_hashes = [
+                existing_hash
+                for existing_node, existing_hash in self._materialized_contracts
+                if existing_node == node_name
+            ]
+            if existing_hashes:
+                logger.warning(
+                    "Version conflict: node already materialized with different contract_hash",
+                    extra={
+                        "node_name": node_name,
+                        "existing_hash": existing_hashes[0],
+                        "incoming_hash": canon_hash,
+                    },
+                )
+                return ModelDynamicMaterializationResult(
+                    contract_name=node_name,
+                    contract_hash=canon_hash,
+                    status=EnumMaterializationStatus.REJECTED,
+                    reason=EnumMaterializationRejection.VERSION_CONFLICT,
+                )
+
+            self._materialized_contracts.add(key)
+            return key
+
+    def _release_materialization_key(self, key: tuple[str, str]) -> None:
+        with self._materialization_lock:
+            self._materialized_contracts.discard(key)
+
+    @staticmethod
+    def _build_event_bus_wiring(
+        config: Mapping[str, object],
+    ) -> ModelEventBusWiring | None:
+        from omnibase_infra.runtime.auto_wiring.models.model_event_bus_wiring import (
+            ModelEventBusWiring,
+        )
+
+        eb_raw = config.get("event_bus")
+        if not isinstance(eb_raw, dict):
+            return None
+
+        sub_raw = eb_raw.get("subscribe_topics")
+        pub_raw = eb_raw.get("publish_topics")
+        cp_raw = eb_raw.get("consumer_purpose")
+        return ModelEventBusWiring(
+            subscribe_topics=tuple(sub_raw) if isinstance(sub_raw, list) else (),
+            publish_topics=tuple(pub_raw) if isinstance(pub_raw, list) else (),
+            consumer_purpose=cp_raw if isinstance(cp_raw, str) else None,
+            plugin_managed=bool(eb_raw.get("plugin_managed", False)),
+        )
+
+    @staticmethod
+    def _build_handler_routing(
+        config: Mapping[str, object],
+    ) -> ModelHandlerRouting | None:
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_ref import (
+            ModelHandlerRef,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing import (
+            ModelHandlerRouting,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing_entry import (
+            ModelHandlerRoutingEntry,
+        )
+
+        hr_raw = config.get("handler_routing")
+        if not isinstance(hr_raw, dict):
+            return None
+
+        entries: list[ModelHandlerRoutingEntry] = []
+        handlers_raw = hr_raw.get("handlers")
+        for handler_item in handlers_raw if isinstance(handlers_raw, list) else []:
+            if not isinstance(handler_item, dict):
+                continue
+            handler_data = handler_item.get("handler") or {}
+            if not isinstance(handler_data, dict):
+                continue
+            event_model_ref = None
+            event_model_data = handler_item.get("event_model")
+            if isinstance(event_model_data, dict):
+                event_model_ref = ModelHandlerRef(
+                    name=event_model_data.get("name", ""),
+                    module=event_model_data.get("module", ""),
+                )
+            entries.append(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name=handler_data.get("name", ""),
+                        module=handler_data.get("module", ""),
+                    ),
+                    event_model=event_model_ref,
+                    operation=handler_item.get("operation"),
+                    event_type=handler_item.get("event_type"),
+                    message_category=handler_item.get("message_category"),
+                )
+            )
+
+        return ModelHandlerRouting(
+            routing_strategy=hr_raw.get("routing_strategy", "payload_type_match"),
+            handlers=tuple(entries),
+        )
+
+    def _build_materialization_contract(
+        self,
+        node_name: str,
+        descriptor: ModelHandlerDescriptor,
+        environment: str | None,
+    ) -> ModelDiscoveredContract:
+        from omnibase_infra.runtime.auto_wiring.models import ModelDiscoveredContract
+        from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
+            ModelContractVersion,
+        )
+
+        ver = descriptor.version
+        effective_env = environment or self._environment
+        config = descriptor.contract_config or {}
+        return ModelDiscoveredContract(
+            name=node_name,
+            node_type=descriptor.handler_kind,
+            description=descriptor.description or "",
+            contract_version=ModelContractVersion(
+                major=ver.major,
+                minor=ver.minor,
+                patch=ver.patch,
+            ),
+            node_version=str(descriptor.version),
+            contract_path=Path(f"/kafka/{effective_env}/{node_name}/contract.yaml"),
+            entry_point_name=f"kafka.{node_name}",
+            package_name="dynamic",
+            event_bus=self._build_event_bus_wiring(config),
+            handler_routing=self._build_handler_routing(config),
+        )
+
     async def materialize_cached_contract(
         self,
         node_name: str,
@@ -1059,145 +1221,21 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 reason=EnumMaterializationRejection.PARSE_FAILURE,
             )
 
-        # Compute canonical hash from contract content for idempotency keying.
-        # Hash the contract_config dict (parsed YAML content) so version conflicts
-        # are detected by actual content change, not stable filesystem path.
-        content_repr = json.dumps(
-            descriptor.contract_config or {}, sort_keys=True, default=str
-        )
-        raw_bytes = content_repr.encode("utf-8")
-        canon_hash = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
-
-        # Idempotency + version-conflict gate (thread-safe).
-        # Reserve the key before wiring to prevent concurrent calls from both
-        # passing the gate and wiring twice.  Key is cleared on failure.
-        with self._materialization_lock:
-            key = (node_name, canon_hash)
-            if key in self._materialized_contracts:
-                return ModelDynamicMaterializationResult(
-                    contract_name=node_name,
-                    contract_hash=canon_hash,
-                    status=EnumMaterializationStatus.ALREADY_MATERIALIZED,
-                )
-            existing_hashes = [
-                h for (n, h) in self._materialized_contracts if n == node_name
-            ]
-            if existing_hashes:
-                logger.warning(
-                    "Version conflict: node already materialized with different contract_hash",
-                    extra={
-                        "node_name": node_name,
-                        "existing_hash": existing_hashes[0],
-                        "incoming_hash": canon_hash,
-                    },
-                )
-                return ModelDynamicMaterializationResult(
-                    contract_name=node_name,
-                    contract_hash=canon_hash,
-                    status=EnumMaterializationStatus.REJECTED,
-                    reason=EnumMaterializationRejection.VERSION_CONFLICT,
-                )
-            # Reserve: prevents concurrent calls with same key from both wiring.
-            self._materialized_contracts.add(key)
+        canon_hash = self._canonical_contract_hash(descriptor)
+        reservation = self._reserve_materialization_key(node_name, canon_hash)
+        if isinstance(reservation, ModelDynamicMaterializationResult):
+            return reservation
+        key = reservation
 
         from omnibase_infra.runtime.auto_wiring.handler_wiring import (
             _wire_single_contract,
         )
-        from omnibase_infra.runtime.auto_wiring.models import (
-            ModelDiscoveredContract,
-        )
-        from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
-            ModelContractVersion,
-        )
-        from omnibase_infra.runtime.auto_wiring.models.model_event_bus_wiring import (
-            ModelEventBusWiring,
-        )
-        from omnibase_infra.runtime.auto_wiring.models.model_handler_ref import (
-            ModelHandlerRef,
-        )
-        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing import (
-            ModelHandlerRouting,
-        )
-        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing_entry import (
-            ModelHandlerRoutingEntry,
-        )
         from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
 
-        # Build ModelContractVersion from descriptor.version (ModelSemVer).
-        ver = descriptor.version
-        contract_version = ModelContractVersion(
-            major=ver.major,
-            minor=ver.minor,
-            patch=ver.patch,
-        )
-
-        # Build event_bus and handler_routing from contract_config if present.
-        config = descriptor.contract_config or {}
-        event_bus_wiring: ModelEventBusWiring | None = None
-        handler_routing: ModelHandlerRouting | None = None
-
-        eb_raw = config.get("event_bus")
-        if isinstance(eb_raw, dict):
-            sub_raw = eb_raw.get("subscribe_topics")
-            pub_raw = eb_raw.get("publish_topics")
-            cp_raw = eb_raw.get("consumer_purpose")
-            event_bus_wiring = ModelEventBusWiring(
-                subscribe_topics=tuple(sub_raw) if isinstance(sub_raw, list) else (),
-                publish_topics=tuple(pub_raw) if isinstance(pub_raw, list) else (),
-                consumer_purpose=cp_raw if isinstance(cp_raw, str) else None,
-                plugin_managed=bool(eb_raw.get("plugin_managed", False)),
-            )
-
-        hr_raw = config.get("handler_routing")
-        if isinstance(hr_raw, dict):
-            entries: list[ModelHandlerRoutingEntry] = []
-            handlers_raw = hr_raw.get("handlers")
-            for h in handlers_raw if isinstance(handlers_raw, list) else []:
-                if not isinstance(h, dict):
-                    continue
-                handler_data = h.get("handler") or {}
-                if not isinstance(handler_data, dict):
-                    continue
-                handler_ref = ModelHandlerRef(
-                    name=handler_data.get("name", ""),
-                    module=handler_data.get("module", ""),
-                )
-                event_model_data = h.get("event_model")
-                event_model_ref: ModelHandlerRef | None = None
-                if isinstance(event_model_data, dict):
-                    event_model_ref = ModelHandlerRef(
-                        name=event_model_data.get("name", ""),
-                        module=event_model_data.get("module", ""),
-                    )
-                entries.append(
-                    ModelHandlerRoutingEntry(
-                        handler=handler_ref,
-                        event_model=event_model_ref,
-                        operation=h.get("operation"),
-                        event_type=h.get("event_type"),
-                        message_category=h.get("message_category"),
-                    )
-                )
-            handler_routing = ModelHandlerRouting(
-                routing_strategy=hr_raw.get("routing_strategy", "payload_type_match"),
-                handlers=tuple(entries),
-            )
-
-        # Synthetic contract_path for Kafka-sourced contracts (not on filesystem).
-        effective_env = environment or self._environment
-        synthetic_path = Path(f"/kafka/{effective_env}/{node_name}/contract.yaml")
-
-        contract = ModelDiscoveredContract(
-            name=node_name,
-            node_type=descriptor.handler_kind,
-            description=descriptor.description or "",
-            contract_version=contract_version,
-            node_version=str(descriptor.version),
-            contract_path=synthetic_path,
-            entry_point_name=f"kafka.{node_name}",
-            package_name="dynamic",
-            event_bus=event_bus_wiring,
-            handler_routing=handler_routing,
+        contract = self._build_materialization_contract(
+            node_name=node_name,
+            descriptor=descriptor,
+            environment=environment,
         )
 
         try:
@@ -1234,8 +1272,7 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 )
 
             # Wiring skipped — release the reservation so a future retry can attempt.
-            with self._materialization_lock:
-                self._materialized_contracts.discard(key)
+            self._release_materialization_key(key)
             logger.warning(
                 "Contract materialization skipped",
                 extra={
@@ -1252,8 +1289,7 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
 
         except Exception as exc:  # noqa: BLE001 — wiring boundary; log and return REJECTED
             # Release the reservation so a future retry can attempt.
-            with self._materialization_lock:
-                self._materialized_contracts.discard(key)
+            self._release_materialization_key(key)
             logger.warning(
                 "Contract materialization failed",
                 extra={

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -1258,7 +1258,7 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 "Contract materialization failed",
                 extra={
                     "node_name": node_name,
-                    "error": sanitize_error_message(str(exc)),
+                    "error": sanitize_error_message(exc),
                     "error_type": type(exc).__name__,
                 },
             )

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -71,6 +71,7 @@ Error Codes:
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import threading
 from pathlib import Path
@@ -110,6 +111,7 @@ from omnibase_infra.runtime.models.model_dynamic_materialization import (
     ModelDynamicMaterializationResult,
 )
 from omnibase_infra.runtime.protocol_contract_source import ProtocolContractSource
+from omnibase_infra.utils import sanitize_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -1057,14 +1059,18 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 reason=EnumMaterializationRejection.PARSE_FAILURE,
             )
 
-        # Compute canonical hash for idempotency keying.
-        contract_yaml_raw = (
-            descriptor.contract_path or f"kafka://{self._environment}/{node_name}"
+        # Compute canonical hash from contract content for idempotency keying.
+        # Hash the contract_config dict (parsed YAML content) so version conflicts
+        # are detected by actual content change, not stable filesystem path.
+        content_repr = json.dumps(
+            descriptor.contract_config or {}, sort_keys=True, default=str
         )
-        raw_bytes = contract_yaml_raw.encode("utf-8")
+        raw_bytes = content_repr.encode("utf-8")
         canon_hash = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
 
         # Idempotency + version-conflict gate (thread-safe).
+        # Reserve the key before wiring to prevent concurrent calls from both
+        # passing the gate and wiring twice.  Key is cleared on failure.
         with self._materialization_lock:
             key = (node_name, canon_hash)
             if key in self._materialized_contracts:
@@ -1091,6 +1097,8 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                     status=EnumMaterializationStatus.REJECTED,
                     reason=EnumMaterializationRejection.VERSION_CONFLICT,
                 )
+            # Reserve: prevents concurrent calls with same key from both wiring.
+            self._materialized_contracts.add(key)
 
         from omnibase_infra.runtime.auto_wiring.handler_wiring import (
             _wire_single_contract,
@@ -1176,7 +1184,8 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             )
 
         # Synthetic contract_path for Kafka-sourced contracts (not on filesystem).
-        synthetic_path = Path(f"/kafka/{self._environment}/{node_name}/contract.yaml")
+        effective_env = environment or self._environment
+        synthetic_path = Path(f"/kafka/{effective_env}/{node_name}/contract.yaml")
 
         contract = ModelDiscoveredContract(
             name=node_name,
@@ -1205,8 +1214,7 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             )
 
             if result.outcome == EnumWiringOutcome.WIRED:
-                with self._materialization_lock:
-                    self._materialized_contracts.add((node_name, canon_hash))
+                # Key was already reserved before wiring; no second add needed.
                 logger.info(
                     "Contract materialized into live dispatch engine",
                     extra={
@@ -1225,6 +1233,9 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                     status=EnumMaterializationStatus.MATERIALIZED,
                 )
 
+            # Wiring skipped — release the reservation so a future retry can attempt.
+            with self._materialization_lock:
+                self._materialized_contracts.discard(key)
             logger.warning(
                 "Contract materialization skipped",
                 extra={
@@ -1240,11 +1251,14 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             )
 
         except Exception as exc:  # noqa: BLE001 — wiring boundary; log and return REJECTED
+            # Release the reservation so a future retry can attempt.
+            with self._materialization_lock:
+                self._materialized_contracts.discard(key)
             logger.warning(
                 "Contract materialization failed",
                 extra={
                     "node_name": node_name,
-                    "error": str(exc),
+                    "error": sanitize_error_message(str(exc)),
                     "error_type": type(exc).__name__,
                 },
             )

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -70,8 +70,10 @@ Error Codes:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
+from pathlib import Path
 from typing import Protocol, cast, get_args, runtime_checkable
 from uuid import UUID, uuid4
 
@@ -97,6 +99,15 @@ from omnibase_infra.runtime.baseline_subscriptions import (
     BASELINE_PLATFORM_TOPICS,
     TOPIC_SUFFIX_CONTRACT_DEREGISTERED,
     TOPIC_SUFFIX_CONTRACT_REGISTERED,
+)
+from omnibase_infra.runtime.enums.enum_materialization_rejection import (
+    EnumMaterializationRejection,
+)
+from omnibase_infra.runtime.enums.enum_materialization_status import (
+    EnumMaterializationStatus,
+)
+from omnibase_infra.runtime.models.model_dynamic_materialization import (
+    ModelDynamicMaterializationResult,
 )
 from omnibase_infra.runtime.protocol_contract_source import ProtocolContractSource
 
@@ -677,6 +688,8 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
         "_correlation_id",
         "_environment",
         "_graceful_mode",
+        "_materialization_lock",
+        "_materialized_contracts",
         "_parser",
     )
 
@@ -700,6 +713,11 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
         self._correlation_id = uuid4()
         self._cache = KafkaContractCache()
         self._parser = ContractYamlParser(environment=environment)
+        # Idempotency set: (node_name, contract_hash) pairs already materialized.
+        # Validation (allowlist, profiles, hash) is performed by
+        # node_contract_registry in omnimarket. Runtime trusts validated events.
+        self._materialized_contracts: set[tuple[str, str]] = set()
+        self._materialization_lock = threading.Lock()
 
         logger.info(
             "KafkaContractSource initialized",
@@ -995,6 +1013,246 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             )
             return False
 
+    async def materialize_cached_contract(
+        self,
+        node_name: str,
+        dispatch_engine: object,
+        event_bus: object | None = None,
+        environment: str | None = None,
+        container: object | None = None,
+    ) -> ModelDynamicMaterializationResult:
+        """Materialize a cached contract descriptor into the live dispatch engine.
+
+        Takes a previously cached descriptor (from on_contract_registered) and
+        wires it into the dispatch engine using _wire_single_contract. This makes
+        the handler live without a container restart.
+
+        Idempotent: same (node_name, contract_hash) pair wires exactly once per
+        runtime boot. Same node_name with a different hash is rejected as a version
+        conflict (defense-in-depth; omnimarket owns upgrade sequencing).
+
+        Policy enforcement (handler allowlist, runtime profiles, hash verification)
+        is performed by node_contract_registry in omnimarket. The runtime trusts
+        validated events on onex.evt.platform.node-registration.v1.
+
+        Args:
+            node_name: Cache key for the descriptor to materialize.
+            dispatch_engine: The live MessageDispatchEngine.
+            event_bus: Optional event bus for Kafka subscriptions.
+            environment: Override environment (defaults to self._environment).
+            container: Optional DI container for handler resolution.
+
+        Returns:
+            ModelDynamicMaterializationResult with enum status and topology data.
+        """
+        descriptor = self._cache.get(node_name)
+        if descriptor is None:
+            logger.debug(
+                "Cannot materialize: no cached descriptor for node",
+                extra={"node_name": node_name},
+            )
+            return ModelDynamicMaterializationResult(
+                contract_name=node_name,
+                status=EnumMaterializationStatus.REJECTED,
+                reason=EnumMaterializationRejection.PARSE_FAILURE,
+            )
+
+        # Compute canonical hash for idempotency keying.
+        contract_yaml_raw = (
+            descriptor.contract_path or f"kafka://{self._environment}/{node_name}"
+        )
+        raw_bytes = contract_yaml_raw.encode("utf-8")
+        canon_hash = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
+
+        # Idempotency + version-conflict gate (thread-safe).
+        with self._materialization_lock:
+            key = (node_name, canon_hash)
+            if key in self._materialized_contracts:
+                return ModelDynamicMaterializationResult(
+                    contract_name=node_name,
+                    contract_hash=canon_hash,
+                    status=EnumMaterializationStatus.ALREADY_MATERIALIZED,
+                )
+            existing_hashes = [
+                h for (n, h) in self._materialized_contracts if n == node_name
+            ]
+            if existing_hashes:
+                logger.warning(
+                    "Version conflict: node already materialized with different contract_hash",
+                    extra={
+                        "node_name": node_name,
+                        "existing_hash": existing_hashes[0],
+                        "incoming_hash": canon_hash,
+                    },
+                )
+                return ModelDynamicMaterializationResult(
+                    contract_name=node_name,
+                    contract_hash=canon_hash,
+                    status=EnumMaterializationStatus.REJECTED,
+                    reason=EnumMaterializationRejection.VERSION_CONFLICT,
+                )
+
+        from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+            _wire_single_contract,
+        )
+        from omnibase_infra.runtime.auto_wiring.models import (
+            ModelDiscoveredContract,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_contract_version import (
+            ModelContractVersion,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_event_bus_wiring import (
+            ModelEventBusWiring,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_ref import (
+            ModelHandlerRef,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing import (
+            ModelHandlerRouting,
+        )
+        from omnibase_infra.runtime.auto_wiring.models.model_handler_routing_entry import (
+            ModelHandlerRoutingEntry,
+        )
+        from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+        # Build ModelContractVersion from descriptor.version (ModelSemVer).
+        ver = descriptor.version
+        contract_version = ModelContractVersion(
+            major=ver.major,
+            minor=ver.minor,
+            patch=ver.patch,
+        )
+
+        # Build event_bus and handler_routing from contract_config if present.
+        config = descriptor.contract_config or {}
+        event_bus_wiring: ModelEventBusWiring | None = None
+        handler_routing: ModelHandlerRouting | None = None
+
+        eb_raw = config.get("event_bus")
+        if isinstance(eb_raw, dict):
+            sub_raw = eb_raw.get("subscribe_topics")
+            pub_raw = eb_raw.get("publish_topics")
+            cp_raw = eb_raw.get("consumer_purpose")
+            event_bus_wiring = ModelEventBusWiring(
+                subscribe_topics=tuple(sub_raw) if isinstance(sub_raw, list) else (),
+                publish_topics=tuple(pub_raw) if isinstance(pub_raw, list) else (),
+                consumer_purpose=cp_raw if isinstance(cp_raw, str) else None,
+                plugin_managed=bool(eb_raw.get("plugin_managed", False)),
+            )
+
+        hr_raw = config.get("handler_routing")
+        if isinstance(hr_raw, dict):
+            entries: list[ModelHandlerRoutingEntry] = []
+            handlers_raw = hr_raw.get("handlers")
+            for h in handlers_raw if isinstance(handlers_raw, list) else []:
+                if not isinstance(h, dict):
+                    continue
+                handler_data = h.get("handler") or {}
+                if not isinstance(handler_data, dict):
+                    continue
+                handler_ref = ModelHandlerRef(
+                    name=handler_data.get("name", ""),
+                    module=handler_data.get("module", ""),
+                )
+                event_model_data = h.get("event_model")
+                event_model_ref: ModelHandlerRef | None = None
+                if isinstance(event_model_data, dict):
+                    event_model_ref = ModelHandlerRef(
+                        name=event_model_data.get("name", ""),
+                        module=event_model_data.get("module", ""),
+                    )
+                entries.append(
+                    ModelHandlerRoutingEntry(
+                        handler=handler_ref,
+                        event_model=event_model_ref,
+                        operation=h.get("operation"),
+                        event_type=h.get("event_type"),
+                        message_category=h.get("message_category"),
+                    )
+                )
+            handler_routing = ModelHandlerRouting(
+                routing_strategy=hr_raw.get("routing_strategy", "payload_type_match"),
+                handlers=tuple(entries),
+            )
+
+        # Synthetic contract_path for Kafka-sourced contracts (not on filesystem).
+        synthetic_path = Path(f"/kafka/{self._environment}/{node_name}/contract.yaml")
+
+        contract = ModelDiscoveredContract(
+            name=node_name,
+            node_type=descriptor.handler_kind,
+            description=descriptor.description or "",
+            contract_version=contract_version,
+            node_version=str(descriptor.version),
+            contract_path=synthetic_path,
+            entry_point_name=f"kafka.{node_name}",
+            package_name="dynamic",
+            event_bus=event_bus_wiring,
+            handler_routing=handler_routing,
+        )
+
+        try:
+            from omnibase_infra.protocols.protocol_dispatch_engine import (
+                ProtocolDispatchEngine,
+            )
+
+            result = await _wire_single_contract(
+                contract=contract,
+                dispatch_engine=cast("ProtocolDispatchEngine", dispatch_engine),
+                event_bus=event_bus,
+                environment=environment or self._environment,
+                container=container,
+            )
+
+            if result.outcome == EnumWiringOutcome.WIRED:
+                with self._materialization_lock:
+                    self._materialized_contracts.add((node_name, canon_hash))
+                logger.info(
+                    "Contract materialized into live dispatch engine",
+                    extra={
+                        "node_name": node_name,
+                        "handler_id": descriptor.handler_id,
+                        "dispatchers": result.dispatchers_registered,
+                        "topics": result.topics_subscribed,
+                    },
+                )
+                return ModelDynamicMaterializationResult(
+                    contract_name=node_name,
+                    contract_hash=canon_hash,
+                    subscribed_topics=result.topics_subscribed,
+                    registered_handlers=result.dispatchers_registered,
+                    materialization_correlation_id=uuid4(),
+                    status=EnumMaterializationStatus.MATERIALIZED,
+                )
+
+            logger.warning(
+                "Contract materialization skipped",
+                extra={
+                    "node_name": node_name,
+                    "outcome": result.outcome.value,
+                    "reason": result.reason,
+                },
+            )
+            return ModelDynamicMaterializationResult(
+                contract_name=node_name,
+                contract_hash=canon_hash,
+                status=EnumMaterializationStatus.REJECTED,
+            )
+
+        except Exception as exc:  # noqa: BLE001 — wiring boundary; log and return REJECTED
+            logger.warning(
+                "Contract materialization failed",
+                extra={
+                    "node_name": node_name,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return ModelDynamicMaterializationResult(
+                contract_name=node_name,
+                status=EnumMaterializationStatus.REJECTED,
+            )
+
     def clear_cache(self) -> int:
         """Clear all cached descriptors.
 
@@ -1030,4 +1288,8 @@ __all__ = [
     "BASELINE_PLATFORM_TOPICS",
     "TOPIC_SUFFIX_CONTRACT_DEREGISTERED",
     "TOPIC_SUFFIX_CONTRACT_REGISTERED",
+    # Materialization result types (OMN-11244)
+    "EnumMaterializationRejection",
+    "EnumMaterializationStatus",
+    "ModelDynamicMaterializationResult",
 ]

--- a/src/omnibase_infra/runtime/models/model_dynamic_materialization.py
+++ b/src/omnibase_infra/runtime/models/model_dynamic_materialization.py
@@ -31,7 +31,7 @@ class ModelDynamicMaterializationResult(BaseModel):
     topology data populated on successful materialization.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     contract_name: str = Field(..., description="Contract name that was materialized")
     status: EnumMaterializationStatus = Field(

--- a/src/omnibase_infra/runtime/models/model_dynamic_materialization.py
+++ b/src/omnibase_infra/runtime/models/model_dynamic_materialization.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Dynamic contract materialization result model (OMN-11244).
+
+Returned by KafkaContractSource.materialize_cached_contract() when wiring
+a cached descriptor into the live dispatch engine post-startup.
+
+Policy enforcement (handler allowlist, runtime profiles, hash verification)
+is performed by node_contract_registry in omnimarket. The runtime trusts
+validated events on onex.evt.platform.node-registration.v1.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.runtime.enums.enum_materialization_rejection import (
+    EnumMaterializationRejection,
+)
+from omnibase_infra.runtime.enums.enum_materialization_status import (
+    EnumMaterializationStatus,
+)
+
+
+class ModelDynamicMaterializationResult(BaseModel):
+    """Result returned by KafkaContractSource.materialize_cached_contract().
+
+    Structured result with enum status, optional rejection reason, and
+    topology data populated on successful materialization.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    contract_name: str = Field(..., description="Contract name that was materialized")
+    status: EnumMaterializationStatus = Field(
+        ..., description="Materialization outcome"
+    )
+    contract_hash: str = Field(
+        default="", description="SHA-256 hash of the contract YAML"
+    )
+    reason: EnumMaterializationRejection | None = Field(
+        default=None, description="Rejection reason (None on success or idempotent)"
+    )
+    subscribed_topics: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Kafka topics subscribed during materialization",
+    )
+    registered_handlers: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Handler dispatcher IDs registered during materialization",
+    )
+    runtime_profile: str = Field(
+        default="",
+        description="Runtime profile from registration event (populated by omnimarket)",
+    )
+    materialization_correlation_id: UUID | None = Field(
+        default=None,
+        description="Correlation UUID for this materialization call",
+    )
+
+
+__all__ = ["ModelDynamicMaterializationResult"]

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3081,6 +3081,17 @@ pattern_exemptions:
       - docker/migrations/forward/075_create_waste_findings.sql (rule_id VARCHAR(64))
     ticket: OMN-10341
   # ==========================================================================
+  # Dynamic Materialization Result (OMN-11244)
+  # ==========================================================================
+  - file_pattern: 'model_dynamic_materialization\.py'
+    violation_pattern: "Field 'contract_name' might reference an entity"
+    reason: >
+      contract_name in ModelDynamicMaterializationResult is the canonical node name string (e.g., "node_registration_orchestrator") identifying which cached contract was materialized. It is the contract's own semantic name, not a foreign-key reference to a database entity. The cache key is the node name; no UUID ID + display_name pattern applies here.
+
+    documentation:
+      - src/omnibase_infra/runtime/models/model_dynamic_materialization.py
+    ticket: OMN-11244
+  # ==========================================================================
   # Contract Verification Models (OMN-7042)
   # ==========================================================================
   # contract_name is a canonical identifier string (e.g., "node_registration_orchestrator")
@@ -3526,3 +3537,14 @@ union_exemptions:
       - CLAUDE.md (Type Annotation Conventions - Union patterns)
       - Standard JSON config pattern (RFC 8259)
     ticket: null
+  # ==========================================================================
+  # Dynamic Materialization Result Exemptions (OMN-11244)
+  # ==========================================================================
+  - file_pattern: 'model_dynamic_materialization\.py'
+    violation_pattern: "Field 'contract_name' might reference an entity"
+    reason: >
+      contract_name is the cache key (node identifier string, e.g. "claude_hook_effect") used to look up the descriptor in KafkaContractCache.get(). It is NOT a reference to a Contract entity — it is a status field on a value-object result model echoing back which key was materialized. No UUID + display_name decomposition applies to a cache-key echo field.
+
+    documentation:
+      - OMN-11244 (event-driven contract materialization)
+    ticket: OMN-11244

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3354,6 +3354,17 @@ pattern_exemptions:
     documentation:
       - src/omnibase_infra/onboarding/model_interactive_policy.py
     ticket: OMN-10782
+  # ==========================================================================
+  # Dynamic Materialization Result Exemptions (OMN-11244)
+  # ==========================================================================
+  - file_pattern: 'model_dynamic_materialization\.py'
+    violation_pattern: "Field 'contract_name' might reference an entity"
+    reason: >
+      contract_name is the cache key (node identifier string, e.g. "claude_hook_effect") used to look up the descriptor in KafkaContractCache.get(). It is NOT a reference to a Contract entity — it is a status field on a value-object result model echoing back which key was materialized. No UUID + display_name decomposition applies to a cache-key echo field.
+
+    documentation:
+      - OMN-11244 (event-driven contract materialization)
+    ticket: OMN-11244
 # Architecture validator exemptions
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:
@@ -3526,14 +3537,3 @@ union_exemptions:
       - CLAUDE.md (Type Annotation Conventions - Union patterns)
       - Standard JSON config pattern (RFC 8259)
     ticket: null
-  # ==========================================================================
-  # Dynamic Materialization Result Exemptions (OMN-11244)
-  # ==========================================================================
-  - file_pattern: 'model_dynamic_materialization\.py'
-    violation_pattern: "Field 'contract_name' might reference an entity"
-    reason: >
-      contract_name is the cache key (node identifier string, e.g. "claude_hook_effect") used to look up the descriptor in KafkaContractCache.get(). It is NOT a reference to a Contract entity — it is a status field on a value-object result model echoing back which key was materialized. No UUID + display_name decomposition applies to a cache-key echo field.
-
-    documentation:
-      - OMN-11244 (event-driven contract materialization)
-    ticket: OMN-11244

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3081,17 +3081,6 @@ pattern_exemptions:
       - docker/migrations/forward/075_create_waste_findings.sql (rule_id VARCHAR(64))
     ticket: OMN-10341
   # ==========================================================================
-  # Dynamic Materialization Result (OMN-11244)
-  # ==========================================================================
-  - file_pattern: 'model_dynamic_materialization\.py'
-    violation_pattern: "Field 'contract_name' might reference an entity"
-    reason: >
-      contract_name in ModelDynamicMaterializationResult is the canonical node name string (e.g., "node_registration_orchestrator") identifying which cached contract was materialized. It is the contract's own semantic name, not a foreign-key reference to a database entity. The cache key is the node name; no UUID ID + display_name pattern applies here.
-
-    documentation:
-      - src/omnibase_infra/runtime/models/model_dynamic_materialization.py
-    ticket: OMN-11244
-  # ==========================================================================
   # Contract Verification Models (OMN-7042)
   # ==========================================================================
   # contract_name is a canonical identifier string (e.g., "node_registration_orchestrator")

--- a/tests/integration/test_kafka_contract_source_materialize_integration.py
+++ b/tests/integration/test_kafka_contract_source_materialize_integration.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for KafkaContractSource.materialize_cached_contract (OMN-11244).
+
+Tests the end-to-end in-memory flow: cache population → contract hash computation
+→ wiring dispatch → idempotency guard. No live Kafka required — these tests exercise
+the materialization path from a populated cache through to the dispatch engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.models.handlers import ModelHandlerDescriptor
+from omnibase_infra.runtime.enums.enum_materialization_rejection import (
+    EnumMaterializationRejection,
+)
+from omnibase_infra.runtime.enums.enum_materialization_status import (
+    EnumMaterializationStatus,
+)
+from omnibase_infra.runtime.kafka_contract_source import KafkaContractSource
+
+pytestmark = pytest.mark.integration
+
+_WIRE_PATCH = "omnibase_infra.runtime.auto_wiring.handler_wiring._wire_single_contract"
+
+
+def _make_descriptor(
+    handler_id: str = "proto.int_test",
+    name: str = "int_test",
+    contract_config: dict | None = None,
+) -> ModelHandlerDescriptor:
+    return ModelHandlerDescriptor(
+        handler_id=handler_id,
+        name=name,
+        version="1.0.0",
+        handler_kind="effect",
+        input_model="omnibase_infra.models.TestInput",
+        output_model="omnibase_infra.models.TestOutput",
+        handler_class="omnibase_infra.handlers.handler_http.HandlerHttp",
+        contract_path=f"kafka://integration/{name}",
+        contract_config=contract_config,
+    )
+
+
+def _make_wiring_result(
+    outcome_value: str = "wired",
+    contract_name: str = "int_test",
+    dispatchers: tuple[str, ...] = ("dispatcher.int_test",),
+    topics: tuple[str, ...] = ("onex.evt.integration.test.v1",),
+) -> object:
+    from omnibase_infra.runtime.auto_wiring.report import (
+        EnumWiringOutcome,
+        ModelContractWiringResult,
+    )
+
+    return ModelContractWiringResult(
+        contract_name=contract_name,
+        package_name="integration",
+        outcome=EnumWiringOutcome(outcome_value),
+        dispatchers_registered=dispatchers,
+        topics_subscribed=topics,
+    )
+
+
+@pytest.mark.integration
+def test_materialize_cached_contract_full_flow() -> None:
+    """Happy path: descriptor in cache → wired → MATERIALIZED result with all fields."""
+    source = KafkaContractSource(environment="integration")
+    descriptor = _make_descriptor()
+    source._cache.add("int_test", descriptor)
+
+    dispatchers = ("dispatcher.int_test",)
+    topics = ("onex.evt.integration.test.v1",)
+    wiring_result = _make_wiring_result(dispatchers=dispatchers, topics=topics)
+
+    with patch(_WIRE_PATCH, new_callable=AsyncMock, return_value=wiring_result):
+        result = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="int_test",
+                dispatch_engine=MagicMock(),
+                event_bus=AsyncMock(),
+            )
+        )
+
+    assert result.status == EnumMaterializationStatus.MATERIALIZED
+    assert result.contract_name == "int_test"
+    assert result.contract_hash.startswith("sha256:")
+    assert len(result.contract_hash) > 7
+    assert result.subscribed_topics == topics
+    assert result.registered_handlers == dispatchers
+    assert result.materialization_correlation_id is not None
+    assert result.reason is None
+
+
+@pytest.mark.integration
+def test_materialize_cached_contract_idempotency_gate() -> None:
+    """Second call with identical (node_name, hash) returns ALREADY_MATERIALIZED without re-wiring."""
+    source = KafkaContractSource(environment="integration")
+    descriptor = _make_descriptor()
+    source._cache.add("int_test", descriptor)
+
+    wiring_result = _make_wiring_result()
+
+    with patch(
+        _WIRE_PATCH, new_callable=AsyncMock, return_value=wiring_result
+    ) as mock_wire:
+        result1 = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="int_test",
+                dispatch_engine=MagicMock(),
+                event_bus=AsyncMock(),
+            )
+        )
+        result2 = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="int_test",
+                dispatch_engine=MagicMock(),
+                event_bus=AsyncMock(),
+            )
+        )
+
+    assert result1.status == EnumMaterializationStatus.MATERIALIZED
+    assert result2.status == EnumMaterializationStatus.ALREADY_MATERIALIZED
+    assert mock_wire.call_count == 1
+
+
+@pytest.mark.integration
+def test_materialize_cached_contract_version_conflict() -> None:
+    """Different hash for same node_name is rejected as VERSION_CONFLICT."""
+    source = KafkaContractSource(environment="integration")
+    descriptor = _make_descriptor()
+    source._cache.add("int_test", descriptor)
+
+    # Inject a stale hash to simulate a prior version already materialized.
+    source._materialized_contracts.add(("int_test", "sha256:000000deadbeef"))
+
+    result = asyncio.run(
+        source.materialize_cached_contract(
+            node_name="int_test",
+            dispatch_engine=MagicMock(),
+            event_bus=AsyncMock(),
+        )
+    )
+
+    assert result.status == EnumMaterializationStatus.REJECTED
+    assert result.reason == EnumMaterializationRejection.VERSION_CONFLICT
+
+
+@pytest.mark.integration
+def test_materialize_cached_contract_tracking_set_populated() -> None:
+    """After successful materialization the (node_name, hash) key is in tracking set."""
+    source = KafkaContractSource(environment="integration")
+    descriptor = _make_descriptor()
+    source._cache.add("int_test", descriptor)
+
+    with patch(_WIRE_PATCH, new_callable=AsyncMock, return_value=_make_wiring_result()):
+        asyncio.run(
+            source.materialize_cached_contract(
+                node_name="int_test",
+                dispatch_engine=MagicMock(),
+                event_bus=AsyncMock(),
+            )
+        )
+
+    assert len(source._materialized_contracts) == 1
+    node_names = {n for (n, _) in source._materialized_contracts}
+    assert "int_test" in node_names
+
+
+@pytest.mark.integration
+def test_materialize_cached_contract_wiring_failure_does_not_persist() -> None:
+    """An exception during wiring leaves no entry in the tracking set (retry possible)."""
+    source = KafkaContractSource(environment="integration")
+    descriptor = _make_descriptor()
+    source._cache.add("int_test", descriptor)
+
+    with patch(
+        _WIRE_PATCH,
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("wiring subsystem unavailable"),
+    ):
+        result = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="int_test",
+                dispatch_engine=MagicMock(),
+                event_bus=AsyncMock(),
+            )
+        )
+
+    assert result.status == EnumMaterializationStatus.REJECTED
+    assert len(source._materialized_contracts) == 0

--- a/tests/unit/models/test_model_serialization_roundtrip.py
+++ b/tests/unit/models/test_model_serialization_roundtrip.py
@@ -178,6 +178,7 @@ UNCOVERED_MODELS: dict[str, str] = {
     "ModelNodeEdge": "Edge definition in runtime node graph (source/target/topic)",
     "ModelRuntimeNodeGraph": "Aggregate runtime node graph model with nodes and edges lists",
     "ModelPatternBBrokerConfig": "Runtime config for Pattern B broker; tested via live integration",
+    "ModelDynamicMaterializationResult": "Covered by test_kafka_contract_source_materialization.py",
 }
 
 

--- a/tests/unit/runtime/test_kafka_contract_source_materialization.py
+++ b/tests/unit/runtime/test_kafka_contract_source_materialization.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for KafkaContractSource.materialize_cached_contract (OMN-11244)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.models.handlers import ModelHandlerDescriptor
+from omnibase_infra.runtime.enums.enum_materialization_rejection import (
+    EnumMaterializationRejection,
+)
+from omnibase_infra.runtime.enums.enum_materialization_status import (
+    EnumMaterializationStatus,
+)
+from omnibase_infra.runtime.kafka_contract_source import KafkaContractSource
+
+pytestmark = pytest.mark.unit
+
+
+_WIRE_PATCH = "omnibase_infra.runtime.auto_wiring.handler_wiring._wire_single_contract"
+
+
+def _make_descriptor(
+    handler_id: str = "proto.test_dynamic",
+    name: str = "test_dynamic",
+    contract_path: str = "kafka://dev/contracts/test_dynamic",
+    contract_config: dict | None = None,
+) -> ModelHandlerDescriptor:
+    return ModelHandlerDescriptor(
+        handler_id=handler_id,
+        name=name,
+        version="1.0.0",
+        handler_kind="effect",
+        input_model="omnibase_infra.models.TestInput",
+        output_model="omnibase_infra.models.TestOutput",
+        handler_class="omnibase_infra.handlers.handler_http.HandlerHttp",
+        contract_path=contract_path,
+        contract_config=contract_config,
+    )
+
+
+def _make_wiring_result(
+    outcome_value: str = "wired",
+    contract_name: str = "test_dynamic",
+    dispatchers: tuple[str, ...] = ("dispatcher.test",),
+    topics: tuple[str, ...] = ("onex.evt.test.topic.v1",),
+) -> MagicMock:
+    from omnibase_infra.runtime.auto_wiring.report import (
+        EnumWiringOutcome,
+        ModelContractWiringResult,
+    )
+
+    outcome = EnumWiringOutcome(outcome_value)
+    return ModelContractWiringResult(
+        contract_name=contract_name,
+        package_name="dynamic",
+        outcome=outcome,
+        dispatchers_registered=dispatchers,
+        topics_subscribed=topics,
+    )
+
+
+class TestMaterializeCachedContractNotCached:
+    """materialize_cached_contract returns REJECTED when node not in cache."""
+
+    def test_returns_rejected_for_unknown_node(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        dispatch_engine = MagicMock()
+        event_bus = MagicMock()
+
+        result = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="nonexistent.node",
+                dispatch_engine=dispatch_engine,
+                event_bus=event_bus,
+            )
+        )
+        assert result.status == EnumMaterializationStatus.REJECTED
+        assert result.reason == EnumMaterializationRejection.PARSE_FAILURE
+        assert result.contract_name == "nonexistent.node"
+
+
+class TestMaterializeCachedContractIdempotency:
+    """Same (node_name, contract_hash) is wired exactly once."""
+
+    def test_second_call_returns_already_materialized(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        dispatch_engine = MagicMock()
+        event_bus = AsyncMock()
+        wiring_result = _make_wiring_result()
+
+        with patch(
+            _WIRE_PATCH,
+            new_callable=AsyncMock,
+            return_value=wiring_result,
+        ) as mock_wire:
+            result1 = asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=dispatch_engine,
+                    event_bus=event_bus,
+                )
+            )
+            assert result1.status == EnumMaterializationStatus.MATERIALIZED
+            assert mock_wire.call_count == 1
+
+            result2 = asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=dispatch_engine,
+                    event_bus=event_bus,
+                )
+            )
+            assert result2.status == EnumMaterializationStatus.ALREADY_MATERIALIZED
+            assert mock_wire.call_count == 1  # not called again
+
+
+class TestMaterializeCachedContractVersionConflict:
+    """Same node_name with different hash is rejected as VERSION_CONFLICT."""
+
+    def test_version_conflict_rejected(self) -> None:
+        source = KafkaContractSource(environment="dev")
+
+        descriptor1 = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor1)
+
+        # Inject a different hash for the same node name to simulate a
+        # version already materialized under a different contract revision.
+        fake_hash = "sha256:aabbccddeeff00112233445566778899"
+        source._materialized_contracts.add(("test_dynamic", fake_hash))
+
+        # Now try to materialize — the canonical hash won't match fake_hash.
+        result = asyncio.run(
+            source.materialize_cached_contract(
+                node_name="test_dynamic",
+                dispatch_engine=MagicMock(),
+                event_bus=MagicMock(),
+            )
+        )
+        assert result.status == EnumMaterializationStatus.REJECTED
+        assert result.reason == EnumMaterializationRejection.VERSION_CONFLICT
+
+
+class TestMaterializeCachedContractSuccess:
+    """Happy-path: descriptor wired into dispatch engine, result populated."""
+
+    def test_materialized_result_fields(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        dispatchers = ("dispatcher.effect_test",)
+        topics = ("onex.evt.test.dynamic.v1",)
+        wiring_result = _make_wiring_result(dispatchers=dispatchers, topics=topics)
+
+        with patch(
+            _WIRE_PATCH,
+            new_callable=AsyncMock,
+            return_value=wiring_result,
+        ):
+            result = asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert result.status == EnumMaterializationStatus.MATERIALIZED
+        assert result.contract_name == "test_dynamic"
+        assert result.contract_hash.startswith("sha256:")
+        assert result.subscribed_topics == topics
+        assert result.registered_handlers == dispatchers
+        assert result.materialization_correlation_id is not None
+
+    def test_materialized_contract_added_to_tracking_set(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        with patch(
+            _WIRE_PATCH,
+            new_callable=AsyncMock,
+            return_value=_make_wiring_result(),
+        ):
+            asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert len(source._materialized_contracts) == 1
+        node_names = {n for (n, _) in source._materialized_contracts}
+        assert "test_dynamic" in node_names
+
+
+class TestMaterializeCachedContractWiringSkipped:
+    """When _wire_single_contract returns SKIPPED, result is REJECTED."""
+
+    def test_skipped_wiring_returns_rejected(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        wiring_result = _make_wiring_result(outcome_value="skipped")
+
+        with patch(
+            _WIRE_PATCH,
+            new_callable=AsyncMock,
+            return_value=wiring_result,
+        ):
+            result = asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert result.status == EnumMaterializationStatus.REJECTED
+        assert result.reason is None
+        # Should NOT have been added to tracking set
+        assert len(source._materialized_contracts) == 0
+
+
+class TestMaterializeCachedContractWiringException:
+    """Exceptions from _wire_single_contract return REJECTED gracefully."""
+
+    def test_exception_returns_rejected(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        with patch(
+            _WIRE_PATCH,
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("dispatch engine is frozen"),
+        ):
+            result = asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert result.status == EnumMaterializationStatus.REJECTED
+        assert len(source._materialized_contracts) == 0
+
+
+class TestMaterializeCachedContractEventBusConfig:
+    """Contracts with event_bus config pass correct wiring to _wire_single_contract."""
+
+    def test_event_bus_topics_passed_to_wiring(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        config = {
+            "event_bus": {
+                "subscribe_topics": ["onex.evt.test.foo.v1"],
+                "publish_topics": ["onex.evt.test.bar.v1"],
+            }
+        }
+        descriptor = _make_descriptor(contract_config=config)
+        source._cache.add("test_dynamic", descriptor)
+
+        captured: list[object] = []
+
+        async def _capture_wire(**kwargs: object) -> object:
+            captured.append(kwargs["contract"])
+            return _make_wiring_result()
+
+        with patch(
+            _WIRE_PATCH,
+            side_effect=_capture_wire,
+        ):
+            asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert len(captured) == 1
+        contract = captured[0]
+        assert hasattr(contract, "event_bus")
+        assert contract.event_bus is not None
+        assert "onex.evt.test.foo.v1" in contract.event_bus.subscribe_topics
+
+
+class TestMaterializeCachedContractHandlerRouting:
+    """Contracts with handler_routing config pass correct routing entries."""
+
+    def test_handler_routing_passed_to_wiring(self) -> None:
+        source = KafkaContractSource(environment="dev")
+        config = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "handlers": [
+                    {
+                        "handler": {
+                            "name": "HandlerHttp",
+                            "module": "omnibase_infra.handlers.handler_http",
+                        },
+                        "event_model": {
+                            "name": "ModelTestEvent",
+                            "module": "omnibase_infra.models.TestEvent",
+                        },
+                    }
+                ],
+            }
+        }
+        descriptor = _make_descriptor(contract_config=config)
+        source._cache.add("test_dynamic", descriptor)
+
+        captured: list[object] = []
+
+        async def _capture_wire(**kwargs: object) -> object:
+            captured.append(kwargs["contract"])
+            return _make_wiring_result()
+
+        with patch(
+            _WIRE_PATCH,
+            side_effect=_capture_wire,
+        ):
+            asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert len(captured) == 1
+        contract = captured[0]
+        assert contract.handler_routing is not None
+        assert contract.handler_routing.routing_strategy == "payload_type_match"
+        assert len(contract.handler_routing.handlers) == 1
+        assert contract.handler_routing.handlers[0].handler.name == "HandlerHttp"
+
+
+class TestMaterializeCachedContractSyntheticPath:
+    """Synthetic contract_path uses /kafka/ prefix for Kafka-sourced contracts."""
+
+    def test_contract_path_is_synthetic(self) -> None:
+        source = KafkaContractSource(environment="staging")
+        descriptor = _make_descriptor()
+        source._cache.add("test_dynamic", descriptor)
+
+        captured: list[object] = []
+
+        async def _capture_wire(**kwargs: object) -> object:
+            captured.append(kwargs["contract"])
+            return _make_wiring_result()
+
+        with patch(
+            _WIRE_PATCH,
+            side_effect=_capture_wire,
+        ):
+            asyncio.run(
+                source.materialize_cached_contract(
+                    node_name="test_dynamic",
+                    dispatch_engine=MagicMock(),
+                    event_bus=AsyncMock(),
+                )
+            )
+
+        assert len(captured) == 1
+        contract_path = captured[0].contract_path
+        assert isinstance(contract_path, Path)
+        assert "kafka" in str(contract_path)
+        assert "staging" in str(contract_path)
+        assert "test_dynamic" in str(contract_path)

--- a/tests/unit/runtime/test_kafka_contract_source_materialization.py
+++ b/tests/unit/runtime/test_kafka_contract_source_materialization.py
@@ -65,21 +65,51 @@ def _make_wiring_result(
     )
 
 
+def _add_default_descriptor(
+    source: KafkaContractSource,
+    contract_config: dict | None = None,
+) -> ModelHandlerDescriptor:
+    descriptor = _make_descriptor(contract_config=contract_config)
+    source._cache.add("test_dynamic", descriptor)
+    return descriptor
+
+
+def _materialize(
+    source: KafkaContractSource,
+    node_name: str = "test_dynamic",
+    event_bus: object | None = None,
+) -> object:
+    return asyncio.run(
+        source.materialize_cached_contract(
+            node_name=node_name,
+            dispatch_engine=MagicMock(),
+            event_bus=event_bus or AsyncMock(),
+        )
+    )
+
+
+def _capture_wired_contract(source: KafkaContractSource) -> object:
+    captured: list[object] = []
+
+    def _capture_wire(**kwargs: object) -> object:
+        captured.append(kwargs["contract"])
+        return _make_wiring_result()
+
+    with patch(_WIRE_PATCH, side_effect=_capture_wire):
+        _materialize(source)
+
+    assert len(captured) == 1
+    return captured[0]
+
+
 class TestMaterializeCachedContractNotCached:
     """materialize_cached_contract returns REJECTED when node not in cache."""
 
     def test_returns_rejected_for_unknown_node(self) -> None:
         source = KafkaContractSource(environment="dev")
-        dispatch_engine = MagicMock()
-        event_bus = MagicMock()
 
-        result = asyncio.run(
-            source.materialize_cached_contract(
-                node_name="nonexistent.node",
-                dispatch_engine=dispatch_engine,
-                event_bus=event_bus,
-            )
-        )
+        result = _materialize(source, node_name="nonexistent.node")
+
         assert result.status == EnumMaterializationStatus.REJECTED
         assert result.reason == EnumMaterializationRejection.PARSE_FAILURE
         assert result.contract_name == "nonexistent.node"
@@ -90,11 +120,8 @@ class TestMaterializeCachedContractIdempotency:
 
     def test_second_call_returns_already_materialized(self) -> None:
         source = KafkaContractSource(environment="dev")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
-        dispatch_engine = MagicMock()
-        event_bus = AsyncMock()
         wiring_result = _make_wiring_result()
 
         with patch(
@@ -102,23 +129,11 @@ class TestMaterializeCachedContractIdempotency:
             new_callable=AsyncMock,
             return_value=wiring_result,
         ) as mock_wire:
-            result1 = asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=dispatch_engine,
-                    event_bus=event_bus,
-                )
-            )
+            result1 = _materialize(source)
             assert result1.status == EnumMaterializationStatus.MATERIALIZED
             assert mock_wire.call_count == 1
 
-            result2 = asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=dispatch_engine,
-                    event_bus=event_bus,
-                )
-            )
+            result2 = _materialize(source)
             assert result2.status == EnumMaterializationStatus.ALREADY_MATERIALIZED
             assert mock_wire.call_count == 1  # not called again
 
@@ -128,23 +143,15 @@ class TestMaterializeCachedContractVersionConflict:
 
     def test_version_conflict_rejected(self) -> None:
         source = KafkaContractSource(environment="dev")
-
-        descriptor1 = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor1)
+        _add_default_descriptor(source)
 
         # Inject a different hash for the same node name to simulate a
         # version already materialized under a different contract revision.
         fake_hash = "sha256:aabbccddeeff00112233445566778899"
         source._materialized_contracts.add(("test_dynamic", fake_hash))
 
-        # Now try to materialize — the canonical hash won't match fake_hash.
-        result = asyncio.run(
-            source.materialize_cached_contract(
-                node_name="test_dynamic",
-                dispatch_engine=MagicMock(),
-                event_bus=MagicMock(),
-            )
-        )
+        result = _materialize(source)
+
         assert result.status == EnumMaterializationStatus.REJECTED
         assert result.reason == EnumMaterializationRejection.VERSION_CONFLICT
 
@@ -154,8 +161,7 @@ class TestMaterializeCachedContractSuccess:
 
     def test_materialized_result_fields(self) -> None:
         source = KafkaContractSource(environment="dev")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
         dispatchers = ("dispatcher.effect_test",)
         topics = ("onex.evt.test.dynamic.v1",)
@@ -166,13 +172,7 @@ class TestMaterializeCachedContractSuccess:
             new_callable=AsyncMock,
             return_value=wiring_result,
         ):
-            result = asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
+            result = _materialize(source)
 
         assert result.status == EnumMaterializationStatus.MATERIALIZED
         assert result.contract_name == "test_dynamic"
@@ -183,21 +183,14 @@ class TestMaterializeCachedContractSuccess:
 
     def test_materialized_contract_added_to_tracking_set(self) -> None:
         source = KafkaContractSource(environment="dev")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
         with patch(
             _WIRE_PATCH,
             new_callable=AsyncMock,
             return_value=_make_wiring_result(),
         ):
-            asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
+            _materialize(source)
 
         assert len(source._materialized_contracts) == 1
         node_names = {n for (n, _) in source._materialized_contracts}
@@ -209,8 +202,7 @@ class TestMaterializeCachedContractWiringSkipped:
 
     def test_skipped_wiring_returns_rejected(self) -> None:
         source = KafkaContractSource(environment="dev")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
         wiring_result = _make_wiring_result(outcome_value="skipped")
 
@@ -219,13 +211,7 @@ class TestMaterializeCachedContractWiringSkipped:
             new_callable=AsyncMock,
             return_value=wiring_result,
         ):
-            result = asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
+            result = _materialize(source)
 
         assert result.status == EnumMaterializationStatus.REJECTED
         assert result.reason is None
@@ -238,21 +224,14 @@ class TestMaterializeCachedContractWiringException:
 
     def test_exception_returns_rejected(self) -> None:
         source = KafkaContractSource(environment="dev")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
         with patch(
             _WIRE_PATCH,
             new_callable=AsyncMock,
             side_effect=RuntimeError("dispatch engine is frozen"),
         ):
-            result = asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
+            result = _materialize(source)
 
         assert result.status == EnumMaterializationStatus.REJECTED
         assert len(source._materialized_contracts) == 0
@@ -269,29 +248,10 @@ class TestMaterializeCachedContractEventBusConfig:
                 "publish_topics": ["onex.evt.test.bar.v1"],
             }
         }
-        descriptor = _make_descriptor(contract_config=config)
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source, contract_config=config)
 
-        captured: list[object] = []
+        contract = _capture_wired_contract(source)
 
-        async def _capture_wire(**kwargs: object) -> object:
-            captured.append(kwargs["contract"])
-            return _make_wiring_result()
-
-        with patch(
-            _WIRE_PATCH,
-            side_effect=_capture_wire,
-        ):
-            asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
-
-        assert len(captured) == 1
-        contract = captured[0]
         assert hasattr(contract, "event_bus")
         assert contract.event_bus is not None
         assert "onex.evt.test.foo.v1" in contract.event_bus.subscribe_topics
@@ -319,29 +279,10 @@ class TestMaterializeCachedContractHandlerRouting:
                 ],
             }
         }
-        descriptor = _make_descriptor(contract_config=config)
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source, contract_config=config)
 
-        captured: list[object] = []
+        contract = _capture_wired_contract(source)
 
-        async def _capture_wire(**kwargs: object) -> object:
-            captured.append(kwargs["contract"])
-            return _make_wiring_result()
-
-        with patch(
-            _WIRE_PATCH,
-            side_effect=_capture_wire,
-        ):
-            asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
-
-        assert len(captured) == 1
-        contract = captured[0]
         assert contract.handler_routing is not None
         assert contract.handler_routing.routing_strategy == "payload_type_match"
         assert len(contract.handler_routing.handlers) == 1
@@ -353,29 +294,10 @@ class TestMaterializeCachedContractSyntheticPath:
 
     def test_contract_path_is_synthetic(self) -> None:
         source = KafkaContractSource(environment="staging")
-        descriptor = _make_descriptor()
-        source._cache.add("test_dynamic", descriptor)
+        _add_default_descriptor(source)
 
-        captured: list[object] = []
+        contract_path = _capture_wired_contract(source).contract_path
 
-        async def _capture_wire(**kwargs: object) -> object:
-            captured.append(kwargs["contract"])
-            return _make_wiring_result()
-
-        with patch(
-            _WIRE_PATCH,
-            side_effect=_capture_wire,
-        ):
-            asyncio.run(
-                source.materialize_cached_contract(
-                    node_name="test_dynamic",
-                    dispatch_engine=MagicMock(),
-                    event_bus=AsyncMock(),
-                )
-            )
-
-        assert len(captured) == 1
-        contract_path = captured[0].contract_path
         assert isinstance(contract_path, Path)
         assert "kafka" in str(contract_path)
         assert "staging" in str(contract_path)

--- a/tests/unit/runtime/test_kafka_contract_source_materialization.py
+++ b/tests/unit/runtime/test_kafka_contract_source_materialization.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
 
 import pytest
 


### PR DESCRIPTION
## Summary

Implements KafkaContractSource.materialize_cached_contract() so that node descriptors already in cache can be wired into the live dispatch engine post-startup without a restart (OMN-11244).

- Adds three new enums: EnumMaterializationStatus, EnumMaterializationRejection, EnumContractSource
- Adds ModelDynamicMaterializationResult frozen Pydantic model with full topology data on success
- Idempotency via _materialized_contracts: set[tuple[str, str]] keyed on (node_name, sha256_hash)
- Version conflict guard: same name + different hash returns REJECTED/VERSION_CONFLICT
- Profile and handler validation delegated to omnimarket per omnigate policy
- 10 unit tests covering all status paths
- Exemption entry in validation_exemptions.yaml for contract_name field

## Test plan

- [x] 10 unit tests pass for materialize_cached_contract()
- [x] mypy --strict clean
- [x] Pre-commit all hooks pass
- [x] 43 existing KafkaContractSource tests pass

OMN-11244

Evidence-Source: OCC#1139
Evidence-Ticket: OMN-11244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic materialization of Kafka-discovered contracts with idempotent single-materialization, version-conflict protection, and explicit materialization outcomes.

* **New Models & Enums**
  * Enums and a frozen result model surface materialization status, rejection reasons, subscribed topics, registered handlers, runtime profile, and a correlation ID.

* **Tests**
  * Expanded unit and integration tests covering success, idempotency, version conflicts, wiring skips/exceptions, and config forwarding.

* **Documentation**
  * Feature contract entry and a validation exemption documenting behavior and rationale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->