### PR TITLE
fix(OMN-11350): silence optional routing startup noise

### DIFF
--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -18,7 +18,7 @@ evidence_requirements:
     command: "uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q"
   - kind: tests
     description: "Runtime contract startup loading skips optional missing handler_routing sections without emitting MISSING_HANDLER_ROUTING errors while preserving strict direct loader behavior."
-    command: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing -q"
+    command: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -47,4 +47,4 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing -q"
+        check_value: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q"

--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -2,7 +2,7 @@
 schema_version: "1.0.0"
 ticket_id: OMN-11350
 title: "Fix stability runtime startup errors"
-summary: "Preserve typed envelopes for envelope-style auto-wired handlers, make projection terminal event emission tolerate materialized dispatch dicts, and repair the ledger projection handler binding expression rejected during stability runtime startup."
+summary: "Preserve typed envelopes for envelope-style auto-wired handlers, make projection terminal event emission tolerate materialized dispatch dicts, repair the ledger projection handler binding expression rejected during stability runtime startup, and suppress false-positive missing handler_routing startup errors for contracts that do not declare that optional subcontract."
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -16,6 +16,9 @@ evidence_requirements:
   - kind: tests
     description: "Operation-bindings loader parses the packaged ledger projection handler contract without the invalid bare ${payload} expression."
     command: "uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q"
+  - kind: tests
+    description: "Runtime contract startup loading skips optional missing handler_routing sections without emitting MISSING_HANDLER_ROUTING errors while preserving strict direct loader behavior."
+    command: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing -q"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -39,3 +42,9 @@ dod_evidence:
     checks:
       - check_type: command
         check_value: "uv run pytest tests/unit/runtime/contract_loaders/test_operation_bindings_loader.py -q"
+  - id: dod-missing-handler-routing-startup-noise
+    description: "Runtime contract startup loading no longer logs missing handler_routing as an error for contracts that omit the optional section."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing -q"

--- a/src/omnibase_infra/runtime/runtime_contract_config_loader.py
+++ b/src/omnibase_infra/runtime/runtime_contract_config_loader.py
@@ -73,6 +73,26 @@ logger = logging.getLogger(__name__)
 CONTRACT_YAML_FILENAME: str = "contract.yaml"
 
 
+def _contract_declares_subcontract(contract_path: Path, section_name: str) -> bool:
+    """Return whether a contract explicitly declares an optional subcontract.
+
+    Startup loading treats missing optional subcontracts as valid, but the
+    section-specific loaders remain strict for direct use. If this lightweight
+    probe cannot parse the file, return True so the strict loader preserves the
+    existing error path.
+    """
+    try:
+        with contract_path.open("r", encoding="utf-8") as f:
+            contract = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return True
+
+    if not isinstance(contract, dict):
+        return True
+
+    return section_name in contract
+
+
 class RuntimeContractConfigLoader:
     """Unified loader for runtime contract configuration.
 
@@ -364,40 +384,46 @@ class RuntimeContractConfigLoader:
         operation_bindings: ModelOperationBindingsSubcontract | None = None
         errors: list[str] = []
 
-        # Try to load handler_routing
-        try:
-            handler_routing = load_handler_routing_subcontract(contract_path)
-            logger.debug(
-                "Loaded handler_routing from %s: %d handlers",
-                contract_path,
-                len(handler_routing.handlers),
-            )
-        except ProtocolConfigurationError as e:
-            # Check if this is "missing section" which is OK
-            if (
-                "MISSING_HANDLER_ROUTING" in str(e)
-                or "handler_routing" in str(e).lower()
-            ):
+        # Try to load handler_routing when the optional section is present.
+        if _contract_declares_subcontract(contract_path, "handler_routing"):
+            try:
+                handler_routing = load_handler_routing_subcontract(contract_path)
                 logger.debug(
-                    "No handler_routing section in %s (this is OK)",
+                    "Loaded handler_routing from %s: %d handlers",
                     contract_path,
+                    len(handler_routing.handlers),
                 )
-            else:
-                error_msg = f"handler_routing load failed: {e}"
+            except ProtocolConfigurationError as e:
+                # Check if this is "missing section" which is OK
+                if (
+                    "MISSING_HANDLER_ROUTING" in str(e)
+                    or "handler_routing" in str(e).lower()
+                ):
+                    logger.debug(
+                        "No handler_routing section in %s (this is OK)",
+                        contract_path,
+                    )
+                else:
+                    error_msg = f"handler_routing load failed: {e}"
+                    logger.warning(
+                        "Failed to load handler_routing from %s: %s",
+                        contract_path,
+                        e,
+                    )
+                    errors.append(error_msg)
+            except Exception as e:  # noqa: BLE001 — boundary: logs warning and degrades
+                error_msg = f"handler_routing load failed: {type(e).__name__}: {e}"
                 logger.warning(
-                    "Failed to load handler_routing from %s: %s",
+                    "Unexpected error loading handler_routing from %s: %s",
                     contract_path,
                     e,
                 )
                 errors.append(error_msg)
-        except Exception as e:  # noqa: BLE001 — boundary: logs warning and degrades
-            error_msg = f"handler_routing load failed: {type(e).__name__}: {e}"
-            logger.warning(
-                "Unexpected error loading handler_routing from %s: %s",
+        else:
+            logger.debug(
+                "No handler_routing section in %s (this is OK)",
                 contract_path,
-                e,
             )
-            errors.append(error_msg)
 
         # Try to load operation_bindings
         try:

--- a/tests/integration/test_runtime_contract_config_startup_noise.py
+++ b/tests/integration/test_runtime_contract_config_startup_noise.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime contract startup noise."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.runtime_contract_config_loader import (
+    RuntimeContractConfigLoader,
+)
+
+
+@pytest.mark.integration
+def test_runtime_contract_loader_omits_missing_handler_routing_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup loader skips optional missing handler_routing without error logs."""
+    node_dir = tmp_path / "node_without_routing"
+    node_dir.mkdir()
+    (node_dir / "contract.yaml").write_text(
+        """
+name: "node_without_routing"
+version: "1.0.0"
+node_type: "COMPUTE_GENERIC"
+description: "Valid node contract with no optional handler_routing subcontract"
+""",
+        encoding="utf-8",
+    )
+
+    loader = RuntimeContractConfigLoader()
+
+    with caplog.at_level(logging.ERROR):
+        config = loader.load_all_contracts(search_paths=[tmp_path])
+
+    assert config.total_contracts_loaded == 1
+    assert config.total_errors == 0
+    assert config.contract_results[0].handler_routing is None
+    assert not any(
+        "MISSING_HANDLER_ROUTING" in record.message
+        or "Missing 'handler_routing' section" in record.message
+        for record in caplog.records
+    )

--- a/tests/integration/test_runtime_contract_loader_optional_subcontracts.py
+++ b/tests/integration/test_runtime_contract_loader_optional_subcontracts.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for optional runtime contract subcontracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.runtime_contract_config_loader import (
+    RuntimeContractConfigLoader,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_runtime_loader_skips_contract_without_handler_routing(tmp_path: Path) -> None:
+    """Startup loader accepts contracts that omit optional handler_routing."""
+    contract_dir = tmp_path / "nodes" / "no_routing_node"
+    contract_dir.mkdir(parents=True)
+    (contract_dir / "contract.yaml").write_text(
+        "\n".join(
+            [
+                'name: "no_routing_node"',
+                'version: "1.0.0"',
+                'node_type: "EFFECT_GENERIC"',
+                'description: "Contract intentionally omits handler_routing"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = RuntimeContractConfigLoader().load_all_contracts([tmp_path / "nodes"])
+
+    assert config.total_contracts_found == 1
+    assert config.total_contracts_loaded == 1
+    assert config.total_errors == 0
+    assert config.contract_results[0].success is True
+    assert config.contract_results[0].handler_routing is None

--- a/tests/unit/runtime/test_runtime_contract_config_loader.py
+++ b/tests/unit/runtime/test_runtime_contract_config_loader.py
@@ -393,6 +393,27 @@ class TestLoadHandlerRouting:
         result = config.contract_results[0]
         assert result.handler_routing is None
 
+    def test_contract_without_handler_routing_does_not_log_error(
+        self,
+        loader: RuntimeContractConfigLoader,
+        contract_without_sections: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Optional missing handler_routing should not emit startup error noise."""
+        import logging
+
+        search_path = contract_without_sections.parent.parent
+
+        with caplog.at_level(logging.ERROR):
+            config = loader.load_all_contracts(search_paths=[search_path])
+
+        assert config.total_contracts_loaded == 1
+        assert not any(
+            "MISSING_HANDLER_ROUTING" in record.message
+            or "Missing 'handler_routing' section" in record.message
+            for record in caplog.records
+        )
+
     def test_handler_routing_with_multiple_handlers(
         self,
         loader: RuntimeContractConfigLoader,


### PR DESCRIPTION
## Summary
- skip strict handler_routing loading during runtime startup when a contract does not declare that optional subcontract
- keep direct handler routing loader behavior strict for callers that explicitly request it
- extend OMN-11350 deploy-contract evidence for the startup-noise regression
- add direct integration coverage for the startup-noise gate

## Verification
- uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py -q
- uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q
- uv run ruff format --check src/omnibase_infra/runtime/runtime_contract_config_loader.py tests/unit/runtime/test_runtime_contract_config_loader.py tests/integration/test_runtime_contract_config_startup_noise.py
- uv run ruff check src/omnibase_infra/runtime/runtime_contract_config_loader.py tests/unit/runtime/test_runtime_contract_config_loader.py tests/integration/test_runtime_contract_config_startup_noise.py
- uv run validate-yaml contracts/OMN-11350.yaml

## Runtime
- .201 deployed from branch head ea9c892fd0b2247c854a376e83c874a8fc700b87
- runtime health 18085 healthy: subscribers/consumers 211/211, failed_handlers {}
- runtime-effects health 18086 healthy: subscribers/consumers 75/75, failed_handlers {}
- fresh container log scan: MISSING_HANDLER_ROUTING=0; missing handler_routing section signature=0; Dispatch completed with errors=0; HandlerNodeHeartbeat failed=0; object has no attribute .payload=0
- residual startup noise after this fix: MISSING_TOPIC=202

Evidence-PR: OCC#1284

Evidence-Source: 0c50fd5ac9ff99917522fe1bbfee943f76d1586e
Evidence-Ticket: OMN-11350
