### PR TITLE
feat(OMN-9265): add FakePostgresAdapter + FakeValkeyClient test fixtures

### DIFF
--- a/src/omnibase_infra/test_utils/__init__.py
+++ b/src/omnibase_infra/test_utils/__init__.py
@@ -13,6 +13,8 @@ instead.
 
 from __future__ import annotations
 
+from omnibase_infra.test_utils.fake_postgres_adapter import FakePostgresAdapter
 from omnibase_infra.test_utils.fake_secret_store import FakeSecretStore
+from omnibase_infra.test_utils.fake_valkey_client import FakeValkeyClient
 
-__all__: list[str] = ["FakeSecretStore"]
+__all__: list[str] = ["FakePostgresAdapter", "FakeSecretStore", "FakeValkeyClient"]

--- a/src/omnibase_infra/test_utils/fake_postgres_adapter.py
+++ b/src/omnibase_infra/test_utils/fake_postgres_adapter.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pure-in-memory ``ProtocolPostgresAdapter`` for tests (OMN-9265).
+
+Used by unit/integration tests that exercise code depending on a
+``ProtocolPostgresAdapter`` without standing up a real PostgreSQL instance.
+
+Packaging note: ships in the ``omnibase_infra.test_utils`` wheel so
+downstream test suites can import it from their own conftests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives import ModelSemVer
+from omnibase_infra.models.model_backend_result import ModelBackendResult
+
+
+class FakePostgresAdapter:
+    """In-memory ``ProtocolPostgresAdapter`` backed by dicts.
+
+    Fully implements ``upsert`` and ``deactivate``.  Concurrent coroutine
+    calls are safe: an ``asyncio.Lock`` guards all mutations.
+
+    Constructor accepts an optional ``fail_on_upsert`` flag and
+    ``fail_on_deactivate`` flag for error-path testing.
+
+    Attributes:
+        records: Mapping of ``node_id`` → latest upsert kwargs, present
+            only for active records.
+        deactivated: Set of ``node_id`` values that have been deactivated.
+        upsert_call_count: Number of ``upsert`` calls received.
+        deactivate_call_count: Number of ``deactivate`` calls received.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_upsert: bool = False,
+        fail_on_deactivate: bool = False,
+    ) -> None:
+        self.records: dict[UUID, dict[str, object]] = {}
+        self.deactivated: set[UUID] = set()
+        self.upsert_call_count: int = 0
+        self.deactivate_call_count: int = 0
+        self._fail_on_upsert = fail_on_upsert
+        self._fail_on_deactivate = fail_on_deactivate
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    async def upsert(
+        self,
+        node_id: UUID,
+        node_type: EnumNodeKind,
+        node_version: ModelSemVer,
+        endpoints: dict[str, str],
+        metadata: dict[str, str],
+    ) -> ModelBackendResult:
+        """Store or update a node registration record in memory.
+
+        Returns a success ``ModelBackendResult`` unless ``fail_on_upsert``
+        was set at construction time, in which case an error result is returned.
+        """
+        async with self._lock:
+            self.upsert_call_count += 1
+            if self._fail_on_upsert:
+                return ModelBackendResult(
+                    success=False,
+                    error="FakePostgresAdapter: forced upsert failure",
+                    backend_id="fake-postgres",
+                )
+            self.records[node_id] = {
+                "node_id": node_id,
+                "node_type": node_type,
+                "node_version": node_version,
+                "endpoints": dict(endpoints),
+                "metadata": dict(metadata),
+            }
+            self.deactivated.discard(node_id)
+            return ModelBackendResult(
+                success=True,
+                backend_id="fake-postgres",
+            )
+
+    async def deactivate(self, node_id: UUID) -> ModelBackendResult:
+        """Soft-delete a node registration record.
+
+        Returns a success ``ModelBackendResult`` unless
+        ``fail_on_deactivate`` was set at construction time.
+        """
+        async with self._lock:
+            self.deactivate_call_count += 1
+            if self._fail_on_deactivate:
+                return ModelBackendResult(
+                    success=False,
+                    error="FakePostgresAdapter: forced deactivate failure",
+                    backend_id="fake-postgres",
+                )
+            self.deactivated.add(node_id)
+            self.records.pop(node_id, None)
+            return ModelBackendResult(
+                success=True,
+                backend_id="fake-postgres",
+            )
+
+
+__all__: list[str] = ["FakePostgresAdapter"]

--- a/src/omnibase_infra/test_utils/fake_valkey_client.py
+++ b/src/omnibase_infra/test_utils/fake_valkey_client.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pure-in-memory Valkey/Redis client for tests (OMN-9265).
+
+Drop-in replacement for ``redis.asyncio.Redis`` used by
+``RuntimeScheduler`` (and any other code that calls ``ping``, ``get``,
+``set``, or ``aclose`` on a Redis client) without requiring a live
+Valkey/Redis process.
+
+Packaging note: ships in the ``omnibase_infra.test_utils`` wheel so
+downstream test suites can import it from their own conftests.
+"""
+
+from __future__ import annotations
+
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+
+class FakeValkeyClient:
+    """In-memory ``redis.asyncio.Redis``-compatible test double.
+
+    Supports the subset of the Redis client interface used by
+    ``RuntimeScheduler``: ``ping``, ``get``, ``set``, and ``aclose``.
+
+    Concurrent coroutine calls are safe; all operations are atomic
+    at the asyncio level.
+
+    Constructor flags for error-path coverage:
+
+    ``ping_error``: if set to an exception instance, ``ping()`` raises it.
+    ``get_error``: if set, ``get()`` raises it.
+    ``set_error``: if set, ``set()`` raises it.
+    ``closed``: start in the already-closed state (``ping`` raises
+        ``RedisConnectionError``).
+
+    Attributes:
+        store: Mapping of key → value (both str).
+        ping_call_count: Number of ``ping`` calls received.
+        get_call_count: Number of ``get`` calls received.
+        set_call_count: Number of ``set`` calls received.
+        aclose_call_count: Number of ``aclose`` calls received.
+    """
+
+    def __init__(
+        self,
+        initial: dict[str, str] | None = None,
+        *,
+        ping_error: Exception | None = None,
+        get_error: Exception | None = None,
+        set_error: Exception | None = None,
+        closed: bool = False,
+    ) -> None:
+        self.store: dict[str, str] = dict(initial) if initial else {}
+        self._ping_error = ping_error
+        self._get_error = get_error
+        self._set_error = set_error
+        self._closed = closed
+
+        self.ping_call_count: int = 0
+        self.get_call_count: int = 0
+        self.set_call_count: int = 0
+        self.aclose_call_count: int = 0
+
+    async def ping(self) -> bool:
+        """Simulate a ``PING``.
+
+        Raises ``RedisConnectionError`` if the client is closed or
+        ``ping_error`` was set at construction time.
+        """
+        self.ping_call_count += 1
+        if self._closed:
+            raise RedisConnectionError("FakeValkeyClient: client is closed")
+        if self._ping_error is not None:
+            raise self._ping_error
+        return True
+
+    async def get(self, key: str) -> str | None:
+        """Return the value stored at *key*, or ``None`` if absent.
+
+        Raises ``get_error`` if one was set at construction time.
+        """
+        self.get_call_count += 1
+        if self._get_error is not None:
+            raise self._get_error
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str) -> bool:
+        """Store *value* at *key*.
+
+        Raises ``set_error`` if one was set at construction time.
+        """
+        self.set_call_count += 1
+        if self._set_error is not None:
+            raise self._set_error
+        self.store[key] = value
+        return True
+
+    async def aclose(self) -> None:
+        """Close the client (idempotent)."""
+        self.aclose_call_count += 1
+        self._closed = True
+
+
+__all__: list[str] = ["FakeValkeyClient"]

--- a/tests/integration/test_fake_fixtures_integration.py
+++ b/tests/integration/test_fake_fixtures_integration.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for FakePostgresAdapter and FakeValkeyClient (OMN-9265).
+
+Validates that both test doubles exercise the full protocol lifecycle
+correctly, satisfying the integration-test gate for src/ changes.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives import ModelSemVer
+from omnibase_infra.nodes.node_registry_effect.protocols.protocol_postgres_adapter import (
+    ProtocolPostgresAdapter,
+)
+from omnibase_infra.test_utils.fake_postgres_adapter import FakePostgresAdapter
+from omnibase_infra.test_utils.fake_valkey_client import FakeValkeyClient
+
+
+@pytest.mark.integration
+async def test_fake_postgres_adapter_protocol_lifecycle() -> None:
+    """Full upsert → deactivate lifecycle through the ProtocolPostgresAdapter interface."""
+    adapter: ProtocolPostgresAdapter = FakePostgresAdapter()
+    node_id = uuid4()
+    version = ModelSemVer(major=1, minor=0, patch=0)
+
+    # Upsert succeeds
+    result = await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=version,
+        endpoints={"grpc": "localhost:50051"},
+        metadata={"env": "test"},
+    )
+    assert result.success is True
+    assert result.error is None
+
+    # Deactivate succeeds and clears the record
+    deactivate_result = await adapter.deactivate(node_id)
+    assert deactivate_result.success is True
+
+    # The fake tracks deactivated nodes for assertion
+    assert node_id in adapter.deactivated  # type: ignore[union-attr]
+    assert node_id not in adapter.records  # type: ignore[union-attr]
+
+
+@pytest.mark.integration
+async def test_fake_valkey_client_scheduler_lifecycle() -> None:
+    """Simulate the RuntimeScheduler Valkey sequence-number persist/load cycle."""
+    client = FakeValkeyClient()
+    seq_key = "test:scheduler:seq"
+
+    # Health check equivalent — ping succeeds
+    assert await client.ping() is True
+
+    # Nothing stored yet
+    assert await client.get(seq_key) is None
+
+    # Persist sequence number
+    assert await client.set(seq_key, "100") is True
+
+    # Load sequence number (simulating restart)
+    raw = await client.get(seq_key)
+    assert raw == "100"
+    assert int(raw) == 100
+
+    # Cleanup
+    await client.aclose()
+    assert client._closed is True

--- a/tests/unit/test_utils/test_fake_postgres_adapter.py
+++ b/tests/unit/test_utils/test_fake_postgres_adapter.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``FakePostgresAdapter`` (OMN-9265).
+
+Verifies protocol compliance, happy-path upsert/deactivate, error-path
+injection, concurrency safety, and counter tracking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.primitives import ModelSemVer
+from omnibase_infra.nodes.node_registry_effect.protocols.protocol_postgres_adapter import (
+    ProtocolPostgresAdapter,
+)
+from omnibase_infra.test_utils.fake_postgres_adapter import FakePostgresAdapter
+
+
+def _semver(major: int = 1, minor: int = 0, patch: int = 0) -> ModelSemVer:
+    return ModelSemVer(major=major, minor=minor, patch=patch)
+
+
+def _make_node_id() -> UUID:
+    return uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_satisfies_protocol_postgres_adapter() -> None:
+    """FakePostgresAdapter must be a structural subtype of ProtocolPostgresAdapter."""
+    assert isinstance(FakePostgresAdapter(), ProtocolPostgresAdapter)
+
+
+# ---------------------------------------------------------------------------
+# upsert — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_returns_success() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    result = await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={"grpc": "localhost:50051"},
+        metadata={"env": "test"},
+    )
+    assert result.success is True
+    assert result.error is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_stores_record() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={"grpc": "localhost:50051"},
+        metadata={},
+    )
+    assert node_id in adapter.records
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_stores_copies_of_mutable_args() -> None:
+    """Mutations to caller-owned dicts must not affect stored records."""
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    endpoints = {"grpc": "localhost:50051"}
+    metadata = {"env": "test"}
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints=endpoints,
+        metadata=metadata,
+    )
+    endpoints["extra"] = "mutated"
+    metadata["extra"] = "mutated"
+    stored = adapter.records[node_id]
+    assert "extra" not in stored["endpoints"]  # type: ignore[operator]
+    assert "extra" not in stored["metadata"]  # type: ignore[operator]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_overwrites_existing_record() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(1, 0, 0),
+        endpoints={"grpc": "old"},
+        metadata={},
+    )
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(1, 1, 0),
+        endpoints={"grpc": "new"},
+        metadata={},
+    )
+    assert adapter.records[node_id]["endpoints"] == {"grpc": "new"}  # type: ignore[index]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_increments_call_count() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    for _ in range(3):
+        await adapter.upsert(
+            node_id=node_id,
+            node_type=EnumNodeKind.EFFECT,
+            node_version=_semver(),
+            endpoints={},
+            metadata={},
+        )
+    assert adapter.upsert_call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# upsert — error injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_error_injection_returns_failure() -> None:
+    adapter = FakePostgresAdapter(fail_on_upsert=True)
+    node_id = _make_node_id()
+    result = await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={},
+        metadata={},
+    )
+    assert result.success is False
+    assert result.error is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_error_injection_does_not_store_record() -> None:
+    adapter = FakePostgresAdapter(fail_on_upsert=True)
+    node_id = _make_node_id()
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={},
+        metadata={},
+    )
+    assert node_id not in adapter.records
+
+
+# ---------------------------------------------------------------------------
+# deactivate — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_returns_success() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={},
+        metadata={},
+    )
+    result = await adapter.deactivate(node_id)
+    assert result.success is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_removes_from_records() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={},
+        metadata={},
+    )
+    await adapter.deactivate(node_id)
+    assert node_id not in adapter.records
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_adds_to_deactivated_set() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.deactivate(node_id)
+    assert node_id in adapter.deactivated
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_then_upsert_removes_from_deactivated() -> None:
+    """Re-registering a previously deactivated node should clear the deactivated flag."""
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.deactivate(node_id)
+    assert node_id in adapter.deactivated
+    await adapter.upsert(
+        node_id=node_id,
+        node_type=EnumNodeKind.EFFECT,
+        node_version=_semver(),
+        endpoints={},
+        metadata={},
+    )
+    assert node_id not in adapter.deactivated
+    assert node_id in adapter.records
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_increments_call_count() -> None:
+    adapter = FakePostgresAdapter()
+    node_id = _make_node_id()
+    await adapter.deactivate(node_id)
+    await adapter.deactivate(node_id)
+    assert adapter.deactivate_call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# deactivate — error injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deactivate_error_injection_returns_failure() -> None:
+    adapter = FakePostgresAdapter(fail_on_deactivate=True)
+    node_id = _make_node_id()
+    result = await adapter.deactivate(node_id)
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_upserts_are_safe() -> None:
+    """Concurrent upserts for distinct nodes should all succeed."""
+    adapter = FakePostgresAdapter()
+    node_ids = [_make_node_id() for _ in range(20)]
+    results = await asyncio.gather(
+        *[
+            adapter.upsert(
+                node_id=nid,
+                node_type=EnumNodeKind.EFFECT,
+                node_version=_semver(),
+                endpoints={},
+                metadata={},
+            )
+            for nid in node_ids
+        ]
+    )
+    assert all(r.success for r in results)
+    assert len(adapter.records) == 20
+    assert adapter.upsert_call_count == 20

--- a/tests/unit/test_utils/test_fake_valkey_client.py
+++ b/tests/unit/test_utils/test_fake_valkey_client.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``FakeValkeyClient`` (OMN-9265).
+
+Verifies interface compliance, happy-path get/set/ping, error injection,
+closed-state behaviour, and counter tracking.
+"""
+
+from __future__ import annotations
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from omnibase_infra.test_utils.fake_valkey_client import FakeValkeyClient
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_returns_true_when_open() -> None:
+    client = FakeValkeyClient()
+    assert await client.ping() is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_raises_when_closed() -> None:
+    client = FakeValkeyClient(closed=True)
+    with pytest.raises(RedisConnectionError):
+        await client.ping()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_raises_injected_error() -> None:
+    err = RedisConnectionError("forced ping failure")
+    client = FakeValkeyClient(ping_error=err)
+    with pytest.raises(RedisConnectionError, match="forced ping failure"):
+        await client.ping()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_raises_redis_timeout_error() -> None:
+    err = RedisTimeoutError("ping timeout")
+    client = FakeValkeyClient(ping_error=err)
+    with pytest.raises(RedisTimeoutError):
+        await client.ping()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_raises_generic_redis_error() -> None:
+    err = RedisError("unexpected")
+    client = FakeValkeyClient(ping_error=err)
+    with pytest.raises(RedisError):
+        await client.ping()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_increments_call_count() -> None:
+    client = FakeValkeyClient()
+    await client.ping()
+    await client.ping()
+    assert client.ping_call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_returns_none_for_missing_key() -> None:
+    client = FakeValkeyClient()
+    assert await client.get("missing") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_returns_preloaded_value() -> None:
+    client = FakeValkeyClient(initial={"seq": "42"})
+    assert await client.get("seq") == "42"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_returns_value_written_by_set() -> None:
+    client = FakeValkeyClient()
+    await client.set("key", "value")
+    assert await client.get("key") == "value"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_raises_injected_error() -> None:
+    err = RedisConnectionError("get failed")
+    client = FakeValkeyClient(get_error=err)
+    with pytest.raises(RedisConnectionError, match="get failed"):
+        await client.get("any")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_raises_asyncio_timeout() -> None:
+    client = FakeValkeyClient(get_error=TimeoutError("timed out"))
+    with pytest.raises(TimeoutError):
+        await client.get("any")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_increments_call_count() -> None:
+    client = FakeValkeyClient()
+    await client.get("a")
+    await client.get("b")
+    assert client.get_call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_returns_true_on_success() -> None:
+    client = FakeValkeyClient()
+    assert await client.set("k", "v") is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_stores_value() -> None:
+    client = FakeValkeyClient()
+    await client.set("seq", "100")
+    assert client.store["seq"] == "100"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_overwrites_existing_value() -> None:
+    client = FakeValkeyClient(initial={"seq": "0"})
+    await client.set("seq", "99")
+    assert client.store["seq"] == "99"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_raises_injected_error() -> None:
+    err = RedisConnectionError("set failed")
+    client = FakeValkeyClient(set_error=err)
+    with pytest.raises(RedisConnectionError, match="set failed"):
+        await client.set("k", "v")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_raises_redis_timeout_error() -> None:
+    client = FakeValkeyClient(set_error=RedisTimeoutError("timeout"))
+    with pytest.raises(RedisTimeoutError):
+        await client.set("k", "v")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_raises_generic_redis_error() -> None:
+    client = FakeValkeyClient(set_error=RedisError("oops"))
+    with pytest.raises(RedisError):
+        await client.set("k", "v")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_increments_call_count() -> None:
+    client = FakeValkeyClient()
+    await client.set("a", "1")
+    await client.set("b", "2")
+    assert client.set_call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_aclose_marks_client_closed() -> None:
+    client = FakeValkeyClient()
+    await client.aclose()
+    assert client._closed is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_aclose_idempotent() -> None:
+    client = FakeValkeyClient()
+    await client.aclose()
+    await client.aclose()
+    assert client.aclose_call_count == 2
+    assert client._closed is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ping_raises_after_aclose() -> None:
+    client = FakeValkeyClient()
+    await client.aclose()
+    with pytest.raises(RedisConnectionError):
+        await client.ping()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_aclose_increments_call_count() -> None:
+    client = FakeValkeyClient()
+    await client.aclose()
+    assert client.aclose_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# initial data isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_initial_data_is_copied_not_referenced() -> None:
+    source = {"key": "original"}
+    client = FakeValkeyClient(initial=source)
+    source["key"] = "mutated"
+    assert await client.get("key") == "original"
+
+
+# ---------------------------------------------------------------------------
+# RuntimeScheduler integration smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scheduler_sequence_round_trip() -> None:
+    """Simulate the sequence number persist/load cycle used by RuntimeScheduler."""
+    client = FakeValkeyClient()
+    seq_key = "scheduler:test:seq"
+
+    # Simulate RuntimeScheduler persisting sequence number
+    assert client.store.get(seq_key) is None
+    await client.set(seq_key, "42")
+
+    # Simulate RuntimeScheduler loading sequence number on restart
+    raw = await client.get(seq_key)
+    assert raw == "42"
+    assert int(raw) == 42


### PR DESCRIPTION
## OMN-9265

Adds two pure-in-memory test doubles to omnibase_infra.test_utils so Tier-1 runtime-boot smoke tests can run without docker-compose.

**FakePostgresAdapter**: implements ProtocolPostgresAdapter (upsert + deactivate), asyncio.Lock-safe, error injection, call counters.

**FakeValkeyClient**: drop-in for redis.asyncio.Redis (ping, get, set, aclose), error injection, idempotent aclose.

**Tests**: 15 unit (postgres) + 25 unit (valkey) + 2 integration = 42 total, all green.

The single pre-existing failure (test_kernel.py bootstrap) tries live Postgres on .201 and fails identically on main.

Ticket: OMN-9265

Evidence-Source: OCC#1155
Evidence-Ticket: OMN-9265