### PR TITLE
fix(OMN-11319): track Pattern B terminal topics

### DIFF
--- a/contracts/OMN-11319.yaml
+++ b/contracts/OMN-11319.yaml
@@ -1,0 +1,40 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11319
+title: "Fix Pattern B terminal topic tracking"
+summary: "Track terminal topics on the direct aiokafka consumer client before assigning partitions so Pattern B publishes worker commands instead of timing out before dispatch."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Pattern B broker unit and integration regression tests pass"
+    command: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q"
+  - kind: "ci"
+    description: "Touched Pattern B broker files pass ruff checks"
+    command: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py"
+  - kind: "manual"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
+    command: "deploy .201 stability runtime from the merged image, then verify /skill publishes the worker command and returns after the delegate-skill terminal event"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-targeted-tests"
+    description: "Pattern B broker unit and integration regression tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q"
+  - id: "dod-ruff-check"
+    description: "Touched Pattern B broker files pass ruff checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py && uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py"
+  - id: "dod-stability-deploy-proof"
+    description: "Post-merge stability runtime rebuild/restart and delegate-skill /skill smoke proof"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy .201 stability runtime from the merged image, then verify /skill publishes the worker command and returns after the delegate-skill terminal event"

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -308,9 +309,7 @@ class RuntimePatternBBroker:
         deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
         expected_topics = set(topics)
         while True:
-            topics_method = getattr(type(consumer), "topics", None)
-            if callable(topics_method):
-                await topics_method(consumer)
+            await self._refresh_terminal_topic_metadata(consumer, topics)
             partitions: set[TopicPartition] = set()
             ready_topics: set[str] = set()
             for topic in topics:
@@ -326,6 +325,31 @@ class RuntimePatternBBroker:
             if asyncio.get_running_loop().time() >= deadline:
                 raise TimeoutError
             await asyncio.sleep(0.05)
+
+    async def _refresh_terminal_topic_metadata(
+        self,
+        consumer: AIOKafkaConsumer,
+        topics: tuple[str, ...],
+    ) -> None:
+        client = getattr(consumer, "_client", None)
+        set_topics = getattr(client, "set_topics", None)
+        if callable(set_topics):
+            result = set_topics(list(topics))
+            if inspect.isawaitable(result):
+                await result
+            return
+
+        add_topic = getattr(client, "add_topic", None)
+        if callable(add_topic):
+            for topic in topics:
+                result = add_topic(topic)
+                if inspect.isawaitable(result):
+                    await result
+            return
+
+        topics_method = getattr(type(consumer), "topics", None)
+        if callable(topics_method):
+            await topics_method(consumer)
 
     def _supports_direct_kafka_terminal_consumer(self) -> bool:
         return (

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -334,17 +333,13 @@ class RuntimePatternBBroker:
         client = getattr(consumer, "_client", None)
         set_topics = getattr(client, "set_topics", None)
         if callable(set_topics):
-            result = set_topics(list(topics))
-            if inspect.isawaitable(result):
-                await result
+            set_topics(list(topics))
             return
 
         add_topic = getattr(client, "add_topic", None)
         if callable(add_topic):
             for topic in topics:
-                result = add_topic(topic)
-                if inspect.isawaitable(result):
-                    await result
+                add_topic(topic)
             return
 
         topics_method = getattr(type(consumer), "topics", None)

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -40,9 +40,11 @@ class _TerminalConsumer:
     def __init__(self, *topics: object, **kwargs: object) -> None:
         self.topics = topics
         self.kwargs = kwargs
+        self._client = _TerminalConsumerClient(self)
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
         self.assigned_partitions: set[object] = set()
         self.topics_calls = 0
+        self.set_topics_calls: list[tuple[str, ...]] = []
         self.seeked_to_end = False
         self.started = False
         self.stopped = False
@@ -52,7 +54,9 @@ class _TerminalConsumer:
         self.started = True
 
     def partitions_for_topic(self, topic: str) -> set[int]:
-        return {0, 1} if self.started and topic else set()
+        if not self.started or topic not in self._client.tracked_topics:
+            return set()
+        return {0, 1}
 
     async def topics(self) -> set[str]:
         self.topics_calls += 1
@@ -74,6 +78,17 @@ class _TerminalConsumer:
 
     async def stop(self) -> None:
         self.stopped = True
+
+
+class _TerminalConsumerClient:
+    def __init__(self, consumer: _TerminalConsumer) -> None:
+        self._consumer = consumer
+        self.tracked_topics: set[str] = set()
+
+    async def set_topics(self, topics: list[str]) -> bool:
+        self.tracked_topics = set(topics)
+        self._consumer.set_topics_calls.append(tuple(topics))
+        return True
 
 
 class _KafkaLikeTransport:
@@ -148,5 +163,7 @@ async def test_pattern_b_terminal_waiter_uses_ungrouped_assigned_consumer(
     assert resolved_route == route
     assert result.status == "completed"
     assert result.payload == {"status": "completed", "response": "stability-smoke-ok"}
-    assert _TerminalConsumer.created[0].topics_calls >= 1
+    assert _TerminalConsumer.created[0].set_topics_calls == [
+        ("onex.evt.omnimarket.delegate-skill-completed.v1",)
+    ]
     assert _TerminalConsumer.created[0].stopped is True

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -85,7 +85,7 @@ class _TerminalConsumerClient:
         self._consumer = consumer
         self.tracked_topics: set[str] = set()
 
-    async def set_topics(self, topics: list[str]) -> bool:
+    def set_topics(self, topics: list[str]) -> bool:
         self.tracked_topics = set(topics)
         self._consumer.set_topics_calls.append(tuple(topics))
         return True

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -164,8 +164,7 @@ class _FakeAIOKafkaClient:
         self._consumer = consumer
         self.tracked_topics: set[str] = set()
 
-    async def set_topics(self, topics: list[str]) -> bool:
-        await asyncio.sleep(0)
+    def set_topics(self, topics: list[str]) -> bool:
         self.tracked_topics = set(topics)
         self._consumer.set_topics_calls.append(tuple(topics))
         self._consumer.metadata_refreshed = True

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -102,10 +102,12 @@ class _FakeAIOKafkaConsumer:
     def __init__(self, *topics: object, **kwargs: object) -> None:
         self.topics = topics
         self.kwargs = kwargs
+        self._client = _FakeAIOKafkaClient(self)
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
         self.assigned_partitions: set[object] = set()
         self.metadata_refreshed = False
         self.topics_calls = 0
+        self.set_topics_calls: list[tuple[str, ...]] = []
         self.seeked_to_end = False
         self.started = False
         self.stopped = False
@@ -127,6 +129,11 @@ class _FakeAIOKafkaConsumer:
         if not self.started or not topic:
             return set()
         if type(self).require_metadata_refresh and not self.metadata_refreshed:
+            return set()
+        if (
+            type(self).require_metadata_refresh
+            and topic not in self._client.tracked_topics
+        ):
             return set()
         if type(self).topic_partitions_by_topic is not None:
             return set(type(self).topic_partitions_by_topic.get(topic, set()))
@@ -150,6 +157,19 @@ class _FakeAIOKafkaConsumer:
         if type(self).stop_error is not None:
             raise type(self).stop_error
         self.stopped = True
+
+
+class _FakeAIOKafkaClient:
+    def __init__(self, consumer: _FakeAIOKafkaConsumer) -> None:
+        self._consumer = consumer
+        self.tracked_topics: set[str] = set()
+
+    async def set_topics(self, topics: list[str]) -> bool:
+        await asyncio.sleep(0)
+        self.tracked_topics = set(topics)
+        self._consumer.set_topics_calls.append(tuple(topics))
+        self._consumer.metadata_refreshed = True
+        return True
 
 
 def _install_fake_aiokafka_consumer(
@@ -418,7 +438,7 @@ async def test_service_pattern_b_broker_kafka_waiter_refreshes_topic_metadata(
 
     assert resolved_route == route
     assert result.status == "completed"
-    assert created_consumers[0].topics_calls >= 1
+    assert created_consumers[0].set_topics_calls
     assert created_consumers[0].assigned_partitions
 
 


### PR DESCRIPTION
Evidence-Source: OCC#1245
Evidence-Ticket: OMN-11319

## Summary
- track terminal topics on the direct aiokafka consumer client before assigning partitions
- keep the fallback all-topic metadata refresh for non-aiokafka fakes/transports
- add regression coverage for the real metadata behavior observed on .201
- simplify metadata refresh to match synchronous aiokafka client methods and resolve CodeQL no-effect review threads

## Verification
- uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py -q
- uv run ruff format --check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py
- uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/integration/test_pattern_b_broker_terminal_waiter.py
- uv run validate-yaml contracts/OMN-11319.yaml
- uv run mypy src/ --strict
- git diff --check

## OCC Evidence
- onex_change_control#1245 merged with refreshed central OMN-11319 contract receipts for the current PR head.

## Runtime Evidence
- .201 rebuilt from omnibase_infra main b8a2347e and both runtime services were healthy.
- /skill smoke correlation a50a826c-89c3-40c0-8295-4b3f4ba8b163 returned dispatch_timeout after 30s.
- command group stayed Stable with MEMBERS=1 and TOTAL-LAG=0, but no command or terminal event existed for the correlation.
- In the runtime container, AIOKafkaConsumer.topics() included onex.evt.omnimarket.delegate-skill-completed.v1 while partitions_for_topic() remained None until the consumer client tracked the topic.

Post-merge deploy proof still required: rebuild/restart the .201 stability runtime from this merged change, rerun /skill smoke, and verify the worker command plus terminal event for the smoke correlation.
