### PR TITLE
feat(OMN-9266): cite ServiceHealth aggregate response-shape model for :8085/health

### DIFF
--- a/contracts/OMN-9266.yaml
+++ b/contracts/OMN-9266.yaml
@@ -1,0 +1,29 @@
+# OMN-9266 contract file for omnibase_infra deploy-gate (OMN-8912).
+# The canonical ticket contract lives in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-9266"
+title: "Cite ServiceHealth aggregate response shape model for health endpoint"
+summary: "Typed runtime health response models for the :8085/health aggregate response shape."
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "protocols"
+  - "events"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-health-model-tests"
+    description: "Runtime aggregate health model tests and serialization round-trip coverage pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/test_model_serialization_roundtrip.py tests/unit/runtime/models/test_model_runtime_aggregate_health.py -q"
+  - id: "dod-deploy"
+    description: "Deploy validation plan for runtime health response shape model; no live runtime restart was performed in this PR."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: after merge, verify docker exec omninode-runtime python -c 'from omnibase_infra.runtime.models import ModelRuntimeAggregateHealth; print(ModelRuntimeAggregateHealth.__name__)'"

--- a/contracts/OMN-9266.yaml
+++ b/contracts/OMN-9266.yaml
@@ -20,7 +20,7 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run pytest tests/unit/models/test_model_serialization_roundtrip.py tests/unit/runtime/models/test_model_runtime_aggregate_health.py -q"
+        check_value: "uv run pytest tests/unit/models/test_model_serialization_roundtrip.py tests/unit/runtime/models/test_model_runtime_aggregate_health.py tests/integration/runtime/test_runtime_aggregate_health_contract.py -q"
   - id: "dod-deploy"
     description: "Deploy validation plan for runtime health response shape model; no live runtime restart was performed in this PR."
     source: "manual"

--- a/src/omnibase_infra/runtime/models/__init__.py
+++ b/src/omnibase_infra/runtime/models/__init__.py
@@ -41,6 +41,8 @@ Exports:
     ModelHealthCheckResponse: HTTP response model for health check endpoints
     ModelComponentHealth: Per-component health status for detailed diagnostics (OMN-519)
     ModelDetailedHealthResponse: Extended response for /health/detailed endpoint (OMN-519)
+    ModelEventBusAggregateHealth: Typed model for the event_bus sub-dict in :8085/health response (OMN-9266)
+    ModelRuntimeAggregateHealth: Canonical typed model for :8085/health aggregate response shape (OMN-9266)
     ModelProjectorPluginLoaderConfig: Projector plugin loader configuration model
     ModelSecretSourceSpec: Source specification for a single secret
     SecretSourceType: Type alias for secret source types (env, vault, file)
@@ -110,6 +112,9 @@ from omnibase_infra.runtime.models.model_duplicate_response import (
 )
 from omnibase_infra.runtime.models.model_enabled_protocols_config import (
     ModelEnabledProtocolsConfig,
+)
+from omnibase_infra.runtime.models.model_event_bus_aggregate_health import (
+    ModelEventBusAggregateHealth,
 )
 from omnibase_infra.runtime.models.model_event_bus_config import ModelEventBusConfig
 from omnibase_infra.runtime.models.model_failed_component import ModelFailedComponent
@@ -195,6 +200,9 @@ from omnibase_infra.runtime.models.model_protocol_registration_config import (
     ModelProtocolRegistrationConfig,
 )
 from omnibase_infra.runtime.models.model_retry_policy import ModelRetryPolicy
+from omnibase_infra.runtime.models.model_runtime_aggregate_health import (
+    ModelRuntimeAggregateHealth,
+)
 from omnibase_infra.runtime.models.model_runtime_config import ModelRuntimeConfig
 from omnibase_infra.runtime.models.model_runtime_contract_config import (
     ModelRuntimeContractConfig,
@@ -316,4 +324,7 @@ __all__: list[str] = [
     "ModelPluginDiscoveryEntry",
     "ModelPluginDiscoveryReport",
     "PluginDiscoveryStatus",
+    # Aggregate health response model (OMN-9266)
+    "ModelEventBusAggregateHealth",
+    "ModelRuntimeAggregateHealth",
 ]

--- a/src/omnibase_infra/runtime/models/model_event_bus_aggregate_health.py
+++ b/src/omnibase_infra/runtime/models/model_event_bus_aggregate_health.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical typed model for the event_bus sub-dict in the :8085/health response.
+
+This module is part of the OMN-9266 response-shape citation work.  The
+``event_bus`` field in the ``GET /health`` aggregate response is populated by
+``EventBusKafka.health_check()``
+(``omnibase_infra/src/omnibase_infra/event_bus/event_bus_kafka.py``,
+method ``health_check``, return dict at lines 2200-2210).
+
+See Also:
+    :mod:`~omnibase_infra.runtime.models.model_runtime_aggregate_health` —
+    outer aggregate model that embeds this as its ``event_bus`` field.
+
+OMN-9266: Cite ServiceHealth aggregate response-shape model for :8085/health.
+
+Example:
+    >>> from omnibase_infra.runtime.models.model_event_bus_aggregate_health import (
+    ...     ModelEventBusAggregateHealth,
+    ... )
+    >>>
+    >>> raw = {
+    ...     "healthy": True,
+    ...     "started": True,
+    ...     "environment": "prod",
+    ...     "bootstrap_servers": "redpanda:9092",
+    ...     "circuit_state": "closed",
+    ...     "subscriber_count": 374,
+    ...     "topic_count": 42,
+    ...     "consumer_count": 12,
+    ... }
+    >>> model = ModelEventBusAggregateHealth.model_validate(raw, strict=False)
+    >>> model.circuit_state
+    'closed'
+    >>> model.subscriber_count
+    374
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelEventBusAggregateHealth(BaseModel):
+    """Typed model for the ``event_bus`` sub-dict in the :8085/health response.
+
+    Populated by ``EventBusKafka.health_check()`` (return dict, lines 2200-2210
+    of ``omnibase_infra/src/omnibase_infra/event_bus/event_bus_kafka.py``).
+
+    The ``circuit_state`` field answers the OMN-9266 open question:
+    it comes from the circuit-breaker flag in
+    ``EventBusKafka._circuit_breaker_open`` and is serialised as
+    ``"open"`` or ``"closed"``.
+
+    Attributes:
+        healthy: Whether the Kafka producer is started and its client is open.
+        started: Whether ``EventBusKafka.start()`` has been called.
+        environment: The ONEX environment string (e.g. ``"prod"``, ``"dev"``).
+        bootstrap_servers: Sanitised Kafka bootstrap server address(es).
+        circuit_state: Circuit-breaker state — ``"open"`` or ``"closed"``.
+        subscriber_count: Total active subscriptions across all topics.
+        topic_count: Number of topics that have at least one subscriber.
+        consumer_count: Max of individual consumer count and group-consumer count.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="allow",
+        from_attributes=True,
+    )
+
+    healthy: bool = Field(
+        ...,
+        description="Whether the Kafka producer is started and its client is not closed",
+    )
+    started: bool = Field(
+        ...,
+        description="Whether EventBusKafka.start() has been called",
+    )
+    environment: str = Field(
+        ...,
+        description="ONEX environment string (e.g. 'prod', 'dev')",
+    )
+    bootstrap_servers: str = Field(
+        ...,
+        description="Sanitised Kafka bootstrap server address(es)",
+    )
+    circuit_state: Literal["open", "closed"] = Field(
+        ...,
+        description=(
+            "Circuit-breaker state from EventBusKafka._circuit_breaker_open. "
+            "'open' means the breaker has tripped and publish calls may be suppressed; "
+            "'closed' is the normal healthy state."
+        ),
+    )
+    subscriber_count: int = Field(
+        ...,
+        ge=0,
+        description="Total active subscriptions across all topics",
+    )
+    topic_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of topics that have at least one subscriber",
+    )
+    consumer_count: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Max of individual consumer count and group-consumer count "
+            "from EventBusKafka._consumers and _group_consumers"
+        ),
+    )
+
+
+__all__: list[str] = ["ModelEventBusAggregateHealth"]

--- a/src/omnibase_infra/runtime/models/model_runtime_aggregate_health.py
+++ b/src/omnibase_infra/runtime/models/model_runtime_aggregate_health.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical typed model for the :8085/health aggregate response shape.
+
+This module defines the canonical response model for the ``GET /health``
+endpoint served by :class:`~omnibase_infra.services.service_health.ServiceHealth`
+on port 8085.  It replaces the ``[provisional-field-source]`` annotation in
+``docs/tracking/2026-04-19-runtime-state-inventory.md §E`` by naming each
+response field and citing its authoritative source.
+
+Field provenance
+----------------
+The ``/health`` response is assembled in two layers:
+
+1. **``RuntimeHostProcess.health_check()``**
+   (``omnibase_infra/src/omnibase_infra/runtime/service_runtime_host_process.py``,
+   method ``health_check``, return dict literal at lines 5153-5179)
+   — owns: ``healthy``, ``degraded``, ``startup_in_progress``, ``is_running``,
+   ``is_draining``, ``pending_message_count``, ``max_concurrent_handlers``,
+   ``handler_pool_size``, ``in_flight_tasks``, ``batch_response_enabled``,
+   ``batch_response_pending``, ``event_bus``, ``event_bus_healthy``,
+   ``failed_handlers``, ``skipped_handlers``, ``registered_handlers``,
+   ``handlers``, ``handler_pools``, ``no_handlers_registered``,
+   ``config_prefetch_status``, ``local_ingress``, ``components``.
+
+2. **``ServiceHealth._handle_health()`` enrichment**
+   (``omnibase_infra/src/omnibase_infra/services/service_health.py``,
+   method ``_handle_health``, enrichment block at lines 1064-1076)
+   — appends: ``degraded`` (overwrite), ``startup_in_progress`` (overwrite),
+   ``components`` (overwrite with typed dicts).
+
+The ``event_bus`` sub-dict is produced by
+``EventBusKafka.health_check()``
+(``omnibase_infra/src/omnibase_infra/event_bus/event_bus_kafka.py``,
+method ``health_check``, return dict at lines 2200-2210),
+which returns the fields captured in
+:class:`~omnibase_infra.runtime.models.model_event_bus_aggregate_health.ModelEventBusAggregateHealth`.
+
+OMN-9266: Cite ServiceHealth aggregate response-shape model for :8085/health.
+
+Example:
+    >>> from omnibase_infra.runtime.models.model_runtime_aggregate_health import (
+    ...     ModelRuntimeAggregateHealth,
+    ... )
+    >>> from omnibase_infra.runtime.models.model_event_bus_aggregate_health import (
+    ...     ModelEventBusAggregateHealth,
+    ... )
+    >>>
+    >>> # Round-trip a raw health_check() dict through the model for validation
+    >>> raw = {
+    ...     "healthy": True,
+    ...     "degraded": False,
+    ...     "startup_in_progress": False,
+    ...     "is_running": True,
+    ...     "is_draining": False,
+    ...     "pending_message_count": 0,
+    ...     "max_concurrent_handlers": 10,
+    ...     "handler_pool_size": 5,
+    ...     "in_flight_tasks": 0,
+    ...     "batch_response_enabled": False,
+    ...     "batch_response_pending": 0,
+    ...     "event_bus": {
+    ...         "healthy": True,
+    ...         "started": True,
+    ...         "environment": "prod",
+    ...         "bootstrap_servers": "redpanda:9092",
+    ...         "circuit_state": "closed",
+    ...         "subscriber_count": 374,
+    ...         "topic_count": 42,
+    ...         "consumer_count": 12,
+    ...     },
+    ...     "event_bus_healthy": True,
+    ...     "failed_handlers": {},
+    ...     "skipped_handlers": {},
+    ...     "registered_handlers": [],
+    ...     "handlers": {},
+    ...     "handler_pools": {},
+    ...     "no_handlers_registered": False,
+    ...     "config_prefetch_status": "ok",
+    ...     "local_ingress": {"enabled": False, "running": False},
+    ...     "components": [],
+    ... }
+    >>> model = ModelRuntimeAggregateHealth.model_validate(raw, strict=False)
+    >>> model.is_running
+    True
+    >>> model.event_bus.subscriber_count
+    374
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+from omnibase_infra.runtime.models.model_event_bus_aggregate_health import (
+    ModelEventBusAggregateHealth,
+)
+
+
+class ModelRuntimeAggregateHealth(BaseModel):
+    """Canonical typed model for the ``GET /health`` aggregate response shape.
+
+    This is the source-of-truth model for the JSON body returned by
+    ``ServiceHealth._handle_health()`` at ``:8085/health``.  It supersedes
+    the ``[provisional-field-source]`` annotation in
+    ``docs/tracking/2026-04-19-runtime-state-inventory.md §E``.
+
+    Construction
+    ------------
+    The response is assembled from two authoritative sources:
+
+    * ``RuntimeHostProcess.health_check()`` — produces the outer dict
+      (``service_runtime_host_process.py``, ``health_check`` return literal,
+      lines 5153-5179).
+    * ``ServiceHealth._handle_health()`` enrichment — overwrites ``degraded``,
+      ``startup_in_progress``, and replaces the raw ``components`` list with
+      typed :class:`~omnibase_infra.runtime.models.model_component_health.ModelComponentHealth`
+      dicts (``service_health.py``, lines 1064-1076).
+
+    Validation
+    ----------
+    ``extra="allow"`` is intentional: future fields added to
+    ``RuntimeHostProcess.health_check()`` must not break existing consumers of
+    this model.  Strict validation gates live in unit tests against the known
+    field set.
+
+    Attributes:
+        healthy: ``True`` only when the runtime is running, the event bus is
+            healthy, no handlers failed to instantiate, all registered handlers
+            are healthy, and at least one handler is registered.
+        degraded: ``True`` when running with failed handlers (reduced capacity)
+            or startup is in progress with a live event bus.
+        startup_in_progress: ``True`` when ``_is_starting`` and not yet
+            ``_is_running`` but the event bus is already healthy.
+        is_running: Whether ``RuntimeHostProcess._is_running`` is ``True``
+            (set after ``start()`` completes).
+        is_draining: Whether the runtime is in its graceful-shutdown drain phase
+            (``_is_draining``).  Load balancers should remove the instance from
+            rotation when this is ``True``.
+        pending_message_count: Number of in-flight messages currently being
+            processed (``_pending_message_count``).
+        max_concurrent_handlers: Configured concurrency ceiling for handler
+            dispatch (``_max_concurrent_handlers``).
+        handler_pool_size: Configured pool size per handler type
+            (``_handler_pool_size``).
+        in_flight_tasks: Length of ``_in_flight_tasks`` set at check time.
+        batch_response_enabled: Whether a batch-response publisher is active.
+        batch_response_pending: Number of pending batch-response messages
+            (0 when ``batch_response_enabled`` is ``False``).
+        event_bus: Nested event-bus health dict from
+            ``EventBusKafka.health_check()``; typed as
+            :class:`~omnibase_infra.runtime.models.model_event_bus_aggregate_health.ModelEventBusAggregateHealth`.
+        event_bus_healthy: Boolean convenience flag extracted from
+            ``event_bus.healthy``.
+        failed_handlers: Map of handler type to error message for handlers that
+            raised during ``start()``.
+        skipped_handlers: Map of handler type to reason for handlers that were
+            intentionally skipped (e.g. disabled via config).
+        registered_handlers: List of handler types that started successfully.
+        handlers: Per-handler health-check results (handler type to details dict).
+        handler_pools: Per-pool health-check results from
+            ``HandlerPool.health_check()`` (pool type to metrics dict).
+        no_handlers_registered: ``True`` when no handlers are registered — a
+            critical configuration error (runtime cannot process events).
+        config_prefetch_status: Infisical config prefetch outcome.
+            Values: ``"pending"``, ``"skipped"``, ``"ok"``,
+            ``"degraded_no_requirements"``, ``"degraded_error"``.
+        local_ingress: Typed health for the local-ingress server (Unix-domain
+            socket or in-process path); serialised from
+            :class:`~omnibase_infra.runtime.models.model_local_runtime_ingress_health.ModelLocalRuntimeIngressHealth`.
+        components: List of per-component health dicts appended by
+            ``ServiceHealth._build_component_health()`` and additional infra
+            checks (``published_events_map``, ``local_ingress_component``).
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="allow",
+        from_attributes=True,
+    )
+
+    # --- Core liveness flags ---
+    healthy: bool = Field(
+        ...,
+        description=(
+            "True only when is_running, event_bus_healthy, no failed handlers, "
+            "all registered handlers healthy, and at least one handler registered"
+        ),
+    )
+    degraded: bool = Field(
+        ...,
+        description=(
+            "True when running with failed handlers or startup_in_progress is True"
+        ),
+    )
+    startup_in_progress: bool = Field(
+        ...,
+        description=(
+            "True when _is_starting=True, _is_running=False, and event bus is already healthy"
+        ),
+    )
+
+    # --- Runtime state flags (OMN-9266 previously-provisional fields) ---
+    is_running: bool = Field(
+        ...,
+        description=(
+            "Source: RuntimeHostProcess._is_running — set True after start() completes, "
+            "set False after stop(). Previously tagged [provisional-field-source]."
+        ),
+    )
+    is_draining: bool = Field(
+        ...,
+        description=(
+            "Source: RuntimeHostProcess._is_draining — True during graceful-shutdown "
+            "drain window. Previously tagged [provisional-field-source]."
+        ),
+    )
+    pending_message_count: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Source: RuntimeHostProcess._pending_message_count — in-flight messages. "
+            "Previously tagged [provisional-field-source]."
+        ),
+    )
+
+    # --- Concurrency metrics ---
+    max_concurrent_handlers: int = Field(
+        ...,
+        ge=0,
+        description="Configured concurrency ceiling for handler dispatch",
+    )
+    handler_pool_size: int = Field(
+        ...,
+        ge=0,
+        description="Configured pool size per handler type",
+    )
+    in_flight_tasks: int = Field(
+        ...,
+        ge=0,
+        description="Number of in-flight asyncio tasks at check time",
+    )
+
+    # --- Batch publisher ---
+    batch_response_enabled: bool = Field(
+        ...,
+        description="Whether a batch-response publisher is active",
+    )
+    batch_response_pending: int = Field(
+        ...,
+        ge=0,
+        description="Pending batch-response message count (0 when disabled)",
+    )
+
+    # --- Event bus sub-shape ---
+    event_bus: ModelEventBusAggregateHealth = Field(
+        ...,
+        description=(
+            "Source: EventBusKafka.health_check() return dict. "
+            "Contains circuit_state, subscriber_count, topic_count, consumer_count. "
+            "Previously tagged [provisional-field-source] for circuit_state."
+        ),
+    )
+    event_bus_healthy: bool = Field(
+        ...,
+        description="Boolean extracted from event_bus.healthy for convenience",
+    )
+
+    # --- Handler registry ---
+    failed_handlers: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Map of handler_type -> error message for handlers that failed during start()",
+    )
+    skipped_handlers: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Map of handler_type -> reason for intentionally skipped handlers",
+    )
+    registered_handlers: list[str] = Field(
+        default_factory=list,
+        description="Handler types that started successfully",
+    )
+
+    # --- Per-handler health results (OMN-9266 previously-provisional field) ---
+    handlers: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description=(
+            "Source: per-handler health_check() results keyed by handler type. "
+            "Previously tagged [provisional-field-source] for handler_pools."
+        ),
+    )
+    handler_pools: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description=(
+            "Source: HandlerPool.health_check() results keyed by pool type. "
+            "Previously tagged [provisional-field-source]."
+        ),
+    )
+    no_handlers_registered: bool = Field(
+        ...,
+        description=(
+            "True when no handlers registered — critical config error; "
+            "runtime cannot process any events"
+        ),
+    )
+
+    # --- Config prefetch ---
+    config_prefetch_status: str = Field(
+        ...,
+        description=(
+            "Infisical config prefetch outcome. "
+            "Values: 'pending', 'skipped', 'ok', 'degraded_no_requirements', 'degraded_error'"
+        ),
+    )
+
+    # --- Local ingress ---
+    local_ingress: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description=(
+            "Serialised ModelLocalRuntimeIngressHealth — enabled, running, socket_path"
+        ),
+    )
+
+    # --- Components list ---
+    components: list[dict[str, JsonType]] = Field(
+        default_factory=list,
+        description=(
+            "Per-component health dicts from ServiceHealth._build_component_health() "
+            "plus published_events_map and local_ingress_component checks"
+        ),
+    )
+
+
+__all__: list[str] = ["ModelRuntimeAggregateHealth"]

--- a/tests/integration/runtime/test_runtime_aggregate_health_contract.py
+++ b/tests/integration/runtime/test_runtime_aggregate_health_contract.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the OMN-9266 runtime health aggregate contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.models import ModelRuntimeAggregateHealth
+
+pytestmark = pytest.mark.integration
+
+
+def test_runtime_aggregate_health_contract_accepts_service_health_shape() -> None:
+    """The exported model validates a representative :8085/health details shape."""
+    payload = {
+        "healthy": True,
+        "degraded": False,
+        "startup_in_progress": False,
+        "is_running": True,
+        "is_draining": False,
+        "pending_message_count": 0,
+        "max_concurrent_handlers": 10,
+        "handler_pool_size": 5,
+        "in_flight_tasks": 0,
+        "batch_response_enabled": False,
+        "batch_response_pending": 0,
+        "event_bus": {
+            "healthy": True,
+            "started": True,
+            "environment": "test",
+            "bootstrap_servers": "redpanda:9092",
+            "circuit_state": "closed",
+            "subscriber_count": 3,
+            "topic_count": 2,
+            "consumer_count": 1,
+        },
+        "event_bus_healthy": True,
+        "failed_handlers": {},
+        "skipped_handlers": {},
+        "registered_handlers": ["HandlerNodeHeartbeat"],
+        "handlers": {"HandlerNodeHeartbeat": {"healthy": True}},
+        "handler_pools": {},
+        "no_handlers_registered": False,
+        "config_prefetch_status": "ok",
+        "local_ingress": {"enabled": False, "running": False},
+        "components": [],
+    }
+
+    model = ModelRuntimeAggregateHealth.model_validate(payload, strict=False)
+
+    assert model.is_running is True
+    assert model.event_bus.circuit_state == "closed"
+    assert model.model_dump(mode="json")["event_bus"]["topic_count"] == 2

--- a/tests/unit/models/test_model_serialization_roundtrip.py
+++ b/tests/unit/models/test_model_serialization_roundtrip.py
@@ -178,6 +178,10 @@ UNCOVERED_MODELS: dict[str, str] = {
     "ModelNodeEdge": "Edge definition in runtime node graph (source/target/topic)",
     "ModelRuntimeNodeGraph": "Aggregate runtime node graph model with nodes and edges lists",
     "ModelPatternBBrokerConfig": "Runtime config for Pattern B broker; tested via live integration",
+    # OMN-9266: Aggregate health response models — round-trip covered in
+    # tests/unit/runtime/models/test_model_runtime_aggregate_health.py
+    "ModelEventBusAggregateHealth": "Round-trip covered in test_model_runtime_aggregate_health; extra='allow' complicates generic factory",
+    "ModelRuntimeAggregateHealth": "Round-trip covered in test_model_runtime_aggregate_health; extra='allow' complicates generic factory",
 }
 
 

--- a/tests/unit/runtime/models/test_model_runtime_aggregate_health.py
+++ b/tests/unit/runtime/models/test_model_runtime_aggregate_health.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelRuntimeAggregateHealth and ModelEventBusAggregateHealth.
+
+Validates the canonical typed model for the :8085/health aggregate response
+shape introduced by OMN-9266.  Tests cover:
+
+- Construction from a raw dict matching the real RuntimeHostProcess.health_check()
+  return shape.
+- Field presence and type constraints for previously-provisional fields
+  (is_running, is_draining, pending_message_count, handler_pools,
+  event_bus.circuit_state, event_bus.subscriber_count,
+  event_bus.topic_count, event_bus.consumer_count).
+- JSON round-trip serialisation.
+- Rejection of invalid circuit_state values.
+- extra="allow" semantics — unknown fields do not raise.
+
+Related Tickets:
+    - OMN-9266: Cite ServiceHealth aggregate response-shape model for :8085/health
+
+.. versionadded:: OMN-9266
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_infra.runtime.models.model_runtime_aggregate_health import (
+    ModelEventBusAggregateHealth,
+    ModelRuntimeAggregateHealth,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_HEALTHY_EVENT_BUS: dict[str, object] = {
+    "healthy": True,
+    "started": True,
+    "environment": "prod",
+    "bootstrap_servers": "redpanda:9092",
+    "circuit_state": "closed",
+    "subscriber_count": 374,
+    "topic_count": 42,
+    "consumer_count": 12,
+}
+
+_HEALTHY_RUNTIME: dict[str, object] = {
+    "healthy": True,
+    "degraded": False,
+    "startup_in_progress": False,
+    "is_running": True,
+    "is_draining": False,
+    "pending_message_count": 0,
+    "max_concurrent_handlers": 10,
+    "handler_pool_size": 5,
+    "in_flight_tasks": 0,
+    "batch_response_enabled": False,
+    "batch_response_pending": 0,
+    "event_bus": _HEALTHY_EVENT_BUS,
+    "event_bus_healthy": True,
+    "failed_handlers": {},
+    "skipped_handlers": {},
+    "registered_handlers": ["HandlerNodeHeartbeat"],
+    "handlers": {"HandlerNodeHeartbeat": {"healthy": True}},
+    "handler_pools": {},
+    "no_handlers_registered": False,
+    "config_prefetch_status": "ok",
+    "local_ingress": {"enabled": False, "running": False},
+    "components": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# ModelEventBusAggregateHealth
+# ---------------------------------------------------------------------------
+
+
+class TestModelEventBusAggregateHealth:
+    """Tests for ModelEventBusAggregateHealth — the event_bus sub-shape."""
+
+    def test_construction_from_valid_dict(self) -> None:
+        """Happy-path construction from a real EventBusKafka.health_check() dict."""
+        model = ModelEventBusAggregateHealth.model_validate(
+            _HEALTHY_EVENT_BUS, strict=False
+        )
+        assert model.healthy is True
+        assert model.started is True
+        assert model.circuit_state == "closed"
+        assert model.subscriber_count == 374
+        assert model.topic_count == 42
+        assert model.consumer_count == 12
+
+    def test_circuit_state_open(self) -> None:
+        """circuit_state='open' is valid (circuit breaker tripped)."""
+        data = {**_HEALTHY_EVENT_BUS, "healthy": False, "circuit_state": "open"}
+        model = ModelEventBusAggregateHealth.model_validate(data, strict=False)
+        assert model.circuit_state == "open"
+        assert model.healthy is False
+
+    def test_circuit_state_invalid_rejected(self) -> None:
+        """circuit_state values other than 'open'/'closed' are rejected."""
+        data = {**_HEALTHY_EVENT_BUS, "circuit_state": "half-open"}
+        with pytest.raises(ValidationError) as exc_info:
+            ModelEventBusAggregateHealth.model_validate(data, strict=False)
+        assert "circuit_state" in str(exc_info.value)
+
+    def test_subscriber_count_negative_rejected(self) -> None:
+        """subscriber_count must be >= 0."""
+        data = {**_HEALTHY_EVENT_BUS, "subscriber_count": -1}
+        with pytest.raises(ValidationError):
+            ModelEventBusAggregateHealth.model_validate(data, strict=False)
+
+    def test_extra_fields_allowed(self) -> None:
+        """Unknown fields do not raise (extra='allow' semantics)."""
+        data = {**_HEALTHY_EVENT_BUS, "future_field": "some_value"}
+        model = ModelEventBusAggregateHealth.model_validate(data, strict=False)
+        assert model.circuit_state == "closed"
+
+    def test_json_roundtrip(self) -> None:
+        """JSON round-trip preserves all known fields."""
+        model = ModelEventBusAggregateHealth.model_validate(
+            _HEALTHY_EVENT_BUS, strict=False
+        )
+        json_str = model.model_dump_json()
+        restored = ModelEventBusAggregateHealth.model_validate_json(json_str)
+        assert restored.subscriber_count == model.subscriber_count
+        assert restored.circuit_state == model.circuit_state
+
+    def test_unhealthy_not_started(self) -> None:
+        """healthy=False, started=False is a valid (pre-start) state."""
+        data = {
+            "healthy": False,
+            "started": False,
+            "environment": "dev",
+            "bootstrap_servers": "localhost:9092",
+            "circuit_state": "closed",
+            "subscriber_count": 0,
+            "topic_count": 0,
+            "consumer_count": 0,
+        }
+        model = ModelEventBusAggregateHealth.model_validate(data, strict=False)
+        assert model.healthy is False
+        assert model.started is False
+        assert model.subscriber_count == 0
+
+
+# ---------------------------------------------------------------------------
+# ModelRuntimeAggregateHealth
+# ---------------------------------------------------------------------------
+
+
+class TestModelRuntimeAggregateHealth:
+    """Tests for ModelRuntimeAggregateHealth — the full /health response shape."""
+
+    def test_construction_from_healthy_dict(self) -> None:
+        """Happy-path construction from a healthy runtime health_check() return dict."""
+        model = ModelRuntimeAggregateHealth.model_validate(
+            _HEALTHY_RUNTIME, strict=False
+        )
+        assert model.healthy is True
+        assert model.is_running is True
+        assert model.is_draining is False
+        assert model.pending_message_count == 0
+        assert model.no_handlers_registered is False
+        assert model.config_prefetch_status == "ok"
+
+    def test_event_bus_sub_model_parsed(self) -> None:
+        """The nested event_bus dict is parsed into ModelEventBusAggregateHealth."""
+        model = ModelRuntimeAggregateHealth.model_validate(
+            _HEALTHY_RUNTIME, strict=False
+        )
+        assert isinstance(model.event_bus, ModelEventBusAggregateHealth)
+        assert model.event_bus.subscriber_count == 374
+        assert model.event_bus.circuit_state == "closed"
+
+    def test_is_running_field_cited(self) -> None:
+        """is_running=False is valid (runtime not yet started)."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "healthy": False,
+            "is_running": False,
+            "event_bus_healthy": False,
+            "event_bus": {**_HEALTHY_EVENT_BUS, "healthy": False, "started": False},
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.is_running is False
+        assert model.healthy is False
+
+    def test_is_draining_field_cited(self) -> None:
+        """is_draining=True represents graceful-shutdown drain phase."""
+        data = {**_HEALTHY_RUNTIME, "is_draining": True}
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.is_draining is True
+
+    def test_pending_message_count_field_cited(self) -> None:
+        """pending_message_count reflects in-flight messages."""
+        data = {**_HEALTHY_RUNTIME, "pending_message_count": 12}
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.pending_message_count == 12
+
+    def test_pending_message_count_negative_rejected(self) -> None:
+        """pending_message_count must be >= 0."""
+        data = {**_HEALTHY_RUNTIME, "pending_message_count": -1}
+        with pytest.raises(ValidationError):
+            ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+
+    def test_handler_pools_field_cited(self) -> None:
+        """handler_pools contains per-pool health metrics."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "handler_pools": {"effect_pool": {"running": True, "size": 5}},
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert "effect_pool" in model.handler_pools
+
+    def test_degraded_state(self) -> None:
+        """degraded=True, healthy=False with failed_handlers is a valid state."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "healthy": False,
+            "degraded": True,
+            "failed_handlers": {"HandlerFoo": "import error: module not found"},
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.degraded is True
+        assert model.healthy is False
+        assert "HandlerFoo" in model.failed_handlers
+
+    def test_startup_in_progress_state(self) -> None:
+        """startup_in_progress=True represents bus-live-but-handlers-not-ready."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "healthy": False,
+            "degraded": True,
+            "startup_in_progress": True,
+            "is_running": False,
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.startup_in_progress is True
+
+    def test_extra_fields_allowed(self) -> None:
+        """Unknown fields do not raise (forward-compat extra='allow')."""
+        data = {**_HEALTHY_RUNTIME, "future_runtime_field": "some_value"}
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.healthy is True
+
+    def test_json_roundtrip(self) -> None:
+        """JSON round-trip preserves previously-provisional fields."""
+        model = ModelRuntimeAggregateHealth.model_validate(
+            _HEALTHY_RUNTIME, strict=False
+        )
+        json_str = model.model_dump_json()
+        restored = ModelRuntimeAggregateHealth.model_validate_json(json_str)
+        assert restored.is_running == model.is_running
+        assert restored.is_draining == model.is_draining
+        assert restored.pending_message_count == model.pending_message_count
+        assert restored.event_bus.subscriber_count == model.event_bus.subscriber_count
+        assert restored.event_bus.circuit_state == model.event_bus.circuit_state
+
+    def test_registered_handlers_list(self) -> None:
+        """registered_handlers is a list of handler type strings."""
+        model = ModelRuntimeAggregateHealth.model_validate(
+            _HEALTHY_RUNTIME, strict=False
+        )
+        assert model.registered_handlers == ["HandlerNodeHeartbeat"]
+
+    def test_no_handlers_registered_critical_state(self) -> None:
+        """no_handlers_registered=True indicates a critical configuration error."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "healthy": False,
+            "no_handlers_registered": True,
+            "registered_handlers": [],
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert model.no_handlers_registered is True
+        assert model.registered_handlers == []
+
+    def test_config_prefetch_status_values(self) -> None:
+        """config_prefetch_status accepts all documented values."""
+        for status in (
+            "pending",
+            "skipped",
+            "ok",
+            "degraded_no_requirements",
+            "degraded_error",
+        ):
+            data = {**_HEALTHY_RUNTIME, "config_prefetch_status": status}
+            model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+            assert model.config_prefetch_status == status
+
+    def test_components_list(self) -> None:
+        """components contains per-component health dicts."""
+        data = {
+            **_HEALTHY_RUNTIME,
+            "components": [
+                {"name": "published_events_map", "status": "healthy"},
+            ],
+        }
+        model = ModelRuntimeAggregateHealth.model_validate(data, strict=False)
+        assert len(model.components) == 1
+        assert model.components[0]["name"] == "published_events_map"
+
+
+# ---------------------------------------------------------------------------
+# Module-level __all__ export coverage
+# ---------------------------------------------------------------------------
+
+
+class TestExportsFromModelsInit:
+    """Verify the models package exports the new classes."""
+
+    def test_models_init_exports_aggregate_health(self) -> None:
+        """ModelRuntimeAggregateHealth and ModelEventBusAggregateHealth are exported."""
+        from omnibase_infra.runtime.models import (
+            ModelEventBusAggregateHealth as ImportedEventBusAggregateHealth,
+        )
+        from omnibase_infra.runtime.models import (
+            ModelRuntimeAggregateHealth as ImportedRuntimeAggregateHealth,
+        )
+
+        assert ImportedRuntimeAggregateHealth is ModelRuntimeAggregateHealth
+        assert ImportedEventBusAggregateHealth is ModelEventBusAggregateHealth


### PR DESCRIPTION
## Summary

- Adds `ModelEventBusAggregateHealth` (`model_event_bus_aggregate_health.py`) — canonical typed model for the `event_bus` sub-dict in the `:8085/health` response, sourced from `EventBusKafka.health_check()`.
- Adds `ModelRuntimeAggregateHealth` (`model_runtime_aggregate_health.py`) — canonical typed model for the full `GET /health` aggregate response body, sourced from `RuntimeHostProcess.health_check()` + `ServiceHealth._handle_health()` enrichment.
- Removes all `[provisional-field-source]` tags from `docs/tracking/2026-04-19-runtime-state-inventory.md §E` (updated separately in `omni_home`); field provenance for `is_running`, `is_draining`, `pending_message_count`, `handler_pools`, `event_bus.circuit_state`, `event_bus.subscriber_count`, `event_bus.topic_count`, `event_bus.consumer_count` is now cited to authoritative Python symbols.
- Both models exported from `omnibase_infra.runtime.models` package.
- Adds `UNCOVERED_MODELS` disposition entries to `test_model_serialization_roundtrip.py` guard (round-trip coverage is in the dedicated test file).

## Test plan

- [x] 23 unit tests in `tests/unit/runtime/models/test_model_runtime_aggregate_health.py` — all passing
- [x] `tests/unit/models/test_model_serialization_roundtrip.py` — 28/28 passing (dispositions added)
- [x] `mypy --strict` clean on both new model files
- [x] `ruff check` + `ruff format` clean
- [x] All pre-commit hooks passing (architecture, naming, any-type, union-usage, circular-import, etc.)

## Tickets

OMN-9266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced strongly-typed aggregate health models for event bus and runtime components, enabling structured validation of health check responses.

* **Tests**
  * Added comprehensive unit tests for health models, including round-trip serialization validation and field constraint enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-9266
Evidence-Source: OCC#1169