### PR TITLE
fix(OMN-11851): remove strict=True from ModelHealthCheckResponse to fix /ready 503

### DIFF
--- a/src/omnibase_infra/runtime/models/model_health_check_response.py
+++ b/src/omnibase_infra/runtime/models/model_health_check_response.py
@@ -66,7 +66,6 @@ class ModelHealthCheckResponse(BaseModel):
     """
 
     model_config = ConfigDict(
-        strict=True,
         frozen=True,
         extra="forbid",
         from_attributes=True,

--- a/tests/integration/runtime/test_health_response_tuple_contract.py
+++ b/tests/integration/runtime/test_health_response_tuple_contract.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration contract for ModelHealthCheckResponse tuple serialization (OMN-11810).
+
+Regression gate: strict=True was removed from ModelHealthCheckResponse.model_config
+to fix /ready returning HTTP 503. The root cause was ModelEventBusReadiness
+producing required_topics as tuple[str, ...] which Pydantic strict mode rejected
+when the details dict was validated against ModelHealthCheckResponse.
+
+These tests prove the fix holds at the model-contract level without a live runtime.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.models.model_health_check_response import (
+    ModelHealthCheckResponse,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_health_response_accepts_readiness_details_with_tuple_topics() -> None:
+    """ModelHealthCheckResponse.success() must not raise when details contain tuples.
+
+    Before the fix (strict=True), Pydantic raised ValidationError because
+    ModelEventBusReadiness.required_topics typed as tuple[str, ...] was
+    preserved by model_dump() without mode='json' and then rejected as
+    non-list by strict mode validation.
+    """
+    readiness_details: dict[str, object] = {
+        "ready": True,
+        "event_bus_readiness": {
+            "healthy": True,
+            "required_topics": ("onex.cmd.test.v1", "onex.evt.test.v1"),
+            "missing_topics": (),
+            "extra_topics": (),
+        },
+    }
+    resp = ModelHealthCheckResponse.success(
+        status="healthy",
+        version="1.0.0",
+        details=readiness_details,  # type: ignore[arg-type]
+    )
+    assert resp.status == "healthy"
+    assert resp.details is not None
+
+
+def test_health_response_json_serializable_with_tuple_topics() -> None:
+    """ModelHealthCheckResponse with tuple in details must produce valid JSON."""
+    readiness_details: dict[str, object] = {
+        "ready": True,
+        "event_bus_readiness": {
+            "healthy": True,
+            "required_topics": ("onex.cmd.test.v1",),
+        },
+    }
+    resp = ModelHealthCheckResponse.success(
+        status="healthy",
+        version="1.0.0",
+        details=readiness_details,  # type: ignore[arg-type]
+    )
+    serialized = resp.model_dump_json()
+    assert "healthy" in serialized

--- a/tests/unit/runtime/models/test_model_health_check_response.py
+++ b/tests/unit/runtime/models/test_model_health_check_response.py
@@ -289,6 +289,36 @@ class TestModelHealthCheckResponseReadinessIntegration:
         json_str = resp.model_dump_json(exclude_none=True)
         assert '"required_topics":[]' in json_str
 
+    def test_readiness_details_with_tuple_topics_serializes(self) -> None:
+        """Regression test: tuple required_topics must not raise ValidationError.
+
+        model_dump() without mode='json' preserves tuple fields. Pydantic strict
+        mode rejected tuple as non-list, causing /ready to return HTTP 503.
+        Removing strict=True from ModelHealthCheckResponse fixes this.
+        """
+        readiness_details: dict[str, object] = {
+            "is_ready": False,
+            "consumers_started": True,
+            "assignments": {"topic-a": [0, 1]},
+            "consume_tasks_alive": {"topic-a": True},
+            "required_topics": ("topic-a", "topic-b"),  # tuple — the failing case
+            "required_topics_ready": False,
+            "last_error": "",
+        }
+        resp = ModelHealthCheckResponse.success(
+            status="unhealthy",
+            version="0.36.0",
+            details={
+                "ready": False,
+                "is_running": True,
+                "is_draining": False,
+                "event_bus_readiness": readiness_details,
+                "correlation_id": "abc-123",
+            },
+        )
+        json_str = resp.model_dump_json(exclude_none=True)
+        assert '"required_topics"' in json_str
+
 
 class TestModelHealthCheckResponseEquality:
     """Tests for ModelHealthCheckResponse equality comparison."""


### PR DESCRIPTION
## Summary

Closes OMN-11851

- **Root cause:** `ModelHealthCheckResponse` had `strict=True` in its `ConfigDict`, which caused Pydantic to reject `tuple` values inside the `details: dict[str, JsonType]` field. `ModelEventBusReadiness.required_topics` is typed as `tuple[str, ...]`, and when `model_dump()` is called without `mode="json"` anywhere in the pipeline, the tuple is preserved. Strict mode does not coerce `tuple` → `list`, so validation raised 15 `ValidationError`s and the health handler re-raised them as HTTP 503.
- **Fix:** Remove `strict=True` from `ModelHealthCheckResponse.model_config`. The model retains `frozen=True` (immutability) and `extra="forbid"` (no unknown fields). The `details` field is a runtime aggregation surface and must accept whatever the runtime health/readiness methods produce.
- **Regression test added:** `test_readiness_details_with_tuple_topics_serializes` — passes a dict with `required_topics` as a `tuple` into `ModelHealthCheckResponse.success()` and asserts it does not raise.
- **Integration test added:** `tests/integration/runtime/test_health_response_tuple_contract.py` — integration contract gate verifying the fix at the model-contract level.

## Affected services

- `omninode-runtime-effects` (port 8086)
- `omninode-runtime-worker` (port 8085)

Both share the `omninode-runtime` image and exhibit the same failure.

## Test plan

- [x] `uv run pytest tests/unit/runtime/models/test_model_health_check_response.py -v` — 20/20 pass
- [x] `uv run pytest tests/unit/ -k health -q` — 639 passed
- [x] `uv run pytest tests/integration/runtime/test_health_response_tuple_contract.py -v` — 2/2 pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] mypy (pre-push hook) — passed

Evidence-Ticket: OMN-11851
Evidence-Source: OCC#1459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health check response validation to properly accept tuple-based required topics in readiness details.

* **Tests**
  * Added integration and unit tests verifying tuple-based topic handling and JSON serialization in health check responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->