### PR TITLE
fix(OMN-11513): replace silent localhost fallbacks with required env vars in LLM path

### DIFF
--- a/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
@@ -156,9 +156,7 @@ class AdapterCodeAnalysisEnrichment:
             temperature: Sampling temperature (lower = more deterministic).
             api_key: Optional Bearer token for authenticated endpoints.
         """
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_CODER_URL", "http://localhost:8000"
-        )
+        self._base_url: str = base_url or os.environ["LLM_CODER_URL"]
         self._model: str = model
         self._max_tokens: int = max_tokens
         self._temperature: float = temperature

--- a/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
@@ -255,9 +255,7 @@ class AdapterCodeReviewAnalysis:
                 "Provide a valid URL or set the LLM_CODER_FAST_URL environment variable.",
                 context=context,
             )
-        resolved_base_url: str = base_url or os.environ.get(
-            "LLM_CODER_FAST_URL", "http://localhost:8001"
-        )
+        resolved_base_url: str = base_url or os.environ["LLM_CODER_FAST_URL"]
         if not resolved_base_url.strip():
             context = ModelInfraErrorContext.with_correlation(
                 transport_type=EnumInfraTransportType.HTTP,

--- a/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
@@ -246,9 +246,7 @@ class AdapterDocumentationGeneration:
                 "Provide a valid URL or set the LLM_DEEPSEEK_R1_URL environment variable.",
                 context=context,
             )
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_DEEPSEEK_R1_URL", "http://localhost:8001"
-        )
+        self._base_url: str = base_url or os.environ["LLM_DEEPSEEK_R1_URL"]
         self._model: str = model
         self._max_tokens: int = max_tokens
         self._temperature: float = temperature

--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -214,9 +214,7 @@ class AdapterLlmProviderOpenai:
         """
         self._provider_name_value = provider_name
         self._provider_type_value = provider_type
-        self._base_url = base_url or os.environ.get(
-            "LLM_CODER_URL", "http://localhost:8000"
-        )
+        self._base_url = base_url or os.environ["LLM_CODER_URL"]
         self._default_model = default_model
         self._api_key = api_key
         self._is_available = True

--- a/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
@@ -192,9 +192,7 @@ class AdapterSummarizationEnrichment:
         if not (0.0 <= temperature <= 2.0):
             raise ValueError(f"temperature must be in [0.0, 2.0], got {temperature}")
 
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_QWEN_72B_URL", "http://localhost:8100"
-        )
+        self._base_url: str = base_url or os.environ["LLM_QWEN_72B_URL"]
         self._model: str = model
         self._token_threshold: int = token_threshold
         self._summary_max_tokens: int = summary_max_tokens

--- a/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
@@ -264,9 +264,7 @@ class AdapterTestBoilerplateGeneration:
                 "Provide a valid URL or set the LLM_CODER_FAST_URL environment variable.",
                 context=context,
             )
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_CODER_FAST_URL", "http://localhost:8001"
-        )
+        self._base_url: str = base_url or os.environ["LLM_CODER_FAST_URL"]
         if not self._base_url.strip():
             context = ModelInfraErrorContext.with_correlation(
                 transport_type=EnumInfraTransportType.HTTP,

--- a/src/omnibase_infra/nodes/node_llm_completion_effect/handlers/handler_llm_completion.py
+++ b/src/omnibase_infra/nodes/node_llm_completion_effect/handlers/handler_llm_completion.py
@@ -140,14 +140,7 @@ class HandlerLLMCompletion:
             if url:
                 return url.rstrip("/")
 
-        url = os.environ.get(  # ONEX_EXCLUDE: archive port
-            "LLM_CODER_URL", ""
-        )
-        if url:
-            return url.rstrip("/")
-
-        # Last resort fallback
-        return "http://localhost:8000"
+        return os.environ["LLM_CODER_URL"].rstrip("/")  # ONEX_EXCLUDE: archive port
 
     async def close(self) -> None:
         """Release HTTP resources if owned by this handler."""


### PR DESCRIPTION
## Summary

- Removes 7 silent \`os.environ.get("VAR", "http://localhost:...")\` fallbacks in the LLM adapter and completion handler path
- Replaces each with \`os.environ["VAR"]\` so missing config raises \`KeyError\` at startup rather than silently routing to localhost (which fails on .201 without any error surface)
- Env vars affected: \`LLM_CODER_URL\`, \`LLM_CODER_FAST_URL\`, \`LLM_DEEPSEEK_R1_URL\`, \`LLM_QWEN_72B_URL\`
- All 7 vars are already set in \`~/.omnibase/.env\` and the generated compose env — no operator action required

## Files changed

- \`nodes/node_llm_completion_effect/handlers/handler_llm_completion.py\`
- \`adapters/llm/adapter_code_analysis_enrichment.py\`
- \`adapters/llm/adapter_llm_provider_openai.py\`
- \`adapters/llm/adapter_code_review_analysis.py\`
- \`adapters/llm/adapter_test_boilerplate_generation.py\`
- \`adapters/llm/adapter_documentation_generation.py\`
- \`adapters/llm/adapter_summarization_enrichment.py\`

## Test plan

- [x] 322 unit tests pass locally (\`uv run pytest tests/ -m unit -k "llm_completion or adapter_llm or ...\`")
- [x] No new test required: behavior change is fail-fast on missing env (KeyError at init) vs. silent wrong-host routing — observable at startup, not a logic branch to unit-test