### PR TITLE
fix(OMN-11320): pin dependency cascade release version

### DIFF
--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -150,8 +150,22 @@ jobs:
         run: |
           git checkout -b "${{ steps.vars.outputs.branch }}"
 
-          # Upgrade the package in the lockfile
-          uv lock --upgrade-package "${{ inputs.package }}"
+          # Upgrade the lockfile to the released version. Passing the explicit
+          # package spec prevents uv from selecting a different latest version.
+          # PyPI's simple index can lag just after publish, so refresh and retry.
+          SPEC="${{ steps.vars.outputs.pkg_hyphen }}==${{ steps.vars.outputs.version }}"
+          for attempt in $(seq 1 12); do
+            if uv lock \
+              --refresh-package "${{ steps.vars.outputs.pkg_hyphen }}" \
+              --upgrade-package "$SPEC"; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "ERROR: failed to resolve $SPEC after $attempt attempts"
+              exit 1
+            fi
+            sleep 10
+          done
 
           # Check if anything changed
           if git diff --quiet uv.lock; then
@@ -168,24 +182,9 @@ jobs:
           BUMP_PACKAGE: ${{ inputs.package }}
         run: |
           PKG_HYPHEN="${BUMP_PACKAGE//_/-}"
-          export PKG_HYPHEN
-
-          RESOLVED=$(python3 - <<'PYEOF'
-          import re, sys, os
-          pkg = os.environ["PKG_HYPHEN"]
-          content = open("uv.lock").read()
-          m = re.search(
-              r'name\s*=\s*"' + re.escape(pkg) + r'".*?version\s*=\s*"([^"]+)"',
-              content, re.DOTALL
-          )
-          if m:
-              print(m.group(1))
-          else:
-              sys.exit(1)
-          PYEOF
-          )
-          echo "Resolved version for ${PKG_HYPHEN}: ${RESOLVED}"
-          export RESOLVED
+          RESOLVED="${{ steps.vars.outputs.version }}"
+          export PKG_HYPHEN RESOLVED
+          echo "Pinned version for ${PKG_HYPHEN}: ${RESOLVED}"
 
           python3 - <<'PYEOF'
           import re, os

--- a/contracts/OMN-11320.yaml
+++ b/contracts/OMN-11320.yaml
@@ -1,0 +1,40 @@
+schema_version: "1.0.0"
+ticket_id: OMN-11320
+title: "Fix dependency cascade release-version pinning"
+summary: "Pin downstream dependency-cascade PRs to the released package version and refresh package metadata with retries so immediate post-release PRs do not select invalid or stale versions."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "manual"
+    description: "Dependency cascade workflow uses the explicit release version and refreshes package metadata before resolving"
+    command: "python3 - <<'PY'\nfrom pathlib import Path\ntext = Path('.github/workflows/dependency-cascade.yml').read_text()\nfor snippet in ('--refresh-package \"${{ steps.vars.outputs.pkg_hyphen }}\"', '--upgrade-package \"$SPEC\"', 'RESOLVED=\"${{ steps.vars.outputs.version }}\"'):\n    assert snippet in text\nPY"
+  - kind: "ci"
+    description: "Workflow patch has no whitespace errors"
+    command: "git diff --check"
+  - kind: "manual"
+    description: "Existing downstream cascade branches resolve omnibase-infra 0.36.0 with locked installs"
+    command: "uv sync --locked in omnimemory and omniclaude cascade worktrees"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-workflow-snippets"
+    description: "Dependency cascade workflow uses explicit version pin, refresh, and retry"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "python3 - <<'PY'\nfrom pathlib import Path\ntext = Path('.github/workflows/dependency-cascade.yml').read_text()\nfor snippet in ('--refresh-package \"${{ steps.vars.outputs.pkg_hyphen }}\"', '--upgrade-package \"$SPEC\"', 'RESOLVED=\"${{ steps.vars.outputs.version }}\"'):\n    assert snippet in text\nPY"
+  - id: "dod-diff-check"
+    description: "Workflow patch has no whitespace errors"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "git diff --check"
+  - id: "dod-downstream-locks"
+    description: "Existing downstream cascade branches resolve omnibase-infra 0.36.0 with locked installs"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv sync --locked in omnimemory and omniclaude cascade worktrees"


### PR DESCRIPTION
## Summary
- pin dependency cascade lock updates to the explicit release version instead of parsing the lockfile
- refresh package metadata and retry so just-published releases are resolvable before opening downstream PRs
- add OMN-11320 contract evidence

## Verification
- `uv run validate-yaml contracts/OMN-11320.yaml`
- workflow snippet assertion for explicit pin/refresh/retry behavior
- `git diff --check`
- downstream repaired branches: `uv sync --locked` in `omnimemory` and `omniclaude` worktrees resolves `omnibase-infra==0.36.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the dependency cascade workflow with improved retry logic and explicit version pinning for package resolution.
  * Added specification documentation for dependency cascade release procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1246

Evidence-Ticket: OMN-11320