### PR TITLE
fix(OMN-11997): remove non-IMMUTABLE ::date functional index from intelligence migrations 024/025

### DIFF
--- a/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
+++ b/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
@@ -87,9 +87,6 @@ CREATE TABLE IF NOT EXISTS llm_delegation_call_log (
         CHECK (latency_ms >= 0)
 );
 
-CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
-    ON llm_delegation_call_log ((created_at::date));
-
 CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_task_type
     ON llm_delegation_call_log (task_type);
 

--- a/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
+++ b/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
@@ -2,19 +2,14 @@
 -- SPDX-License-Identifier: MIT
 --
 -- Migration: 025_fix_llm_delegation_call_log_date_index
--- Description: Corrective migration for idx_llm_delegation_call_log_date.
---              Migration 024 used date(created_at) which is STABLE not IMMUTABLE
---              in PostgreSQL, causing CREATE INDEX to fail on some deployments.
---              This migration drops the broken index (if it exists) and
---              recreates it using the IMMUTABLE (created_at::date) cast form.
--- Ticket: OMN-11966
+-- Description: Remove idx_llm_delegation_call_log_date introduced in migration 024.
+--              (created_at::date) is not IMMUTABLE in PostgreSQL 16, so the functional
+--              index fails to build. The plain created_at index (also in 024) already
+--              serves range and equality queries on the timestamp column; the date cast
+--              index provides no additional query coverage.
+-- Ticket: OMN-11997
 --
 -- Idempotency:
---   DROP INDEX IF EXISTS + CREATE INDEX IF NOT EXISTS — safe to re-apply.
+--   DROP INDEX IF EXISTS — safe to re-apply.
 
--- Drop the STABLE-function-based index if it was successfully created
 DROP INDEX IF EXISTS idx_llm_delegation_call_log_date;
-
--- Recreate with IMMUTABLE ::date cast form
-CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
-    ON llm_delegation_call_log ((created_at::date));

--- a/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
@@ -19,3 +19,5 @@ class EnumOmnimarketTopic(str, Enum):
     Members are sorted by (kind, event_name, version).
     """
     EVT_BUILD_LOOP_ORCHESTRATOR_COMPLETED_V1 = "onex.evt.omnimarket.build-loop-orchestrator-completed.v1"  # onex.evt.omnimarket.build-loop-orchestrator-completed.v1
+    EVT_DELEGATE_SKILL_COMPLETED_V1 = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex.evt.omnimarket.delegate-skill-completed.v1
+    EVT_DELEGATE_SKILL_FAILED_V1 = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex.evt.omnimarket.delegate-skill-failed.v1

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -517,8 +517,18 @@ TOPIC_DELEGATION_BASELINE_COMPARISON: Final[str] = (
 )
 """Command topic for baseline comparison compute from the delegation orchestrator."""
 
+TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
+    "onex.evt.omnimarket.delegate-skill-completed.v1"
+)
+"""Event topic published by node_delegate_skill_orchestrator on successful skill dispatch."""
+
+TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
+"""Event topic published by node_delegate_skill_orchestrator on skill dispatch failure."""
+
 
 __all__ = [
+    "TOPIC_DELEGATE_SKILL_COMPLETED",
+    "TOPIC_DELEGATE_SKILL_FAILED",
     "TOPIC_DELEGATION_COMPLETED",
     "TOPIC_DELEGATION_FAILED",
     "TOPIC_DELEGATION_AGENT_TASK_LIFECYCLE",

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2011,14 +2011,20 @@ async def bootstrap() -> int:
 
             # node_delegate_skill_orchestrator publishes completed/failed to omnimarket topics.
             # Without this applier the handler result is silently discarded and the CLI adapter
-            # times out waiting for onex.evt.omnimarket.delegate-skill-completed.v1 (OMN-11996).
-            _DSO_COMPLETED = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
-            _DSO_FAILED = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            # times out waiting for the completed topic (OMN-11996).
+            from omnibase_infra.event_bus.topic_constants import (
+                TOPIC_DELEGATE_SKILL_COMPLETED,
+                TOPIC_DELEGATE_SKILL_FAILED,
+            )
+
             auto_wiring_result_appliers["node_delegate_skill_orchestrator"] = (
                 DispatchResultApplier(
                     event_bus=event_bus,
-                    output_topic=_DSO_COMPLETED,
-                    allowed_output_topics=[_DSO_COMPLETED, _DSO_FAILED],
+                    output_topic=TOPIC_DELEGATE_SKILL_COMPLETED,
+                    allowed_output_topics=[
+                        TOPIC_DELEGATE_SKILL_COMPLETED,
+                        TOPIC_DELEGATE_SKILL_FAILED,
+                    ],
                 )
             )
             logger.info(

--- a/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
@@ -26,6 +26,12 @@ from omnibase_infra.adapters.llm.model_llm_provider_config import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _llm_coder_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide the required contract-driven LLM endpoint for adapter unit tests."""
+    monkeypatch.setenv("LLM_CODER_URL", "http://10.0.0.1:8000")
+
+
 class TestAdapterLlmProviderOpenaiProperties:
     """Tests for provider properties."""
 


### PR DESCRIPTION
## Summary

- Migration 024 created \`idx_llm_delegation_call_log_date\` using \`(created_at::date)\`, which is STABLE not IMMUTABLE on PG 16.14 — \`CREATE INDEX\` fails at startup
- Migration 025 was supposed to fix this but recreated the same broken index form
- Fix: remove the date-cast index from 024 entirely (a plain \`created_at\` index already exists on the same table and serves range queries), and update 025 to only \`DROP INDEX IF EXISTS\` with no recreation
- Also fixes pre-existing arch invariant: moves hardcoded topic literals in service_kernel.py to topic_constants.py

## Changes

- \`docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql\`: removed non-IMMUTABLE date-cast functional index
- \`docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql\`: updated to only drop the index (no recreate)
- \`src/omnibase_infra/event_bus/topic_constants.py\`: added TOPIC_DELEGATE_SKILL_COMPLETED and TOPIC_DELEGATE_SKILL_FAILED
- \`src/omnibase_infra/enums/generated/enum_omnimarket_topic.py\`: regenerated with new enum members
- \`src/omnibase_infra/runtime/service_kernel.py\`: use constants instead of raw topic strings

## Test plan

- [x] All migration CI tests pass: \`uv run pytest tests/ci/ -v\` — 48/48 passed locally
- [x] Pre-commit hooks pass (including no-hardcoded-topics)
- [x] No functional query coverage lost: plain \`created_at\` index already exists

## Ticket

OMN-11997

Evidence-Source: OCC#1612
Evidence-Ticket: OMN-11997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved database compatibility issue with PostgreSQL 16 affecting date-based indexing in delegation tracking.

* **Chores**
  * Enhanced internal event handling infrastructure for skill delegation workflow completion and failure scenarios.
  * Improved test coverage for LLM provider integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->