### PR TITLE
fix(OMN-12196): resolve bifrost source contract from omnimarket package on first boot

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -145,7 +145,7 @@ x-runtime-env: &runtime-env
   ONEX_CONTRACTS_DIR: /app/contracts
   ONEX_STATE_ROOT: /app/data/.onex_state
   BIFROST_CONTRACT_PATH: ${BIFROST_CONTRACT_PATH:-/app/data/delegation/bifrost_delegation.yaml}
-  BIFROST_SOURCE_CONTRACT_PATH: ${BIFROST_SOURCE_CONTRACT_PATH:-/app/src/omnibase_infra/configs/bifrost_delegation.yaml}
+  BIFROST_SOURCE_CONTRACT_PATH: ${BIFROST_SOURCE_CONTRACT_PATH:-}
   BIFROST_VERIFY_ENDPOINTS: ${BIFROST_VERIFY_ENDPOINTS:?runtime policy contract must set BIFROST_VERIFY_ENDPOINTS}
   # Restrict the runtime surface to first-party infra + marketplace packages.
   ONEX_ACTIVE_RUNTIME_PACKAGES: ${ONEX_ACTIVE_RUNTIME_PACKAGES:?runtime policy contract must set ONEX_ACTIVE_RUNTIME_PACKAGES}

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -2,5 +2,5 @@
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
 sha256:6f4891be982289898e5cf47ded9921e301136041df1a2859a3e5f4487532d46f
-generated_at: 2026-05-25T23:08:52Z
+generated_at: 2026-05-26T02:17:12Z
 migration_file_count: 69

--- a/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
+++ b/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
@@ -11,6 +11,7 @@ contract artifact, not scattered environment variables.
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import os
 import sys
@@ -24,8 +25,30 @@ import yaml
 
 from omnibase_infra.errors import ProtocolConfigurationError
 
-_DEFAULT_SOURCE_PATH = Path("/app/src/omnibase_infra/configs/bifrost_delegation.yaml")
+_LEGACY_SOURCE_PATH = Path("/app/src/omnibase_infra/configs/bifrost_delegation.yaml")
 _DEFAULT_TARGET_PATH = Path("/app/data/delegation/bifrost_delegation.yaml")
+
+
+def _resolve_default_source_path() -> Path:
+    """Resolve the bundled bifrost_delegation.yaml source path.
+
+    Prefers the omnimarket package (canonical home since OMN-10865). Falls back
+    to the legacy infra path so existing explicit BIFROST_SOURCE_CONTRACT_PATH
+    overrides continue to work without change.
+    """
+    try:
+        ref = importlib.resources.files("omnimarket").joinpath(
+            "configs/bifrost_delegation.yaml"
+        )
+        candidate = Path(str(ref))
+        if candidate.exists():
+            return candidate
+    except (ModuleNotFoundError, TypeError, AttributeError):
+        pass
+    return _LEGACY_SOURCE_PATH
+
+
+_DEFAULT_SOURCE_PATH = _resolve_default_source_path()
 _DEFAULT_ENDPOINT_PROBE_TIMEOUT_SECONDS = 3.0
 
 EndpointProbe = Callable[[str, str, float], str | None]
@@ -317,9 +340,8 @@ def render_bifrost_delegation_contract(
         else verify_endpoints
     )
     probe = endpoint_probe or _probe_openai_model_endpoint
-    source = source_path or Path(
-        env.get("BIFROST_SOURCE_CONTRACT_PATH", str(_DEFAULT_SOURCE_PATH))
-    )
+    _source_env = env.get("BIFROST_SOURCE_CONTRACT_PATH", "").strip()
+    source = source_path or (Path(_source_env) if _source_env else _DEFAULT_SOURCE_PATH)
     target = target_path or Path(
         env.get("BIFROST_CONTRACT_PATH", str(_DEFAULT_TARGET_PATH))
     )

--- a/tests/unit/infra/test_compose_no_silent_fallbacks.py
+++ b/tests/unit/infra/test_compose_no_silent_fallbacks.py
@@ -44,6 +44,9 @@ ALLOWED_EMPTY_DEFAULTS = {
     "ONEX_RUNTIME_INFISICAL_ENVIRONMENT",
     # Keycloak: opt-in auth; empty = keycloak not configured
     "KEYCLOAK_ADMIN_CLIENT_SECRET",
+    # OMN-12196: bifrost source contract path; empty = resolve from omnimarket
+    # package via importlib.resources (opt-in override for custom source path)
+    "BIFROST_SOURCE_CONTRACT_PATH",
 }
 
 

--- a/tests/unit/runtime/test_render_bifrost_delegation_contract.py
+++ b/tests/unit/runtime/test_render_bifrost_delegation_contract.py
@@ -4,14 +4,17 @@
 
 from __future__ import annotations
 
+import importlib.resources
 from collections.abc import Callable
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import yaml
 
 from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.runtime.render_bifrost_delegation_contract import (
+    _resolve_default_source_path,
     render_bifrost_delegation_contract,
 )
 
@@ -275,3 +278,79 @@ def test_optional_endpoint_probe_failure_leaves_backend_unpopulated(
     loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
     assert loaded["backends"][0]["endpoint_url"] == _http_url("coder.local:8000")
     assert loaded["backends"][1]["endpoint_url"] == ""
+
+
+@pytest.mark.unit
+def test_resolve_default_source_path_uses_omnimarket_when_available(
+    tmp_path: Path,
+) -> None:
+    """_resolve_default_source_path prefers omnimarket package when present."""
+    fake_yaml = tmp_path / "bifrost_delegation.yaml"
+    fake_yaml.write_text("backends: []\n", encoding="utf-8")
+
+    fake_traversable = mock.MagicMock()
+    fake_traversable.__str__ = mock.Mock(return_value=str(fake_yaml))
+
+    with mock.patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value = fake_traversable
+        result = _resolve_default_source_path()
+
+    assert result == fake_yaml
+
+
+@pytest.mark.unit
+def test_resolve_default_source_path_falls_back_when_omnimarket_absent() -> None:
+    """_resolve_default_source_path falls back to legacy path when omnimarket missing."""
+    from omnibase_infra.runtime.render_bifrost_delegation_contract import (
+        _LEGACY_SOURCE_PATH,
+    )
+
+    with mock.patch("importlib.resources.files", side_effect=ModuleNotFoundError):
+        result = _resolve_default_source_path()
+
+    assert result == _LEGACY_SOURCE_PATH
+
+
+@pytest.mark.unit
+def test_empty_target_renders_from_omnimarket_source(tmp_path: Path) -> None:
+    """First-boot: 0-byte target is replaced using a source resolved from omnimarket."""
+    source = _source_contract(tmp_path / "source.yaml")
+    target = tmp_path / "rendered" / "bifrost_delegation.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("", encoding="utf-8")
+
+    with mock.patch(
+        "omnibase_infra.runtime.render_bifrost_delegation_contract._DEFAULT_SOURCE_PATH",
+        source,
+    ):
+        rendered = render_bifrost_delegation_contract(
+            target_path=target,
+            environ={"LLM_CODER_URL": _http_url("coder.local:8000")},
+        )
+
+    assert rendered == target
+    loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert loaded["backends"][0]["endpoint_url"] == _http_url("coder.local:8000")
+
+
+@pytest.mark.unit
+def test_empty_bifrost_source_env_uses_resolved_default(tmp_path: Path) -> None:
+    """Empty BIFROST_SOURCE_CONTRACT_PATH env var falls through to _DEFAULT_SOURCE_PATH."""
+    source = _source_contract(tmp_path / "source.yaml")
+    target = tmp_path / "rendered.yaml"
+
+    with mock.patch(
+        "omnibase_infra.runtime.render_bifrost_delegation_contract._DEFAULT_SOURCE_PATH",
+        source,
+    ):
+        rendered = render_bifrost_delegation_contract(
+            target_path=target,
+            environ={
+                "BIFROST_SOURCE_CONTRACT_PATH": "",
+                "LLM_CODER_URL": _http_url("coder.local:8000"),
+            },
+        )
+
+    assert rendered == target
+    loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert loaded["backends"][0]["endpoint_url"] == _http_url("coder.local:8000")


### PR DESCRIPTION
## Summary

- **Root cause**: OMN-10865 deleted `omnibase_infra/configs/bifrost_delegation.yaml` when delegation moved to omnimarket, but `BIFROST_SOURCE_CONTRACT_PATH` in `docker-compose.infra.yml` still defaulted to the deleted file path. On first boot (or after a mid-write crash leaves a 0-byte target), the render script tries to load from source, gets `ProtocolConfigurationError: Bifrost source contract not found`.
- **Fix**: `_resolve_default_source_path()` resolves from `omnimarket` package via `importlib.resources` at import time, falling back to the legacy infra path when omnimarket is unavailable. Empty `BIFROST_SOURCE_CONTRACT_PATH` env var now falls through to the resolved default (previously produced `Path("")` = cwd). Cleared the stale default in `docker-compose.infra.yml`.
- **Tests**: 4 new unit tests — omnimarket resolution succeeds, module-absent fallback, 0-byte target re-renders from resolved source, empty env var uses resolved default. All 13 tests pass.

## Ticket

OMN-12196

## Test plan

- [x] `uv run pytest tests/unit/runtime/test_render_bifrost_delegation_contract.py -v` — 13/13 pass
- [x] `uv run mypy src/omnibase_infra/runtime/render_bifrost_delegation_contract.py --strict` — clean
- [x] `uv run ruff check --fix` + `ruff format` — no changes
- [x] Pre-commit hooks passed on changed files

Evidence-Source: OCC#1653
Evidence-Ticket: OMN-12196

Evidence-Source: OCC#1653
Evidence-Ticket: OMN-12196