### PR TITLE
chore(OMN-11513): update pricing manifest to current fleet model IDs

### DIFF
--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -291,61 +291,76 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-coder-30b-a3b:
+  qwen3.6-35b-a3b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 5090 (port 8000) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on RTX 5090 .201:8000 (vLLM, GPTQ-Int4, 131072 ctx, ~180 t/s) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-14b:
+  qwen3.6-27b-mtp-iq4xs:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 4090 (port 8001) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on .201:8001 (llamacpp, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-embedding-8b:
+  text-embedding-gte:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local embedding model on M2 Ultra (port 8100) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local embedding model on .201:8002 (vLLM, gte-Qwen2-1.5B, 8192 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  deepseek-r1-distill-qwen-32b:
+  deepseek-v4-flash:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 4090 .201 (port 8001) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on .200:8101 (ds4.c, DeepSeek V4 Flash 284B, 131072 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
+  deepseek-v4-pro:
+    input_cost_per_1k: 0.0
+    output_cost_per_1k: 0.0
+    effective_date: '2026-05-25'
+    note: Local model on .200:8101 (ds4.c, DeepSeek V4 Flash 284B alias with higher reasoning effort, 131072 ctx) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20


### PR DESCRIPTION
## Summary

- Replaces four stale local model entries (qwen3-coder-30b-a3b, qwen3-14b, qwen3-embedding-8b, deepseek-r1-distill-qwen-32b) with the five current fleet models from OMN-11513 lane map evidence (2026-05-22)
- New entries: qwen3.6-35b-a3b (.201:8000), qwen3.6-27b-mtp-iq4xs (.201:8001), text-embedding-gte (.201:8002), deepseek-v4-flash (.200:8101), deepseek-v4-pro (.200:8101 alias)
- All local models retain zero API cost (LOCAL_ZERO_API_COST_POLICY); cloud model entries unchanged

## Test plan

- [x] `tests/ci/test_pricing_manifest_schema.py` — 10/10 pass locally (schema validation, zero-cost local model assertion, no duplicate IDs)
- [x] `scripts/lint_pricing_manifest.py` — no seed-prefixed keys

[skip-receipt-gate: chore — pricing manifest config update, no deployable node or handler change, no associated ticket required]