### PR TITLE
fix(OMN-11886): add redpanda-partition-cap init service to dev compose

### DIFF
--- a/docker/catalog/services/redpanda-partition-cap.yaml
+++ b/docker/catalog/services/redpanda-partition-cap.yaml
@@ -1,0 +1,27 @@
+name: redpanda-partition-cap
+description: One-shot Redpanda init service that persists partition capacity settings before runtime startup
+image: redpandadata/redpanda:v24.2.7
+layer: infrastructure
+container_name: omnibase-infra-redpanda-partition-cap
+required_env: []
+hardcoded_env: {}
+operational_defaults: {}
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+restart: "no"
+resources: null
+command:
+  - /bin/sh
+  - -c
+  - |
+    set -eu
+    /usr/bin/rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644 cluster config set topic_partitions_per_shard 7000
+    /usr/bin/rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644 cluster config set topic_memory_per_partition 1048576
+labels:
+  com.omninode.service: redpanda-partition-cap
+  com.omninode.layer: infrastructure
+  com.omninode.ticket: OMN-11886

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -334,6 +334,37 @@ services:
       - "com.omninode.service=redpanda"
       - "com.omninode.layer=infrastructure"
   # ==========================================================================
+  # Redpanda Partition Cap - Init Service (OMN-11886)
+  # ==========================================================================
+  # One-shot init container that raises the per-shard partition limit from the
+  # Redpanda default (1000) to 7000 via rpk cluster config set, matching the
+  # prod and stability-test lane values. This complements the --set flag already
+  # passed in dev-container mode by ensuring the value is persisted to cluster
+  # config and visible to rpk introspection tools.
+  #
+  # Runtime services that auto-create topics (omninode-runtime) must wait for
+  # this container to complete before starting, to avoid hitting partition limits
+  # on fresh Redpanda volumes.
+  redpanda-partition-cap:
+    image: redpandadata/redpanda:v24.2.7
+    container_name: omnibase-infra-redpanda-partition-cap
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        /usr/bin/rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644 cluster config set topic_partitions_per_shard 7000
+        /usr/bin/rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644 cluster config set topic_memory_per_partition 1048576
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    networks:
+      - omnibase-infra-network
+    restart: "no"
+    labels:
+      - "com.omninode.service=redpanda-partition-cap"
+      - "com.omninode.layer=infrastructure"
+      - "com.omninode.ticket=OMN-11886"
+  # ==========================================================================
   # Topic Provisioning
   # ==========================================================================
   # Topics are provisioned by TopicProvisioner on runtime boot (service_kernel.py).
@@ -625,6 +656,8 @@ services:
         condition: service_completed_successfully
       redpanda:
         condition: service_healthy
+      redpanda-partition-cap:
+        condition: service_completed_successfully
       valkey:
         condition: service_healthy
     environment:


### PR DESCRIPTION
## Summary

- Dev lane was missing the `redpanda-partition-cap` init service that prod and stability-test already have
- Fresh Redpanda volumes hit the default partition limit after ~4512 auto-created partitions; this service runs `rpk cluster config set topic_partitions_per_shard=7000` after Redpanda is healthy
- Also sets `topic_memory_per_partition=1048576` to match prod/stability-test
- `omninode-runtime` now depends on `redpanda-partition-cap: condition: service_completed_successfully` so topics are not auto-created before the cap is in place
- The `--set topic_partitions_per_shard=7000` flag already in the dev-container command remains as-is; this init service complements it by persisting the value to cluster config via `rpk`

## Test plan

- [ ] Verify `docker compose -f docker/docker-compose.infra.yml config` parses without error
- [ ] Bring up dev lane and confirm `omnibase-infra-redpanda-partition-cap` container exits 0 before `omninode-runtime` starts
- [ ] Confirm `rpk cluster config get topic_partitions_per_shard` returns `7000` on the dev lane after startup

OMN-11886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Redpanda cluster initialization with optimized partition capacity and memory configuration settings to ensure proper resource allocation before runtime startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-11886
Evidence-Source: OCC#1505
