### PR TITLE
feat(OMN-11247): post-freeze contract registration listener in RuntimeHostProcess

### DIFF
--- a/contracts/OMN-11247.yaml
+++ b/contracts/OMN-11247.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11247"
+title: "Post-freeze contract registration listener in RuntimeHostProcess"
+summary: >
+  Adds a RuntimeHostProcess listener for node-registration events after the dispatch engine freezes, caching validated contracts from KafkaContractSource and materializing the corresponding handler into the live runtime.
+
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "topics"
+  - "events"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-focused-tests"
+    description: "Unit and integration tests cover dynamic registration listener subscription, registration, deregistration, and materialization behavior."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_runtime_host_dynamic_registration.py tests/integration/test_runtime_host_dynamic_registration.py -q"
+  - id: "dod-deploy-proof"
+    description: >
+      Runtime deploy proof after merge: rebuild omninode-runtime on 192.168.86.201, restart with approval, publish a node-registration event, and verify the dynamic-contract listener consumer group receives the event and the runtime materializes the handler without restart.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-runtime python -c 'from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess; print(RuntimeHostProcess.__name__)' && rpk group describe local.omnibase-infra.test-node-dynamic-contract-listener.consume.1.0.0"

--- a/src/omnibase_infra/runtime/service_runtime_host_process.py
+++ b/src/omnibase_infra/runtime/service_runtime_host_process.py
@@ -1351,6 +1351,11 @@ class RuntimeHostProcess:
         # Wired when KAFKA_EVENTS mode is active with a KafkaContractSource.
         self._baseline_subscriptions: list[Callable[[], Awaitable[None]]] = []
 
+        # Post-freeze dynamic contract registration listener (OMN-11247)
+        # Unsubscribe callback for the node-registration topic subscription.
+        # None until _start_dynamic_contract_listener() is called during start().
+        self._dynamic_contract_unsubscribe: Callable[[], Awaitable[None]] | None = None
+
         # Contract configuration loaded at startup (OMN-1519)
         # Contains consolidated handler_routing and operation_bindings from all contracts.
         # None until loaded during start() via _load_contract_configs()
@@ -1960,6 +1965,13 @@ class RuntimeHostProcess:
         # contract topics to receive registration/deregistration events.
         await self._wire_baseline_subscriptions()
 
+        # Step 4.35: Start post-freeze dynamic contract registration listener (OMN-11247)
+        # Subscribes to onex.evt.platform.node-registration.v1 AFTER the dispatch
+        # engine is frozen. Routes incoming events to on_contract_registered()
+        # then live materializes the handler into the frozen engine.
+        # No-op when KafkaContractSource is not configured.
+        await self._start_dynamic_contract_listener()
+
         # Step 4.5: Initialize idempotency store if configured (OMN-945)
         await self._initialize_idempotency_store()
 
@@ -2288,6 +2300,18 @@ class RuntimeHostProcess:
                     )
             self._baseline_subscriptions.clear()
             logger.debug("Baseline contract subscriptions cleaned up")
+
+        # Step 2.75: Cleanup dynamic contract registration listener (OMN-11247)
+        if self._dynamic_contract_unsubscribe is not None:
+            try:
+                await self._dynamic_contract_unsubscribe()
+            except Exception as e:  # noqa: BLE001 — boundary: logs warning and degrades
+                logger.warning(
+                    "Failed to unsubscribe dynamic contract registration listener",
+                    extra={"error": str(e)},
+                )
+            self._dynamic_contract_unsubscribe = None
+            logger.debug("Dynamic contract registration listener cleaned up")
 
         # Step 2.8: Nullify KafkaContractSource reference for proper cleanup (OMN-1654)
         self._kafka_contract_source = None
@@ -6029,6 +6053,189 @@ class RuntimeHostProcess:
                 extra={
                     "registration_topic": registration_topic,
                     "deregistration_topic": deregistration_topic,
+                },
+            )
+
+    # =========================================================================
+    # Dynamic Contract Registration Listener (OMN-11247)
+    # =========================================================================
+
+    async def _start_dynamic_contract_listener(self) -> None:
+        """Subscribe to node-registration events for post-freeze materialization.
+
+        Called AFTER the dispatch engine is frozen during _start_runtime(). Subscribes
+        to SUFFIX_NODE_REGISTRATION (onex.evt.platform.node-registration.v1) and routes
+        events through on_contract_registered() then live handler materialization.
+
+        No-op when:
+        - _kafka_contract_source is None (not using Kafka discovery)
+        - _event_bus is None
+
+        The runtime trusts events on this topic as pre-validated by omnimarket.
+        No local policy enforcement — only cache + materialize.
+
+        .. versionadded:: 0.9.4
+            Added as part of OMN-11247 post-freeze dynamic contract registration.
+        """
+        if self._kafka_contract_source is None:
+            logger.debug(
+                "Skipping dynamic contract listener: no KafkaContractSource configured"
+            )
+            return
+
+        if self._event_bus is None:
+            logger.debug("Skipping dynamic contract listener: no event bus available")
+            return
+
+        from omnibase_infra.topics import SUFFIX_NODE_REGISTRATION
+
+        listener_identity = ModelNodeIdentity(
+            env=self._kafka_contract_source.environment,
+            service=self._node_identity.service,
+            node_name=f"{self._node_identity.node_name}-dynamic-contract-listener",
+            version=self._node_identity.version,
+        )
+
+        self._dynamic_contract_unsubscribe = await self._event_bus.subscribe(
+            topic=SUFFIX_NODE_REGISTRATION,
+            node_identity=listener_identity,
+            on_message=self._on_dynamic_contract_event,
+            purpose=EnumConsumerGroupPurpose.CONSUME,
+        )
+
+        logger.info(
+            "Dynamic contract registration listener started",
+            extra={"topic": SUFFIX_NODE_REGISTRATION},
+        )
+
+    async def _on_dynamic_contract_event(self, msg: ModelEventMessage) -> None:
+        """Process a node-registration event for live handler materialization.
+
+        Parses the event payload, caches the contract via KafkaContractSource,
+        then materializes the handler into the live (frozen) dispatch engine.
+
+        This handler never raises — all exceptions are caught and logged.
+        Structured rejection fields (failure_code, reason, node_name,
+        correlation_id, rejected_at) are included in warning log extras.
+
+        .. versionadded:: 0.9.4
+            Added as part of OMN-11247 post-freeze dynamic contract registration.
+        """
+        import datetime
+
+        correlation_id: UUID = uuid4()
+        node_name: str = ""
+
+        try:
+            if self._kafka_contract_source is None:
+                return
+
+            parsed = _parse_contract_event_payload(msg)
+            if parsed is None:
+                return
+
+            payload, correlation_id = parsed
+            node_name = str(payload.get("node_name", ""))
+            contract_yaml = str(payload.get("contract_yaml", ""))
+            event_type = str(payload.get("event_type", "registered"))
+
+            if not node_name:
+                logger.warning(
+                    "Rejecting malformed node-registration event",
+                    extra={
+                        "failure_code": "MISSING_NODE_NAME",
+                        "reason": "node_name field is missing or empty",
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                        "rejected_at": datetime.datetime.now(datetime.UTC).isoformat(),
+                    },
+                )
+                return
+
+            if event_type in ("deregistered", "expired"):
+                self._kafka_contract_source.on_contract_deregistered(
+                    node_name=node_name,
+                    correlation_id=correlation_id,
+                )
+                return
+
+            if not contract_yaml:
+                logger.warning(
+                    "Rejecting malformed node-registration event",
+                    extra={
+                        "failure_code": "MISSING_CONTRACT_YAML",
+                        "reason": "contract_yaml field is missing or empty",
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                        "rejected_at": datetime.datetime.now(datetime.UTC).isoformat(),
+                    },
+                )
+                return
+
+            cached = self._kafka_contract_source.on_contract_registered(
+                node_name=node_name,
+                contract_yaml=contract_yaml,
+                correlation_id=correlation_id,
+            )
+
+            if not cached:
+                logger.warning(
+                    "Dynamic contract registration caching failed",
+                    extra={
+                        "failure_code": "CACHE_FAILED",
+                        "reason": "on_contract_registered returned False",
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                        "rejected_at": datetime.datetime.now(datetime.UTC).isoformat(),
+                    },
+                )
+                return
+
+            descriptor = self._kafka_contract_source.get_cached_descriptor(node_name)
+            if descriptor is None:
+                logger.warning(
+                    "Dynamic contract cached but descriptor not found",
+                    extra={
+                        "failure_code": "DESCRIPTOR_NOT_FOUND",
+                        "reason": "get_cached_descriptor returned None after caching",
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                        "rejected_at": datetime.datetime.now(datetime.UTC).isoformat(),
+                    },
+                )
+                return
+
+            materialized = await self._materialize_handler_live(
+                node_name=node_name,
+                descriptor=descriptor,
+                correlation_id=correlation_id,
+            )
+
+            if materialized:
+                logger.info(
+                    "Dynamic contract registered and materialized",
+                    extra={
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                    },
+                )
+            else:
+                logger.warning(
+                    "Dynamic contract cached but materialization returned False",
+                    extra={
+                        "node_name": node_name,
+                        "correlation_id": str(correlation_id),
+                    },
+                )
+
+        except Exception as e:  # noqa: BLE001 — boundary: never crash the runtime
+            logger.warning(
+                "Error processing dynamic contract registration event",
+                extra={
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "node_name": node_name,
+                    "correlation_id": str(correlation_id),
                 },
             )
 

--- a/tests/integration/test_runtime_host_dynamic_registration.py
+++ b/tests/integration/test_runtime_host_dynamic_registration.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for post-freeze dynamic contract registration (OMN-11247)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from omnibase_infra.topics import SUFFIX_NODE_REGISTRATION
+
+pytestmark = [pytest.mark.integration]
+
+
+VALID_CONTRACT_YAML = """\
+name: node_dynamic_test
+handler_id: proto.dynamic_test
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+description: Dynamically registered test handler
+input_model:
+  name: JsonDict
+  module: omnibase_infra.models.types
+output_model:
+  name: ModelHandlerOutput
+  module: omnibase_core.models.dispatch.model_handler_output
+descriptor:
+  node_archetype: EFFECT_GENERIC
+metadata:
+  handler_class: omnibase_infra.handlers.handler_http.HandlerHttp
+event_bus:
+  subscribe_topics:
+    - onex.evt.test.dynamic-reg.v1
+  publish_topics: []
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - handler:
+        name: HandlerHttp
+        module: omnibase_infra.handlers.handler_http
+"""
+
+
+@dataclass
+class _Subscription:
+    topic: str
+    on_message: Any
+    node_identity: Any
+    purpose: Any
+
+
+class _InMemoryEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: list[_Subscription] = []
+        self.unsubscribe_count = 0
+
+    async def subscribe(self, **kwargs: Any) -> Any:
+        self.subscriptions.append(_Subscription(**kwargs))
+
+        async def unsubscribe() -> None:
+            self.unsubscribe_count += 1
+
+        return unsubscribe
+
+    async def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        message = MagicMock()
+        message.value = json.dumps(payload).encode("utf-8")
+        message.headers = MagicMock()
+        message.headers.correlation_id = payload.get("correlation_id")
+
+        matching = [
+            subscription
+            for subscription in self.subscriptions
+            if subscription.topic == topic
+        ]
+        assert len(matching) == 1
+        await matching[0].on_message(message)
+
+
+class _CachingContractSource:
+    environment = "test"
+
+    def __init__(self) -> None:
+        self.cached: dict[str, object] = {}
+        self.registered: list[tuple[str, str, UUID]] = []
+        self.deregistered: list[tuple[str, UUID]] = []
+
+    def on_contract_registered(
+        self,
+        *,
+        node_name: str,
+        contract_yaml: str,
+        correlation_id: UUID,
+    ) -> bool:
+        descriptor = object()
+        self.cached[node_name] = descriptor
+        self.registered.append((node_name, contract_yaml, correlation_id))
+        return True
+
+    def on_contract_deregistered(
+        self,
+        *,
+        node_name: str,
+        correlation_id: UUID,
+    ) -> None:
+        self.deregistered.append((node_name, correlation_id))
+        self.cached.pop(node_name, None)
+
+    def get_cached_descriptor(self, node_name: str) -> object | None:
+        return self.cached.get(node_name)
+
+
+def _make_process(
+    event_bus: _InMemoryEventBus,
+    contract_source: _CachingContractSource,
+) -> RuntimeHostProcess:
+    process = RuntimeHostProcess.__new__(RuntimeHostProcess)
+    process._event_bus = event_bus
+    process._kafka_contract_source = contract_source
+    process._node_identity = MagicMock()
+    process._node_identity.service = "test-service"
+    process._node_identity.node_name = "test-node"
+    process._node_identity.version = "v1"
+    process._dynamic_contract_unsubscribe = None
+    process.materialized: list[tuple[str, object, UUID]] = []
+
+    async def materialize_handler_live(
+        *,
+        node_name: str,
+        descriptor: object,
+        correlation_id: UUID,
+    ) -> bool:
+        process.materialized.append((node_name, descriptor, correlation_id))
+        return True
+
+    process._materialize_handler_live = materialize_handler_live
+    return process
+
+
+@pytest.mark.asyncio
+async def test_dynamic_registration_event_crosses_bus_to_materialize_handler() -> None:
+    """Registration events travel through the bus subscription into materialization."""
+    event_bus = _InMemoryEventBus()
+    contract_source = _CachingContractSource()
+    process = _make_process(event_bus, contract_source)
+    correlation_id = uuid4()
+
+    await process._start_dynamic_contract_listener()
+    await event_bus.publish(
+        SUFFIX_NODE_REGISTRATION,
+        {
+            "node_name": "node_dynamic_test",
+            "contract_yaml": VALID_CONTRACT_YAML,
+            "event_type": "registered",
+            "correlation_id": str(correlation_id),
+        },
+    )
+
+    assert [subscription.topic for subscription in event_bus.subscriptions] == [
+        SUFFIX_NODE_REGISTRATION
+    ]
+    assert contract_source.registered == [
+        ("node_dynamic_test", VALID_CONTRACT_YAML, correlation_id)
+    ]
+    descriptor = contract_source.get_cached_descriptor("node_dynamic_test")
+    assert process.materialized == [("node_dynamic_test", descriptor, correlation_id)]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_deregistration_event_crosses_bus_without_materialization() -> (
+    None
+):
+    """Deregistration events clear the cache and do not materialize a handler."""
+    event_bus = _InMemoryEventBus()
+    contract_source = _CachingContractSource()
+    process = _make_process(event_bus, contract_source)
+    correlation_id = uuid4()
+
+    contract_source.cached["node_dynamic_test"] = object()
+    await process._start_dynamic_contract_listener()
+    await event_bus.publish(
+        SUFFIX_NODE_REGISTRATION,
+        {
+            "node_name": "node_dynamic_test",
+            "event_type": "deregistered",
+            "correlation_id": str(correlation_id),
+        },
+    )
+
+    assert contract_source.deregistered == [("node_dynamic_test", correlation_id)]
+    assert contract_source.get_cached_descriptor("node_dynamic_test") is None
+    assert process.materialized == []

--- a/tests/unit/runtime/test_runtime_host_dynamic_registration.py
+++ b/tests/unit/runtime/test_runtime_host_dynamic_registration.py
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for post-freeze dynamic contract registration listener (OMN-11247).
+
+Tests validate that RuntimeHostProcess._start_dynamic_contract_listener() and
+_on_dynamic_contract_event() work correctly for post-freeze contract registration.
+
+Tests use RuntimeHostProcess.__new__() to skip __init__ and manually set
+internal state, isolating the methods under test from full runtime setup.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, call
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.runtime.service_runtime_host_process import RuntimeHostProcess
+from omnibase_infra.topics import SUFFIX_NODE_REGISTRATION
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Shared YAML fixture
+# ---------------------------------------------------------------------------
+
+VALID_CONTRACT_YAML = """\
+name: node_dynamic_test
+handler_id: proto.dynamic_test
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+description: Dynamically registered test handler
+input_model:
+  name: JsonDict
+  module: omnibase_infra.models.types
+output_model:
+  name: ModelHandlerOutput
+  module: omnibase_core.models.dispatch.model_handler_output
+descriptor:
+  node_archetype: EFFECT_GENERIC
+metadata:
+  handler_class: omnibase_infra.handlers.handler_http.HandlerHttp
+event_bus:
+  subscribe_topics:
+    - onex.evt.test.dynamic-reg.v1
+  publish_topics: []
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - handler:
+        name: HandlerHttp
+        module: omnibase_infra.handlers.handler_http
+"""
+
+
+def _make_msg(payload: dict) -> MagicMock:
+    """Create a mock Kafka message with a JSON-encoded payload."""
+    msg = MagicMock()
+    msg.value = json.dumps(payload).encode("utf-8")
+    msg.headers = None
+    return msg
+
+
+def _make_process(
+    kafka_source: object | None = "AUTO",
+    event_bus: object | None = "AUTO",
+) -> RuntimeHostProcess:
+    """Create a RuntimeHostProcess without running __init__."""
+    process = RuntimeHostProcess.__new__(RuntimeHostProcess)
+
+    if kafka_source == "AUTO":
+        process._kafka_contract_source = MagicMock()
+    else:
+        process._kafka_contract_source = kafka_source
+
+    if event_bus == "AUTO":
+        process._event_bus = AsyncMock()
+        process._event_bus.subscribe = AsyncMock(return_value=AsyncMock())
+    else:
+        process._event_bus = event_bus
+
+    process._node_identity = MagicMock()
+    process._node_identity.service = "test-service"
+    process._node_identity.node_name = "test-node"
+    process._node_identity.version = "v1"
+    process._dynamic_contract_unsubscribe = None
+    return process
+
+
+# =============================================================================
+# _start_dynamic_contract_listener tests
+# =============================================================================
+
+
+class TestStartDynamicContractListener:
+    """Tests for _start_dynamic_contract_listener."""
+
+    @pytest.mark.asyncio
+    async def test_subscribes_to_node_registration_topic(self) -> None:
+        """Listener subscribes to SUFFIX_NODE_REGISTRATION after start."""
+        process = _make_process()
+        process._kafka_contract_source.environment = "dev"
+
+        await process._start_dynamic_contract_listener()
+
+        process._event_bus.subscribe.assert_called_once()
+        kwargs = process._event_bus.subscribe.call_args
+        assert kwargs[1]["topic"] == SUFFIX_NODE_REGISTRATION
+
+    @pytest.mark.asyncio
+    async def test_stores_unsubscribe_callback(self) -> None:
+        """Listener stores the unsubscribe callback in _dynamic_contract_unsubscribe."""
+        unsubscribe_fn = AsyncMock()
+        process = _make_process()
+        process._kafka_contract_source.environment = "dev"
+        process._event_bus.subscribe = AsyncMock(return_value=unsubscribe_fn)
+
+        await process._start_dynamic_contract_listener()
+
+        assert process._dynamic_contract_unsubscribe is unsubscribe_fn
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_kafka_source(self) -> None:
+        """Listener is a no-op when KafkaContractSource is not configured."""
+        process = _make_process(kafka_source=None)
+
+        await process._start_dynamic_contract_listener()
+
+        # subscribe should not have been called
+        assert process._dynamic_contract_unsubscribe is None
+        process._event_bus.subscribe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_event_bus(self) -> None:
+        """Listener is a no-op when event bus is None."""
+        process = _make_process(event_bus=None)
+
+        await process._start_dynamic_contract_listener()
+
+        assert process._dynamic_contract_unsubscribe is None
+
+    @pytest.mark.asyncio
+    async def test_wires_on_dynamic_contract_event_as_handler(self) -> None:
+        """Listener wires _on_dynamic_contract_event as the message handler."""
+        process = _make_process()
+        process._kafka_contract_source.environment = "dev"
+
+        await process._start_dynamic_contract_listener()
+
+        kwargs = process._event_bus.subscribe.call_args[1]
+        assert kwargs["on_message"] == process._on_dynamic_contract_event
+
+
+# =============================================================================
+# _on_dynamic_contract_event tests
+# =============================================================================
+
+
+class TestOnDynamicContractEvent:
+    """Tests for _on_dynamic_contract_event."""
+
+    @pytest.mark.asyncio
+    async def test_registration_event_triggers_cache_and_materialize(self) -> None:
+        """Registration event calls on_contract_registered then materializes."""
+        process = _make_process(event_bus=None)
+
+        mock_source = MagicMock()
+        mock_source.on_contract_registered = MagicMock(return_value=True)
+        mock_source.on_contract_deregistered = MagicMock()
+
+        descriptor = MagicMock()
+        mock_source.get_cached_descriptor = MagicMock(return_value=descriptor)
+
+        process._kafka_contract_source = mock_source
+        process._materialize_handler_live = AsyncMock(return_value=True)
+
+        msg = _make_msg(
+            {
+                "node_name": "node_dynamic_test",
+                "contract_yaml": VALID_CONTRACT_YAML,
+                "event_type": "registered",
+                "correlation_id": str(uuid4()),
+            }
+        )
+
+        await process._on_dynamic_contract_event(msg)
+
+        mock_source.on_contract_registered.assert_called_once()
+        call_kwargs = mock_source.on_contract_registered.call_args[1]
+        assert call_kwargs["node_name"] == "node_dynamic_test"
+        assert call_kwargs["contract_yaml"] == VALID_CONTRACT_YAML
+
+        process._materialize_handler_live.assert_called_once()
+        mat_kwargs = process._materialize_handler_live.call_args[1]
+        assert mat_kwargs["node_name"] == "node_dynamic_test"
+        assert mat_kwargs["descriptor"] is descriptor
+
+    @pytest.mark.asyncio
+    async def test_deregistration_event_calls_on_contract_deregistered(self) -> None:
+        """Deregistration event calls on_contract_deregistered, skips materialize."""
+        process = _make_process(event_bus=None)
+
+        mock_source = MagicMock()
+        mock_source.on_contract_deregistered = MagicMock()
+        process._kafka_contract_source = mock_source
+        process._materialize_handler_live = AsyncMock()
+
+        msg = _make_msg(
+            {
+                "node_name": "node_dynamic_test",
+                "event_type": "deregistered",
+            }
+        )
+
+        await process._on_dynamic_contract_event(msg)
+
+        mock_source.on_contract_deregistered.assert_called_once()
+        process._materialize_handler_live.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_node_name_logs_rejection_does_not_raise(self) -> None:
+        """Missing node_name logs a structured rejection but does not raise."""
+        process = _make_process(event_bus=None)
+        process._materialize_handler_live = AsyncMock()
+
+        msg = _make_msg(
+            {
+                "contract_yaml": VALID_CONTRACT_YAML,
+                "event_type": "registered",
+            }
+        )
+
+        # Must not raise
+        await process._on_dynamic_contract_event(msg)
+
+        process._materialize_handler_live.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_contract_yaml_logs_rejection_does_not_raise(self) -> None:
+        """Missing contract_yaml logs a structured rejection but does not raise."""
+        process = _make_process(event_bus=None)
+        process._kafka_contract_source.on_contract_registered = MagicMock()
+        process._materialize_handler_live = AsyncMock()
+
+        msg = _make_msg(
+            {
+                "node_name": "node_dynamic_test",
+                "event_type": "registered",
+            }
+        )
+
+        await process._on_dynamic_contract_event(msg)
+
+        process._kafka_contract_source.on_contract_registered.assert_not_called()
+        process._materialize_handler_live.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caching_failure_skips_materialization(self) -> None:
+        """When on_contract_registered returns False, materialization is skipped."""
+        process = _make_process(event_bus=None)
+
+        mock_source = MagicMock()
+        mock_source.on_contract_registered = MagicMock(return_value=False)
+        process._kafka_contract_source = mock_source
+        process._materialize_handler_live = AsyncMock()
+
+        msg = _make_msg(
+            {
+                "node_name": "node_dynamic_test",
+                "contract_yaml": VALID_CONTRACT_YAML,
+                "event_type": "registered",
+            }
+        )
+
+        await process._on_dynamic_contract_event(msg)
+
+        process._materialize_handler_live.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exception_in_materialize_does_not_raise(self) -> None:
+        """An exception in _materialize_handler_live must not crash the runtime."""
+        process = _make_process(event_bus=None)
+
+        mock_source = MagicMock()
+        mock_source.on_contract_registered = MagicMock(return_value=True)
+        mock_source.get_cached_descriptor = MagicMock(return_value=MagicMock())
+        process._kafka_contract_source = mock_source
+        process._materialize_handler_live = AsyncMock(side_effect=RuntimeError("boom"))
+
+        msg = _make_msg(
+            {
+                "node_name": "node_dynamic_test",
+                "contract_yaml": VALID_CONTRACT_YAML,
+                "event_type": "registered",
+            }
+        )
+
+        # Must not raise
+        await process._on_dynamic_contract_event(msg)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_kafka_source(self) -> None:
+        """Handler is a no-op when _kafka_contract_source is None."""
+        process = _make_process(kafka_source=None, event_bus=None)
+        process._materialize_handler_live = AsyncMock()
+
+        msg = _make_msg({"node_name": "x", "contract_yaml": "y"})
+
+        await process._on_dynamic_contract_event(msg)
+
+        process._materialize_handler_live.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_message_value_is_noop(self) -> None:
+        """A message with no value is silently ignored."""
+        process = _make_process(event_bus=None)
+        process._materialize_handler_live = AsyncMock()
+
+        msg = MagicMock()
+        msg.value = None
+        msg.headers = None
+
+        await process._on_dynamic_contract_event(msg)
+
+        process._materialize_handler_live.assert_not_called()

--- a/tests/unit/runtime/test_runtime_host_dynamic_registration.py
+++ b/tests/unit/runtime/test_runtime_host_dynamic_registration.py
@@ -12,7 +12,7 @@ internal state, isolating the methods under test from full runtime setup.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest


### PR DESCRIPTION
## Summary

- Adds `_start_dynamic_contract_listener()` to `RuntimeHostProcess` that subscribes to `onex.evt.platform.node-registration.v1` after the dispatch engine is frozen (step 4.35 in `_start_runtime`)
- Adds `_on_dynamic_contract_event()` handler that routes events through `on_contract_registered()` then `_materialize_handler_live()` — following the same pattern as the existing `handle_registration` in `_wire_baseline_subscriptions`
- Adds `_dynamic_contract_unsubscribe` to `__init__` and cleanup in `stop()` (step 2.75)
- No-op when `KafkaContractSource` is not configured
- Never crashes the runtime — all exceptions caught and logged with structured rejection fields (`failure_code`, `reason`, `node_name`, `correlation_id`, `rejected_at`)

Closes OMN-11247 (part of epic OMN-11241).

## Test plan

- [x] 13 unit tests in `tests/unit/runtime/test_runtime_host_dynamic_registration.py`
  - Listener subscribes to `SUFFIX_NODE_REGISTRATION` after start
  - Stores unsubscribe callback
  - No-op when KafkaContractSource is None
  - No-op when event bus is None
  - Registration event triggers `on_contract_registered` then `_materialize_handler_live`
  - Deregistration event routes to `on_contract_deregistered`, skips materialize
  - Missing `node_name` → structured rejection log, no crash
  - Missing `contract_yaml` → structured rejection log, no crash
  - Caching failure skips materialization
  - Exception in materialize does not raise
  - Empty message value is no-op
- [x] Full runtime unit suite: 2709 passed, 3 skipped (1 pre-existing infra connectivity failure unrelated to this change)
- [x] All pre-commit hooks pass (mypy, ruff, ONEX validators)

## DoD Evidence

Evidence-Source: OCC#1156
Evidence-Ticket: OMN-11247