### PR TITLE
fix(OMN-11884): support default_handler shorthand in handler_routing parser

### DIFF
--- a/src/omnibase_infra/runtime/kafka_contract_source.py
+++ b/src/omnibase_infra/runtime/kafka_contract_source.py
@@ -1160,31 +1160,53 @@ class KafkaContractSource(MixinTypedContractEvents, ProtocolContractSource):
 
         entries: list[ModelHandlerRoutingEntry] = []
         handlers_raw = hr_raw.get("handlers")
-        for handler_item in handlers_raw if isinstance(handlers_raw, list) else []:
-            if not isinstance(handler_item, dict):
-                continue
-            handler_data = handler_item.get("handler") or {}
-            if not isinstance(handler_data, dict):
-                continue
-            event_model_ref = None
-            event_model_data = handler_item.get("event_model")
-            if isinstance(event_model_data, dict):
-                event_model_ref = ModelHandlerRef(
-                    name=event_model_data.get("name", ""),
-                    module=event_model_data.get("module", ""),
+
+        # When a handlers list is present it takes priority.  When absent,
+        # fall back to the ``default_handler`` shorthand.
+        if not isinstance(handlers_raw, list):
+            default_handler = hr_raw.get("default_handler")
+            if (
+                isinstance(default_handler, str)
+                and default_handler
+                and ":" in default_handler
+            ):
+                module_ref, class_name = default_handler.rsplit(":", 1)
+                # Bare name (no dots) like ``handler`` is kept as-is; fully
+                # qualified paths (``pkg.sub.module``) are used verbatim.
+                entries.append(
+                    ModelHandlerRoutingEntry(
+                        handler=ModelHandlerRef(
+                            name=class_name.strip(),
+                            module=module_ref.strip(),
+                        ),
+                    )
                 )
-            entries.append(
-                ModelHandlerRoutingEntry(
-                    handler=ModelHandlerRef(
-                        name=handler_data.get("name", ""),
-                        module=handler_data.get("module", ""),
-                    ),
-                    event_model=event_model_ref,
-                    operation=handler_item.get("operation"),
-                    event_type=handler_item.get("event_type"),
-                    message_category=handler_item.get("message_category"),
+        else:
+            for handler_item in handlers_raw:
+                if not isinstance(handler_item, dict):
+                    continue
+                handler_data = handler_item.get("handler") or {}
+                if not isinstance(handler_data, dict):
+                    continue
+                event_model_ref = None
+                event_model_data = handler_item.get("event_model")
+                if isinstance(event_model_data, dict):
+                    event_model_ref = ModelHandlerRef(
+                        name=event_model_data.get("name", ""),
+                        module=event_model_data.get("module", ""),
+                    )
+                entries.append(
+                    ModelHandlerRoutingEntry(
+                        handler=ModelHandlerRef(
+                            name=handler_data.get("name", ""),
+                            module=handler_data.get("module", ""),
+                        ),
+                        event_model=event_model_ref,
+                        operation=handler_item.get("operation"),
+                        event_type=handler_item.get("event_type"),
+                        message_category=handler_item.get("message_category"),
+                    )
                 )
-            )
 
         return ModelHandlerRouting(
             routing_strategy=hr_raw.get("routing_strategy", "payload_type_match"),

--- a/tests/integration/test_kafka_contract_source_default_handler.py
+++ b/tests/integration/test_kafka_contract_source_default_handler.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for Kafka contract default_handler materialization."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.runtime.kafka_contract_source import KafkaContractSource
+
+pytestmark = pytest.mark.integration
+
+
+def test_kafka_contract_source_materializes_default_handler_shorthand() -> None:
+    """Kafka-discovered contracts preserve default_handler routing for wiring."""
+    source = KafkaContractSource(environment="test", graceful_mode=False)
+    node_name = f"test.default_handler.{uuid4().hex[:8]}"
+    contract_yaml = dedent(
+        """\
+        handler_id: "effect.test.default_handler"
+        name: "Default Handler Effect"
+        contract_version:
+          major: 1
+          minor: 0
+          patch: 0
+        descriptor:
+          node_archetype: "effect"
+        input_model: "tests.fixtures.handler_proof_noop.ModelProofNoopRequest"
+        output_model: "omnibase_core.models.dispatch.ModelHandlerOutput"
+        metadata:
+          handler_class: "tests.fixtures.handler_proof_noop.HandlerProofNoop"
+        event_bus:
+          subscribe_topics:
+            - onex.cmd.test.default-handler.v1
+          publish_topics:
+            - onex.evt.test.default-handler-completed.v1
+          consumer_purpose: consume
+        handler_routing:
+          default_handler: tests.fixtures.handler_proof_noop:HandlerProofNoop
+        """
+    )
+
+    assert source.on_contract_registered(node_name, contract_yaml) is True
+    descriptor = source.get_cached_descriptor(node_name)
+    assert descriptor is not None
+
+    contract = source._build_materialization_contract(
+        node_name=node_name,
+        descriptor=descriptor,
+        environment="test",
+    )
+
+    assert contract.handler_routing is not None
+    assert len(contract.handler_routing.handlers) == 1
+    entry = contract.handler_routing.handlers[0]
+    assert entry.handler.module == "tests.fixtures.handler_proof_noop"
+    assert entry.handler.name == "HandlerProofNoop"
+    assert contract.event_bus is not None
+    assert contract.event_bus.subscribe_topics == ("onex.cmd.test.default-handler.v1",)

--- a/tests/unit/runtime/test_build_handler_routing_default_handler.py
+++ b/tests/unit/runtime/test_build_handler_routing_default_handler.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for KafkaContractSource._build_handler_routing default_handler shorthand (OMN-11884).
+
+The ``default_handler`` key allows a contract to declare a single handler using
+a ``module_ref:ClassName`` shorthand instead of a full ``handlers:`` list.
+
+Covered cases:
+- default_handler shorthand (``handler:ClassName``) with no handlers list
+- default_handler with fully-qualified module path
+- handlers list present — handlers list takes priority, default_handler ignored
+- both absent — returns ModelHandlerRouting with empty handlers tuple
+- handler_routing absent — returns None
+- default_handler with no colon — ignored (not a valid shorthand)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.runtime.kafka_contract_source import KafkaContractSource
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildHandlerRoutingDefaultHandler:
+    """Tests for _build_handler_routing default_handler shorthand (OMN-11884)."""
+
+    def test_default_handler_bare_module_colon_class(self) -> None:
+        """default_handler: handler:ClassName is parsed into a single-entry handlers tuple."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "default_handler": "handler:NodeFooCompute",
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert len(result.handlers) == 1
+        entry = result.handlers[0]
+        assert entry.handler.name == "NodeFooCompute"
+        assert entry.handler.module == "handler"
+        assert entry.event_model is None
+        assert entry.operation is None
+
+    def test_default_handler_fully_qualified_module(self) -> None:
+        """default_handler: full.module.path:ClassName is parsed correctly."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "default_handler": (
+                    "omnimarket.nodes.node_foo.handlers.handler_foo:HandlerFoo"
+                ),
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert len(result.handlers) == 1
+        entry = result.handlers[0]
+        assert entry.handler.name == "HandlerFoo"
+        assert entry.handler.module == (
+            "omnimarket.nodes.node_foo.handlers.handler_foo"
+        )
+
+    def test_handlers_list_takes_priority_over_default_handler(self) -> None:
+        """When handlers list is present, default_handler is ignored."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "operation_match",
+                "default_handler": "handler:ShouldBeIgnored",
+                "handlers": [
+                    {
+                        "operation": "do_something",
+                        "handler": {
+                            "name": "HandlerReal",
+                            "module": "some.module",
+                        },
+                    }
+                ],
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert len(result.handlers) == 1
+        assert result.handlers[0].handler.name == "HandlerReal"
+        assert result.handlers[0].handler.module == "some.module"
+        assert result.routing_strategy == "operation_match"
+
+    def test_neither_handlers_nor_default_handler_returns_empty(self) -> None:
+        """When neither handlers nor default_handler is present, returns empty handlers."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert result.handlers == ()
+
+    def test_handler_routing_absent_returns_none(self) -> None:
+        """When handler_routing key is missing entirely, returns None."""
+        config: dict[str, object] = {"event_bus": {"subscribe_topics": []}}
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is None
+
+    def test_default_handler_without_colon_is_ignored(self) -> None:
+        """default_handler without a colon separator is not a valid shorthand; ignored."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "default_handler": "postgresql",
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        # No colon means it cannot be parsed as module:ClassName — skip silently
+        assert result.handlers == ()
+
+    def test_default_handler_null_is_ignored(self) -> None:
+        """default_handler: null (None) is treated as absent."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "payload_type_match",
+                "default_handler": None,
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert result.handlers == ()
+
+    def test_routing_strategy_preserved_with_default_handler(self) -> None:
+        """routing_strategy from YAML is forwarded even when using default_handler."""
+        config: dict[str, object] = {
+            "handler_routing": {
+                "routing_strategy": "operation_match",
+                "default_handler": "handler:HandlerFoo",
+            }
+        }
+
+        result = KafkaContractSource._build_handler_routing(config)
+
+        assert result is not None
+        assert result.routing_strategy == "operation_match"


### PR DESCRIPTION
## Summary

- `_build_handler_routing()` in `kafka_contract_source.py` now parses the `default_handler: handler:ClassName` shorthand
- Also handles fully-qualified paths: `default_handler: pkg.mod.handler:ClassName`
- When `handlers:` list is present, it takes priority and `default_handler` is ignored
- When neither is present, returns `ModelHandlerRouting` with an empty handlers tuple
- Values without a `:` separator (e.g. `default_handler: "postgresql"`) are silently ignored — not valid shorthand

## Test plan

- [x] 8 new unit tests in `tests/unit/runtime/test_build_handler_routing_default_handler.py`
- [x] All 8 pass locally
- [x] `uv run mypy src/ --strict` — clean (no issues in 2365 source files)
- [x] Full unit suite: 20032 passed, 1 pre-existing failure (`test_cli.py::TestCLIMain::test_registration_only` — confirmed pre-existing on `main`)
- [x] `pre-commit run --all-files` — all hooks passed

OMN-11884

Evidence-Ticket: OMN-11884
Evidence-Source: OCC#1505
