### PR TITLE
fix(OMN-11350): repair ledger projection binding expression

### DIFF
--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -1,8 +1,8 @@
 # OMN-11350 contract file for omnibase_infra deploy-gate.
 schema_version: "1.0.0"
 ticket_id: OMN-11350
-title: "Fix stability runtime auto-wiring errors"
-summary: "Preserve typed envelopes for envelope-style auto-wired handlers and make projection terminal event emission tolerate materialized dispatch dicts."
+title: "Fix stability runtime startup errors"
+summary: "Preserve typed envelopes for envelope-style auto-wired handlers, make projection terminal event emission tolerate materialized dispatch dicts, and repair the ledger projection handler binding expression rejected during stability runtime startup."
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -13,6 +13,9 @@ evidence_requirements:
   - kind: manual
     description: "Deploy proof: .201 stability runtime rebuilt and restarted from PR source, then health and log scans verified the previous auto-wiring failures are gone."
     command: "deploy: rebuild omninode-runtime and runtime-effects on .201; verify /health on 18085 and 18086 plus log scan for prior HandlerNodeHeartbeat and projection terminal AttributeError signatures"
+  - kind: tests
+    description: "Operation-bindings loader parses the packaged ledger projection handler contract without the invalid bare ${payload} expression."
+    command: "uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -30,3 +33,9 @@ dod_evidence:
     checks:
       - check_type: command
         check_value: "deploy: .201 stability runtime rebuilt from PR source; omninode-runtime and runtime-effects healthy; prior HandlerNodeHeartbeat payload AttributeError, projection terminal correlation_id AttributeError, and Dispatch completed with errors signatures absent in steady-state log scan"
+  - id: dod-ledger-binding-loader
+    description: "Ledger projection handler contract no longer uses invalid bare payload binding syntax."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q"

--- a/src/omnibase_infra/nodes/node_ledger_projection_compute/handlers/contract.yaml
+++ b/src/omnibase_infra/nodes/node_ledger_projection_compute/handlers/contract.yaml
@@ -40,7 +40,7 @@ operation_bindings:
   bindings:
     "ledger.project":
       - parameter_name: "message"
-        expression: "${payload}"
+        expression: "${envelope.payload}"
         required: true
 metadata:
   description: "Ledger projection handler that transforms ModelEventMessage to ModelIntent with ModelPayloadLedgerAppend for audit ledger persistence"

--- a/tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py
+++ b/tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py
@@ -119,6 +119,24 @@ class TestLoadOperationBindingsHappyPath:
         assert "test.operation" in result.bindings
         assert len(result.bindings["test.operation"]) == 1
 
+    def test_load_packaged_ledger_projection_contract(self) -> None:
+        """Packaged ledger projection contract uses valid binding expressions."""
+        contract_path = (
+            Path("src/omnibase_infra/nodes/node_ledger_projection_compute")
+            / "handlers/contract.yaml"
+        )
+
+        result = load_operation_bindings_subcontract(
+            contract_path,
+            io_operations=["ledger.project"],
+        )
+
+        binding = result.bindings["ledger.project"][0]
+        assert binding.parameter_name == "message"
+        assert binding.source == "envelope"
+        assert binding.path_segments == ("payload",)
+        assert binding.original_expression == "${envelope.payload}"
+
     def test_load_with_global_bindings(self, tmp_path: Path) -> None:
         """Contract with global_bindings loads correctly."""
         contract = {

--- a/tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py
+++ b/tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py
@@ -119,6 +119,8 @@ class TestLoadOperationBindingsHappyPath:
         assert "test.operation" in result.bindings
         assert len(result.bindings["test.operation"]) == 1
 
+    @pytest.mark.unit
+    @pytest.mark.unit
     def test_load_packaged_ledger_projection_contract(self) -> None:
         """Packaged ledger projection contract uses valid binding expressions."""
         contract_path = (


### PR DESCRIPTION
## Summary
- Replace the invalid bare `${payload}` operation binding in the ledger projection handler contract with `${envelope.payload}`.
- Add a packaged-contract loader regression test so startup binding syntax errors are caught locally.
- Extend the repo-local OMN-11350 deploy contract with the ledger binding proof.

## Verification
- `uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q` -> 76 passed
- `uv run ruff format --check tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py`
- `uv run ruff check tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py`
- `uv run validate-yaml contracts/OMN-11350.yaml`
- `.201` stability runtime rebuilt/recreated from commit `62727494daa3ae0d5937230f1fb1b85726c4dc6d`
- `.201` `:18085/health`: healthy, version `0.36.1`, failed_handlers `{}`, subscribers/consumers `211/211`
- `.201` `:18086/health`: healthy, version `0.36.1`, failed_handlers `{}`, subscribers/consumers `75/75`
- `.201` log scan found no `Invalid expression syntax: ${payload}`, no `HandlerNodeHeartbeat.*failed`, no `.payload` AttributeError, no projection terminal correlation-id error, and no `Dispatch completed with errors`
- CodeRabbit regression follow-up: `@pytest.mark.unit` added; focused pytest remains 76 passed

## Notes
Residual startup validation noise remains separate: `MISSING_TOPIC` and `MISSING_HANDLER_ROUTING` still appear on `.201` and should be handled as follow-up runtime cleanup.

Evidence-Source: 3f1b475038888bc48211e9cabc37d991ff1e85f3
Evidence-PR: OCC#1277
Evidence-Ticket: OMN-11350
