### PR TITLE
feat(OMN-11542): wire stability projection API runtime

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -208,7 +208,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # required dependency but we use --no-deps for the source install, so it must
 # be present first. The GitHub archive source avoids recursive submodule
 # checkout from the repository while PyPI publishing is automated.
-ARG OMNIBASE_COMPAT_REF="a0aa0045083e750fd29ad1584fbd028bce95d24e"
+ARG OMNIBASE_COMPAT_REF="c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1"
+ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1.tar.gz"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "https://github.com/OmniNode-ai/omnibase_compat/archive/${OMNIBASE_COMPAT_REF}.tar.gz"

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -208,10 +208,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # required dependency but we use --no-deps for the source install, so it must
 # be present first. The GitHub archive source avoids recursive submodule
 # checkout from the repository while PyPI publishing is automated.
-ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1.tar.gz"
+ARG OMNIBASE_COMPAT_REF="a0aa0045083e750fd29ad1584fbd028bce95d24e"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
-    "${OMNIBASE_COMPAT_SOURCE}"
+    "https://github.com/OmniNode-ai/omnibase_compat/archive/${OMNIBASE_COMPAT_REF}.tar.gz"
 
 # Install onex_change_control before omnimarket — omnimarket's node_overseer_verifier
 # imports it at module level but omnimarket is installed --no-deps, so it must

--- a/docker/catalog/services/projection-api.yaml
+++ b/docker/catalog/services/projection-api.yaml
@@ -1,0 +1,46 @@
+name: projection-api
+description: OmniMarket projection API server for reducer-owned projection snapshots (OMN-11542)
+image: omnibase-infra-runtime:latest
+layer: runtime
+container_name: omnimarket-projection-api
+required_env:
+  - POSTGRES_PASSWORD
+hardcoded_env:
+  OMNIBASE_INFRA_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra'
+  OTEL_SERVICE_NAME: omnimarket-projection-api
+  RUNTIME_PROFILE: projection-api
+operational_defaults: {}
+ports:
+  external: 3002
+  internal: 3002
+healthcheck:
+  test:
+    - curl
+    - -sf
+    - http://localhost:3002/health
+  interval_s: 30
+  timeout_s: 10
+  retries: 5
+  start_period_s: 60
+volumes: []
+depends_on:
+  - service: migration-gate
+    condition: service_healthy
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - omnimarket-projection-api
+labels:
+  com.omninode.service: projection-api
+  com.omninode.layer: runtime
+  com.omninode.version: ${RUNTIME_VERSION:-0.1.0}
+  autoheal: "true"

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -720,6 +720,40 @@ services:
       - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
       - "autoheal=true"
   # ==========================================================================
+  # OmniMarket Projection API (Runtime Profile)
+  # ==========================================================================
+  # Serves reducer-owned projection snapshots. This is an API over materialized
+  # Postgres projection state; it is not an authority over client state.
+  projection-api:
+    !!merge <<: *runtime-base
+    container_name: omnimarket-projection-api
+    profiles: ["runtime", "full"]
+    depends_on:
+      migration-gate:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    command: ["omnimarket-projection-api"]
+    environment:
+      !!merge <<: *runtime-env
+      OTEL_SERVICE_NAME: omnimarket-projection-api
+      RUNTIME_PROFILE: projection-api
+    ports:
+      - "${PROJECTION_API_PORT:-3002}:3002"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    labels:
+      - "com.omninode.service=projection-api"
+      - "com.omninode.layer=runtime"
+      - "com.omninode.version=${RUNTIME_VERSION:-0.1.0}"
+      - "autoheal=true"
+  # ==========================================================================
   # ONEX Runtime - Workers (Runtime Profile)
   # ==========================================================================
   # Scalable worker containers for parallel compute operations.

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -167,6 +167,19 @@ services:
       - "com.omninode.layer=runtime"
       - "com.omninode.runtime.address=runtime://omninode-pc/prod/effects"
       - "com.omninode.runtime.id=prod-effects"
+  projection-api:
+    container_name: omnimarket-prod-projection-api
+    restart: unless-stopped
+    environment:
+      ONEX_ENVIRONMENT: prod
+      KAFKA_ENVIRONMENT: prod
+      OTEL_SERVICE_NAME: omnimarket-prod-projection-api
+    ports: !override
+      - "${PROD_PROJECTION_API_PORT:-23002}:3002"
+    labels:
+      - "com.omninode.lane=prod"
+      - "com.omninode.service=projection-api"
+      - "com.omninode.layer=runtime"
   runtime-worker:
     container_name: omninode-prod-runtime-worker
     restart: unless-stopped

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -154,6 +154,19 @@ services:
       - "com.omninode.ticket=OMN-10281"
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/effects"
       - "com.omninode.runtime.id=stability-test-effects"
+  projection-api:
+    container_name: omnimarket-stability-test-projection-api
+    restart: unless-stopped
+    environment:
+      ONEX_ENVIRONMENT: stability-test
+      KAFKA_ENVIRONMENT: stability-test
+      OTEL_SERVICE_NAME: omnimarket-stability-test-projection-api
+    ports: !override
+      - "${STABILITY_TEST_PROJECTION_API_PORT:-13002}:3002"
+    labels:
+      - "com.omninode.lane=stability-test"
+      - "com.omninode.ticket=OMN-11542"
+      - "com.omninode.service=projection-api"
   runtime-worker:
     container_name: omninode-stability-test-runtime-worker
     restart: unless-stopped

--- a/docker/migrations/forward/081_create_evidence_dashboard_projection_tables.sql
+++ b/docker/migrations/forward/081_create_evidence_dashboard_projection_tables.sql
@@ -1,0 +1,98 @@
+-- OMN-11542: projection tables for evidence dashboard live stability proof.
+-- Mirrors omnimarket node_evidence_dashboard_reducer migration 0001.
+
+CREATE TABLE IF NOT EXISTS evidence_dashboard_projection (
+    projection_key TEXT PRIMARY KEY,
+    correlation_id TEXT NOT NULL,
+    ticket_id TEXT,
+    repo TEXT,
+    pr_number INT,
+    validation_run_id TEXT,
+    current_stage TEXT NOT NULL,
+    status TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    projection_cursor TEXT NOT NULL,
+    last_event_id TEXT NOT NULL,
+    last_ingest_sequence BIGINT,
+    freshness_state TEXT NOT NULL,
+    degraded_reason TEXT,
+    observed_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS evidence_correlation_trace_projection (
+    event_id TEXT PRIMARY KEY,
+    correlation_id TEXT NOT NULL,
+    ticket_id TEXT,
+    repo TEXT,
+    pr_number INT,
+    source_topic TEXT NOT NULL,
+    source_event_type TEXT NOT NULL,
+    normalized_stage TEXT NOT NULL,
+    status TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    ingest_sequence BIGINT,
+    projection_cursor TEXT NOT NULL,
+    last_event_id TEXT NOT NULL,
+    last_ingest_sequence BIGINT,
+    freshness_state TEXT NOT NULL,
+    degraded_reason TEXT,
+    observed_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS evidence_readiness_aggregate_projection (
+    aggregate_key TEXT PRIMARY KEY,
+    correlation_id TEXT NOT NULL,
+    ticket_id TEXT,
+    repo TEXT,
+    pr_number INT,
+    readiness_state TEXT NOT NULL,
+    total_events INT NOT NULL DEFAULT 0,
+    error_events INT NOT NULL DEFAULT 0,
+    warning_events INT NOT NULL DEFAULT 0,
+    projection_cursor TEXT NOT NULL,
+    last_event_id TEXT NOT NULL,
+    last_ingest_sequence BIGINT,
+    freshness_state TEXT NOT NULL,
+    degraded_reason TEXT,
+    observed_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_dashboard_projection_cursor
+    ON evidence_dashboard_projection (projection_cursor);
+CREATE INDEX IF NOT EXISTS idx_evidence_dashboard_observed_at
+    ON evidence_dashboard_projection (observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_evidence_dashboard_expires_at
+    ON evidence_dashboard_projection (expires_at);
+CREATE INDEX IF NOT EXISTS idx_evidence_dashboard_ticket
+    ON evidence_dashboard_projection (ticket_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_dashboard_repo_pr
+    ON evidence_dashboard_projection (repo, pr_number);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_trace_correlation_sequence
+    ON evidence_correlation_trace_projection (
+        correlation_id,
+        ingest_sequence,
+        observed_at
+    );
+CREATE INDEX IF NOT EXISTS idx_evidence_trace_projection_cursor
+    ON evidence_correlation_trace_projection (projection_cursor);
+CREATE INDEX IF NOT EXISTS idx_evidence_trace_expires_at
+    ON evidence_correlation_trace_projection (expires_at);
+CREATE INDEX IF NOT EXISTS idx_evidence_trace_ticket
+    ON evidence_correlation_trace_projection (ticket_id);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_readiness_projection_cursor
+    ON evidence_readiness_aggregate_projection (projection_cursor);
+CREATE INDEX IF NOT EXISTS idx_evidence_readiness_observed_at
+    ON evidence_readiness_aggregate_projection (observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_evidence_readiness_expires_at
+    ON evidence_readiness_aggregate_projection (expires_at);
+CREATE INDEX IF NOT EXISTS idx_evidence_readiness_ticket
+    ON evidence_readiness_aggregate_projection (ticket_id);

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:1d54d2e4649786559654070697fb18ffff1ae41d5a047c1cd0919680544c62cc
-generated_at: 2026-05-22T11:58:00Z
-migration_file_count: 66
+sha256:c73231978c0c8ef7b567c7fccf2918c291869f831da9039da48de3e207f158af
+generated_at: 2026-05-22T14:49:20Z
+migration_file_count: 67

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -645,9 +645,10 @@ class DeployExecutor:
         Without this arg, Docker serves a cached layer even after git pull, so
         the running container silently ships pre-pull code (root cause: PR #1231).
 
-        Also passes OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF as full commit
-        SHAs so the uv cache mount (keyed on URL) misses and fetches fresh code
-        every time main advances (OMN-10728).
+        Also passes OMNIBASE_COMPAT_REF, OMNIMARKET_REF, and
+        ONEX_CHANGE_CONTROL_REF as full commit SHAs so the uv cache mount
+        (keyed on URL) misses and fetches fresh code every time main advances
+        (OMN-10728 / OMN-11542).
         """
         timeout = PHASE_TIMEOUTS.get(
             Phase.CORE if scope == Scope.CORE else Phase.RUNTIME, 300
@@ -658,13 +659,19 @@ class DeployExecutor:
         omnimarket_ref = (
             self._resolve_plugin_ref(f"{omni_home}/omnimarket") if omni_home else "main"
         )
+        compat_ref = (
+            self._resolve_plugin_ref(f"{omni_home}/omnibase_compat")
+            if omni_home
+            else "main"
+        )
         occ_ref = (
             self._resolve_plugin_ref(f"{omni_home}/onex_change_control")
             if omni_home
             else "main"
         )
         logger.info(
-            "_compose_build: OMNIMARKET_REF=%s ONEX_CHANGE_CONTROL_REF=%s",
+            "_compose_build: OMNIBASE_COMPAT_REF=%s OMNIMARKET_REF=%s ONEX_CHANGE_CONTROL_REF=%s",
+            compat_ref[:12],
             omnimarket_ref[:12],
             occ_ref[:12],
         )
@@ -681,6 +688,8 @@ class DeployExecutor:
             "build",
             "--build-arg",
             f"GIT_SHA={git_sha}",
+            "--build-arg",
+            f"OMNIBASE_COMPAT_REF={compat_ref}",
             "--build-arg",
             f"OMNIMARKET_REF={omnimarket_ref}",
             "--build-arg",

--- a/scripts/deploy-agent/tests/unit/test_executor_build_source.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_build_source.py
@@ -171,3 +171,8 @@ def test_runtime_dockerfile_validates_and_stamps_build_source() -> None:
     assert "BUILD_SOURCE=workspace requires OMNI_HOME" in dockerfile
     assert 'com.omninode.build_source="${BUILD_SOURCE}"' in dockerfile
     assert "BUILD_SOURCE=${BUILD_SOURCE}" in dockerfile
+    assert "ARG OMNIBASE_COMPAT_REF=" in dockerfile
+    assert (
+        "https://github.com/OmniNode-ai/omnibase_compat/archive/${OMNIBASE_COMPAT_REF}.tar.gz"
+        in dockerfile
+    )

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -5,8 +5,9 @@
 Without this, Docker's layer cache silently serves stale COPY src/ layers even when
 git is at the correct SHA (root cause of PR #1231 verification failure).
 
-Also covers OMN-10728: OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF must be passed as
-full commit SHAs so the uv cache mount (keyed on URL) misses when main advances.
+Also covers OMN-10728 / OMN-11542: OMNIBASE_COMPAT_REF, OMNIMARKET_REF, and
+ONEX_CHANGE_CONTROL_REF must be passed as full commit SHAs so the uv cache mount
+(keyed on URL) misses when main advances.
 """
 
 from __future__ import annotations
@@ -129,9 +130,11 @@ class TestCacheBust:
 
 
 class TestUvCacheBustPluginRefs:
-    """OMN-10728: _compose_build must pass OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF
-    as full commit SHAs so the BuildKit uv cache mount (keyed on URL) misses when
-    main advances — preventing stale plugin sdists from being served.
+    """Builds must pass plugin refs as full SHAs for BuildKit cache invalidation.
+
+    OMN-10728 covered omnimarket and onex_change_control. OMN-11542 adds
+    omnibase_compat because runtime evidence DTOs were stale even though the
+    installed package version looked current.
     """
 
     def _fake_run_ok(
@@ -175,6 +178,42 @@ class TestUvCacheBustPluginRefs:
         }
         assert f"OMNIMARKET_REF={sentinel_sha}" in build_args, (
             f"Expected OMNIMARKET_REF={sentinel_sha!r} in build args; got {build_args}"
+        )
+
+    def test_compose_build_passes_omnibase_compat_ref_build_arg(self) -> None:
+        """_compose_build must include --build-arg OMNIBASE_COMPAT_REF=<sha>."""
+        executor = DeployExecutor()
+        sentinel_sha = "face1234abcd5678"
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        with (
+            patch.dict("os.environ", {"OMNI_HOME": "/workspace/omni_home"}),
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(
+                DeployExecutor, "_resolve_plugin_ref", return_value=sentinel_sha
+            ),
+        ):
+            executor._compose_build(Scope.RUNTIME, "abc123", _noop_phase_update)
+
+        build_cmds = [c for c in captured_cmds if "build" in c]
+        assert build_cmds, "Expected at least one 'docker compose build' call"
+        build_cmd = build_cmds[0]
+        build_args = {
+            build_cmd[i + 1]
+            for i, tok in enumerate(build_cmd)
+            if tok == "--build-arg" and i + 1 < len(build_cmd)
+        }
+        assert f"OMNIBASE_COMPAT_REF={sentinel_sha}" in build_args, (
+            f"Expected OMNIBASE_COMPAT_REF={sentinel_sha!r} in build args; got {build_args}"
         )
 
     def test_compose_build_passes_onex_change_control_ref_build_arg(self) -> None:
@@ -268,6 +307,9 @@ class TestUvCacheBustPluginRefs:
         }
         assert "OMNIMARKET_REF=main" in build_args, (
             f"Expected OMNIMARKET_REF=main when OMNI_HOME unset; got {build_args}"
+        )
+        assert "OMNIBASE_COMPAT_REF=main" in build_args, (
+            f"Expected OMNIBASE_COMPAT_REF=main when OMNI_HOME unset; got {build_args}"
         )
         assert "ONEX_CHANGE_CONTROL_REF=main" in build_args, (
             f"Expected ONEX_CHANGE_CONTROL_REF=main when OMNI_HOME unset; got {build_args}"

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -54,6 +54,7 @@ readonly RUNTIME_SERVICES=(
     omninode-runtime
     runtime-effects
     runtime-worker
+    projection-api
     agent-actions-consumer
     skill-lifecycle-consumer
     intelligence-api
@@ -443,6 +444,20 @@ read_git_sha() {
     fi
 
     echo "${sha}"
+}
+
+read_repo_ref_or_main() {
+    # Return a full git SHA for sibling workspace repos when available. Docker
+    # build args use the value in install URLs, so "main" is only a fallback.
+    local repo_path="$1"
+    local sha
+
+    sha="$(git -C "${repo_path}" rev-parse HEAD 2>/dev/null || true)"
+    if [[ -n "${sha}" ]]; then
+        echo "${sha}"
+    else
+        echo "main"
+    fi
 }
 
 check_git_dirty() {
@@ -1163,6 +1178,15 @@ build_images() {
 
     local build_date
     build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    local omni_home="${OMNI_HOME:-}"
+    local compat_ref="main"
+    local omnimarket_ref="main"
+    local occ_ref="main"
+    if [[ -n "${omni_home}" ]]; then
+        compat_ref="$(read_repo_ref_or_main "${omni_home}/omnibase_compat")"
+        omnimarket_ref="$(read_repo_ref_or_main "${omni_home}/omnimarket")"
+        occ_ref="$(read_repo_ref_or_main "${omni_home}/onex_change_control")"
+    fi
 
     # Build timeout in seconds (default: 15 minutes). Prevents the known issue
     # where `docker compose build` hangs indefinitely after images are built.
@@ -1180,9 +1204,13 @@ build_images() {
         --build-arg "BUILD_DATE=${build_date}"
         --build-arg "RUNTIME_SOURCE_HASH=${git_sha}"
         --build-arg "COMPOSE_PROJECT=${compose_project}"
+        --build-arg "OMNIBASE_COMPAT_REF=${compat_ref}"
+        --build-arg "OMNIMARKET_REF=${omnimarket_ref}"
+        --build-arg "ONEX_CHANGE_CONTROL_REF=${occ_ref}"
     )
 
     log_info "Building images with VCS_REF=${git_sha} RUNTIME_SOURCE_HASH=${git_sha} COMPOSE_PROJECT=${compose_project}..."
+    log_info "Plugin refs: OMNIBASE_COMPAT_REF=${compat_ref} OMNIMARKET_REF=${omnimarket_ref} ONEX_CHANGE_CONTROL_REF=${occ_ref}"
     log_info "Build timeout: ${build_timeout}s (set DOCKER_BUILD_TIMEOUT_SECONDS to override)"
     log_cmd "${cmd[*]}"
 
@@ -1335,7 +1363,10 @@ print_compose_commands() {
     log_info "    --build-arg VCS_REF=${git_sha} \\"
     log_info "    --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \\"
     log_info "    --build-arg RUNTIME_SOURCE_HASH=${git_sha} \\"
-    log_info "    --build-arg COMPOSE_PROJECT=${compose_project}"
+    log_info "    --build-arg COMPOSE_PROJECT=${compose_project} \\"
+    log_info "    --build-arg OMNIBASE_COMPAT_REF=\${OMNIBASE_COMPAT_REF:-main} \\"
+    log_info "    --build-arg OMNIMARKET_REF=\${OMNIMARKET_REF:-main} \\"
+    log_info "    --build-arg ONEX_CHANGE_CONTROL_REF=\${ONEX_CHANGE_CONTROL_REF:-main}"
     log_info ""
     log_info "Restart runtime services:"
     log_info "  docker compose \\"


### PR DESCRIPTION
Ticket: OMN-11542
Evidence-Source: OCC#1335
Evidence-Ticket: OMN-11542



## Summary
- adds the projection-api runtime service for reducer-owned projection snapshots
- wires stability/prod lane ports without adding domain activation overrides to compose
- bumps runtime compat source via OMNIBASE_COMPAT_REF so evidence-pipeline DTOs are present
- passes OMNIBASE_COMPAT_REF through deploy-agent/deploy-runtime cache-bust build args
- adds forward migration for evidence dashboard projection tables

Depends on omnimarket PR #747 for the installed omnimarket-projection-api entry point.

## Verification
- bash -n scripts/deploy-runtime.sh
- uv run pytest scripts/deploy-agent/tests/unit/test_executor_cache_bust.py scripts/deploy-agent/tests/unit/test_executor_build_source.py -q
- docker compose -f docker/docker-compose.infra.yml --profile runtime config --quiet
- docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
- docker compose -f docker/docker-compose.infra.yml -f docker/docker-compose.prod.yml --profile runtime config --quiet