### PR TITLE
fix(OMN-11350): suppress recoverable topic startup noise

### DIFF
--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -2,7 +2,7 @@
 schema_version: "1.0.0"
 ticket_id: OMN-11350
 title: "Fix stability runtime startup errors"
-summary: "Preserve typed envelopes for envelope-style auto-wired handlers, make projection terminal event emission tolerate materialized dispatch dicts, repair the ledger projection handler binding expression rejected during stability runtime startup, and suppress false-positive missing handler_routing startup errors for contracts that do not declare that optional subcontract."
+summary: "Preserve typed envelopes for envelope-style auto-wired handlers, make projection terminal event emission tolerate materialized dispatch dicts, repair the ledger projection handler binding expression rejected during stability runtime startup, suppress false-positive missing handler_routing startup errors for contracts that do not declare that optional subcontract, and suppress recoverable pre-auto-create MISSING_TOPIC startup noise."
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -19,6 +19,9 @@ evidence_requirements:
   - kind: tests
     description: "Runtime contract startup loading skips optional missing handler_routing sections without emitting MISSING_HANDLER_ROUTING errors while preserving strict direct loader behavior."
     command: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q"
+  - kind: tests
+    description: "Topic startup validation suppresses per-topic MISSING_TOPIC logs during the runtime pre-auto-create validation pass, then revalidates after auto-create while preserving direct validator logging semantics."
+    command: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py -q"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -48,3 +51,9 @@ dod_evidence:
     checks:
       - check_type: command
         check_value: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q"
+  - id: dod-missing-topic-startup-noise
+    description: "Runtime topic startup validation no longer emits per-topic MISSING_TOPIC errors before the best-effort auto-create/revalidation path can recover."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py -q"

--- a/contracts/OMN-11350.yaml
+++ b/contracts/OMN-11350.yaml
@@ -21,7 +21,7 @@ evidence_requirements:
     command: "uv run pytest tests/unit/runtime/test_runtime_contract_config_loader.py tests/unit/runtime/contract_loaders/test_handler_routing_loader.py::TestLoadHandlerRoutingSubcontractErrors::test_missing_handler_routing_section_raises_error tests/integration/runtime/test_kernel_auto_wiring.py::test_auto_wiring_skips_contract_without_handler_routing tests/integration/test_runtime_contract_config_startup_noise.py -q"
   - kind: tests
     description: "Topic startup validation suppresses per-topic MISSING_TOPIC logs during the runtime pre-auto-create validation pass, then revalidates after auto-create while preserving direct validator logging semantics."
-    command: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py -q"
+    command: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py tests/integration/test_topic_startup_noise.py -q"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -56,4 +56,4 @@ dod_evidence:
     source: manual
     checks:
       - check_type: command
-        check_value: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py -q"
+        check_value: "uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py tests/integration/test_topic_startup_noise.py -q"

--- a/src/omnibase_infra/event_bus/service_topic_startup_validator.py
+++ b/src/omnibase_infra/event_bus/service_topic_startup_validator.py
@@ -74,6 +74,8 @@ class TopicStartupValidator:
     async def validate(
         self,
         correlation_id: UUID | None = None,
+        *,
+        log_missing: bool = True,
     ) -> ModelTopicValidationResult:
         """Validate that all required platform topics exist on the broker.
 
@@ -82,6 +84,10 @@ class TopicStartupValidator:
 
         Args:
             correlation_id: Optional correlation ID for tracing.
+            log_missing: Emit per-topic ``MISSING_TOPIC`` error logs when topics
+                are absent. Runtime startup uses ``False`` before its
+                best-effort auto-create pass so recoverable first-boot gaps do
+                not look like hard failures.
 
         Returns:
             ``ModelTopicValidationResult`` with validation outcome.
@@ -141,12 +147,13 @@ class TopicStartupValidator:
         missing = tuple(t for t in required if t not in broker_topics)
 
         if missing:
-            for topic in missing:
-                logger.error(
-                    "MISSING_TOPIC: Required topic '%s' not in broker",
-                    topic,
-                    extra={"correlation_id": str(correlation_id)},
-                )
+            if log_missing:
+                for topic in missing:
+                    logger.error(
+                        "MISSING_TOPIC: Required topic '%s' not in broker",
+                        topic,
+                        extra={"correlation_id": str(correlation_id)},
+                    )
             return ModelTopicValidationResult(
                 required_topics=required,
                 present_topics=present,

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1147,8 +1147,12 @@ async def bootstrap() -> int:
                 validator = TopicStartupValidator(
                     bootstrap_servers=kafka_bootstrap_servers,
                 )
+                strict_topic_validation = (
+                    os.environ.get("STARTUP_VALIDATION_STRICT") == "1"
+                )
                 validation_result = await validator.validate(
                     correlation_id=correlation_id,
+                    log_missing=False,
                 )
                 if not validation_result.is_valid:
                     # OMN-7810: Auto-create missing topics before failing strict
@@ -1178,6 +1182,16 @@ async def bootstrap() -> int:
                                 _auto_result["created"],
                                 correlation_id,
                             )
+                        validation_result = await validator.validate(
+                            correlation_id=correlation_id,
+                            log_missing=strict_topic_validation,
+                        )
+                        if validation_result.status == "success":
+                            logger.info(
+                                "Topic validation recovered after auto-create "
+                                "(correlation_id=%s)",
+                                correlation_id,
+                            )
                     except Exception:  # noqa: BLE001
                         logger.warning(
                             "Auto-create missing topics failed (best-effort) "
@@ -1186,16 +1200,17 @@ async def bootstrap() -> int:
                             exc_info=True,
                         )
 
-                    if os.environ.get("STARTUP_VALIDATION_STRICT") == "1":
+                    if strict_topic_validation:
                         raise RuntimeError(
                             f"Missing topics: {validation_result.missing_topics}"
                         )
-                    logger.warning(
-                        "Topic validation: %d missing (non-blocking) "
-                        "(correlation_id=%s)",
-                        len(validation_result.missing_topics),
-                        correlation_id,
-                    )
+                    if not validation_result.is_valid:
+                        logger.warning(
+                            "Topic validation: %d missing (non-blocking) "
+                            "(correlation_id=%s)",
+                            len(validation_result.missing_topics),
+                            correlation_id,
+                        )
             except RuntimeError:
                 raise
             except Exception:  # noqa: BLE001 — boundary: logs warning and degrades

--- a/tests/integration/test_topic_startup_noise.py
+++ b/tests/integration/test_topic_startup_noise.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for runtime topic-startup noise suppression."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from omnibase_infra.runtime import service_kernel
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_runtime_topic_validation_suppresses_pre_create_missing_topic_logs() -> None:
+    """Runtime startup validates quietly before auto-create and revalidates after."""
+    source = inspect.getsource(service_kernel)
+
+    assert "log_missing=False" in source
+    assert "log_missing=strict_topic_validation" in source
+    assert "Topic validation recovered after auto-create" in source

--- a/tests/unit/event_bus/test_topic_startup_validator.py
+++ b/tests/unit/event_bus/test_topic_startup_validator.py
@@ -142,6 +142,34 @@ async def test_topics_missing(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_topics_missing_can_suppress_per_topic_error_logs(
+    validator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Topics missing + log_missing=False -> degraded result without MISSING_TOPIC logs."""
+    broker_topics = {SAMPLE_SUFFIXES[0]: MagicMock()}
+    mock_admin = _make_mock_admin(broker_topics=broker_topics)
+
+    with (
+        patch(
+            "omnibase_infra.event_bus.service_topic_startup_validator.ALL_PROVISIONED_SUFFIXES",
+            SAMPLE_SUFFIXES,
+        ),
+        _patch_aiokafka_import(mock_admin),
+        caplog.at_level(logging.ERROR),
+    ):
+        result = await validator.validate(correlation_id=uuid4(), log_missing=False)
+
+    assert result.is_valid is False
+    assert result.status == "degraded"
+    assert len(result.missing_topics) == 2
+
+    error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+    assert not any("MISSING_TOPIC" in msg for msg in error_messages)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_strict_mode_raises(
     validator,
 ) -> None:

--- a/tests/unit/runtime/test_topic_provisioner_integration.py
+++ b/tests/unit/runtime/test_topic_provisioner_integration.py
@@ -50,6 +50,17 @@ class TestKernelBootTopicProvisioning:
         assert "TopicProvisioner" in source
         assert "ensure_provisioned_topics_exist" in source
 
+    def test_validation_suppresses_pre_auto_create_missing_topic_logs(self) -> None:
+        """Kernel suppresses per-topic MISSING_TOPIC logs before auto-create retry."""
+        import inspect
+
+        from omnibase_infra.runtime import service_kernel
+
+        source = inspect.getsource(service_kernel)
+        assert "log_missing=False" in source
+        assert "strict_topic_validation" in source
+        assert "Topic validation recovered after auto-create" in source
+
     def test_provisioner_import_path_is_correct(self) -> None:
         """TopicProvisioner can be imported from the path used by service_kernel.py."""
         from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner


### PR DESCRIPTION
## Summary
- suppress per-topic `MISSING_TOPIC` error logs during the runtime pre-auto-create validation pass
- revalidate after best-effort topic auto-create before warning or strict failure handling
- preserve direct `TopicStartupValidator.validate()` logging behavior by default

## Verification
- `uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py -q` (`15 passed`)
- `uv run pytest tests/integration/test_runtime_crash_loop_fix.py -q` (`3 passed`)
- `uv run pytest tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py tests/integration/test_runtime_crash_loop_fix.py -q` (`18 passed`)
- `uv run ruff format --check src/omnibase_infra/event_bus/service_topic_startup_validator.py src/omnibase_infra/runtime/service_kernel.py tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py`
- `uv run ruff check src/omnibase_infra/event_bus/service_topic_startup_validator.py src/omnibase_infra/runtime/service_kernel.py tests/unit/event_bus/test_topic_startup_validator.py tests/unit/runtime/test_topic_provisioner_integration.py`
- `uv run validate-yaml contracts/OMN-11350.yaml`

## Runtime Context
- Previous merged runtime proof on `.201` at `d45955c55824ec9688cd8c14e84330938e8e63e5` showed both runtime endpoints healthy, failed handlers `{}`, and `MISSING_TOPIC=101` in each runtime container.
- This PR targets that remaining recoverable startup-noise path.

Evidence-Ticket: OMN-11350



Evidence-Source: 6395c857029e405b9745b4dbe8892e1c6d414069
