### PR TITLE
fix(OMN-11299): support composite projection upsert keys

### DIFF
--- a/contracts/OMN-11299.yaml
+++ b/contracts/OMN-11299.yaml
@@ -1,0 +1,28 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-11299"
+title: "Support composite projection upsert keys in sync DB adapter"
+summary: >
+  Allow the sync projection DB adapter to accept comma-separated composite conflict keys (e.g. "session_id,event_timestamp,model_local,model_cloud_baseline") for savings_estimates-style projection tables. No schema change, no new topics, no migrations — purely a logic fix to the SQL generation path in handler_wiring.py.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-tests
+    description: "Unit and integration tests pass for composite and single conflict key paths."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/integration/test_sync_db_adapter_composite_conflict_key.py -v"
+  - id: dod-deploy
+    description: >
+      Pure logic fix to SQL generation — no new tables, topics, migrations, or Dockerfile changes. Rolling restart on .201 after merge is sufficient.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy: docker exec omninode-runtime python -c 'from omnibase_infra.runtime.auto_wiring.handler_wiring import _build_sync_db_adapter; print(\"composite key adapter loaded\")'"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -624,18 +624,33 @@ def _build_sync_db_adapter(db_url: str) -> object:
         def upsert(self, table: str, conflict_key: str, row: dict[str, object]) -> bool:
             if not _TABLE_NAME_RE.match(table):
                 raise ValueError(f"Invalid table name: {table!r}")
-            if not _TABLE_NAME_RE.match(conflict_key):
+            conflict_keys = [
+                key.strip() for key in conflict_key.split(",") if key.strip()
+            ]
+            if not conflict_keys:
+                raise ValueError("conflict_key must contain at least one column")
+            bad_conflict_keys = [
+                key for key in conflict_keys if not _TABLE_NAME_RE.match(key)
+            ]
+            if bad_conflict_keys:
                 raise ValueError(f"Invalid conflict key: {conflict_key!r}")
             conn = self._get_conn()
             cols = list(row.keys())
             bad_cols = [c for c in cols if not _TABLE_NAME_RE.match(str(c))]
             if bad_cols:
                 raise ValueError(f"Invalid column names: {bad_cols!r}")
+            missing_conflict_keys = [key for key in conflict_keys if key not in row]
+            if missing_conflict_keys:
+                raise KeyError(
+                    f"row missing conflict key(s): {missing_conflict_keys!r}"
+                )
             quoted_cols = ", ".join(f'"{c}"' for c in cols)
             placeholders = ", ".join(f"%({c})s" for c in cols)
+            conflict_key_set = set(conflict_keys)
             updates = ", ".join(
-                f'"{c}" = EXCLUDED."{c}"' for c in cols if c != conflict_key
+                f'"{c}" = EXCLUDED."{c}"' for c in cols if c not in conflict_key_set
             )
+            conflict_columns = ", ".join(f'"{key}"' for key in conflict_keys)
             adapted_row = {
                 key: psycopg2.extras.Json(value)
                 if isinstance(value, (dict, list))
@@ -646,7 +661,7 @@ def _build_sync_db_adapter(db_url: str) -> object:
             parts = [
                 f'INSERT INTO "{table}" ({quoted_cols})',
                 f"VALUES ({placeholders})",
-                f'ON CONFLICT ("{conflict_key}") DO UPDATE SET {updates}',
+                f"ON CONFLICT ({conflict_columns}) DO UPDATE SET {updates}",
             ]
             insert_sql = " ".join(parts)
             with conn.cursor() as cur:  # type: ignore[union-attr, attr-defined]

--- a/tests/integration/test_sync_db_adapter_composite_conflict_key.py
+++ b/tests/integration/test_sync_db_adapter_composite_conflict_key.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration contract for sync DB adapter composite conflict key support (OMN-11299).
+
+Verifies that the projection upsert adapter correctly generates SQL with
+composite ON CONFLICT clauses when multiple conflict columns are provided,
+matching the savings_estimates projection schema.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _build_sync_db_adapter
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_sync_db_adapter_composite_conflict_key_sql_shape() -> None:
+    cursor = MagicMock()
+    cursor_context = MagicMock()
+    cursor_context.__enter__.return_value = cursor
+    conn = MagicMock()
+    conn.closed = False
+    conn.cursor.return_value = cursor_context
+
+    with patch("psycopg2.connect", return_value=conn):
+        adapter = _build_sync_db_adapter("postgresql://user:pass@host/db")
+        result = adapter.upsert(
+            "savings_estimates",
+            "session_id,event_timestamp,model_local,model_cloud_baseline",
+            {
+                "session_id": "sess-1",
+                "event_timestamp": "2026-05-20T20:00:00+00:00",
+                "model_local": "local-model",
+                "model_cloud_baseline": "cloud-model",
+                "savings_usd": "0.001",
+            },
+        )
+
+    assert result is True
+    sql = cursor.execute.call_args.args[0]
+    assert (
+        'ON CONFLICT ("session_id", "event_timestamp", '
+        '"model_local", "model_cloud_baseline") DO UPDATE SET'
+    ) in sql
+    assert '"savings_usd" = EXCLUDED."savings_usd"' in sql
+    assert '"session_id" = EXCLUDED."session_id"' not in sql
+
+
+def test_sync_db_adapter_single_conflict_key_unchanged() -> None:
+    cursor = MagicMock()
+    cursor_context = MagicMock()
+    cursor_context.__enter__.return_value = cursor
+    conn = MagicMock()
+    conn.closed = False
+    conn.cursor.return_value = cursor_context
+
+    with patch("psycopg2.connect", return_value=conn):
+        adapter = _build_sync_db_adapter("postgresql://user:pass@host/db")
+        result = adapter.upsert(
+            "node_registrations",
+            "node_id",
+            {"node_id": "n1", "status": "active"},
+        )
+
+    assert result is True
+    sql = cursor.execute.call_args.args[0]
+    assert 'ON CONFLICT ("node_id") DO UPDATE SET' in sql
+    assert '"status" = EXCLUDED."status"' in sql

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _build_sync_db_adapter,
     _make_dispatch_callback,
     _make_projection_dispatch_callback,
     _read_db_io_tables,
@@ -213,6 +214,39 @@ def test_projection_callback_logs_type_error_not_raises(
 
     assert result is None
     assert any("TypeError" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_sync_db_adapter_accepts_multi_column_conflict_key() -> None:
+    """Projection DB adapter preserves protocol support for composite UPSERT keys."""
+    cursor = MagicMock()
+    cursor_context = MagicMock()
+    cursor_context.__enter__.return_value = cursor
+    conn = MagicMock()
+    conn.closed = False
+    conn.cursor.return_value = cursor_context
+
+    with patch("psycopg2.connect", return_value=conn):
+        adapter = _build_sync_db_adapter("postgresql://user:pass@host/db")
+        result = adapter.upsert(
+            "savings_estimates",
+            "session_id,event_timestamp,model_local,model_cloud_baseline",
+            {
+                "session_id": "sess-1",
+                "event_timestamp": "2026-05-20T20:00:00+00:00",
+                "model_local": "local-model",
+                "model_cloud_baseline": "cloud-model",
+                "savings_usd": "0.001",
+            },
+        )
+
+    assert result is True
+    sql = cursor.execute.call_args.args[0]
+    assert (
+        'ON CONFLICT ("session_id", "event_timestamp", '
+        '"model_local", "model_cloud_baseline") DO UPDATE SET'
+    ) in sql
+    assert '"savings_usd" = EXCLUDED."savings_usd"' in sql
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow sync projection DB adapter to accept composite conflict keys
- keep validation for table/column names and missing conflict columns
- add unit coverage for savings_estimates-style composite UPSERT keys

## Verification
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py -q
- uv run pytest tests/integration/test_sync_db_adapter_composite_conflict_key.py -v
- pre-commit hooks via git commit
- pre-push hooks via git push

## Stability runtime evidence
- Hot-patched .201 stability runtime with this adapter fix.
- Live delegate-skill terminal projections wrote delegation tokens and savings rows after migrations were applied.

## Evidence
Evidence-Ticket: OMN-11299
Evidence-Source: OCC#1234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync DB adapter now supports composite (multi-column) conflict keys for upsert operations, while preserving single-column behavior.

* **Tests**
  * Added unit and integration tests validating composite upsert keys, SQL shape, and backward compatibility with single-column keys.

* **Chores**
  * Added ticket/config entry documenting the change and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->