### PR TITLE
fix(OMN-11425): harden GitHub and capability hotspot parsing

### DIFF
--- a/src/omnibase_infra/adapters/github/adapter_github_client.py
+++ b/src/omnibase_infra/adapters/github/adapter_github_client.py
@@ -193,29 +193,37 @@ query($owner: String!, $name: String!, $after: String) {
     ) -> list[dict[str, object]]:
         """Fetch CI check conclusions for a PR via REST API."""
         results: list[dict[str, object]] = []
-        detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
-        if detail:
-            head_oid = detail.get("headRefOid", "")
-            if head_oid:
-                data = self._rest_get(
-                    f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15
-                )
-                if isinstance(data, dict):
-                    check_runs = data.get("check_runs") or []
-                    if isinstance(check_runs, list):
-                        for run in check_runs:
-                            if not isinstance(run, dict):
-                                continue
-                            conclusion = str(run.get("conclusion") or "").upper()
-                            results.append(
-                                {
-                                    "name": str(run.get("name") or ""),
-                                    "conclusion": conclusion,
-                                    "status": str(run.get("status") or ""),
-                                    "isRequired": True,
-                                }
-                            )
+        for run in self._fetch_pr_check_runs(repo, pr_number):
+            conclusion = str(run.get("conclusion") or "").upper()
+            results.append(
+                {
+                    "name": str(run.get("name") or ""),
+                    "conclusion": conclusion,
+                    "status": str(run.get("status") or ""),
+                    "isRequired": True,
+                }
+            )
         return results
+
+    def _fetch_pr_check_runs(
+        self, repo: str, pr_number: int
+    ) -> list[dict[str, object]]:
+        """Fetch raw check-run dictionaries for the PR head commit."""
+        detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
+        if not detail:
+            return []
+        head_oid = detail.get("headRefOid", "")
+        if not head_oid:
+            return []
+        data = self._rest_get(
+            f"/repos/{repo}/commits/{head_oid}/check-runs", timeout=15
+        )
+        if not isinstance(data, dict):
+            return []
+        check_runs = data.get("check_runs") or []
+        if not isinstance(check_runs, list):
+            return []
+        return [run for run in check_runs if isinstance(run, dict)]
 
     def fetch_pr_detail(
         self, repo: str, pr_number: int, fields: str = "id,headRefName"
@@ -273,38 +281,13 @@ query($owner: String!, $name: String!, $number: Int!) {
 
     def fetch_failing_run_id(self, repo: str, pr_number: int) -> str | None:
         """Find the most recent failing GitHub Actions run ID for a PR."""
-        checks = self._fetch_pr_checks_rest(repo, pr_number)
-        for ctx in checks:
-            if ctx.get("conclusion") == "FAILURE":
-                detail = self.fetch_pr_detail(repo, pr_number, "headRefOid")
-                if detail:
-                    head_oid = detail.get("headRefOid", "")
-                    if head_oid:
-                        data = self._rest_get(
-                            f"/repos/{repo}/commits/{head_oid}/check-runs"
-                        )
-                        if isinstance(data, dict):
-                            check_runs = data.get("check_runs") or []
-                            if isinstance(check_runs, list):
-                                for run in check_runs:
-                                    if not isinstance(run, dict):
-                                        continue
-                                    if (
-                                        str(run.get("conclusion") or "").upper()
-                                        == "FAILURE"
-                                    ):
-                                        url = str(
-                                            run.get("details_url")
-                                            or run.get("html_url")
-                                            or ""
-                                        )
-                                        run_id = (
-                                            url.rstrip("/").split("/")[-1]
-                                            if url
-                                            else None
-                                        )
-                                        if run_id:
-                                            return run_id
+        for run in self._fetch_pr_check_runs(repo, pr_number):
+            if str(run.get("conclusion") or "").upper() != "FAILURE":
+                continue
+            for key in ("details_url", "html_url"):
+                run_id = _github_actions_run_id_from_url(str(run.get(key) or ""))
+                if run_id:
+                    return run_id
         return None
 
     def fetch_failing_job_name(self, repo: str, pr_number: int) -> str | None:
@@ -433,6 +416,15 @@ def _split_repo(repo: str) -> tuple[str, str]:
     if len(parts) != 2:
         raise ValueError(f"Invalid repo format: {repo!r} — expected 'org/name'")
     return parts[0], parts[1]
+
+
+def _github_actions_run_id_from_url(url: str) -> str | None:
+    """Extract the Actions run id from a GitHub run or job URL."""
+    parts = [part for part in url.rstrip("/").split("/") if part]
+    for index, part in enumerate(parts):
+        if part == "runs" and index + 1 < len(parts):
+            return parts[index + 1]
+    return None
 
 
 __all__: list[str] = ["GitHubHttpClient"]

--- a/src/omnibase_infra/capabilities/contract_capability_extractor.py
+++ b/src/omnibase_infra/capabilities/contract_capability_extractor.py
@@ -158,34 +158,8 @@ class ContractCapabilityExtractor:
         """Extract protocol names from dependencies and interfaces."""
         protocols: list[str] = []
 
-        # From protocol_interfaces field
-        if hasattr(contract, "protocol_interfaces"):
-            protocol_interfaces = contract.protocol_interfaces
-            if protocol_interfaces:
-                for proto in protocol_interfaces:
-                    if proto is not None:  # Skip None values
-                        protocols.append(proto)
-
-        # From dependencies where type is protocol
-        if hasattr(contract, "dependencies"):
-            dependencies = contract.dependencies
-            if dependencies:
-                for dep in dependencies:
-                    # Check if it's a protocol dependency using is_protocol() method
-                    if hasattr(dep, "is_protocol") and dep.is_protocol():
-                        if hasattr(dep, "name") and dep.name:
-                            protocols.append(dep.name)
-                    # Fallback: check dependency_type directly
-                    elif hasattr(dep, "dependency_type"):
-                        dep_type = dep.dependency_type
-                        type_str = (
-                            dep_type.value
-                            if hasattr(dep_type, "value")
-                            else str(dep_type)
-                        )
-                        if type_str.upper() == "PROTOCOL":
-                            if hasattr(dep, "name") and dep.name:
-                                protocols.append(dep.name)
+        protocols.extend(_extract_protocol_interfaces(contract))
+        protocols.extend(_extract_dependency_protocols(contract))
 
         return protocols
 
@@ -222,3 +196,58 @@ class ContractCapabilityExtractor:
                         tags.append(tag)
 
         return tags
+
+
+def _extract_protocol_interfaces(contract: ModelContractBase) -> list[str]:
+    """Extract protocol names from the protocol_interfaces field."""
+    if not hasattr(contract, "protocol_interfaces"):
+        return []
+    protocol_interfaces = contract.protocol_interfaces
+    if not protocol_interfaces:
+        return []
+    return [proto for proto in protocol_interfaces if isinstance(proto, str)]
+
+
+def _extract_dependency_protocols(contract: ModelContractBase) -> list[str]:
+    """Extract protocol dependency names from contract dependencies."""
+    if not hasattr(contract, "dependencies"):
+        return []
+    dependencies = contract.dependencies
+    if not dependencies:
+        return []
+    protocols: list[str] = []
+    for dep in dependencies:
+        protocol_name = _dependency_protocol_name(dep)
+        if protocol_name:
+            protocols.append(protocol_name)
+    return protocols
+
+
+def _dependency_protocol_name(dependency: object) -> str | None:
+    """Return a dependency name only when the dependency represents a protocol."""
+    if _dependency_uses_protocol_marker(dependency):
+        return _dependency_name(dependency)
+    if _dependency_type_is_protocol(dependency):
+        return _dependency_name(dependency)
+    return None
+
+
+def _dependency_uses_protocol_marker(dependency: object) -> bool:
+    """Return True when dependency.is_protocol() marks a protocol dependency."""
+    marker = getattr(dependency, "is_protocol", None)
+    return bool(marker()) if callable(marker) else False
+
+
+def _dependency_type_is_protocol(dependency: object) -> bool:
+    """Return True when dependency_type is PROTOCOL."""
+    if not hasattr(dependency, "dependency_type"):
+        return False
+    dep_type = dependency.dependency_type
+    type_str = dep_type.value if hasattr(dep_type, "value") else str(dep_type)
+    return type_str.upper() == "PROTOCOL"
+
+
+def _dependency_name(dependency: object) -> str | None:
+    """Return a non-empty dependency name."""
+    name = getattr(dependency, "name", None)
+    return name if isinstance(name, str) and name else None

--- a/tests/integration/adapters/test_github_http_client_integration.py
+++ b/tests/integration/adapters/test_github_http_client_integration.py
@@ -321,6 +321,23 @@ class TestGitHubHttpClientIntegration:
             name = c.fetch_failing_job_name("OmniNode-ai/omnimarket", 42)
         assert name == "Lint"
 
+    def test_fetch_failing_run_id_extracts_run_from_job_url(
+        self, fake_server: str
+    ) -> None:
+        c = GitHubHttpClient(token="fake-token")
+        with (
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_GRAPHQL",
+                f"{fake_server}/graphql",
+            ),
+            patch(
+                "omnibase_infra.adapters.github.adapter_github_client._GITHUB_REST",
+                fake_server,
+            ),
+        ):
+            run_id = c.fetch_failing_run_id("OmniNode-ai/omnimarket", 42)
+        assert run_id == "88888"
+
     def test_missing_token_raises(self) -> None:
         with patch.dict("os.environ", {}, clear=True):
             import os

--- a/tests/unit/capabilities/test_contract_capability_extractor.py
+++ b/tests/unit/capabilities/test_contract_capability_extractor.py
@@ -448,6 +448,23 @@ class TestProtocolExtraction:
         assert result is not None
         assert "SomeService" not in result.protocols
 
+    def test_skips_protocol_dependency_without_string_name(
+        self,
+        extractor: ContractCapabilityExtractor,
+        minimal_effect_contract: MagicMock,
+    ) -> None:
+        """Protocol dependencies without valid names should not leak mock values."""
+        dep = MagicMock()
+        dep.name = MagicMock()
+        dep.is_protocol = MagicMock(return_value=True)
+
+        minimal_effect_contract.dependencies = [dep]
+
+        result = extractor.extract(minimal_effect_contract)
+
+        assert result is not None
+        assert result.protocols == []
+
 
 # =============================================================================
 # TestIntentTypeExtraction - Intent type extraction
@@ -1026,6 +1043,23 @@ class TestEdgeCases:
                 "valid" in result.capability_tags
                 or "also_valid" in result.capability_tags
             )
+
+    def test_non_string_protocol_interfaces_filtered_out(
+        self,
+        extractor: ContractCapabilityExtractor,
+        minimal_effect_contract: MagicMock,
+    ) -> None:
+        """Malformed protocol interface entries should not enter sorted output."""
+        minimal_effect_contract.protocol_interfaces = [
+            "ProtocolA",
+            MagicMock(),
+            None,
+        ]
+
+        result = extractor.extract(minimal_effect_contract)
+
+        assert result is not None
+        assert result.protocols == ["ProtocolA"]
 
     def test_special_characters_in_tags(
         self,


### PR DESCRIPTION
## Summary
- classify Repowise critical rows and apply scoped low-risk fixes in GitHub adapter and capability extraction paths
- deduplicate PR check-run fetching and correctly extract GitHub Actions run IDs from job URLs
- flatten contract protocol extraction and filter malformed non-string protocol/dependency names before deterministic sorting

## Verification
- uv run pytest tests/integration/adapters/test_github_http_client_integration.py tests/unit/capabilities/test_contract_capability_extractor.py -q
- uv run ruff check src/omnibase_infra/adapters/github/adapter_github_client.py src/omnibase_infra/capabilities/contract_capability_extractor.py tests/integration/adapters/test_github_http_client_integration.py tests/unit/capabilities/test_contract_capability_extractor.py
- uv run ruff format --check src/omnibase_infra/adapters/github/adapter_github_client.py src/omnibase_infra/capabilities/contract_capability_extractor.py tests/integration/adapters/test_github_http_client_integration.py tests/unit/capabilities/test_contract_capability_extractor.py
- uv run python scripts/validation/check_ai_slop.py src/omnibase_infra/adapters/github/adapter_github_client.py src/omnibase_infra/capabilities/contract_capability_extractor.py tests/integration/adapters/test_github_http_client_integration.py tests/unit/capabilities/test_contract_capability_extractor.py
- pre-commit hooks during commit passed
- push hooks passed: mypy, ONEX Architecture Layer Validation

## Worktree
- remains at /Users/jonah/Code/omni_home/omni_worktrees/OMN-11425/omnibase_infra for PR follow-up; not cleaned until merge

Evidence-Source: OCC#1297
Evidence-Ticket: OMN-11425
