### PR TITLE
fix(OMN-12162): Resolve stub handler_registry.register_handlers_from_config

### DIFF
--- a/src/omnibase_infra/runtime/__init__.py
+++ b/src/omnibase_infra/runtime/__init__.py
@@ -80,7 +80,6 @@ from omnibase_infra.runtime.handler_registry import (
     get_event_bus_registry,
     get_handler_class,
     get_handler_registry,
-    register_handlers_from_config,
 )
 
 from omnibase_infra.runtime.service_kernel import bootstrap as kernel_bootstrap
@@ -363,7 +362,6 @@ __all__: list[str] = [
     "load_runtime_config",
     "validate_kafka_broker_allowlist",
     "propagate_chain_context",
-    "register_handlers_from_config",
     "validate_dispatch_chain",
     "validate_envelope",
     "wire_custom_event_bus",

--- a/src/omnibase_infra/runtime/handler_registry.py
+++ b/src/omnibase_infra/runtime/handler_registry.py
@@ -61,8 +61,6 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING
 
-from omnibase_infra.runtime.models import ModelProtocolRegistrationConfig
-
 # Import registry classes from their canonical locations
 from omnibase_infra.runtime.registry.registry_event_bus_binding import (
     RegistryEventBusBinding,
@@ -242,53 +240,6 @@ def get_event_bus_class(bus_kind: str) -> type[ProtocolEventBus]:
     return get_event_bus_registry().get(bus_kind)
 
 
-def register_handlers_from_config(  # stub-ok: tracked in OMN-41
-    runtime: object,  # Will be BaseRuntimeHostProcess
-    protocol_configs: list[ModelProtocolRegistrationConfig],
-) -> None:
-    """Register protocol handlers from configuration.
-
-    Called by BaseRuntimeHostProcess to wire up handlers based on contract config.
-    This function validates and processes protocol registration configurations,
-    registering the appropriate handlers with the runtime.
-
-    Args:
-        runtime: The runtime host process instance (BaseRuntimeHostProcess).
-            Typed as object temporarily until BaseRuntimeHostProcess is implemented.
-        protocol_configs: List of ModelProtocolRegistrationConfig instances from contract.
-            Each config specifies type, protocol_class, enabled flag, and options.
-
-    Example:
-        >>> from omnibase_infra.runtime.models import ModelProtocolRegistrationConfig
-        >>> protocol_configs = [
-        ...     ModelProtocolRegistrationConfig(
-        ...         type="http", protocol_class="HttpHandler", enabled=True
-        ...     ),
-        ...     ModelProtocolRegistrationConfig(
-        ...         type="db", protocol_class="PostgresHandler", enabled=True
-        ...     ),
-        ... ]
-        >>> register_handlers_from_config(runtime, protocol_configs)
-
-    Note:
-        **Placeholder implementation** - only validates config structure.
-
-        TODO(OMN-41): Implement full handler resolution:
-        1. Use importlib to resolve protocol_class string to actual class
-        2. Validate class implements ProtocolContainerAware protocol
-        3. Register handler with runtime via get_handler_registry()
-        4. Support handler instantiation options from config.options
-    """
-    # Placeholder: validate config structure only, defer registration to OMN-41
-    for config in protocol_configs:
-        if not config.enabled:
-            continue
-
-        if config.type and config.protocol_class:
-            # Config structure is valid - actual resolution deferred to OMN-41
-            _ = config  # Explicit acknowledgment that config is intentionally unused
-
-
 # =============================================================================
 # Module Exports
 # =============================================================================
@@ -317,5 +268,4 @@ __all__: list[str] = [
     "get_handler_class",
     # Singleton accessors
     "get_handler_registry",
-    "register_handlers_from_config",
 ]

--- a/tests/unit/runtime/test_handler_registry_stub_removed.py
+++ b/tests/unit/runtime/test_handler_registry_stub_removed.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-12162: verify register_handlers_from_config stub is fully removed."""
+
+import pytest
+
+
+@pytest.mark.unit
+def test_register_handlers_from_config_not_in_module() -> None:
+    import omnibase_infra.runtime.handler_registry as registry_module
+
+    assert not hasattr(registry_module, "register_handlers_from_config"), (
+        "stub register_handlers_from_config must be removed (OMN-12162)"
+    )
+
+
+@pytest.mark.unit
+def test_register_handlers_from_config_not_in_runtime_init() -> None:
+    import omnibase_infra.runtime as runtime_module
+
+    assert not hasattr(runtime_module, "register_handlers_from_config"), (
+        "stub register_handlers_from_config must not be re-exported from runtime (OMN-12162)"
+    )
+
+
+@pytest.mark.unit
+def test_register_handlers_from_config_not_in_all() -> None:
+    import omnibase_infra.runtime.handler_registry as registry_module
+
+    all_exports: list[str] = getattr(registry_module, "__all__", [])
+    assert "register_handlers_from_config" not in all_exports, (
+        "register_handlers_from_config must not appear in handler_registry.__all__ (OMN-12162)"
+    )


### PR DESCRIPTION
## Summary

- `register_handlers_from_config` in `handler_registry.py` was a no-op stub (annotated `# stub-ok: tracked in OMN-41`) with zero actual callers — only defined and re-exported, never invoked anywhere in the repo or downstream repos.
- Real handler registration is fully implemented via `wire_from_manifest` in `auto_wiring/handler_wiring.py` (the path that landed with the auto-wiring engine).
- Removed the stub function, its orphaned `ModelProtocolRegistrationConfig` import, and the `runtime/__init__.py` re-export entry.
- Added 3 unit tests (`test_handler_registry_stub_removed.py`) that assert the function does not exist in the module, the runtime package, or `__all__`.

## Verification

- Import scan: `grep -r register_handlers_from_config src/` → no results
- `uv run pytest tests/unit/runtime/test_handler_registry_stub_removed.py -v` → 3 passed
- `uv run pytest tests/ -v -k handler_registry` → 43 passed, 0 failed
- Pre-commit on changed files → all hooks passed

## Ticket

OMN-12162 (epic OMN-12152)

## dod_evidence

- stub removed: `handler_registry.py:register_handlers_from_config` deleted
- import scan: zero callers found across all repos
- tests: `tests/unit/runtime/test_handler_registry_stub_removed.py` (3 assertions)

Evidence-Source: OCC#1655
Evidence-Ticket: OMN-12162