### PR TITLE
fix(OMN-12151): skip terminal event when handle_async returns None

### DIFF
--- a/contracts/runtime/runtime_protocol.lock.json
+++ b/contracts/runtime/runtime_protocol.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "package_version": "0.34.1",
+  "package_version": "0.36.1",
   "protocol_count": 23,
   "protocols": {
     "ProtocolAutoWiringManifestLike": {
@@ -375,7 +375,7 @@
             {
               "name": "result",
               "kind": "POSITIONAL_OR_KEYWORD",
-              "annotation": "ModelDispatchResult",
+              "annotation": "ModelDispatchResult | None",
               "default": null
             },
             {

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -2,5 +2,5 @@
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
 sha256:6f4891be982289898e5cf47ded9921e301136041df1a2859a3e5f4487532d46f
-generated_at: 2026-05-25T23:08:52Z
+generated_at: 2026-05-26T02:16:59Z
 migration_file_count: 69

--- a/src/omnibase_infra/protocols/protocol_dispatch_result_applier.py
+++ b/src/omnibase_infra/protocols/protocol_dispatch_result_applier.py
@@ -16,11 +16,15 @@ if TYPE_CHECKING:
 
 
 class ProtocolDispatchResultApplier(Protocol):
-    """Applies a handler dispatch result to its output/effect path."""
+    """Applies a handler dispatch result to its output/effect path.
+
+    When ``result`` is ``None`` the applier must return immediately without
+    publishing any terminal event or executing any intents (OMN-12151).
+    """
 
     async def apply(
         self,
-        result: ModelDispatchResult,
+        result: ModelDispatchResult | None,
         correlation_id: UUID | None = None,
     ) -> None:
         raise NotImplementedError

--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -395,7 +395,7 @@ class DispatchResultApplier:
 
     async def apply(
         self,
-        result: ModelDispatchResult,
+        result: ModelDispatchResult | None,
         correlation_id: UUID | None = None,
     ) -> None:
         """Process a dispatch result: project, execute intents, then publish output events.
@@ -418,8 +418,18 @@ class DispatchResultApplier:
             intents are published on projection failure — no partial state
             emission.
 
+        None-result opt-out (OMN-12151):
+            When ``result`` is ``None``, the applier exits immediately without
+            publishing any terminal event or executing any intents.  This is the
+            canonical opt-out for multi-step FSM orchestrators that publish
+            sub-commands mid-flight and must not emit a terminal event until the
+            FSM reaches its final state.  Handlers that drive their own event
+            publication (e.g. ``handle_async`` flushes sub-commands directly)
+            should return ``None`` for non-terminal FSM states.
+
         Args:
-            result: The dispatch result from the dispatch engine.
+            result: The dispatch result from the dispatch engine, or ``None``
+                to suppress terminal-event publication entirely.
             correlation_id: Optional correlation ID for tracing.
 
         Raises:
@@ -427,6 +437,13 @@ class DispatchResultApplier:
             RuntimeHostError: If intent execution misconfiguration is detected.
             Exception: Re-raised from intent execution or Kafka publish failures.
         """
+        if result is None:
+            logger.debug(
+                "DispatchResultApplier.apply received None result — "
+                "suppressing terminal event publication (OMN-12151)"
+            )
+            return
+
         effective_correlation_id = correlation_id or result.correlation_id
         if effective_correlation_id is None:
             effective_correlation_id = uuid4()

--- a/tests/unit/runtime/test_service_dispatch_result_applier.py
+++ b/tests/unit/runtime/test_service_dispatch_result_applier.py
@@ -118,6 +118,28 @@ class TestEarlyExit:
         bus.publish_envelope.assert_not_called()
         executor.execute_all.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_none_result_suppresses_terminal_event(self) -> None:
+        """None result must skip all publication and intent execution (OMN-12151).
+
+        Multi-step FSM orchestrators (e.g. swarm dispatcher) return None from
+        handle_async for non-terminal FSM states.  The result applier must not
+        publish any terminal event or execute any intents when it receives None,
+        preventing the FSM from being short-circuited before sub-commands fire.
+        """
+        bus = AsyncMock()
+        executor = AsyncMock()
+        applier = DispatchResultApplier(
+            event_bus=bus,
+            output_topic="out.topic",
+            intent_executor=executor,
+        )
+
+        await applier.apply(None)
+
+        bus.publish_envelope.assert_not_called()
+        executor.execute_all.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Ordering contract tests


### PR DESCRIPTION
## Summary

- `DispatchResultApplier.apply()` now accepts `ModelDispatchResult | None`. When `None` is passed it returns immediately — no projection, no intents, no Kafka publish.
- `ProtocolDispatchResultApplier` signature widened to match.
- Protocol lockfile regenerated.
- New test `test_none_result_suppresses_terminal_event` proves `None` suppresses all side effects.

## Root cause (OMN-12151)

The swarm dispatch orchestrator's `handle_async` returned a `ModelSwarmDispatchResult` even for the non-terminal RECEIVED state. `_normalize_handler_result` wrapped it as an output event and `DispatchResultApplier.apply()` published it as a terminal Kafka event — before any sub-commands reached the effect nodes. This short-circuited the 7-state FSM.

## Fix

The opt-out contract: any handler that drives its own sub-command publication via `_flush` should return `None` for non-terminal states. `apply(None)` is now a no-op with a debug log. One-shot handlers that return a result continue to work unchanged.

The companion omnimarket PR (`jonah/omn-12151-orchestrator-return-none`) makes `handle_async` return `None`.

## Test plan

- [x] `test_none_result_suppresses_terminal_event` — `apply(None)` calls neither `publish_envelope` nor `execute_all`
- [x] Existing `TestEarlyExit` tests for non-success statuses still pass (22/22)
- [x] Protocol lockfile snapshot tests pass (19/19)
- [x] Full unit suite: 1391 passed

OMN-12151

Evidence-Source: fc95ec149d5ea0e3ec1ff9b88b531a3a269c954f
Evidence-Ticket: OMN-12151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dispatch result handling to support optional results, enabling graceful processing of `None` results and preventing unwanted terminal event publication and intent execution in multi-step orchestration scenarios.

* **Tests**
  * Added comprehensive test coverage to verify `None` dispatch result behavior and validate that the system correctly suppresses terminal events and intent execution when results are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->