### PR TITLE
fix(OMN-10813): complete DEC-003 constructor injection migration for 4 effect nodes

### DIFF
--- a/src/omnibase_infra/nodes/node_contract_persistence_effect/node.py
+++ b/src/omnibase_infra/nodes/node_contract_persistence_effect/node.py
@@ -56,14 +56,8 @@ from omnibase_core.nodes.node_effect import NodeEffect
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
 
 
-# ONEX_EXCLUDE: declarative_node - OMN-1732 DEC-003 requires constructor injection
-# for protocol dependencies. The _resolved_dependencies instance variable stores
-# pre-resolved protocols from ContractDependencyResolver.
 class NodeContractPersistenceEffect(NodeEffect):
     """Declarative effect node for contract registry persistence.
 
@@ -82,9 +76,6 @@ class NodeContractPersistenceEffect(NodeEffect):
 
     Args:
         container: ONEX dependency injection container.
-        dependencies: Optional pre-resolved protocol dependencies. If provided,
-            the node will use these instead of resolving from container.
-            Part of OMN-1732 runtime dependency injection.
 
     Dependency Injection:
         Backend adapters (PostgreSQL) are resolved via container.
@@ -111,21 +102,8 @@ class NodeContractPersistenceEffect(NodeEffect):
         ```
     """
 
-    def __init__(
-        self,
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> None:
-        """Initialize effect node with container dependency injection.
-
-        Args:
-            container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. If provided, the node uses these
-                instead of resolving from container. Part of OMN-1732.
-        """
+    def __init__(self, container: ModelONEXContainer) -> None:
         super().__init__(container)
-        self._resolved_dependencies = dependencies
 
 
 __all__ = ["NodeContractPersistenceEffect"]

--- a/src/omnibase_infra/nodes/node_contract_persistence_effect/registry/registry_infra_contract_persistence_effect.py
+++ b/src/omnibase_infra/nodes/node_contract_persistence_effect/registry/registry_infra_contract_persistence_effect.py
@@ -29,9 +29,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
     from omnibase_infra.nodes.node_contract_persistence_effect.node import (
         NodeContractPersistenceEffect,
     )
@@ -66,24 +63,14 @@ class RegistryInfraContractPersistenceEffect:
     """
 
     @staticmethod
-    def create(
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> NodeContractPersistenceEffect:
-        """Create a NodeContractPersistenceEffect instance with resolved dependencies.
-
-        Factory method that creates a fully configured NodeContractPersistenceEffect
-        using the provided ONEX container for dependency injection.
+    def create(container: ModelONEXContainer) -> NodeContractPersistenceEffect:
+        """Create a NodeContractPersistenceEffect instance.
 
         Args:
             container: ONEX dependency injection container. Must have the
                 following protocols registered:
                 - ProtocolPostgresAdapter: PostgreSQL database operations
                 - ProtocolCircuitBreakerAware: Backend circuit breaker protection
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. If provided, the node uses these
-                instead of resolving from container. Part of OMN-1732 runtime
-                dependency injection.
 
         Returns:
             Configured NodeContractPersistenceEffect instance ready for operation.
@@ -91,26 +78,13 @@ class RegistryInfraContractPersistenceEffect:
         Raises:
             OnexError: If required protocols are not registered in container.
 
-        Example:
-            >>> container = ModelONEXContainer()
-            >>> container.register(ProtocolPostgresAdapter, postgres_adapter)
-            >>> effect = RegistryInfraContractPersistenceEffect.create(container)
-            >>>
-            >>> # With pre-resolved dependencies (OMN-1732)
-            >>> resolved = resolver.resolve(contract)
-            >>> effect = RegistryInfraContractPersistenceEffect.create(
-            ...     container, dependencies=resolved
-            ... )
-
         .. versionadded:: 0.5.0
-        .. versionchanged:: 0.6.0
-            Added optional ``dependencies`` parameter for constructor injection (OMN-1732).
         """
         from omnibase_infra.nodes.node_contract_persistence_effect.node import (
             NodeContractPersistenceEffect,
         )
 
-        return NodeContractPersistenceEffect(container, dependencies=dependencies)
+        return NodeContractPersistenceEffect(container)
 
     @staticmethod
     def get_required_protocols() -> list[str]:

--- a/src/omnibase_infra/nodes/node_decision_store_effect/node.py
+++ b/src/omnibase_infra/nodes/node_decision_store_effect/node.py
@@ -44,14 +44,8 @@ from omnibase_core.nodes.node_effect import NodeEffect
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
 
 
-# ONEX_EXCLUDE: declarative_node — OMN-1732 DEC-003 requires constructor injection
-# for protocol dependencies. The _resolved_dependencies instance variable stores
-# pre-resolved protocols from ContractDependencyResolver.
 class NodeDecisionStoreEffect(NodeEffect):
     """Declarative effect node for decision store persistence.
 
@@ -64,26 +58,10 @@ class NodeDecisionStoreEffect(NodeEffect):
 
     Args:
         container: ONEX dependency injection container.
-        dependencies: Optional pre-resolved protocol dependencies. If provided,
-            the node will use these instead of resolving from container.
-            Part of OMN-1732 runtime dependency injection.
     """
 
-    def __init__(
-        self,
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> None:
-        """Initialise effect node with container dependency injection.
-
-        Args:
-            container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. If provided, the node uses these
-                instead of resolving from container. Part of OMN-1732.
-        """
+    def __init__(self, container: ModelONEXContainer) -> None:
         super().__init__(container)
-        self._resolved_dependencies = dependencies
 
 
 __all__ = ["NodeDecisionStoreEffect"]

--- a/src/omnibase_infra/nodes/node_decision_store_effect/registry/registry_infra_decision_store_effect.py
+++ b/src/omnibase_infra/nodes/node_decision_store_effect/registry/registry_infra_decision_store_effect.py
@@ -25,9 +25,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
     from omnibase_infra.nodes.node_decision_store_effect.node import (
         NodeDecisionStoreEffect,
     )
@@ -52,19 +49,14 @@ class RegistryInfraDecisionStoreEffect:
     """
 
     @staticmethod
-    def create(
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> NodeDecisionStoreEffect:
-        """Create a NodeDecisionStoreEffect instance with resolved dependencies.
+    def create(container: ModelONEXContainer) -> NodeDecisionStoreEffect:
+        """Create a NodeDecisionStoreEffect instance.
 
         Args:
             container: ONEX dependency injection container. Must have the
                 following protocols registered:
                 - ProtocolPostgresAdapter: PostgreSQL database operations
                 - ProtocolCircuitBreakerAware: Backend circuit breaker protection
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. Part of OMN-1732 runtime DI.
 
         Returns:
             Configured NodeDecisionStoreEffect instance ready for operation.
@@ -78,7 +70,7 @@ class RegistryInfraDecisionStoreEffect:
             NodeDecisionStoreEffect,
         )
 
-        return NodeDecisionStoreEffect(container, dependencies=dependencies)
+        return NodeDecisionStoreEffect(container)
 
     @staticmethod
     def get_required_protocols() -> list[str]:

--- a/src/omnibase_infra/nodes/node_delta_bundle_effect/node.py
+++ b/src/omnibase_infra/nodes/node_delta_bundle_effect/node.py
@@ -38,14 +38,8 @@ from omnibase_core.nodes.node_effect import NodeEffect
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
 
 
-# ONEX_EXCLUDE: declarative_node -- OMN-1732 DEC-003 requires constructor injection
-# for protocol dependencies. The _resolved_dependencies instance variable stores
-# pre-resolved protocols from ContractDependencyResolver.
 class NodeDeltaBundleEffect(NodeEffect):
     """Declarative effect node for delta bundle persistence.
 
@@ -57,26 +51,10 @@ class NodeDeltaBundleEffect(NodeEffect):
 
     Args:
         container: ONEX dependency injection container.
-        dependencies: Optional pre-resolved protocol dependencies. If provided,
-            the node will use these instead of resolving from container.
-            Part of OMN-1732 runtime dependency injection.
     """
 
-    def __init__(
-        self,
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> None:
-        """Initialise effect node with container dependency injection.
-
-        Args:
-            container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. If provided, the node uses these
-                instead of resolving from container. Part of OMN-1732.
-        """
+    def __init__(self, container: ModelONEXContainer) -> None:
         super().__init__(container)
-        self._resolved_dependencies = dependencies
 
 
 __all__ = ["NodeDeltaBundleEffect"]

--- a/src/omnibase_infra/nodes/node_delta_bundle_effect/registry/registry_infra_delta_bundle_effect.py
+++ b/src/omnibase_infra/nodes/node_delta_bundle_effect/registry/registry_infra_delta_bundle_effect.py
@@ -21,9 +21,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
     from omnibase_infra.nodes.node_delta_bundle_effect.node import (
         NodeDeltaBundleEffect,
     )
@@ -39,16 +36,11 @@ class RegistryInfraDeltaBundleEffect:
     """
 
     @staticmethod
-    def create(
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> NodeDeltaBundleEffect:
-        """Create a NodeDeltaBundleEffect instance with resolved dependencies.
+    def create(container: ModelONEXContainer) -> NodeDeltaBundleEffect:
+        """Create a NodeDeltaBundleEffect instance.
 
         Args:
             container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. Part of OMN-1732 runtime DI.
 
         Returns:
             Configured NodeDeltaBundleEffect instance ready for operation.
@@ -59,7 +51,7 @@ class RegistryInfraDeltaBundleEffect:
             NodeDeltaBundleEffect,
         )
 
-        return NodeDeltaBundleEffect(container, dependencies=dependencies)
+        return NodeDeltaBundleEffect(container)
 
     @staticmethod
     def get_required_protocols() -> list[str]:

--- a/src/omnibase_infra/nodes/node_delta_metrics_effect/node.py
+++ b/src/omnibase_infra/nodes/node_delta_metrics_effect/node.py
@@ -24,12 +24,8 @@ from omnibase_core.nodes.node_effect import NodeEffect
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
 
 
-# ONEX_EXCLUDE: declarative_node -- OMN-1732 DEC-003 requires constructor injection
 class NodeDeltaMetricsEffect(NodeEffect):
     """Declarative effect node for delta metrics rollup.
 
@@ -41,23 +37,10 @@ class NodeDeltaMetricsEffect(NodeEffect):
 
     Args:
         container: ONEX dependency injection container.
-        dependencies: Optional pre-resolved protocol dependencies.
     """
 
-    def __init__(
-        self,
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> None:
-        """Initialise effect node with container dependency injection.
-
-        Args:
-            container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. Part of OMN-1732.
-        """
+    def __init__(self, container: ModelONEXContainer) -> None:
         super().__init__(container)
-        self._resolved_dependencies = dependencies
 
 
 __all__ = ["NodeDeltaMetricsEffect"]

--- a/src/omnibase_infra/nodes/node_delta_metrics_effect/registry/registry_infra_delta_metrics_effect.py
+++ b/src/omnibase_infra/nodes/node_delta_metrics_effect/registry/registry_infra_delta_metrics_effect.py
@@ -21,9 +21,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
-    from omnibase_infra.models.runtime.model_resolved_dependencies import (
-        ModelResolvedDependencies,
-    )
     from omnibase_infra.nodes.node_delta_metrics_effect.node import (
         NodeDeltaMetricsEffect,
     )
@@ -39,16 +36,11 @@ class RegistryInfraDeltaMetricsEffect:
     """
 
     @staticmethod
-    def create(
-        container: ModelONEXContainer,
-        dependencies: ModelResolvedDependencies | None = None,
-    ) -> NodeDeltaMetricsEffect:
-        """Create a NodeDeltaMetricsEffect instance with resolved dependencies.
+    def create(container: ModelONEXContainer) -> NodeDeltaMetricsEffect:
+        """Create a NodeDeltaMetricsEffect instance.
 
         Args:
             container: ONEX dependency injection container.
-            dependencies: Optional pre-resolved protocol dependencies from
-                ContractDependencyResolver. Part of OMN-1732 runtime DI.
 
         Returns:
             Configured NodeDeltaMetricsEffect instance ready for operation.
@@ -59,7 +51,7 @@ class RegistryInfraDeltaMetricsEffect:
             NodeDeltaMetricsEffect,
         )
 
-        return NodeDeltaMetricsEffect(container, dependencies=dependencies)
+        return NodeDeltaMetricsEffect(container)
 
     @staticmethod
     def get_required_protocols() -> list[str]:


### PR DESCRIPTION
## Summary

- Removes \`ONEX_EXCLUDE: declarative_node\` bypass comments from 4 effect nodes: \`node_contract_persistence_effect\`, \`node_delta_bundle_effect\`, \`node_decision_store_effect\`, \`node_delta_metrics_effect\`
- Strips dead \`dependencies: ModelResolvedDependencies | None = None\` parameter and \`self._resolved_dependencies = dependencies\` assignment from each node's \`__init__\` — this was dead storage, never read by the runtime which injects dependencies directly into handlers
- Updates registry \`create()\` methods to match simplified constructor signature
- All 4 nodes now pass \`ValidatorDeclarativeNode\` with zero violations

## Evidence

Declarative node validator: 4/4 nodes \`passed=True, violations=0\`
Unit test suite: 3309 passed, 3 skipped

Evidence-Ticket: OMN-10813
Evidence-Source: 1046b7e2c6182d41b9dba2e8d895b1cb307a7dde