### PR TITLE
fix(OMN-11996): register DispatchResultApplier for node_delegate_skill_orchestrator

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2009,6 +2009,24 @@ async def bootstrap() -> int:
                 correlation_id,
             )
 
+            # node_delegate_skill_orchestrator publishes completed/failed to omnimarket topics.
+            # Without this applier the handler result is silently discarded and the CLI adapter
+            # times out waiting for onex.evt.omnimarket.delegate-skill-completed.v1 (OMN-11996).
+            _DSO_COMPLETED = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            _DSO_FAILED = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            auto_wiring_result_appliers["node_delegate_skill_orchestrator"] = (
+                DispatchResultApplier(
+                    event_bus=event_bus,
+                    output_topic=_DSO_COMPLETED,
+                    allowed_output_topics=[_DSO_COMPLETED, _DSO_FAILED],
+                )
+            )
+            logger.info(
+                "Delegate-skill orchestrator terminal result applier registered "
+                "(contract=node_delegate_skill_orchestrator, correlation_id=%s)",
+                correlation_id,
+            )
+
         build_loop_dsn = (os.getenv("OMNIBASE_INFRA_DB_URL") or "").strip()
         if event_bus is not None and build_loop_dsn:
             from omnibase_infra.handlers.handler_db import HandlerDb


### PR DESCRIPTION
## Summary

- `HandlerDelegateSkill` was processing delegation commands correctly but the handler result was silently discarded because no `DispatchResultApplier` was registered for `node_delegate_skill_orchestrator` in `service_kernel.py`
- `onex.evt.omnimarket.delegate-skill-completed.v1` was never published, causing the CLI adapter to time out on every invocation — this is the B9 gate blocker
- Adds the registration following the identical pattern used for `build_loop_orchestrator`

## Root Cause

`auto_wiring_result_appliers` in `service_kernel.py` only had entries for `build_loop_orchestrator`, `node_build_loop_projection_compute`, and `node_registration_orchestrator`. Without an entry for `node_delegate_skill_orchestrator`, the auto-wiring callback at `handler_wiring.py:1047` skips `result_applier.apply()` entirely (the guard is `if result_applier is not None`).

## Change

`service_kernel.py`: registers `DispatchResultApplier` for `node_delegate_skill_orchestrator` with:
- `output_topic = onex.evt.omnimarket.delegate-skill-completed.v1`
- `allowed_output_topics = [completed, failed]`

Both topics are declared in the node's `contract.yaml` `event_bus.publish_topics`.

## Test plan

- [x] `uv run pytest tests/unit/runtime/ tests/unit/services/` — 6502 passed, 0 failed
- [x] `uv run ruff format` + `uv run ruff check --fix` — clean
- [x] `uv run mypy src/omnibase_infra/runtime/service_kernel.py --strict` — no issues
- [x] `pre-commit run --all-files` — all hooks passed

OMN-11996