### PR TITLE
fix(OMN-11177): publish baselines batch through bus

### DIFF
--- a/scripts/check_subscribe_wiring_health.py
+++ b/scripts/check_subscribe_wiring_health.py
@@ -75,6 +75,10 @@ _EXTERNAL_PUBLISHER_ALLOWLIST: dict[str, str] = {
     # RuntimePatternBBroker consumes them but no contract-declared node publishes them.
     "onex.cmd.omnibase-infra.pattern-b-dispatch.v1": "Published by local runtime transport / runtime-backed skill clients | owner: jonah | expiry: 2026-12-01",
     "onex.evt.omnibase-infra.runtime-manifest-published.v1": "Published by runtime startup self-report, not a contract-declared node | owner: jonah | expiry: 2026-12-01",
+    # Baselines batch compute — triggered by scripts/run_baselines_batch_compute.py CLI publisher,
+    # not a contract-declared node publisher. The script publishes to this topic to trigger the
+    # node_baselines_batch_compute effect node. (OMN-11177)
+    "onex.cmd.omnibase-infra.baselines-batch-compute.v1": "Published by scripts/run_baselines_batch_compute.py CLI trigger, not a contract-declared node | owner: jonah | expiry: 2026-12-01",
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -35,8 +35,11 @@ import logging
 import os
 import sys
 from pathlib import Path
-from types import ModuleType
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
 from uuid import UUID, uuid4
 
 import yaml  # ONEX_EXCLUDE: manual_yaml - reads node contract for command topic
@@ -60,7 +63,8 @@ class _BaselinesBatchCommand(Protocol):
 
     correlation_id: UUID
 
-    def model_dump(self, *, mode: str) -> dict[str, object]: ...
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        pass
 
 
 def _command_model_module_path() -> Path:

--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -35,11 +35,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast
-
-if TYPE_CHECKING:
-    from types import ModuleType
-
+from typing import Any, Protocol, cast
 from uuid import UUID, uuid4
 
 import yaml  # ONEX_EXCLUDE: manual_yaml - reads node contract for command topic
@@ -126,7 +122,7 @@ def _load_command_model_class() -> type[Any]:
         raise RuntimeError(message)
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(cast("ModuleType", module))
+    spec.loader.exec_module(module)
     return cast("type[Any]", module.ModelBaselinesBatchComputeCommand)
 
 

--- a/scripts/run_baselines_batch_compute.py
+++ b/scripts/run_baselines_batch_compute.py
@@ -3,164 +3,243 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2026 OmniNode Team
-"""One-shot runner for NodeBaselinesBatchCompute.
+"""Publish a command that triggers NodeBaselinesBatchCompute.
 
-Connects to PostgreSQL and Kafka, runs the 3-phase baselines batch computation,
-emits a baselines-computed snapshot event, then exits.
-
-Intended to be invoked by a scheduler (cron, GitHub Actions) rather than running
-as a long-lived service.
+This script is intentionally a thin bus publisher. It validates the existing
+``ModelBaselinesBatchComputeCommand`` payload, wraps it in a
+``ModelEventEnvelope``, publishes to the node command topic, then exits. The
+runtime-owned node handler performs database work and emits the
+baselines-computed event.
 
 Usage:
     uv run python scripts/run_baselines_batch_compute.py
+    uv run python scripts/run_baselines_batch_compute.py --dry-run
 
 Environment Variables:
-    OMNIBASE_INFRA_DB_URL (required)
-        Full PostgreSQL DSN, e.g.:
-        postgresql://postgres:pass@localhost:5436/omnibase_infra
-
     KAFKA_BOOTSTRAP_SERVERS (optional, default: localhost:19092)
-        Kafka bootstrap address. Set to empty string to skip event emission
-        (DB computation still runs, but no baselines-computed event is emitted).
+        Kafka bootstrap address for publishing the command.
 
 Exit Codes:
-    0  Success
-    1  Configuration or runtime error
+    0  Command published, or dry-run payload validated
+    1  Configuration, validation, or delivery error
 
-Ticket: OMN-3335
+Ticket: OMN-3335, OMN-11177
 """
 
 from __future__ import annotations
 
-import asyncio
+import argparse
+import importlib.util
 import json
 import logging
 import os
 import sys
-from uuid import uuid4
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Protocol, cast
+from uuid import UUID, uuid4
 
-import asyncpg
-from aiokafka import AIOKafkaProducer
-from aiokafka.errors import KafkaError
+import yaml  # ONEX_EXCLUDE: manual_yaml - reads node contract for command topic
 
-from omnibase_infra.nodes.node_baselines_batch_compute import (
-    HandlerBaselinesBatchCompute,
-    ModelBaselinesBatchComputeCommand,
-)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+DEFAULT_BOOTSTRAP_SERVERS = "localhost:19092"
+SOURCE_TOOL = "run_baselines_batch_compute"
+TARGET_TOOL = "node_baselines_batch_compute"
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     stream=sys.stderr,
 )
-logger = logging.getLogger("run_baselines_batch_compute")
+logger = logging.getLogger(SOURCE_TOOL)
 
 
-def _make_publisher(
-    producer: AIOKafkaProducer,
-) -> HandlerBaselinesBatchCompute.ProtocolPublisher:  # type: ignore[attr-defined]
-    """Wrap AIOKafkaProducer as the ProtocolPublisher callable expected by the handler."""
+class _BaselinesBatchCommand(Protocol):
+    """Structural protocol for the command model loaded from the node model file."""
 
-    async def publish(
-        event_type: str,
-        payload: object,
-        topic: str | None,
-        correlation_id: object,
-        **kwargs: object,
-    ) -> bool:
-        if topic is None:
-            logger.warning("publish called with topic=None, skipping emission")
-            return False
-        body = json.dumps(
-            {
-                "event_type": event_type,
-                "payload": payload,
-                "correlation_id": str(correlation_id),
-            }
-        ).encode("utf-8")
-        await producer.send_and_wait(topic, body)
-        logger.info("Emitted event %s to topic %s", event_type, topic)
-        return True
+    correlation_id: UUID
 
-    return publish  # type: ignore[return-value]
+    def model_dump(self, *, mode: str) -> dict[str, object]: ...
 
 
-async def _run() -> int:
-    db_url = os.environ.get("OMNIBASE_INFRA_DB_URL", "").strip()
-    if not db_url:
-        logger.error("OMNIBASE_INFRA_DB_URL is required but not set")
-        return 1
+def _command_model_module_path() -> Path:
+    return _node_contract_dir() / "models" / "model_baselines_batch_compute_command.py"
 
-    kafka_servers = os.environ.get(
-        "KAFKA_BOOTSTRAP_SERVERS",
-        "localhost:19092",  # fallback-ok: ops script, env overrideable
-    ).strip()
-    use_kafka = bool(kafka_servers)
 
-    correlation_id = uuid4()
-    logger.info(
-        "Starting baselines batch compute run (correlation_id=%s)", correlation_id
+def _node_contract_dir() -> Path:
+    return (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "omnibase_infra"
+        / "nodes"
+        / "node_baselines_batch_compute"
     )
 
-    pool: asyncpg.Pool | None = None
-    producer: AIOKafkaProducer | None = None
+
+def _load_command_topic() -> str:
+    contract_path = _node_contract_dir() / "contract.yaml"
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    if not isinstance(contract, dict):
+        message = f"Invalid node contract at {contract_path}"
+        raise RuntimeError(message)
+    event_bus = contract.get("event_bus")
+    if not isinstance(event_bus, dict):
+        message = f"Node contract has no event_bus section: {contract_path}"
+        raise RuntimeError(message)
+    subscribe_topics = event_bus.get("subscribe_topics")
+    if not isinstance(subscribe_topics, list):
+        message = f"Node contract has no event_bus.subscribe_topics: {contract_path}"
+        raise RuntimeError(message)
+    command_topics = [
+        topic.strip()
+        for topic in subscribe_topics
+        if isinstance(topic, str) and topic.strip().startswith("onex.cmd.")
+    ]
+    if len(command_topics) != 1:
+        message = (
+            "Node contract must declare exactly one onex.cmd.* subscribe topic; "
+            f"found {len(command_topics)} in {contract_path}"
+        )
+        raise RuntimeError(message)
+    return command_topics[0]
+
+
+def _load_command_model_class() -> type[Any]:
+    """Load the command model without importing the node package root.
+
+    The node package ``__init__`` currently re-exports its handler. Importing
+    the model through the package path would therefore import the handler as a
+    side effect, which defeats this script's bus-publisher boundary.
+    """
+    module_path = _command_model_module_path()
+    spec = importlib.util.spec_from_file_location(
+        "_onex_baselines_batch_compute_command_model",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        message = f"Cannot load command model from {module_path}"
+        raise RuntimeError(message)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(cast("ModuleType", module))
+    return cast("type[Any]", module.ModelBaselinesBatchComputeCommand)
+
+
+def build_command(correlation_id: UUID) -> _BaselinesBatchCommand:
+    """Build and validate the typed baselines batch compute command."""
+    command_model = _load_command_model_class()
+    return cast("_BaselinesBatchCommand", command_model(correlation_id=correlation_id))
+
+
+def build_envelope(correlation_id: UUID) -> ModelEventEnvelope[dict[str, object]]:
+    """Build the command envelope published to the event bus."""
+    command = build_command(correlation_id)
+    command_topic = _load_command_topic()
+    return ModelEventEnvelope[dict[str, object]](
+        payload=command.model_dump(mode="json"),
+        correlation_id=command.correlation_id,
+        event_type=command_topic,
+        source_tool=SOURCE_TOOL,
+        target_tool=TARGET_TOOL,
+        payload_type="ModelBaselinesBatchComputeCommand",
+    )
+
+
+def _publish(
+    envelope: ModelEventEnvelope[dict[str, object]], bootstrap_servers: str
+) -> None:
+    """Publish a command envelope to Kafka synchronously."""
+    topic = str(envelope.event_type or "").strip()
+    if not topic:
+        message = "Command envelope has no event_type topic"
+        raise RuntimeError(message)
+    try:
+        from confluent_kafka import Producer
+    except ImportError as exc:
+        message = (
+            "confluent-kafka is required. Install it with: pip install confluent-kafka"
+        )
+        raise RuntimeError(message) from exc
+
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    delivery_error: list[BaseException] = []
+
+    def _on_delivery(err: object, _msg: object) -> None:
+        if err is not None:
+            delivery_error.append(RuntimeError(f"Kafka delivery failed: {err}"))
+
+    producer.produce(
+        topic=topic,
+        key=str(envelope.correlation_id).encode("utf-8"),
+        value=envelope.model_dump_json().encode("utf-8"),
+        on_delivery=_on_delivery,
+    )
+    remaining = producer.flush(timeout=10.0)
+    if remaining:
+        message = f"Kafka delivery timed out with {remaining} message(s) still queued"
+        raise RuntimeError(message)
+    if delivery_error:
+        raise delivery_error[0]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Publish a baselines batch compute command to the ONEX bus.",
+    )
+    parser.add_argument(
+        "--bootstrap-servers",
+        default=os.environ.get("KAFKA_BOOTSTRAP_SERVERS", DEFAULT_BOOTSTRAP_SERVERS),
+        help="Kafka bootstrap servers (default: KAFKA_BOOTSTRAP_SERVERS or localhost:19092).",
+    )
+    parser.add_argument(
+        "--correlation-id",
+        type=UUID,
+        default=None,
+        help="Correlation UUID to use. Defaults to a generated UUID4.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print the command envelope without publishing.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    correlation_id = args.correlation_id or uuid4()
 
     try:
-        pool = await asyncpg.create_pool(
-            db_url, min_size=1, max_size=3, command_timeout=60
-        )
-
-        publisher = None
-        if use_kafka:
-            producer = AIOKafkaProducer(
-                bootstrap_servers=kafka_servers,
-                acks="all",
-                enable_idempotence=True,
-            )
-            try:
-                await producer.start()
-                publisher = _make_publisher(producer)
-                logger.info("Kafka producer connected to %s", kafka_servers)
-            except KafkaError:
-                logger.warning(
-                    "Kafka unavailable (%s) — computation will run but no event emitted",
-                    kafka_servers,
-                    exc_info=True,
-                )
-                producer = None
-
-        handler = HandlerBaselinesBatchCompute(pool=pool, publisher=publisher)
-        command = ModelBaselinesBatchComputeCommand(correlation_id=correlation_id)
-        result = await handler.handle(command)
-
-        logger.info(
-            "Baselines computation complete: comparisons=%d trend=%d breakdown=%d snapshot_emitted=%s",
-            result.result.comparisons_rows,
-            result.result.trend_rows,
-            result.result.breakdown_rows,
-            result.snapshot_emitted,
-        )
-
-        if result.result.has_errors:
-            logger.warning("Computation finished with errors: %s", result.result.errors)
-            return 1
-
-        return 0
-
+        envelope = build_envelope(correlation_id)
     except Exception:
-        logger.exception("Baselines batch compute failed")
+        logger.exception("Failed to build baselines batch compute command")
         return 1
 
-    finally:
-        if producer is not None:
-            await producer.stop()
-        if pool is not None:
-            await pool.close()
+    envelope_json = envelope.model_dump(mode="json")
+    if args.dry_run:
+        print(json.dumps(envelope_json, indent=2, sort_keys=True))
+        print(f"(dry-run: skipping publish to {envelope.event_type})")
+        return 0
 
+    bootstrap_servers = str(args.bootstrap_servers or "").strip()
+    if not bootstrap_servers:
+        logger.error("Kafka bootstrap servers resolved empty; cannot publish command")
+        return 1
 
-def main() -> None:
-    sys.exit(asyncio.run(_run()))
+    try:
+        _publish(envelope, bootstrap_servers)
+    except Exception:
+        logger.exception("Failed to publish baselines batch compute command")
+        return 1
+
+    logger.info(
+        "Published baselines batch compute command to %s (correlation_id=%s)",
+        envelope.event_type,
+        correlation_id,
+    )
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -19,6 +19,7 @@ class EnumOmnibaseInfraTopic(str, Enum):
     Members are sorted by (kind, event_name, version).
     """
     CMD_BASELINE_COMPARISON_REQUEST_V1 = "onex.cmd.omnibase-infra.baseline-comparison-request.v1"  # onex.cmd.omnibase-infra.baseline-comparison-request.v1
+    CMD_BASELINES_BATCH_COMPUTE_V1 = "onex.cmd.omnibase-infra.baselines-batch-compute.v1"  # onex.cmd.omnibase-infra.baselines-batch-compute.v1
     CMD_BUILD_LOOP_APPEND_V1 = "onex.cmd.omnibase-infra.build-loop-append.v1"  # onex.cmd.omnibase-infra.build-loop-append.v1
     CMD_CHAIN_LEARN_V1 = "onex.cmd.omnibase-infra.chain-learn.v1"  # onex.cmd.omnibase-infra.chain-learn.v1
     CMD_CONSUMER_RESTART_V1 = "onex.cmd.omnibase-infra.consumer-restart.v1"  # onex.cmd.omnibase-infra.consumer-restart.v1

--- a/src/omnibase_infra/nodes/node_baselines_batch_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_baselines_batch_compute/contract.yaml
@@ -21,6 +21,8 @@ output_model:
   module: "omnibase_infra.nodes.node_baselines_batch_compute.models"
   description: "Result row counts and snapshot_emitted flag."
 event_bus:
+  subscribe_topics:
+    - "onex.cmd.omnibase-infra.baselines-batch-compute.v1"
   publish_topics:
     - "onex.evt.omnibase-infra.baselines-computed.v1"
 handler_routing:

--- a/tests/integration/scripts/test_run_baselines_batch_compute.py
+++ b/tests/integration/scripts/test_run_baselines_batch_compute.py
@@ -138,11 +138,6 @@ def test_envelope_schema_is_valid_for_bus_consumption() -> None:
 def test_command_model_loads_via_importlib_isolation() -> None:
     """The script must load ModelBaselinesBatchComputeCommand without importing the full node."""
     module = _load_script()
-    command_cls = (
-        module.build_command.__func__
-        if hasattr(module.build_command, "__func__")
-        else None
-    )  # type: ignore[attr-defined]
 
     # Use the module's public build_command function with a known correlation_id
     from uuid import UUID

--- a/tests/integration/scripts/test_run_baselines_batch_compute.py
+++ b/tests/integration/scripts/test_run_baselines_batch_compute.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration tests for scripts/run_baselines_batch_compute.py [OMN-11177].
+
+Validates the bus-publisher integration contract:
+  - The command topic is read from the canonical contract.yaml at runtime (not hardcoded)
+  - The command model class loads cleanly via importlib isolation
+  - dry-run mode produces a valid, schema-correct ModelEventEnvelope
+  - The published topic matches the node contract subscribe_topic declaration
+
+No Kafka connection is required; tests use --dry-run mode throughout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_baselines_batch_compute.py"
+CONTRACT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "omnibase_infra"
+    / "nodes"
+    / "node_baselines_batch_compute"
+    / "contract.yaml"
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _load_script() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "_test_run_baselines_batch_compute_integration",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.integration
+def test_command_topic_matches_node_contract_subscribe_topic() -> None:
+    """The script must read its publish target from the node contract at runtime.
+
+    This integration test verifies the full round-trip: the script loads the
+    contract.yaml, extracts the subscribe_topic, and uses it as the event_type
+    in the published envelope — ensuring topic drift between the script and the
+    node contract is caught automatically.
+    """
+    contract = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
+    subscribe_topics = contract["event_bus"]["subscribe_topics"]
+    cmd_topics = [t for t in subscribe_topics if t.startswith("onex.cmd.")]
+    assert len(cmd_topics) == 1, (
+        f"Expected exactly one onex.cmd.* subscribe topic in node contract, "
+        f"got {cmd_topics}"
+    )
+    expected_topic = cmd_topics[0]
+
+    correlation_id = str(uuid4())
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--correlation-id",
+            correlation_id,
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+    payload_text = result.stdout.split("\n(dry-run:", maxsplit=1)[0]
+    envelope = json.loads(payload_text)
+    assert envelope["event_type"] == expected_topic, (
+        f"Script published to {envelope['event_type']!r} but contract declares "
+        f"{expected_topic!r} as the subscribe_topic. They must match."
+    )
+
+
+@pytest.mark.integration
+def test_envelope_schema_is_valid_for_bus_consumption() -> None:
+    """The published envelope must carry all required ModelEventEnvelope fields."""
+    correlation_id = "00000000-0000-4000-a000-000011177001"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--correlation-id",
+            correlation_id,
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+    payload_text = result.stdout.split("\n(dry-run:", maxsplit=1)[0]
+    envelope = json.loads(payload_text)
+
+    # All fields required by ModelEventEnvelope for bus consumption
+    required_fields = {
+        "event_type",
+        "source_tool",
+        "target_tool",
+        "payload_type",
+        "correlation_id",
+        "payload",
+    }
+    missing = required_fields - envelope.keys()
+    assert not missing, f"Envelope is missing required fields: {missing}"
+
+    # payload must be a dict (not null) with correlation_id propagated
+    assert isinstance(envelope["payload"], dict), "payload must be a dict"
+    assert envelope["payload"]["correlation_id"] == correlation_id
+
+    # UUID round-trip: correlation_id must be a valid UUID
+    assert UUID(envelope["correlation_id"]) == UUID(correlation_id)
+
+
+@pytest.mark.integration
+def test_command_model_loads_via_importlib_isolation() -> None:
+    """The script must load ModelBaselinesBatchComputeCommand without importing the full node."""
+    module = _load_script()
+    command_cls = (
+        module.build_command.__func__
+        if hasattr(module.build_command, "__func__")
+        else None
+    )  # type: ignore[attr-defined]
+
+    # Use the module's public build_command function with a known correlation_id
+    from uuid import UUID
+
+    correlation_id = UUID("00000000-0000-4000-b000-000011177002")
+    command = module.build_command(correlation_id)  # type: ignore[attr-defined]
+
+    assert command.correlation_id == correlation_id
+    dumped = command.model_dump(mode="json")
+    assert dumped["correlation_id"] == str(correlation_id)

--- a/tests/unit/scripts/test_run_baselines_batch_compute.py
+++ b/tests/unit/scripts/test_run_baselines_batch_compute.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/run_baselines_batch_compute.py [OMN-11177]."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from uuid import UUID
+
+import pytest
+import yaml
+
+from omnibase_core.validators.contract_config_compliance import validate_file
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_baselines_batch_compute.py"
+CONTRACT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "omnibase_infra"
+    / "nodes"
+    / "node_baselines_batch_compute"
+    / "contract.yaml"
+)
+COMMAND_TOPIC = "onex.cmd.omnibase-infra.baselines-batch-compute.v1"
+HANDLER_MODULE = (
+    "omnibase_infra.nodes.node_baselines_batch_compute.handlers."
+    "handler_baselines_batch_compute"
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_test_run_baselines_batch_compute",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dry_run_prints_typed_command_envelope() -> None:
+    correlation_id = "00000000-0000-4000-8000-000000011177"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--correlation-id",
+            correlation_id,
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload_text = result.stdout.split("\n(dry-run:", maxsplit=1)[0]
+    envelope = json.loads(payload_text)
+
+    assert envelope["event_type"] == COMMAND_TOPIC
+    assert envelope["source_tool"] == "run_baselines_batch_compute"
+    assert envelope["target_tool"] == "node_baselines_batch_compute"
+    assert envelope["payload_type"] == "ModelBaselinesBatchComputeCommand"
+    assert envelope["correlation_id"] == correlation_id
+    assert envelope["payload"] == {
+        "operation": "baselines.batch_compute",
+        "correlation_id": correlation_id,
+    }
+
+
+def test_build_envelope_does_not_import_handler_module() -> None:
+    sys.modules.pop(HANDLER_MODULE, None)
+    script = _load_script()
+
+    envelope = script.build_envelope(UUID("00000000-0000-4000-8000-000000011177"))
+
+    assert envelope.event_type == COMMAND_TOPIC
+    assert HANDLER_MODULE not in sys.modules
+
+
+def test_contract_config_validator_has_no_bus_bypass_import_finding() -> None:
+    findings = validate_file(SCRIPT_PATH, frozenset({"bus_bypass_import"}))
+
+    assert findings == []
+
+
+def test_node_contract_declares_command_subscription() -> None:
+    contract = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert COMMAND_TOPIC in contract["event_bus"]["subscribe_topics"]


### PR DESCRIPTION
## Summary

Recovered valid dirty worktree changes during workspace cleanup and preserved them in a draft PR instead of deleting local work.

## Verification

- `git diff --check` passed before commit
- Repository pre-commit hooks passed during commit
- Dead-letter subscription fixed: added `onex.cmd.omnibase-infra.baselines-batch-compute.v1` to `_EXTERNAL_PUBLISHER_ALLOWLIST`
- Integration tests added in `tests/integration/scripts/test_run_baselines_batch_compute.py`

## Evidence

OMN-11177

Evidence-Source: OCC#1307
Evidence-Ticket: OMN-11177

## Cleanup note

Source worktree: `/Users/jonah/Code/omni_home/omni_worktrees/OMN-11177/omnibase_infra`