### PR TITLE
fix(OMN-11318): avoid grouped Pattern B terminal waits

### DIFF
--- a/contracts/OMN-11318.yaml
+++ b/contracts/OMN-11318.yaml
@@ -7,11 +7,11 @@ interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: "tests"
-    description: "Pattern B broker regression tests pass"
-    command: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"
+    description: "Pattern B broker unit and integration regression tests pass"
+    command: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q"
   - kind: "ci"
     description: "Touched Pattern B broker files pass ruff checks"
-    command: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py"
+    command: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py"
   - kind: "manual"
     description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
     command: "deploy .201 stability runtime from the merged image, then verify /skill returns after delegate-skill terminal event and command-topic lag remains zero"
@@ -21,17 +21,17 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-targeted-tests"
-    description: "Pattern B broker regression tests pass"
+    description: "Pattern B broker unit and integration regression tests pass"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"
+        check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q"
   - id: "dod-ruff-check"
     description: "Touched Pattern B broker files pass ruff checks"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py"
+        check_value: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py"
   - id: "dod-stability-deploy-proof"
     description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
     source: "manual"

--- a/contracts/OMN-11318.yaml
+++ b/contracts/OMN-11318.yaml
@@ -1,0 +1,40 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11318
+title: "Fix Pattern B terminal waiter local ingress hang"
+summary: "Use an ungrouped, manually assigned Kafka consumer for one-shot Pattern B terminal waits so local ingress returns after a request-correlated terminal event is published."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Pattern B broker regression tests pass"
+    command: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"
+  - kind: "ci"
+    description: "Touched Pattern B broker files pass ruff checks"
+    command: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py"
+  - kind: "manual"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
+    command: "deploy .201 stability runtime from the merged image, then verify /skill returns after delegate-skill terminal event and command-topic lag remains zero"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-targeted-tests"
+    description: "Pattern B broker regression tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q"
+  - id: "dod-ruff-check"
+    description: "Touched Pattern B broker files pass ruff checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py"
+  - id: "dod-stability-deploy-proof"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy .201 stability runtime from the merged image, then verify /skill returns after delegate-skill terminal event and command-topic lag remains zero"

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 from typing import cast
 from uuid import UUID
 
-from aiokafka import AIOKafkaConsumer
+from aiokafka import AIOKafkaConsumer, TopicPartition
 
 from omnibase_core.models.dispatch.model_dispatch_bus_command import (
     ModelDispatchBusCommand,
@@ -248,9 +248,8 @@ class RuntimePatternBBroker:
         kafka_event_bus = self._kafka_event_bus()
         config = getattr(kafka_event_bus, "config", SimpleNamespace())
         consumer = AIOKafkaConsumer(
-            *terminal_topics,
             bootstrap_servers=self._kafka_bootstrap_servers(),
-            group_id=_terminal_group_id(command.correlation_id),
+            group_id=None,
             auto_offset_reset="latest",
             enable_auto_commit=False,
             session_timeout_ms=getattr(config, "session_timeout_ms", 45000),
@@ -264,7 +263,11 @@ class RuntimePatternBBroker:
             await asyncio.wait_for(
                 consumer.start(), timeout=min(30, command.timeout_seconds)
             )
-            await self._wait_for_kafka_assignment(consumer, command.timeout_seconds)
+            await self._assign_terminal_topic_partitions(
+                consumer,
+                terminal_topics,
+                command.timeout_seconds,
+            )
             await consumer.seek_to_end(*consumer.assignment())
             await self._publish_worker_command(command, route)
 
@@ -296,13 +299,23 @@ class RuntimePatternBBroker:
                     sanitize_error_message(exc),
                 )
 
-    async def _wait_for_kafka_assignment(
+    async def _assign_terminal_topic_partitions(
         self,
         consumer: AIOKafkaConsumer,
+        topics: tuple[str, ...],
         timeout_seconds: int,
     ) -> None:
         deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
-        while not consumer.assignment():
+        while True:
+            partitions: set[TopicPartition] = set()
+            for topic in topics:
+                topic_partitions = consumer.partitions_for_topic(topic) or set()
+                partitions.update(
+                    TopicPartition(topic, partition) for partition in topic_partitions
+                )
+            if partitions:
+                consumer.assign(partitions)
+                return
             if asyncio.get_running_loop().time() >= deadline:
                 raise TimeoutError
             await asyncio.sleep(0.05)

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -306,14 +306,18 @@ class RuntimePatternBBroker:
         timeout_seconds: int,
     ) -> None:
         deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
+        expected_topics = set(topics)
         while True:
             partitions: set[TopicPartition] = set()
+            ready_topics: set[str] = set()
             for topic in topics:
                 topic_partitions = consumer.partitions_for_topic(topic) or set()
+                if topic_partitions:
+                    ready_topics.add(topic)
                 partitions.update(
                     TopicPartition(topic, partition) for partition in topic_partitions
                 )
-            if partitions:
+            if ready_topics == expected_topics:
                 consumer.assign(partitions)
                 return
             if asyncio.get_running_loop().time() >= deadline:

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for Pattern B one-shot terminal waits."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
+
+pytestmark = [pytest.mark.integration]
+
+
+def _route() -> RuntimeLocalIngressRoute:
+    return RuntimeLocalIngressRoute(
+        node_name="node_delegate_skill_orchestrator",
+        contract_name="delegate_skill.orchestrate",
+        command_topic="onex.cmd.omnimarket.delegate-skill.v1",
+        event_type="omnimarket.delegate-skill",
+        terminal_event="onex.evt.omnimarket.delegate-skill-completed.v1",
+        terminal_events=("onex.evt.omnimarket.delegate-skill-completed.v1",),
+        contract_path="/tmp/node_delegate_skill_orchestrator/contract.yaml",  # noqa: S108
+        package_name="omnimarket",
+    )
+
+
+class _TerminalConsumer:
+    created: ClassVar[list[_TerminalConsumer]] = []
+
+    def __init__(self, *topics: object, **kwargs: object) -> None:
+        self.topics = topics
+        self.kwargs = kwargs
+        self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
+        self.assigned_partitions: set[object] = set()
+        self.seeked_to_end = False
+        self.started = False
+        self.stopped = False
+        type(self).created.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    def partitions_for_topic(self, topic: str) -> set[int]:
+        return {0, 1} if self.started and topic else set()
+
+    def assign(self, partitions: set[object]) -> None:
+        self.assigned_partitions = partitions
+
+    def assignment(self) -> set[object]:
+        return self.assigned_partitions
+
+    async def seek_to_end(self, *_assignment: object) -> None:
+        self.seeked_to_end = True
+
+    async def getone(self) -> SimpleNamespace:
+        return await self.messages.get()
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _KafkaLikeTransport:
+    config = SimpleNamespace(
+        session_timeout_ms=45000,
+        heartbeat_interval_ms=15000,
+        max_poll_interval_ms=1800000,
+        reconnect_backoff_ms=2000,
+    )
+    _bootstrap_servers = "redpanda:9092"
+
+    def __init__(self, route: RuntimeLocalIngressRoute) -> None:
+        self._route = route
+
+    def _build_auth_kwargs(self) -> dict[str, object]:
+        return {}
+
+    async def publish(
+        self,
+        _topic: str,
+        _key: bytes | None,
+        value: bytes,
+        _headers: object | None = None,
+    ) -> None:
+        consumer = _TerminalConsumer.created[-1]
+        assert consumer.kwargs["group_id"] is None
+        assert consumer.topics == ()
+        assert consumer.assigned_partitions
+        assert consumer.seeked_to_end is True
+
+        command_envelope = ModelEventEnvelope[object].model_validate_json(value)
+        terminal_envelope = ModelEventEnvelope[object](
+            payload={"status": "completed", "response": "stability-smoke-ok"},
+            correlation_id=command_envelope.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=self._route.terminal_event,
+            source_tool="node_delegate_skill_orchestrator",
+        )
+        await consumer.messages.put(
+            SimpleNamespace(
+                topic=self._route.terminal_event,
+                value=terminal_envelope.model_dump_json().encode(),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_pattern_b_terminal_waiter_uses_ungrouped_assigned_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _TerminalConsumer.created = []
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _TerminalConsumer,
+    )
+    route = _route()
+    broker = RuntimePatternBBroker(
+        _KafkaLikeTransport(route),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"delegate_skill.orchestrate": route},
+    )
+    command = ModelDispatchBusCommand(
+        command_name="delegate_skill.orchestrate",
+        requester="codex",
+        payload={"prompt": "stability smoke"},
+        response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+        timeout_seconds=1,
+    )
+
+    resolved_route, result = await broker.dispatch_request(command)
+
+    assert resolved_route == route
+    assert result.status == "completed"
+    assert result.payload == {"status": "completed", "response": "stability-smoke-ok"}
+    assert _TerminalConsumer.created[0].stopped is True

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -76,7 +76,7 @@ class _KafkaLikeTransport:
         max_poll_interval_ms=1800000,
         reconnect_backoff_ms=2000,
     )
-    _bootstrap_servers = "redpanda:9092"
+    _bootstrap_servers = "pattern-b-test-broker"
 
     def __init__(self, route: RuntimeLocalIngressRoute) -> None:
         self._route = route

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -97,9 +97,11 @@ class _FakeAIOKafkaConsumer:
     created: ClassVar[list[_FakeAIOKafkaConsumer]] = []
     stop_error: ClassVar[Exception | None] = None
 
-    def __init__(self, *topics: object, **_kwargs: object) -> None:
+    def __init__(self, *topics: object, **kwargs: object) -> None:
         self.topics = topics
+        self.kwargs = kwargs
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
+        self.assigned_partitions: set[object] = set()
         self.seeked_to_end = False
         self.started = False
         self.stopped = False
@@ -109,8 +111,14 @@ class _FakeAIOKafkaConsumer:
         await asyncio.sleep(0)
         self.started = True
 
-    def assignment(self) -> set[str]:
-        return {"partition-0"} if self.started else set()
+    def partitions_for_topic(self, topic: str) -> set[int]:
+        return {0} if self.started and topic else set()
+
+    def assign(self, partitions: set[object]) -> None:
+        self.assigned_partitions = partitions
+
+    def assignment(self) -> set[object]:
+        return self.assigned_partitions
 
     async def seek_to_end(self, *_assignment: object) -> None:
         await asyncio.sleep(0)
@@ -360,6 +368,8 @@ async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
     assert resolved_route == route
     assert result.status == "completed"
     assert result.payload == {"status": "complete", "dispatch_count": 5}
+    assert created_consumers[0].kwargs["group_id"] is None
+    assert created_consumers[0].assigned_partitions
     assert created_consumers[0].stopped is True
 
 
@@ -394,7 +404,12 @@ async def test_service_pattern_b_broker_kafka_waiter_consumes_failure_terminal(
     resolved_route, result = await broker.dispatch_request(command)
 
     assert resolved_route == route
-    assert created_consumers[0].topics[:2] == route.terminal_events
+    assert created_consumers[0].topics == ()
+    assert created_consumers[0].kwargs["group_id"] is None
+    assert {
+        getattr(partition, "topic", "")
+        for partition in created_consumers[0].assigned_partitions
+    } == set(route.terminal_events)
     assert result.status == "failed"
     assert result.error_message == "routing contract missing"
     assert created_consumers[0].stopped is True

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -96,6 +96,7 @@ async def _collect_terminal_result(
 class _FakeAIOKafkaConsumer:
     created: ClassVar[list[_FakeAIOKafkaConsumer]] = []
     stop_error: ClassVar[Exception | None] = None
+    topic_partitions_by_topic: ClassVar[dict[str, set[int]] | None] = None
 
     def __init__(self, *topics: object, **kwargs: object) -> None:
         self.topics = topics
@@ -112,7 +113,11 @@ class _FakeAIOKafkaConsumer:
         self.started = True
 
     def partitions_for_topic(self, topic: str) -> set[int]:
-        return {0} if self.started and topic else set()
+        if not self.started or not topic:
+            return set()
+        if type(self).topic_partitions_by_topic is not None:
+            return set(type(self).topic_partitions_by_topic.get(topic, set()))
+        return {0}
 
     def assign(self, partitions: set[object]) -> None:
         self.assigned_partitions = partitions
@@ -141,6 +146,7 @@ def _install_fake_aiokafka_consumer(
 ) -> list[_FakeAIOKafkaConsumer]:
     _FakeAIOKafkaConsumer.created = []
     _FakeAIOKafkaConsumer.stop_error = stop_error
+    _FakeAIOKafkaConsumer.topic_partitions_by_topic = None
     monkeypatch.setattr(
         "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
         _FakeAIOKafkaConsumer,
@@ -155,7 +161,7 @@ class _FakeKafkaTransport:
         max_poll_interval_ms=300000,
         reconnect_backoff_ms=2000,
     )
-    _bootstrap_servers = "redpanda:9092"
+    _bootstrap_servers = "pattern-b-test-broker"
 
     def __init__(
         self,
@@ -413,6 +419,34 @@ async def test_service_pattern_b_broker_kafka_waiter_consumes_failure_terminal(
     assert result.status == "failed"
     assert result.error_message == "routing contract missing"
     assert created_consumers[0].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_kafka_waiter_requires_all_terminal_topics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route_with_failure_terminal()
+    _install_fake_aiokafka_consumer(monkeypatch)
+    _FakeAIOKafkaConsumer.topic_partitions_by_topic = {
+        route.terminal_events[0]: {0},
+        route.terminal_events[1]: set(),
+    }
+    consumer = _FakeAIOKafkaConsumer()
+    await consumer.start()
+    broker = RuntimePatternBBroker(
+        _FakeKafkaTransport(route, [consumer]),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+
+    with pytest.raises(TimeoutError):
+        await broker._assign_terminal_topic_partitions(
+            consumer,
+            route.terminal_events,
+            timeout_seconds=0,
+        )
+
+    assert consumer.assigned_partitions == set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Evidence-Ticket: OMN-11318
## Summary
- switch the Pattern B one-shot terminal waiter to an ungrouped, manually assigned Kafka consumer
- keep the waiter seeking terminal partitions before dispatching the worker command
- add OMN-11318 deploy-gate contract and regression coverage

## Verification
- `uv run validate-yaml contracts/OMN-11318.yaml`
- `uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py -q`
- `uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py`
- `uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py`
- pre-commit hooks passed
- pre-push hooks passed

## Runtime Evidence
- `.201` runtime rebuilt from merged infra `363b05b2` was healthy, and delegate-skill command consumer group was stable with 1 member and 0 lag.
- `/skill` smoke correlation `86622b02-46b5-4339-ab13-2758b2851255` emitted `onex.evt.omnimarket.delegate-skill-completed.v1`, but the HTTP request did not return, proving this terminal waiter boundary.

Post-merge deploy proof still required: rebuild/restart the `.201` stability runtime from this merged change, then rerun the `/skill` smoke and verify it returns after the terminal event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pattern B terminal waiter now uses an ungrouped, manually assigned consumer for more reliable request-correlated terminal event handling.

* **Tests**
  * Enhanced unit and new integration tests to validate the updated terminal-wait behavior and consumer lifecycle.

* **Documentation**
  * Added a contract/spec file documenting the change and defining done-of-delivery checks and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1242

