### PR TITLE
fix(OMN-11966): migration 024 index IMMUTABLE bug

### DIFF
--- a/contracts/OMN-11069.yaml
+++ b/contracts/OMN-11069.yaml
@@ -2,10 +2,7 @@ schema_version: "1.0.0"
 ticket_id: OMN-11069
 title: "feat(OMN-11069): Contract-overlay configuration — replace .env with contract overlays"
 summary: >-
-  Wire the overlay infrastructure into runtime boot and onboarding so that
-  contracts plus overlays replace .env files as the single configuration source
-  of truth. Includes OverlayFileLoader, OverlayWriter, cold-start detection, and
-  typed overlay error handling.
+  Wire the overlay infrastructure into runtime boot and onboarding so that contracts plus overlays replace .env files as the single configuration source of truth. Includes OverlayFileLoader, OverlayWriter, cold-start detection, and typed overlay error handling.
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:

--- a/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
+++ b/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS llm_delegation_call_log (
 );
 
 CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
-    ON llm_delegation_call_log (date(created_at));
+    ON llm_delegation_call_log ((created_at::date));
 
 CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_task_type
     ON llm_delegation_call_log (task_type);

--- a/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
+++ b/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
@@ -1,0 +1,20 @@
+-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Migration: 025_fix_llm_delegation_call_log_date_index
+-- Description: Corrective migration for idx_llm_delegation_call_log_date.
+--              Migration 024 used date(created_at) which is STABLE not IMMUTABLE
+--              in PostgreSQL, causing CREATE INDEX to fail on some deployments.
+--              This migration drops the broken index (if it exists) and
+--              recreates it using the IMMUTABLE (created_at::date) cast form.
+-- Ticket: OMN-11966
+--
+-- Idempotency:
+--   DROP INDEX IF EXISTS + CREATE INDEX IF NOT EXISTS — safe to re-apply.
+
+-- Drop the STABLE-function-based index if it was successfully created
+DROP INDEX IF EXISTS idx_llm_delegation_call_log_date;
+
+-- Recreate with IMMUTABLE ::date cast form
+CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
+    ON llm_delegation_call_log ((created_at::date));


### PR DESCRIPTION
## Summary
- Fix functional index in migration 024 to use IMMUTABLE `(created_at::date)` cast form — `date(timestamptz)` is STABLE not IMMUTABLE in PostgreSQL, causing `CREATE INDEX` to fail
- Add corrective migration 025 for deployments that already ran 024: drops the broken index if it exists and recreates it with the IMMUTABLE cast form

## Root cause
`date(timestamptz)` resolves to a STABLE function (timezone-aware). PostgreSQL requires functional index expressions to be IMMUTABLE. The `::date` cast operator is IMMUTABLE and produces the same result without timezone conversion.

Evidence-Ticket: OMN-11966
Evidence-Source: b5383bd5e3f65304c8310fc333c31e27e3ac2819