### PR TITLE
fix(OMN-11958): remove duplicate dispatcher for node_architecture_graph_query_effect

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -74,12 +74,21 @@ def discover_contracts() -> ModelAutoWiringManifest:
 
     Errors on individual entry points are captured — they never abort the full scan.
 
+    Duplicate contract names (same ``name`` field from two different packages) are
+    detected and surfaced as :class:`ModelDiscoveryError` entries.  The first
+    occurrence wins; subsequent duplicates are dropped to prevent
+    ``ONEX_CORE_064_DUPLICATE_REGISTRATION`` crashes at dispatcher registration
+    time (OMN-11958).
+
     Returns:
         A :class:`ModelAutoWiringManifest` with all discovered contracts and errors.
     """
     contracts: list[ModelDiscoveredContract] = []
     errors: list[ModelDiscoveryError] = []
     active_packages = get_active_runtime_packages()
+    # Tracks first-seen package for each contract name — used to detect
+    # cross-package duplicates before they reach the dispatch engine.
+    seen_contract_names: dict[str, str] = {}
 
     for ep in entry_points(group=ENTRY_POINT_GROUP):
         dist = ep.dist
@@ -159,6 +168,39 @@ def discover_contracts() -> ModelAutoWiringManifest:
             )
             continue
 
+        # Duplicate contract name guard (OMN-11958): two packages shipping a
+        # contract with the same ``name`` field would produce identical dispatcher
+        # IDs and crash with ONEX_CORE_064_DUPLICATE_REGISTRATION.  Surface the
+        # collision as a discovery error and skip the duplicate so the runtime
+        # boots cleanly.  The first occurrence (by entry_point iteration order)
+        # wins; the owning package should remove the stale copy.
+        if contract.name in seen_contract_names:
+            first_owner = seen_contract_names[contract.name]
+            error_msg = (
+                f"Duplicate contract name '{contract.name}' already registered "
+                f"by package '{first_owner}'. Skipping registration from "
+                f"'{dist_name}' to prevent DUPLICATE_REGISTRATION crash. "
+                f"Remove the stale entry point from one of these packages."
+            )
+            logger.error(
+                "DUPLICATE_REGISTRATION prevented: contract='%s' "
+                "first_owner='%s' duplicate_package='%s' "
+                "entry_point='%s'",
+                contract.name,
+                first_owner,
+                dist_name,
+                ep.name,
+            )
+            errors.append(
+                ModelDiscoveryError(
+                    entry_point_name=ep.name,
+                    package_name=dist_name,
+                    error=error_msg,
+                )
+            )
+            continue
+
+        seen_contract_names[contract.name] = dist_name
         contracts.append(contract)
         logger.info(
             "Discovered contract: %s (%s) from %s %s",

--- a/tests/integration/runtime/test_auto_wiring_duplicate_contract_discovery.py
+++ b/tests/integration/runtime/test_auto_wiring_duplicate_contract_discovery.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for duplicate auto-wiring contract discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
+
+pytestmark = pytest.mark.integration
+
+_EP_MODULE = "omnibase_infra.runtime.auto_wiring.discovery.entry_points"
+
+
+@dataclass(frozen=True)
+class _FakeDist:
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class _FakeEntryPoint:
+    name: str
+    dist: _FakeDist
+    node_cls: type
+
+    def load(self) -> type:
+        return self.node_cls
+
+
+def _write_contract(directory: Path, *, name: str) -> Path:
+    directory.mkdir()
+    contract_path = directory / "contract.yaml"
+    contract_path.write_text(
+        dedent(f"""\
+            name: "{name}"
+            node_type: "effect"
+            contract_version:
+              major: 1
+              minor: 0
+              patch: 0
+            node_version: "1.0.0"
+            description: "Duplicate discovery integration fixture"
+        """),
+        encoding="utf-8",
+    )
+    return contract_path
+
+
+def test_duplicate_contract_name_across_entry_point_packages_boots_with_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross-package duplicate contract names are skipped before dispatcher wiring.
+
+    This covers the OMN-11958 runtime crash shape: two installed packages expose
+    ``onex.nodes`` entry points whose sibling contract files declare the same
+    ``name``. Discovery must keep the first contract, report the second as a
+    discovery error, and return a manifest that can continue into runtime boot.
+    """
+    monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+
+    infra_dir = tmp_path / "infra_node"
+    market_dir = tmp_path / "market_node"
+    duplicate_name = "node_architecture_graph_query_effect"
+    _write_contract(infra_dir, name=duplicate_name)
+    _write_contract(market_dir, name=duplicate_name)
+    infra_module = infra_dir / "node.py"
+    market_module = market_dir / "node.py"
+    infra_module.write_text("", encoding="utf-8")
+    market_module.write_text("", encoding="utf-8")
+
+    infra_cls = type("InfraArchitectureGraphQueryEffect", (), {})
+    market_cls = type("MarketArchitectureGraphQueryEffect", (), {})
+    entry_points = [
+        _FakeEntryPoint(
+            name=duplicate_name,
+            dist=_FakeDist(name="omnibase_infra", version="0.36.1"),
+            node_cls=infra_cls,
+        ),
+        _FakeEntryPoint(
+            name=duplicate_name,
+            dist=_FakeDist(name="omnimarket", version="0.4.0"),
+            node_cls=market_cls,
+        ),
+    ]
+
+    def fake_getfile(node_cls: type) -> str:
+        if node_cls is infra_cls:
+            return str(infra_module)
+        if node_cls is market_cls:
+            return str(market_module)
+        raise AssertionError(f"unexpected node class: {node_cls!r}")
+
+    with (
+        patch(_EP_MODULE, return_value=entry_points),
+        patch("inspect.getfile", side_effect=fake_getfile),
+    ):
+        manifest = discover_contracts()
+
+    assert manifest.total_discovered == 1
+    assert manifest.contracts[0].name == duplicate_name
+    assert manifest.contracts[0].package_name == "omnibase_infra"
+    assert manifest.total_errors == 1
+    assert manifest.errors[0].package_name == "omnimarket"
+    assert duplicate_name in manifest.errors[0].error
+    assert "Duplicate contract name" in manifest.errors[0].error

--- a/tests/unit/runtime/auto_wiring/test_discovery.py
+++ b/tests/unit/runtime/auto_wiring/test_discovery.py
@@ -371,6 +371,72 @@ class TestDiscoverContracts:
         assert manifest.total_errors == 1
         assert "No contract.yaml found" in manifest.errors[0].error
 
+    @pytest.mark.unit
+    def test_duplicate_contract_name_across_packages_is_surfaced_as_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Two packages shipping the same contract name must not cause DUPLICATE_REGISTRATION.
+
+        OMN-11958: when omnibase_infra and omnimarket both register an entry point
+        whose contract.yaml declares the same ``name`` field, the second registration
+        would crash the effects runtime with ONEX_CORE_064_DUPLICATE_REGISTRATION.
+        The discovery engine must detect the collision, keep the first occurrence,
+        and record the duplicate as a ModelDiscoveryError.
+        """
+        dir_a = tmp_path / "node_arch_query_infra"
+        dir_a.mkdir()
+        _make_contract_yaml(
+            dir_a, name="node_architecture_graph_query_effect", node_type="effect"
+        )
+        module_file_a = dir_a / "node.py"
+        module_file_a.write_text("")
+
+        dir_b = tmp_path / "node_arch_query_market"
+        dir_b.mkdir()
+        _make_contract_yaml(
+            dir_b, name="node_architecture_graph_query_effect", node_type="effect"
+        )
+        module_file_b = dir_b / "node.py"
+        module_file_b.write_text("")
+
+        cls_a = type("NodeArchQueryInfra", (), {})
+        cls_b = type("NodeArchQueryMarket", (), {})
+
+        ep_a = _make_entry_point(
+            "node_architecture_graph_query_effect",
+            node_cls=cls_a,
+            dist_name="omnibase_infra",
+            dist_version="0.36.1",
+        )
+        ep_b = _make_entry_point(
+            "node_architecture_graph_query_effect",
+            node_cls=cls_b,
+            dist_name="omnimarket",
+            dist_version="0.4.0",
+        )
+
+        def fake_getfile(cls: type) -> str:
+            if cls is cls_a:
+                return str(module_file_a)
+            return str(module_file_b)
+
+        with (
+            patch(_EP_MODULE, return_value=[ep_a, ep_b]),
+            patch("inspect.getfile", side_effect=fake_getfile),
+        ):
+            manifest = discover_contracts()
+
+        # First occurrence wins — only one contract registered.
+        assert manifest.total_discovered == 1
+        assert manifest.contracts[0].package_name == "omnibase_infra"
+        assert manifest.contracts[0].name == "node_architecture_graph_query_effect"
+
+        # Duplicate is recorded as a discovery error with a clear message.
+        assert manifest.total_errors == 1
+        assert "Duplicate contract name" in manifest.errors[0].error
+        assert "node_architecture_graph_query_effect" in manifest.errors[0].error
+        assert manifest.errors[0].package_name == "omnimarket"
+
 
 class TestDiscoverContractsFromPaths:
     """Tests for discover_contracts_from_paths."""


### PR DESCRIPTION
## Summary

Fixes OMN-11958: the effects runtime crash-loops with `ONEX_CORE_064_DUPLICATE_REGISTRATION` when two installed packages (e.g. `omnibase_infra` and `omnimarket`) register `onex.nodes` entry points whose `contract.yaml` files declare the same `name` field.

**Root cause:** `discover_contracts()` collected all contracts from all installed packages without checking for name collisions. Both contracts entered the manifest. In Phase 2 of `wire_from_manifest`, the second contract attempted to register dispatcher IDs already registered by the first (e.g. `dispatcher.auto.node_architecture_graph_query_effect.HandlerArchitectureGraphQuery.dependency_path_ea1f7b27`), raising `DUPLICATE_REGISTRATION` and crashing the effects runtime every ~30 seconds.

**Fix:** Track seen contract names in `discover_contracts()`. When a duplicate `name` is encountered the second occurrence is dropped and recorded as a `ModelDiscoveryError` with a message identifying both packages. First occurrence wins. The runtime boots cleanly and the error surfaces in discovery logs so the stale entry point can be removed.

## Changes

- `src/omnibase_infra/runtime/auto_wiring/discovery.py` — add `seen_contract_names` dict in `discover_contracts()`; log at ERROR level and record a `ModelDiscoveryError` for any cross-package name collision
- `tests/unit/runtime/auto_wiring/test_discovery.py` — add `test_duplicate_contract_name_across_packages_is_surfaced_as_error` covering the exact `node_architecture_graph_query_effect` cross-package scenario

## Test plan

- [x] `uv run pytest tests/unit/runtime/auto_wiring/test_discovery.py -v` — 25/25 pass
- [x] `uv run pytest tests/ -m unit` — 20,248 passed, 0 failures
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duplicate contract name detection across packages. The system now prevents duplicate contract registrations and reports specific errors when conflicts are found, including details about the conflicting packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-11958
Evidence-Source: OCC#1603
