### PR TITLE
feat(OMN-12131): add log_entries migration to omnidash_analytics

### DIFF
--- a/docker/migrations/forward/083_create_log_entries.sql
+++ b/docker/migrations/forward/083_create_log_entries.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- MIGRATION: Create log_entries table in omnidash_analytics
+-- =============================================================================
+-- Ticket: OMN-12131 (Event Bus Observability — log_entries table)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   Creates the log_entries table in the omnidash_analytics database to store
+--   structured log events emitted by ONEX nodes. Feeds the event bus
+--   observability pipeline consumed by node_log_persistence_effect.
+--
+--   Retention: 30-day rolling window. Rows older than 30 days should be
+--   purged by a scheduled maintenance job (e.g., pg_cron or a nightly
+--   retention node). The ingested_at column is the retention anchor.
+--
+-- IDEMPOTENCY:
+--   - CREATE TABLE IF NOT EXISTS is safe to re-run.
+--   - CREATE INDEX IF NOT EXISTS is safe to re-run.
+--
+-- ROLLBACK:
+--   See rollback/rollback_083_create_log_entries.sql
+-- =============================================================================
+
+\connect omnidash_analytics
+
+-- =============================================================================
+-- TABLE: log_entries
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS log_entries (
+    entry_id        UUID            PRIMARY KEY,
+    timestamp       TIMESTAMPTZ     NOT NULL,
+    node_name       TEXT            NOT NULL,
+    function_name   TEXT            NOT NULL DEFAULT '',
+    level           TEXT            NOT NULL DEFAULT 'info',
+    message         TEXT            NOT NULL,
+    correlation_id  TEXT,
+    duration_ms     DOUBLE PRECISION,
+    metadata        JSONB           NOT NULL DEFAULT '{}',
+    ingested_at     TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE log_entries IS
+    'Structured log events from ONEX nodes (OMN-12131). '
+    '30-day retention window anchored on ingested_at. '
+    'Consumed by node_log_persistence_effect via onex.evt.*.log-emitted.v1.';
+
+COMMENT ON COLUMN log_entries.entry_id IS
+    'Client-supplied UUID — idempotency key for exactly-once ingestion.';
+
+COMMENT ON COLUMN log_entries.ingested_at IS
+    '30-day retention anchor. Rows with ingested_at < NOW() - INTERVAL ''30 days'' '
+    'are eligible for pruning by the nightly retention job.';
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Partial index: correlation lookups (skip NULL rows to reduce index size)
+CREATE INDEX IF NOT EXISTS idx_log_entries_correlation
+    ON log_entries (correlation_id)
+    WHERE correlation_id IS NOT NULL;
+
+-- Composite: node-scoped time-range queries (dashboard primary query path)
+CREATE INDEX IF NOT EXISTS idx_log_entries_node_ts
+    ON log_entries (node_name, timestamp DESC);
+
+-- Composite: level-filtered time-range queries (error/warn filtering)
+CREATE INDEX IF NOT EXISTS idx_log_entries_level_ts
+    ON log_entries (level, timestamp DESC);
+
+-- Standalone timestamp: full time-range scans and retention sweeps
+CREATE INDEX IF NOT EXISTS idx_log_entries_ts
+    ON log_entries (timestamp DESC);

--- a/docker/migrations/rollback/rollback_083_create_log_entries.sql
+++ b/docker/migrations/rollback/rollback_083_create_log_entries.sql
@@ -1,0 +1,8 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+--
+-- Rollback: 083_create_log_entries
+
+\connect omnidash_analytics
+
+DROP TABLE IF EXISTS log_entries;


### PR DESCRIPTION
## Summary

- Adds `083_create_log_entries.sql` (forward migration) creating the `log_entries` table in `omnidash_analytics`
- Adds `rollback_083_create_log_entries.sql` (rollback) dropping the table
- Schema matches the contract defined in OMN-12131: UUID PK, timestamptz, node_name, level, message, correlation_id, duration_ms, metadata JSONB, ingested_at
- Four indexes: correlation (partial WHERE NOT NULL), node+ts, level+ts, ts
- 30-day retention window anchored on `ingested_at` documented in column comment

## Ticket

OMN-12131

## Test plan

- [ ] Verify forward migration applies cleanly against a fresh `omnidash_analytics` database
- [ ] Verify rollback drops the table without error
- [ ] Confirm all four indexes are created (`\d log_entries` in psql)
- [ ] Confirm `\connect omnidash_analytics` routes to the correct database (not `omnibase_infra`)