### PR TITLE
fix(OMN-11318): refresh Pattern B terminal metadata

### DIFF
--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -308,6 +308,9 @@ class RuntimePatternBBroker:
         deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
         expected_topics = set(topics)
         while True:
+            topics_method = getattr(type(consumer), "topics", None)
+            if callable(topics_method):
+                await topics_method(consumer)
             partitions: set[TopicPartition] = set()
             ready_topics: set[str] = set()
             for topic in topics:

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -42,6 +42,7 @@ class _TerminalConsumer:
         self.kwargs = kwargs
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
         self.assigned_partitions: set[object] = set()
+        self.topics_calls = 0
         self.seeked_to_end = False
         self.started = False
         self.stopped = False
@@ -52,6 +53,12 @@ class _TerminalConsumer:
 
     def partitions_for_topic(self, topic: str) -> set[int]:
         return {0, 1} if self.started and topic else set()
+
+    async def topics(self) -> set[str]:
+        self.topics_calls += 1
+        return {
+            "onex.evt.omnimarket.delegate-skill-completed.v1",
+        }
 
     def assign(self, partitions: set[object]) -> None:
         self.assigned_partitions = partitions
@@ -141,4 +148,5 @@ async def test_pattern_b_terminal_waiter_uses_ungrouped_assigned_consumer(
     assert resolved_route == route
     assert result.status == "completed"
     assert result.payload == {"status": "completed", "response": "stability-smoke-ok"}
+    assert _TerminalConsumer.created[0].topics_calls >= 1
     assert _TerminalConsumer.created[0].stopped is True

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -97,12 +97,15 @@ class _FakeAIOKafkaConsumer:
     created: ClassVar[list[_FakeAIOKafkaConsumer]] = []
     stop_error: ClassVar[Exception | None] = None
     topic_partitions_by_topic: ClassVar[dict[str, set[int]] | None] = None
+    require_metadata_refresh: ClassVar[bool] = False
 
     def __init__(self, *topics: object, **kwargs: object) -> None:
         self.topics = topics
         self.kwargs = kwargs
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
         self.assigned_partitions: set[object] = set()
+        self.metadata_refreshed = False
+        self.topics_calls = 0
         self.seeked_to_end = False
         self.started = False
         self.stopped = False
@@ -112,8 +115,18 @@ class _FakeAIOKafkaConsumer:
         await asyncio.sleep(0)
         self.started = True
 
+    async def topics(self) -> set[str]:
+        await asyncio.sleep(0)
+        self.topics_calls += 1
+        self.metadata_refreshed = True
+        if type(self).topic_partitions_by_topic is not None:
+            return set(type(self).topic_partitions_by_topic)
+        return {"onex.evt.omnimarket.session-orchestrator-completed.v1"}
+
     def partitions_for_topic(self, topic: str) -> set[int]:
         if not self.started or not topic:
+            return set()
+        if type(self).require_metadata_refresh and not self.metadata_refreshed:
             return set()
         if type(self).topic_partitions_by_topic is not None:
             return set(type(self).topic_partitions_by_topic.get(topic, set()))
@@ -147,6 +160,7 @@ def _install_fake_aiokafka_consumer(
     _FakeAIOKafkaConsumer.created = []
     _FakeAIOKafkaConsumer.stop_error = stop_error
     _FakeAIOKafkaConsumer.topic_partitions_by_topic = None
+    _FakeAIOKafkaConsumer.require_metadata_refresh = False
     monkeypatch.setattr(
         "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
         _FakeAIOKafkaConsumer,
@@ -377,6 +391,35 @@ async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
     assert created_consumers[0].kwargs["group_id"] is None
     assert created_consumers[0].assigned_partitions
     assert created_consumers[0].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_service_pattern_b_broker_kafka_waiter_refreshes_topic_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    created_consumers = _install_fake_aiokafka_consumer(monkeypatch)
+    _FakeAIOKafkaConsumer.require_metadata_refresh = True
+
+    broker = RuntimePatternBBroker(
+        _FakeKafkaTransport(route, created_consumers, assert_seeked=True),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"session_orchestrator": route},
+    )
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+        timeout_seconds=1,
+    )
+
+    resolved_route, result = await broker.dispatch_request(command)
+
+    assert resolved_route == route
+    assert result.status == "completed"
+    assert created_consumers[0].topics_calls >= 1
+    assert created_consumers[0].assigned_partitions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Evidence-Source: OCC#1243
Evidence-Ticket: OMN-11318

## Summary
- refresh AIOKafkaConsumer topic metadata before assigning direct terminal partitions
- add regression coverage for the cached-metadata failure that timed out before worker command publish

## Verification
- uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q
- uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py
- uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py
- uv run validate-yaml contracts/OMN-11318.yaml
- git diff --check

## Runtime Evidence
- .201 stability smoke after #1680 returned HTTP 200 but dispatch_timeout after 30s before worker command publish
- command topic and terminal topics had no matching correlation event; AIOKafkaConsumer.partitions_for_topic reads cached metadata only, so terminal partition assignment could time out before dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Kafka consumer metadata initialization to ensure topic metadata is properly refreshed before partition assignment, improving message broker stability and reducing potential initialization failures during startup and message dispatch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->