### PR TITLE
fix(OMN-11756): grant Trivy SARIF upload permission

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -322,6 +322,10 @@ jobs:
       }}
     needs: docker-build
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary
- grant `security-events: write` to the Docker Build Trivy SARIF upload job
- keep job permissions scoped to contents read, packages read, and security-events write

## Verification
- parsed `.github/workflows/docker-build.yml` and asserted security-scan permissions
- `uv run pre-commit run --files .github/workflows/docker-build.yml`

Evidence-Ticket: OMN-11756
Evidence-Source: 460ae6fb4299f9f3a07c4dabc979ca9f1e06ee7f