### PR TITLE
fix(OMN-12164): Fix datetime.now() in omnibase_infra handlers

### DIFF
--- a/src/omnibase_infra/nodes/node_rsd_score_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_rsd_score_compute/contract.yaml
@@ -7,10 +7,10 @@ node_type: "COMPUTE_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
 description: >
-  Pure computation: calculates RSD 5-factor priority scores. Factors: dependency distance (40%), failure surface (25%), time decay (15%), agent utility (10%), user weighting (10%). No I/O - all data provided as input.
+  Pure computation: calculates RSD 5-factor priority scores. Factors: dependency distance (40%), failure surface (25%), time decay (15%), agent utility (10%), user weighting (10%). Time decay normalizes naive created_at timestamps to UTC before age arithmetic. No I/O - all data provided as input.
 
 input_model:
   name: "ModelRsdScoreInput"

--- a/src/omnibase_infra/nodes/node_rsd_score_compute/handlers/handler_rsd_score_calculate.py
+++ b/src/omnibase_infra/nodes/node_rsd_score_compute/handlers/handler_rsd_score_calculate.py
@@ -294,15 +294,14 @@ def _calculate_time_decay(ticket: ModelTicketData) -> float:
     if ticket.created_at is None:
         return 0.5
 
-    now = datetime.now(
-        tz=ticket.created_at.tzinfo if ticket.created_at.tzinfo else None
+    now = datetime.now(tz=UTC)
+    created_at = (
+        ticket.created_at.replace(tzinfo=UTC)
+        if ticket.created_at.tzinfo is None
+        else ticket.created_at
     )
-    if now.tzinfo is None and ticket.created_at.tzinfo is not None:
-        now = datetime.now(tz=UTC)
-    elif now.tzinfo is not None and ticket.created_at.tzinfo is None:
-        now = datetime.now()
 
-    age_days = max(0, (now - ticket.created_at).days)
+    age_days = max(0, (now - created_at).days)
 
     # Exponential decay with 30-day half-life (score increases with age)
     decay_factor = 0.5 ** (age_days / 30.0)


### PR DESCRIPTION
## Summary

- Replaces the naive `datetime.now()` call in `_calculate_time_decay` (`handler_rsd_score_calculate.py`) with `datetime.now(tz=UTC)`
- Normalizes naive `created_at` values to UTC via `.replace(tzinfo=UTC)` so timezone arithmetic is consistent
- Updates the `node_rsd_score_compute` contract to document UTC normalization for time decay

## Test plan

- [x] `PYTHONPATH="$PWD/src:$PWD/.venv/lib/python3.12/site-packages" uv run pytest tests/unit/nodes/test_rsd_priority_engine -v` — 40 passed
- [x] `uv run ruff check src/omnibase_infra/nodes/node_rsd_score_compute tests/unit/nodes/test_rsd_priority_engine` — all checks passed
- [x] `VALIDATE_PR_FILES=... bash scripts/validate-pr-contract-sync.sh --from-env` — passed
- [x] `PYTHONPATH="$PWD/src:$PWD/.venv/lib/python3.12/site-packages" uv run python scripts/batch_validate_node_contracts.py --directory src/omnibase_infra/nodes/node_rsd_score_compute -v` — 1/1 passed

Evidence-Source: OCC#1667
Evidence-Ticket: OMN-12164