### PR TITLE
fix(OMN-11350): preserve typed envelopes in auto wiring

### DIFF
--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -1,0 +1,32 @@
+# OMN-11350 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-11350
+title: "Fix stability runtime auto-wiring errors"
+summary: "Preserve typed envelopes for envelope-style auto-wired handlers and make projection terminal event emission tolerate materialized dispatch dicts."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Focused unit and integration tests cover typed payload handlers, typed envelope handlers, materialized dispatch dicts, and heartbeat dispatcher compatibility."
+    command: "uv run pytest tests/integration/test_auto_wiring_typed_envelope_runtime.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/registration/dispatchers/test_dispatcher_node_heartbeat.py -q"
+  - kind: manual
+    description: "Deploy proof: .201 stability runtime rebuilt and restarted from PR source, then health and log scans verified the previous auto-wiring failures are gone."
+    command: "deploy: rebuild omninode-runtime and runtime-effects on .201; verify /health on 18085 and 18086 plus log scan for prior HandlerNodeHeartbeat and projection terminal AttributeError signatures"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-focused-auto-wiring-tests
+    description: "Focused unit and integration tests for the auto-wiring regression pass."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/integration/test_auto_wiring_typed_envelope_runtime.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/registration/dispatchers/test_dispatcher_node_heartbeat.py -q"
+  - id: dod-deploy-stability-runtime
+    description: "Deploy scope: runtime path change was rebuilt and validated on the .201 stability runtime."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: .201 stability runtime rebuilt from PR source; omninode-runtime and runtime-effects healthy; prior HandlerNodeHeartbeat payload AttributeError, projection terminal correlation_id AttributeError, and Dispatch completed with errors signatures absent in steady-state log scan"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -34,7 +34,14 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast, get_args, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Protocol,
+    cast,
+    get_args,
+    get_origin,
+    runtime_checkable,
+)
 
 from pydantic import BaseModel
 
@@ -328,7 +335,9 @@ def _make_dispatch_callback(
     """Create a dispatch callback wrapping a handler instance.
 
     Legacy handlers receive the materialized dispatch envelope. Contract-typed
-    handlers receive a validated payload model and may be sync or async.
+    handlers receive a validated payload model and may be sync or async. Handlers
+    that declare an envelope-shaped signature keep receiving a typed envelope
+    even when their contract declares ``event_model``.
     """
 
     async def _callback(
@@ -354,6 +363,20 @@ def _make_dispatch_callback(
             if isinstance(payload, model_cls)
             else model_cls.model_validate(payload)
         )
+        if _handler_accepts_event_envelope(handle_method):
+            handler_envelope = _materialize_typed_event_envelope(
+                envelope,
+                typed_payload,
+                event_model.name,
+            )
+            typed_handle = cast("Callable[[object], object]", handle_method)
+            envelope_result: object = typed_handle(handler_envelope)
+            if asyncio.iscoroutine(envelope_result):
+                envelope_result = await cast("Awaitable[object]", envelope_result)
+            return _normalize_handler_result(
+                envelope_result, envelope, event_model.name
+            )
+
         typed_handle = cast("Callable[[object], object]", handle_method)
         typed_result: object = typed_handle(typed_payload)
         if asyncio.iscoroutine(typed_result):
@@ -372,6 +395,131 @@ def _import_event_model_class(event_model: ModelHandlerRef) -> type[BaseModel]:
             "does not expose model_validate"
         )
     return cast("type[BaseModel]", model_cls)
+
+
+def _handler_accepts_event_envelope(handle_method: object) -> bool:
+    """Return true when a handler's first parameter is envelope-shaped."""
+    try:
+        signature = inspect.signature(cast("Callable[..., object]", handle_method))
+    except (TypeError, ValueError):
+        return False
+
+    for parameter in signature.parameters.values():
+        if parameter.name == "self":
+            continue
+        if parameter.kind not in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            continue
+        if parameter.name == "envelope":
+            return True
+        return _annotation_mentions_event_envelope(parameter.annotation)
+    return False
+
+
+def _annotation_mentions_event_envelope(annotation: object) -> bool:
+    if annotation is inspect.Signature.empty:
+        return False
+    if isinstance(annotation, str):
+        return "ModelEventEnvelope" in annotation
+    if getattr(annotation, "__name__", "") == "ModelEventEnvelope":
+        return True
+    origin = get_origin(annotation)
+    if getattr(origin, "__name__", "") == "ModelEventEnvelope":
+        return True
+    return any(_annotation_mentions_event_envelope(arg) for arg in get_args(annotation))
+
+
+def _coerce_uuid_or_none(value: object) -> object | None:
+    from uuid import UUID
+
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return UUID(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_datetime_or_none(value: object) -> object | None:
+    from datetime import UTC, datetime
+
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if isinstance(value, str) and value:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _extract_dispatch_envelope_timestamp(envelope: object) -> object | None:
+    if isinstance(envelope, Mapping):
+        candidate = envelope.get("envelope_timestamp")
+        if candidate is not None:
+            return candidate
+        candidate = envelope.get("timestamp")
+        if candidate is not None:
+            return candidate
+        debug_trace = envelope.get("__debug_trace")
+        if isinstance(debug_trace, Mapping):
+            return debug_trace.get("envelope_timestamp") or debug_trace.get("timestamp")
+    return getattr(envelope, "envelope_timestamp", None)
+
+
+def _extract_dispatch_event_type(envelope: object) -> object | None:
+    if isinstance(envelope, Mapping):
+        candidate = envelope.get("event_type")
+        if candidate is not None:
+            return candidate
+        debug_trace = envelope.get("__debug_trace")
+        if isinstance(debug_trace, Mapping):
+            return debug_trace.get("event_type")
+    return getattr(envelope, "event_type", None)
+
+
+def _materialize_typed_event_envelope(
+    envelope: object,
+    typed_payload: BaseModel,
+    fallback_event_type: str,
+) -> ModelEventEnvelope[object]:
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+    if isinstance(envelope, ModelEventEnvelope):
+        updates: dict[str, object] = {"payload": typed_payload}
+        if envelope.event_type is None:
+            updates["event_type"] = fallback_event_type
+        if envelope.payload_type is None:
+            updates["payload_type"] = type(typed_payload).__name__
+        return envelope.model_copy(update=updates)
+
+    correlation_id = _coerce_uuid_or_none(
+        _extract_dispatch_correlation_id(envelope, typed_payload)
+    )
+    envelope_timestamp = _coerce_datetime_or_none(
+        _extract_dispatch_envelope_timestamp(envelope)
+    )
+    event_type = _extract_dispatch_event_type(envelope)
+
+    return ModelEventEnvelope[object](
+        payload=typed_payload,
+        correlation_id=correlation_id if correlation_id is not None else uuid4(),
+        envelope_timestamp=(
+            envelope_timestamp if envelope_timestamp is not None else datetime.now(UTC)
+        ),
+        event_type=str(event_type or fallback_event_type),
+        payload_type=type(typed_payload).__name__,
+        source_tool="auto-wiring",
+    )
 
 
 def _extract_dispatch_payload(envelope: object) -> object:
@@ -791,7 +939,7 @@ def _make_projection_dispatch_callback(
 async def _emit_projection_terminal_event(
     event_bus: object,
     terminal_event: str,
-    source_envelope: ModelEventEnvelope[object],
+    source_envelope: object,
 ) -> None:
     """Publish a terminal event after a successful DB projection.
 
@@ -804,9 +952,13 @@ async def _emit_projection_terminal_event(
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 
     try:
+        source_payload = _extract_dispatch_payload(source_envelope)
+        correlation_id = _coerce_uuid_or_none(
+            _extract_dispatch_correlation_id(source_envelope, source_payload)
+        )
         terminal_envelope = ModelEventEnvelope[object](
             payload={"projected": True},
-            correlation_id=source_envelope.correlation_id,
+            correlation_id=correlation_id,
             envelope_timestamp=datetime.now(UTC),
             event_type=terminal_event,
             source_tool="projection-reducer",

--- a/tests/integration/test_auto_wiring_typed_envelope_runtime.py
+++ b/tests/integration/test_auto_wiring_typed_envelope_runtime.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration regressions for runtime auto-wiring typed envelope dispatch."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.enums import EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _make_dispatch_callback
+from omnibase_infra.runtime.auto_wiring.models import ModelHandlerRef
+
+
+class RuntimeTypedPayload(BaseModel):
+    correlation_id: UUID
+    value: str
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_event_model_dispatch_preserves_envelope_handler_signature() -> None:
+    """Declared event_model routes still support ProtocolMessageHandler shape."""
+    received: list[ModelEventEnvelope[RuntimeTypedPayload]] = []
+
+    class Handler:
+        async def handle(
+            self,
+            envelope: ModelEventEnvelope[RuntimeTypedPayload],
+        ) -> ModelHandlerOutput[object]:
+            received.append(envelope)
+            return ModelHandlerOutput(
+                input_envelope_id=envelope.envelope_id,
+                correlation_id=envelope.payload.correlation_id,
+                handler_id="handler-runtime-typed-envelope",
+                node_kind=EnumNodeKind.ORCHESTRATOR,
+                events=(),
+                intents=(),
+                projections=(),
+                result=None,
+                processing_time_ms=0.0,
+                timestamp=envelope.envelope_timestamp,
+            )
+
+    correlation_id = UUID("33333333-3333-4333-8333-333333333333")
+    callback = _make_dispatch_callback(
+        Handler(),
+        ModelHandlerRef(name="RuntimeTypedPayload", module=__name__),
+    )
+
+    result = await callback(
+        {
+            "payload": {
+                "correlation_id": str(correlation_id),
+                "value": "heartbeat",
+            },
+            "__debug_trace": {
+                "topic": "onex.evt.platform.node-heartbeat.v1",
+                "event_type": "platform.node-heartbeat",
+                "correlation_id": str(correlation_id),
+            },
+        }
+    )
+
+    assert len(received) == 1
+    assert isinstance(received[0], ModelEventEnvelope)
+    assert isinstance(received[0].payload, RuntimeTypedPayload)
+    assert received[0].payload.value == "heartbeat"
+    assert received[0].correlation_id == correlation_id
+    assert result is not None
+    assert result.correlation_id == correlation_id

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -339,6 +339,56 @@ def test_projection_callback_emits_terminal_event_on_success() -> None:
 
 
 @pytest.mark.unit
+def test_projection_callback_emits_terminal_event_from_materialized_dict() -> None:
+    """Terminal event correlation is extracted from materialized dispatch dicts."""
+    import json
+    import uuid
+
+    published: list[tuple] = []
+    test_correlation_id = uuid.uuid4()
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            return {"rows_upserted": 1}
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    terminal_topic = "onex.evt.omnimarket.projection-delegation-applied.v1"
+    callback = _make_projection_dispatch_callback(
+        FakeHandler(),
+        db_tables,
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        event_bus=FakeEventBus(),
+        terminal_event=terminal_topic,
+    )
+    envelope = {
+        "payload": {"task_type": "code-review"},
+        "__debug_trace": {
+            "topic": "onex.evt.omniclaude.task-delegated.v1",
+            "correlation_id": str(test_correlation_id),
+        },
+    }
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))  # type: ignore[arg-type]
+
+    assert len(published) == 1
+    topic_published, _, raw_bytes = published[0]
+    assert topic_published == terminal_topic
+    parsed = json.loads(raw_bytes.decode("utf-8"))
+    assert parsed["event_type"] == terminal_topic
+    assert parsed["correlation_id"] == str(test_correlation_id)
+
+
+@pytest.mark.unit
 def test_projection_callback_does_not_emit_terminal_event_on_handler_error() -> None:
     """When handler raises, no terminal event is emitted."""
     published: list[tuple] = []

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -272,6 +272,57 @@ class TestMakeDispatchCallback:
         assert isinstance(result.output_events[0], FakeTypedOutput)
         assert result.output_events[0].result == "handled:market"
 
+    @pytest.mark.asyncio
+    async def test_callback_preserves_envelope_for_typed_envelope_handler(
+        self,
+    ) -> None:
+        received: list[ModelEventEnvelope[FakeTypedPayload]] = []
+
+        class Handler:
+            async def handle(
+                self,
+                envelope: ModelEventEnvelope[FakeTypedPayload],
+            ) -> FakeTypedOutput:
+                received.append(envelope)
+                return FakeTypedOutput(
+                    correlation_id=envelope.payload.correlation_id,
+                    result=f"handled:{envelope.payload.value}",
+                )
+
+        correlation_id = UUID("22222222-2222-4222-8222-222222222222")
+        callback = _make_dispatch_callback(
+            Handler(),
+            ModelHandlerRef(
+                name="FakeTypedPayload",
+                module=__name__,
+            ),
+        )
+
+        result = await callback(
+            {
+                "payload": {
+                    "correlation_id": str(correlation_id),
+                    "value": "registration",
+                },
+                "__debug_trace": {
+                    "topic": "onex.evt.platform.node-heartbeat.v1",
+                    "event_type": "platform.node-heartbeat",
+                    "correlation_id": str(correlation_id),
+                },
+            }
+        )
+
+        assert len(received) == 1
+        assert isinstance(received[0], ModelEventEnvelope)
+        assert isinstance(received[0].payload, FakeTypedPayload)
+        assert received[0].correlation_id == correlation_id
+        assert received[0].event_type == "platform.node-heartbeat"
+        assert result is not None
+        assert result.correlation_id == correlation_id
+        assert len(result.output_events) == 1
+        assert isinstance(result.output_events[0], FakeTypedOutput)
+        assert result.output_events[0].result == "handled:registration"
+
 
 class TestTerminalEventResultApplier:
     @pytest.mark.asyncio


### PR DESCRIPTION
Evidence-Source: 655e7e487c8a4f872589bc692129e95fbc87bb47
Evidence-Ticket: OMN-11350
Ticket: OMN-11350

## Summary
- Preserve envelope-style handler signatures when auto-wiring validates a declared event_model payload.
- Materialize typed envelopes from dispatch dicts so registration orchestrator handlers keep receiving ModelEventEnvelope payloads.
- Emit projection terminal events from materialized dispatch dicts by extracting correlation_id without assuming object attributes.

## Verification
- uv run pytest tests/integration/test_auto_wiring_typed_envelope_runtime.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/registration/dispatchers/test_dispatcher_node_heartbeat.py -q
- pre-commit during commit: all local hooks passed
- pre-push: mypy and architecture layer validation passed
- Stability runtime .201 rebuilt/restarted from commit 1d7e7dbb; /health healthy on 18085 and 18086
- Stability runtime log scan clean for previous failures: HandlerNodeHeartbeat payload AttributeError, projection terminal correlation_id AttributeError, and Dispatch completed with errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event envelope handling and dispatching capabilities in the runtime system for improved event processing

* **Chores**
  * Added new deployment verification contract for ticket OMN-11350
  * Expanded test coverage for event envelope dispatch scenarios and correlation ID preservation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->