### PR TITLE
OMN-9539: Ground registration verifier DB probe

### DIFF
--- a/src/omnibase_infra/verification/cli.py
+++ b/src/omnibase_infra/verification/cli.py
@@ -22,6 +22,7 @@ import importlib.resources
 import json
 import logging
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,51 @@ def _find_registration_contracts(contracts_dir: Path) -> list[Path]:
     return contracts
 
 
+RuntimeDbQueryFn = Callable[[str], list[dict[str, str]]]
+
+
+def _make_runtime_db_query_fn() -> RuntimeDbQueryFn | None:
+    """Build a synchronous DB query function from runtime DB configuration.
+
+    The runtime registration projector writes to the database identified by
+    ``OMNIBASE_INFRA_DB_URL``. Returning ``None`` lets callers report an
+    ungrounded probe instead of turning missing DB configuration into empty
+    ``registration_projections`` evidence.
+    """
+    from omnibase_infra.runtime.models.model_postgres_pool_config import (
+        ModelPostgresPoolConfig,
+    )
+
+    try:
+        config = ModelPostgresPoolConfig.from_env("OMNIBASE_INFRA_DB_URL")
+    except ValueError:
+        return None
+
+    def _query(sql: str) -> list[dict[str, str]]:
+        import psycopg2
+
+        with psycopg2.connect(
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            dbname=config.database,
+            connect_timeout=5,
+        ) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(sql)
+                column_names = [col[0] for col in cursor.description or ()]
+                return [
+                    {
+                        column: "" if value is None else str(value)
+                        for column, value in zip(column_names, row, strict=False)
+                    }
+                    for row in cursor.fetchall()
+                ]
+
+    return _query
+
+
 def _aggregate_verdict(
     reports: list[ModelContractVerificationReport],
 ) -> EnumValidationVerdict:
@@ -103,11 +149,13 @@ def _run_registration_only(
         logger.error("No registration contracts found in %s", contracts_dir)
         return 1
 
-    # For registration-only, we use placeholder fns that produce QUARANTINE
-    # since the real infra may not be available. The verify_registration_contract
-    # function has its own dependency injection.
-    def _noop_db(sql: str) -> list[dict[str, str]]:
-        return []
+    # Use the same runtime DB that the registration projector writes to. If the
+    # DB target is not configured, fail closed into probe quarantine rather than
+    # fabricating empty registration_projections evidence.
+    db_query_fn = _make_runtime_db_query_fn()
+
+    def _ungrounded_db(sql: str) -> list[dict[str, str]]:
+        raise RuntimeError("OMNIBASE_INFRA_DB_URL is not configured")
 
     def _noop_kafka(_group_id: str) -> set[str]:
         return set()
@@ -118,7 +166,7 @@ def _run_registration_only(
     reports: list[ModelContractVerificationReport] = []
     for contract_path in contracts:
         report = verify_registration_contract(
-            db_query_fn=_noop_db,
+            db_query_fn=db_query_fn or _ungrounded_db,
             kafka_admin_fn=_noop_kafka,
             watermark_fn=_noop_watermark,
             contract_path=contract_path,

--- a/src/omnibase_infra/verification/verify_registration.py
+++ b/src/omnibase_infra/verification/verify_registration.py
@@ -86,10 +86,10 @@ def _check_registration(
         return ModelContractCheckResult(
             check_type=EnumContractCheckType.REGISTRATION,
             severity=EnumCheckSeverity.REQUIRED,
-            verdict=EnumValidationVerdict.FAIL,
+            verdict=EnumValidationVerdict.QUARANTINE,
             evidence=f"Schema introspection failed: {exc}",
             contract_name=contract_name,
-            message="Registration check failed: could not introspect schema.",
+            message="Registration check quarantined: could not introspect schema.",
         )
 
     actual_columns = {row.get("column_name", "") for row in schema_rows}

--- a/tests/integration/verification/test_registration_schema_grounding_integration.py
+++ b/tests/integration/verification/test_registration_schema_grounding_integration.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration coverage for schema-grounded registration verification."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
+from omnibase_infra.verification.verify_registration import _check_registration
+
+
+@pytest.mark.integration
+def test_registration_probe_uses_live_projection_schema_shape() -> None:
+    """Registration probe must validate schema before querying node state."""
+    captured_sql: list[str] = []
+
+    def db_query_fn(sql: str) -> list[dict[str, str]]:
+        captured_sql.append(sql)
+        if "information_schema.columns" in sql:
+            return [
+                {"column_name": "entity_id"},
+                {"column_name": "domain"},
+                {"column_name": "current_state"},
+                {"column_name": "node_type"},
+                {"column_name": "node_version"},
+                {"column_name": "capabilities"},
+            ]
+        return [
+            {
+                "entity_id": "registration-orchestrator",
+                "current_state": "active",
+                "node_type": "orchestrator",
+            }
+        ]
+
+    result = _check_registration("node_registration_orchestrator", db_query_fn)
+
+    assert result.verdict == EnumValidationVerdict.PASS
+    data_queries = [sql for sql in captured_sql if "information_schema" not in sql]
+    assert data_queries == [
+        "SELECT entity_id, current_state, node_type "
+        "FROM registration_projections "
+        "WHERE node_type = 'orchestrator' LIMIT 1"
+    ]
+
+
+@pytest.mark.integration
+def test_registration_probe_quarantines_when_live_schema_is_not_authoritative() -> None:
+    """A missing projection column is quarantine evidence, not an empty PASS."""
+
+    def db_query_fn(sql: str) -> list[dict[str, str]]:
+        if "information_schema.columns" in sql:
+            return [
+                {"column_name": "entity_id"},
+                {"column_name": "current_state"},
+            ]
+        raise AssertionError("data query should not run when schema is incomplete")
+
+    result = _check_registration("node_registration_orchestrator", db_query_fn)
+
+    assert result.verdict == EnumValidationVerdict.QUARANTINE
+    assert "schema mismatch" in result.evidence.lower()

--- a/tests/unit/verification/test_cli.py
+++ b/tests/unit/verification/test_cli.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 import yaml
 
+from omnibase_infra.verification import cli
 from omnibase_infra.verification.cli import build_parser, main
 
 
@@ -158,8 +159,81 @@ class TestCLIMain:
         output = json.loads(captured.out)
         assert isinstance(output, list)
         assert len(output) == 3
-        # All use noop fns so expect FAIL (noop db returns empty rows)
-        assert exit_code == 1
+        # No runtime DB is configured in this unit test, so DB-backed checks
+        # quarantine instead of fabricating empty projection rows.
+        assert exit_code in (1, 2)
+
+    def test_registration_only_uses_runtime_db_for_projection_state(
+        self,
+        tmp_path: Path,
+        capsys: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OMN-9539/9540/9541: configured DB rows drive projection_state PASS."""
+        for node_name, node_type in (
+            ("node_registration_orchestrator", "ORCHESTRATOR_GENERIC"),
+            ("node_registration_reducer", "REDUCER_GENERIC"),
+            ("node_registration_storage_effect", "EFFECT_GENERIC"),
+        ):
+            contract = _make_contract(name=node_name, node_type=node_type)
+            _write_contract(tmp_path, contract, node_name)
+
+        def db_query_fn(sql: str) -> list[dict[str, str]]:
+            if "information_schema.columns" in sql:
+                return [
+                    {"column_name": "entity_id"},
+                    {"column_name": "current_state"},
+                    {"column_name": "node_type"},
+                    {"column_name": "data_provenance"},
+                ]
+            if "WHERE node_type = 'orchestrator'" in sql:
+                return [
+                    {
+                        "entity_id": "orchestrator-1",
+                        "current_state": "active",
+                        "node_type": "orchestrator",
+                    }
+                ]
+            return [
+                {
+                    "entity_id": "orchestrator-1",
+                    "current_state": "active",
+                    "node_type": "orchestrator",
+                },
+                {
+                    "entity_id": "reducer-1",
+                    "current_state": "active",
+                    "node_type": "reducer",
+                },
+                {
+                    "entity_id": "effect-1",
+                    "current_state": "active",
+                    "node_type": "effect",
+                },
+            ]
+
+        monkeypatch.setattr(cli, "_make_runtime_db_query_fn", lambda: db_query_fn)
+
+        exit_code = cli.main(["--registration-only", "--contracts-dir", str(tmp_path)])
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert isinstance(output, list)
+        assert len(output) == 3
+        assert exit_code == 0
+
+        for report in output:
+            projection_check = next(
+                check
+                for check in report["checks"]
+                if check["check_type"] == "projection_state"
+            )
+            assert projection_check["verdict"] == "pass"
+            assert "Found 3/3 rows in terminal states" in projection_check["evidence"]
+            assert (
+                "No rows found in registration_projections"
+                not in projection_check["evidence"]
+            )
 
     def test_registration_only_no_contracts(self, tmp_path: Path) -> None:
         """--registration-only with empty dir -> exit 1."""

--- a/tests/unit/verification/test_projection_state_schema_grounding.py
+++ b/tests/unit/verification/test_projection_state_schema_grounding.py
@@ -13,6 +13,35 @@ from omnibase_infra.verification.verify_registration import (
     _check_projection_state_via_db,
 )
 
+_LIVE_REGISTRATION_PROJECTION_COLUMNS: tuple[str, ...] = (
+    "entity_id",
+    "domain",
+    "current_state",
+    "node_type",
+    "node_version",
+    "capabilities",
+    "contract_type",
+    "intent_types",
+    "protocols",
+    "capability_tags",
+    "contract_version",
+    "subscribe_topics",
+    "publish_topics",
+    "ack_deadline",
+    "liveness_deadline",
+    "last_heartbeat_at",
+    "ack_timeout_emitted_at",
+    "liveness_timeout_emitted_at",
+    "last_applied_event_id",
+    "last_applied_offset",
+    "last_applied_sequence",
+    "last_applied_partition",
+    "registered_at",
+    "updated_at",
+    "correlation_id",
+    "data_provenance",
+)
+
 
 @pytest.mark.unit
 def test_projection_state_validates_schema_before_querying() -> None:
@@ -83,3 +112,49 @@ def test_projection_state_passes_when_schema_valid_and_data_present() -> None:
 
     result = _check_projection_state_via_db("test_contract", db_query_fn)
     assert result.verdict == EnumValidationVerdict.PASS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "contract_name",
+    [
+        "node_registration_orchestrator",
+        "node_registration_reducer",
+        "node_registration_storage_effect",
+    ],
+)
+def test_projection_state_passes_for_registration_contracts_with_live_schema_shape(
+    contract_name: str,
+) -> None:
+    """OMN-9539/9540/9541: live-shaped rows must not false-negative as empty."""
+
+    def db_query_fn(sql: str) -> list[dict[str, str]]:
+        if "information_schema.columns" in sql:
+            assert "table_schema = 'public'" in sql
+            return [
+                {"column_name": column}
+                for column in _LIVE_REGISTRATION_PROJECTION_COLUMNS
+            ]
+        return [
+            {
+                "entity_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "current_state": "active",
+                "node_type": "orchestrator",
+            },
+            {
+                "entity_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "current_state": "active",
+                "node_type": "reducer",
+            },
+            {
+                "entity_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "current_state": "active",
+                "node_type": "effect",
+            },
+        ]
+
+    result = _check_projection_state_via_db(contract_name, db_query_fn)
+
+    assert result.verdict == EnumValidationVerdict.PASS
+    assert "Found 3/3 rows in terminal states" in result.evidence
+    assert "No rows found in registration_projections" not in result.evidence

--- a/tests/unit/verification/test_registration_contract_verify_unit.py
+++ b/tests/unit/verification/test_registration_contract_verify_unit.py
@@ -326,7 +326,7 @@ class TestVerifyRegistrationFails:
         )
         assert proj_check.verdict == EnumValidationVerdict.FAIL
 
-    def test_fail_when_db_raises(self) -> None:
+    def test_quarantine_when_db_raises(self) -> None:
         def failing_db(sql: str) -> list[dict[str, Any]]:
             raise ConnectionError("Connection refused")
 
@@ -336,7 +336,7 @@ class TestVerifyRegistrationFails:
             watermark_fn=_make_watermark_fn(),
             contract_path=_CONTRACT_PATH,
         )
-        assert report.overall_verdict == EnumValidationVerdict.FAIL
+        assert report.overall_verdict == EnumValidationVerdict.QUARANTINE
 
     def test_fail_when_kafka_admin_raises(self) -> None:
         def failing_kafka(_group_id: str) -> set[str]:

--- a/tests/unit/verification/test_verify_registration_schema_grounding.py
+++ b/tests/unit/verification/test_verify_registration_schema_grounding.py
@@ -86,8 +86,8 @@ def test_check_registration_queries_by_node_type_not_node_name() -> None:
 
 
 @pytest.mark.unit
-def test_check_registration_schema_introspection_failure_returns_fail() -> None:
-    """If schema introspection itself fails, return FAIL (not crash)."""
+def test_check_registration_schema_introspection_failure_quarantines() -> None:
+    """If schema introspection itself fails, return QUARANTINE (not crash)."""
 
     def db_query_fn(sql: str) -> list[dict[str, str]]:
         if "information_schema" in sql:
@@ -95,5 +95,5 @@ def test_check_registration_schema_introspection_failure_returns_fail() -> None:
         return []
 
     result = _check_registration("node_registration_orchestrator", db_query_fn)
-    assert result.verdict == EnumValidationVerdict.FAIL
+    assert result.verdict == EnumValidationVerdict.QUARANTINE
     assert "schema introspection failed" in result.evidence.lower()


### PR DESCRIPTION
## Summary
- Grounds registration-only verification against the configured runtime database (`OMNIBASE_INFRA_DB_URL`) instead of placeholder empty DB results.
- Fails closed into QUARANTINE when DB schema/probe introspection is unavailable, avoiding false empty `registration_projections` evidence.
- Adds live-schema-shaped regression coverage for the registration orchestrator, reducer, and storage effect verifier path.

## Covered Tickets
- OMN-9539
- OMN-9540
- OMN-9541

## Verification
- `.venv/bin/python -m pytest tests/unit/verification/test_cli.py tests/unit/verification/test_projection_state_schema_grounding.py tests/unit/verification/test_registration_contract_verify_unit.py tests/unit/verification/test_verify_registration_schema_grounding.py tests/integration/verification/test_registration_schema_grounding_integration.py -q` -> 48 passed.

## OCC Evidence
Evidence-Source: OCC#1159
Evidence-Ticket: OMN-9539

Central OCC also covers OMN-9540 and OMN-9541 for this verification slice.


