### PR TITLE
fix(OMN-11350): validate runtime smoke consumer groups

### DIFF
--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -25,7 +25,8 @@
 #       - `RuntimeHostError` / `ServiceResolutionError` raised at boot
 #       - `load_runtime_config` fatal errors (service_kernel.py config gate)
 #   * registration_projections row count > 0 (active + fresh heartbeat)
-#   * rpk group list contains `onex-runtime` with >= 1 member
+#   * /health reports runtime + runtime-effects Kafka consumers and rpk group
+#     list contains stable deterministic runtime consumer groups
 #
 # Warn-only observations (never fail the job):
 #   * subscriber_count < 300 (empirical .201 threshold; see
@@ -476,33 +477,62 @@ jobs:
             exit 1
           fi
 
-      - name: Assert onex-runtime consumer group has members
+      - name: Assert runtime consumer groups are active
         id: rpk_groups
         run: |
           set -euo pipefail
-          if [[ "${{ inputs.mode }}" == "compose" ]]; then
-            raw=$(docker exec omnibase-infra-redpanda rpk group list)
-          else
-            user="${{ inputs.real_ssh_user }}"
-            if [[ -z "$user" ]]; then
-              user="$(whoami)"
+
+          runtime_consumer_count=$(jq -r '.details.event_bus.consumer_count // 0' health_initial.json)
+          effects_consumer_count=$(jq -r '.details.event_bus.consumer_count // 0' effects_health_initial.json)
+          if [[ "${runtime_consumer_count}" -lt 1 ]]; then
+            echo "::error::runtime /health reports 0 Kafka consumers"
+            jq -c '{status, details: {event_bus: .details.event_bus}}' health_initial.json || true
+            exit 1
+          fi
+          if [[ "${effects_consumer_count}" -lt 1 ]]; then
+            echo "::error::runtime-effects /health reports 0 Kafka consumers"
+            jq -c '{status, details: {event_bus: .details.event_bus}}' effects_health_initial.json || true
+            exit 1
+          fi
+
+          for attempt in $(seq 1 10); do
+            if [[ "${{ inputs.mode }}" == "compose" ]]; then
+              raw=$(docker exec omnibase-infra-redpanda rpk group list)
+            else
+              user="${{ inputs.real_ssh_user }}"
+              if [[ -z "$user" ]]; then
+                user="$(whoami)"
+              fi
+              raw=$(ssh -o StrictHostKeyChecking=no "${user}@${RUNTIME_HOST}" "docker exec omnibase-infra-redpanda rpk group list")
             fi
-            raw=$(ssh -o StrictHostKeyChecking=no "${user}@${RUNTIME_HOST}" "docker exec omnibase-infra-redpanda rpk group list")
+            echo "$raw" > rpk_groups.txt
+
+            runtime_group_count=$(awk 'NR > 1 && $2 ~ /^local\.omnibase_infra\./ {count++} END {print count + 0}' rpk_groups.txt)
+            effects_group_count=$(awk 'NR > 1 && $2 ~ /^local\.runtime_config\./ {count++} END {print count + 0}' rpk_groups.txt)
+            unstable_groups=$(awk 'NR > 1 && $2 ~ /^local\.(omnibase_infra|runtime_config)\./ && $3 != "Stable" {print}' rpk_groups.txt)
+            if [[ "${runtime_group_count}" -gt 0 && "${effects_group_count}" -gt 0 && -z "${unstable_groups}" ]]; then
+              echo "runtime consumer groups active: runtime=${runtime_group_count} effects=${effects_group_count}"
+              exit 0
+            fi
+            echo "waiting for runtime consumer groups: attempt=${attempt} runtime=${runtime_group_count} effects=${effects_group_count}"
+            if [[ -n "${unstable_groups}" ]]; then
+              echo "unstable runtime groups:"
+              echo "${unstable_groups}"
+            fi
+            sleep 2
+          done
+
+          echo "::error::runtime consumer groups did not stabilize"
+          runtime_group_count=$(awk 'NR > 1 && $2 ~ /^local\.omnibase_infra\./ {count++} END {print count + 0}' rpk_groups.txt)
+          effects_group_count=$(awk 'NR > 1 && $2 ~ /^local\.runtime_config\./ {count++} END {print count + 0}' rpk_groups.txt)
+          echo "runtime_group_count=${runtime_group_count} effects_group_count=${effects_group_count}"
+          unstable_groups=$(awk 'NR > 1 && $2 ~ /^local\.(omnibase_infra|runtime_config)\./ && $3 != "Stable" {print}' rpk_groups.txt)
+          if [[ -n "${unstable_groups}" ]]; then
+            echo "unstable runtime groups:"
+            echo "${unstable_groups}"
           fi
-          echo "$raw" > rpk_groups.txt
-          if ! grep -qE '(^|[[:space:]])onex-runtime([[:space:]]|$)' rpk_groups.txt; then
-            echo "::error::rpk group list missing onex-runtime group"
-            cat rpk_groups.txt
-            exit 1
-          fi
-          # Assert the group has at least one member — presence alone is not enough.
-          member_count=$(echo "$raw" | awk '/onex-runtime/{print $NF}' | grep -E '^[0-9]+$' | head -1 || echo "0")
-          if [[ -z "$member_count" ]] || [[ "$member_count" -lt 1 ]]; then
-            echo "::error::onex-runtime consumer group has 0 members (got '${member_count}')"
-            cat rpk_groups.txt
-            exit 1
-          fi
-          echo "onex-runtime group member_count=${member_count}"
+          cat rpk_groups.txt
+          exit 1
 
       - name: Emit smoke-result.json artifact
         if: always()

--- a/tests/ci/test_reusable_runtime_boot_schema.py
+++ b/tests/ci/test_reusable_runtime_boot_schema.py
@@ -20,9 +20,9 @@ Tier-2 regression (OMN-9252) can safely call it via `workflow_call`. Asserts:
   60s hold with both PIDs alive + both health checks (compose) / flapping
   tolerance (real), startup log gating for duplicate dispatcher /
   auto-wiring / service-resolution failures (OMN-9458), psql
-  registration_projections liveness query, rpk group list check, and
-  smoke-result.json artifact upload guarded against missing intermediate
-  files.
+  registration_projections liveness query, deterministic runtime consumer-group
+  liveness check, and smoke-result.json artifact upload guarded against missing
+  intermediate files.
 """
 
 from __future__ import annotations
@@ -330,6 +330,11 @@ def test_boot_has_rpk_group_list_step(workflow: Workflow) -> None:
     steps = _boot_steps(workflow)
     matched = [s for s in steps if "rpk group list" in _step_text(s)]
     assert matched, "rpk group list check missing"
+    step_texts = "\n".join(_step_text(s) for s in matched)
+    assert "consumer_count" in step_texts
+    assert "local\\.omnibase_infra" in step_texts
+    assert "local\\.runtime_config" in step_texts
+    assert "onex-runtime" not in step_texts
 
 
 def test_boot_uploads_smoke_result_artifact(workflow: Workflow) -> None:


### PR DESCRIPTION
## Summary
- Replace stale onex-runtime aggregate group assertion in reusable runtime boot smoke
- Validate runtime and runtime-effects health consumer counts plus stable deterministic rpk group prefixes
- Update workflow schema test coverage for the current group contract

## Verification
- uv run pytest tests/ci/test_reusable_runtime_boot_schema.py -q
- uv run ruff format --check tests/ci/test_reusable_runtime_boot_schema.py
- uv run ruff check tests/ci/test_reusable_runtime_boot_schema.py
- Parsed failed CI artifact: runtime=60 effects=62 stable runtime groups
- CI Summary: pass
- Runtime Boot Smoke (compose): pass

Linear: OMN-11350

Evidence-Source: 36871cf6aaf1c29bc2780d8c449888a37477e2a8
Evidence-PR: OCC#1274
Evidence-Ticket: OMN-11350
