### PR TITLE
fix(OMN-12198): synthesize envelope for raw non-envelope Kafka payloads in auto-wiring callback

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1053,10 +1053,32 @@ def _make_event_bus_callback(
                 data = json.loads(
                     raw.decode("utf-8") if isinstance(raw, bytes) else raw
                 )
-                envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
-                    object
-                ].model_validate(data)
-                explicit_event_type = data.get("event_type")
+                from pydantic import ValidationError as PydanticValidationError
+
+                try:
+                    envelope: ModelEventEnvelope[object] = ModelEventEnvelope[
+                        object
+                    ].model_validate(data)
+                except PydanticValidationError:
+                    # Raw command payload (no envelope wrapper) — synthesize one.
+                    from datetime import UTC, datetime
+                    from uuid import uuid4
+
+                    raw_corr = (
+                        data.get("correlation_id") if isinstance(data, dict) else None
+                    )
+                    corr = _coerce_uuid_or_none(raw_corr) or uuid4()
+                    derived = _derive_event_type_from_topic(topic)
+                    envelope = ModelEventEnvelope[object](
+                        payload=data,
+                        correlation_id=corr,
+                        envelope_timestamp=datetime.now(UTC),
+                        event_type=derived or topic,
+                        source_tool="auto-wiring",
+                    )
+                explicit_event_type = (
+                    data.get("event_type") if isinstance(data, dict) else None
+                )
                 if explicit_event_type:
                     envelope = envelope.model_copy(
                         update={"event_type": explicit_event_type}


### PR DESCRIPTION
## Summary

Fixes OMN-12198 (omnibase_infra side): the auto-wiring callback for cmd topics fails when a Kafka producer sends a flat dict payload without wrapping it in a `ModelEventEnvelope` structure.

- When `ModelEventEnvelope.model_validate(data)` fails with a missing `payload` field, the callback now synthesizes a valid envelope using the raw dict as `payload`
- Correlation ID is extracted from the raw dict if present; otherwise a new UUID is generated
- `event_type` is derived from the topic name (existing logic)
- This is a non-breaking fallback — well-formed envelope messages continue to use the existing code path

## Root cause

The first ValidationError from stability-test logs (`00:26:49`):
```
Auto-wiring callback error: topic=onex.cmd.omnimarket.swarm-dispatch.v1
error=1 validation error for ModelEventEnvelope[object]
payload
  Field required [type=missing, ...]
```

The `rpk topic produce` test dispatch publishes raw JSON without wrapping in `ModelEventEnvelope`. The callback previously propagated the ValidationError and dropped the message.

## Test plan

- [x] `uv run pytest tests/ -k "handler_wiring or auto_wiring or wiring" -q` — 730 passed, 0 failures
- [x] `uv run ruff format src/ tests/ && uv run ruff check src/ tests/` — clean

## dod_evidence

ticket: OMN-12198
fix: envelope synthesis fallback for raw dict payloads in _make_event_bus_callback
test_suite: 730 passed

Evidence-Source: OCC#1662
Evidence-Ticket: OMN-12198
