### PR TITLE
feat(OMN-11926): add LLM topology and registry drift validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Check type-ignore budget gate (OMN-10822)
         run: PYTHONPATH=src uv run python -m omnibase_infra.validators.type_ignore_budget --max-violations 74 src/omnibase_infra
 
+      - name: LLM topology contract drift validator (OMN-11926)
+        run: PYTHONPATH=src uv run python -m omnibase_infra.validators.llm_topology_validator contracts/llm_endpoints.yaml
+
       - name: Run mypy type checking
         run: uv run mypy src/omnibase_infra
 

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -177,12 +177,40 @@ jobs:
             echo "OMNIBASE_INFRA_VALKEY_VOLUME=${OMNIBASE_INFRA_VALKEY_VOLUME}"
             echo "OMNIBASE_INFRA_RUNTIME_LOG_VOLUME=${OMNIBASE_INFRA_RUNTIME_LOG_VOLUME}"
           } >> "$GITHUB_ENV"
-          POSTGRES_PORT="${{ inputs.compose_pg_port }}" \
+          pick_free_port() {
+            python - <<'PY'
+          import socket
+
+          with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+              sock.bind(("127.0.0.1", 0))
+              print(sock.getsockname()[1])
+          PY
+          }
+
+          export POSTGRES_PORT="$(pick_free_port)"
+          export KAFKA_PORT="$(pick_free_port)"
+          export REDPANDA_ADMIN_PORT="$(pick_free_port)"
+          export REDPANDA_SCHEMA_REGISTRY_PORT="$(pick_free_port)"
+          export REDPANDA_PANDAPROXY_PORT="$(pick_free_port)"
+          {
+            echo "POSTGRES_PORT=${POSTGRES_PORT}"
+            echo "PG_PORT=${POSTGRES_PORT}"
+            echo "KAFKA_PORT=${KAFKA_PORT}"
+            echo "REDPANDA_ADMIN_PORT=${REDPANDA_ADMIN_PORT}"
+            echo "REDPANDA_SCHEMA_REGISTRY_PORT=${REDPANDA_SCHEMA_REGISTRY_PORT}"
+            echo "REDPANDA_PANDAPROXY_PORT=${REDPANDA_PANDAPROXY_PORT}"
+          } >> "$GITHUB_ENV"
+
+          POSTGRES_PORT="${POSTGRES_PORT}" \
+          KAFKA_PORT="${KAFKA_PORT}" \
+          REDPANDA_ADMIN_PORT="${REDPANDA_ADMIN_PORT}" \
+          REDPANDA_SCHEMA_REGISTRY_PORT="${REDPANDA_SCHEMA_REGISTRY_PORT}" \
+          REDPANDA_PANDAPROXY_PORT="${REDPANDA_PANDAPROXY_PORT}" \
             docker compose -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml up -d postgres redpanda
 
           # Self-hosted CI runners run inside Docker containers that share the
           # host Docker daemon via /var/run/docker.sock. Port bindings on the
-          # host (localhost:5433, localhost:19092) are NOT reachable from the
+          # host (localhost:$POSTGRES_PORT, localhost:$KAFKA_PORT) are NOT reachable from the
           # runner container. Connect the runner to the compose network so the
           # runtime can reach services by container name on internal ports.
           runner_container_id=""
@@ -255,12 +283,12 @@ jobs:
               echo "KAFKA_BROKER_ALLOWLIST=redpanda:"
               echo "OMNIBASE_INFRA_DB_URL=postgresql://postgres:test-password@postgres:5432/omnibase_infra"
             } >> "$GITHUB_ENV"
-          elif can_connect localhost "${{ inputs.compose_pg_port }}" && can_connect localhost 19092; then
+          elif can_connect localhost "${POSTGRES_PORT}" && can_connect localhost "${KAFKA_PORT}"; then
             echo "compose service endpoints reachable by host-published ports"
             {
-              echo "KAFKA_BOOTSTRAP_SERVERS=localhost:19092"
+              echo "KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT}"
               echo "KAFKA_BROKER_ALLOWLIST=localhost:"
-              echo "OMNIBASE_INFRA_DB_URL=postgresql://postgres:test-password@localhost:${{ inputs.compose_pg_port }}/omnibase_infra"
+              echo "OMNIBASE_INFRA_DB_URL=postgresql://postgres:test-password@localhost:${POSTGRES_PORT}/omnibase_infra"
             } >> "$GITHUB_ENV"
           else
             echo "::error::compose services are healthy but unreachable from the runner by Docker DNS or localhost published ports"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -507,6 +507,15 @@ repos:
         language: script
         pass_filenames: true
         stages: [commit-msg]
+      # OMN-11926: LLM topology contract drift validator
+      # Fails on any shape violation in contracts/llm_endpoints.yaml.
+      - id: llm-topology-validator
+        name: LLM topology contract drift validator (OMN-11926)
+        entry: env PYTHONPATH=src uv run --frozen python -m omnibase_infra.validators.llm_topology_validator contracts/llm_endpoints.yaml
+        language: system
+        files: ^contracts/llm_endpoints\.yaml$
+        pass_filenames: false
+        stages: [pre-commit]
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -96,9 +96,9 @@ services:
       # host-side Kafka clients (runtime, aiokafka) resolve to the correct
       # port. Without this, broker metadata advertises 29092 (container port)
       # which is unreachable from the host even though 19092 is mapped.
-      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:${KAFKA_PORT:-19092}
       - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
-      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:18082
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:${REDPANDA_PANDAPROXY_PORT:-18082}
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
       - --rpc-addr redpanda:33145
       - --advertise-rpc-addr redpanda:33145
@@ -111,7 +111,7 @@ services:
       # Kafka external listener (for host access)
       - "${KAFKA_PORT:-19092}:29092"
       # Admin API
-      - "9644:9644"
+      - "${REDPANDA_ADMIN_PORT:-9644}:9644"
       # Schema Registry (external)
       - "${REDPANDA_SCHEMA_REGISTRY_PORT:-18081}:18081"
       # Pandaproxy (external)

--- a/src/omnibase_infra/validators/llm_registry_validator.py
+++ b/src/omnibase_infra/validators/llm_registry_validator.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""LLM model registry drift validator (OMN-11926).
+
+Validates the model_registry_v1.yaml (or equivalent) for schema completeness
+and internal consistency. Fails (exit 1) on any violation.
+
+Checks performed:
+  - Required top-level keys: schema_version, model_registry_version,
+    pricing_manifest_version, observed_at, models
+  - Every model entry has required pricing manifest fields
+  - model_id field matches the registry key
+  - valid cost_basis values
+  - context_window is a positive integer
+  - observed_at is present
+  - Cloud providers require requires_api_key_env
+  - No duplicate endpoint_env across local/same-provider models
+
+Usage:
+    python -m omnibase_infra.validators.llm_registry_validator \\
+        path/to/model_registry_v1.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+VALID_COST_BASES = frozenset(
+    {
+        "zero_marginal_api_cost",
+        "cloud_api_cost",
+    }
+)
+
+# Providers that must supply a requires_api_key_env
+CLOUD_PROVIDERS = frozenset({"anthropic", "openai", "openrouter", "z.ai"})
+
+REQUIRED_TOP_LEVEL = (
+    "schema_version",
+    "model_registry_version",
+    "pricing_manifest_version",
+    "observed_at",
+    "models",
+)
+
+REQUIRED_MODEL_FIELDS = (
+    "model_id",
+    "provider",
+    "endpoint_env",
+    "cost_basis",
+    "pricing_per_1m_input",
+    "pricing_per_1m_output",
+    "context_window",
+    "observed_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A single registry violation."""
+
+    model_key: str
+    rule: str
+    message: str
+
+    def format(self) -> str:
+        return f"[{self.rule}] {self.message}"
+
+
+def _str_field(entry: dict[str, object], key: str) -> str:
+    """Return entry[key] as a string, or '' if absent/None."""
+    val = entry.get(key)
+    return str(val) if val is not None else ""
+
+
+def validate_registry_yaml(path: Path) -> list[Finding]:
+    """Validate a model registry YAML file. Returns findings (empty = clean)."""
+    if not path.exists():
+        return [
+            Finding(
+                model_key="<file>",
+                rule="file_exists",
+                message=f"Registry file not found: {path}",
+            )
+        ]
+
+    if yaml is None:
+        return [
+            Finding(
+                model_key="<file>",
+                rule="yaml_available",
+                message="PyYAML is not installed; cannot parse model registry",
+            )
+        ]
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [
+            Finding(
+                model_key="<file>",
+                rule="yaml_parse",
+                message=f"Failed to parse YAML registry: {exc}",
+            )
+        ]
+
+    if not isinstance(raw, dict):
+        return [
+            Finding(
+                model_key="<file>",
+                rule="yaml_parse",
+                message="Registry YAML root must be a mapping",
+            )
+        ]
+
+    findings: list[Finding] = []
+
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in raw:
+            findings.append(
+                Finding(
+                    model_key="<file>",
+                    rule=f"missing_{key}",
+                    message=f"Registry is missing required top-level key: {key}",
+                )
+            )
+
+    if "models" not in raw:
+        return findings
+
+    models = raw["models"]
+    if not isinstance(models, dict):
+        findings.append(
+            Finding(
+                model_key="<file>",
+                rule="models_type",
+                message="'models' must be a mapping of model_key → model entry",
+            )
+        )
+        return findings
+
+    seen_endpoint_envs: dict[str, str] = {}
+
+    for model_key, entry in models.items():
+        if not isinstance(entry, dict):
+            findings.append(
+                Finding(
+                    model_key=str(model_key),
+                    rule="entry_type",
+                    message=f"Model entry '{model_key}' is not a mapping",
+                )
+            )
+            continue
+        findings.extend(
+            _validate_model_entry(str(model_key), entry, seen_endpoint_envs)
+        )
+
+    return findings
+
+
+def _validate_model_entry(
+    model_key: str,
+    entry: dict[str, object],
+    seen_endpoint_envs: dict[str, str],
+) -> list[Finding]:
+    findings: list[Finding] = []
+
+    # Required fields
+    for field in REQUIRED_MODEL_FIELDS:
+        if field not in entry:
+            findings.append(
+                Finding(
+                    model_key=model_key,
+                    rule=f"missing_{field}",
+                    message=f"Model '{model_key}' is missing required field: {field}",
+                )
+            )
+
+    # model_id must match the registry key
+    model_id = _str_field(entry, "model_id")
+    if model_id and model_id != model_key:
+        findings.append(
+            Finding(
+                model_key=model_key,
+                rule="model_id_key_mismatch",
+                message=(
+                    f"Model '{model_key}' has model_id='{model_id}' which does not match "
+                    "the registry key. They must be identical."
+                ),
+            )
+        )
+
+    # cost_basis validation
+    cost_basis = _str_field(entry, "cost_basis")
+    if cost_basis and cost_basis not in VALID_COST_BASES:
+        findings.append(
+            Finding(
+                model_key=model_key,
+                rule="invalid_cost_basis",
+                message=(
+                    f"Model '{model_key}' has invalid cost_basis='{cost_basis}'. "
+                    f"Valid values: {', '.join(sorted(VALID_COST_BASES))}"
+                ),
+            )
+        )
+
+    # context_window must be a positive integer
+    context_window = entry.get("context_window")
+    if context_window is not None:
+        if not isinstance(context_window, int) or context_window <= 0:
+            findings.append(
+                Finding(
+                    model_key=model_key,
+                    rule="invalid_context_window",
+                    message=(
+                        f"Model '{model_key}' has invalid context_window='{context_window}'. "
+                        "Must be a positive integer."
+                    ),
+                )
+            )
+
+    # Cloud providers require requires_api_key_env
+    provider = _str_field(entry, "provider")
+    if provider in CLOUD_PROVIDERS and "requires_api_key_env" not in entry:
+        findings.append(
+            Finding(
+                model_key=model_key,
+                rule="cloud_missing_api_key_env",
+                message=(
+                    f"Model '{model_key}' uses cloud provider='{provider}' but is missing "
+                    "required field: requires_api_key_env"
+                ),
+            )
+        )
+
+    # No duplicate endpoint_env across same-provider local models
+    endpoint_env = _str_field(entry, "endpoint_env")
+    if endpoint_env:
+        dupe_key = f"{provider}:{endpoint_env}"
+        if dupe_key in seen_endpoint_envs:
+            findings.append(
+                Finding(
+                    model_key=model_key,
+                    rule="duplicate_endpoint_env",
+                    message=(
+                        f"Duplicate endpoint_env '{endpoint_env}' for provider '{provider}' "
+                        f"on model '{model_key}'. Already claimed by '{seen_endpoint_envs[dupe_key]}'."
+                    ),
+                )
+            )
+        else:
+            seen_endpoint_envs[dupe_key] = model_key
+
+    return findings
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate model registry YAML for completeness and consistency (OMN-11926)."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path("src/omnimarket/data/model_registry/model_registry_v1.yaml"),
+        help="Path to model_registry_v1.yaml",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_registry_yaml(args.path)
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"LLM registry validator found {len(findings)} violation(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/omnibase_infra/validators/llm_topology_validator.py
+++ b/src/omnibase_infra/validators/llm_topology_validator.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""LLM topology contract drift validator (OMN-11926).
+
+Validates contracts/llm_endpoints.yaml for shape correctness. Fails (exit 1)
+on any violation — this is enforcement, not detection.
+
+Checks performed:
+  - Required top-level key: endpoints
+  - Every entry has slot_id, role, status
+  - Valid role taxonomy (closed set)
+  - Valid status values (running | disabled | on_demand | planned)
+  - Status-specific nullability: running slots require host/port/endpoint_url/model_hf_id
+  - Planned slots must have null host/port/endpoint_url/model_hf_id
+  - Disabled slots must not own a url_env_var (runtime env var ownership)
+  - endpoint_url must be consistent with host:port when all three are non-null
+  - No duplicate slot_id values
+  - No duplicate url_env_var values across running slots
+
+Usage:
+    python -m omnibase_infra.validators.llm_topology_validator contracts/llm_endpoints.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+VALID_ROLES = frozenset(
+    {
+        "coder_slow",
+        "coder_fast",
+        "embedding",
+        "reasoning",
+        "reasoning_fast",
+        "reasoning_lightweight",
+        "reasoning_transient",
+        "vision",
+        "stt",
+        "tts",
+        "reranker",
+    }
+)
+
+VALID_STATUSES = frozenset({"running", "disabled", "on_demand", "planned"})
+
+# Fields that must be non-null when status=running
+RUNNING_REQUIRED_FIELDS = ("host", "port", "endpoint_url", "model_hf_id")
+
+# Fields that must be null when status=planned
+PLANNED_NULL_FIELDS = ("host", "port", "endpoint_url", "model_hf_id")
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A single topology violation."""
+
+    slot_id: str
+    rule: str
+    message: str
+
+    def format(self) -> str:
+        return f"[{self.rule}] {self.message}"
+
+
+def _str_field(entry: dict[str, object], key: str) -> str:
+    """Return entry[key] as a string, or '' if absent/None."""
+    val = entry.get(key)
+    return str(val) if val is not None else ""
+
+
+def validate_topology_yaml(path: Path) -> list[Finding]:
+    """Validate an llm_endpoints.yaml file. Returns findings (empty = clean)."""
+    if not path.exists():
+        return [
+            Finding(
+                slot_id="<file>",
+                rule="file_exists",
+                message=f"Contract file not found: {path}",
+            )
+        ]
+
+    if yaml is None:
+        return [
+            Finding(
+                slot_id="<file>",
+                rule="yaml_available",
+                message="PyYAML is not installed; cannot parse topology contract",
+            )
+        ]
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [
+            Finding(
+                slot_id="<file>",
+                rule="yaml_parse",
+                message=f"Failed to parse YAML contract: {exc}",
+            )
+        ]
+
+    if not isinstance(raw, dict):
+        return [
+            Finding(
+                slot_id="<file>",
+                rule="yaml_parse",
+                message="Contract YAML root must be a mapping",
+            )
+        ]
+
+    findings: list[Finding] = []
+
+    if "endpoints" not in raw:
+        findings.append(
+            Finding(
+                slot_id="<file>",
+                rule="missing_endpoints_key",
+                message="Contract is missing required top-level key: endpoints",
+            )
+        )
+        return findings
+
+    endpoints = raw["endpoints"]
+    if not isinstance(endpoints, list):
+        findings.append(
+            Finding(
+                slot_id="<file>",
+                rule="endpoints_type",
+                message="'endpoints' must be a list",
+            )
+        )
+        return findings
+
+    seen_slot_ids: dict[str, int] = {}
+    seen_url_env_vars: dict[str, str] = {}
+
+    for idx, entry in enumerate(endpoints):
+        if not isinstance(entry, dict):
+            findings.append(
+                Finding(
+                    slot_id=f"<index {idx}>",
+                    rule="entry_type",
+                    message=f"Endpoint at index {idx} is not a mapping",
+                )
+            )
+            continue
+
+        slot_id = _str_field(entry, "slot_id")
+        label = slot_id or f"<index {idx}>"
+
+        if not slot_id:
+            findings.append(
+                Finding(
+                    slot_id=label,
+                    rule="missing_slot_id",
+                    message=f"Endpoint at index {idx} is missing required field: slot_id",
+                )
+            )
+
+        findings.extend(_validate_entry(label, entry, seen_slot_ids, seen_url_env_vars))
+
+    return findings
+
+
+def _validate_entry(
+    label: str,
+    entry: dict[str, object],
+    seen_slot_ids: dict[str, int],
+    seen_url_env_vars: dict[str, str],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    slot_id = _str_field(entry, "slot_id")
+    status = _str_field(entry, "status")
+    role = _str_field(entry, "role")
+
+    # Duplicate slot_id
+    if slot_id:
+        if slot_id in seen_slot_ids:
+            findings.append(
+                Finding(
+                    slot_id=slot_id,
+                    rule="duplicate_slot_id",
+                    message=f"Duplicate slot_id '{slot_id}' — already seen at index {seen_slot_ids[slot_id]}",
+                )
+            )
+        else:
+            seen_slot_ids[slot_id] = len(seen_slot_ids)
+
+    # role validation
+    if not role:
+        findings.append(
+            Finding(
+                slot_id=label,
+                rule="missing_role",
+                message=f"Endpoint '{label}' is missing required field: role",
+            )
+        )
+    elif role not in VALID_ROLES:
+        findings.append(
+            Finding(
+                slot_id=label,
+                rule="invalid_role",
+                message=(
+                    f"Endpoint '{label}' has invalid role '{role}'. "
+                    f"Valid roles: {', '.join(sorted(VALID_ROLES))}"
+                ),
+            )
+        )
+
+    # status validation
+    if not status:
+        findings.append(
+            Finding(
+                slot_id=label,
+                rule="missing_status",
+                message=f"Endpoint '{label}' is missing required field: status",
+            )
+        )
+    elif status not in VALID_STATUSES:
+        findings.append(
+            Finding(
+                slot_id=label,
+                rule="invalid_status",
+                message=(
+                    f"Endpoint '{label}' has invalid status '{status}'. "
+                    f"Valid statuses: {', '.join(sorted(VALID_STATUSES))}"
+                ),
+            )
+        )
+
+    if status not in VALID_STATUSES:
+        return findings
+
+    # Status-specific nullability checks
+    if status == "running":
+        for field in RUNNING_REQUIRED_FIELDS:
+            if entry.get(field) is None:
+                findings.append(
+                    Finding(
+                        slot_id=label,
+                        rule="running_field_null",
+                        message=(
+                            f"Endpoint '{label}' has status=running but '{field}' is null. "
+                            f"All of {RUNNING_REQUIRED_FIELDS} must be non-null when running."
+                        ),
+                    )
+                )
+
+    if status == "planned":
+        for field in PLANNED_NULL_FIELDS:
+            if entry.get(field) is not None:
+                findings.append(
+                    Finding(
+                        slot_id=label,
+                        rule="planned_field_non_null",
+                        message=(
+                            f"Endpoint '{label}' has status=planned but '{field}' is non-null. "
+                            f"Planned slots must have null {', '.join(PLANNED_NULL_FIELDS)}."
+                        ),
+                    )
+                )
+
+    # Disabled slots must not own a url_env_var
+    if status == "disabled" and entry.get("url_env_var") is not None:
+        url_env_var_val = _str_field(entry, "url_env_var")
+        findings.append(
+            Finding(
+                slot_id=label,
+                rule="disabled_owns_url_env_var",
+                message=(
+                    f"Endpoint '{label}' is disabled but has url_env_var='{url_env_var_val}'. "
+                    "Disabled slots must not own runtime env vars."
+                ),
+            )
+        )
+
+    # endpoint_url consistency check (host:port vs endpoint_url)
+    host = entry.get("host")
+    port = entry.get("port")
+    endpoint_url = entry.get("endpoint_url")
+    if host is not None and port is not None and endpoint_url is not None:
+        expected_url = f"http://{host}:{port}"
+        if endpoint_url != expected_url:
+            findings.append(
+                Finding(
+                    slot_id=label,
+                    rule="endpoint_url_mismatch",
+                    message=(
+                        f"Endpoint '{label}' endpoint_url '{endpoint_url}' does not match "
+                        f"derived URL from host+port: '{expected_url}'"
+                    ),
+                )
+            )
+
+    # Duplicate url_env_var across running/on_demand slots
+    url_env_var = _str_field(entry, "url_env_var")
+    if url_env_var and status in ("running", "on_demand"):
+        if url_env_var in seen_url_env_vars:
+            findings.append(
+                Finding(
+                    slot_id=label,
+                    rule="duplicate_url_env_var",
+                    message=(
+                        f"Duplicate url_env_var '{url_env_var}' on slot '{label}'. "
+                        f"Already claimed by slot '{seen_url_env_vars[url_env_var]}'."
+                    ),
+                )
+            )
+        else:
+            seen_url_env_vars[url_env_var] = label
+
+    return findings
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate llm_endpoints.yaml topology contract (OMN-11926)."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path("contracts/llm_endpoints.yaml"),
+        help="Path to llm_endpoints.yaml (default: contracts/llm_endpoints.yaml)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_topology_yaml(args.path)
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"LLM topology validator found {len(findings)} violation(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_reusable_runtime_boot_schema.py
+++ b/tests/ci/test_reusable_runtime_boot_schema.py
@@ -161,9 +161,9 @@ def test_compose_env_is_selected_after_network_probe(workflow: Workflow) -> None
     assert "compose service endpoints reachable by host-published ports" in compose_text
     assert "unreachable from the runner by docker dns or localhost" in compose_text
     assert "kafka_bootstrap_servers=redpanda:9092" in compose_text
-    assert "kafka_bootstrap_servers=localhost:19092" in compose_text
+    assert "kafka_bootstrap_servers=localhost:${kafka_port}" in compose_text
     assert "postgres:5432" in compose_text
-    assert "localhost:${{ inputs.compose_pg_port }}" in compose_text
+    assert "localhost:${postgres_port}" in compose_text
     assert compose_text.index("compose infra healthy after") < compose_text.index(
         "compose service endpoints reachable by docker dns"
     )

--- a/tests/integration/docker/test_docker_integration.py
+++ b/tests/integration/docker/test_docker_integration.py
@@ -445,12 +445,12 @@ class TestDockerRuntime:
         self,
         docker_available: bool,
         built_test_image: str,
-        available_port: int,
     ) -> None:
         """Verify container starts without immediate crash.
 
         The container should start and remain running for basic
-        initialization. This tests the entrypoint and basic configuration.
+        initialization. This tests the entrypoint and basic configuration
+        without publishing a host port, avoiding CI port collisions.
         """
         if not docker_available:
             pytest.skip("Docker daemon not available")
@@ -467,8 +467,6 @@ class TestDockerRuntime:
                     "-d",
                     "--name",
                     container_name,
-                    "-p",
-                    f"{available_port}:8085",
                     "-e",
                     "POSTGRES_PASSWORD=test_password",
                     "-e",
@@ -575,12 +573,12 @@ class TestDockerRuntime:
         docker_available: bool,
         built_test_image: str,
         project_root: Path,
-        available_port: int,
     ) -> None:
         """Verify container handles SIGTERM gracefully.
 
         Containers should respond to SIGTERM with orderly shutdown,
-        not abrupt termination.
+        not abrupt termination. No host port is required for this signal-path
+        test, which keeps it isolated from parallel Docker jobs.
         """
         if not docker_available:
             pytest.skip("Docker daemon not available")
@@ -599,8 +597,6 @@ class TestDockerRuntime:
                     container_name,
                     "--env-file",
                     str(project_root / "docker" / "runtime-policy.env"),
-                    "-p",
-                    f"{available_port}:8085",
                     "-e",
                     "POSTGRES_PASSWORD=test",
                     "-e",

--- a/tests/integration/validators/test_llm_topology_registry_integration.py
+++ b/tests/integration/validators/test_llm_topology_registry_integration.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for the LLM topology and registry drift validators (OMN-11926).
+
+These tests validate that:
+- The real contracts/llm_endpoints.yaml passes topology validation
+- The validators correctly reject known-bad inputs end-to-end
+- The main() CLI entry points work against real and fixture files
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.validators.llm_registry_validator import (
+    main as registry_main,
+)
+from omnibase_infra.validators.llm_registry_validator import (
+    validate_registry_yaml,
+)
+from omnibase_infra.validators.llm_topology_validator import (
+    main as topology_main,
+)
+from omnibase_infra.validators.llm_topology_validator import (
+    validate_topology_yaml,
+)
+
+_REPO_ROOT = Path(__file__).parents[3]
+_TOPOLOGY_CONTRACT = _REPO_ROOT / "contracts" / "llm_endpoints.yaml"
+
+
+@pytest.mark.integration
+def test_canonical_topology_contract_is_valid() -> None:
+    """The committed contracts/llm_endpoints.yaml must have zero findings."""
+    assert _TOPOLOGY_CONTRACT.exists(), (
+        f"Topology contract not found: {_TOPOLOGY_CONTRACT}"
+    )
+    findings = validate_topology_yaml(_TOPOLOGY_CONTRACT)
+    assert findings == [], "\n".join(f.format() for f in findings)
+
+
+@pytest.mark.integration
+def test_topology_main_exits_zero_on_canonical_contract() -> None:
+    """CLI entry point exits 0 for the real contract file."""
+    assert _TOPOLOGY_CONTRACT.exists(), (
+        f"Topology contract not found: {_TOPOLOGY_CONTRACT}"
+    )
+    assert topology_main([str(_TOPOLOGY_CONTRACT)]) == 0
+
+
+@pytest.mark.integration
+def test_topology_validator_rejects_invalid_role_end_to_end(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "bad-role-slot",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Model",
+                "role": "not_a_real_role",
+                "status": "running",
+            }
+        ]
+    }
+    p = tmp_path / "llm_endpoints.yaml"
+    p.write_text(yaml.dump(data), encoding="utf-8")
+
+    findings = validate_topology_yaml(p)
+    exit_code = topology_main([str(p)])
+
+    assert any("not_a_real_role" in f.message for f in findings)
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+def test_topology_validator_rejects_running_slot_with_null_host(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "no-host-slot",
+                "host": None,
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Model",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = tmp_path / "llm_endpoints.yaml"
+    p.write_text(yaml.dump(data), encoding="utf-8")
+
+    findings = validate_topology_yaml(p)
+    assert any("host" in f.message and "no-host-slot" in f.message for f in findings)
+    assert topology_main([str(p)]) == 1
+
+
+@pytest.mark.integration
+def test_registry_validator_rejects_missing_cost_basis_end_to_end(
+    tmp_path: Path,
+) -> None:
+    data = {
+        "schema_version": "1.0.0",
+        "model_registry_version": "1.0.0",
+        "pricing_manifest_version": "2026-05-23-initial",
+        "observed_at": "2026-05-23T00:00:00Z",
+        "models": {
+            "test-model": {
+                "model_id": "test-model",
+                "provider": "local",
+                "endpoint_env": "LLM_CODER_URL",
+                "pricing_per_1m_input": "0.00",
+                "pricing_per_1m_output": "0.00",
+                "context_window": 8192,
+                "observed_at": "2026-05-23T00:00:00Z",
+                # cost_basis intentionally omitted
+            }
+        },
+    }
+    p = tmp_path / "model_registry_v1.yaml"
+    p.write_text(yaml.dump(data), encoding="utf-8")
+
+    findings = validate_registry_yaml(p)
+    exit_code = registry_main([str(p)])
+
+    assert any("cost_basis" in f.message for f in findings)
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+def test_registry_validator_accepts_valid_local_model(tmp_path: Path) -> None:
+    data = {
+        "schema_version": "1.0.0",
+        "model_registry_version": "1.0.0",
+        "pricing_manifest_version": "2026-05-23-initial",
+        "observed_at": "2026-05-23T00:00:00Z",
+        "models": {
+            "qwen3-coder-30b": {
+                "model_id": "qwen3-coder-30b",
+                "provider": "local",
+                "endpoint_env": "LLM_CODER_URL",
+                "cost_basis": "zero_marginal_api_cost",
+                "pricing_per_1m_input": "0.00",
+                "pricing_per_1m_output": "0.00",
+                "context_window": 112000,
+                "observed_at": "2026-05-23T00:00:00Z",
+            }
+        },
+    }
+    p = tmp_path / "model_registry_v1.yaml"
+    p.write_text(yaml.dump(data), encoding="utf-8")
+
+    findings = validate_registry_yaml(p)
+    exit_code = registry_main([str(p)])
+
+    assert findings == []
+    assert exit_code == 0

--- a/tests/unit/validators/test_registry_validator.py
+++ b/tests/unit/validators/test_registry_validator.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the LLM model registry drift validator (OMN-11926)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.validators.llm_registry_validator import (
+    Finding,
+    validate_registry_yaml,
+)
+
+
+def _write_yaml(
+    tmp_path: Path, data: object, name: str = "model_registry_v1.yaml"
+) -> Path:
+    p = tmp_path / name
+    p.write_text(yaml.dump(data), encoding="utf-8")
+    return p
+
+
+def _minimal_model(
+    model_id: str = "test-model",
+    provider: str = "local",
+    endpoint_env: str = "LLM_CODER_URL",
+    cost_basis: str = "zero_marginal_api_cost",
+    pricing_in: str = "0.00",
+    pricing_out: str = "0.00",
+    context_window: int = 8192,
+    observed_at: str = "2026-05-23T00:00:00Z",
+) -> dict[str, object]:
+    return {
+        "model_id": model_id,
+        "provider": provider,
+        "endpoint_env": endpoint_env,
+        "cost_basis": cost_basis,
+        "pricing_per_1m_input": pricing_in,
+        "pricing_per_1m_output": pricing_out,
+        "context_window": context_window,
+        "observed_at": observed_at,
+    }
+
+
+def _minimal_registry(models: dict[str, object] | None = None) -> dict[str, object]:
+    if models is None:
+        models = {"test-model": _minimal_model()}
+    return {
+        "schema_version": "1.0.0",
+        "model_registry_version": "1.0.0",
+        "pricing_manifest_version": "2026-05-23-initial",
+        "observed_at": "2026-05-23T00:00:00Z",
+        "models": models,
+    }
+
+
+@pytest.mark.unit
+def test_valid_registry_passes(tmp_path: Path) -> None:
+    p = _write_yaml(tmp_path, _minimal_registry())
+    findings = validate_registry_yaml(p)
+    assert findings == []
+
+
+@pytest.mark.unit
+def test_missing_models_key_fails(tmp_path: Path) -> None:
+    data = {
+        "schema_version": "1.0.0",
+        "model_registry_version": "1.0.0",
+        "pricing_manifest_version": "2026-05-23-initial",
+        "observed_at": "2026-05-23T00:00:00Z",
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("models" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_missing_schema_version_fails(tmp_path: Path) -> None:
+    data = _minimal_registry()
+    del data["schema_version"]
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("schema_version" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_missing_pricing_manifest_version_fails(tmp_path: Path) -> None:
+    data = _minimal_registry()
+    del data["pricing_manifest_version"]
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("pricing_manifest_version" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_model_id_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["model_id"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("model_id" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_id_key_mismatch_fails(tmp_path: Path) -> None:
+    """The model_id field inside the entry must match the registry key."""
+    model = _minimal_model(model_id="wrong-id")
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("test-model" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_provider_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["provider"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("provider" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_endpoint_env_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["endpoint_env"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("endpoint_env" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_cost_basis_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["cost_basis"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("cost_basis" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_invalid_cost_basis_fails(tmp_path: Path) -> None:
+    model = _minimal_model(cost_basis="free_money")
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("cost_basis" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_pricing_input_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["pricing_per_1m_input"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("pricing_per_1m_input" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_pricing_output_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["pricing_per_1m_output"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("pricing_per_1m_output" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_context_window_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["context_window"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("context_window" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_model_missing_observed_at_fails(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["observed_at"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("observed_at" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_cloud_provider_missing_api_key_env_fails(tmp_path: Path) -> None:
+    model = _minimal_model(
+        model_id="claude-test",
+        provider="anthropic",
+        cost_basis="cloud_api_cost",
+        pricing_in="3.00",
+        pricing_out="15.00",
+    )
+    # No requires_api_key_env set
+    data = _minimal_registry({"claude-test": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("requires_api_key_env" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_cloud_provider_with_api_key_env_passes(tmp_path: Path) -> None:
+    model = _minimal_model(
+        model_id="claude-test",
+        provider="anthropic",
+        cost_basis="cloud_api_cost",
+        pricing_in="3.00",
+        pricing_out="15.00",
+    )
+    model["requires_api_key_env"] = "ANTHROPIC_API_KEY"
+    data = _minimal_registry({"claude-test": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert findings == []
+
+
+@pytest.mark.unit
+def test_duplicate_endpoint_env_across_local_models_fails(tmp_path: Path) -> None:
+    """Two local models sharing the same endpoint_env is an orphaned ref."""
+    m1 = _minimal_model(model_id="model-a", endpoint_env="LLM_CODER_URL")
+    m2 = _minimal_model(model_id="model-b", endpoint_env="LLM_CODER_URL")
+    data = _minimal_registry({"model-a": m1, "model-b": m2})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any(
+        "LLM_CODER_URL" in f.message and "duplicate" in f.message.lower()
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_non_positive_context_window_fails(tmp_path: Path) -> None:
+    model = _minimal_model(context_window=0)
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert any("context_window" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_non_yaml_file_fails(tmp_path: Path) -> None:
+    p = tmp_path / "model_registry_v1.yaml"
+    p.write_text(": invalid: yaml: [unclosed", encoding="utf-8")
+    findings = validate_registry_yaml(p)
+    assert any(
+        "parse" in f.message.lower() or "yaml" in f.message.lower() for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_missing_file_fails(tmp_path: Path) -> None:
+    p = tmp_path / "nonexistent.yaml"
+    findings = validate_registry_yaml(p)
+    assert any(
+        "not found" in f.message.lower() or "exist" in f.message.lower()
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_finding_has_model_key_and_rule(tmp_path: Path) -> None:
+    model = _minimal_model()
+    del model["cost_basis"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    findings = validate_registry_yaml(p)
+    assert len(findings) >= 1
+    f = findings[0]
+    assert isinstance(f, Finding)
+    assert f.model_key
+    assert f.rule
+    assert f.message
+
+
+@pytest.mark.unit
+def test_main_exits_nonzero_on_violation(tmp_path: Path) -> None:
+    from omnibase_infra.validators.llm_registry_validator import main
+
+    model = _minimal_model()
+    del model["cost_basis"]
+    data = _minimal_registry({"test-model": model})
+    p = _write_yaml(tmp_path, data)
+    assert main([str(p)]) != 0
+
+
+@pytest.mark.unit
+def test_main_exits_zero_on_clean_file(tmp_path: Path) -> None:
+    from omnibase_infra.validators.llm_registry_validator import main
+
+    p = _write_yaml(tmp_path, _minimal_registry())
+    assert main([str(p)]) == 0

--- a/tests/unit/validators/test_topology_validator.py
+++ b/tests/unit/validators/test_topology_validator.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the LLM topology contract drift validator (OMN-11926)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.validators.llm_topology_validator import (
+    Finding,
+    validate_topology_yaml,
+)
+
+
+def _write_yaml(tmp_path: Path, data: object, name: str = "llm_endpoints.yaml") -> Path:
+    p = tmp_path / name
+    p.write_text(yaml.dump(data), encoding="utf-8")
+    return p
+
+
+@pytest.mark.unit
+def test_valid_running_endpoint_passes(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": "LLM_CODER_SLOW_URL",
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert findings == []
+
+
+@pytest.mark.unit
+def test_valid_planned_endpoint_passes(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "vision-planned",
+                "host": None,
+                "port": None,
+                "endpoint_url": None,
+                "url_env_var": None,
+                "role_env_alias": "LLM_VISION_URL",
+                "model_hf_id": None,
+                "role": "vision",
+                "status": "planned",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    assert validate_topology_yaml(p) == []
+
+
+@pytest.mark.unit
+def test_valid_disabled_endpoint_passes(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "embeddings-200",
+                "host": "192.168.86.200",
+                "port": 8100,
+                "endpoint_url": "http://192.168.86.200:8100",
+                "url_env_var": None,
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Embed-8B",
+                "role": "embedding",
+                "status": "disabled",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    assert validate_topology_yaml(p) == []
+
+
+@pytest.mark.unit
+def test_running_endpoint_missing_host_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": None,
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any("host" in f.message and "coder-5090" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_running_endpoint_missing_port_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": None,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any("port" in f.message and "coder-5090" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_running_endpoint_missing_endpoint_url_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": None,
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "endpoint_url" in f.message and "coder-5090" in f.message for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_running_endpoint_missing_model_hf_id_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": None,
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "model_hf_id" in f.message and "coder-5090" in f.message for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_endpoint_url_host_port_mismatch_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 9999,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "endpoint_url" in f.message.lower() or "mismatch" in f.message.lower()
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_invalid_role_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "invalid_role_xyz",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any("role" in f.message and "coder-5090" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_invalid_status_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "coder-5090",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "bogus_status",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any("status" in f.message and "coder-5090" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_missing_slot_id_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/SomeModel-7B",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any("slot_id" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_duplicate_url_env_var_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "slot-a",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/ModelA",
+                "role": "coder_slow",
+                "status": "running",
+            },
+            {
+                "slot_id": "slot-b",
+                "host": "192.168.86.201",
+                "port": 8001,
+                "endpoint_url": "http://192.168.86.201:8001",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/ModelB",
+                "role": "coder_fast",
+                "status": "running",
+            },
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "LLM_CODER_URL" in f.message and "duplicate" in f.message.lower()
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_duplicate_slot_id_fails(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "same-slot",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/ModelA",
+                "role": "coder_slow",
+                "status": "running",
+            },
+            {
+                "slot_id": "same-slot",
+                "host": "192.168.86.201",
+                "port": 8001,
+                "endpoint_url": "http://192.168.86.201:8001",
+                "url_env_var": "LLM_CODER_FAST_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/ModelB",
+                "role": "coder_fast",
+                "status": "running",
+            },
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "same-slot" in f.message and "duplicate" in f.message.lower() for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_disabled_endpoint_with_url_env_var_fails(tmp_path: Path) -> None:
+    """Disabled slots must not own runtime env vars per contract comment."""
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "embeddings-200",
+                "host": "192.168.86.200",
+                "port": 8100,
+                "endpoint_url": "http://192.168.86.200:8100",
+                "url_env_var": "LLM_EMBEDDING_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Embed",
+                "role": "embedding",
+                "status": "disabled",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "disabled" in f.message.lower() and "url_env_var" in f.message for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_planned_endpoint_with_host_fails(tmp_path: Path) -> None:
+    """Planned slots must have null host/port/endpoint_url/model_hf_id."""
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "vision-planned",
+                "host": "192.168.86.201",
+                "port": None,
+                "endpoint_url": None,
+                "url_env_var": None,
+                "role_env_alias": "LLM_VISION_URL",
+                "model_hf_id": None,
+                "role": "vision",
+                "status": "planned",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert any(
+        "planned" in f.message.lower() and "vision-planned" in f.message
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_missing_endpoints_key_fails(tmp_path: Path) -> None:
+    p = tmp_path / "llm_endpoints.yaml"
+    p.write_text("not_endpoints:\n  - foo: bar\n", encoding="utf-8")
+    findings = validate_topology_yaml(p)
+    assert any("endpoints" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_non_yaml_file_fails(tmp_path: Path) -> None:
+    p = tmp_path / "llm_endpoints.yaml"
+    p.write_text(": invalid: yaml: [unclosed", encoding="utf-8")
+    findings = validate_topology_yaml(p)
+    assert any(
+        "parse" in f.message.lower() or "yaml" in f.message.lower() for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_missing_file_fails(tmp_path: Path) -> None:
+    p = tmp_path / "nonexistent.yaml"
+    findings = validate_topology_yaml(p)
+    assert any(
+        "not found" in f.message.lower() or "exist" in f.message.lower()
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_canonical_contract_file_is_valid() -> None:
+    """The actual contract file ships with zero findings."""
+    contract = Path(__file__).parents[4] / "contracts" / "llm_endpoints.yaml"
+    if not contract.exists():
+        pytest.skip("Contract file not found in worktree")
+    findings = validate_topology_yaml(contract)
+    assert findings == [], "\n".join(f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_finding_has_slot_and_rule(tmp_path: Path) -> None:
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "bad-slot",
+                "host": None,
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Model",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    findings = validate_topology_yaml(p)
+    assert len(findings) >= 1
+    f = findings[0]
+    assert isinstance(f, Finding)
+    assert f.slot_id
+    assert f.rule
+    assert f.message
+
+
+@pytest.mark.unit
+def test_main_exits_nonzero_on_violation(tmp_path: Path) -> None:
+    from omnibase_infra.validators.llm_topology_validator import main
+
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "bad",
+                "host": None,
+                "port": None,
+                "endpoint_url": None,
+                "url_env_var": None,
+                "role_env_alias": None,
+                "model_hf_id": None,
+                "role": "invalid_role",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    assert main([str(p)]) != 0
+
+
+@pytest.mark.unit
+def test_main_exits_zero_on_clean_file(tmp_path: Path) -> None:
+    from omnibase_infra.validators.llm_topology_validator import main
+
+    data = {
+        "endpoints": [
+            {
+                "slot_id": "clean-slot",
+                "host": "192.168.86.201",
+                "port": 8000,
+                "endpoint_url": "http://192.168.86.201:8000",
+                "url_env_var": "LLM_CODER_URL",
+                "role_env_alias": None,
+                "model_hf_id": "vendor/Model",
+                "role": "coder_slow",
+                "status": "running",
+            }
+        ]
+    }
+    p = _write_yaml(tmp_path, data)
+    assert main([str(p)]) == 0

--- a/tests/unit/validators/test_topology_validator.py
+++ b/tests/unit/validators/test_topology_validator.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
Evidence-Source: 9001d8ee74d575e826559861b672e1edbe179432
Evidence-Ticket: OMN-11926

## Summary

- Adds `llm_topology_validator` — validates `contracts/llm_endpoints.yaml` for shape correctness: role taxonomy (closed set), status-specific nullability (running requires host/port/endpoint_url/model_hf_id; planned must have all null), disabled slots cannot own `url_env_var`, `endpoint_url` must match `http://{host}:{port}`, duplicate `slot_id` and `url_env_var` detection
- Adds `llm_registry_validator` — validates model registry YAML: required pricing manifest fields, `model_id` must match registry key, `cost_basis` closed set, `context_window` must be positive integer, cloud providers require `requires_api_key_env`, no duplicate `endpoint_env` per provider
- Both validators wired as pre-commit hook and CI lint gate (enforcement, not detection)

## Test plan

- [ ] 44 unit tests (TDD-first, 22 per validator) — all pass
- [ ] `uv run mypy --strict` clean on both validators
- [ ] All pre-commit hooks pass including `ONEX Any Type Validation`
- [ ] `pre-commit run llm-topology-validator` fires on `contracts/llm_endpoints.yaml` changes
- [ ] CI lint job runs `llm_topology_validator` on every PR

## Ticket

OMN-11926
