### PR TITLE
fix(OMN-11513): align pricing manifest keys with vLLM-served model IDs

### DIFF
--- a/docker/migrations/forward/082_swarm_runs.sql
+++ b/docker/migrations/forward/082_swarm_runs.sql
@@ -1,0 +1,33 @@
+-- Swarm dispatch projection table (OMN-11998)
+-- Owned by node_projection_swarm in omnimarket
+CREATE TABLE IF NOT EXISTS swarm_runs (
+  run_id            TEXT PRIMARY KEY,
+  correlation_id    TEXT NOT NULL,
+  status            TEXT NOT NULL,
+  task_hash         TEXT NOT NULL DEFAULT '',
+  subtask_count     INTEGER NOT NULL DEFAULT 0,
+  succeeded_count   INTEGER NOT NULL DEFAULT 0,
+  failed_count      INTEGER NOT NULL DEFAULT 0,
+  skipped_count     INTEGER NOT NULL DEFAULT 0,
+  models_used       TEXT[] DEFAULT '{}',
+  machines_used     TEXT[] DEFAULT '{}',
+  total_cost_usd                DOUBLE PRECISION DEFAULT 0.0,
+  cloud_equivalent_cost_usd     DOUBLE PRECISION DEFAULT 0.0,
+  savings_usd                   DOUBLE PRECISION DEFAULT 0.0,
+  parallelism_speedup_ratio     DOUBLE PRECISION DEFAULT 1.0,
+  decomposition_latency_ms      INTEGER DEFAULT 0,
+  dispatch_wall_latency_ms      INTEGER DEFAULT 0,
+  aggregation_latency_ms        INTEGER DEFAULT 0,
+  total_latency_ms              INTEGER DEFAULT 0,
+  endpoint_registry_hash        TEXT DEFAULT '',
+  registry_schema_version       TEXT DEFAULT '',
+  projection_cursor             TEXT DEFAULT '',
+  source_event_id               TEXT DEFAULT '',
+  source_topic                  TEXT DEFAULT '',
+  source_partition              INTEGER DEFAULT 0,
+  source_offset                 INTEGER DEFAULT 0,
+  reducer_version               TEXT DEFAULT '1.0.0',
+  freshness_state               TEXT DEFAULT 'fresh',
+  observed_at                   TIMESTAMPTZ,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
+++ b/docker/migrations/intelligence/024_create_llm_delegation_projection_tables.sql
@@ -87,9 +87,6 @@ CREATE TABLE IF NOT EXISTS llm_delegation_call_log (
         CHECK (latency_ms >= 0)
 );
 
-CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
-    ON llm_delegation_call_log ((created_at::date));
-
 CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_task_type
     ON llm_delegation_call_log (task_type);
 

--- a/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
+++ b/docker/migrations/intelligence/025_fix_llm_delegation_call_log_date_index.sql
@@ -2,19 +2,14 @@
 -- SPDX-License-Identifier: MIT
 --
 -- Migration: 025_fix_llm_delegation_call_log_date_index
--- Description: Corrective migration for idx_llm_delegation_call_log_date.
---              Migration 024 used date(created_at) which is STABLE not IMMUTABLE
---              in PostgreSQL, causing CREATE INDEX to fail on some deployments.
---              This migration drops the broken index (if it exists) and
---              recreates it using the IMMUTABLE (created_at::date) cast form.
--- Ticket: OMN-11966
+-- Description: Remove idx_llm_delegation_call_log_date introduced in migration 024.
+--              (created_at::date) is not IMMUTABLE in PostgreSQL 16, so the functional
+--              index fails to build. The plain created_at index (also in 024) already
+--              serves range and equality queries on the timestamp column; the date cast
+--              index provides no additional query coverage.
+-- Ticket: OMN-11997
 --
 -- Idempotency:
---   DROP INDEX IF EXISTS + CREATE INDEX IF NOT EXISTS — safe to re-apply.
+--   DROP INDEX IF EXISTS — safe to re-apply.
 
--- Drop the STABLE-function-based index if it was successfully created
 DROP INDEX IF EXISTS idx_llm_delegation_call_log_date;
-
--- Recreate with IMMUTABLE ::date cast form
-CREATE INDEX IF NOT EXISTS idx_llm_delegation_call_log_date
-    ON llm_delegation_call_log ((created_at::date));

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:c73231978c0c8ef7b567c7fccf2918c291869f831da9039da48de3e207f158af
-generated_at: 2026-05-22T14:49:20Z
-migration_file_count: 67
+sha256:1f9089477a08750f5b925e291252c2090e591b09593617793b5eb0f837130de7
+generated_at: 2026-05-25T15:02:15Z
+migration_file_count: 68

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -2,7 +2,7 @@
 # Pre-existing violations grandfathered in on 2026-03-02 (updated 2026-03-10 for SPDX line shifts).
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
-# Total entries: 121
+# Total entries: 123
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -120,4 +120,6 @@ src/omnibase_infra/tui/consumers/consumer_status.py:39
 src/omnibase_infra/tui/consumers/consumer_status.py:40
 src/omnibase_infra/tui/consumers/consumer_status.py:41
 src/omnibase_infra/tui/consumers/consumer_status.py:42
+src/omnibase_infra/runtime/service_kernel.py:2015
+src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -2,7 +2,7 @@
 # Pre-existing violations grandfathered in on 2026-03-02 (updated 2026-03-10 for SPDX line shifts).
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
-# Total entries: 123
+# Total entries: 121
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -120,6 +120,4 @@ src/omnibase_infra/tui/consumers/consumer_status.py:39
 src/omnibase_infra/tui/consumers/consumer_status.py:40
 src/omnibase_infra/tui/consumers/consumer_status.py:41
 src/omnibase_infra/tui/consumers/consumer_status.py:42
-src/omnibase_infra/runtime/service_kernel.py:2015
-src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76

--- a/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
@@ -156,9 +156,7 @@ class AdapterCodeAnalysisEnrichment:
             temperature: Sampling temperature (lower = more deterministic).
             api_key: Optional Bearer token for authenticated endpoints.
         """
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_CODER_URL", "http://localhost:8000"
-        )
+        self._base_url: str = base_url or os.environ["LLM_CODER_URL"]
         self._model: str = model
         self._max_tokens: int = max_tokens
         self._temperature: float = temperature

--- a/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
@@ -255,9 +255,7 @@ class AdapterCodeReviewAnalysis:
                 "Provide a valid URL or set the LLM_CODER_FAST_URL environment variable.",
                 context=context,
             )
-        resolved_base_url: str = base_url or os.environ.get(
-            "LLM_CODER_FAST_URL", "http://localhost:8001"
-        )
+        resolved_base_url: str = base_url or os.environ["LLM_CODER_FAST_URL"]
         if not resolved_base_url.strip():
             context = ModelInfraErrorContext.with_correlation(
                 transport_type=EnumInfraTransportType.HTTP,

--- a/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
@@ -246,9 +246,7 @@ class AdapterDocumentationGeneration:
                 "Provide a valid URL or set the LLM_DEEPSEEK_R1_URL environment variable.",
                 context=context,
             )
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_DEEPSEEK_R1_URL", "http://localhost:8001"
-        )
+        self._base_url: str = base_url or os.environ["LLM_DEEPSEEK_R1_URL"]
         self._model: str = model
         self._max_tokens: int = max_tokens
         self._temperature: float = temperature

--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -214,9 +214,7 @@ class AdapterLlmProviderOpenai:
         """
         self._provider_name_value = provider_name
         self._provider_type_value = provider_type
-        self._base_url = base_url or os.environ.get(
-            "LLM_CODER_URL", "http://localhost:8000"
-        )
+        self._base_url = base_url or os.environ["LLM_CODER_URL"]
         self._default_model = default_model
         self._api_key = api_key
         self._is_available = True

--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -203,8 +203,8 @@ class AdapterLlmProviderOpenai:
         """Initialize the OpenAI-compatible provider adapter.
 
         Args:
-            base_url: Base URL of the LLM endpoint. Defaults to
-                ``LLM_CODER_URL`` env var, falling back to ``http://localhost:8000``.
+            base_url: Base URL of the LLM endpoint. Defaults to the required
+                ``LLM_CODER_URL`` env var.
             default_model: Default model identifier.
             api_key: Optional API key for Bearer token auth.
             provider_name: Provider identifier for logging/routing.

--- a/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
@@ -192,9 +192,7 @@ class AdapterSummarizationEnrichment:
         if not (0.0 <= temperature <= 2.0):
             raise ValueError(f"temperature must be in [0.0, 2.0], got {temperature}")
 
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_QWEN_72B_URL", "http://localhost:8100"
-        )
+        self._base_url: str = base_url or os.environ["LLM_QWEN_72B_URL"]
         self._model: str = model
         self._token_threshold: int = token_threshold
         self._summary_max_tokens: int = summary_max_tokens

--- a/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
@@ -264,9 +264,7 @@ class AdapterTestBoilerplateGeneration:
                 "Provide a valid URL or set the LLM_CODER_FAST_URL environment variable.",
                 context=context,
             )
-        self._base_url: str = base_url or os.environ.get(
-            "LLM_CODER_FAST_URL", "http://localhost:8001"
-        )
+        self._base_url: str = base_url or os.environ["LLM_CODER_FAST_URL"]
         if not self._base_url.strip():
             context = ModelInfraErrorContext.with_correlation(
                 transport_type=EnumInfraTransportType.HTTP,

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -291,61 +291,76 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-coder-30b-a3b:
+  qwen3.6-35b-a3b:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 5090 (port 8000) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on RTX 5090 .201:8000 (vLLM, GPTQ-Int4, 131072 ctx, ~180 t/s) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-14b:
+  qwen3.6-27b-mtp-iq4xs:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 4090 (port 8001) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on .201:8001 (llamacpp, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3-embedding-8b:
+  text-embedding-gte:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local embedding model on M2 Ultra (port 8100) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local embedding model on .201:8002 (vLLM, gte-Qwen2-1.5B, 8192 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  deepseek-r1-distill-qwen-32b:
+  deepseek-v4-flash:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
-    effective_date: '2026-03-19'
-    note: Local model on RTX 4090 .201 (port 8001) - zero API cost
+    effective_date: '2026-05-25'
+    note: Local model on .200:8101 (ds4.c, DeepSeek V4 Flash 284B, 131072 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0
     evidence:
-      generated_at: '2026-04-29T00:00:00+00:00'
+      generated_at: '2026-05-25T00:00:00+00:00'
+      sample_window_days: 7
+      sample_count: 0
+      min_samples: 20
+      query: llm_call_metrics usage_source=API created_at>=now-7d
+      authoritative: false
+  deepseek-v4-pro:
+    input_cost_per_1k: 0.0
+    output_cost_per_1k: 0.0
+    effective_date: '2026-05-25'
+    note: Local model on .200:8101 (ds4.c, DeepSeek V4 Flash 284B alias with higher reasoning effort, 131072 ctx) - zero API cost
+    confidence: LOW_CONFIDENCE
+    source: LOCAL_ZERO_API_COST_POLICY
+    sample_count: 0
+    evidence:
+      generated_at: '2026-05-25T00:00:00+00:00'
       sample_window_days: 7
       sample_count: 0
       min_samples: 20

--- a/src/omnibase_infra/configs/pricing_manifest.yaml
+++ b/src/omnibase_infra/configs/pricing_manifest.yaml
@@ -291,7 +291,7 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3.6-35b-a3b:
+  Qwen3.6-35B-A3B:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
     effective_date: '2026-05-25'
@@ -306,11 +306,11 @@ models:
       min_samples: 20
       query: llm_call_metrics usage_source=API created_at>=now-7d
       authoritative: false
-  qwen3.6-27b-mtp-iq4xs:
+  Qwen3.6-27B-MTP-IQ4_XS.gguf:
     input_cost_per_1k: 0.0
     output_cost_per_1k: 0.0
     effective_date: '2026-05-25'
-    note: Local model on .201:8001 (llamacpp, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
+    note: Local model on .201:8001 (vLLM, Qwen3.6-27B-MTP-IQ4_XS.gguf, 98304 ctx) - zero API cost
     confidence: LOW_CONFIDENCE
     source: LOCAL_ZERO_API_COST_POLICY
     sample_count: 0

--- a/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
@@ -18,7 +18,6 @@ class EnumOmnimarketTopic(str, Enum):
     All values are raw topic strings as declared in contract.yaml.
     Members are sorted by (kind, event_name, version).
     """
-
     EVT_BUILD_LOOP_ORCHESTRATOR_COMPLETED_V1 = "onex.evt.omnimarket.build-loop-orchestrator-completed.v1"  # onex.evt.omnimarket.build-loop-orchestrator-completed.v1
     EVT_DELEGATE_SKILL_COMPLETED_V1 = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex.evt.omnimarket.delegate-skill-completed.v1
     EVT_DELEGATE_SKILL_FAILED_V1 = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex.evt.omnimarket.delegate-skill-failed.v1

--- a/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnimarket_topic.py
@@ -19,3 +19,5 @@ class EnumOmnimarketTopic(str, Enum):
     Members are sorted by (kind, event_name, version).
     """
     EVT_BUILD_LOOP_ORCHESTRATOR_COMPLETED_V1 = "onex.evt.omnimarket.build-loop-orchestrator-completed.v1"  # onex.evt.omnimarket.build-loop-orchestrator-completed.v1
+    EVT_DELEGATE_SKILL_COMPLETED_V1 = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex.evt.omnimarket.delegate-skill-completed.v1
+    EVT_DELEGATE_SKILL_FAILED_V1 = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex.evt.omnimarket.delegate-skill-failed.v1

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -2275,7 +2275,11 @@ class EventBusKafka(
         if not self._started:
             await self.start()
 
-        # Collect topics that need consumers while holding lock briefly
+        # Collect topics that need consumers while holding lock briefly.
+        # Pre-populate _pending_consumer_keys inside the lock so concurrent
+        # _start_consumer_for_topic_unlocked calls (via asyncio.gather below)
+        # cannot race and create duplicate consumers — the same reservation
+        # pattern used by subscribe().
         topics_to_start: list[tuple[str, str]] = []
         async with self._lock:
             for topic in self._subscribers:
@@ -2284,12 +2288,30 @@ class EventBusKafka(
                     if group_id in seen_group_ids:
                         continue
                     seen_group_ids.add(group_id)
-                    if (topic, group_id) not in self._group_consumers:
+                    consumer_key = (topic, group_id)
+                    if (
+                        consumer_key not in self._group_consumers
+                        and consumer_key not in self._pending_consumer_keys
+                    ):
+                        self._pending_consumer_keys.add(consumer_key)
                         topics_to_start.append((topic, group_id))
 
-        # Start consumers outside the lock to avoid blocking
-        for topic, group_id in topics_to_start:
-            await self._start_consumer_for_topic(topic, group_id)
+        # Start all consumers concurrently — wall-clock time becomes the
+        # slowest single consumer rather than the sum of all N consumers.
+        # return_exceptions=True lets every consumer attempt to start; we
+        # collect failures and re-raise the first one after all have settled
+        # so a single bad topic does not starve the rest.
+        if topics_to_start:
+            results = await asyncio.gather(
+                *[
+                    self._start_consumer_for_topic_unlocked(topic, group_id)
+                    for topic, group_id in topics_to_start
+                ],
+                return_exceptions=True,
+            )
+            errors = [r for r in results if isinstance(r, BaseException)]
+            if errors:
+                raise errors[0]
 
         # Block until shutdown
         while not self._shutdown:

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -525,20 +525,6 @@ TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
 TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
 """Event topic published by node_delegate_skill_orchestrator on skill dispatch failure."""
 
-
-# ---------------------------------------------------------------------------
-# Delegate-Skill Orchestrator Topics (OMN-11996)
-# ---------------------------------------------------------------------------
-
-TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
-    "onex.evt.omnimarket.delegate-skill-completed.v1"
-)
-"""Terminal success event from node_delegate_skill_orchestrator."""
-
-TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
-"""Terminal failure event from node_delegate_skill_orchestrator."""
-
-
 __all__ = [
     "TOPIC_DELEGATE_SKILL_COMPLETED",
     "TOPIC_DELEGATE_SKILL_FAILED",

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -526,6 +526,19 @@ TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-fa
 """Event topic published by node_delegate_skill_orchestrator on skill dispatch failure."""
 
 
+# ---------------------------------------------------------------------------
+# Delegate-Skill Orchestrator Topics (OMN-11996)
+# ---------------------------------------------------------------------------
+
+TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
+    "onex.evt.omnimarket.delegate-skill-completed.v1"
+)
+"""Terminal success event from node_delegate_skill_orchestrator."""
+
+TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
+"""Terminal failure event from node_delegate_skill_orchestrator."""
+
+
 __all__ = [
     "TOPIC_DELEGATE_SKILL_COMPLETED",
     "TOPIC_DELEGATE_SKILL_FAILED",
@@ -539,6 +552,8 @@ __all__ = [
     "TOPIC_DELEGATION_QUALITY_GATE_RESULT",
     "TOPIC_DELEGATION_REQUEST",
     "TOPIC_DELEGATION_ROUTING_DECISION",
+    "TOPIC_DELEGATE_SKILL_COMPLETED",
+    "TOPIC_DELEGATE_SKILL_FAILED",
     "TOPIC_EVAL_COMPLETED",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -517,8 +517,18 @@ TOPIC_DELEGATION_BASELINE_COMPARISON: Final[str] = (
 )
 """Command topic for baseline comparison compute from the delegation orchestrator."""
 
+TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
+    "onex.evt.omnimarket.delegate-skill-completed.v1"
+)
+"""Event topic published by node_delegate_skill_orchestrator on successful skill dispatch."""
+
+TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
+"""Event topic published by node_delegate_skill_orchestrator on skill dispatch failure."""
+
 
 __all__ = [
+    "TOPIC_DELEGATE_SKILL_COMPLETED",
+    "TOPIC_DELEGATE_SKILL_FAILED",
     "TOPIC_DELEGATION_COMPLETED",
     "TOPIC_DELEGATION_FAILED",
     "TOPIC_DELEGATION_AGENT_TASK_LIFECYCLE",

--- a/src/omnibase_infra/nodes/node_llm_completion_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_completion_effect/contract.yaml
@@ -10,10 +10,10 @@ node_type: "EFFECT_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
 description: >
-  Effect node that sends chat completion requests to OpenAI-compatible LLM endpoints (vLLM, LiteLLM, Ollama).  Supports model routing by token count and async streaming.
+  Effect node that sends chat completion requests to OpenAI-compatible LLM endpoints (vLLM, LiteLLM, Ollama). Supports model routing by token count and async streaming. Endpoint resolution is contract/config driven and requires LLM_CODER_URL when no provider endpoint is supplied.
 
 input_model:
   name: "ModelLLMCompletionRequest"
@@ -43,7 +43,7 @@ handler_routing:
 dependencies:
   - type: "environment"
     name: "LLM_CODER_URL"
-    description: "Base URL for the primary LLM endpoint"
+    description: "Required base URL for the primary LLM endpoint when no contract/provider endpoint is supplied; no localhost fallback is permitted"
   - type: "environment"
     name: "LLM_CODER_FAST_URL"
     description: "Base URL for the fast/mid-tier LLM endpoint"

--- a/src/omnibase_infra/nodes/node_llm_completion_effect/handlers/handler_llm_completion.py
+++ b/src/omnibase_infra/nodes/node_llm_completion_effect/handlers/handler_llm_completion.py
@@ -140,14 +140,7 @@ class HandlerLLMCompletion:
             if url:
                 return url.rstrip("/")
 
-        url = os.environ.get(  # ONEX_EXCLUDE: archive port
-            "LLM_CODER_URL", ""
-        )
-        if url:
-            return url.rstrip("/")
-
-        # Last resort fallback
-        return "http://localhost:8000"
+        return os.environ["LLM_CODER_URL"].rstrip("/")  # ONEX_EXCLUDE: archive port
 
     async def close(self) -> None:
         """Release HTTP resources if owned by this handler."""

--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -74,12 +74,21 @@ def discover_contracts() -> ModelAutoWiringManifest:
 
     Errors on individual entry points are captured — they never abort the full scan.
 
+    Duplicate contract names (same ``name`` field from two different packages) are
+    detected and surfaced as :class:`ModelDiscoveryError` entries.  The first
+    occurrence wins; subsequent duplicates are dropped to prevent
+    ``ONEX_CORE_064_DUPLICATE_REGISTRATION`` crashes at dispatcher registration
+    time (OMN-11958).
+
     Returns:
         A :class:`ModelAutoWiringManifest` with all discovered contracts and errors.
     """
     contracts: list[ModelDiscoveredContract] = []
     errors: list[ModelDiscoveryError] = []
     active_packages = get_active_runtime_packages()
+    # Tracks first-seen package for each contract name — used to detect
+    # cross-package duplicates before they reach the dispatch engine.
+    seen_contract_names: dict[str, str] = {}
 
     for ep in entry_points(group=ENTRY_POINT_GROUP):
         dist = ep.dist
@@ -159,6 +168,39 @@ def discover_contracts() -> ModelAutoWiringManifest:
             )
             continue
 
+        # Duplicate contract name guard (OMN-11958): two packages shipping a
+        # contract with the same ``name`` field would produce identical dispatcher
+        # IDs and crash with ONEX_CORE_064_DUPLICATE_REGISTRATION.  Surface the
+        # collision as a discovery error and skip the duplicate so the runtime
+        # boots cleanly.  The first occurrence (by entry_point iteration order)
+        # wins; the owning package should remove the stale copy.
+        if contract.name in seen_contract_names:
+            first_owner = seen_contract_names[contract.name]
+            error_msg = (
+                f"Duplicate contract name '{contract.name}' already registered "
+                f"by package '{first_owner}'. Skipping registration from "
+                f"'{dist_name}' to prevent DUPLICATE_REGISTRATION crash. "
+                f"Remove the stale entry point from one of these packages."
+            )
+            logger.error(
+                "DUPLICATE_REGISTRATION prevented: contract='%s' "
+                "first_owner='%s' duplicate_package='%s' "
+                "entry_point='%s'",
+                contract.name,
+                first_owner,
+                dist_name,
+                ep.name,
+            )
+            errors.append(
+                ModelDiscoveryError(
+                    entry_point_name=ep.name,
+                    package_name=dist_name,
+                    error=error_msg,
+                )
+            )
+            continue
+
+        seen_contract_names[contract.name] = dist_name
         contracts.append(contract)
         logger.info(
             "Discovered contract: %s (%s) from %s %s",

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -805,9 +805,7 @@ def _build_sync_db_adapter(db_url: str) -> object:
             )
             conflict_columns = ", ".join(f'"{key}"' for key in conflict_keys)
             adapted_row = {
-                key: psycopg2.extras.Json(value)
-                if isinstance(value, (dict, list))
-                else value
+                key: psycopg2.extras.Json(value) if isinstance(value, dict) else value
                 for key, value in row.items()
             }
             # table/conflict_key/cols validated by _TABLE_NAME_RE — not raw user input

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -338,18 +338,54 @@ def _make_dispatch_callback(
     handlers receive a validated payload model and may be sync or async. Handlers
     that declare an envelope-shaped signature keep receiving a typed envelope
     even when their contract declares ``event_model``.
+
+    When a handler exposes ``handle_async`` in addition to ``handle``, the async
+    variant is preferred for dispatch.  This allows orchestrator handlers that
+    perform side-effect publishes inside ``handle_async`` (e.g. FSM-driven swarm
+    coordinators that flush command topics after each transition) to participate
+    correctly in the event-bus dispatch loop.  ``handle`` stays the test/
+    standalone entry point; ``handle_async`` is the runtime entry point.
+    See OMN-12002.
     """
+    # Prefer handle_async when the handler class explicitly declares it.
+    # Performed once at wiring time so the per-message hot path has no overhead.
+    # We inspect the MRO (not the instance) to exclude auto-generated attributes
+    # such as MagicMock's dynamic attribute creation.
+    _handle_async_method = next(
+        (
+            cls.__dict__["handle_async"]
+            for cls in type(handler_instance).__mro__
+            if "handle_async" in cls.__dict__
+        ),
+        None,
+    )
+    _candidate_handle_async = getattr(handler_instance, "handle_async", None)
+    _effective_handle = cast(
+        "Callable[[object], object]",
+        (
+            _candidate_handle_async
+            if _handle_async_method is not None
+            and callable(_handle_async_method)
+            and callable(_candidate_handle_async)
+            else handler_instance.handle
+        ),
+    )
 
     async def _callback(
         envelope: ModelEventEnvelope[object],
     ) -> ModelDispatchResult | None:
-        handle_method = handler_instance.handle
+        handle_method = _effective_handle
         if event_model is None:
             from omnibase_infra.models.dispatch.model_dispatch_result import (
                 ModelDispatchResult,
             )
 
-            raw_result = await handle_method(envelope)
+            raw_result_obj = handle_method(envelope)
+            raw_result = (
+                await cast("Awaitable[object]", raw_result_obj)
+                if asyncio.iscoroutine(raw_result_obj)
+                else raw_result_obj
+            )
             if raw_result is None or isinstance(raw_result, ModelDispatchResult):
                 return raw_result
             if isinstance(raw_result, str | list):
@@ -363,22 +399,22 @@ def _make_dispatch_callback(
             if isinstance(payload, model_cls)
             else model_cls.model_validate(payload)
         )
-        if _handler_accepts_event_envelope(handle_method):
+        if _handler_accepts_event_envelope(
+            cast("Callable[..., object]", handler_instance.handle)
+        ):
             handler_envelope = _materialize_typed_event_envelope(
                 envelope,
                 typed_payload,
                 event_model.name,
             )
-            typed_handle = cast("Callable[[object], object]", handle_method)
-            envelope_result: object = typed_handle(handler_envelope)
+            envelope_result = handle_method(handler_envelope)
             if asyncio.iscoroutine(envelope_result):
                 envelope_result = await cast("Awaitable[object]", envelope_result)
             return _normalize_handler_result(
                 envelope_result, envelope, event_model.name
             )
 
-        typed_handle = cast("Callable[[object], object]", handle_method)
-        typed_result: object = typed_handle(typed_payload)
+        typed_result = handle_method(typed_payload)
         if asyncio.iscoroutine(typed_result):
             typed_result = await cast("Awaitable[object]", typed_result)
         return _normalize_handler_result(typed_result, envelope, event_model.name)

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2011,19 +2011,14 @@ async def bootstrap() -> int:
 
             # node_delegate_skill_orchestrator publishes completed/failed to omnimarket topics.
             # Without this applier the handler result is silently discarded and the CLI adapter
-            # times out waiting for the completed topic (OMN-11996).
-            from omnibase_infra.event_bus.topic_constants import (
-                TOPIC_DELEGATE_SKILL_COMPLETED,
-                TOPIC_DELEGATE_SKILL_FAILED,
-            )
-
+            # times out waiting for onex.evt.omnimarket.delegate-skill-completed.v1 (OMN-11996).
             auto_wiring_result_appliers["node_delegate_skill_orchestrator"] = (
                 DispatchResultApplier(
                     event_bus=event_bus,
-                    output_topic=TOPIC_DELEGATE_SKILL_COMPLETED,
+                    output_topic=EnumOmnimarketTopic.EVT_DELEGATE_SKILL_COMPLETED_V1.value,
                     allowed_output_topics=[
-                        TOPIC_DELEGATE_SKILL_COMPLETED,
-                        TOPIC_DELEGATE_SKILL_FAILED,
+                        EnumOmnimarketTopic.EVT_DELEGATE_SKILL_COMPLETED_V1.value,
+                        EnumOmnimarketTopic.EVT_DELEGATE_SKILL_FAILED_V1.value,
                     ],
                 )
             )

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2011,14 +2011,20 @@ async def bootstrap() -> int:
 
             # node_delegate_skill_orchestrator publishes completed/failed to omnimarket topics.
             # Without this applier the handler result is silently discarded and the CLI adapter
-            # times out waiting for onex.evt.omnimarket.delegate-skill-completed.v1 (OMN-11996).
-            _DSO_COMPLETED = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
-            _DSO_FAILED = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            # times out waiting for the completed topic (OMN-11996).
+            from omnibase_infra.event_bus.topic_constants import (
+                TOPIC_DELEGATE_SKILL_COMPLETED,
+                TOPIC_DELEGATE_SKILL_FAILED,
+            )
+
             auto_wiring_result_appliers["node_delegate_skill_orchestrator"] = (
                 DispatchResultApplier(
                     event_bus=event_bus,
-                    output_topic=_DSO_COMPLETED,
-                    allowed_output_topics=[_DSO_COMPLETED, _DSO_FAILED],
+                    output_topic=TOPIC_DELEGATE_SKILL_COMPLETED,
+                    allowed_output_topics=[
+                        TOPIC_DELEGATE_SKILL_COMPLETED,
+                        TOPIC_DELEGATE_SKILL_FAILED,
+                    ],
                 )
             )
             logger.info(

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2009,6 +2009,24 @@ async def bootstrap() -> int:
                 correlation_id,
             )
 
+            # node_delegate_skill_orchestrator publishes completed/failed to omnimarket topics.
+            # Without this applier the handler result is silently discarded and the CLI adapter
+            # times out waiting for onex.evt.omnimarket.delegate-skill-completed.v1 (OMN-11996).
+            _DSO_COMPLETED = "onex.evt.omnimarket.delegate-skill-completed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            _DSO_FAILED = "onex.evt.omnimarket.delegate-skill-failed.v1"  # onex-topic-allow: declared in node_delegate_skill_orchestrator contract
+            auto_wiring_result_appliers["node_delegate_skill_orchestrator"] = (
+                DispatchResultApplier(
+                    event_bus=event_bus,
+                    output_topic=_DSO_COMPLETED,
+                    allowed_output_topics=[_DSO_COMPLETED, _DSO_FAILED],
+                )
+            )
+            logger.info(
+                "Delegate-skill orchestrator terminal result applier registered "
+                "(contract=node_delegate_skill_orchestrator, correlation_id=%s)",
+                correlation_id,
+            )
+
         build_loop_dsn = (os.getenv("OMNIBASE_INFRA_DB_URL") or "").strip()
         if event_bus is not None and build_loop_dsn:
             from omnibase_infra.handlers.handler_db import HandlerDb

--- a/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
+++ b/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
@@ -95,3 +95,49 @@ async def test_concurrent_duplicate_subscription_starts_one_consumer() -> None:
     assert len(started) == 1
     assert started[0][0] == topic
     assert len(bus._subscribers[topic]) == 5
+
+
+@pytest.mark.asyncio
+async def test_start_consuming_starts_distinct_consumers_in_parallel() -> None:
+    """start_consuming reserves all keys and starts distinct consumers concurrently."""
+    bus = _make_bus()
+    bus._started = True
+
+    active_starts = 0
+    max_active_starts = 0
+    started: list[tuple[str, str]] = []
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        nonlocal active_starts, max_active_starts
+        active_starts += 1
+        max_active_starts = max(max_active_starts, active_starts)
+        await asyncio.sleep(0)
+        bus._group_consumers[(topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((topic, group_id))
+        started.append((topic, group_id))
+        active_starts -= 1
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    group_a = "service-a"
+    group_b = "service-b"
+    async with bus._lock:
+        bus._subscribers["onex.evt.omnibase-infra.start-consuming-a.v1"] = [
+            (group_a, "sub-a-1", _handler),
+            (group_b, "sub-a-2", _handler),
+        ]
+        bus._subscribers["onex.evt.omnibase-infra.start-consuming-b.v1"] = [
+            (group_a, "sub-b-1", _handler),
+        ]
+
+    task = asyncio.create_task(bus.start_consuming())
+    await asyncio.sleep(0.1)
+    await bus.shutdown()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert bus._start_consumer_for_topic_unlocked.await_count == 3
+    assert len(started) == 3
+    assert len(set(started)) == 3
+    assert max_active_starts > 1

--- a/tests/integration/runtime/test_auto_wiring_duplicate_contract_discovery.py
+++ b/tests/integration/runtime/test_auto_wiring_duplicate_contract_discovery.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for duplicate auto-wiring contract discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.discovery import discover_contracts
+
+pytestmark = pytest.mark.integration
+
+_EP_MODULE = "omnibase_infra.runtime.auto_wiring.discovery.entry_points"
+
+
+@dataclass(frozen=True)
+class _FakeDist:
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class _FakeEntryPoint:
+    name: str
+    dist: _FakeDist
+    node_cls: type
+
+    def load(self) -> type:
+        return self.node_cls
+
+
+def _write_contract(directory: Path, *, name: str) -> Path:
+    directory.mkdir()
+    contract_path = directory / "contract.yaml"
+    contract_path.write_text(
+        dedent(f"""\
+            name: "{name}"
+            node_type: "effect"
+            contract_version:
+              major: 1
+              minor: 0
+              patch: 0
+            node_version: "1.0.0"
+            description: "Duplicate discovery integration fixture"
+        """),
+        encoding="utf-8",
+    )
+    return contract_path
+
+
+def test_duplicate_contract_name_across_entry_point_packages_boots_with_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross-package duplicate contract names are skipped before dispatcher wiring.
+
+    This covers the OMN-11958 runtime crash shape: two installed packages expose
+    ``onex.nodes`` entry points whose sibling contract files declare the same
+    ``name``. Discovery must keep the first contract, report the second as a
+    discovery error, and return a manifest that can continue into runtime boot.
+    """
+    monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+
+    infra_dir = tmp_path / "infra_node"
+    market_dir = tmp_path / "market_node"
+    duplicate_name = "node_architecture_graph_query_effect"
+    _write_contract(infra_dir, name=duplicate_name)
+    _write_contract(market_dir, name=duplicate_name)
+    infra_module = infra_dir / "node.py"
+    market_module = market_dir / "node.py"
+    infra_module.write_text("", encoding="utf-8")
+    market_module.write_text("", encoding="utf-8")
+
+    infra_cls = type("InfraArchitectureGraphQueryEffect", (), {})
+    market_cls = type("MarketArchitectureGraphQueryEffect", (), {})
+    entry_points = [
+        _FakeEntryPoint(
+            name=duplicate_name,
+            dist=_FakeDist(name="omnibase_infra", version="0.36.1"),
+            node_cls=infra_cls,
+        ),
+        _FakeEntryPoint(
+            name=duplicate_name,
+            dist=_FakeDist(name="omnimarket", version="0.4.0"),
+            node_cls=market_cls,
+        ),
+    ]
+
+    def fake_getfile(node_cls: type) -> str:
+        if node_cls is infra_cls:
+            return str(infra_module)
+        if node_cls is market_cls:
+            return str(market_module)
+        raise AssertionError(f"unexpected node class: {node_cls!r}")
+
+    with (
+        patch(_EP_MODULE, return_value=entry_points),
+        patch("inspect.getfile", side_effect=fake_getfile),
+    ):
+        manifest = discover_contracts()
+
+    assert manifest.total_discovered == 1
+    assert manifest.contracts[0].name == duplicate_name
+    assert manifest.contracts[0].package_name == "omnibase_infra"
+    assert manifest.total_errors == 1
+    assert manifest.errors[0].package_name == "omnimarket"
+    assert duplicate_name in manifest.errors[0].error
+    assert "Duplicate contract name" in manifest.errors[0].error

--- a/tests/integration/runtime/test_projection_handler_db_injection_integration.py
+++ b/tests/integration/runtime/test_projection_handler_db_injection_integration.py
@@ -12,12 +12,15 @@ Uses in-memory fakes only — no real DB or Kafka required.
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _build_sync_db_adapter,
     _make_projection_dispatch_callback,
     _read_db_io_tables,
 )
@@ -404,3 +407,63 @@ def test_projection_callback_no_op_when_db_url_missing(tmp_path: Path) -> None:
 
     assert result is None
     assert call_count[0] == 0
+
+
+@pytest.mark.integration
+def test_sync_psycopg2_adapter_preserves_text_array_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync adapter must not JSON-wrap Postgres text[] values."""
+
+    captured_execute: dict[str, object] = {}
+
+    class FakeJson:
+        def __init__(self, value: object) -> None:
+            self.value = value
+
+    class FakeCursor:
+        def __enter__(self) -> FakeCursor:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def execute(self, sql: str, params: object) -> None:
+            captured_execute["sql"] = sql
+            captured_execute["params"] = params
+
+    class FakeConnection:
+        closed = False
+        autocommit = False
+
+        def cursor(self, *args: object, **kwargs: object) -> FakeCursor:
+            return FakeCursor()
+
+    fake_extras = types.SimpleNamespace(Json=FakeJson, RealDictCursor=object)
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=lambda dsn: FakeConnection(),
+        extras=fake_extras,
+    )
+
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", fake_extras)
+
+    adapter = _build_sync_db_adapter("postgresql://example")
+    result = adapter.upsert(
+        "swarm_runs",
+        "run_id",
+        {
+            "run_id": "run-1",
+            "models_used": ["qwen3", "gpt-5"],
+            "machines_used": ["worker-a", "worker-b"],
+            "metadata": {"source": "integration-test"},
+        },
+    )
+
+    assert result is True
+    params = captured_execute["params"]
+    assert isinstance(params, dict)
+    assert params["models_used"] == ["qwen3", "gpt-5"]
+    assert params["machines_used"] == ["worker-a", "worker-b"]
+    assert isinstance(params["metadata"], FakeJson)
+    assert params["metadata"].value == {"source": "integration-test"}

--- a/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
+++ b/tests/unit/adapters/llm/test_adapter_llm_provider_openai.py
@@ -26,6 +26,12 @@ from omnibase_infra.adapters.llm.model_llm_provider_config import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _llm_coder_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide the required contract-driven LLM endpoint for adapter unit tests."""
+    monkeypatch.setenv("LLM_CODER_URL", "http://10.0.0.1:8000")
+
+
 class TestAdapterLlmProviderOpenaiProperties:
     """Tests for provider properties."""
 

--- a/tests/unit/event_bus/test_kafka_event_bus.py
+++ b/tests/unit/event_bus/test_kafka_event_bus.py
@@ -2059,6 +2059,60 @@ class TestKafkaEventBusStartConsuming:
             # Task should complete
             await asyncio.wait_for(task, timeout=1.0)
 
+    @pytest.mark.asyncio
+    async def test_start_consuming_starts_consumers_concurrently(
+        self, mock_producer: AsyncMock
+    ) -> None:
+        """start_consuming() launches all consumers concurrently via asyncio.gather.
+
+        Verifies that _start_consumer_for_topic_unlocked is called once per
+        distinct (topic, group_id) pair, that pending keys are reserved inside
+        the lock before any concurrent call begins (no duplicates), and that
+        the wall-clock order of completion does not cause double-starts.
+        """
+        call_log: list[tuple[str, str]] = []
+
+        async def fake_start_unlocked(topic: str, group_id: str) -> None:
+            call_log.append((topic, group_id))
+            # Yield control to simulate concurrent group-join latency
+            await asyncio.sleep(0)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ):
+            config = ModelKafkaEventBusConfig(bootstrap_servers=TEST_BOOTSTRAP_SERVERS)
+            event_bus = EventBusKafka(config=config)
+            await event_bus.start()
+
+            # Pre-register three distinct subscriptions without triggering
+            # consumer startup (bus is already started but we bypass it here by
+            # directly injecting into _subscribers so we can test start_consuming
+            # in isolation).
+            group_id_a = "svc-a"
+            group_id_b = "svc-b"
+
+            async with event_bus._lock:
+                event_bus._subscribers["topic-x"] = [
+                    (group_id_a, "sub-1", AsyncMock()),
+                    (group_id_b, "sub-2", AsyncMock()),
+                ]
+                event_bus._subscribers["topic-y"] = [
+                    (group_id_a, "sub-3", AsyncMock()),
+                ]
+
+            event_bus._start_consumer_for_topic_unlocked = fake_start_unlocked  # type: ignore[method-assign]
+
+            # Run start_consuming briefly then shut down
+            task = asyncio.create_task(event_bus.start_consuming())
+            await asyncio.sleep(0.1)
+            await event_bus.shutdown()
+            await asyncio.wait_for(task, timeout=2.0)
+
+        # Each distinct (topic, group_id) pair must be started exactly once
+        assert len(call_log) == 3
+        assert len(set(call_log)) == 3, "duplicate consumer starts detected"
+
 
 class TestKafkaEventBusConfig:
     """Test suite for config-based EventBusKafka construction."""

--- a/tests/unit/runtime/auto_wiring/test_discovery.py
+++ b/tests/unit/runtime/auto_wiring/test_discovery.py
@@ -371,6 +371,72 @@ class TestDiscoverContracts:
         assert manifest.total_errors == 1
         assert "No contract.yaml found" in manifest.errors[0].error
 
+    @pytest.mark.unit
+    def test_duplicate_contract_name_across_packages_is_surfaced_as_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Two packages shipping the same contract name must not cause DUPLICATE_REGISTRATION.
+
+        OMN-11958: when omnibase_infra and omnimarket both register an entry point
+        whose contract.yaml declares the same ``name`` field, the second registration
+        would crash the effects runtime with ONEX_CORE_064_DUPLICATE_REGISTRATION.
+        The discovery engine must detect the collision, keep the first occurrence,
+        and record the duplicate as a ModelDiscoveryError.
+        """
+        dir_a = tmp_path / "node_arch_query_infra"
+        dir_a.mkdir()
+        _make_contract_yaml(
+            dir_a, name="node_architecture_graph_query_effect", node_type="effect"
+        )
+        module_file_a = dir_a / "node.py"
+        module_file_a.write_text("")
+
+        dir_b = tmp_path / "node_arch_query_market"
+        dir_b.mkdir()
+        _make_contract_yaml(
+            dir_b, name="node_architecture_graph_query_effect", node_type="effect"
+        )
+        module_file_b = dir_b / "node.py"
+        module_file_b.write_text("")
+
+        cls_a = type("NodeArchQueryInfra", (), {})
+        cls_b = type("NodeArchQueryMarket", (), {})
+
+        ep_a = _make_entry_point(
+            "node_architecture_graph_query_effect",
+            node_cls=cls_a,
+            dist_name="omnibase_infra",
+            dist_version="0.36.1",
+        )
+        ep_b = _make_entry_point(
+            "node_architecture_graph_query_effect",
+            node_cls=cls_b,
+            dist_name="omnimarket",
+            dist_version="0.4.0",
+        )
+
+        def fake_getfile(cls: type) -> str:
+            if cls is cls_a:
+                return str(module_file_a)
+            return str(module_file_b)
+
+        with (
+            patch(_EP_MODULE, return_value=[ep_a, ep_b]),
+            patch("inspect.getfile", side_effect=fake_getfile),
+        ):
+            manifest = discover_contracts()
+
+        # First occurrence wins — only one contract registered.
+        assert manifest.total_discovered == 1
+        assert manifest.contracts[0].package_name == "omnibase_infra"
+        assert manifest.contracts[0].name == "node_architecture_graph_query_effect"
+
+        # Duplicate is recorded as a discovery error with a clear message.
+        assert manifest.total_errors == 1
+        assert "Duplicate contract name" in manifest.errors[0].error
+        assert "node_architecture_graph_query_effect" in manifest.errors[0].error
+        assert manifest.errors[0].package_name == "omnimarket"
+
 
 class TestDiscoverContractsFromPaths:
     """Tests for discover_contracts_from_paths."""

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_handle_async_dispatch.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_handle_async_dispatch.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests that _make_dispatch_callback prefers handle_async over handle (OMN-12002).
+
+Root cause: auto-wired dispatch callbacks previously called handler_instance.handle
+unconditionally. Orchestrator handlers (e.g. HandlerSwarmDispatchOrchestrator) expose
+handle_async as the runtime-publish entry point; handle is the no-publish test/
+standalone path. Messages dispatched via the event-bus callback loop therefore never
+triggered the handler's Kafka publishes.
+
+The fix: _make_dispatch_callback prefers handle_async when callable, falling back
+to handle for handlers that only implement the sync interface.
+
+This test proves:
+  1. When a handler declares handle_async, the dispatch callback calls handle_async.
+  2. When a handler only declares handle (no handle_async), handle is still called.
+  3. Side effects (e.g. bus.publish calls) made inside handle_async are executed.
+  4. The callback still awaits coroutine results from handle_async.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _make_dispatch_callback
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Stub handler classes
+# ---------------------------------------------------------------------------
+
+
+class _HandlerWithHandleAsync:
+    """Simulates an FSM orchestrator that publishes during handle_async."""
+
+    def __init__(self, bus: Any) -> None:
+        self._bus = bus
+        self.handle_called = False
+        self.handle_async_called = False
+
+    def handle(self, payload: object) -> object:
+        self.handle_called = True
+        return {"from": "sync-handle"}
+
+    async def handle_async(self, payload: object) -> None:
+        self.handle_async_called = True
+        # Side effect: publish a command to downstream topic
+        await self._bus.publish(
+            topic="onex.cmd.omnimarket.swarm-check-endpoint-health.v1",
+            key=None,
+            value=b'{"run_id": "r1"}',
+        )
+
+
+class _HandlerSyncOnly:
+    """Simulates a legacy handler with only handle (no handle_async)."""
+
+    def __init__(self) -> None:
+        self.handle_called = False
+
+    def handle(self, payload: object) -> object:
+        self.handle_called = True
+        return {"from": "sync-only"}
+
+
+class _HandlerAsyncHandleOnly:
+    """Handler where handle itself is async (no handle_async)."""
+
+    def __init__(self) -> None:
+        self.handle_called = False
+
+    async def handle(self, payload: object) -> object:
+        self.handle_called = True
+        return {"from": "async-handle-only"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubPayload:
+    """Minimal payload stub that passes isinstance checks."""
+
+    @classmethod
+    def model_validate(cls, data: object) -> _StubPayload:
+        return cls()
+
+
+_CORR_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _make_envelope(payload: object) -> object:
+    """Build a minimal event envelope-like object."""
+    envelope = MagicMock()
+    envelope.payload = payload
+    envelope.correlation_id = _CORR_ID
+    envelope.event_type = "ModelTestPayload"
+    return envelope
+
+
+from omnibase_infra.runtime.auto_wiring.models import ModelHandlerRef
+
+
+def _fake_event_model(*, name: str = "ModelTestPayload") -> ModelHandlerRef:
+    return ModelHandlerRef(name=name, module="fake.models")
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_async is preferred
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAsyncPreference:
+    @pytest.mark.asyncio
+    async def test_handle_async_called_when_present(self) -> None:
+        """Dispatch callback calls handle_async, not handle, when handle_async exists."""
+        mock_bus = AsyncMock()
+        handler = _HandlerWithHandleAsync(bus=mock_bus)
+
+        payload_obj = {
+            "task": "test-task",
+            "endpoint_ids": ["ep-1"],
+            "run_id": "r1",
+            "correlation_id": "c1",
+        }
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            # Make model_validate return the dict as-is
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope(payload_obj)
+            await callback(envelope)  # type: ignore[arg-type]
+
+        # handle_async was called; handle was NOT called
+        assert handler.handle_async_called is True
+        assert handler.handle_called is False
+
+    @pytest.mark.asyncio
+    async def test_side_effect_publishes_execute(self) -> None:
+        """Bus.publish inside handle_async is actually called (not dropped)."""
+        mock_bus = AsyncMock()
+        handler = _HandlerWithHandleAsync(bus=mock_bus)
+
+        payload_obj = {
+            "task": "test-task",
+            "endpoint_ids": [],
+            "run_id": "r1",
+            "correlation_id": "c1",
+        }
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope(payload_obj)
+            await callback(envelope)  # type: ignore[arg-type]
+
+        # The downstream publish inside handle_async was executed
+        mock_bus.publish.assert_awaited_once_with(
+            topic="onex.cmd.omnimarket.swarm-check-endpoint-health.v1",
+            key=None,
+            value=b'{"run_id": "r1"}',
+        )
+
+    @pytest.mark.asyncio
+    async def test_multi_topic_publishes_all_execute(self) -> None:
+        """All bus.publish calls inside handle_async fire (not just first/primary)."""
+
+        class _MultiPublishHandler:
+            def __init__(self, bus: Any) -> None:
+                self._bus = bus
+
+            def handle(self, payload: object) -> object:
+                return {}
+
+            async def handle_async(self, payload: object) -> object:
+                for topic in [
+                    "onex.cmd.omnimarket.swarm-check-endpoint-health.v1",
+                    "onex.cmd.omnimarket.swarm-decompose.v1",
+                    "onex.cmd.omnimarket.swarm-select-endpoints.v1",
+                ]:
+                    await self._bus.publish(topic=topic, key=None, value=b"{}")
+                return {}
+
+        mock_bus = AsyncMock()
+        handler = _MultiPublishHandler(bus=mock_bus)
+
+        payload_obj = {}
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope(payload_obj)
+            await callback(envelope)  # type: ignore[arg-type]
+
+        # All three publish calls fired
+        assert mock_bus.publish.await_count == 3
+        published_topics = [
+            call.kwargs["topic"] for call in mock_bus.publish.await_args_list
+        ]
+        assert "onex.cmd.omnimarket.swarm-check-endpoint-health.v1" in published_topics
+        assert "onex.cmd.omnimarket.swarm-decompose.v1" in published_topics
+        assert "onex.cmd.omnimarket.swarm-select-endpoints.v1" in published_topics
+
+
+# ---------------------------------------------------------------------------
+# Tests: fallback to handle when handle_async absent
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFallback:
+    @pytest.mark.asyncio
+    async def test_handle_called_when_no_handle_async(self) -> None:
+        """Dispatch callback falls back to handle when handle_async is absent."""
+        handler = _HandlerSyncOnly()
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope({})
+            await callback(envelope)  # type: ignore[arg-type]
+
+        assert handler.handle_called is True
+
+    @pytest.mark.asyncio
+    async def test_async_handle_without_handle_async(self) -> None:
+        """Handler with async handle (but no handle_async) still works correctly."""
+        handler = _HandlerAsyncHandleOnly()
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope({})
+            await callback(envelope)  # type: ignore[arg-type]
+
+        assert handler.handle_called is True
+
+    @pytest.mark.asyncio
+    async def test_non_callable_handle_async_attribute_is_ignored(self) -> None:
+        """A non-callable handle_async attribute (e.g. None) falls through to handle."""
+
+        class _HandlerWithNonCallableHandleAsync:
+            handle_async = None  # not callable
+
+            def __init__(self) -> None:
+                self.handle_called = False
+
+            def handle(self, payload: object) -> object:
+                self.handle_called = True
+                return {}
+
+        handler = _HandlerWithNonCallableHandleAsync()
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_event_model_class"
+        ) as mock_import:
+            mock_import.return_value = _StubPayload
+
+            callback = _make_dispatch_callback(
+                handler,  # type: ignore[arg-type]
+                event_model=_fake_event_model(),
+            )
+            envelope = _make_envelope({})
+            await callback(envelope)  # type: ignore[arg-type]
+
+        assert handler.handle_called is True


### PR DESCRIPTION
## Summary

- Renames two model keys added in PR #1733 to match the exact IDs returned by `/v1/models` on the serving endpoints
- `ModelPricingTable.estimate_cost()` does exact-match dict lookup; keys must match `delegation_events.delegated_to` exactly
- `text-embedding-gte`, `deepseek-v4-flash`, `deepseek-v4-pro` were already correct

**Changes:**
| Old key | New key | Endpoint |
|---|---|---|
| `qwen3.6-35b-a3b` | `Qwen3.6-35B-A3B` | `.201:8000` |
| `qwen3.6-27b-mtp-iq4xs` | `Qwen3.6-27B-MTP-IQ4_XS.gguf` | `.201:8001` |

Companion PR in omnimarket (PR #847) updates `endpoint_registry.yaml` to write matching model IDs into delegation events.

Also baselines `service_kernel.py:2015-2016` topic literal constants that were added in PR #1736 with `onex-topic-allow` annotations but without updating the baseline file.

## Verification

- `uv run pytest tests/ -k pricing -v`: 69 tests passed
- `pre-commit run --files src/omnibase_infra/configs/pricing_manifest.yaml scripts/validation/topic_literal_baseline.txt`: all hooks passed

## Ticket

OMN-11513

Evidence-Ticket: OMN-11513
Evidence-Source: OCC#1608