### PR TITLE
feat(OMN-11268): runner health models and state enum — add __all__ and OOM_KILLED emoji

### DIFF
--- a/src/omnibase_infra/observability/runner_health/model_runner_health_alert.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_health_alert.py
@@ -48,6 +48,7 @@ class ModelRunnerHealthAlert(BaseModel):
                 EnumRunnerHealthState.GITHUB_OFFLINE: ":red_circle:",
                 EnumRunnerHealthState.CRASH_LOOPING: ":rotating_light:",
                 EnumRunnerHealthState.DOCKER_UNHEALTHY: ":warning:",
+                EnumRunnerHealthState.OOM_KILLED: ":skull:",
                 EnumRunnerHealthState.STALE_REGISTRATION: ":ghost:",
                 EnumRunnerHealthState.MISSING: ":question:",
             }.get(r.state, ":x:")
@@ -57,3 +58,6 @@ class ModelRunnerHealthAlert(BaseModel):
                 f"(GitHub: {r.github_status}, Docker: {r.docker_status}){detail}"
             )
         return "\n".join(lines)
+
+
+__all__ = ["ModelRunnerHealthAlert"]

--- a/src/omnibase_infra/observability/runner_health/model_runner_health_snapshot.py
+++ b/src/omnibase_infra/observability/runner_health/model_runner_health_snapshot.py
@@ -51,3 +51,6 @@ class ModelRunnerHealthSnapshot(BaseModel):
     host_disk_percent: float = Field(
         default=0.0, description="Host disk usage percentage"
     )
+
+
+__all__ = ["ModelRunnerHealthSnapshot"]

--- a/tests/integration/observability/test_runner_health_models_integration.py
+++ b/tests/integration/observability/test_runner_health_models_integration.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration checks for runner health model public API surface (OMN-11268)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.observability.runner_health import (
+    EnumRunnerHealthState,
+    ModelRunnerHealthAlert,
+    ModelRunnerHealthSnapshot,
+    ModelRunnerStatus,
+)
+
+
+@pytest.mark.integration
+def test_runner_health_package_exports_all_required_symbols() -> None:
+    """All four public symbols must be importable from the package __init__."""
+    assert EnumRunnerHealthState
+    assert ModelRunnerStatus
+    assert ModelRunnerHealthSnapshot
+    assert ModelRunnerHealthAlert
+
+
+@pytest.mark.integration
+def test_enum_runner_health_state_has_required_members() -> None:
+    required = {
+        "HEALTHY",
+        "GITHUB_OFFLINE",
+        "DOCKER_UNHEALTHY",
+        "CRASH_LOOPING",
+        "STALE_REGISTRATION",
+        "MISSING",
+    }
+    actual = {m.name for m in EnumRunnerHealthState}
+    assert required <= actual, f"Missing members: {required - actual}"
+
+
+@pytest.mark.integration
+def test_alert_to_slack_message_covers_all_degraded_states() -> None:
+    degraded_states = [
+        s for s in EnumRunnerHealthState if s != EnumRunnerHealthState.HEALTHY
+    ]
+    runners = tuple(
+        ModelRunnerStatus(
+            name=f"runner-{s.value}",
+            github_status="offline",
+            github_busy=False,
+            docker_status="unhealthy",
+            docker_uptime="",
+            state=s,
+            error=f"error for {s.value}",
+        )
+        for s in degraded_states
+    )
+    alert = ModelRunnerHealthAlert(
+        correlation_id=uuid4(),
+        degraded_runners=runners,
+        total_runners=len(runners),
+        healthy_count=0,
+        host="192.168.86.201",
+    )
+    msg = alert.to_slack_message()
+    for r in runners:
+        assert r.name in msg, f"Runner {r.name} missing from Slack message"
+        assert r.state.value in msg, f"State {r.state.value} missing from Slack message"
+
+
+@pytest.mark.integration
+def test_snapshot_roundtrip_via_model_dump() -> None:
+    runner = ModelRunnerStatus(
+        name="omninode-runner-1",
+        github_status="online",
+        github_busy=False,
+        docker_status="healthy",
+        docker_uptime="Up 3h",
+        state=EnumRunnerHealthState.HEALTHY,
+    )
+    snap = ModelRunnerHealthSnapshot(
+        correlation_id=uuid4(),
+        collected_at=datetime.now(tz=UTC),
+        runners=(runner,),
+        expected_runners=4,
+        observed_runners=1,
+        healthy_count=1,
+        degraded_count=0,
+        host="192.168.86.201",
+    )
+    dumped = snap.model_dump(mode="json")
+    assert dumped["healthy_count"] == 1
+    assert dumped["runners"][0]["name"] == "omninode-runner-1"

--- a/tests/integration/observability/test_runner_health_models_integration.py
+++ b/tests/integration/observability/test_runner_health_models_integration.py
@@ -32,6 +32,7 @@ def test_enum_runner_health_state_has_required_members() -> None:
         "HEALTHY",
         "GITHUB_OFFLINE",
         "DOCKER_UNHEALTHY",
+        "OOM_KILLED",
         "CRASH_LOOPING",
         "STALE_REGISTRATION",
         "MISSING",


### PR DESCRIPTION
Evidence-Ticket: OMN-11268
Evidence-Source: 1b771764c82d78214eb7689a63e21a76993199e6


## Summary

Closes OMN-11268.

The `ModelRunnerStatus`, `ModelRunnerHealthSnapshot`, `ModelRunnerHealthAlert`, and `EnumRunnerHealthState` models were already implemented in main (OMN-6075, OMN-6049). This PR adds missing polish items:

- `__all__` declarations on `ModelRunnerHealthSnapshot` and `ModelRunnerHealthAlert`
- `OOM_KILLED` emoji mapping in `ModelRunnerHealthAlert.to_slack_message()`
- Integration tests covering package exports, enum coverage, state coverage, and snapshot roundtrip

## Acceptance criteria

- [x] `ModelRunnerStatus` frozen with 7 fields
- [x] `EnumRunnerHealthState` has HEALTHY, GITHUB_OFFLINE, DOCKER_UNHEALTHY, OOM_KILLED, CRASH_LOOPING, STALE_REGISTRATION, MISSING
- [x] `ModelRunnerHealthSnapshot` frozen with all required fields
- [x] `ModelRunnerHealthAlert.to_slack_message()` covers all degraded states
- [x] 7 unit tests + 4 integration tests pass


## dod_evidence

ticket: OMN-11268
tests_passed: 7 unit + 4 integration (all PASS)
pre_commit: all hooks passed
occ_contract: onex_change_control PR #1176