### PR TITLE
chore(OMN-6679): narrow infra Any annotations

### DIFF
--- a/src/omnibase_infra/models/llm/model_llm_function_def.py
+++ b/src/omnibase_infra/models/llm/model_llm_function_def.py
@@ -12,9 +12,9 @@ Related:
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
 
 
 class ModelLlmFunctionDef(BaseModel):
@@ -46,10 +46,7 @@ class ModelLlmFunctionDef(BaseModel):
         default="",
         description="Human-readable summary shown to the model.",
     )
-    # ONEX_EXCLUDE: any_type - JSON Schema objects are inherently untyped dicts.
-    # The parameters field mirrors the OpenAI function-calling spec where parameter
-    # schemas are arbitrary JSON Schema objects with no fixed structure.
-    parameters: dict[str, Any] = Field(
+    parameters: dict[str, JsonType] = Field(
         default_factory=dict,
         description="JSON Schema object describing accepted arguments.",
     )

--- a/src/omnibase_infra/models/llm/model_llm_usage.py
+++ b/src/omnibase_infra/models/llm/model_llm_usage.py
@@ -22,10 +22,9 @@ Related:
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.types import JsonType
 from omnibase_spi.contracts.measurement import ContractEnumUsageSource
 
 
@@ -93,10 +92,7 @@ class ModelLlmUsage(BaseModel):
             "ESTIMATED (locally computed), or MISSING (no data)."
         ),
     )
-    # ONEX_EXCLUDE: any_type - Raw provider usage payload is an untyped dict
-    # because each LLM provider (OpenAI, Ollama, vLLM) returns a different
-    # wire format. The verbatim data is preserved for auditing, not processed.
-    raw_provider_usage: dict[str, Any] | None = Field(
+    raw_provider_usage: dict[str, JsonType] | None = Field(
         default=None,
         description=(
             "Verbatim provider response usage block for auditing. "

--- a/src/omnibase_infra/models/pricing/model_pricing_table.py
+++ b/src/omnibase_infra/models/pricing/model_pricing_table.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -275,8 +274,7 @@ class ModelPricingTable(BaseModel):
         return ModelPricingTable._from_raw_dict(data)
 
     @staticmethod
-    # ONEX_EXCLUDE: any_type - dict[str, Any] required for raw YAML manifest data
-    def from_dict(data: dict[str, Any]) -> ModelPricingTable:
+    def from_dict(data: dict[str, object]) -> ModelPricingTable:
         """Construct a pricing table from a raw dictionary.
 
         Useful for programmatic construction and testing.
@@ -290,8 +288,7 @@ class ModelPricingTable(BaseModel):
         return ModelPricingTable._from_raw_dict(data)
 
     @staticmethod
-    # ONEX_EXCLUDE: any_type - dict[str, Any] required for raw YAML manifest data
-    def _from_raw_dict(data: dict[str, Any]) -> ModelPricingTable:
+    def _from_raw_dict(data: dict[str, object]) -> ModelPricingTable:
         """Internal constructor from a raw manifest dictionary.
 
         Parses the ``models`` section into :class:`ModelPricingEntry`

--- a/src/omnibase_infra/models/runtime/model_resolved_dependencies.py
+++ b/src/omnibase_infra/models/runtime/model_resolved_dependencies.py
@@ -10,8 +10,6 @@ Part of OMN-1732: Runtime dependency injection for zero-code nodes.
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -44,16 +42,12 @@ class ModelResolvedDependencies(BaseModel):
         arbitrary_types_allowed=True,  # Required for protocol instances
     )
 
-    # ONEX_EXCLUDE: any_type - dict[str, Any] required for heterogeneous protocol instances
-    # resolved from container.service_registry. Type varies by protocol (ProtocolPostgresAdapter,
-    # ProtocolCircuitBreakerAware, etc.). Cannot use Union as protocols are open-ended.
-    protocols: dict[str, Any] = Field(
+    protocols: dict[str, object] = Field(
         default_factory=dict,
         description="Map of protocol class names to resolved instances",
     )
 
-    # ONEX_EXCLUDE: any_type - returns heterogeneous protocol instance from protocols dict
-    def get(self, protocol_name: str) -> Any:
+    def get(self, protocol_name: str) -> object:
         """Get a resolved protocol by name.
 
         Args:
@@ -75,8 +69,9 @@ class ModelResolvedDependencies(BaseModel):
             )
         return self.protocols[protocol_name]
 
-    # ONEX_EXCLUDE: any_type - returns heterogeneous protocol instance, default can be any type
-    def get_optional(self, protocol_name: str, default: Any = None) -> Any:
+    def get_optional(
+        self, protocol_name: str, default: object | None = None
+    ) -> object | None:
         """Get a resolved protocol by name, returning default if not found.
 
         Args:

--- a/src/omnibase_infra/nodes/node_decision_store_query_compute/models/model_result_decision_list.py
+++ b/src/omnibase_infra/nodes/node_decision_store_query_compute/models/model_result_decision_list.py
@@ -9,14 +9,12 @@ including next_cursor for page continuation and total_active for count display.
 
 Note on ModelDecisionStoreEntry dependency:
     ModelDecisionStoreEntry is defined in omnibase_core (OMN-2763, PR #562),
-    which is not yet released. The decisions field uses Any at runtime and is
-    typed as tuple[ModelDecisionStoreEntry, ...] for static analysis only.
+    which is not yet released. The decisions field uses object at runtime until
+    the concrete entry type is available for static analysis.
     Once OMN-2763 is merged, this model can be tightened to use the concrete type.
 """
 
 from __future__ import annotations
-
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -43,13 +41,12 @@ class ModelResultDecisionList(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
 
-    # NOTE: Using Any pending OMN-2763 (ModelDecisionStoreEntry not yet in installed omnibase_core)
-    decisions: tuple[Any, ...] = Field(
+    decisions: tuple[object, ...] = Field(
         default=(),
         description=(
             "Ordered tuple of matching ModelDecisionStoreEntry instances for this page, "
             "sorted by (created_at DESC, decision_id DESC). "
-            "Element type is Any pending OMN-2763 (omnibase_core) merge."
+            "Element type is object pending OMN-2763 (omnibase_core) merge."
         ),
     )
     next_cursor: str | None = Field(

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
@@ -17,11 +17,10 @@ Related:
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.cost import EnumUsageSource
+from omnibase_core.types import JsonType
 from omnibase_infra.enums import EnumLlmOperationType
 from omnibase_infra.models.llm.model_llm_tool_choice import (
     ModelLlmToolChoice,
@@ -109,10 +108,7 @@ class ModelLlmInferenceRequest(BaseModel):
         min_length=1,
         description="Model identifier to use for inference.",
     )
-    # ONEX_EXCLUDE: any_type - Chat messages follow the OpenAI wire format with
-    # heterogeneous content (text, tool_call results, images). Strict typing would
-    # require a large union type that mirrors the full OpenAI message spec.
-    messages: tuple[dict[str, Any], ...] = Field(
+    messages: tuple[dict[str, JsonType], ...] = Field(
         default_factory=tuple,
         description="Chat messages for CHAT_COMPLETION operations.",
     )

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/models/model_projection_record.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/models/model_projection_record.py
@@ -15,10 +15,11 @@ Related:
 
 from __future__ import annotations
 
-from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
 
 
 class ModelProjectionRecord(BaseModel):
@@ -69,10 +70,7 @@ class ModelProjectionRecord(BaseModel):
             "in schema_registration_projection.sql."
         ),
     )
-    # ONEX_EXCLUDE: any_type - dict[str, Any] required for dynamic projection columns
-    # that vary by projector schema. Cannot use a typed model because columns differ
-    # per projector (e.g., ack_deadline, capabilities, node_version).
-    data: dict[str, Any] = Field(
+    data: dict[str, JsonType] = Field(
         default_factory=dict,
         description=(
             "Dynamic projection columns that vary by projector schema. "

--- a/src/omnibase_infra/nodes/node_registry_api_effect/models/model_registry_api_response.py
+++ b/src/omnibase_infra/nodes/node_registry_api_effect/models/model_registry_api_response.py
@@ -9,10 +9,11 @@ Ticket: OMN-1441
 
 from __future__ import annotations
 
-from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
+
+from omnibase_core.types import JsonType
 
 
 class ModelRegistryApiResponse(BaseModel):
@@ -38,8 +39,7 @@ class ModelRegistryApiResponse(BaseModel):
     success: bool = Field(
         description="Whether the operation completed without fatal errors."
     )
-    # ONEX_EXCLUDE: any_type - response data is a generic JSON envelope; values are operation-specific
-    data: dict[str, Any] = Field(
+    data: dict[str, JsonType] = Field(
         default_factory=dict, description="Operation-specific payload."
     )
     warnings: list[str] = Field(

--- a/src/omnibase_infra/runtime/contract_dependency_resolver.py
+++ b/src/omnibase_infra/runtime/contract_dependency_resolver.py
@@ -114,6 +114,9 @@ class ContractDependencyResolver:
             return ModelResolvedDependencies()
 
         # Resolve each protocol from container
+        # Why: protocol instances are open-ended DI objects resolved from
+        # contract-declared classes; the concrete protocol type is known only
+        # after the dependency's module/class pair is imported.
         # ONEX_EXCLUDE: any_type - dict holds heterogeneous protocol instances resolved at runtime
         resolved: dict[str, Any] = {}
         missing: list[str] = []
@@ -233,6 +236,8 @@ class ContractDependencyResolver:
 
         return dependencies
 
+    # Why: dependency declarations can arrive as contract model objects or raw
+    # YAML dicts while this resolver bridges old and new contract loaders.
     # ONEX_EXCLUDE: any_type - dep can be ModelContractDependency or dict from various sources
     def _is_protocol_dependency(self, dep: Any) -> bool:
         """Check if a dependency is a protocol dependency.
@@ -307,6 +312,8 @@ class ContractDependencyResolver:
                 f"Class '{class_name}' not found in module '{module_path}': {e}"
             ) from e
 
+    # Why: container lookups return an implementation of the runtime-imported
+    # protocol class; callers cast to the protocol they requested.
     # ONEX_EXCLUDE: any_type - returns protocol instance, type varies by resolved protocol class
     async def _resolve_from_container(self, protocol_class: type) -> Any:
         """Resolve a protocol instance from the container.
@@ -399,6 +406,8 @@ class ContractDependencyResolver:
         # The resolver uses getattr() internally so any object with name/dependencies works
         return await self.resolve(contract, allow_missing=allow_missing)  # type: ignore[arg-type]
 
+    # Why: raw contract YAML is heterogeneous until the dependency schema is
+    # normalized into SimpleNamespace declarations.
     # ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict, values vary by contract schema
     def _load_contract_yaml(self, path: Path) -> dict[str, Any]:
         """Load and parse a contract.yaml file.

--- a/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
+++ b/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
@@ -94,9 +94,9 @@ class ModelContractNodeType(BaseModel):
     node_type: EnumNodeType = Field(
         ..., description="Validated node type from contract YAML"
     )
-    # NOTE: raw stores the heterogeneous YAML dict from yaml.safe_load — values
-    # are primitives, lists, or nested dicts; no stricter type is available.
-    # ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous contract dict
+    # Why: raw preserves validated contract YAML for downstream schema-specific
+    # loaders; values are heterogeneous until the concrete section parser runs.
+    # ONEX_EXCLUDE: any_type - contract YAML values vary by section schema
     raw: dict[str, Any] = Field(
         ..., description="Full raw contract dict for downstream use"
     )
@@ -280,7 +280,8 @@ def _load_and_validate_contract_yaml(  # stub-ok: tracked in OMN-41
     return contract, handler_routing
 
 
-# ONEX_EXCLUDE: any_type - raw is a heterogeneous YAML dict from yaml.safe_load
+# Why: raw is validated contract YAML loaded before schema-specific parsing.
+# ONEX_EXCLUDE: any_type - contract YAML values vary by section schema
 def _dispatch_contract_model(raw: dict[str, Any]) -> ModelContractNodeType:
     """Validate node_type from raw contract dict and return a typed ModelContractNodeType.
 

--- a/src/omnibase_infra/runtime/contract_loaders/tiered_resolution_contract_loader.py
+++ b/src/omnibase_infra/runtime/contract_loaders/tiered_resolution_contract_loader.py
@@ -179,7 +179,9 @@ def _check_file_size(contract_path: Path, operation: str) -> None:
         )
 
 
-# ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict from contract YAML
+# Why: raw contract YAML is heterogeneous until individual tier/trust-domain
+# parsers validate their sections.
+# ONEX_EXCLUDE: any_type - contract YAML values vary by section schema
 def _load_contract_yaml(
     contract_path: Path,
     operation: str,

--- a/src/omnibase_infra/runtime/dependency_materializer.py
+++ b/src/omnibase_infra/runtime/dependency_materializer.py
@@ -108,6 +108,8 @@ class DependencyMaterializer:
         self._lock = asyncio.Lock()
 
         # Resource cache: type -> resource instance (deduplication)
+        # Why: resources are runtime handles from different libraries
+        # (asyncpg.Pool, AIOKafkaProducer, httpx.AsyncClient) keyed by contract type.
         # ONEX_EXCLUDE: any_type - heterogeneous resource instances
         self._resource_by_type: dict[str, Any] = {}
 
@@ -153,6 +155,8 @@ class DependencyMaterializer:
             extra={"dependency_count": len(infra_deps)},
         )
 
+        # Why: each dependency name points to the runtime handle created for its
+        # resource type; concrete types vary by provider.
         # ONEX_EXCLUDE: any_type - heterogeneous resource instances
         resources: dict[str, Any] = {}
 
@@ -341,6 +345,8 @@ class DependencyMaterializer:
 
         return deps
 
+    # Why: factory dispatch returns one of several provider-specific runtime
+    # handles selected by contract resource type.
     # ONEX_EXCLUDE: any_type - returns heterogeneous resource instance
     async def _create_resource(self, resource_type: str, correlation_id: UUID) -> Any:
         """Create a resource using the appropriate provider.
@@ -400,6 +406,8 @@ class DependencyMaterializer:
             context=context,
         )
 
+    # Why: raw contract YAML is heterogeneous until the dependency materializer
+    # validates and extracts dependency declarations.
     # ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict
     def _load_contract_yaml(self, path: Path, correlation_id: UUID) -> dict[str, Any]:
         """Load and parse a contract YAML file.

--- a/src/omnibase_infra/runtime/models/model_materialized_resources.py
+++ b/src/omnibase_infra/runtime/models/model_materialized_resources.py
@@ -10,8 +10,6 @@ Part of OMN-1976: Contract dependency materialization.
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -41,15 +39,12 @@ class ModelMaterializedResources(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    # ONEX_EXCLUDE: any_type - dict holds heterogeneous resource instances
-    # (asyncpg.Pool, AIOKafkaProducer, httpx.AsyncClient). Type varies by resource.
-    resources: dict[str, Any] = Field(
+    resources: dict[str, object] = Field(
         default_factory=dict,
         description="Map of dependency names to materialized resource instances",
     )
 
-    # ONEX_EXCLUDE: any_type - returns heterogeneous resource instance
-    def get(self, name: str) -> Any:
+    def get(self, name: str) -> object:
         """Get a materialized resource by dependency name.
 
         Args:
@@ -68,8 +63,7 @@ class ModelMaterializedResources(BaseModel):
             )
         return self.resources[name]
 
-    # ONEX_EXCLUDE: any_type - returns heterogeneous resource instance or default
-    def get_optional(self, name: str, default: Any = None) -> Any:
+    def get_optional(self, name: str, default: object | None = None) -> object | None:
         """Get a resource by name, returning default if not found."""
         return self.resources.get(name, default)
 

--- a/src/omnibase_infra/runtime/providers/provider_http_client.py
+++ b/src/omnibase_infra/runtime/providers/provider_http_client.py
@@ -10,7 +10,6 @@ Part of OMN-1976: Contract dependency materialization.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import httpx
 
@@ -36,8 +35,7 @@ class ProviderHttpClient:
         """
         self._config = config
 
-    # ONEX_EXCLUDE: any_type - returns httpx.AsyncClient
-    async def create(self) -> Any:
+    async def create(self) -> httpx.AsyncClient:
         """Create an httpx.AsyncClient.
 
         Returns:
@@ -60,8 +58,7 @@ class ProviderHttpClient:
         return client
 
     @staticmethod
-    # ONEX_EXCLUDE: any_type - resource is httpx.AsyncClient, typed as Any for provider interface
-    async def close(resource: Any) -> None:
+    async def close(resource: httpx.AsyncClient | None) -> None:
         """Close an HTTP client.
 
         Args:

--- a/src/omnibase_infra/runtime/providers/provider_kafka_producer.py
+++ b/src/omnibase_infra/runtime/providers/provider_kafka_producer.py
@@ -13,13 +13,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
 
 from omnibase_infra.runtime.models.model_kafka_producer_config import (
     ModelKafkaProducerConfig,
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from aiokafka import AIOKafkaProducer
 
 
 class ProviderKafkaProducer:
@@ -41,8 +44,7 @@ class ProviderKafkaProducer:
         """
         self._config = config
 
-    # ONEX_EXCLUDE: any_type - returns AIOKafkaProducer which varies by runtime
-    async def create(self) -> Any:
+    async def create(self) -> AIOKafkaProducer:
         """Create and start a Kafka producer.
 
         Returns:
@@ -84,8 +86,7 @@ class ProviderKafkaProducer:
         return producer
 
     @staticmethod
-    # ONEX_EXCLUDE: any_type - resource is AIOKafkaProducer, typed as Any for provider interface
-    async def close(resource: Any) -> None:
+    async def close(resource: AIOKafkaProducer | None) -> None:
         """Stop a Kafka producer.
 
         Args:

--- a/src/omnibase_infra/runtime/providers/provider_postgres_pool.py
+++ b/src/omnibase_infra/runtime/providers/provider_postgres_pool.py
@@ -10,7 +10,6 @@ Part of OMN-1976: Contract dependency materialization.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import asyncpg
 
@@ -36,8 +35,7 @@ class ProviderPostgresPool:
         """
         self._config = config
 
-    # ONEX_EXCLUDE: any_type - returns asyncpg.Pool which is not a standard type
-    async def create(self) -> Any:
+    async def create(self) -> asyncpg.Pool:
         """Create an asyncpg connection pool.
 
         Returns:
@@ -71,8 +69,7 @@ class ProviderPostgresPool:
         return pool
 
     @staticmethod
-    # ONEX_EXCLUDE: any_type - resource is asyncpg.Pool, typed as Any for provider interface
-    async def close(resource: Any) -> None:
+    async def close(resource: asyncpg.Pool | None) -> None:
         """Close an asyncpg connection pool.
 
         Args:

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/config.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Literal, Self
+from typing import Literal, Self
 from urllib.parse import urlparse
 
 from pydantic import Field, field_validator, model_validator
@@ -244,8 +244,7 @@ class ConfigLlmCostAggregation(BaseSettings):
 
     @model_validator(mode="before")
     @classmethod
-    # ONEX_EXCLUDE: any_type - dict[str, Any] required for pydantic mode="before" validator
-    def warn_unrecognized_env_vars(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def warn_unrecognized_env_vars(cls, data: object) -> object:
         """Log warnings for environment variables matching the prefix but not a known field.
 
         Pydantic-settings silently drops env vars that match the prefix but

--- a/src/omnibase_infra/validation/infra_validators.py
+++ b/src/omnibase_infra/validation/infra_validators.py
@@ -34,7 +34,7 @@ import logging
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict
 
 # Third-party imports
 import yaml
@@ -169,8 +169,9 @@ def _load_exemptions_yaml() -> dict[str, list[ExemptionPattern]]:
         }
 
 
-# ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict, values vary by exemption schema
-def _convert_yaml_exemptions(yaml_list: list[dict[str, Any]]) -> list[ExemptionPattern]:
+def _convert_yaml_exemptions(
+    yaml_list: list[dict[str, object]],
+) -> list[ExemptionPattern]:
     """
     Convert YAML exemption entries to ExemptionPattern format.
 

--- a/src/omnibase_infra/validation/linter_contract.py
+++ b/src/omnibase_infra/validation/linter_contract.py
@@ -71,7 +71,7 @@ import importlib
 import logging
 import re
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID, uuid4
 
 import yaml
@@ -767,7 +767,7 @@ class ContractLinter:
     def _validate_required_fields(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate that all required top-level fields are present."""
@@ -791,7 +791,7 @@ class ContractLinter:
     def _validate_node_type(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate node_type is one of the valid ONEX 4-node types."""
@@ -841,7 +841,7 @@ class ContractLinter:
     def _validate_contract_version(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate contract_version has proper semver structure."""
@@ -905,7 +905,7 @@ class ContractLinter:
     def _validate_model_reference(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         field_name: Literal["input_model", "output_model"],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
@@ -985,7 +985,7 @@ class ContractLinter:
         self,
         file_path: str,
         field_name: str,
-        model_ref: dict[str, Any],
+        model_ref: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Check if the model's module is importable."""
@@ -1035,7 +1035,7 @@ class ContractLinter:
     def _validate_name_convention(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate name follows snake_case convention."""
@@ -1064,7 +1064,7 @@ class ContractLinter:
     def _check_recommended_fields(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Check for recommended but optional fields."""
@@ -1089,7 +1089,7 @@ class ContractLinter:
     def _validate_unknown_fields(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Detect unrecognized top-level fields and suggest corrections.
@@ -1144,7 +1144,7 @@ class ContractLinter:
     def _validate_dependencies(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate contract dependency declarations.
@@ -1298,7 +1298,7 @@ class ContractLinter:
     def _validate_version_compatibility(
         self,
         file_path: str,
-        content: dict[str, Any],
+        content: dict[str, object],
         line_map: dict[str, int],
     ) -> list[ModelContractViolation]:
         """Validate contract version is compatible with the current runtime.

--- a/src/omnibase_infra/validation/service_artifact_store.py
+++ b/src/omnibase_infra/validation/service_artifact_store.py
@@ -34,7 +34,7 @@ import logging
 import os
 import uuid as _uuid_mod
 from pathlib import Path
-from typing import Any
+from typing import cast
 from uuid import UUID
 
 import yaml
@@ -292,7 +292,7 @@ class ServiceArtifactStore:
     # ------------------------------------------------------------------
 
     # ONEX_EXCLUDE: any_type - YAML plan data is heterogeneous dict from yaml.safe_load
-    def write_plan(self, candidate_id: UUID, plan_data: dict[str, Any]) -> Path:
+    def write_plan(self, candidate_id: UUID, plan_data: dict[str, object]) -> Path:
         """Write the validation plan to disk.
 
         The plan is stored at ``{candidate_dir}/plan.yaml`` and is
@@ -325,7 +325,7 @@ class ServiceArtifactStore:
 
     # ONEX_EXCLUDE: any_type - YAML result data is heterogeneous dict for yaml.dump
     def write_result(
-        self, candidate_id: UUID, run_id: UUID, result_data: dict[str, Any]
+        self, candidate_id: UUID, run_id: UUID, result_data: dict[str, object]
     ) -> Path:
         """Write the executor result to disk.
 
@@ -355,7 +355,7 @@ class ServiceArtifactStore:
 
     # ONEX_EXCLUDE: any_type - YAML verdict data is heterogeneous dict for yaml.dump
     def write_verdict(
-        self, candidate_id: UUID, run_id: UUID, verdict_data: dict[str, Any]
+        self, candidate_id: UUID, run_id: UUID, verdict_data: dict[str, object]
     ) -> Path:
         """Write the verdict to disk.
 
@@ -385,7 +385,7 @@ class ServiceArtifactStore:
 
     # ONEX_EXCLUDE: any_type - YAML attribution data is heterogeneous dict for yaml.dump
     def write_attribution(
-        self, candidate_id: UUID, run_id: UUID, attribution_data: dict[str, Any]
+        self, candidate_id: UUID, run_id: UUID, attribution_data: dict[str, object]
     ) -> Path:
         """Write attribution data to disk.
 
@@ -476,8 +476,7 @@ class ServiceArtifactStore:
     # Read artifacts
     # ------------------------------------------------------------------
 
-    # ONEX_EXCLUDE: any_type - YAML plan data is heterogeneous dict from yaml.safe_load
-    def read_plan(self, candidate_id: UUID) -> dict[str, Any] | None:
+    def read_plan(self, candidate_id: UUID) -> dict[str, object] | None:
         """Read the validation plan from disk.
 
         Args:
@@ -494,12 +493,12 @@ class ServiceArtifactStore:
         if not plan_path.is_file():
             return None
         content = plan_path.read_text(encoding="utf-8")
-        # ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict
-        result: dict[str, Any] | None = yaml.safe_load(content)
+        result = cast("dict[str, object] | None", yaml.safe_load(content))
         return result
 
-    # ONEX_EXCLUDE: any_type - YAML verdict data is heterogeneous dict from yaml.safe_load
-    def read_verdict(self, candidate_id: UUID, run_id: UUID) -> dict[str, Any] | None:
+    def read_verdict(
+        self, candidate_id: UUID, run_id: UUID
+    ) -> dict[str, object] | None:
         """Read the verdict from disk.
 
         Args:
@@ -517,8 +516,7 @@ class ServiceArtifactStore:
         if not verdict_path.is_file():
             return None
         content = verdict_path.read_text(encoding="utf-8")
-        # ONEX_EXCLUDE: any_type - yaml.safe_load returns heterogeneous dict
-        result: dict[str, Any] | None = yaml.safe_load(content)
+        result = cast("dict[str, object] | None", yaml.safe_load(content))
         return result
 
     # ------------------------------------------------------------------

--- a/src/omnibase_infra/verification/contract_parser.py
+++ b/src/omnibase_infra/verification/contract_parser.py
@@ -13,7 +13,7 @@ verification needs.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -78,12 +78,13 @@ class ModelParsedContractForVerification(BaseModel):
     )
 
 
-# ONEX_EXCLUDE: any_type - YAML safe_load returns untyped dicts
 def _extract_handler_names(
-    data: dict[str, Any],
+    data: dict[str, object],
 ) -> tuple[str, ...]:
     """Extract handler names from handler_routing section."""
     handler_routing = data.get("handler_routing", {})
+    if not isinstance(handler_routing, dict):
+        return ()
     if not handler_routing:
         return ()
 
@@ -102,8 +103,7 @@ def _extract_handler_names(
     return tuple(names)
 
 
-# ONEX_EXCLUDE: any_type - YAML safe_load returns untyped dicts
-def _extract_fsm_states(data: dict[str, Any]) -> tuple[str, ...]:
+def _extract_fsm_states(data: dict[str, object]) -> tuple[str, ...]:
     """Extract FSM states from handler_routing state_decision_matrix entries.
 
     The state_decision_matrix can be either:
@@ -111,6 +111,8 @@ def _extract_fsm_states(data: dict[str, Any]) -> tuple[str, ...]:
     - A list of dicts with 'current_state' keys (current format)
     """
     handler_routing = data.get("handler_routing", {})
+    if not isinstance(handler_routing, dict):
+        return ()
     if not handler_routing:
         return ()
 
@@ -132,9 +134,8 @@ def _extract_fsm_states(data: dict[str, Any]) -> tuple[str, ...]:
     return tuple(sorted(states))
 
 
-# ONEX_EXCLUDE: any_type - YAML safe_load returns untyped dicts
 def _extract_event_types(
-    events_section: list[dict[str, Any]] | None,
+    events_section: list[dict[str, object]] | None,
 ) -> tuple[str, ...]:
     """Extract event type names from consumed_events or published_events."""
     if not events_section:
@@ -145,7 +146,7 @@ def _extract_event_types(
         if isinstance(event, dict):
             event_type = event.get("event_type", "")
             if event_type:
-                types.append(event_type)
+                types.append(str(event_type))
     return tuple(types)
 
 
@@ -165,19 +166,20 @@ def parse_contract_for_verification(
         yaml.YAMLError: If the YAML is malformed.
     """
     with open(contract_path) as f:
-        data = yaml.safe_load(f) or {}
+        data = cast("dict[str, object]", yaml.safe_load(f) or {})
 
-    name = data.get("name", contract_path.parent.name)
-    node_type = data.get("node_type", "UNKNOWN")
+    name = str(data.get("name", contract_path.parent.name))
+    node_type = str(data.get("node_type", "UNKNOWN"))
 
     # Event bus topics — entries may be plain strings or dicts with a "topic" key
-    event_bus = data.get("event_bus", {}) or {}
+    event_bus_raw = data.get("event_bus", {}) or {}
+    event_bus = event_bus_raw if isinstance(event_bus_raw, dict) else {}
     subscribe_topics = tuple(
-        entry["topic"] if isinstance(entry, dict) else entry
+        str(entry["topic"] if isinstance(entry, dict) else entry)
         for entry in (event_bus.get("subscribe_topics", []) or [])
     )
     publish_topics = tuple(
-        entry["topic"] if isinstance(entry, dict) else entry
+        str(entry["topic"] if isinstance(entry, dict) else entry)
         for entry in (event_bus.get("publish_topics", []) or [])
     )
 
@@ -186,8 +188,14 @@ def parse_contract_for_verification(
     fsm_states = _extract_fsm_states(data)
 
     # Consumed and published events
-    consumed_events = _extract_event_types(data.get("consumed_events"))
-    published_events = _extract_event_types(data.get("published_events"))
+    consumed_events_raw = data.get("consumed_events")
+    consumed_events = _extract_event_types(
+        consumed_events_raw if isinstance(consumed_events_raw, list) else None
+    )
+    published_events_raw = data.get("published_events")
+    published_events = _extract_event_types(
+        published_events_raw if isinstance(published_events_raw, list) else None
+    )
 
     return ModelParsedContractForVerification(
         name=name,

--- a/src/omnibase_infra/verification/event_emission.py
+++ b/src/omnibase_infra/verification/event_emission.py
@@ -15,10 +15,10 @@ import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 import yaml
 
+from omnibase_core.types import JsonType
 from omnibase_infra.verification.models import ModelContractVerificationReport
 
 logger = logging.getLogger(__name__)
@@ -26,8 +26,7 @@ logger = logging.getLogger(__name__)
 # Path to this module's contract.yaml (co-located).
 _CONTRACT_PATH = Path(__file__).parent / "contract.yaml"
 
-# ONEX_EXCLUDE: any_type - event payloads are heterogeneous dicts for Kafka serialization
-PublishFn = Callable[[str, dict[str, Any]], None]
+PublishFn = Callable[[str, dict[str, JsonType]], None]
 
 
 def _load_publish_topic() -> str:
@@ -47,10 +46,9 @@ def _load_publish_topic() -> str:
     return result
 
 
-# ONEX_EXCLUDE: any_type - event payloads are heterogeneous dicts for Kafka serialization
 def _build_event_payload(
     report: ModelContractVerificationReport,
-) -> dict[str, Any]:
+) -> dict[str, JsonType]:
     """Build the event payload from a verification report.
 
     Includes freshness fields (checked_at, fingerprint) so consumers

--- a/src/omnibase_infra/verification/probes/probe_projection.py
+++ b/src/omnibase_infra/verification/probes/probe_projection.py
@@ -10,8 +10,6 @@ by checking the registration_projections table for rows in terminal states.
 
 from __future__ import annotations
 
-from typing import Any
-
 from omnibase_infra.enums.enum_check_severity import EnumCheckSeverity
 from omnibase_infra.enums.enum_contract_check_type import EnumContractCheckType
 from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
@@ -25,10 +23,9 @@ from omnibase_infra.verification.models.model_contract_check_result import (
 TERMINAL_STATES: frozenset[str] = frozenset({"active", "ack_received"})
 
 
-# ONEX_EXCLUDE: any_type - DB rows are untyped dicts from SQL queries
 def check_projection_state(
     contract_name: str,
-    db_rows: list[dict[str, Any]],
+    db_rows: list[dict[str, object]],
 ) -> ModelContractCheckResult:
     """Check registration projection state for evidence of completed FSM cycles.
 

--- a/src/omnibase_infra/verification/probes/probe_projection.py
+++ b/src/omnibase_infra/verification/probes/probe_projection.py
@@ -10,6 +10,8 @@ by checking the registration_projections table for rows in terminal states.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+
 from omnibase_infra.enums.enum_check_severity import EnumCheckSeverity
 from omnibase_infra.enums.enum_contract_check_type import EnumContractCheckType
 from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
@@ -25,7 +27,7 @@ TERMINAL_STATES: frozenset[str] = frozenset({"active", "ack_received"})
 
 def check_projection_state(
     contract_name: str,
-    db_rows: list[dict[str, object]],
+    db_rows: Sequence[Mapping[str, object]],
 ) -> ModelContractCheckResult:
     """Check registration projection state for evidence of completed FSM cycles.
 

--- a/tests/integration/test_omn_6679_projection_probe_rows.py
+++ b/tests/integration/test_omn_6679_projection_probe_rows.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration guard for OMN-6679 projection row typing."""
+
+from __future__ import annotations
+
+from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
+from omnibase_infra.verification.probes.probe_projection import check_projection_state
+
+
+def test_omn_6679_projection_probe_accepts_string_rows() -> None:
+    rows: list[dict[str, str]] = [
+        {
+            "current_state": "active",
+            "entity_id": "node-registration-orchestrator",
+            "node_type": "effect",
+        }
+    ]
+
+    result = check_projection_state("node_registration_orchestrator", rows)
+
+    assert result.verdict == EnumValidationVerdict.PASS


### PR DESCRIPTION
## Summary
- replace JSON-shaped payload annotations with JsonType where the data is serializable
- replace concrete runtime provider return/close annotations with httpx, asyncpg, and aiokafka types
- use object for generic runtime containers where callers must cast to the requested protocol/resource
- add explicit inline rationale for remaining dynamic YAML/protocol/resource Any boundaries
- widen projection probe row typing and add an integration guard for string-only DB rows

## Verification
- env -u PYTHONPATH uv run python scripts/validate.py any_types
- env -u PYTHONPATH uv run mypy <touched module set>
- env -u PYTHONPATH uv run ruff check <touched module set>
- env -u PYTHONPATH uv run ruff format --check <touched module set>
- env -u PYTHONPATH uv run pytest targeted model/runtime/contract-loader suites -q (373 passed)
- uv run mypy src/omnibase_infra/verification/probes/probe_projection.py src/omnibase_infra/verification/verify_registration.py src/omnibase_infra/verification/orchestrator.py
- uv run pytest tests/integration/test_omn_6679_projection_probe_rows.py tests/unit/verification/test_projection_probe.py -q
- uv run ruff format --check src/omnibase_infra/verification/probes/probe_projection.py tests/integration/test_omn_6679_projection_probe_rows.py
- uv run ruff check src/omnibase_infra/verification/probes/probe_projection.py tests/integration/test_omn_6679_projection_probe_rows.py
- commit hooks passed, including ONEX Any Type Validation
- push hooks passed, including mypy and architecture layer validation

Linear: OMN-6679

Evidence-Source: OCC#1379
Evidence-Ticket: OMN-6679