### PR TITLE
fix(OMN-12195): pin OMNIMARKET_REF to dev branch in runtime Dockerfile

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -225,14 +225,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "git+https://github.com/OmniNode-ai/onex_change_control.git@${ONEX_CHANGE_CONTROL_REF}#egg=onex-change-control"
 
-# Install omnimarket from git main until PyPI releases are automated (OMN-7980).
-# Pinned to main so every image rebuild picks up the latest merged nodes.
-# Switch back to PyPI range pin once the auto-tag-on-merge release pipeline
-# is confirmed publishing on each merge: "omnimarket>=0.2.0,<2.0.0"
+# Install omnimarket from git dev until PyPI releases are automated (OMN-7980).
+# Pinned to dev (omnimarket's default branch) so every image rebuild picks up
+# the latest merged nodes. Switch back to PyPI range pin once the auto-tag-on-merge
+# release pipeline is confirmed publishing on each merge: "omnimarket>=0.2.0,<2.0.0"
 # OMN-10728: OMNIMARKET_REF must be the full commit SHA so that the install URL
-# itself changes when main advances — this busts the uv cache mount (keyed on
+# itself changes when dev advances — this busts the uv cache mount (keyed on
 # URL, not on resolved HEAD) and forces a fresh fetch.
-ARG OMNIMARKET_REF=main
+# OMN-12195: default branch is dev, not main — use dev to avoid stale SHA from
+# Docker's git cache resolving @main to an older commit.
+ARG OMNIMARKET_REF=dev
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps \
     "git+https://github.com/OmniNode-ai/omnimarket.git@${OMNIMARKET_REF}#egg=omnimarket"

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -2,5 +2,5 @@
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
 sha256:6f4891be982289898e5cf47ded9921e301136041df1a2859a3e5f4487532d46f
-generated_at: 2026-05-25T23:08:52Z
+generated_at: 2026-05-26T02:17:06Z
 migration_file_count: 69

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -643,7 +643,7 @@ class DeployExecutor:
         if result.returncode == 0:
             return result.stdout.strip()
         logger.warning(
-            "_resolve_plugin_ref: git rev-parse failed for %s (exit=%d): %s — falling back to 'main'",
+            "_resolve_plugin_ref: git rev-parse failed for %s (exit=%d): %s — falling back to branch default",
             repo_dir,
             result.returncode,
             result.stderr[:200],
@@ -676,7 +676,7 @@ class DeployExecutor:
 
         omni_home = os.environ.get("OMNI_HOME", "").strip()
         omnimarket_ref = (
-            self._resolve_plugin_ref(f"{omni_home}/omnimarket") if omni_home else "main"
+            self._resolve_plugin_ref(f"{omni_home}/omnimarket") if omni_home else "dev"
         )
         compat_ref = (
             self._resolve_plugin_ref(f"{omni_home}/omnibase_compat")

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -272,8 +272,10 @@ class TestUvCacheBustPluginRefs:
             sha = DeployExecutor._resolve_plugin_ref("/nonexistent/repo")
         assert sha == "main"
 
-    def test_compose_build_uses_main_fallback_when_omni_home_unset(self) -> None:
-        """When OMNI_HOME is not set, OMNIMARKET_REF and ONEX_CHANGE_CONTROL_REF default to 'main'."""
+    def test_compose_build_uses_dev_fallback_for_omnimarket_when_omni_home_unset(
+        self,
+    ) -> None:
+        """When OMNI_HOME is not set, OMNIMARKET_REF defaults to 'dev' (OMN-12195: dev is the default branch)."""
         executor = DeployExecutor()
         captured_cmds: list[list[str]] = []
 
@@ -305,8 +307,8 @@ class TestUvCacheBustPluginRefs:
             for i, tok in enumerate(build_cmd)
             if tok == "--build-arg" and i + 1 < len(build_cmd)
         }
-        assert "OMNIMARKET_REF=main" in build_args, (
-            f"Expected OMNIMARKET_REF=main when OMNI_HOME unset; got {build_args}"
+        assert "OMNIMARKET_REF=dev" in build_args, (
+            f"Expected OMNIMARKET_REF=dev when OMNI_HOME unset (OMN-12195: dev is omnimarket default branch); got {build_args}"
         )
         assert "OMNIBASE_COMPAT_REF=main" in build_args, (
             f"Expected OMNIBASE_COMPAT_REF=main when OMNI_HOME unset; got {build_args}"

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1185,7 +1185,7 @@ build_images() {
     build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     local omni_home="${OMNI_HOME:-}"
     local compat_ref="main"
-    local omnimarket_ref="main"
+    local omnimarket_ref="dev"
     local occ_ref="main"
     if [[ -n "${omni_home}" ]]; then
         compat_ref="$(read_repo_ref_or_main "${omni_home}/omnibase_compat")"
@@ -1370,7 +1370,7 @@ print_compose_commands() {
     log_info "    --build-arg RUNTIME_SOURCE_HASH=${git_sha} \\"
     log_info "    --build-arg COMPOSE_PROJECT=${compose_project} \\"
     log_info "    --build-arg OMNIBASE_COMPAT_REF=\${OMNIBASE_COMPAT_REF:-main} \\"
-    log_info "    --build-arg OMNIMARKET_REF=\${OMNIMARKET_REF:-main} \\"
+    log_info "    --build-arg OMNIMARKET_REF=\${OMNIMARKET_REF:-dev} \\"
     log_info "    --build-arg ONEX_CHANGE_CONTROL_REF=\${ONEX_CHANGE_CONTROL_REF:-main}"
     log_info ""
     log_info "Restart runtime services:"


### PR DESCRIPTION
## Summary

- omnimarket's default branch is `dev`, not `main` — Docker's git cache resolves `@main` to a stale SHA on rebuilds
- Changes `ARG OMNIMARKET_REF=main` → `ARG OMNIMARKET_REF=dev` in `Dockerfile.runtime`
- Changes `omnimarket_ref="main"` fallback → `"dev"` in `deploy-runtime.sh`
- Changes `OMNI_HOME`-unset fallback in `executor.py` for omnimarket from `"main"` → `"dev"`
- Updates `test_executor_cache_bust` to assert the new `dev` fallback

## Ticket

OMN-12195

## Test plan

- [ ] `uv run pytest scripts/deploy-agent/tests/unit/test_executor_cache_bust.py -v` — all 10 pass
- [ ] Pre-commit hooks: all pass
- [ ] `--build-arg OMNIMARKET_REF=<sha>` override still works for pinning to a specific commit (no code change to SHA-resolution path)

Evidence-Source: OCC#1653
Evidence-Ticket: OMN-12195

Evidence-Source: OCC#1653
Evidence-Ticket: OMN-12195