### PR TITLE
fix(OMN-11315): extend stability runtime poll interval

### DIFF
--- a/contracts/OMN-11315.yaml
+++ b/contracts/OMN-11315.yaml
@@ -1,0 +1,40 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11315
+title: "Extend stability runtime Kafka poll interval"
+summary: "Allow and configure a longer Kafka max poll interval for the stability-test runtime lane so long delegate-skill LLM handlers keep consumer membership until terminal events are emitted."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Kafka timeout config and stability lane regression tests pass"
+    command: "uv run pytest tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q"
+  - kind: "ci"
+    description: "Touched runtime config and stability lane files pass ruff checks"
+    command: "uv run ruff format --check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && uv run ruff check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py"
+  - kind: "manual"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill smoke proof"
+    command: "deploy .201 stability runtime from the merged image, then verify the delegate-skill smoke terminal event and zero command-topic lag"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-targeted-tests"
+    description: "Kafka timeout config and stability lane regression tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q"
+  - id: "dod-ruff-check"
+    description: "Touched runtime config and stability lane files pass ruff checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff format --check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && uv run ruff check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py"
+  - id: "dod-stability-deploy-proof"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill smoke proof"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy .201 stability runtime from the merged image, then run rpk group describe for the delegate-skill consumer group and verify terminal completion"

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -108,6 +108,7 @@ services:
       ONEX_RUNTIME_CAPABILITIES: market.skill-proof,workflow.orchestration,runtime.main
       ONEX_GROUP_ID: onex-stability-test-runtime-main
       KAFKA_INSTANCE_ID: stability-test-main
+      KAFKA_MAX_POLL_INTERVAL_MS: "1800000"
       BIFROST_VERIFY_ENDPOINTS: "0"
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-main
     ports: !override
@@ -139,6 +140,7 @@ services:
       ONEX_RUNTIME_CAPABILITIES: effects.consumer,market.skill-proof,runtime.effects
       ONEX_GROUP_ID: onex-stability-test-runtime-effects
       KAFKA_INSTANCE_ID: stability-test-effects
+      KAFKA_MAX_POLL_INTERVAL_MS: "1800000"
       BIFROST_VERIFY_ENDPOINTS: "0"
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-effects
     ports: !override
@@ -170,6 +172,7 @@ services:
       ONEX_RUNTIME_CAPABILITIES: workflow.dispatch,contract.update,runtime.worker
       ONEX_GROUP_ID: onex-stability-test-runtime-workers
       KAFKA_INSTANCE_ID: stability-test-worker
+      KAFKA_MAX_POLL_INTERVAL_MS: "1800000"
       BIFROST_VERIFY_ENDPOINTS: "0"
       OTEL_SERVICE_NAME: omninode-stability-test-runtime-worker
     volumes: !override

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -323,7 +323,7 @@ class ModelKafkaEventBusConfig(BaseModel):
     max_poll_interval_ms: int = Field(
         default=300000,
         ge=10000,
-        le=600000,
+        le=3600000,
         description=(
             "Maximum time in ms between poll() calls before the consumer is "
             "considered failed. Default 300s (5 min). Set high enough to "

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -239,6 +239,7 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
+        assert environment["KAFKA_MAX_POLL_INTERVAL_MS"] == "1800000"
         assert "image" not in services[service_name]
         assert services[service_name]["restart"] == "unless-stopped"
         assert environment["ONEX_RUNTIME_ADDRESS"].startswith(

--- a/tests/unit/event_bus/test_kafka_config_session_timeout.py
+++ b/tests/unit/event_bus/test_kafka_config_session_timeout.py
@@ -65,6 +65,15 @@ class TestSessionTimeoutCustomValues:
         )
         assert config.max_poll_interval_ms == 600000
 
+    @pytest.mark.unit
+    def test_slow_runtime_max_poll_interval_ms(self) -> None:
+        config = ModelKafkaEventBusConfig(
+            session_timeout_ms=45000,
+            heartbeat_interval_ms=15000,
+            max_poll_interval_ms=1800000,
+        )
+        assert config.max_poll_interval_ms == 1800000
+
 
 class TestSessionTimeoutValidator:
     """Test the validate_session_timeout_ratio cross-field validator."""

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -132,6 +132,7 @@ def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
         assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
         assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
+        assert environment["KAFKA_MAX_POLL_INTERVAL_MS"] == "1800000"
 
         group_id = environment["ONEX_GROUP_ID"]
         assert group_id.startswith("onex-stability-test-")


### PR DESCRIPTION
Evidence-Source: OCC#1239
Evidence-Ticket: OMN-11315

## Summary
- allow Kafka max_poll_interval_ms up to 60 minutes in typed runtime config
- set the stability-test runtime lane to a 30-minute poll interval for long delegate-skill LLM work
- add unit/render assertions so the stability lane keeps that poll budget

## Verification
- uv run pytest tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
- uv run ruff format --check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- uv run ruff check src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_session_timeout.py tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- uv run validate-yaml contracts/OMN-11315.yaml

## Runtime evidence
- Stability runtime health was OK, but delegate-skill live smoke left the worker consumer group empty with lag after aiokafka reported max_poll_interval_ms was exceeded.
- This PR makes the stability lane accept and pass a 30-minute poll interval before rerunning the live smoke after merge/deploy.

Refs OMN-11315