### PR TITLE
fix(OMN-11994): handler_wiring psycopg2 list adaptation for text[] columns

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -805,9 +805,7 @@ def _build_sync_db_adapter(db_url: str) -> object:
             )
             conflict_columns = ", ".join(f'"{key}"' for key in conflict_keys)
             adapted_row = {
-                key: psycopg2.extras.Json(value)
-                if isinstance(value, (dict, list))
-                else value
+                key: psycopg2.extras.Json(value) if isinstance(value, dict) else value
                 for key, value in row.items()
             }
             # table/conflict_key/cols validated by _TABLE_NAME_RE — not raw user input

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -410,7 +410,9 @@ def test_projection_callback_no_op_when_db_url_missing(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
-def test_sync_psycopg2_adapter_preserves_text_array_lists(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sync_psycopg2_adapter_preserves_text_array_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The sync adapter must not JSON-wrap Postgres text[] values."""
 
     captured_execute: dict[str, object] = {}

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -12,12 +12,15 @@ Uses in-memory fakes only — no real DB or Kafka required.
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _build_sync_db_adapter,
     _make_projection_dispatch_callback,
     _read_db_io_tables,
 )
@@ -404,3 +407,61 @@ def test_projection_callback_no_op_when_db_url_missing(tmp_path: Path) -> None:
 
     assert result is None
     assert call_count[0] == 0
+
+
+@pytest.mark.integration
+def test_sync_psycopg2_adapter_preserves_text_array_lists(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sync adapter must not JSON-wrap Postgres text[] values."""
+
+    captured_execute: dict[str, object] = {}
+
+    class FakeJson:
+        def __init__(self, value: object) -> None:
+            self.value = value
+
+    class FakeCursor:
+        def __enter__(self) -> FakeCursor:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def execute(self, sql: str, params: object) -> None:
+            captured_execute["sql"] = sql
+            captured_execute["params"] = params
+
+    class FakeConnection:
+        closed = False
+        autocommit = False
+
+        def cursor(self, *args: object, **kwargs: object) -> FakeCursor:
+            return FakeCursor()
+
+    fake_extras = types.SimpleNamespace(Json=FakeJson, RealDictCursor=object)
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=lambda dsn: FakeConnection(),
+        extras=fake_extras,
+    )
+
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", fake_extras)
+
+    adapter = _build_sync_db_adapter("postgresql://example")
+    result = adapter.upsert(
+        "swarm_runs",
+        "run_id",
+        {
+            "run_id": "run-1",
+            "models_used": ["qwen3", "gpt-5"],
+            "machines_used": ["worker-a", "worker-b"],
+            "metadata": {"source": "integration-test"},
+        },
+    )
+
+    assert result is True
+    params = captured_execute["params"]
+    assert isinstance(params, dict)
+    assert params["models_used"] == ["qwen3", "gpt-5"]
+    assert params["machines_used"] == ["worker-a", "worker-b"]
+    assert isinstance(params["metadata"], FakeJson)
+    assert params["metadata"].value == {"source": "integration-test"}


### PR DESCRIPTION
## Summary

Lands the omnibase_infra-side swarm hot-patch (patched5) as a proper source fix.

OMN-11994

- In `handler_wiring.py` `upsert()` method, changed `isinstance(value, (dict, list))` to `isinstance(value, dict)` when deciding whether to wrap values in `psycopg2.extras.Json()`
- **Root cause**: `models_used` and `machines_used` columns in `swarm_runs` are `text[]` Postgres array columns. Wrapping Python lists in `Json()` produced malformed array literals (`["foo"]` instead of `{foo}`)
- Only `dict` values intended for `jsonb` columns should be wrapped; `list` values pass through as native psycopg2 Python→text[] adaptation

## Test plan

- [ ] `uv run pytest tests/ -v -k "handler_wiring"` — 93 passed
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated serialization handling for list-typed fields during database upsert operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-11994
Evidence-Source: OCC#1601