### PR TITLE
feat(OMN-12193): Create AdapterProjectTrackerLinear migration target

### DIFF
--- a/src/omnibase_infra/adapters/project_tracker/adapter_project_tracker_linear.py
+++ b/src/omnibase_infra/adapters/project_tracker/adapter_project_tracker_linear.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Migration target for omnibase_compat.adapters.adapter_project_tracker_linear.
+
+Provides list_teams, list_issue_labels, and list_issue_statuses via
+the Linear GraphQL API using httpx.AsyncClient + MixinAsyncCircuitBreaker.
+
+Migrated from omnibase_compat (compat removal date: 2026-09-01, OMN-12193).
+The compat version used synchronous urllib; this version uses async httpx and
+the standard infra error hierarchy.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Final, cast
+
+import httpx
+
+from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
+    ModelProjectTrackerIssueStatus,
+    ModelProjectTrackerLabel,
+    ModelProjectTrackerTeam,
+)
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.errors import (
+    InfraAuthenticationError,
+    InfraConnectionError,
+    InfraTimeoutError,
+    ModelInfraErrorContext,
+    ModelTimeoutErrorContext,
+)
+from omnibase_infra.mixins import MixinAsyncCircuitBreaker
+from omnibase_infra.utils.util_error_sanitization import sanitize_error_string
+
+DEFAULT_LINEAR_GRAPHQL_ENDPOINT: Final[str] = "https://api.linear.app/graphql"
+DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
+SERVICE_NAME: Final[str] = "linear-project-tracker"
+
+_QUERY_LIST_TEAMS: Final[str] = """
+query {
+    teams { nodes { id name key } }
+}
+"""
+
+_QUERY_LIST_LABELS: Final[str] = """
+query ($filter: IssueLabelFilter!) {
+    issueLabels(filter: $filter) {
+        nodes { id name color team { id } }
+    }
+}
+"""
+
+_QUERY_LIST_STATUSES: Final[str] = """
+query ($filter: WorkflowStateFilter!) {
+    workflowStates(filter: $filter) {
+        nodes { id name type team { id } }
+    }
+}
+"""
+
+
+def _nested_id(raw: dict[str, Any], key: str) -> str | None:
+    val = raw.get(key)
+    if isinstance(val, dict):
+        inner = val.get("id")
+        return inner if isinstance(inner, str) else None
+    return None
+
+
+def _extract_nodes(data: dict[str, Any], root_key: str) -> list[dict[str, Any]]:
+    # _execute already unwraps the top-level "data" envelope; receive it directly.
+    root = data.get(root_key)
+    if not isinstance(root, dict):
+        raise ValueError(f"Missing '{root_key}' in Linear response: {data}")
+    nodes = root.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError(f"Missing 'nodes' under '{root_key}': {root}")
+    return [n for n in nodes if isinstance(n, dict)]
+
+
+class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
+    """Async Linear GraphQL adapter for team/label/status discovery.
+
+    Migration target for omnibase_compat.adapters.adapter_project_tracker_linear.
+    Exposes list_teams, list_issue_labels, and list_issue_statuses.
+
+    Auth via constructor api_key arg or LINEAR_API_KEY / LINEAR_TOKEN env vars.
+    Resilience via MixinAsyncCircuitBreaker (threshold=5, reset=60s).
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        endpoint: str = DEFAULT_LINEAR_GRAPHQL_ENDPOINT,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        resolved_key = (
+            api_key
+            or os.environ.get("LINEAR_API_KEY")
+            or os.environ.get("LINEAR_TOKEN")
+        )
+        if resolved_key is not None:
+            resolved_key = resolved_key.strip()
+        if not resolved_key:
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation="construct",
+                target_name=SERVICE_NAME,
+            )
+            raise InfraAuthenticationError(
+                "AdapterProjectTrackerLinear requires LINEAR_API_KEY or LINEAR_TOKEN",
+                context=context,
+                auth_method="api_key",
+            )
+
+        self._api_key: str = resolved_key
+        self._endpoint: str = endpoint
+        self._timeout_seconds: float = timeout_seconds
+        self._request_headers: dict[str, str] = {
+            "Authorization": resolved_key,
+            "Content-Type": "application/json",
+        }
+        self._owns_client: bool = client is None
+        self._client: httpx.AsyncClient = client or httpx.AsyncClient(
+            timeout=timeout_seconds,
+            headers=self._request_headers,
+        )
+
+        self._init_circuit_breaker(
+            threshold=5,
+            reset_timeout=60.0,
+            service_name=SERVICE_NAME,
+            transport_type=EnumInfraTransportType.HTTP,
+            half_open_successes=1,
+        )
+
+    async def close(self) -> None:
+        await self.cancel_active_recovery()
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def list_teams(self) -> list[ModelProjectTrackerTeam]:
+        data = await self._execute(_QUERY_LIST_TEAMS, operation="list_teams")
+        nodes = _extract_nodes(cast("dict[str, Any]", data), "teams")
+        return [
+            ModelProjectTrackerTeam(
+                id=n["id"],
+                name=n["name"],
+                key=n["key"],
+            )
+            for n in nodes
+        ]
+
+    async def list_issue_labels(self, team: str) -> list[ModelProjectTrackerLabel]:
+        data = await self._execute(
+            _QUERY_LIST_LABELS,
+            operation="list_issue_labels",
+            variables={"filter": {"team": {"key": {"eq": team}}}},
+        )
+        nodes = _extract_nodes(cast("dict[str, Any]", data), "issueLabels")
+        return [
+            ModelProjectTrackerLabel(
+                id=n["id"],
+                name=n["name"],
+                color=n.get("color"),
+                team_id=_nested_id(n, "team"),
+            )
+            for n in nodes
+        ]
+
+    async def list_issue_statuses(
+        self, team: str
+    ) -> list[ModelProjectTrackerIssueStatus]:
+        data = await self._execute(
+            _QUERY_LIST_STATUSES,
+            operation="list_issue_statuses",
+            variables={"filter": {"team": {"key": {"eq": team}}}},
+        )
+        nodes = _extract_nodes(cast("dict[str, Any]", data), "workflowStates")
+        return [
+            ModelProjectTrackerIssueStatus(
+                id=n["id"],
+                name=n["name"],
+                type=n["type"],
+                team_id=_nested_id(n, "team"),
+            )
+            for n in nodes
+        ]
+
+    async def _execute(
+        self,
+        query: str,
+        operation: str,
+        variables: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        async with self._circuit_breaker_lock:
+            await self._check_circuit_breaker(operation=operation)
+
+        payload: dict[str, object] = {"query": query}
+        if variables is not None:
+            payload["variables"] = variables
+
+        try:
+            response = await self._client.post(
+                self._endpoint,
+                json=payload,
+                headers=self._request_headers,
+                timeout=self._timeout_seconds,
+            )
+        except httpx.TimeoutException as exc:
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure(operation=operation)
+            timeout_ctx = ModelTimeoutErrorContext(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+                timeout_seconds=self._timeout_seconds,
+            )
+            raise InfraTimeoutError(
+                f"Linear GraphQL request timed out: {operation}",
+                context=timeout_ctx,
+            ) from exc
+        except httpx.HTTPError as exc:
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure(operation=operation)
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                f"Linear GraphQL transport error: {operation}",
+                context=context,
+            ) from exc
+
+        status = response.status_code
+        if status in (401, 403):
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraAuthenticationError(
+                f"Linear API rejected credential (HTTP {status})",
+                context=context,
+                auth_method="api_key",
+            )
+        if status >= 500:
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure(operation=operation)
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                f"Linear GraphQL HTTP {status}",
+                context=context,
+            )
+        if status >= 400:
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                f"Linear GraphQL HTTP {status}",
+                context=context,
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure(operation=operation)
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                "Linear GraphQL response was not valid JSON",
+                context=context,
+            ) from exc
+
+        if not isinstance(body, dict):
+            async with self._circuit_breaker_lock:
+                await self._record_circuit_failure(operation=operation)
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                "Linear GraphQL response was not a JSON object",
+                context=context,
+            )
+
+        errors = body.get("errors")
+        if errors:
+            first_msg = "unknown"
+            if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+                first_msg = sanitize_error_string(
+                    str(errors[0].get("message", "unknown"))
+                )
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.HTTP,
+                operation=operation,
+                target_name=SERVICE_NAME,
+            )
+            raise InfraConnectionError(
+                f"Linear GraphQL error: {first_msg}",
+                context=context,
+            )
+
+        async with self._circuit_breaker_lock:
+            await self._reset_circuit_breaker()
+
+        data = body.get("data")
+        if not isinstance(data, dict):
+            return {}
+        return cast("dict[str, object]", data)
+
+
+__all__: list[str] = [
+    "AdapterProjectTrackerLinear",
+]

--- a/src/omnibase_infra/adapters/project_tracker/adapter_project_tracker_linear.py
+++ b/src/omnibase_infra/adapters/project_tracker/adapter_project_tracker_linear.py
@@ -14,13 +14,18 @@ the standard infra error hierarchy.
 from __future__ import annotations
 
 import os
-from typing import Any, Final, cast
+from collections.abc import Mapping
+from typing import Final, cast
 
 import httpx
 
-from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
+from omnibase_infra.adapters.project_tracker.model_project_tracker_issue_status import (
     ModelProjectTrackerIssueStatus,
+)
+from omnibase_infra.adapters.project_tracker.model_project_tracker_label import (
     ModelProjectTrackerLabel,
+)
+from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
     ModelProjectTrackerTeam,
 )
 from omnibase_infra.enums import EnumInfraTransportType
@@ -37,6 +42,7 @@ from omnibase_infra.utils.util_error_sanitization import sanitize_error_string
 DEFAULT_LINEAR_GRAPHQL_ENDPOINT: Final[str] = "https://api.linear.app/graphql"
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
 SERVICE_NAME: Final[str] = "linear-project-tracker"
+JsonObject = dict[str, object]
 
 _QUERY_LIST_TEAMS: Final[str] = """
 query {
@@ -61,23 +67,37 @@ query ($filter: WorkflowStateFilter!) {
 """
 
 
-def _nested_id(raw: dict[str, Any], key: str) -> str | None:
+def _nested_id(raw: Mapping[str, object], key: str) -> str | None:
     val = raw.get(key)
-    if isinstance(val, dict):
+    if isinstance(val, Mapping):
         inner = val.get("id")
         return inner if isinstance(inner, str) else None
     return None
 
 
-def _extract_nodes(data: dict[str, Any], root_key: str) -> list[dict[str, Any]]:
+def _required_str(raw: Mapping[str, object], key: str) -> str:
+    val = raw.get(key)
+    if isinstance(val, str):
+        return val
+    raise ValueError(f"Missing string field '{key}' in Linear response node: {raw}")
+
+
+def _optional_str(raw: Mapping[str, object], key: str) -> str | None:
+    val = raw.get(key)
+    if val is None or isinstance(val, str):
+        return val
+    raise ValueError(f"Expected optional string field '{key}' in Linear response node")
+
+
+def _extract_nodes(data: Mapping[str, object], root_key: str) -> list[JsonObject]:
     # _execute already unwraps the top-level "data" envelope; receive it directly.
     root = data.get(root_key)
-    if not isinstance(root, dict):
+    if not isinstance(root, Mapping):
         raise ValueError(f"Missing '{root_key}' in Linear response: {data}")
     nodes = root.get("nodes")
     if not isinstance(nodes, list):
         raise ValueError(f"Missing 'nodes' under '{root_key}': {root}")
-    return [n for n in nodes if isinstance(n, dict)]
+    return [cast("JsonObject", n) for n in nodes if isinstance(n, dict)]
 
 
 class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
@@ -144,12 +164,12 @@ class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
 
     async def list_teams(self) -> list[ModelProjectTrackerTeam]:
         data = await self._execute(_QUERY_LIST_TEAMS, operation="list_teams")
-        nodes = _extract_nodes(cast("dict[str, Any]", data), "teams")
+        nodes = _extract_nodes(data, "teams")
         return [
             ModelProjectTrackerTeam(
-                id=n["id"],
-                name=n["name"],
-                key=n["key"],
+                id=_required_str(n, "id"),
+                name=_required_str(n, "name"),
+                key=_required_str(n, "key"),
             )
             for n in nodes
         ]
@@ -160,12 +180,12 @@ class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
             operation="list_issue_labels",
             variables={"filter": {"team": {"key": {"eq": team}}}},
         )
-        nodes = _extract_nodes(cast("dict[str, Any]", data), "issueLabels")
+        nodes = _extract_nodes(data, "issueLabels")
         return [
             ModelProjectTrackerLabel(
-                id=n["id"],
-                name=n["name"],
-                color=n.get("color"),
+                id=_required_str(n, "id"),
+                name=_required_str(n, "name"),
+                color=_optional_str(n, "color"),
                 team_id=_nested_id(n, "team"),
             )
             for n in nodes
@@ -179,12 +199,12 @@ class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
             operation="list_issue_statuses",
             variables={"filter": {"team": {"key": {"eq": team}}}},
         )
-        nodes = _extract_nodes(cast("dict[str, Any]", data), "workflowStates")
+        nodes = _extract_nodes(data, "workflowStates")
         return [
             ModelProjectTrackerIssueStatus(
-                id=n["id"],
-                name=n["name"],
-                type=n["type"],
+                id=_required_str(n, "id"),
+                name=_required_str(n, "name"),
+                type=_required_str(n, "type"),
                 team_id=_nested_id(n, "team"),
             )
             for n in nodes
@@ -195,7 +215,7 @@ class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
         query: str,
         operation: str,
         variables: dict[str, object] | None = None,
-    ) -> dict[str, object]:
+    ) -> JsonObject:
         async with self._circuit_breaker_lock:
             await self._check_circuit_breaker(operation=operation)
 
@@ -322,7 +342,7 @@ class AdapterProjectTrackerLinear(MixinAsyncCircuitBreaker):
         data = body.get("data")
         if not isinstance(data, dict):
             return {}
-        return cast("dict[str, object]", data)
+        return cast("JsonObject", data)
 
 
 __all__: list[str] = [

--- a/src/omnibase_infra/adapters/project_tracker/enum_project_tracker_issue_status_type.py
+++ b/src/omnibase_infra/adapters/project_tracker/enum_project_tracker_issue_status_type.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumProjectTrackerIssueStatusType(StrEnum):
+    """Linear workflow state type values."""
+
+    BACKLOG = "backlog"
+    UNSTARTED = "unstarted"
+    STARTED = "started"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+
+
+__all__: list[str] = [
+    "EnumProjectTrackerIssueStatusType",
+]

--- a/src/omnibase_infra/adapters/project_tracker/model_project_tracker_issue_status.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_project_tracker_issue_status.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.adapters.project_tracker.enum_project_tracker_issue_status_type import (
+    EnumProjectTrackerIssueStatusType,
+)
+
+
+class ModelProjectTrackerIssueStatus(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    id: str
+    name: str
+    type: EnumProjectTrackerIssueStatusType
+    team_id: str | None = Field(default=None)
+
+
+__all__: list[str] = [
+    "ModelProjectTrackerIssueStatus",
+]

--- a/src/omnibase_infra/adapters/project_tracker/model_project_tracker_label.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_project_tracker_label.py
@@ -3,17 +3,18 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class ModelProjectTrackerTeam(BaseModel):
+class ModelProjectTrackerLabel(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     id: str
     name: str
-    key: str
+    color: str | None = Field(default=None)
+    team_id: str | None = Field(default=None)
 
 
 __all__: list[str] = [
-    "ModelProjectTrackerTeam",
+    "ModelProjectTrackerLabel",
 ]

--- a/src/omnibase_infra/adapters/project_tracker/model_project_tracker_team.py
+++ b/src/omnibase_infra/adapters/project_tracker/model_project_tracker_team.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelProjectTrackerTeam(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    id: str
+    name: str
+    key: str
+
+
+class ModelProjectTrackerLabel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    id: str
+    name: str
+    color: str | None = Field(default=None)
+    team_id: str | None = Field(default=None)
+
+
+class ModelProjectTrackerIssueStatus(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    id: str
+    name: str
+    type: str
+    team_id: str | None = Field(default=None)
+
+
+__all__: list[str] = [
+    "ModelProjectTrackerIssueStatus",
+    "ModelProjectTrackerLabel",
+    "ModelProjectTrackerTeam",
+]

--- a/tests/unit/adapters/test_adapter_project_tracker_linear.py
+++ b/tests/unit/adapters/test_adapter_project_tracker_linear.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for AdapterProjectTrackerLinear (OMN-12193 migration target).
+
+Covers list_teams, list_issue_labels, list_issue_statuses, and error-mapping
+paths. Uses httpx.MockTransport so no real network calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from omnibase_infra.adapters.project_tracker.adapter_project_tracker_linear import (
+    AdapterProjectTrackerLinear,
+)
+from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
+    ModelProjectTrackerIssueStatus,
+    ModelProjectTrackerLabel,
+    ModelProjectTrackerTeam,
+)
+from omnibase_infra.errors import (
+    InfraAuthenticationError,
+    InfraConnectionError,
+    InfraTimeoutError,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------- fixtures ----------
+
+_TEAMS_RESPONSE: dict[str, object] = {
+    "data": {
+        "teams": {
+            "nodes": [
+                {"id": "t1", "name": "Engineering", "key": "ENG"},
+                {"id": "t2", "name": "Product", "key": "PROD"},
+            ]
+        }
+    }
+}
+
+_LABELS_RESPONSE: dict[str, object] = {
+    "data": {
+        "issueLabels": {
+            "nodes": [
+                {"id": "l1", "name": "bug", "color": "#ff0000", "team": {"id": "t1"}},
+                {
+                    "id": "l2",
+                    "name": "feature",
+                    "color": "#00ff00",
+                    "team": {"id": "t1"},
+                },
+            ]
+        }
+    }
+}
+
+_STATUSES_RESPONSE: dict[str, object] = {
+    "data": {
+        "workflowStates": {
+            "nodes": [
+                {
+                    "id": "s1",
+                    "name": "Backlog",
+                    "type": "unstarted",
+                    "team": {"id": "t1"},
+                },
+                {
+                    "id": "s2",
+                    "name": "In Progress",
+                    "type": "started",
+                    "team": {"id": "t1"},
+                },
+                {"id": "s3", "name": "Done", "type": "completed", "team": {"id": "t1"}},
+            ]
+        }
+    }
+}
+
+
+def _json_transport(body: object, status: int = 200) -> httpx.MockTransport:
+    raw = json.dumps(body).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status, content=raw, headers={"content-type": "application/json"}
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _build_adapter(
+    transport: httpx.MockTransport,
+    api_key: str = "test-key",
+) -> AdapterProjectTrackerLinear:
+    client = httpx.AsyncClient(transport=transport)
+    adapter = AdapterProjectTrackerLinear(api_key=api_key, client=client)
+    adapter._owns_client = True
+    return adapter
+
+
+# ---------- construction ----------
+
+
+@pytest.mark.asyncio
+async def test_raises_on_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    monkeypatch.delenv("LINEAR_TOKEN", raising=False)
+    with pytest.raises(InfraAuthenticationError):
+        AdapterProjectTrackerLinear(api_key=None)
+
+
+@pytest.mark.asyncio
+async def test_custom_endpoint_stored() -> None:
+    adapter = AdapterProjectTrackerLinear(
+        api_key="key", endpoint="http://localhost:8080"
+    )
+    assert adapter._endpoint == "http://localhost:8080"
+    await adapter.close()
+
+
+# ---------- list_teams ----------
+
+
+@pytest.mark.asyncio
+async def test_list_teams_returns_models() -> None:
+    adapter = _build_adapter(_json_transport(_TEAMS_RESPONSE))
+    teams = await adapter.list_teams()
+    assert teams == [
+        ModelProjectTrackerTeam(id="t1", name="Engineering", key="ENG"),
+        ModelProjectTrackerTeam(id="t2", name="Product", key="PROD"),
+    ]
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_list_teams_empty() -> None:
+    adapter = _build_adapter(_json_transport({"data": {"teams": {"nodes": []}}}))
+    assert await adapter.list_teams() == []
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_list_teams_sends_auth_header() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            content=json.dumps(_TEAMS_RESPONSE).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = AdapterProjectTrackerLinear(api_key="lin_api_testkey", client=client)
+    adapter._owns_client = True
+    await adapter.list_teams()
+    await adapter.close()
+    assert captured[0].headers.get("authorization") == "lin_api_testkey"
+
+
+# ---------- list_issue_labels ----------
+
+
+@pytest.mark.asyncio
+async def test_list_issue_labels_returns_models() -> None:
+    adapter = _build_adapter(_json_transport(_LABELS_RESPONSE))
+    labels = await adapter.list_issue_labels("ENG")
+    assert labels == [
+        ModelProjectTrackerLabel(id="l1", name="bug", color="#ff0000", team_id="t1"),
+        ModelProjectTrackerLabel(
+            id="l2", name="feature", color="#00ff00", team_id="t1"
+        ),
+    ]
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_list_issue_labels_sends_team_filter() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            content=json.dumps(_LABELS_RESPONSE).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = AdapterProjectTrackerLinear(api_key="key", client=client)
+    adapter._owns_client = True
+    await adapter.list_issue_labels("ENG")
+    await adapter.close()
+    body = json.loads(captured[0].content)
+    assert body["variables"]["filter"]["team"]["key"]["eq"] == "ENG"
+
+
+# ---------- list_issue_statuses ----------
+
+
+@pytest.mark.asyncio
+async def test_list_issue_statuses_returns_models() -> None:
+    adapter = _build_adapter(_json_transport(_STATUSES_RESPONSE))
+    statuses = await adapter.list_issue_statuses("ENG")
+    assert statuses == [
+        ModelProjectTrackerIssueStatus(
+            id="s1", name="Backlog", type="unstarted", team_id="t1"
+        ),
+        ModelProjectTrackerIssueStatus(
+            id="s2", name="In Progress", type="started", team_id="t1"
+        ),
+        ModelProjectTrackerIssueStatus(
+            id="s3", name="Done", type="completed", team_id="t1"
+        ),
+    ]
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_list_issue_statuses_sends_team_filter() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            content=json.dumps(_STATUSES_RESPONSE).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = AdapterProjectTrackerLinear(api_key="key", client=client)
+    adapter._owns_client = True
+    await adapter.list_issue_statuses("ENG")
+    await adapter.close()
+    body = json.loads(captured[0].content)
+    assert body["variables"]["filter"]["team"]["key"]["eq"] == "ENG"
+
+
+# ---------- error mapping ----------
+
+
+@pytest.mark.asyncio
+async def test_401_raises_auth_error() -> None:
+    adapter = _build_adapter(_json_transport({}, status=401))
+    with pytest.raises(InfraAuthenticationError):
+        await adapter.list_teams()
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_403_raises_auth_error() -> None:
+    adapter = _build_adapter(_json_transport({}, status=403))
+    with pytest.raises(InfraAuthenticationError):
+        await adapter.list_teams()
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_500_raises_connection_error() -> None:
+    adapter = _build_adapter(_json_transport({}, status=500))
+    with pytest.raises(InfraConnectionError):
+        await adapter.list_teams()
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_graphql_errors_raises_connection_error() -> None:
+    body = {"errors": [{"message": "bad token"}], "data": None}
+    adapter = _build_adapter(_json_transport(body))
+    with pytest.raises(InfraConnectionError, match="Linear GraphQL error"):
+        await adapter.list_teams()
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_timeout_raises_infra_timeout() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("timed out", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = AdapterProjectTrackerLinear(api_key="key", client=client)
+    adapter._owns_client = True
+    with pytest.raises(InfraTimeoutError):
+        await adapter.list_teams()
+    await adapter.close()
+
+
+# ---------- model invariants ----------
+
+
+def test_models_are_frozen() -> None:
+    team = ModelProjectTrackerTeam(id="t1", name="Eng", key="ENG")
+    with pytest.raises(Exception):
+        team.name = "changed"  # type: ignore[misc]
+
+    label = ModelProjectTrackerLabel(id="l1", name="bug", color="#f00", team_id="t1")
+    with pytest.raises(Exception):
+        label.name = "changed"  # type: ignore[misc]
+
+    status = ModelProjectTrackerIssueStatus(
+        id="s1", name="Backlog", type="unstarted", team_id="t1"
+    )
+    with pytest.raises(Exception):
+        status.name = "changed"  # type: ignore[misc]

--- a/tests/unit/adapters/test_adapter_project_tracker_linear.py
+++ b/tests/unit/adapters/test_adapter_project_tracker_linear.py
@@ -17,9 +17,13 @@ import pytest
 from omnibase_infra.adapters.project_tracker.adapter_project_tracker_linear import (
     AdapterProjectTrackerLinear,
 )
-from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
+from omnibase_infra.adapters.project_tracker.model_project_tracker_issue_status import (
     ModelProjectTrackerIssueStatus,
+)
+from omnibase_infra.adapters.project_tracker.model_project_tracker_label import (
     ModelProjectTrackerLabel,
+)
+from omnibase_infra.adapters.project_tracker.model_project_tracker_team import (
     ModelProjectTrackerTeam,
 )
 from omnibase_infra.errors import (


### PR DESCRIPTION
## Summary

- Adds `AdapterProjectTrackerLinear` to `omnibase_infra.adapters.project_tracker` as the canonical migration target for the compat shim (`omnibase_compat.adapters.adapter_project_tracker_linear`, removal date 2026-09-01)
- Implements `list_teams`, `list_issue_labels`, and `list_issue_statuses` via async httpx + `MixinAsyncCircuitBreaker`, replacing the compat sync urllib implementation
- Adds `ModelProjectTrackerTeam`, `ModelProjectTrackerLabel`, and `ModelProjectTrackerIssueStatus` as frozen Pydantic models in infra, replacing the compat wire models

## Ticket

OMN-12193 (epic OMN-12152)

## Test plan

- [ ] 15 unit tests in `tests/unit/adapters/test_adapter_project_tracker_linear.py` covering all three methods, auth header forwarding, team-filter payloads, error mapping (401/403/500/timeout/GraphQL errors), and model immutability
- [ ] `uv run pytest tests/unit/adapters/ -q` → 517 passed (no regressions)
- [ ] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` → all checks passed

Evidence-Source: OCC#1668
Evidence-Ticket: OMN-12193