### PR TITLE
ci(OMN-11718): add dev branch workflow triggers

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -20,7 +20,7 @@ name: Receipt Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    branches: [main]
+    branches: [main, dev]
   merge_group:
 
 permissions:

--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -15,7 +15,7 @@ name: Reject skip-gate bypass tokens
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev]
   merge_group:
 
 permissions:

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -6,7 +6,7 @@ name: Sibling Compat Check (OMN-4315)
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
     paths:
       - 'pyproject.toml'
       - 'uv.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -22,7 +22,7 @@ name: Contract Validation
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -12,7 +12,7 @@ name: Deploy Gate
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
 
 concurrency:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,7 @@ on:
       - 'tests/integration/docker/**'
       - 'src/omnibase_infra/runtime/**'
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
     paths:
       - 'docker/**'
       - 'Dockerfile*'

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -9,7 +9,7 @@ on:
       - "docker/docker-compose*.yml"
       - "tests/ci/test_env_parity.py"
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
     paths:
       - "docker/docker-compose*.yml"
       - "tests/ci/test_env_parity.py"

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -19,7 +19,7 @@ name: Integration Test Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Promotion date: 14 days after first deployment. Update this date
 # when the check is first deployed to track the promotion timeline.

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -24,6 +24,7 @@ on:
     types: [closed]
     branches:
       - main
+      - dev
 
 jobs:
   publish-pr-merged-event:

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -25,6 +25,7 @@ on:
     types: [closed]
     branches:
       - main
+      - dev
 
 jobs:
   trigger-rebuild:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -19,7 +19,7 @@ name: Stale TODO Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   stale-todo-gate:

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -28,6 +28,7 @@ on:
     types: [closed]
     branches:
       - main
+      - dev
 
 jobs:
   todo-audit:


### PR DESCRIPTION
## Summary
- Adds dev alongside main for PR workflow branch filters.
- Adds dev coverage to merge_group branch filters where branch filters exist.
- Keeps release or deploy-only workflows scoped to main where they are not PR validation gates.

Evidence-Ticket: OMN-11718
Evidence-Source: f2d2e3ee7f12613c49c775bfe56c51577ab9cd24
Related: OMN-11730, OMN-11731

## Verification
- Workflow YAML parse passed.
- Trigger audit passed: no main-targeted PR or merge_group branch filter is missing dev.
- git diff --check.
- actionlint scoped to modified files passed or only reported pre-existing findings outside this trigger edit.