### PR TITLE
fix(OMN-11879): replace deprecated version field with contract_version in verification contract

### DIFF
--- a/src/omnibase_infra/verification/contract.yaml
+++ b/src/omnibase_infra/verification/contract.yaml
@@ -7,7 +7,10 @@
 # COMPUTE_GENERIC node that emits verification results as Kafka events.
 # No subscriptions — triggered programmatically by the verification batch runner.
 name: "verification_event_emitter"
-version: "0.1.0"
+contract_version:
+  major: 1
+  minor: 0
+  patch: 0
 node_type: "COMPUTE_GENERIC"
 event_bus:
   subscribe_topics: []


### PR DESCRIPTION
## Summary

- Fixes `src/omnibase_infra/verification/contract.yaml` which had `version: "0.1.0"` introduced by PR #1746
- The ONEX validator (`ModelYamlContract.reject_deprecated_version_field`) rejects the `version` key per OMN-1431
- Replaces with the correct `contract_version: major/minor/patch` structure

## Root Cause

PR #1746 added `version: "0.1.0"` to contracts missing this field, but the correct field name is `contract_version` with major/minor/patch semver. One contract (`verification/contract.yaml`) was newly added with the wrong field in the squash merge.

## Verification

- `grep -r "^version:" src/omnibase_infra/verification/contract.yaml` → 0 matches
- Contract has correct `contract_version:` field with major/minor/patch

Evidence-Source: OCC#1643