### PR TITLE
fix(OMN-8694): populate cost fields for non-dispatch savings estimates

### DIFF
--- a/src/omnibase_infra/services/observability/savings_estimation/consumer.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/consumer.py
@@ -687,6 +687,13 @@ class ServiceSavingsEstimator:
             if buf.treatment_group:
                 result["treatment_group"] = buf.treatment_group
 
+            # Always populate cost/model fields required by the savings_estimates
+            # projection handler. For dispatch sessions, use measured costs from the
+            # dispatch eval. For pure injection/LLM sessions, derive from actual_cost_usd
+            # and estimated savings so the projection handler never silently drops events.
+            estimated_total_savings = float(
+                result.get("estimated_total_savings_usd", 0.0)
+            )
             if buf.dispatch_evals:
                 first_dispatch = buf.dispatch_evals[0]
                 result["task_id"] = first_dispatch.task_id
@@ -701,11 +708,20 @@ class ServiceSavingsEstimator:
                 result["model_cloud_baseline"] = counterfactual
                 result["local_cost_usd"] = first_dispatch.dollars_cost
                 result["cloud_cost_usd"] = round(
-                    first_dispatch.dollars_cost
-                    + float(result.get("estimated_total_savings_usd", 0.0)),
+                    first_dispatch.dollars_cost + estimated_total_savings,
                     10,
                 )
-                result["savings_usd"] = result["estimated_total_savings_usd"]
+                result["savings_usd"] = estimated_total_savings
+            else:
+                # Pure injection/LLM session: derive costs from actual_cost_usd.
+                actual_cost = float(result.get("actual_cost_usd", 0.0))
+                result["model_local"] = actual_model_id
+                result["model_cloud_baseline"] = counterfactual
+                result["local_cost_usd"] = actual_cost
+                result["cloud_cost_usd"] = round(
+                    actual_cost + estimated_total_savings, 10
+                )
+                result["savings_usd"] = estimated_total_savings
             return result
         except Exception:
             logger.exception(

--- a/tests/integration/observability/test_savings_estimation_non_dispatch_projection.py
+++ b/tests/integration/observability/test_savings_estimation_non_dispatch_projection.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for non-dispatch savings projection fields."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.services.observability.savings_estimation.config import (
+    ConfigSavingsEstimation,
+)
+from omnibase_infra.services.observability.savings_estimation.consumer import (
+    ServiceSavingsEstimator,
+)
+
+TOPIC_LLM_CALL = "onex.evt.omniintelligence.llm-call-completed.v1"
+TOPIC_HOOK_INJECTION = "onex.evt.omniclaude.hook-context-injected.v1"
+TOPIC_SESSION_OUTCOME = "onex.evt.omniclaude.session-outcome.v1"
+
+
+def _service() -> ServiceSavingsEstimator:
+    return ServiceSavingsEstimator(
+        ConfigSavingsEstimation(
+            kafka_bootstrap_servers="localhost:19092",
+            grace_window_seconds=1.0,
+            session_timeout_seconds=3600.0,
+            max_sessions=100,
+            finalized_session_cache_size=1000,
+            schema_version="1.0",
+        )
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_non_dispatch_session_projects_cost_and_model_fields() -> None:
+    service = _service()
+
+    with patch("time.monotonic", return_value=1000.0):
+        service.ingest_event(
+            TOPIC_LLM_CALL,
+            {
+                "session_id": "session-non-dispatch",
+                "model_id": "claude-sonnet-4",
+                "prompt_tokens": 5000,
+                "completion_tokens": 1000,
+            },
+        )
+        service.ingest_event(
+            TOPIC_HOOK_INJECTION,
+            {
+                "session_id": "session-non-dispatch",
+                "tokens_injected": 300,
+                "patterns_count": 3,
+            },
+        )
+        service.ingest_event(
+            TOPIC_SESSION_OUTCOME,
+            {
+                "session_id": "session-non-dispatch",
+                "correlation_id": "corr-non-dispatch",
+            },
+        )
+
+    with patch("time.monotonic", return_value=1002.0):
+        results = await service.finalize_ready_sessions()
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["session_id"] == "session-non-dispatch"
+    assert row["model_local"] == "claude-sonnet-4"
+    assert row["model_cloud_baseline"] == "claude-opus-4-6"
+    assert row["local_cost_usd"] == row["actual_cost_usd"]
+    assert row["cloud_cost_usd"] == pytest.approx(
+        row["actual_cost_usd"] + row["estimated_total_savings_usd"]
+    )
+    assert row["savings_usd"] == row["estimated_total_savings_usd"]

--- a/tests/integration/observability/test_savings_estimation_non_dispatch_projection.py
+++ b/tests/integration/observability/test_savings_estimation_non_dispatch_projection.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -20,10 +21,14 @@ TOPIC_HOOK_INJECTION = "onex.evt.omniclaude.hook-context-injected.v1"
 TOPIC_SESSION_OUTCOME = "onex.evt.omniclaude.session-outcome.v1"
 
 
+def _kafka_bootstrap_servers() -> str:
+    return os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+
+
 def _service() -> ServiceSavingsEstimator:
     return ServiceSavingsEstimator(
         ConfigSavingsEstimation(
-            kafka_bootstrap_servers="localhost:19092",
+            kafka_bootstrap_servers=_kafka_bootstrap_servers(),
             grace_window_seconds=1.0,
             session_timeout_seconds=3600.0,
             max_sessions=100,

--- a/tests/integration/test_savings_estimation_non_dispatch_projection.py
+++ b/tests/integration/test_savings_estimation_non_dispatch_projection.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Root integration coverage for non-dispatch savings projection fields."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.services.observability.savings_estimation.config import (
+    ConfigSavingsEstimation,
+)
+from omnibase_infra.services.observability.savings_estimation.consumer import (
+    ServiceSavingsEstimator,
+)
+
+
+def _service() -> ServiceSavingsEstimator:
+    return ServiceSavingsEstimator(
+        ConfigSavingsEstimation(
+            kafka_bootstrap_servers="localhost:19092",
+            grace_window_seconds=1.0,
+            session_timeout_seconds=3600.0,
+            max_sessions=100,
+            finalized_session_cache_size=1000,
+            schema_version="1.0",
+        )
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_non_dispatch_session_populates_projection_costs() -> None:
+    service = _service()
+
+    with patch("time.monotonic", return_value=1000.0):
+        service.ingest_event(
+            "onex.evt.omniintelligence.llm-call-completed.v1",
+            {
+                "session_id": "session-non-dispatch-root",
+                "model_id": "claude-sonnet-4",
+                "prompt_tokens": 5000,
+                "completion_tokens": 1000,
+            },
+        )
+        service.ingest_event(
+            "onex.evt.omniclaude.hook-context-injected.v1",
+            {
+                "session_id": "session-non-dispatch-root",
+                "tokens_injected": 300,
+                "patterns_count": 3,
+            },
+        )
+        service.ingest_event(
+            "onex.evt.omniclaude.session-outcome.v1",
+            {"session_id": "session-non-dispatch-root"},
+        )
+
+    with patch("time.monotonic", return_value=1002.0):
+        results = await service.finalize_ready_sessions()
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["model_local"] == "claude-sonnet-4"
+    assert row["model_cloud_baseline"] == "claude-opus-4-6"
+    assert row["local_cost_usd"] == row["actual_cost_usd"]
+    assert row["cloud_cost_usd"] == pytest.approx(
+        row["actual_cost_usd"] + row["estimated_total_savings_usd"]
+    )
+    assert row["savings_usd"] == row["estimated_total_savings_usd"]

--- a/tests/integration/test_savings_estimation_non_dispatch_projection.py
+++ b/tests/integration/test_savings_estimation_non_dispatch_projection.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -16,10 +17,14 @@ from omnibase_infra.services.observability.savings_estimation.consumer import (
 )
 
 
+def _kafka_bootstrap_servers() -> str:
+    return os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+
+
 def _service() -> ServiceSavingsEstimator:
     return ServiceSavingsEstimator(
         ConfigSavingsEstimation(
-            kafka_bootstrap_servers="localhost:19092",
+            kafka_bootstrap_servers=_kafka_bootstrap_servers(),
             grace_window_seconds=1.0,
             session_timeout_seconds=3600.0,
             max_sessions=100,

--- a/tests/unit/services/test_savings_estimation_non_dispatch.py
+++ b/tests/unit/services/test_savings_estimation_non_dispatch.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit coverage for non-dispatch savings projection defaults."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.services.observability.savings_estimation.config import (
+    ConfigSavingsEstimation,
+)
+from omnibase_infra.services.observability.savings_estimation.consumer import (
+    ServiceSavingsEstimator,
+)
+
+
+def _service() -> ServiceSavingsEstimator:
+    return ServiceSavingsEstimator(
+        ConfigSavingsEstimation(
+            kafka_bootstrap_servers="localhost:19092",
+            grace_window_seconds=1.0,
+            session_timeout_seconds=3600.0,
+            max_sessions=10,
+            finalized_session_cache_size=10,
+            schema_version="1.0",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_dispatch_projection_fields_are_populated() -> None:
+    service = _service()
+
+    with patch("time.monotonic", return_value=1000.0):
+        service.ingest_event(
+            "onex.evt.omniintelligence.llm-call-completed.v1",
+            {
+                "session_id": "session-unit-non-dispatch",
+                "model_id": "claude-sonnet-4",
+                "prompt_tokens": 1000,
+                "completion_tokens": 200,
+            },
+        )
+        service.ingest_event(
+            "onex.evt.omniclaude.hook-context-injected.v1",
+            {
+                "session_id": "session-unit-non-dispatch",
+                "tokens_injected": 120,
+                "patterns_count": 2,
+            },
+        )
+        service.ingest_event(
+            "onex.evt.omniclaude.session-outcome.v1",
+            {"session_id": "session-unit-non-dispatch"},
+        )
+
+    with patch("time.monotonic", return_value=1002.0):
+        results = await service.finalize_ready_sessions()
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["model_local"] == "claude-sonnet-4"
+    assert row["model_cloud_baseline"] == "claude-opus-4-6"
+    assert row["local_cost_usd"] == row["actual_cost_usd"]
+    assert row["cloud_cost_usd"] == pytest.approx(
+        row["actual_cost_usd"] + row["estimated_total_savings_usd"]
+    )
+    assert row["savings_usd"] == row["estimated_total_savings_usd"]

--- a/tests/unit/services/test_savings_estimation_non_dispatch.py
+++ b/tests/unit/services/test_savings_estimation_non_dispatch.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -16,19 +17,24 @@ from omnibase_infra.services.observability.savings_estimation.consumer import (
 )
 
 
+def _kafka_bootstrap_servers() -> str:
+    return os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+
+
 def _service() -> ServiceSavingsEstimator:
     return ServiceSavingsEstimator(
         ConfigSavingsEstimation(
-            kafka_bootstrap_servers="localhost:19092",
+            kafka_bootstrap_servers=_kafka_bootstrap_servers(),
             grace_window_seconds=1.0,
             session_timeout_seconds=3600.0,
-            max_sessions=10,
-            finalized_session_cache_size=10,
+            max_sessions=100,
+            finalized_session_cache_size=1000,
             schema_version="1.0",
         )
     )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_non_dispatch_projection_fields_are_populated() -> None:
     service = _service()


### PR DESCRIPTION
## Summary

- `ServiceSavingsEstimator._finalize_session()` only populated `model_local`, `model_cloud_baseline`, `local_cost_usd`, `cloud_cost_usd`, `savings_usd` for sessions with `dispatch_evals`. Pure injection/LLM-only sessions emitted savings-estimated events missing these fields.
- The omnimarket `SavingsProjectionRunner` silently drops events where those fields are None (line 134) or where cost arithmetic fails (line 140), causing `savings_estimates` to remain at 0 rows despite active sessions.
- Fix: add `else` branch in `_finalize_session` to populate cost fields from `actual_cost_usd` for non-dispatch sessions.

## Root cause

```
consumer._finalize_session() → savings-estimated event (missing cost fields)
→ omnimarket SavingsProjectionRunner.project_event() → returns True (silently drops)
→ savings_estimates table: 0 rows
```

## Test plan

- [x] Existing unit tests in `tests/unit/consumers/` pass (21 tests)
- [x] Pre-commit hooks pass
- [x] Linting and mypy pass

Evidence-Ticket: OMN-8694
Evidence-Source: 74eed5272e1d70616a0b2b473a57fd8a0a6fcc78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed savings estimation calculations to always compute total savings and properly populate cost and model fields for all session types, including non-dispatch scenarios.

* **Tests**
  * Added unit and integration test suites to validate non-dispatch savings estimation accuracy, including cost consistency checks and savings field relationships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->