### PR TITLE
feat(OMN-7465): infra-up shell functions delegate to remote host when .env points to .201

### DIFF
--- a/scripts/onex-cli.sh
+++ b/scripts/onex-cli.sh
@@ -9,6 +9,173 @@
 set -euo pipefail
 
 INFRA_DIR="${OMNIBASE_INFRA_DIR:-$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")}"
+ONEX_INFRA_REMOTE_LOCAL_EXIT=2
+
+_onex_trim() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+_onex_env_value() {
+    local key="$1"
+    local env_file="${OMNIBASE_ENV_FILE:-${HOME}/.omnibase/.env}"
+    local current_value=""
+
+    if [[ -f "$env_file" ]]; then
+        local line value
+        line=$(grep -E "^[[:space:]]*${key}=" "$env_file" | tail -n 1 || true)
+        if [[ -n "$line" ]]; then
+            value="${line#*=}"
+            value="$(_onex_trim "$value")"
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            printf '%s' "$value"
+            return 0
+        fi
+    fi
+
+    current_value="${!key-}"
+    if [[ -n "$current_value" ]]; then
+        printf '%s' "$current_value"
+        return 0
+    fi
+
+    return 1
+}
+
+_onex_host_from_endpoint() {
+    local endpoint="$1"
+    endpoint="${endpoint%%,*}"
+    endpoint="${endpoint#*://}"
+    endpoint="${endpoint%%/*}"
+    endpoint="${endpoint%%:*}"
+    printf '%s' "$endpoint"
+}
+
+_onex_infra_target_host() {
+    local postgres_host kafka_bootstrap
+
+    postgres_host="$(_onex_env_value POSTGRES_HOST || true)"
+    if [[ -n "$postgres_host" ]]; then
+        _onex_host_from_endpoint "$postgres_host"
+        return 0
+    fi
+
+    kafka_bootstrap="$(_onex_env_value KAFKA_BOOTSTRAP_SERVERS || true)"
+    if [[ -n "$kafka_bootstrap" ]]; then
+        _onex_host_from_endpoint "$kafka_bootstrap"
+        return 0
+    fi
+
+    return 1
+}
+
+_onex_host_is_local() {
+    local host="$1"
+    case "$host" in
+        "" | "localhost" | "localhost.localdomain" | "127."* | "::1" | "0.0.0.0")
+            return 0
+            ;;
+    esac
+
+    if [[ "$host" == "$(hostname 2>/dev/null || true)" ]]; then
+        return 0
+    fi
+
+    if command -v hostname >/dev/null 2>&1; then
+        if hostname -I >/dev/null 2>&1 && hostname -I | tr ' ' '\n' | grep -Fxq "$host"; then
+            return 0
+        fi
+    fi
+
+    if command -v ipconfig >/dev/null 2>&1; then
+        local iface
+        for iface in en0 en1 en2; do
+            if [[ "$(ipconfig getifaddr "$iface" 2>/dev/null || true)" == "$host" ]]; then
+                return 0
+            fi
+        done
+    fi
+
+    return 1
+}
+
+_onex_quote_words() {
+    local quoted=""
+    local arg
+    for arg in "$@"; do
+        printf -v arg '%q' "$arg"
+        quoted="${quoted:+$quoted }$arg"
+    done
+    printf '%s' "$quoted"
+}
+
+_onex_remote_target() {
+    local host="$1"
+    if [[ -n "${ONEX_INFRA_REMOTE_USER:-}" ]]; then
+        printf '%s@%s' "$ONEX_INFRA_REMOTE_USER" "$host"
+    else
+        printf '%s' "$host"
+    fi
+}
+
+_onex_infra_remote_guard() {
+    local entrypoint="$1"
+    shift
+
+    if [[ "${ONEX_INFRA_REMOTE_DELEGATED:-}" == "1" ]]; then
+        return "$ONEX_INFRA_REMOTE_LOCAL_EXIT"
+    fi
+
+    local target_host
+    target_host="$(_onex_infra_target_host || true)"
+    if _onex_host_is_local "$target_host"; then
+        return "$ONEX_INFRA_REMOTE_LOCAL_EXIT"
+    fi
+
+    local remote_target
+    remote_target="$(_onex_remote_target "$target_host")"
+
+    if [[ "${ONEX_INFRA_REMOTE_BEHAVIOR:-ssh}" == "fail" ]]; then
+        echo "[infra] ERROR: Infrastructure is configured to run on ${target_host}." >&2
+        echo "[infra] Run ${entrypoint} on that host or use: ssh ${remote_target} '${entrypoint}'" >&2
+        return 1
+    fi
+
+    if ! command -v ssh >/dev/null 2>&1; then
+        echo "[infra] ERROR: Infrastructure is configured to run on ${target_host}, but ssh is not available." >&2
+        echo "[infra] Run ${entrypoint} on that host or use: ssh ${remote_target} '${entrypoint}'" >&2
+        return 1
+    fi
+
+    local remote_args remote_cmd remote_shell
+    remote_args="$(_onex_quote_words "$@")"
+    remote_cmd="ONEX_INFRA_REMOTE_DELEGATED=1 ${entrypoint}${remote_args:+ $remote_args}"
+    remote_shell="${ONEX_INFRA_REMOTE_SHELL:-zsh -lic}"
+
+    echo "[infra] Infrastructure is configured for ${target_host}; delegating ${entrypoint} over SSH." >&2
+    # Command is deliberately assembled and quoted locally.
+    # shellcheck disable=SC2029
+    ssh "$remote_target" "${remote_shell} $(_onex_quote_words "$remote_cmd")"
+}
+
+_onex_remote_guard_or_return() {
+    local entrypoint="$1"
+    shift
+    _onex_infra_remote_guard "$entrypoint" "$@"
+    local status=$?
+    if [[ "$status" -eq 0 ]]; then
+        return 0
+    fi
+    if [[ "$status" -ne "$ONEX_INFRA_REMOTE_LOCAL_EXIT" ]]; then
+        return "$status"
+    fi
+    return "$ONEX_INFRA_REMOTE_LOCAL_EXIT"
+}
 
 onex_up() {
     local force_build=0
@@ -63,6 +230,80 @@ onex_validate() {
     local bundles="$*"
     # shellcheck disable=SC2086
     (cd "$INFRA_DIR" && uv run python -m omnibase_infra.docker.catalog.cli validate $bundles)
+}
+
+_onex_continue_locally_or_return() {
+    local status="$1"
+    if [[ "$status" -ne "$ONEX_INFRA_REMOTE_LOCAL_EXIT" ]]; then
+        return "$status"
+    fi
+    return 0
+}
+
+infra-up() {
+    local status
+    if _onex_remote_guard_or_return infra-up "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_up core "$@"
+}
+
+infra-up-runtime() {
+    local status
+    if _onex_remote_guard_or_return infra-up-runtime "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_up runtime "$@"
+}
+
+infra-up-memory() {
+    local status
+    if _onex_remote_guard_or_return infra-up-memory "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_up runtime memgraph "$@"
+}
+
+infra-up-auth() {
+    local status
+    if _onex_remote_guard_or_return infra-up-auth "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_up core auth "$@"
+}
+
+infra-down() {
+    local status
+    if _onex_remote_guard_or_return infra-down "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_down "$@"
+}
+
+infra-status() {
+    local status
+    if _onex_remote_guard_or_return infra-status "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    _onex_continue_locally_or_return "$status" || return $?
+    onex_status "$@"
 }
 
 # Backwards-compat mapping:

--- a/tests/scripts/test_onex_cli_remote_delegation.py
+++ b/tests/scripts/test_onex_cli_remote_delegation.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for infra shell wrapper remote-target guards (OMN-7465)."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "onex-cli.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _run_infra_function(
+    tmp_path: Path,
+    env_text: str,
+    invocation: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    infra_dir = tmp_path / "omnibase_infra"
+    infra_dir.mkdir()
+    (infra_dir / "scripts").mkdir()
+    _write_executable(
+        infra_dir / "scripts" / "check-stale-images.sh",
+        "#!/usr/bin/env bash\nexit 0\n",
+    )
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(env_text)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uv",
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$ONEX_TEST_UV_LOG"\n',
+    )
+    _write_executable(
+        bin_dir / "ssh",
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$@" > "$ONEX_TEST_SSH_LOG"\n',
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "OMNIBASE_ENV_FILE": str(env_file),
+        "OMNIBASE_INFRA_DIR": str(infra_dir),
+        "ONEX_TEST_SSH_LOG": str(tmp_path / "ssh.log"),
+        "ONEX_TEST_UV_LOG": str(tmp_path / "uv.log"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+    }
+    env.pop("POSTGRES_HOST", None)
+    env.pop("KAFKA_BOOTSTRAP_SERVERS", None)
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        ["bash", "-c", f"source {shlex.quote(str(SCRIPT))}; {invocation}"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.mark.unit
+def test_infra_up_delegates_to_remote_host_from_postgres_env(tmp_path: Path) -> None:
+    result = _run_infra_function(
+        tmp_path,
+        "POSTGRES_HOST=192.168.86.201\n",
+        "infra-up --build",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "delegating infra-up over SSH" in result.stderr
+    assert not (tmp_path / "uv.log").exists()
+
+    ssh_args = (tmp_path / "ssh.log").read_text().splitlines()
+    assert ssh_args[0] == "192.168.86.201"
+    assert "zsh -lic" in ssh_args[1]
+    assert "ONEX_INFRA_REMOTE_DELEGATED=1" in ssh_args[1]
+    assert "infra-up" in ssh_args[1]
+    assert "--build" in ssh_args[1]
+
+
+@pytest.mark.unit
+def test_remote_fail_mode_blocks_local_compose(tmp_path: Path) -> None:
+    result = _run_infra_function(
+        tmp_path,
+        "POSTGRES_HOST=192.168.86.201\n",
+        "infra-up-runtime",
+        {"ONEX_INFRA_REMOTE_BEHAVIOR": "fail"},
+    )
+
+    assert result.returncode == 1
+    assert "Infrastructure is configured to run on 192.168.86.201" in result.stderr
+    assert "ssh 192.168.86.201 'infra-up-runtime'" in result.stderr
+    assert not (tmp_path / "ssh.log").exists()
+    assert not (tmp_path / "uv.log").exists()
+
+
+@pytest.mark.unit
+def test_local_postgres_host_starts_local_onex_bundle(tmp_path: Path) -> None:
+    result = _run_infra_function(
+        tmp_path,
+        "POSTGRES_HOST=localhost\n",
+        "infra-up --build",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "ssh.log").exists()
+    assert (tmp_path / "uv.log").read_text() == (
+        "run python -m omnibase_infra.docker.catalog.cli up --build core\n"
+    )
+
+
+@pytest.mark.unit
+def test_delegated_marker_allows_remote_host_to_run_locally(tmp_path: Path) -> None:
+    result = _run_infra_function(
+        tmp_path,
+        "POSTGRES_HOST=192.168.86.201\n",
+        "infra-status",
+        {"ONEX_INFRA_REMOTE_DELEGATED": "1"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "ssh.log").exists()
+    assert (tmp_path / "uv.log").read_text() == (
+        "run python -m omnibase_infra.docker.catalog.cli status\n"
+    )
+
+
+@pytest.mark.unit
+def test_kafka_bootstrap_host_delegates_when_postgres_is_unset(tmp_path: Path) -> None:
+    result = _run_infra_function(
+        tmp_path,
+        "KAFKA_BOOTSTRAP_SERVERS=192.168.86.201:19092,localhost:19092\n",  # kafka-fallback-ok
+        "infra-up-memory",
+        {"ONEX_INFRA_REMOTE_USER": "jonah"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    ssh_args = (tmp_path / "ssh.log").read_text().splitlines()
+    assert ssh_args[0] == "jonah@192.168.86.201"
+    assert "infra-up-memory" in ssh_args[1]
+    assert not (tmp_path / "uv.log").exists()


### PR DESCRIPTION
## Summary

Fixes the silent local-container startup problem when \`~/.omnibase/.env\` points infrastructure at \`.201\`.

- **\`scripts/onex-cli.sh\`** — adds remote-host guard logic (\`_onex_infra_remote_guard\`) that detects when \`POSTGRES_HOST\` or \`KAFKA_BOOTSTRAP_SERVERS\` resolves to a non-local address, then either delegates the command over SSH or fails with a clear error message
- All six shell functions (\`infra-up\`, \`infra-up-runtime\`, \`infra-up-memory\`, \`infra-up-auth\`, \`infra-down\`, \`infra-status\`) are guarded
- Default behavior (\`ONEX_INFRA_REMOTE_BEHAVIOR=ssh\`): delegates via SSH, forwarding all args including \`--build\`
- \`ONEX_INFRA_REMOTE_BEHAVIOR=fail\`: prints error with ssh hint and exits 1, never touches Docker
- \`ONEX_INFRA_REMOTE_DELEGATED=1\`: set on the remote side to prevent re-delegation
- \`ONEX_INFRA_REMOTE_USER\`: optional user@host prefix
- **\`tests/scripts/test_onex_cli_remote_delegation.py\`** — 5 unit tests covering SSH delegation, fail-mode, local-host pass-through, delegated-marker bypass, and Kafka bootstrap host detection

## Test plan

- [x] \`uv run pytest tests/scripts/test_onex_cli_remote_delegation.py -v\` — 5/5 pass
- [x] \`pre-commit run --all-files\` — all hooks pass
- [x] Full unit suite — no regressions introduced

## DoD Evidence

Evidence-Source: OCC#1154
Evidence-Ticket: OMN-7465