### PR TITLE
fix(OMN-11513): align pricing manifest keys with vLLM-served model IDs

### DIFF
--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -2,7 +2,7 @@
 # Pre-existing violations grandfathered in on 2026-03-02 (updated 2026-03-10 for SPDX line shifts).
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
-# Total entries: 121
+# Total entries: 123
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -120,4 +120,6 @@ src/omnibase_infra/tui/consumers/consumer_status.py:39
 src/omnibase_infra/tui/consumers/consumer_status.py:40
 src/omnibase_infra/tui/consumers/consumer_status.py:41
 src/omnibase_infra/tui/consumers/consumer_status.py:42
+src/omnibase_infra/runtime/service_kernel.py:2015
+src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -2,7 +2,7 @@
 # Pre-existing violations grandfathered in on 2026-03-02 (updated 2026-03-10 for SPDX line shifts).
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
-# Total entries: 123
+# Total entries: 121
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -120,6 +120,4 @@ src/omnibase_infra/tui/consumers/consumer_status.py:39
 src/omnibase_infra/tui/consumers/consumer_status.py:40
 src/omnibase_infra/tui/consumers/consumer_status.py:41
 src/omnibase_infra/tui/consumers/consumer_status.py:42
-src/omnibase_infra/runtime/service_kernel.py:2015
-src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -291,7 +291,7 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3.6-35b-a3b:
+  Qwen3.6-35B-A3B:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
     effective_date: '2026-05-25'
@@ -306,11 +306,11 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3.6-27b-mtp-iq4xs:
+  Qwen3.6-27B-MTP-IQ4_XS.gguf:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
     effective_date: '2026-05-25'
-    note: Local model on .201:8001 (llamacpp, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
+    note: Local model on .201:8001 (vLLM, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0


### PR DESCRIPTION
## Summary

- Renames two model keys added in PR #1733 to match the exact IDs returned by `/v1/models` on the serving endpoints
- `ModelPricingTable.estimate_cost()` does exact-match dict lookup; keys must match `delegation_events.delegated_to` exactly
- `text-embedding-gte`, `deepseek-v4-flash`, `deepseek-v4-pro` were already correct

**Changes:**
| Old key | New key | Endpoint |
|---|---|---|
| `qwen3.6-35b-a3b` | `Qwen3.6-35B-A3B` | `.201:8000` |
| `qwen3.6-27b-mtp-iq4xs` | `Qwen3.6-27B-MTP-IQ4_XS.gguf` | `.201:8001` |

Companion PR in omnimarket (PR #847) updates `endpoint_registry.yaml` to write matching model IDs into delegation events.

## Verification

- `uv run pytest tests/ -k pricing -v`: 69 tests passed
- `pre-commit run --files src/omnibase_infra/configs/pricing_manifest.yaml`: all hooks passed including Lint pricing manifest seed keys and ONEX Contract Validation

## Ticket

OMN-11513

Evidence-Ticket: OMN-11513
Evidence-Source: OCC#1607