### PR TITLE
feat(OMN-11248): integration test — dynamic contract registration E2E

### DIFF
--- a/contracts/OMN-11248.yaml
+++ b/contracts/OMN-11248.yaml
@@ -7,8 +7,7 @@ summary: >-
   Adds dynamic contract registration E2E coverage and hardens dynamic materialization so off-allowlist handler paths return a structured HANDLER_ALLOWLIST rejection before runtime auto-wiring attempts imports.
 is_seam_ticket: true
 interface_change: false
-interfaces_touched:
-  - "runtime_dynamic_materialization"
+interfaces_touched: []
 evidence_requirements:
   - kind: "tests"
     description: "Dynamic contract registration E2E and Kafka materialization tests pass"

--- a/contracts/OMN-11248.yaml
+++ b/contracts/OMN-11248.yaml
@@ -1,0 +1,49 @@
+# OMN-11248 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-11248"
+title: "feat(OMN-11248): integration test - dynamic contract registration E2E"
+summary: >-
+  Adds dynamic contract registration E2E coverage and hardens dynamic materialization so off-allowlist handler paths return a structured HANDLER_ALLOWLIST rejection before runtime auto-wiring attempts imports.
+is_seam_ticket: true
+interface_change: false
+interfaces_touched:
+  - "runtime_dynamic_materialization"
+evidence_requirements:
+  - kind: "tests"
+    description: "Dynamic contract registration E2E and Kafka materialization tests pass"
+    command: >-
+      uv run pytest tests/integration/runtime/test_dynamic_contract_registration_e2e.py tests/unit/runtime/test_kafka_contract_source_materialization.py -q
+  - kind: "ci"
+    description: "CI gates pass on omnibase_infra PR #1656"
+    command: "gh pr checks 1656 --repo OmniNode-ai/omnibase_infra"
+  - kind: "manual"
+    description: "Post-merge deploy validation exercises dynamic allowlist rejection"
+    command: >-
+      deploy omninode-runtime on the stability runtime after merge and verify a dynamic contract with handler module outside TRUSTED_HANDLER_NAMESPACE_PREFIXES is rejected with HANDLER_ALLOWLIST before import.
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-contract-artifact"
+    description: "Repo-local deploy evidence contract is present for OMN-11248"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "test -f contracts/OMN-11248.yaml"
+  - id: "dod-tests"
+    description: "Dynamic registration E2E and materialization tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest tests/integration/runtime/test_dynamic_contract_registration_e2e.py tests/unit/runtime/test_kafka_contract_source_materialization.py -q
+  - id: "dod-deploy"
+    description: >-
+      Deploy validation required after merge: install the merged runtime on the stability runtime and verify dynamic handler allowlist rejection is surfaced as HANDLER_ALLOWLIST before import.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          deploy omninode-runtime on the stability runtime after merge and run a dynamic materialization smoke that rejects an off-allowlist handler with HANDLER_ALLOWLIST

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -1038,6 +1038,10 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
         raw_bytes = content_repr.encode("utf-8")
         return "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
 
+    @staticmethod
+    def _fingerprint_handler_path(handler_path: str) -> str:
+        return "sha256:" + hashlib.sha256(handler_path.encode("utf-8")).hexdigest()
+
     def _reserve_materialization_key(
         self, node_name: str, canon_hash: str
     ) -> ModelDynamicMaterializationResult | tuple[str, str]:
@@ -1274,14 +1278,16 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             environment=effective_env,
         )
         if rejected_handler_path is not None:
+            allowed_namespaces = self._handler_namespace_prefixes(effective_env)
             logger.warning(
                 "Rejected dynamic materialization: handler path outside allowed namespaces",
                 extra={
                     "node_name": node_name,
-                    "handler_path": rejected_handler_path,
-                    "allowed_namespaces": list(
-                        self._handler_namespace_prefixes(effective_env)
+                    "handler_path_fingerprint": self._fingerprint_handler_path(
+                        rejected_handler_path
                     ),
+                    "handler_path_length": len(rejected_handler_path),
+                    "allowed_namespace_count": len(allowed_namespaces),
                 },
             )
             return ModelDynamicMaterializationResult(

--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -102,6 +102,9 @@ from omnibase_infra.runtime.baseline_subscriptions import (
     TOPIC_SUFFIX_CONTRACT_DEREGISTERED,
     TOPIC_SUFFIX_CONTRACT_REGISTERED,
 )
+from omnibase_infra.runtime.constants_security import (
+    TRUSTED_HANDLER_NAMESPACE_PREFIXES,
+)
 from omnibase_infra.runtime.enums.enum_materialization_rejection import (
     EnumMaterializationRejection,
 )
@@ -133,6 +136,7 @@ ModelContractDiscoveryResult.model_rebuild()
 
 # Maximum contract size (same as other sources)
 MAX_CONTRACT_SIZE = 10 * 1024 * 1024  # 10MB
+_TEST_HANDLER_NAMESPACE_PREFIXES = ("tests.",)
 
 
 class ContractYamlParser:  # ai-slop-ok: pre-existing
@@ -726,8 +730,9 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
         self._cache = KafkaContractCache()
         self._parser = ContractYamlParser(environment=environment)
         # Idempotency set: (node_name, contract_hash) pairs already materialized.
-        # Validation (allowlist, profiles, hash) is performed by
-        # node_contract_registry in omnimarket. Runtime trusts validated events.
+        # Node contract registry owns policy enforcement. Runtime repeats the
+        # handler namespace allowlist check before dynamic imports as defense
+        # in depth.
         self._materialized_contracts: set[tuple[str, str]] = set()
         self._materialization_lock = threading.Lock()
 
@@ -1074,6 +1079,42 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
             self._materialized_contracts.discard(key)
 
     @staticmethod
+    def _handler_namespace_prefixes(environment: str | None) -> tuple[str, ...]:
+        if environment == "test":
+            return TRUSTED_HANDLER_NAMESPACE_PREFIXES + _TEST_HANDLER_NAMESPACE_PREFIXES
+        return TRUSTED_HANDLER_NAMESPACE_PREFIXES
+
+    @classmethod
+    def _is_handler_path_allowed(
+        cls, handler_path: str | None, environment: str | None
+    ) -> bool:
+        if not handler_path:
+            return True
+        return handler_path.startswith(cls._handler_namespace_prefixes(environment))
+
+    @classmethod
+    def _dynamic_materialization_allowlist_rejection(
+        cls,
+        *,
+        descriptor: ModelHandlerDescriptor,
+        contract: ModelDiscoveredContract,
+        environment: str | None,
+    ) -> str | None:
+        handler_class = descriptor.handler_class
+        if not cls._is_handler_path_allowed(handler_class, environment):
+            return handler_class
+
+        if contract.handler_routing is None:
+            return None
+
+        for entry in contract.handler_routing.handlers:
+            module_path = entry.handler.module
+            if not cls._is_handler_path_allowed(module_path, environment):
+                return module_path
+
+        return None
+
+    @staticmethod
     def _build_event_bus_wiring(
         config: Mapping[str, object],
     ) -> ModelEventBusWiring | None:
@@ -1221,6 +1262,35 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 reason=EnumMaterializationRejection.PARSE_FAILURE,
             )
 
+        contract = self._build_materialization_contract(
+            node_name=node_name,
+            descriptor=descriptor,
+            environment=environment,
+        )
+        effective_env = environment or self._environment
+        rejected_handler_path = self._dynamic_materialization_allowlist_rejection(
+            descriptor=descriptor,
+            contract=contract,
+            environment=effective_env,
+        )
+        if rejected_handler_path is not None:
+            logger.warning(
+                "Rejected dynamic materialization: handler path outside allowed namespaces",
+                extra={
+                    "node_name": node_name,
+                    "handler_path": rejected_handler_path,
+                    "allowed_namespaces": list(
+                        self._handler_namespace_prefixes(effective_env)
+                    ),
+                },
+            )
+            return ModelDynamicMaterializationResult(
+                contract_name=node_name,
+                contract_hash=self._canonical_contract_hash(descriptor),
+                status=EnumMaterializationStatus.REJECTED,
+                reason=EnumMaterializationRejection.HANDLER_ALLOWLIST,
+            )
+
         canon_hash = self._canonical_contract_hash(descriptor)
         reservation = self._reserve_materialization_key(node_name, canon_hash)
         if isinstance(reservation, ModelDynamicMaterializationResult):
@@ -1232,12 +1302,6 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
         )
         from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
 
-        contract = self._build_materialization_contract(
-            node_name=node_name,
-            descriptor=descriptor,
-            environment=environment,
-        )
-
         try:
             from omnibase_infra.protocols.protocol_dispatch_engine import (
                 ProtocolDispatchEngine,
@@ -1247,7 +1311,7 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
                 contract=contract,
                 dispatch_engine=cast("ProtocolDispatchEngine", dispatch_engine),
                 event_bus=event_bus,
-                environment=environment or self._environment,
+                environment=effective_env,
                 container=container,
             )
 

--- a/tests/fixtures/handler_noop.py
+++ b/tests/fixtures/handler_noop.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Minimal no-op handler for integration tests.
+
+Used by dynamic contract registration E2E tests (OMN-11248) as a
+lightweight in-process handler that avoids network dependencies.
+"""
+
+from __future__ import annotations
+
+
+class HandlerNoop:
+    """No-op handler: accepts any input, returns None."""
+
+    async def handle(self, envelope: object) -> None:
+        return None

--- a/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
+++ b/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
@@ -348,6 +348,5 @@ async def test_handler_outside_allowed_namespace_wiring_fails_gracefully() -> No
         event_bus=bus,
         environment="test",
     )
-    # Either wiring is rejected or the handler fails to instantiate;
-    # either way the status must not be MATERIALIZED.
-    assert result.status != EnumMaterializationStatus.MATERIALIZED
+    assert result.status == EnumMaterializationStatus.REJECTED
+    assert result.reason == EnumMaterializationRejection.HANDLER_ALLOWLIST

--- a/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
+++ b/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""E2E integration test for dynamic contract registration (OMN-11248).
+
+Proves the full dynamic registration flow with real MessageDispatchEngine
+and EventBusInmemory (no mocks on the wiring path):
+
+    register contract -> materialize -> dispatcher in engine
+    -> topic subscribed -> idempotency -> deregistration -> version conflict
+    -> malformed YAML
+
+Uses HandlerNoop (tests.fixtures.handler_noop) as the in-process handler
+to avoid network dependencies.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.runtime.enums.enum_materialization_rejection import (
+    EnumMaterializationRejection,
+)
+from omnibase_infra.runtime.enums.enum_materialization_status import (
+    EnumMaterializationStatus,
+)
+from omnibase_infra.runtime.kafka_contract_source import KafkaContractSource
+from omnibase_infra.runtime.service_message_dispatch_engine import (
+    MessageDispatchEngine,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Minimal contract YAML for a Noop in-process handler.
+# handler_class in metadata so ContractYamlParser can extract it.
+# NOTE: topic strings here are contract-declared per ONEX convention.
+# ---------------------------------------------------------------------------
+
+_NOOP_CONTRACT_YAML = """\
+handler_id: proto.e2e_dynamic
+name: node_e2e_dynamic
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
+descriptor:
+  node_archetype: effect
+input_model: omnibase_infra.models.types.JsonDict
+output_model: omnibase_core.models.dispatch.model_handler_output.ModelHandlerOutput
+description: E2E test for dynamic contract registration
+metadata:
+  handler_class: tests.fixtures.handler_noop.HandlerNoop
+event_bus:
+  subscribe_topics:
+    - onex.evt.test.e2e-dynamic.v1
+  publish_topics: []
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - handler:
+        name: HandlerNoop
+        module: tests.fixtures.handler_noop
+"""
+
+_EVIL_MODULE_CONTRACT_YAML = (
+    _NOOP_CONTRACT_YAML.replace(
+        "module: tests.fixtures.handler_noop",
+        "module: os",
+    )
+    .replace(
+        "name: HandlerNoop",
+        "name: system",
+    )
+    .replace(
+        "handler_class: tests.fixtures.handler_noop.HandlerNoop",
+        "handler_class: os.system",
+    )
+)
+
+_MALFORMED_YAML = "this: is: [not: valid: yaml: {{"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source() -> KafkaContractSource:
+    return KafkaContractSource(environment="test", graceful_mode=True)
+
+
+def _make_engine() -> MessageDispatchEngine:
+    return MessageDispatchEngine()
+
+
+def _make_bus() -> EventBusInmemory:
+    return EventBusInmemory(environment="test")
+
+
+# ---------------------------------------------------------------------------
+# Test: full registration flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_then_materialize_wires_dispatcher_and_topic() -> None:
+    """Full flow: register -> materialize -> dispatcher in engine -> topic subscribed."""
+    source = _make_source()
+    engine = _make_engine()
+    bus = _make_bus()
+
+    # Step 1: cache the contract.
+    cached = source.on_contract_registered(
+        node_name="node_e2e_dynamic",
+        contract_yaml=_NOOP_CONTRACT_YAML,
+        correlation_id=uuid4(),
+    )
+    assert cached is True
+    assert source.cached_count == 1
+
+    descriptor = source.get_cached_descriptor("node_e2e_dynamic")
+    assert descriptor is not None
+    assert descriptor.handler_id == "proto.e2e_dynamic"
+
+    # Step 2: materialize into live engine.
+    result = await source.materialize_cached_contract(
+        node_name="node_e2e_dynamic",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result.status == EnumMaterializationStatus.MATERIALIZED
+    assert result.contract_name == "node_e2e_dynamic"
+    assert result.contract_hash.startswith("sha256:")
+    assert result.materialization_correlation_id is not None
+
+    # Step 3: verify dispatcher registered in engine.
+    # _dispatchers/_routes inspection is test-only.
+    dynamic_dispatcher_ids = [
+        did
+        for did in engine._dispatchers
+        if "e2e_dynamic" in did or "HandlerNoop" in did
+    ]
+    assert len(dynamic_dispatcher_ids) > 0, (
+        f"Expected dynamic dispatcher, found: {list(engine._dispatchers.keys())}"
+    )
+
+    # Step 4: verify at least one topic was subscribed via EventBusInmemory.
+    subscribed = await bus.get_topics()
+    assert "onex.evt.test.e2e-dynamic.v1" in subscribed, (
+        f"Expected topic subscription, found: {subscribed}"
+    )
+
+    # Step 5: result.subscribed_topics reflects the wiring.
+    assert "onex.evt.test.e2e-dynamic.v1" in result.subscribed_topics
+
+
+# ---------------------------------------------------------------------------
+# Test: idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_materialize_is_already_materialized() -> None:
+    """Second materialize_cached_contract call for same node is ALREADY_MATERIALIZED."""
+    source = _make_source()
+    engine = _make_engine()
+    bus = _make_bus()
+
+    source.on_contract_registered(
+        node_name="node_e2e_dynamic",
+        contract_yaml=_NOOP_CONTRACT_YAML,
+        correlation_id=uuid4(),
+    )
+
+    result1 = await source.materialize_cached_contract(
+        node_name="node_e2e_dynamic",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result1.status == EnumMaterializationStatus.MATERIALIZED
+
+    dispatchers_after_first = set(engine._dispatchers)
+
+    result2 = await source.materialize_cached_contract(
+        node_name="node_e2e_dynamic",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result2.status == EnumMaterializationStatus.ALREADY_MATERIALIZED
+
+    # Dispatcher count must not have changed.
+    assert set(engine._dispatchers) == dispatchers_after_first
+
+
+# ---------------------------------------------------------------------------
+# Test: deregistration removes cache but NOT live dispatchers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deregistration_removes_cache_not_live_dispatchers() -> None:
+    """Deregistration removes descriptor from cache; live dispatchers remain (MVP)."""
+    source = _make_source()
+    engine = _make_engine()
+    bus = _make_bus()
+    correlation_id = uuid4()
+
+    dereg_yaml = _NOOP_CONTRACT_YAML.replace(
+        "node_e2e_dynamic", "node_e2e_dereg"
+    ).replace("proto.e2e_dynamic", "proto.e2e_dereg")
+
+    source.on_contract_registered(
+        node_name="node_e2e_dereg",
+        contract_yaml=dereg_yaml,
+        correlation_id=correlation_id,
+    )
+
+    result = await source.materialize_cached_contract(
+        node_name="node_e2e_dereg",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result.status == EnumMaterializationStatus.MATERIALIZED
+
+    dispatchers_before = set(engine._dispatchers)
+    assert len(dispatchers_before) > 0
+
+    # Deregister from cache.
+    removed = source.on_contract_deregistered(
+        node_name="node_e2e_dereg",
+        correlation_id=correlation_id,
+    )
+    assert removed is True
+    assert source.cached_count == 0
+
+    # Live dispatchers must still exist after cache deregistration (MVP: no hot-unload).
+    assert set(engine._dispatchers) == dispatchers_before
+
+
+# ---------------------------------------------------------------------------
+# Test: version conflict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_version_conflict_rejected() -> None:
+    """Same node_name re-materialized with different hash -> VERSION_CONFLICT."""
+    source = _make_source()
+    engine = _make_engine()
+    bus = _make_bus()
+
+    versioned_yaml = _NOOP_CONTRACT_YAML.replace(
+        "node_e2e_dynamic", "node_versioned"
+    ).replace("proto.e2e_dynamic", "proto.versioned")
+
+    source.on_contract_registered(
+        node_name="node_versioned",
+        contract_yaml=versioned_yaml,
+        correlation_id=uuid4(),
+    )
+    result1 = await source.materialize_cached_contract(
+        node_name="node_versioned",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result1.status == EnumMaterializationStatus.MATERIALIZED
+
+    # Inject a fake pre-existing hash to force a conflict on the next call.
+    # (materialize_cached_contract computes a canonical hash from contract_path;
+    # injecting a different hash for the same node_name triggers VERSION_CONFLICT.)
+    fake_hash = "sha256:" + "a" * 64
+    source._materialized_contracts.discard(
+        next(e for e in source._materialized_contracts if e[0] == "node_versioned")
+    )
+    source._materialized_contracts.add(("node_versioned", fake_hash))
+
+    result2 = await source.materialize_cached_contract(
+        node_name="node_versioned",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    assert result2.status == EnumMaterializationStatus.REJECTED
+    assert result2.reason == EnumMaterializationRejection.VERSION_CONFLICT
+
+
+# ---------------------------------------------------------------------------
+# Test: malformed YAML
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_yaml_does_not_crash() -> None:
+    """Malformed YAML: on_contract_registered returns False; materialize returns REJECTED."""
+    source = _make_source()
+    engine = _make_engine()
+
+    cached = source.on_contract_registered(
+        node_name="bad_node",
+        contract_yaml=_MALFORMED_YAML,
+        correlation_id=uuid4(),
+    )
+    assert cached is False
+    assert source.cached_count == 0
+
+    # Not in cache -> REJECTED with PARSE_FAILURE reason.
+    result = await source.materialize_cached_contract(
+        node_name="bad_node",
+        dispatch_engine=engine,
+    )
+    assert result.status == EnumMaterializationStatus.REJECTED
+    assert result.reason == EnumMaterializationRejection.PARSE_FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Test: handler module outside allowed namespaces is rejected by wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_outside_allowed_namespace_wiring_fails_gracefully() -> None:
+    """Contract with handler module outside any allowed namespace returns REJECTED.
+
+    The handler_class points to os.system — this will either fail to import
+    as a proper handler class or fail to wire, returning REJECTED.
+    """
+    source = _make_source()
+    engine = _make_engine()
+    bus = _make_bus()
+
+    source.on_contract_registered(
+        node_name="node_evil",
+        contract_yaml=_EVIL_MODULE_CONTRACT_YAML,
+        correlation_id=uuid4(),
+    )
+
+    result = await source.materialize_cached_contract(
+        node_name="node_evil",
+        dispatch_engine=engine,
+        event_bus=bus,
+        environment="test",
+    )
+    # Either wiring is rejected or the handler fails to instantiate;
+    # either way the status must not be MATERIALIZED.
+    assert result.status != EnumMaterializationStatus.MATERIALIZED

--- a/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
+++ b/tests/integration/runtime/test_dynamic_contract_registration_e2e.py
@@ -15,6 +15,7 @@ to avoid network dependencies.
 
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 import pytest
@@ -326,7 +327,9 @@ async def test_malformed_yaml_does_not_crash() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handler_outside_allowed_namespace_wiring_fails_gracefully() -> None:
+async def test_handler_outside_allowed_namespace_wiring_fails_gracefully(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Contract with handler module outside any allowed namespace returns REJECTED.
 
     The handler_class points to os.system — this will either fail to import
@@ -335,6 +338,10 @@ async def test_handler_outside_allowed_namespace_wiring_fails_gracefully() -> No
     source = _make_source()
     engine = _make_engine()
     bus = _make_bus()
+    caplog.set_level(
+        logging.WARNING,
+        logger="omnibase_infra.runtime.kafka_contract_source",
+    )
 
     source.on_contract_registered(
         node_name="node_evil",
@@ -350,3 +357,16 @@ async def test_handler_outside_allowed_namespace_wiring_fails_gracefully() -> No
     )
     assert result.status == EnumMaterializationStatus.REJECTED
     assert result.reason == EnumMaterializationRejection.HANDLER_ALLOWLIST
+    assert "os.system" not in caplog.text
+
+    rejection_records = [
+        record
+        for record in caplog.records
+        if record.getMessage()
+        == "Rejected dynamic materialization: handler path outside allowed namespaces"
+    ]
+    assert rejection_records
+    for record in rejection_records:
+        assert "handler_path" not in record.__dict__
+        assert record.__dict__["handler_path_fingerprint"].startswith("sha256:")
+        assert record.__dict__["handler_path_length"] == len("os.system")


### PR DESCRIPTION
## Summary

- Adds 6 E2E integration tests proving the full dynamic contract registration flow in `omnibase_infra`
- Uses real `MessageDispatchEngine` and `EventBusInmemory` (no mocks on wiring path) with `HandlerNoop` as the in-process test handler
- Adds `pattern_exemptions` entry in `validation_exemptions.yaml` for `contract_name` field in `ModelDynamicMaterializationResult`

## Test Cases

- `test_register_then_materialize_wires_dispatcher_and_topic` — full register→materialize→dispatcher→topic flow
- `test_second_materialize_is_already_materialized` — idempotency returns `ALREADY_MATERIALIZED`
- `test_deregistration_removes_cache_not_live_dispatchers` — deregistration removes cache but not live dispatchers (MVP)
- `test_version_conflict_rejected` — duplicate contract with different hash returns `REJECTED` / `VERSION_CONFLICT`
- `test_malformed_yaml_does_not_crash` — malformed YAML returns `REJECTED` / `PARSE_FAILURE`, no exception
- `test_handler_outside_allowed_namespace_wiring_fails_gracefully` — handler module outside allowed namespaces returns `REJECTED` / `HANDLER_ALLOWLIST`

## Ticket

OMN-11248

## DoD Evidence

All 6 tests pass locally via `uv run pytest tests/integration/runtime/test_dynamic_contract_registration_e2e.py -v`. Pre-commit clean. All assertions use `EnumMaterializationStatus` enum values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic contract materialization enforces a handler-namespace allowlist and returns a clear rejection status for handlers outside trusted namespaces.

* **Tests**
  * Added an async no-op handler fixture and a comprehensive end-to-end test suite covering registration, materialization, idempotency, deregistration, version conflicts, malformed contracts, and handler-allowlist rejection.

* **Documentation**
  * Added deploy/validation guidance and CI evidence requirements for the new E2E coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1142
Evidence-Ticket: OMN-11248