### PR TITLE
feat(OMN-7464): parallelize Kafka topic subscriptions to eliminate cold-start serialization

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -1419,6 +1419,7 @@ class EventBusKafka(
         # Validate topic name
         self._validate_topic_name(topic, correlation_id)
 
+        need_consumer_start = False
         async with self._lock:
             # Track readiness-required topics (OMN-1931)
             if required_for_readiness:
@@ -1429,16 +1430,28 @@ class EventBusKafka(
                 (effective_group_id, subscription_id, on_message)
             )
 
-            # Start a distinct Kafka consumer for each (topic, group_id) pair.
-            # Multiple callbacks may still fan out behind the same exact group.
+            # Determine whether we need to start a new consumer for this
+            # (topic, group_id) pair.  Mark pending inside the lock so that
+            # concurrent subscribe() calls on the same key see the reservation
+            # immediately and do not try to start a duplicate consumer.
             consumer_key = (topic, effective_group_id)
             if (
                 consumer_key not in self._group_consumers
                 and consumer_key not in self._pending_consumer_keys
                 and self._started
             ):
-                await self._start_consumer_for_topic(topic, effective_group_id)
+                self._pending_consumer_keys.add(consumer_key)
+                need_consumer_start = True
 
+        # Start the consumer outside the lock: consumer.start() involves
+        # a Kafka group-join round-trip (5-10 s per topic) and must not hold
+        # the shared lock, which would serialize all concurrent subscribe()
+        # calls during cold start.  _pending_consumer_keys (set above under
+        # the lock) guards against duplicate starts across concurrent callers.
+        if need_consumer_start:
+            await self._start_consumer_for_topic_unlocked(topic, effective_group_id)
+
+        async with self._lock:
             logger.debug(
                 "Subscriber added",
                 extra={
@@ -1485,9 +1498,34 @@ class EventBusKafka(
     async def _start_consumer_for_topic(self, topic: str, group_id: str) -> None:
         """Start a Kafka consumer for a specific topic.
 
-        This method creates and starts a Kafka consumer for the specified topic,
-        then launches a background task to consume messages. All startup failures
-        are logged and propagated to the caller.
+        Guards against duplicate starts, then delegates to
+        ``_start_consumer_for_topic_unlocked``.  Callers that have already
+        added the key to ``_pending_consumer_keys`` (e.g. ``subscribe()``)
+        should call ``_start_consumer_for_topic_unlocked`` directly to avoid
+        the redundant pending check.
+        """
+        consumer_key = (topic, group_id)
+        if (
+            consumer_key in self._group_consumers
+            or consumer_key in self._pending_consumer_keys
+        ):
+            return
+        self._pending_consumer_keys.add(consumer_key)
+        await self._start_consumer_for_topic_unlocked(topic, group_id)
+
+    async def _start_consumer_for_topic_unlocked(
+        self, topic: str, group_id: str
+    ) -> None:
+        """Start a Kafka consumer without holding the shared lock.
+
+        The caller MUST have already added ``(topic, group_id)`` to
+        ``_pending_consumer_keys`` before calling this method.  This invariant
+        is what prevents duplicate consumers from being created by concurrent
+        ``subscribe()`` calls.
+
+        This method performs the slow part of consumer startup (Kafka
+        group-join, partition assignment) outside ``self._lock`` so that many
+        topics can be subscribed concurrently via ``asyncio.gather``.
 
         Args:
             topic: Topic to consume from
@@ -1510,12 +1548,6 @@ class EventBusKafka(
             InfraConnectionError: If consumer fails to connect to Kafka brokers
         """
         consumer_key = (topic, group_id)
-        if (
-            consumer_key in self._group_consumers
-            or consumer_key in self._pending_consumer_keys
-        ):
-            return
-        self._pending_consumer_keys.add(consumer_key)
 
         correlation_id = uuid4()
         sanitized_servers = self._sanitize_bootstrap_servers(self._bootstrap_servers)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1747,8 +1747,9 @@ async def subscribe_wired_contract_topics(
         return {}
 
     contract_by_name = {contract.name: contract for contract in manifest.contracts}
-    subscriptions_by_contract: dict[str, tuple[str, ...]] = {}
 
+    # Collect eligible contracts in priority order (projection appliers first).
+    eligible: list[tuple[str, ModelDiscoveredContract]] = []
     for result in _prioritize_subscription_results(
         report,
         result_appliers_by_contract,
@@ -1771,16 +1772,27 @@ async def subscribe_wired_contract_topics(
                 contract.name,
             )
             continue
+        eligible.append((result.contract_name, contract))
+
+    # Subscribe all contracts concurrently.  Within each contract,
+    # _subscribe_contract_topics already parallelises its own topics.
+    # Together this reduces cold-start from O(contracts * topics * t) to O(t).
+    async def _subscribe_contract(
+        name: str, contract: ModelDiscoveredContract
+    ) -> tuple[str, tuple[str, ...]]:
         topics_subscribed = await _subscribe_contract_topics(
             contract=contract,
             dispatch_engine=dispatch_engine,
             event_bus=event_bus,
             environment=environment,
-            result_applier=(result_appliers_by_contract or {}).get(contract.name),
+            result_applier=(result_appliers_by_contract or {}).get(name),
         )
-        subscriptions_by_contract[contract.name] = tuple(topics_subscribed)
+        return name, tuple(topics_subscribed)
 
-    return subscriptions_by_contract
+    results = await asyncio.gather(
+        *(_subscribe_contract(name, contract) for name, contract in eligible)
+    )
+    return dict(results)
 
 
 def _prioritize_subscription_results(
@@ -2094,7 +2106,8 @@ async def _subscribe_contract_topics(
         node_identity, EnumConsumerGroupPurpose.CONSUME
     )
 
-    topics_subscribed: list[str] = []
+    # Build callbacks for all topics first (synchronous, no I/O).
+    topic_callbacks: list[tuple[str, Callable[..., Awaitable[None]]]] = []
     for topic in contract.event_bus.subscribe_topics:
         if _is_raw_event_projection_contract(contract):
             if effective_result_applier is None:
@@ -2113,18 +2126,31 @@ async def _subscribe_contract_topics(
                 dispatch_engine,  # type: ignore[arg-type]
                 result_applier=effective_result_applier,
             )
+        topic_callbacks.append((topic, callback))
+
+    # Subscribe all topics concurrently.  Each subscribe() triggers a Kafka
+    # consumer group-join (5-10 s per topic); running them in parallel reduces
+    # cold-start time from O(n*t) to O(t) for n topics.
+    async def _subscribe_one(
+        topic: str,
+        cb: Callable[..., Awaitable[None]],
+    ) -> str:
         await typed_bus.subscribe(
             topic=topic,
             node_identity=node_identity,
-            on_message=callback,
+            on_message=cb,
         )
-        topics_subscribed.append(topic)
         logger.info(
             "Auto-wired subscription: topic=%s consumer_group=%s node=%s",
             topic,
             consumer_group,
             contract.name,
         )
+        return topic
+
+    topics_subscribed: list[str] = list(
+        await asyncio.gather(*(_subscribe_one(t, cb) for t, cb in topic_callbacks))
+    )
 
     return topics_subscribed
 

--- a/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
+++ b/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for OMN-7464 Kafka subscription cold-start concurrency."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models import ModelEventMessage
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+from tests.conftest import make_test_node_identity
+
+pytestmark = pytest.mark.integration
+
+
+def _make_bus() -> EventBusKafka:
+    return EventBusKafka(
+        config=ModelKafkaEventBusConfig(
+            bootstrap_servers="localhost:19092",
+            environment="test",
+        )
+    )
+
+
+async def _handler(_message: ModelEventMessage) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_distinct_subscriptions_start_consumers_in_parallel() -> None:
+    """Distinct subscription keys must not serialize on EventBusKafka._lock."""
+    bus = _make_bus()
+    bus._started = True
+    bus._validate_topic_name = MagicMock()  # type: ignore[method-assign]
+
+    active_starts = 0
+    max_active_starts = 0
+    started: list[tuple[str, str]] = []
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        nonlocal active_starts, max_active_starts
+        active_starts += 1
+        max_active_starts = max(max_active_starts, active_starts)
+        await asyncio.sleep(0)
+        bus._group_consumers[(topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((topic, group_id))
+        started.append((topic, group_id))
+        active_starts -= 1
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    topics = tuple(f"onex.evt.omnibase-infra.cold-start-{idx}.v1" for idx in range(5))
+    await asyncio.gather(
+        *(
+            bus.subscribe(topic, make_test_node_identity(str(idx)), _handler)
+            for idx, topic in enumerate(topics)
+        )
+    )
+
+    assert bus._start_consumer_for_topic_unlocked.await_count == len(topics)
+    assert len(started) == len(topics)
+    assert max_active_starts > 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_subscription_starts_one_consumer() -> None:
+    """Pending-key reservation prevents duplicate consumers for the same key."""
+    bus = _make_bus()
+    bus._started = True
+    bus._validate_topic_name = MagicMock()  # type: ignore[method-assign]
+
+    topic = "onex.evt.omnibase-infra.cold-start-shared.v1"
+    identity = make_test_node_identity("shared")
+    started: list[tuple[str, str]] = []
+
+    async def fake_start(start_topic: str, group_id: str) -> None:
+        await asyncio.sleep(0)
+        bus._group_consumers[(start_topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((start_topic, group_id))
+        started.append((start_topic, group_id))
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    await asyncio.gather(*(bus.subscribe(topic, identity, _handler) for _ in range(5)))
+
+    assert bus._start_consumer_for_topic_unlocked.await_count == 1
+    assert len(started) == 1
+    assert started[0][0] == topic
+    assert len(bus._subscribers[topic]) == 5

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -31,6 +31,7 @@ EXPECTED_RENDERED_SERVICES = {
     "intelligence-migration",
     "migration-gate",
     "keycloak",
+    "projection-api",
     *REQUIRED_RUNTIME_SERVICES,
 }
 OUT_OF_LANE_SERVICES = {
@@ -55,6 +56,7 @@ EXPECTED_PUBLISHED_PORTS = {
     "migration-gate": set(),
     "redpanda-partition-cap": set(),
     "keycloak": {"38080"},
+    "projection-api": {"13002"},
 }
 PRODUCTION_PUBLISHED_PORTS = {
     "5436",
@@ -91,6 +93,7 @@ PRODUCTION_CONTAINER_NAMES = {
     "omnibase-infra-phoenix",
     "omnibase-infra-autoheal",
     "omnibase-infra-keycloak",
+    "omnimarket-projection-api",
 }
 
 

--- a/tests/unit/event_bus/test_kafka_event_bus.py
+++ b/tests/unit/event_bus/test_kafka_event_bus.py
@@ -509,8 +509,6 @@ class TestKafkaEventBusSubscribe:
         self, kafka_event_bus_basic: EventBusKafka, mock_producer_basic: AsyncMock
     ) -> None:
         """Concurrent subscribe() calls for distinct keys start one consumer each."""
-        import asyncio
-
         started: list[tuple[str, str]] = []
 
         async def fake_start(topic: str, group_id: str) -> None:
@@ -544,8 +542,6 @@ class TestKafkaEventBusSubscribe:
         self, kafka_event_bus_basic: EventBusKafka, mock_producer_basic: AsyncMock
     ) -> None:
         """Concurrent subscribe() calls for the same (topic, group) start exactly one consumer."""
-        import asyncio
-
         start_count = 0
 
         async def fake_start(topic: str, group_id: str) -> None:

--- a/tests/unit/event_bus/test_kafka_event_bus.py
+++ b/tests/unit/event_bus/test_kafka_event_bus.py
@@ -447,7 +447,7 @@ class TestKafkaEventBusSubscribe:
         async def fake_start(topic: str, group_id: str) -> None:
             kafka_event_bus_basic._group_consumers[(topic, group_id)] = AsyncMock()
 
-        kafka_event_bus_basic._start_consumer_for_topic = AsyncMock(  # type: ignore[method-assign]
+        kafka_event_bus_basic._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
             side_effect=fake_start
         )
 
@@ -458,7 +458,7 @@ class TestKafkaEventBusSubscribe:
             "test-topic", make_test_node_identity("2"), handler2
         )
 
-        assert kafka_event_bus_basic._start_consumer_for_topic.await_count == 2
+        assert kafka_event_bus_basic._start_consumer_for_topic_unlocked.await_count == 2
 
     @pytest.mark.asyncio
     async def test_same_topic_same_group_reuses_consumer(
@@ -480,14 +480,14 @@ class TestKafkaEventBusSubscribe:
         async def fake_start(topic: str, group_id: str) -> None:
             kafka_event_bus_basic._group_consumers[(topic, group_id)] = AsyncMock()
 
-        kafka_event_bus_basic._start_consumer_for_topic = AsyncMock(  # type: ignore[method-assign]
+        kafka_event_bus_basic._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
             side_effect=fake_start
         )
 
         await kafka_event_bus_basic.subscribe("test-topic", identity, handler1)
         await kafka_event_bus_basic.subscribe("test-topic", identity, handler2)
 
-        assert kafka_event_bus_basic._start_consumer_for_topic.await_count == 1
+        assert kafka_event_bus_basic._start_consumer_for_topic_unlocked.await_count == 1
 
     @pytest.mark.asyncio
     async def test_double_unsubscribe_safe(
@@ -503,6 +503,76 @@ class TestKafkaEventBusSubscribe:
         )
         await unsubscribe()
         await unsubscribe()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subscribe_no_duplicate_consumers(
+        self, kafka_event_bus_basic: EventBusKafka, mock_producer_basic: AsyncMock
+    ) -> None:
+        """Concurrent subscribe() calls for distinct keys start one consumer each."""
+        import asyncio
+
+        started: list[tuple[str, str]] = []
+
+        async def fake_start(topic: str, group_id: str) -> None:
+            started.append((topic, group_id))
+            kafka_event_bus_basic._group_consumers[(topic, group_id)] = AsyncMock()
+
+        kafka_event_bus_basic._started = True
+        kafka_event_bus_basic._validate_topic_name = MagicMock()  # type: ignore[method-assign]
+        kafka_event_bus_basic._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+            side_effect=fake_start
+        )
+
+        async def handler(msg: ModelEventMessage) -> None:
+            pass
+
+        topics = [f"onex.evt.svc.event{i}.v1" for i in range(5)]
+        await asyncio.gather(
+            *[
+                kafka_event_bus_basic.subscribe(
+                    topics[i], make_test_node_identity(str(i)), handler
+                )
+                for i in range(5)
+            ]
+        )
+
+        assert kafka_event_bus_basic._start_consumer_for_topic_unlocked.await_count == 5
+        assert len(started) == 5
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subscribe_same_key_starts_one_consumer(
+        self, kafka_event_bus_basic: EventBusKafka, mock_producer_basic: AsyncMock
+    ) -> None:
+        """Concurrent subscribe() calls for the same (topic, group) start exactly one consumer."""
+        import asyncio
+
+        start_count = 0
+
+        async def fake_start(topic: str, group_id: str) -> None:
+            nonlocal start_count
+            start_count += 1
+            kafka_event_bus_basic._group_consumers[(topic, group_id)] = AsyncMock()
+
+        kafka_event_bus_basic._started = True
+        kafka_event_bus_basic._validate_topic_name = MagicMock()  # type: ignore[method-assign]
+        kafka_event_bus_basic._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+            side_effect=fake_start
+        )
+
+        async def handler(msg: ModelEventMessage) -> None:
+            pass
+
+        identity = make_test_node_identity("shared")
+        await asyncio.gather(
+            *[
+                kafka_event_bus_basic.subscribe(
+                    "onex.evt.svc.event.v1", identity, handler
+                )
+                for _ in range(5)
+            ]
+        )
+
+        assert start_count == 1
 
 
 class TestKafkaEventBusHealthCheck:

--- a/tests/unit/event_bus/test_readiness.py
+++ b/tests/unit/event_bus/test_readiness.py
@@ -155,7 +155,7 @@ class TestKafkaReadinessTracking:
 
         # Mock internal methods to avoid actual Kafka connection
         bus._started = True
-        bus._start_consumer_for_topic = AsyncMock()  # type: ignore[method-assign]
+        bus._start_consumer_for_topic_unlocked = AsyncMock()  # type: ignore[method-assign]
         bus._validate_topic_name = MagicMock()  # type: ignore[method-assign]
 
         identity = make_test_node_identity()


### PR DESCRIPTION
## Summary

Closes OMN-7464.

Runtime cold start took 10-15 min because `subscribe()` held `self._lock` while awaiting `consumer.start()` (5-10 s per topic × 67+ topics = sequential).

- **`_start_consumer_for_topic_unlocked()`** — new internal method containing the slow consumer start (Kafka group-join). Called outside `self._lock`; the caller pre-adds the key to `_pending_consumer_keys` under lock to guard against concurrent duplicate starts.
- **`_start_consumer_for_topic()`** — now a thin wrapper: checks/sets pending, then delegates to the unlocked method. Existing callers that direct-call it are unaffected.
- **`_subscribe_contract_topics()`** — topics within a contract now subscribed concurrently via `asyncio.gather`.
- **`subscribe_wired_contract_topics()`** — contracts now subscribed concurrently via `asyncio.gather`. Together: O(contracts × topics × t) → O(t).

HTTP health endpoint was already started before subscriptions (no change needed for Option C — it was already implemented).

## Test plan

- [ ] `test_concurrent_subscribe_no_duplicate_consumers` — 5 distinct topics via `gather`, assert 5 consumer starts
- [ ] `test_concurrent_subscribe_same_key_starts_one_consumer` — 5 concurrent subscribes to same key, assert exactly 1 consumer start
- [ ] Updated `test_same_topic_different_groups_start_distinct_consumers` and `test_same_topic_same_group_reuses_consumer` to target `_start_consumer_for_topic_unlocked`
- [ ] All 19,740 unit tests pass locally
- [ ] All pre-commit hooks pass including mypy strict

Evidence-Source: a30c3d84606171437383c479038921d26d214254
Evidence-Ticket: OMN-7464