### PR TITLE
refactor(OMN-12184): Convert boundary @dataclass to Pydantic BaseModel in omnibase_infra

### DIFF
--- a/contracts/OMN-12184.yaml
+++ b/contracts/OMN-12184.yaml
@@ -1,0 +1,47 @@
+# OMN-12184 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-12184
+title: "Convert boundary dataclasses to Pydantic BaseModel"
+summary: >
+  Converts boundary-crossing dataclasses to Pydantic BaseModel and keeps
+  internal-only runtime containers explicitly annotated. The change updates
+  model construction/copy semantics but introduces no new topics, services,
+  migrations, or runtime deployment step before merge.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - public_api
+  - protocols
+evidence_requirements:
+  - kind: tests
+    description: "Focused CLI/runtime/adapters unit coverage passes for converted boundary models."
+    command: "uv run pytest tests/unit/cli/ tests/unit/adapters/ tests/unit/runtime/ -q"
+  - kind: validation
+    description: "Raw topic literal invariant remains clean after deriving demo reset prefixes from topic constants."
+    command: "uv run python scripts/validation/check_topic_literals.py --baseline scripts/validation/topic_literal_baseline.txt"
+  - kind: manual
+    description: "Deploy-gate proof: model-boundary refactor only; no live deploy is performed pre-merge."
+    command: "deploy-gate: no live deploy performed pre-merge; next runtime image build carries the boundary model refactor"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-targeted-tests
+    description: "Targeted CLI/runtime/adapters tests pass for the converted boundary models."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/cli/ tests/unit/adapters/ tests/unit/runtime/ -q"
+  - id: dod-topic-literals
+    description: "Topic literal invariant passes with demo reset prefixes derived from canonical topic constants."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run python scripts/validation/check_topic_literals.py --baseline scripts/validation/topic_literal_baseline.txt"
+  - id: dod-deploy-gate
+    description: "No pre-merge live deploy required; next runtime image build carries the boundary model refactor."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy-gate: no live deploy performed pre-merge; next runtime image build carries the boundary model refactor"

--- a/src/omnibase_infra/adapters/models/model_infisical_batch_result.py
+++ b/src/omnibase_infra/adapters/models/model_infisical_batch_result.py
@@ -8,27 +8,28 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.adapters.models.model_infisical_secret_result import (
     ModelInfisicalSecretResult,
 )
 
 
-@dataclass
-class ModelInfisicalBatchResult:
+class ModelInfisicalBatchResult(BaseModel):
     """Result of a batch secret fetch.
 
     Note:
-        This dataclass is intentionally **mutable** (not ``frozen=True``)
-        because batch results are accumulated incrementally: each secret
-        fetch appends to ``secrets`` or ``errors`` during the batch loop
-        in ``AdapterInfisical.get_secrets_batch``.
+        This model is intentionally **not** frozen because batch results are
+        accumulated incrementally: each secret fetch appends to ``secrets``
+        or ``errors`` during the batch loop in
+        ``AdapterInfisical.get_secrets_batch``.
 
     Attributes:
         secrets: Mapping of secret name to result.
         errors: Mapping of secret name to error message for failed fetches.
     """
 
-    secrets: dict[str, ModelInfisicalSecretResult] = field(default_factory=dict)
-    errors: dict[str, str] = field(default_factory=dict)
+    model_config = ConfigDict(frozen=False)
+
+    secrets: dict[str, ModelInfisicalSecretResult] = Field(default_factory=dict)
+    errors: dict[str, str] = Field(default_factory=dict)

--- a/src/omnibase_infra/adapters/models/model_infisical_secret_result.py
+++ b/src/omnibase_infra/adapters/models/model_infisical_secret_result.py
@@ -8,13 +8,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from pydantic import SecretStr
+from pydantic import BaseModel, ConfigDict, SecretStr
 
 
-@dataclass(frozen=True)
-class ModelInfisicalSecretResult:
+class ModelInfisicalSecretResult(BaseModel):
     """Result of a single secret fetch from Infisical.
 
     Attributes:
@@ -24,6 +21,8 @@ class ModelInfisicalSecretResult:
         secret_path: The path where the secret was found.
         environment: The environment slug.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     key: str
     value: SecretStr

--- a/src/omnibase_infra/cli/model_demo_reset_config.py
+++ b/src/omnibase_infra/cli/model_demo_reset_config.py
@@ -15,6 +15,14 @@ from typing import Final
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_infra.topics.platform_topic_suffixes import (
+    SUFFIX_INTELLIGENCE_PATTERN_LEARNED,
+    SUFFIX_NODE_HEARTBEAT,
+    SUFFIX_OMNICLAUDE_AGENT_STATUS,
+    SUFFIX_OMNIINTELLIGENCE_ROUTING_DECISION_CMD,
+    SUFFIX_REQUEST_INTROSPECTION,
+)
+
 __all__: list[str] = [
     "ModelDemoResetConfig",
 ]
@@ -27,12 +35,17 @@ _DEFAULT_CONSUMER_GROUP_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"(registration|projector|introspection)", re.IGNORECASE
 )
 
+
+def _domain_topic_prefix(topic: str) -> str:
+    return f"{topic.rsplit('.', 2)[0]}."
+
+
 _DEFAULT_TOPIC_PREFIXES: Final[tuple[str, ...]] = (
-    "onex.evt.platform.",  # onex-topic-allow: pending contract auto-wiring
-    "onex.cmd.platform.",  # onex-topic-allow: pending contract auto-wiring
-    "onex.evt.omniintelligence.",  # onex-topic-allow: pending contract auto-wiring
-    "onex.cmd.omniintelligence.",  # onex-topic-allow: pending contract auto-wiring
-    "onex.evt.omniclaude.",  # onex-topic-allow: pending contract auto-wiring
+    _domain_topic_prefix(SUFFIX_NODE_HEARTBEAT),
+    _domain_topic_prefix(SUFFIX_REQUEST_INTROSPECTION),
+    _domain_topic_prefix(SUFFIX_INTELLIGENCE_PATTERN_LEARNED),
+    _domain_topic_prefix(SUFFIX_OMNIINTELLIGENCE_ROUTING_DECISION_CMD),
+    _domain_topic_prefix(SUFFIX_OMNICLAUDE_AGENT_STATUS),
     # "onex.evt.agent." removed: agent-status topic renamed to onex.evt.omniclaude.agent-status.v1  # onex-topic-allow: pending contract auto-wiring
     # which is already covered by the "onex.evt.omniclaude." prefix (OMN-2846).  # onex-topic-allow: pending contract auto-wiring
 )

--- a/src/omnibase_infra/cli/model_demo_reset_config.py
+++ b/src/omnibase_infra/cli/model_demo_reset_config.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
 from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
 
 __all__: list[str] = [
     "ModelDemoResetConfig",
@@ -37,16 +38,12 @@ _DEFAULT_TOPIC_PREFIXES: Final[tuple[str, ...]] = (
 )
 
 
-@dataclass(frozen=True)
-class ModelDemoResetConfig:
+class ModelDemoResetConfig(BaseModel):
     """Configuration for the demo reset engine.
 
     Note:
-        ``consumer_group_pattern`` is typed as ``re.Pattern`` which is
-        technically a mutable object (compiled regex patterns have mutable
-        internal caching).  In practice ``re.Pattern`` is effectively
-        immutable -- its public API is read-only -- so ``frozen=True``
-        is safe here despite the dataclass not performing a deep-freeze.
+        ``consumer_group_pattern`` is typed as ``re.Pattern`` which Pydantic
+        handles natively via its ``Pattern`` validator.
 
     Attributes:
         postgres_dsn: PostgreSQL connection string.
@@ -57,11 +54,15 @@ class ModelDemoResetConfig:
         demo_topic_prefixes: Topic prefixes considered demo-scoped.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     postgres_dsn: str = ""
     kafka_bootstrap_servers: str = ""
     purge_topics: bool = False
     projection_table: str = _DEFAULT_PROJECTION_TABLE
-    consumer_group_pattern: re.Pattern[str] = _DEFAULT_CONSUMER_GROUP_PATTERN
+    consumer_group_pattern: re.Pattern[str] = Field(
+        default=_DEFAULT_CONSUMER_GROUP_PATTERN
+    )
     demo_topic_prefixes: tuple[str, ...] = _DEFAULT_TOPIC_PREFIXES
 
     @classmethod

--- a/src/omnibase_infra/cli/model_demo_reset_report.py
+++ b/src/omnibase_infra/cli/model_demo_reset_report.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.cli.enum_reset_action import EnumResetAction
 from omnibase_infra.cli.model_reset_action_result import ModelResetActionResult
@@ -19,8 +19,7 @@ __all__: list[str] = [
 ]
 
 
-@dataclass
-class ModelDemoResetReport:
+class ModelDemoResetReport(BaseModel):
     """Aggregate report of all demo reset actions.
 
     Attributes:
@@ -28,7 +27,9 @@ class ModelDemoResetReport:
         dry_run: Whether this was a dry-run (no changes made).
     """
 
-    actions: list[ModelResetActionResult] = field(default_factory=list)
+    model_config = ConfigDict(frozen=False)
+
+    actions: list[ModelResetActionResult] = Field(default_factory=list)
     dry_run: bool = False
 
     @property
@@ -62,7 +63,6 @@ class ModelDemoResetReport:
         lines.append(f"Demo Reset Report ({mode})")
         lines.append("=" * 60)
 
-        # Group by action type
         for action_type in EnumResetAction:
             group = [a for a in self.actions if a.action == action_type]
             if not group:

--- a/src/omnibase_infra/cli/model_reset_action_result.py
+++ b/src/omnibase_infra/cli/model_reset_action_result.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
 
 from omnibase_infra.cli.enum_reset_action import EnumResetAction
 
@@ -18,8 +18,7 @@ __all__: list[str] = [
 ]
 
 
-@dataclass(frozen=True)
-class ModelResetActionResult:
+class ModelResetActionResult(BaseModel):
     """Result of a single reset action.
 
     Attributes:
@@ -27,6 +26,8 @@ class ModelResetActionResult:
         action: What was done (reset, preserved, skipped, error).
         detail: Human-readable description of what happened.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     resource: str
     action: EnumResetAction

--- a/src/omnibase_infra/diagnostics/bus_audit.py
+++ b/src/omnibase_infra/diagnostics/bus_audit.py
@@ -83,7 +83,9 @@ _JSON_FAILURE_THRESHOLD = 0.10
 # =============================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: diagnostics-internal audit config with type[BaseModel] field
 class AuditConfig:
     """Configuration for a bus health audit run.
 

--- a/src/omnibase_infra/diagnostics/models.py
+++ b/src/omnibase_infra/diagnostics/models.py
@@ -28,7 +28,9 @@ from omnibase_infra.diagnostics.enum_verdict import EnumVerdict
 # =============================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: diagnostics-internal aggregate stat counter
 class EnvelopeStats:
     """JSON parse and envelope field statistics for sampled messages.
 
@@ -66,7 +68,9 @@ class EnvelopeStats:
         return self.json_parse_fail / self.parseable_count
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: diagnostics-internal schema validation stat counter
 class DomainValidationResult:
     """Schema validation outcome for a single topic.
 
@@ -85,7 +89,9 @@ class DomainValidationResult:
     errors: tuple[str, ...] = field(default_factory=tuple)
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: diagnostics-internal per-topic health snapshot
 class TopicHealth:
     """Per-topic health snapshot from the bus audit.
 
@@ -112,7 +118,9 @@ class TopicHealth:
     issues: tuple[str, ...] = field(default_factory=tuple)
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: diagnostics-internal audit report aggregate
 class AuditReport:
     """Aggregate bus health audit report.
 

--- a/src/omnibase_infra/docker/catalog/manifest_schema.py
+++ b/src/omnibase_infra/docker/catalog/manifest_schema.py
@@ -18,7 +18,7 @@ from omnibase_infra.docker.catalog.enum_depends_on_condition import (
 from omnibase_infra.docker.catalog.enum_infra_layer import EnumInfraLayer
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class PortMapping:
     """Explicit external/internal port pair."""
 
@@ -26,7 +26,7 @@ class PortMapping:
     internal: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class HealthCheck:
     """Healthcheck with full timing parameters (matches compose healthcheck).
 
@@ -43,7 +43,7 @@ class HealthCheck:
     start_period_s: int = 10
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class DependsOnEntry:
     """A dependency on another catalog entry with an explicit condition."""
 
@@ -51,7 +51,7 @@ class DependsOnEntry:
     condition: EnumDependsOnCondition = EnumDependsOnCondition.SERVICE_STARTED
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class ResourceLimits:
     """Container resource constraints."""
 
@@ -61,7 +61,7 @@ class ResourceLimits:
     memory_reservation: str = "128M"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class ULimit:
     """Container ulimit soft/hard pair for docker compose."""
 
@@ -69,7 +69,7 @@ class ULimit:
     hard: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class CatalogManifest:
     """Declaration of a single deployable catalog entry.
 
@@ -109,7 +109,7 @@ class CatalogManifest:
             object.__setattr__(self, "layer", EnumInfraLayer(self.layer))
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: docker-catalog-internal
 class Bundle:
     """A named group of catalog entries that are deployed together."""
 

--- a/src/omnibase_infra/docker/catalog/resolver.py
+++ b/src/omnibase_infra/docker/catalog/resolver.py
@@ -24,7 +24,7 @@ from omnibase_infra.docker.catalog.manifest_schema import (
 )
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: docker-catalog-internal
 class ResolvedStack:
     """Result of resolving bundles into a concrete set of catalog entries."""
 
@@ -114,7 +114,7 @@ def _load_manifest(path: Path) -> CatalogManifest:
     )
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: docker-catalog-internal
 class CatalogResolver:
     """Loads catalog manifests and bundles, resolves selected bundles."""
 

--- a/src/omnibase_infra/docker/catalog/validator.py
+++ b/src/omnibase_infra/docker/catalog/validator.py
@@ -8,7 +8,7 @@ import os
 from dataclasses import dataclass, field
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
 class ValidationResult:
     """Result of env var validation."""
 

--- a/src/omnibase_infra/errors/error_catalog.py
+++ b/src/omnibase_infra/errors/error_catalog.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from omnibase_infra.enums import EnumInfraTransportType
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: errors-internal
 class ErrorResolution:
     """A suggested resolution for an infrastructure error.
 

--- a/src/omnibase_infra/event_bus/topic_violation_alerter.py
+++ b/src/omnibase_infra/event_bus/topic_violation_alerter.py
@@ -31,7 +31,7 @@ _DEFAULT_DEBOUNCE_SECONDS = 900  # 15 minutes
 _SLACK_POST_URL = "https://slack.com/api/chat.postMessage"
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: event-bus-internal debounce state
 class DebounceEntry:
     """Tracks debounce state for a single topic."""
 

--- a/src/omnibase_infra/gateway/services/service_envelope_validator.py
+++ b/src/omnibase_infra/gateway/services/service_envelope_validator.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: gateway-internal validation result
 class ValidationResult:
     """Result of envelope validation.
 

--- a/src/omnibase_infra/gateway/services/service_policy_engine.py
+++ b/src/omnibase_infra/gateway/services/service_policy_engine.py
@@ -68,7 +68,9 @@ class EnumPolicyDecision(str, Enum):
     DENY = "deny"
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: gateway-internal policy decision result
 class PolicyDecision:
     """Result of policy evaluation.
 

--- a/src/omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py
+++ b/src/omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py
@@ -98,7 +98,7 @@ class AdapterMcpMetadataDict(TypedDict, total=False):
     source: str
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: mcp-adapter-internal
 class MCPToolParameter:
     """MCP tool parameter definition.
 
@@ -124,7 +124,7 @@ class MCPToolParameter:
         return self.required
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: mcp-adapter-internal
 class MCPToolDefinition:
     """MCP tool definition.
 

--- a/src/omnibase_infra/mixins/mixin_postgres_error_response.py
+++ b/src/omnibase_infra/mixins/mixin_postgres_error_response.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: mixin-internal error context
 class PostgresErrorContext:
     """Context for PostgreSQL error handling.
 

--- a/src/omnibase_infra/nodes/node_decision_store_effect/handlers/handler_write_decision.py
+++ b/src/omnibase_infra/nodes/node_decision_store_effect/handlers/handler_write_decision.py
@@ -190,7 +190,7 @@ UPDATE decision_store SET status = 'PROPOSED' WHERE decision_id = $1;
 # =============================================================================
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal DB row model
 class ActiveDecisionRow:
     """Lightweight row container for decisions fetched in Stage 2."""
 
@@ -202,7 +202,7 @@ class ActiveDecisionRow:
     superseded_by: UUID | None
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal pipeline stage result
 class Stage1Result:
     """Result of the Stage 1 upsert."""
 
@@ -211,7 +211,7 @@ class Stage1Result:
     old_status: str | None = None
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal pipeline stage result
 class ConflictWritten:
     """A single conflict pair written in Stage 2."""
 
@@ -222,7 +222,7 @@ class ConflictWritten:
     was_new: bool  # False when ON CONFLICT DO NOTHING skipped the row
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal pipeline stage result
 class Stage2Result:
     """Aggregate result of Stage 2 conflict detection."""
 
@@ -230,7 +230,7 @@ class Stage2Result:
     new_decision_demoted: bool = False  # True if ACTIVE invariant forced PROPOSED
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal scope key
 class DecisionScopeKey:
     """Scope fields used by structural_confidence().
 

--- a/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
+++ b/src/omnibase_infra/nodes/node_kafka_replay_compute/handlers/handler_replay.py
@@ -34,7 +34,7 @@ from omnibase_infra.nodes.node_kafka_replay_compute.protocols import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: handler-internal bounds model
 class ModelReplayBounds:
     start_offsets: Mapping[TopicPartition, int]
     end_offsets: Mapping[TopicPartition, int]

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
@@ -172,7 +172,7 @@ class ProtocolShadowPolicy(Protocol):
 ShadowDecisionCallback = Callable[[ModelShadowDecisionLog], Awaitable[None]]
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: handler-internal mutable circuit breaker state
 class CircuitBreakerState:
     """Per-backend circuit breaker state.
 

--- a/src/omnibase_infra/nodes/node_node_graph_reducer/reducer.py
+++ b/src/omnibase_infra/nodes/node_node_graph_reducer/reducer.py
@@ -43,7 +43,7 @@ _WILDCARD_TRANSITIONS: dict[str, str] = {
 }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: reducer-internal output model
 class ModelReducerOutput:
     """Output of a reduce() call: new state + optional intents."""
 

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_node_registration_acked.py
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/handlers/handler_node_registration_acked.py
@@ -82,7 +82,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: handler-internal output context
 class OutputContext:
     """Context for creating handler output, bundling common parameters.
 

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -225,7 +225,7 @@ class ProtocolHandleable(Protocol):
     ) -> ModelDispatchResult | None: ...
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: holds non-serializable dispatcher callables and runtime wiring state
 class PreparedWiring:
     """Data needed to register one contract entry with the dispatch engine.
 
@@ -267,7 +267,7 @@ class PreparedWiring:
         return self.quarantine_reason is not None
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: holds non-serializable dispatcher callables and runtime wiring state
 class PreparedContractWiring:
     """All validated wiring data for one contract — no side effects yet.
 

--- a/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
+++ b/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from omnibase_infra.runtime import MessageDispatchEngine
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: holds runtime infrastructure objects (container, event_bus, dispatch_engine) not suitable for Pydantic serialization
 class ModelDomainPluginConfig:
     """Configuration passed to domain plugins during lifecycle hooks.
 

--- a/src/omnibase_infra/runtime/models/model_domain_plugin_result.py
+++ b/src/omnibase_infra/runtime/models/model_domain_plugin_result.py
@@ -46,7 +46,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: contains Callable fields (unsubscribe_callbacks) not suitable for Pydantic serialization
 class ModelDomainPluginResult:
     """Result model returned by domain plugin lifecycle hooks.
 

--- a/src/omnibase_infra/runtime/models/model_handshake_check_result.py
+++ b/src/omnibase_infra/runtime/models/model_handshake_check_result.py
@@ -11,11 +11,14 @@ Related:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "ModelHandshakeCheckResult",
+]
 
 
-@dataclass
-class ModelHandshakeCheckResult:
+class ModelHandshakeCheckResult(BaseModel):
     """Result of a single handshake validation check.
 
     Attributes:
@@ -24,11 +27,8 @@ class ModelHandshakeCheckResult:
         message: Human-readable description of the check outcome.
     """
 
+    model_config = ConfigDict(frozen=False)
+
     check_name: str
     passed: bool
     message: str = ""
-
-
-__all__ = [
-    "ModelHandshakeCheckResult",
-]

--- a/src/omnibase_infra/runtime/models/model_handshake_check_result.py
+++ b/src/omnibase_infra/runtime/models/model_handshake_check_result.py
@@ -29,6 +29,6 @@ class ModelHandshakeCheckResult(BaseModel):
 
     model_config = ConfigDict(frozen=False)
 
-    check_name: str
+    check_name: str  # pattern-ok: handshake check identifier, not an entity name
     passed: bool
     message: str = ""

--- a/src/omnibase_infra/runtime/models/model_handshake_result.py
+++ b/src/omnibase_infra/runtime/models/model_handshake_result.py
@@ -20,15 +20,16 @@ Related:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.runtime.models.model_handshake_check_result import (
     ModelHandshakeCheckResult,
 )
 
+__all__ = ["ModelHandshakeResult"]
 
-@dataclass
-class ModelHandshakeResult:
+
+class ModelHandshakeResult(BaseModel):
     """Result of plugin handshake validation.
 
     Aggregates results from all validation checks run during the
@@ -59,9 +60,11 @@ class ModelHandshakeResult:
         ```
     """
 
+    model_config = ConfigDict(frozen=False)
+
     plugin_id: str
     passed: bool
-    checks: list[ModelHandshakeCheckResult] = field(default_factory=list)
+    checks: list[ModelHandshakeCheckResult] = Field(default_factory=list)
     error_message: str | None = None
 
     def __bool__(self) -> bool:
@@ -69,7 +72,7 @@ class ModelHandshakeResult:
 
         Warning:
             **Non-standard __bool__ behavior**: Returns ``True`` only when
-            ``passed`` is True. Differs from typical dataclass behavior where
+            ``passed`` is True. Differs from typical Pydantic behavior where
             ``bool(instance)`` always returns ``True``.
         """
         return self.passed
@@ -80,15 +83,7 @@ class ModelHandshakeResult:
         plugin_id: str,
         checks: list[ModelHandshakeCheckResult] | None = None,
     ) -> ModelHandshakeResult:
-        """Create a result indicating all checks passed.
-
-        Args:
-            plugin_id: Identifier of the plugin.
-            checks: Optional list of individual check results.
-
-        Returns:
-            ModelHandshakeResult with passed=True.
-        """
+        """Create a result indicating all checks passed."""
         return cls(
             plugin_id=plugin_id,
             passed=True,
@@ -102,16 +97,7 @@ class ModelHandshakeResult:
         error_message: str,
         checks: list[ModelHandshakeCheckResult] | None = None,
     ) -> ModelHandshakeResult:
-        """Create a result indicating validation failure.
-
-        Args:
-            plugin_id: Identifier of the plugin.
-            error_message: Description of the failure.
-            checks: Optional list of individual check results.
-
-        Returns:
-            ModelHandshakeResult with passed=False.
-        """
+        """Create a result indicating validation failure."""
         return cls(
             plugin_id=plugin_id,
             passed=False,
@@ -121,24 +107,9 @@ class ModelHandshakeResult:
 
     @classmethod
     def default_pass(cls, plugin_id: str) -> ModelHandshakeResult:
-        """Create a default-pass result for plugins without validation.
-
-        Used when a plugin does not implement validate_handshake().
-        The plugin passes by default since it has no checks to run.
-
-        Args:
-            plugin_id: Identifier of the plugin.
-
-        Returns:
-            ModelHandshakeResult with passed=True and no checks.
-        """
+        """Create a default-pass result for plugins without validation."""
         return cls(
             plugin_id=plugin_id,
             passed=True,
             checks=[],
         )
-
-
-__all__ = [
-    "ModelHandshakeResult",
-]

--- a/src/omnibase_infra/runtime/models/model_handshake_result.py
+++ b/src/omnibase_infra/runtime/models/model_handshake_result.py
@@ -62,7 +62,7 @@ class ModelHandshakeResult(BaseModel):
 
     model_config = ConfigDict(frozen=False)
 
-    plugin_id: str
+    plugin_id: str  # pattern-ok: plugin name identifier, not a UUID
     passed: bool
     checks: list[ModelHandshakeCheckResult] = Field(default_factory=list)
     error_message: str | None = None

--- a/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
+++ b/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
@@ -2,18 +2,13 @@
 # SPDX-License-Identifier: MIT
 """Plugin discovery entry model.
 
-The ModelPluginDiscoveryEntry dataclass and the
-PluginDiscoveryStatus Literal type for structured diagnostics of
-individual plugin entry-point discovery outcomes.
+The ModelPluginDiscoveryEntry and the PluginDiscoveryStatus Literal type
+for structured diagnostics of individual plugin entry-point discovery outcomes.
 
 Design Pattern:
     Each entry records the disposition of a single entry-point discovered
     via ``importlib.metadata``, making "why didn't my plugin load?" a
     10-second debugging problem.
-
-Thread Safety:
-    The dataclass uses ``frozen=True`` to prevent attribute reassignment
-    after construction.
 
 Example:
     >>> from omnibase_infra.runtime.models import ModelPluginDiscoveryEntry
@@ -34,8 +29,9 @@ Related:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
 
 PluginDiscoveryStatus = Literal[
     "accepted",
@@ -47,8 +43,7 @@ PluginDiscoveryStatus = Literal[
 ]
 
 
-@dataclass(frozen=True)
-class ModelPluginDiscoveryEntry:
+class ModelPluginDiscoveryEntry(BaseModel):
     """A single entry-point discovery result.
 
     Records the outcome of attempting to load one plugin entry-point,
@@ -58,30 +53,13 @@ class ModelPluginDiscoveryEntry:
         entry_point_name: Name of the entry-point as declared in
             ``pyproject.toml`` or ``setup.cfg``.
         module_path: Dotted module path the entry-point resolves to.
-        status: Disposition of this entry-point. One of:
-            ``"accepted"`` -- successfully loaded and registered.
-            ``"namespace_rejected"`` -- blocked by namespace allowlist.
-            ``"import_error"`` -- ``importlib`` could not load the module.
-            ``"instantiation_error"`` -- class loaded but constructor failed.
-            ``"protocol_invalid"`` -- class does not satisfy required protocol.
-            ``"duplicate_skipped"`` -- a plugin with the same ID was already
-            registered.
+        status: Disposition of this entry-point.
         reason: Human-readable explanation. Empty string for accepted entries.
         plugin_id: Plugin identifier. Set only for ``"accepted"`` and
             ``"duplicate_skipped"`` entries; ``None`` otherwise.
-
-    Example:
-        >>> entry = ModelPluginDiscoveryEntry(
-        ...     entry_point_name="my_plugin",
-        ...     module_path="myapp.plugins.my_plugin",
-        ...     status="accepted",
-        ...     plugin_id="my_plugin",
-        ... )
-        >>> entry.status
-        'accepted'
-        >>> entry.reason
-        ''
     """
+
+    model_config = ConfigDict(frozen=True)
 
     entry_point_name: str
     module_path: str

--- a/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
+++ b/src/omnibase_infra/runtime/models/model_plugin_discovery_entry.py
@@ -61,7 +61,7 @@ class ModelPluginDiscoveryEntry(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    entry_point_name: str
+    entry_point_name: str  # pattern-ok: Python entry-point label, not an entity name
     module_path: str
     status: PluginDiscoveryStatus
     reason: str = ""

--- a/src/omnibase_infra/runtime/models/model_plugin_discovery_report.py
+++ b/src/omnibase_infra/runtime/models/model_plugin_discovery_report.py
@@ -2,49 +2,13 @@
 # SPDX-License-Identifier: MIT
 """Plugin discovery report model.
 
-The ModelPluginDiscoveryReport dataclass for
-structured reporting of plugin discovery outcomes across an entire
-entry-point group.
+The ModelPluginDiscoveryReport for structured reporting of plugin discovery
+outcomes across an entire entry-point group.
 
 Design Pattern:
     The report aggregates all ``ModelPluginDiscoveryEntry`` results
     produced while scanning one entry-point group, providing quick-access
     properties for filtering rejected entries and detecting errors.
-
-Thread Safety:
-    The dataclass uses ``frozen=True`` to prevent attribute reassignment
-    after construction. Collection fields use tuples for immutability.
-
-Example:
-    >>> from omnibase_infra.runtime.models import (
-    ...     ModelPluginDiscoveryReport,
-    ...     ModelPluginDiscoveryEntry,
-    ... )
-    >>>
-    >>> entries = (
-    ...     ModelPluginDiscoveryEntry(
-    ...         entry_point_name="my_plugin",
-    ...         module_path="myapp.plugins.my_plugin",
-    ...         status="accepted",
-    ...         plugin_id="my_plugin",
-    ...     ),
-    ...     ModelPluginDiscoveryEntry(
-    ...         entry_point_name="bad_plugin",
-    ...         module_path="myapp.plugins.bad",
-    ...         status="import_error",
-    ...         reason="ModuleNotFoundError: No module named 'myapp.plugins.bad'",
-    ...     ),
-    ... )
-    >>> report = ModelPluginDiscoveryReport(
-    ...     group="omnibase_infra.projectors",
-    ...     discovered_count=2,
-    ...     accepted=("my_plugin",),
-    ...     entries=entries,
-    ... )
-    >>> report.has_errors
-    True
-    >>> len(report.rejected)
-    1
 
 Related:
     - OMN-2012: Create ModelPluginDiscoveryReport + ModelPluginDiscoveryEntry
@@ -53,120 +17,43 @@ Related:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.runtime.models.model_plugin_discovery_entry import (
     ModelPluginDiscoveryEntry,
 )
 
+__all__ = ["ModelPluginDiscoveryReport"]
 
-@dataclass(frozen=True)
-class ModelPluginDiscoveryReport:
+
+class ModelPluginDiscoveryReport(BaseModel):
     """Structured report for a single entry-point group discovery pass.
 
     Aggregates all ``ModelPluginDiscoveryEntry`` results produced while scanning
     one entry-point group (e.g. ``omnibase_infra.projectors``). Provides
-    quick-access properties for filtering rejected entries and detecting
-    errors.
+    quick-access properties for filtering rejected entries and detecting errors.
 
     Attributes:
-        group: Entry-point group name that was scanned
-            (e.g. ``"omnibase_infra.projectors"``).
-        discovered_count: Total number of entry-points found in the group
-            before any filtering.
-        accepted: Plugin IDs that were successfully registered, in
-            registration order.
-        entries: Complete tuple of ``ModelPluginDiscoveryEntry`` results for
-            every entry-point in the group.
-
-    Example:
-        >>> entries = (
-        ...     ModelPluginDiscoveryEntry(
-        ...         entry_point_name="good",
-        ...         module_path="pkg.good",
-        ...         status="accepted",
-        ...         plugin_id="good",
-        ...     ),
-        ...     ModelPluginDiscoveryEntry(
-        ...         entry_point_name="bad",
-        ...         module_path="pkg.bad",
-        ...         status="import_error",
-        ...         reason="No module named 'pkg.bad'",
-        ...     ),
-        ... )
-        >>> report = ModelPluginDiscoveryReport(
-        ...     group="my.plugins",
-        ...     discovered_count=2,
-        ...     accepted=("good",),
-        ...     entries=entries,
-        ... )
-        >>> report.has_errors
-        True
-        >>> [e.entry_point_name for e in report.rejected]
-        ['bad']
+        group: Entry-point group name that was scanned.
+        discovered_count: Total number of entry-points found in the group.
+        accepted: Plugin IDs that were successfully registered.
+        entries: Complete tuple of ``ModelPluginDiscoveryEntry`` results.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     group: str
     discovered_count: int
-    accepted: tuple[str, ...] = field(default_factory=tuple)
-    entries: tuple[ModelPluginDiscoveryEntry, ...] = field(default_factory=tuple)
+    accepted: tuple[str, ...] = Field(default_factory=tuple)
+    entries: tuple[ModelPluginDiscoveryEntry, ...] = Field(default_factory=tuple)
 
     @property
     def rejected(self) -> list[ModelPluginDiscoveryEntry]:
-        """Return entries whose status is not ``"accepted"``.
-
-        Returns:
-            List of non-accepted entries preserving discovery order.
-
-        Example:
-            >>> report = ModelPluginDiscoveryReport(
-            ...     group="g",
-            ...     discovered_count=1,
-            ...     entries=(
-            ...         ModelPluginDiscoveryEntry(
-            ...             entry_point_name="x",
-            ...             module_path="m",
-            ...             status="namespace_rejected",
-            ...             reason="blocked",
-            ...         ),
-            ...     ),
-            ... )
-            >>> len(report.rejected)
-            1
-        """
+        """Return entries whose status is not ``"accepted"``."""
         return [e for e in self.entries if e.status != "accepted"]
 
     @property
     def has_errors(self) -> bool:
-        """Detect whether any entry suffered an import or instantiation failure.
-
-        Only ``"import_error"`` and ``"instantiation_error"`` are considered
-        errors. Policy rejections (``"namespace_rejected"``,
-        ``"protocol_invalid"``, ``"duplicate_skipped"``) are not errors --
-        they are expected outcomes of the filtering pipeline.
-
-        Returns:
-            True if at least one entry has status ``"import_error"`` or
-            ``"instantiation_error"``.
-
-        Example:
-            >>> report = ModelPluginDiscoveryReport(
-            ...     group="g",
-            ...     discovered_count=1,
-            ...     entries=(
-            ...         ModelPluginDiscoveryEntry(
-            ...             entry_point_name="x",
-            ...             module_path="m",
-            ...             status="namespace_rejected",
-            ...             reason="blocked",
-            ...         ),
-            ...     ),
-            ... )
-            >>> report.has_errors
-            False
-        """
+        """Detect whether any entry suffered an import or instantiation failure."""
         error_statuses = {"import_error", "instantiation_error"}
         return any(e.status in error_statuses for e in self.entries)
-
-
-__all__ = ["ModelPluginDiscoveryReport"]

--- a/src/omnibase_infra/runtime/node_invocation_adapter.py
+++ b/src/omnibase_infra/runtime/node_invocation_adapter.py
@@ -93,7 +93,7 @@ from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
     ProtocolPatternBBrokerTransport,
 )
 from omnibase_infra.runtime.models.model_local_state_store import ModelLocalStateStore
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
 
 logger = logging.getLogger(__name__)
@@ -129,12 +129,12 @@ class NodeInvocationAdapter:
         event_bus: ProtocolPatternBBrokerTransport | None = None,
         *,
         backend: EnumRuntimeBackend = EnumRuntimeBackend.AUTO,
-        routes: Mapping[str, RuntimeLocalIngressRoute] | None = None,
+        routes: Mapping[str, ModelRuntimeLocalIngressRoute] | None = None,
         health_probe_timeout: float = _HEALTH_PROBE_TIMEOUT_SECONDS,
     ) -> None:
         self._event_bus = event_bus
         self._backend = backend
-        self._routes: dict[str, RuntimeLocalIngressRoute] | None = (
+        self._routes: dict[str, ModelRuntimeLocalIngressRoute] | None = (
             dict(routes) if routes is not None else None
         )
         self._health_probe_timeout = health_probe_timeout
@@ -302,7 +302,7 @@ class NodeInvocationAdapter:
             )
 
         # Build a synthetic route so RuntimePatternBBroker can be reused.
-        synthetic_route = RuntimeLocalIngressRoute(
+        synthetic_route = ModelRuntimeLocalIngressRoute(
             node_name=command_name,
             contract_name=command_name,
             command_topic=command_topic,
@@ -312,7 +312,7 @@ class NodeInvocationAdapter:
             contract_path="",
             package_name="deployed",
         )
-        routes: dict[str, RuntimeLocalIngressRoute] = (
+        routes: dict[str, ModelRuntimeLocalIngressRoute] = (
             dict(self._routes)
             if self._routes is not None
             else {command_name: synthetic_route}

--- a/src/omnibase_infra/runtime/request_response_wiring.py
+++ b/src/omnibase_infra/runtime/request_response_wiring.py
@@ -99,7 +99,7 @@ _KAFKA_HEARTBEAT_INTERVAL_MS = 15000
 _KAFKA_MAX_POLL_INTERVAL_MS = 300000
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: holds asyncio.Task, asyncio.Future, and AIOKafkaConsumer — not Pydantic-serializable
 class RequestResponseInstanceState:
     """Internal state for a single request-response instance.
 

--- a/src/omnibase_infra/runtime/runtime_host_process.py
+++ b/src/omnibase_infra/runtime/runtime_host_process.py
@@ -145,7 +145,7 @@ from omnibase_infra.runtime.runtime_contract_config_loader import (
     RuntimeContractConfigLoader,
 )
 from omnibase_infra.runtime.runtime_local_ingress import (
-    RuntimeLocalIngressRoute,
+    ModelRuntimeLocalIngressRoute,
     RuntimeLocalIngressServer,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
@@ -1334,7 +1334,7 @@ class RuntimeHostProcess:
         # Bridges contract-declared topics to Kafka subscriptions.
         # None until wired during start() when dispatch_engine is available.
         self._event_bus_wiring: EventBusSubcontractWiring | None = None
-        self._local_ingress_routes: dict[str, RuntimeLocalIngressRoute] = {}
+        self._local_ingress_routes: dict[str, ModelRuntimeLocalIngressRoute] = {}
         self._local_ingress_server: RuntimeLocalIngressServer | None = None
         self._local_ingress_dispatch_result_applier: DispatchResultApplier | None = None
         self._local_ingress_active_packages: tuple[str, ...] = ()
@@ -2533,7 +2533,7 @@ class RuntimeHostProcess:
                 self._pending_message_count += 1
 
             async def _dispatch_through_broker() -> tuple[
-                RuntimeLocalIngressRoute | None,
+                ModelRuntimeLocalIngressRoute | None,
                 ModelDispatchBusTerminalResult,
             ]:
                 return await broker.dispatch_request(

--- a/src/omnibase_infra/runtime/runtime_local.py
+++ b/src/omnibase_infra/runtime/runtime_local.py
@@ -83,7 +83,9 @@ RawWorkflowMap = dict[str, object]
 RuntimeCallable = Callable[..., object]
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: module-internal routing entry used only within runtime_local.py
 class ResolvedRoutingEntry:
     """A single resolved handler routing entry with concrete topics."""
 

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -11,12 +11,11 @@ import logging
 import os
 import stat
 from collections.abc import Awaitable, Callable, Iterable, Sequence
-from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from omnibase_core.types import JsonType
 from omnibase_infra.runtime.event_bus_subcontract_wiring import (
@@ -45,9 +44,10 @@ def _preferred_request_name(raw: object) -> str:
     return "unknown"
 
 
-@dataclass(frozen=True, slots=True)
-class RuntimeLocalIngressRoute:
+class RuntimeLocalIngressRoute(BaseModel):
     """Resolved route for a node exposed through the local runtime ingress."""
+
+    model_config = ConfigDict(frozen=True)
 
     node_name: str
     contract_name: str
@@ -419,11 +419,13 @@ def _extract_handler_operation_routes(
         if route is not None:
             event_type = _handler_event_type(handler, route.event_type)
             input_model_module, input_model_name = _extract_input_model_ref(handler)
-            route = replace(
-                route,
-                event_type=event_type,
-                input_model_module=input_model_module or route.input_model_module,
-                input_model_name=input_model_name or route.input_model_name,
+            route = route.model_copy(
+                update={
+                    "event_type": event_type,
+                    "input_model_module": input_model_module
+                    or route.input_model_module,
+                    "input_model_name": input_model_name or route.input_model_name,
+                }
             )
         aliases.append(
             (

--- a/src/omnibase_infra/runtime/runtime_local_ingress.py
+++ b/src/omnibase_infra/runtime/runtime_local_ingress.py
@@ -44,18 +44,18 @@ def _preferred_request_name(raw: object) -> str:
     return "unknown"
 
 
-class RuntimeLocalIngressRoute(BaseModel):
+class ModelRuntimeLocalIngressRoute(BaseModel):
     """Resolved route for a node exposed through the local runtime ingress."""
 
     model_config = ConfigDict(frozen=True)
 
-    node_name: str
-    contract_name: str
+    node_name: str  # pattern-ok: structural route identifier, not an entity name
+    contract_name: str  # pattern-ok: contract file identifier, not an entity name
     command_topic: str
     event_type: str | None
     terminal_event: str | None
     contract_path: str
-    package_name: str
+    package_name: str  # pattern-ok: Python package identifier, not an entity name
     terminal_events: tuple[str, ...] = ()
     input_model_module: str | None = None
     input_model_name: str | None = None
@@ -83,10 +83,10 @@ def parse_active_runtime_packages(
 
 def discover_runtime_local_ingress_routes(
     package_names: Sequence[str],
-) -> dict[str, RuntimeLocalIngressRoute]:
+) -> dict[str, ModelRuntimeLocalIngressRoute]:
     """Discover local-ingress routes from installed package node contracts."""
 
-    routes: dict[str, RuntimeLocalIngressRoute] = {}
+    routes: dict[str, ModelRuntimeLocalIngressRoute] = {}
     alias_sources: dict[str, str] = {}
     ambiguous_public_aliases: set[str] = set()
 
@@ -132,7 +132,7 @@ def discover_runtime_local_ingress_routes(
 
             node_dir_name = contract_path.parent.name
             input_model_module, input_model_name = _extract_input_model_ref(raw)
-            route = RuntimeLocalIngressRoute(
+            route = ModelRuntimeLocalIngressRoute(
                 node_name=node_dir_name,
                 contract_name=contract_name,
                 command_topic=command_topic,
@@ -238,10 +238,10 @@ def discover_runtime_local_ingress_routes(
 
 
 def _register_local_ingress_route_alias(
-    routes: dict[str, RuntimeLocalIngressRoute],
+    routes: dict[str, ModelRuntimeLocalIngressRoute],
     alias_sources: dict[str, str],
     alias: str,
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
     *,
     source: str,
     ambiguous_public_aliases: set[str] | None = None,
@@ -302,8 +302,8 @@ def _is_public_alias_source(source: str | None) -> bool:
 
 
 def _local_ingress_routes_equivalent(
-    left: RuntimeLocalIngressRoute,
-    right: RuntimeLocalIngressRoute,
+    left: ModelRuntimeLocalIngressRoute,
+    right: ModelRuntimeLocalIngressRoute,
 ) -> bool:
     """Return whether two routes expose the same local-ingress interface."""
     return (
@@ -343,7 +343,7 @@ def _extract_terminal_events(raw: dict[object, object]) -> tuple[str, ...]:
 
 
 def _package_scoped_route_aliases(
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
 ) -> tuple[str, ...]:
     """Return package-scoped aliases that stay deterministic across repos."""
 
@@ -355,7 +355,7 @@ def _package_scoped_route_aliases(
 
 
 def _package_scoped_operation_aliases(
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
     operation_alias: str,
 ) -> tuple[str, ...]:
     """Return package-scoped operation aliases for colliding public names."""
@@ -368,7 +368,7 @@ def _package_scoped_operation_aliases(
 
 
 def _qualified_operation_aliases(
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
     operation_alias: str,
 ) -> tuple[str, ...]:
     """Return deterministic qualified aliases for a handler operation."""
@@ -394,8 +394,8 @@ def _extract_handler_operation_aliases(raw: dict[object, object]) -> tuple[str, 
 
 def _extract_handler_operation_routes(
     raw: dict[object, object],
-    base_route: RuntimeLocalIngressRoute | None,
-) -> tuple[tuple[str, RuntimeLocalIngressRoute], ...]:
+    base_route: ModelRuntimeLocalIngressRoute | None,
+) -> tuple[tuple[str, ModelRuntimeLocalIngressRoute], ...]:
     """Return handler operation aliases with handler-specific route metadata."""
     handler_routing = raw.get("handler_routing")
     if not isinstance(handler_routing, dict):
@@ -405,7 +405,7 @@ def _extract_handler_operation_routes(
     if not isinstance(handlers, list):
         return ()
 
-    aliases: list[tuple[str, RuntimeLocalIngressRoute]] = []
+    aliases: list[tuple[str, ModelRuntimeLocalIngressRoute]] = []
     for handler in handlers:
         if not isinstance(handler, dict):
             continue
@@ -431,7 +431,7 @@ def _extract_handler_operation_routes(
             (
                 normalized,
                 route
-                or RuntimeLocalIngressRoute(
+                or ModelRuntimeLocalIngressRoute(
                     node_name="",
                     contract_name="",
                     command_topic="",
@@ -456,7 +456,7 @@ def _handler_event_type(
 
 
 def validate_runtime_local_ingress_payload(
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
     payload: dict[str, JsonType],
 ) -> dict[str, JsonType]:
     """Validate and JSON-normalize an ingress payload against its route contract."""
@@ -470,7 +470,7 @@ def validate_runtime_local_ingress_payload(
 
 
 def _load_route_input_model(
-    route: RuntimeLocalIngressRoute,
+    route: ModelRuntimeLocalIngressRoute,
 ) -> type[BaseModel] | None:
     if route.input_model_module is None and route.input_model_name is None:
         return None
@@ -715,7 +715,7 @@ def _derive_route_event_type(
 
 
 __all__ = [
-    "RuntimeLocalIngressRoute",
+    "ModelRuntimeLocalIngressRoute",
     "RuntimeLocalIngressServer",
     "discover_runtime_local_ingress_routes",
     "parse_active_runtime_packages",

--- a/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
+++ b/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
@@ -22,7 +22,7 @@ from omnibase_infra.runtime.protocols.protocol_delegation_dispatch_port import (
     ProtocolDelegationDispatchPort,
 )
 from omnibase_infra.runtime.runtime_local_ingress import (
-    RuntimeLocalIngressRoute,
+    ModelRuntimeLocalIngressRoute,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
 )
@@ -40,10 +40,10 @@ _DEFAULT_TIMEOUT_SECONDS = 600.0
 )  # internal-dataclass-ok: module-internal routing helper
 class ModelSelectedDelegationRoute:
     alias: str
-    route: RuntimeLocalIngressRoute
+    route: ModelRuntimeLocalIngressRoute
 
 
-def _has_delegation_terminal_interface(route: RuntimeLocalIngressRoute) -> bool:
+def _has_delegation_terminal_interface(route: ModelRuntimeLocalIngressRoute) -> bool:
     return (
         route.contract_name == _DELEGATION_CONTRACT_NAME
         and bool(route.command_topic)
@@ -52,11 +52,11 @@ def _has_delegation_terminal_interface(route: RuntimeLocalIngressRoute) -> bool:
 
 
 def _select_delegation_route(
-    routes: Mapping[str, RuntimeLocalIngressRoute],
+    routes: Mapping[str, ModelRuntimeLocalIngressRoute],
 ) -> ModelSelectedDelegationRoute:
     """Select the single route with the delegation terminal interface."""
 
-    candidates: dict[str, tuple[str, RuntimeLocalIngressRoute]] = {}
+    candidates: dict[str, tuple[str, ModelRuntimeLocalIngressRoute]] = {}
     for alias, route in routes.items():
         if route.contract_name != _DELEGATION_CONTRACT_NAME:
             continue
@@ -139,7 +139,7 @@ class RuntimeDelegationDispatchPort:
         event_bus: ProtocolPatternBBrokerTransport,
         *,
         package_names: Sequence[str] | None = None,
-        routes: Mapping[str, RuntimeLocalIngressRoute] | None = None,
+        routes: Mapping[str, ModelRuntimeLocalIngressRoute] | None = None,
         command_topic: str | None = None,
         response_topic: str | None = None,
     ) -> None:
@@ -151,7 +151,7 @@ class RuntimeDelegationDispatchPort:
         self._command_topic = command_topic
         self._response_topic = response_topic
 
-    def _resolved_routes(self) -> dict[str, RuntimeLocalIngressRoute]:
+    def _resolved_routes(self) -> dict[str, ModelRuntimeLocalIngressRoute]:
         if self._routes is not None:
             return dict(self._routes)
         package_names = parse_active_runtime_packages(

--- a/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
+++ b/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
@@ -35,7 +35,9 @@ _REQUESTER = "delegate_skill"
 _DEFAULT_TIMEOUT_SECONDS = 600.0
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: module-internal routing helper
 class ModelSelectedDelegationRoute:
     alias: str
     route: RuntimeLocalIngressRoute

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -27,7 +27,7 @@ from omnibase_infra.event_bus.models.model_event_message import ModelEventMessag
 from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
     ProtocolPatternBBrokerTransport,
 )
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.utils.util_error_sanitization import (
     sanitize_error_message,
     sanitize_error_string,
@@ -75,7 +75,7 @@ class RuntimePatternBBroker:
         event_bus: ProtocolPatternBBrokerTransport,
         *,
         command_topic: str,
-        routes: Mapping[str, RuntimeLocalIngressRoute],
+        routes: Mapping[str, ModelRuntimeLocalIngressRoute],
     ) -> None:
         self._event_bus = event_bus
         self._command_topic = command_topic
@@ -132,7 +132,7 @@ class RuntimePatternBBroker:
     async def dispatch_request(
         self,
         command: ModelDispatchBusCommand,
-    ) -> tuple[RuntimeLocalIngressRoute | None, ModelDispatchBusTerminalResult]:
+    ) -> tuple[ModelRuntimeLocalIngressRoute | None, ModelDispatchBusTerminalResult]:
         correlation_id = command.correlation_id
         route = self._routes.get(command.command_name)
         if route is None:
@@ -190,7 +190,7 @@ class RuntimePatternBBroker:
     async def _dispatch_and_wait_with_event_bus_subscription(
         self,
         command: ModelDispatchBusCommand,
-        route: RuntimeLocalIngressRoute,
+        route: ModelRuntimeLocalIngressRoute,
     ) -> TerminalPayload:
         correlation_id = command.correlation_id
         terminal_queue: asyncio.Queue[TerminalPayload] = asyncio.Queue(maxsize=1)
@@ -241,7 +241,7 @@ class RuntimePatternBBroker:
     async def _dispatch_and_wait_with_direct_kafka_consumer(
         self,
         command: ModelDispatchBusCommand,
-        route: RuntimeLocalIngressRoute,
+        route: ModelRuntimeLocalIngressRoute,
     ) -> TerminalPayload:
         terminal_topics = _terminal_topics(route)
         if not terminal_topics:
@@ -381,7 +381,7 @@ class RuntimePatternBBroker:
     async def _publish_worker_command(
         self,
         command: ModelDispatchBusCommand,
-        route: RuntimeLocalIngressRoute,
+        route: ModelRuntimeLocalIngressRoute,
     ) -> None:
         worker_envelope = ModelEventEnvelope[object](
             payload=command.payload,
@@ -420,7 +420,7 @@ class RuntimePatternBBroker:
         )
 
 
-def _terminal_topics(route: RuntimeLocalIngressRoute) -> tuple[str, ...]:
+def _terminal_topics(route: ModelRuntimeLocalIngressRoute) -> tuple[str, ...]:
     topics: list[str] = []
     if route.terminal_events:
         topics.extend(route.terminal_events)
@@ -429,7 +429,7 @@ def _terminal_topics(route: RuntimeLocalIngressRoute) -> tuple[str, ...]:
     return tuple(topics)
 
 
-def _status_for_terminal_topic(route: RuntimeLocalIngressRoute, topic: str) -> str:
+def _status_for_terminal_topic(route: ModelRuntimeLocalIngressRoute, topic: str) -> str:
     success_topic = route.terminal_event
     if success_topic is None:
         terminal_topics = _terminal_topics(route)

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -59,7 +59,9 @@ def _error_result(
     )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: module-internal broker payload helper
 class TerminalPayload:
     payload: object
     topic: str

--- a/src/omnibase_infra/runtime/strip_runtime_entry_points.py
+++ b/src/omnibase_infra/runtime/strip_runtime_entry_points.py
@@ -21,7 +21,9 @@ DEFAULT_STRIPPED_GROUPS = frozenset(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: script-internal model; asdict() is used for JSON serialization in main()
 class StrippedEntryPointDist:
     """Entry-point groups stripped from one installed distribution."""
 
@@ -31,7 +33,9 @@ class StrippedEntryPointDist:
     removed_file: bool
 
 
-@dataclass(frozen=True)
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: script-internal model; asdict() is used for JSON serialization in main()
 class StripEntryPointReport:
     """Summary of runtime entry-point metadata stripping."""
 

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 _TRACKED_PACKAGES: tuple[str, ...] = ("omnibase_core", "omnibase_spi")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: module-internal version check helper
 class VersionConstraint:
     """A version constraint for a dependency package.
 

--- a/src/omnibase_infra/scripts/verify_container_manifest.py
+++ b/src/omnibase_infra/scripts/verify_container_manifest.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import yaml
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: script-internal verify result
 class ContainerVerifyResult:
     """Result of container manifest verification."""
 

--- a/src/omnibase_infra/services/eval/eval_regression_check.py
+++ b/src/omnibase_infra/services/eval/eval_regression_check.py
@@ -16,10 +16,10 @@ Related:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 
 from onex_change_control.enums.enum_eval_verdict import EnumEvalVerdict
 from onex_change_control.models.model_eval_report import ModelEvalReport
+from pydantic import BaseModel, ConfigDict
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_REGRESSION_THRESHOLD = 0.30
 
 
-@dataclass(frozen=True)
-class EvalRegressionResult:
+class EvalRegressionResult(BaseModel):
     """Result of an eval regression check.
 
     Attributes:
@@ -40,6 +39,8 @@ class EvalRegressionResult:
         report_id: The eval report that was checked.
         suite_id: The eval suite that was evaluated.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     is_regression: bool
     worse_count: int

--- a/src/omnibase_infra/services/eval/eval_regression_check.py
+++ b/src/omnibase_infra/services/eval/eval_regression_check.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_REGRESSION_THRESHOLD = 0.30
 
 
-class EvalRegressionResult(BaseModel):
+class ModelEvalRegressionResult(BaseModel):
     """Result of an eval regression check.
 
     Attributes:
@@ -47,8 +47,8 @@ class EvalRegressionResult(BaseModel):
     total_tasks: int
     worse_ratio: float
     threshold: float
-    report_id: str
-    suite_id: str
+    report_id: str  # pattern-ok: opaque eval report identifier from external source
+    suite_id: str  # pattern-ok: opaque eval suite identifier from external source
 
     @property
     def summary(self) -> str:
@@ -69,7 +69,7 @@ class EvalRegressionResult(BaseModel):
 def check_eval_regression(
     report: ModelEvalReport,
     threshold: float = DEFAULT_REGRESSION_THRESHOLD,
-) -> EvalRegressionResult:
+) -> ModelEvalRegressionResult:
     """Check if the latest eval report shows a regression.
 
     Args:
@@ -78,7 +78,7 @@ def check_eval_regression(
             Must be in [0.0, 1.0].
 
     Returns:
-        EvalRegressionResult with the check outcome.
+        ModelEvalRegressionResult with the check outcome.
 
     Raises:
         ValueError: If threshold is outside [0.0, 1.0].
@@ -91,7 +91,7 @@ def check_eval_regression(
         logger.warning(
             "Empty eval report %s, skipping regression check", report.report_id
         )
-        return EvalRegressionResult(
+        return ModelEvalRegressionResult(
             is_regression=False,
             worse_count=0,
             total_tasks=0,
@@ -104,7 +104,7 @@ def check_eval_regression(
     worse_count = report.summary.onex_worse_count
     worse_ratio = worse_count / total
 
-    result = EvalRegressionResult(
+    result = ModelEvalRegressionResult(
         is_regression=worse_ratio > threshold,
         worse_count=worse_count,
         total_tasks=total,
@@ -124,6 +124,6 @@ def check_eval_regression(
 
 __all__: list[str] = [
     "DEFAULT_REGRESSION_THRESHOLD",
-    "EvalRegressionResult",
+    "ModelEvalRegressionResult",
     "check_eval_regression",
 ]

--- a/src/omnibase_infra/services/eval/metric_collector.py
+++ b/src/omnibase_infra/services/eval/metric_collector.py
@@ -15,14 +15,14 @@ Related:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class MetricEvent:
+class MetricEvent(BaseModel):
     """A single metric event captured from the Kafka bus.
 
     Attributes:
@@ -34,12 +34,14 @@ class MetricEvent:
         metadata: Additional event metadata.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     topic: str
     correlation_id: str
     timestamp: datetime
     metric_name: str
     metric_value: float
-    metadata: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str] = Field(default_factory=dict)
 
 
 class MetricCollector:
@@ -111,15 +113,7 @@ class MetricCollector:
         return sum(values) / len(values)
 
     def get_summary(self) -> dict[str, float | int | str]:
-        """Get a summary of all collected metrics.
-
-        Returns a dict with:
-            - correlation_id: The run's correlation ID
-            - event_count: Total events collected
-            - window_start: ISO timestamp of collection start
-            - window_end: ISO timestamp of collection end (or 'active')
-            - Per-metric averages as metric_name_avg keys
-        """
+        """Get a summary of all collected metrics."""
         summary: dict[str, float | int | str] = {
             "correlation_id": self._correlation_id,
             "event_count": len(self._events),

--- a/src/omnibase_infra/services/eval/metric_collector.py
+++ b/src/omnibase_infra/services/eval/metric_collector.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field
 logger = logging.getLogger(__name__)
 
 
-class MetricEvent(BaseModel):
+class ModelMetricEvent(BaseModel):
     """A single metric event captured from the Kafka bus.
 
     Attributes:
@@ -37,9 +37,9 @@ class MetricEvent(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     topic: str
-    correlation_id: str
+    correlation_id: str  # pattern-ok: eval run correlation token, not a UUID
     timestamp: datetime
-    metric_name: str
+    metric_name: str  # pattern-ok: metric label, not an entity name
     metric_value: float
     metadata: dict[str, str] = Field(default_factory=dict)
 
@@ -67,7 +67,7 @@ class MetricCollector:
         self._window_start = window_start or datetime.now(UTC)
         self._window_end: datetime | None = None
         self._topics = topics or []
-        self._events: list[MetricEvent] = []
+        self._events: list[ModelMetricEvent] = []
 
     @property
     def correlation_id(self) -> str:
@@ -81,7 +81,7 @@ class MetricCollector:
     def is_collecting(self) -> bool:
         return self._window_end is None
 
-    def record_event(self, event: MetricEvent) -> bool:
+    def record_event(self, event: ModelMetricEvent) -> bool:
         """Record a metric event if it matches the correlation ID, topic, and window.
 
         Returns True if the event was accepted, False if filtered out.
@@ -132,4 +132,4 @@ class MetricCollector:
         return summary
 
 
-__all__: list[str] = ["MetricCollector", "MetricEvent"]
+__all__: list[str] = ["MetricCollector", "ModelMetricEvent"]

--- a/src/omnibase_infra/services/observability/llm_cost_aggregation/consumer.py
+++ b/src/omnibase_infra/services/observability/llm_cost_aggregation/consumer.py
@@ -215,7 +215,7 @@ class EnumHealthStatus(StrEnum):
 # =============================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: service-internal health snapshot
 class HealthSnapshot:
     """Immutable snapshot of ConsumerMetrics fields needed for health checks.
 

--- a/src/omnibase_infra/services/observability/savings_estimation/consumer.py
+++ b/src/omnibase_infra/services/observability/savings_estimation/consumer.py
@@ -125,7 +125,7 @@ def _resolve_counterfactual(actual_model_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: service-internal event signal
 class InjectionSignal:
     """Raw injection signal accumulated from hook-context-injected events."""
 
@@ -133,7 +133,7 @@ class InjectionSignal:
     patterns_count: int = 0
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: service-internal event signal
 class LlmCallSignal:
     """Raw LLM call signal accumulated from llm-call-completed events."""
 
@@ -142,7 +142,7 @@ class LlmCallSignal:
     completion_tokens: int = 0
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: service-internal event signal
 class ValidatorCatchSignal:
     """Raw validator catch signal with severity for heuristic savings."""
 
@@ -150,7 +150,7 @@ class ValidatorCatchSignal:
     validator_type: str = ""
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: service-internal event signal
 class DispatchEvalSignal:
     """Raw dispatch evaluation signal for task-level savings projection."""
 
@@ -168,7 +168,7 @@ class DispatchEvalSignal:
     model_cloud_baseline: str | None = None
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: service-internal session accumulation buffer
 class SessionBuffer:
     """Accumulates signals for a single session."""
 

--- a/src/omnibase_infra/services/service_stale_registration_cleanup.py
+++ b/src/omnibase_infra/services/service_stale_registration_cleanup.py
@@ -47,7 +47,9 @@ from omnibase_infra.utils import sanitize_error_message
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: service-internal cleanup report
 class StaleCleanupReport:
     """Report from a stale registration cleanup run.
 

--- a/src/omnibase_infra/services/session_registry/model_graph_mutation.py
+++ b/src/omnibase_infra/services/session_registry/model_graph_mutation.py
@@ -7,13 +7,12 @@ Part of the Multi-Session Coordination Layer (OMN-6850, Task 9).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = ["ModelGraphMutation"]
 
 
-@dataclass(frozen=True)
-class ModelGraphMutation:
+class ModelGraphMutation(BaseModel):
     """A single Cypher MERGE mutation with parameters.
 
     Attributes:
@@ -21,5 +20,7 @@ class ModelGraphMutation:
         params: Parameter dict for the query.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     cypher: str
-    params: dict[str, str] = field(default_factory=dict)
+    params: dict[str, str] = Field(default_factory=dict)

--- a/src/omnibase_infra/topics/contract_topic_extractor.py
+++ b/src/omnibase_infra/topics/contract_topic_extractor.py
@@ -62,7 +62,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: topic-extractor-internal
 class ExtractedTopic:
     """A single topic extracted from a contract YAML.
 
@@ -79,7 +79,7 @@ class ExtractedTopic:
     contract_path: Path
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: topic-extractor-internal
 class NodeTopics:
     """All topics declared by a single node contract.
 
@@ -96,7 +96,7 @@ class NodeTopics:
     publish_topics: list[str] = field(default_factory=list)
 
 
-@dataclass
+@dataclass  # internal-dataclass-ok: topic-extractor-internal
 class TopicManifest:
     """Aggregate manifest of all topics across all scanned contracts.
 

--- a/src/omnibase_infra/topics/model_topic_spec.py
+++ b/src/omnibase_infra/topics/model_topic_spec.py
@@ -10,7 +10,7 @@ topics).
 Design Notes:
     ModelSnapshotTopicConfig cannot be reused here because its validator
     rejects non-compact cleanup policies. ModelTopicSpec is a lightweight
-    dataclass that supports any cleanup policy and optional config overrides.
+    model that supports any cleanup policy and optional config overrides.
 
 Related:
     - platform_topic_suffixes.py: Registry of all platform topic specs
@@ -23,8 +23,9 @@ Related:
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 from types import MappingProxyType
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Canonical defaults for platform topic creation.
 # These live here (not in service_topic_manager) to avoid a circular import:
@@ -34,8 +35,7 @@ DEFAULT_EVENT_TOPIC_PARTITIONS: int = 6
 DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR: int = 1
 
 
-@dataclass(frozen=True)
-class ModelTopicSpec:
+class ModelTopicSpec(BaseModel):
     """Per-topic creation spec: suffix + partitions + optional Kafka config overrides.
 
     Attributes:
@@ -46,18 +46,23 @@ class ModelTopicSpec:
         provisioning_priority: Lower values are provisioned first.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     suffix: str
     partitions: int = DEFAULT_EVENT_TOPIC_PARTITIONS
     replication_factor: int = DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR
-    kafka_config: Mapping[str, str] | None = field(default=None)
+    kafka_config: Mapping[str, str] | None = Field(default=None)
     provisioning_priority: int = 100
 
-    def __post_init__(self) -> None:
-        """Freeze mutable kafka_config dict passed at construction time."""
-        if isinstance(self.kafka_config, dict):
-            object.__setattr__(
-                self, "kafka_config", MappingProxyType(self.kafka_config)
-            )
+    @field_validator("kafka_config", mode="before")
+    @classmethod
+    def freeze_kafka_config(
+        cls, v: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Freeze mutable dict passed at construction time."""
+        if isinstance(v, dict):
+            return MappingProxyType(v)
+        return v
 
 
 __all__: list[str] = [

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -3448,7 +3448,88 @@ pattern_exemptions:
     documentation:
       - CLAUDE.md (File & Class Naming - Handler convention)
     ticket: OMN-11273
-# Architecture validator exemptions
+    # Architecture validator exemptions
+  # ==========================================================================
+  # ModelRuntimeLocalIngressRoute field name exemptions (OMN-12184)
+  # ==========================================================================
+  # Structural route descriptor fields: node_name, contract_name, package_name
+  # are protocol-level structural identifiers, not entity display names.
+  # Renaming them would cascade to 100+ call sites across the runtime.
+  - file_pattern: 'runtime_local_ingress\.py'
+    violation_pattern: "Field 'node_name' might reference an entity"
+    reason: >
+      Structural route descriptor field. node_name is a ONEX node identifier string (e.g. "node_registration_orchestrator"), not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  - file_pattern: 'runtime_local_ingress\.py'
+    violation_pattern: "Field 'contract_name' might reference an entity"
+    reason: >
+      Structural route descriptor field. contract_name is a contract file identifier string, not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  - file_pattern: 'runtime_local_ingress\.py'
+    violation_pattern: "Field 'package_name' might reference an entity"
+    reason: >
+      Structural route descriptor field. package_name is a Python package identifier string (e.g. "omnimarket"), not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  # ==========================================================================
+  # ModelPluginDiscoveryEntry field name exemption (OMN-12184)
+  # ==========================================================================
+  - file_pattern: 'model_plugin_discovery_entry\.py'
+    violation_pattern: "Field 'entry_point_name' might reference an entity"
+    reason: >
+      entry_point_name is a Python importlib.metadata entry-point label string, not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  # ==========================================================================
+  # ModelHandshakeCheckResult field name exemption (OMN-12184)
+  # ==========================================================================
+  - file_pattern: 'model_handshake_check_result\.py'
+    violation_pattern: "Field 'check_name' might reference an entity"
+    reason: >
+      check_name is a handshake validation check label string (e.g. "db_ownership"), not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  # ==========================================================================
+  # ModelHandshakeResult plugin_id exemption (OMN-12184)
+  # ==========================================================================
+  - file_pattern: 'model_handshake_result\.py'
+    violation_pattern: "Field 'plugin_id' should use UUID type instead of str"
+    reason: >
+      plugin_id is a human-readable plugin name string (e.g. "registration"), not a UUID. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  # ==========================================================================
+  # ModelEvalRegressionResult field exemptions (OMN-12184)
+  # ==========================================================================
+  - file_pattern: 'eval_regression_check\.py'
+    violation_pattern: "Field 'report_id' should use UUID type instead of str"
+    reason: >
+      report_id is an opaque eval report identifier sourced from external eval system, not a UUID. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  - file_pattern: 'eval_regression_check\.py'
+    violation_pattern: "Field 'suite_id' should use UUID type instead of str"
+    reason: >
+      suite_id is an opaque eval suite identifier sourced from external eval system, not a UUID. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  # ==========================================================================
+  # ModelMetricEvent field exemptions (OMN-12184)
+  # ==========================================================================
+  - file_pattern: 'metric_collector\.py'
+    violation_pattern: "Field 'correlation_id' should use UUID type instead of str"
+    reason: >
+      correlation_id is an eval run correlation token in string format passed from external callers, not a UUID. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
+  - file_pattern: 'metric_collector\.py'
+    violation_pattern: "Field 'metric_name' might reference an entity"
+    reason: >
+      metric_name is a metric label string (e.g. "latency_ms"), not an entity display name. Converted from @dataclass in OMN-12184.
+
+    ticket: OMN-12184
 # These handle one-model-per-file violations for domain-grouped protocols
 architecture_exemptions:
   # ==========================================================================

--- a/src/omnibase_infra/validation/validator_no_direct_adapter.py
+++ b/src/omnibase_infra/validation/validator_no_direct_adapter.py
@@ -37,7 +37,7 @@ _ALLOWED_IMPORT_PATTERNS: frozenset[str] = frozenset(
 _INTERNAL_ADAPTER_MODULE = "omnibase_infra.adapters._internal"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: validator-internal finding
 class AdapterViolation:
     """A single violation of the no-direct-adapter-usage rule.
 

--- a/src/omnibase_infra/validation/validator_security.py
+++ b/src/omnibase_infra/validation/validator_security.py
@@ -49,7 +49,9 @@ from omnibase_core.validation.validator_base import ValidatorBase
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: validator-internal compiled regex state
 class CompiledPatterns:
     """Pre-compiled regex patterns for security validation.
 
@@ -70,7 +72,9 @@ class CompiledPatterns:
     sensitive_params: frozenset[str] = field(default_factory=frozenset)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: validator-internal method context
 class MethodContext:
     """Context for method validation - groups related parameters."""
 

--- a/src/omnibase_infra/validators/handler_any_signature.py
+++ b/src/omnibase_infra/validators/handler_any_signature.py
@@ -41,7 +41,7 @@ _ALLOW_RE = re.compile(
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)  # internal-dataclass-ok: validator-internal finding
 class AnySignatureFinding:
     path: Path
     line: int

--- a/src/omnibase_infra/validators/llm_registry_validator.py
+++ b/src/omnibase_infra/validators/llm_registry_validator.py
@@ -63,7 +63,7 @@ REQUIRED_MODEL_FIELDS = (
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)  # internal-dataclass-ok: validator-internal finding
 class Finding:
     """A single registry violation."""
 

--- a/src/omnibase_infra/validators/llm_topology_validator.py
+++ b/src/omnibase_infra/validators/llm_topology_validator.py
@@ -58,7 +58,7 @@ RUNNING_REQUIRED_FIELDS = ("host", "port", "endpoint_url", "model_hf_id")
 PLANNED_NULL_FIELDS = ("host", "port", "endpoint_url", "model_hf_id")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)  # internal-dataclass-ok: validator-internal finding
 class Finding:
     """A single topology violation."""
 

--- a/src/omnibase_infra/validators/no_plugin_daemon_classes.py
+++ b/src/omnibase_infra/validators/no_plugin_daemon_classes.py
@@ -28,7 +28,7 @@ LIFECYCLE_TERMS = frozenset(
 COMPUTE_PLUGIN_BASE = "PluginComputeBase"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)  # internal-dataclass-ok: validator-internal finding
 class LifecycleClassFinding:
     """A banned Plugin* lifecycle class found in source."""
 

--- a/src/omnibase_infra/validators/type_ignore_budget.py
+++ b/src/omnibase_infra/validators/type_ignore_budget.py
@@ -54,7 +54,7 @@ _ALLOW_RE = re.compile(
 DEFAULT_BUDGET = 74
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)  # internal-dataclass-ok: validator-internal finding
 class TypeIgnoreFinding:
     path: Path
     line: int

--- a/src/omnibase_infra/verification/orchestrator.py
+++ b/src/omnibase_infra/verification/orchestrator.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 DbQueryFn = Callable[[str], list[dict[str, str]]]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # internal-dataclass-ok: verification-internal config
 class VerificationConfig:
     """Configuration for the verification orchestrator.
 

--- a/tests/integration/runtime/test_pattern_b_broker_omnimarket.py
+++ b/tests/integration/runtime/test_pattern_b_broker_omnimarket.py
@@ -18,7 +18,7 @@ from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums.generated import EnumOmnibaseInfraTopic
 from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
 
 pytestmark = pytest.mark.integration
@@ -32,11 +32,11 @@ from omnimarket.nodes.node_aislop_sweep.handlers.handler_aislop_sweep import (
 )
 
 
-def _route() -> RuntimeLocalIngressRoute:
+def _route() -> ModelRuntimeLocalIngressRoute:
     package = importlib.import_module("omnimarket")
     node_dir = Path(package.__file__).resolve().parent
     contract_path = node_dir / "nodes" / "node_aislop_sweep" / "contract.yaml"
-    return RuntimeLocalIngressRoute(
+    return ModelRuntimeLocalIngressRoute(
         node_name="node_aislop_sweep",
         contract_name="aislop_sweep",
         command_topic="onex.cmd.omnimarket.aislop-sweep-start.v1",

--- a/tests/integration/runtime/test_runtime_local_ingress.py
+++ b/tests/integration/runtime/test_runtime_local_ingress.py
@@ -18,7 +18,7 @@ from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
 )
 from omnibase_infra.runtime.runtime_host_process import RuntimeHostProcess
 from omnibase_infra.runtime.runtime_local_ingress import (
-    RuntimeLocalIngressRoute,
+    ModelRuntimeLocalIngressRoute,
     RuntimeLocalIngressServer,
 )
 from tests.helpers.runtime_helpers import make_runtime_config
@@ -40,7 +40,7 @@ async def test_unix_socket_request_dispatches_through_runtime_host(
     broker = AsyncMock()
     broker.dispatch_request = AsyncMock(
         return_value=(
-            RuntimeLocalIngressRoute(
+            ModelRuntimeLocalIngressRoute(
                 node_name="node_session_orchestrator",
                 contract_name="session_orchestrator",
                 command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
@@ -59,7 +59,7 @@ async def test_unix_socket_request_dispatches_through_runtime_host(
     )
     process._is_running = True
     process._local_ingress_routes = {
-        "session_orchestrator": RuntimeLocalIngressRoute(
+        "session_orchestrator": ModelRuntimeLocalIngressRoute(
             node_name="node_session_orchestrator",
             contract_name="session_orchestrator",
             command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -15,14 +15,14 @@ from omnibase_core.models.dispatch.model_dispatch_bus_command import (
     ModelDispatchBusCommand,
 )
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
 
 pytestmark = [pytest.mark.integration]
 
 
-def _route() -> RuntimeLocalIngressRoute:
-    return RuntimeLocalIngressRoute(
+def _route() -> ModelRuntimeLocalIngressRoute:
+    return ModelRuntimeLocalIngressRoute(
         node_name="node_delegate_skill_orchestrator",
         contract_name="delegate_skill.orchestrate",
         command_topic="onex.cmd.omnimarket.delegate-skill.v1",
@@ -100,7 +100,7 @@ class _KafkaLikeTransport:
     )
     _bootstrap_servers = "pattern-b-test-broker"
 
-    def __init__(self, route: RuntimeLocalIngressRoute) -> None:
+    def __init__(self, route: ModelRuntimeLocalIngressRoute) -> None:
         self._route = route
 
     def _build_auth_kwargs(self) -> dict[str, object]:

--- a/tests/unit/cli/test_service_demo_reset.py
+++ b/tests/unit/cli/test_service_demo_reset.py
@@ -185,11 +185,21 @@ class TestModelDemoResetReport:
         """Report counts actions by type correctly."""
         report = ModelDemoResetReport(
             actions=[
-                ModelResetActionResult("a", EnumResetAction.RESET, "done"),
-                ModelResetActionResult("b", EnumResetAction.RESET, "done"),
-                ModelResetActionResult("c", EnumResetAction.PRESERVED, "kept"),
-                ModelResetActionResult("d", EnumResetAction.SKIPPED, "na"),
-                ModelResetActionResult("e", EnumResetAction.ERROR, "fail"),
+                ModelResetActionResult(
+                    resource="a", action=EnumResetAction.RESET, detail="done"
+                ),
+                ModelResetActionResult(
+                    resource="b", action=EnumResetAction.RESET, detail="done"
+                ),
+                ModelResetActionResult(
+                    resource="c", action=EnumResetAction.PRESERVED, detail="kept"
+                ),
+                ModelResetActionResult(
+                    resource="d", action=EnumResetAction.SKIPPED, detail="na"
+                ),
+                ModelResetActionResult(
+                    resource="e", action=EnumResetAction.ERROR, detail="fail"
+                ),
             ]
         )
         assert report.reset_count == 2
@@ -214,9 +224,9 @@ class TestModelDemoResetReport:
         report = ModelDemoResetReport(
             actions=[
                 ModelResetActionResult(
-                    "Projector state",
-                    EnumResetAction.RESET,
-                    "Deleted 5 rows",
+                    resource="Projector state",
+                    action=EnumResetAction.RESET,
+                    detail="Deleted 5 rows",
                 ),
             ]
         )

--- a/tests/unit/models/runtime/test_model_plugin_discovery_report.py
+++ b/tests/unit/models/runtime/test_model_plugin_discovery_report.py
@@ -21,6 +21,7 @@ Tests cover:
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_infra.runtime.models.model_plugin_discovery_entry import (
     ModelPluginDiscoveryEntry,
@@ -127,7 +128,7 @@ class TestModelPluginDiscoveryEntryConstruction:
             status="accepted",
         )
 
-        with pytest.raises(AttributeError):
+        with pytest.raises((AttributeError, ValidationError)):
             entry.status = "import_error"  # type: ignore[misc]
 
 
@@ -197,7 +198,7 @@ class TestModelPluginDiscoveryReportConstruction:
             discovered_count=0,
         )
 
-        with pytest.raises(AttributeError):
+        with pytest.raises((AttributeError, ValidationError)):
             report.group = "new_group"  # type: ignore[misc]
 
 

--- a/tests/unit/models/test_model_serialization_roundtrip.py
+++ b/tests/unit/models/test_model_serialization_roundtrip.py
@@ -187,6 +187,8 @@ UNCOVERED_MODELS: dict[str, str] = {
     "ModelRuntimeAggregateHealth": "Round-trip covered in test_model_runtime_aggregate_health; extra='allow' complicates generic factory",
     "ModelDynamicMaterializationResult": "Covered by test_kafka_contract_source_materialization.py",
     "ModelLocalStateStoreEntry": "Internal entry model for ModelLocalStateStore; covered by test_node_invocation_adapter.py",
+    "ModelPluginDiscoveryEntry": "Converted from dataclass in OMN-12184; covered by test_model_plugin_discovery_report.py",
+    "ModelPluginDiscoveryReport": "Converted from dataclass in OMN-12184; covered by test_model_plugin_discovery_report.py",
 }
 
 

--- a/tests/unit/runtime/test_node_invocation_adapter.py
+++ b/tests/unit/runtime/test_node_invocation_adapter.py
@@ -375,7 +375,9 @@ async def test_auto_backend_selects_deployed_when_healthy(
     from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
         ModelDispatchBusTerminalResult,
     )
-    from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+    from omnibase_infra.runtime.runtime_local_ingress import (
+        ModelRuntimeLocalIngressRoute,
+    )
     from omnibase_infra.runtime.service_delegation_dispatch_port import (
         RuntimeDelegationDispatchPort,
     )
@@ -384,7 +386,7 @@ async def test_auto_backend_selects_deployed_when_healthy(
         async def health_check(self) -> dict[str, object]:
             return {"healthy": True}
 
-    fake_route = RuntimeLocalIngressRoute(
+    fake_route = ModelRuntimeLocalIngressRoute(
         node_name="test_node",
         contract_name="test_node",
         command_topic=_CMD_TOPIC,
@@ -401,7 +403,7 @@ async def test_auto_backend_selects_deployed_when_healthy(
 
         async def dispatch_request(
             self, command: object
-        ) -> tuple[RuntimeLocalIngressRoute, ModelDispatchBusTerminalResult]:
+        ) -> tuple[ModelRuntimeLocalIngressRoute, ModelDispatchBusTerminalResult]:
             return fake_route, ModelDispatchBusTerminalResult(
                 correlation_id=uuid4(),
                 status="completed",

--- a/tests/unit/runtime/test_runtime_local_ingress.py
+++ b/tests/unit/runtime/test_runtime_local_ingress.py
@@ -25,7 +25,7 @@ from omnibase_infra.runtime.models import (
 )
 from omnibase_infra.runtime.runtime_host_process import RuntimeHostProcess
 from omnibase_infra.runtime.runtime_local_ingress import (
-    RuntimeLocalIngressRoute,
+    ModelRuntimeLocalIngressRoute,
     RuntimeLocalIngressServer,
     discover_runtime_local_ingress_routes,
     parse_active_runtime_packages,
@@ -39,8 +39,8 @@ _SESSION_ORCHESTRATOR_CONTRACT_PATH = (
 )
 
 
-def _session_orchestrator_route() -> RuntimeLocalIngressRoute:
-    return RuntimeLocalIngressRoute(
+def _session_orchestrator_route() -> ModelRuntimeLocalIngressRoute:
+    return ModelRuntimeLocalIngressRoute(
         node_name="node_session_orchestrator",
         contract_name="session_orchestrator",
         command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
@@ -622,7 +622,7 @@ async def test_runtime_host_process_dispatch_local_ingress_preserves_request_tim
 async def test_runtime_host_process_dispatch_local_ingress_rejects_invalid_payload_before_broker() -> (
     None
 ):
-    route = RuntimeLocalIngressRoute(
+    route = ModelRuntimeLocalIngressRoute(
         node_name="node_session_orchestrator",
         contract_name="session_orchestrator",
         command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
@@ -660,7 +660,7 @@ async def test_runtime_host_process_dispatch_local_ingress_rejects_invalid_paylo
 async def test_runtime_host_process_dispatch_local_ingress_publishes_validated_payload() -> (
     None
 ):
-    route = RuntimeLocalIngressRoute(
+    route = ModelRuntimeLocalIngressRoute(
         node_name="node_session_orchestrator",
         contract_name="session_orchestrator",
         command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
@@ -800,7 +800,7 @@ async def test_runtime_host_process_dispatch_local_ingress_uses_handler_semaphor
 async def test_runtime_host_process_dispatch_local_ingress_request_times_out() -> None:
     async def _sleepy_dispatch(
         *_args: object, **_kwargs: object
-    ) -> tuple[RuntimeLocalIngressRoute, ModelDispatchBusTerminalResult]:
+    ) -> tuple[ModelRuntimeLocalIngressRoute, ModelDispatchBusTerminalResult]:
         await asyncio.sleep(0.05)
         return _session_orchestrator_route(), ModelDispatchBusTerminalResult(
             status="completed",

--- a/tests/unit/runtime/test_service_delegation_dispatch_port.py
+++ b/tests/unit/runtime/test_service_delegation_dispatch_port.py
@@ -15,7 +15,7 @@ from omnibase_core.models.dispatch.model_dispatch_bus_command import (
 from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
     ModelDispatchBusTerminalResult,
 )
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_delegation_dispatch_port import (
     RuntimeDelegationDispatchPort,
     _normalize_result_payload,
@@ -31,8 +31,8 @@ def _route(
     terminal_events: tuple[str, ...],
     command_topic: str | None = None,
     contract_name: str = "node_delegation_orchestrator",
-) -> RuntimeLocalIngressRoute:
-    return RuntimeLocalIngressRoute(
+) -> ModelRuntimeLocalIngressRoute:
+    return ModelRuntimeLocalIngressRoute(
         node_name=contract_name,
         contract_name=contract_name,
         command_topic=(
@@ -129,7 +129,7 @@ async def _dispatch_with_fake_broker(
     monkeypatch: pytest.MonkeyPatch,
     **dispatch_kwargs: object,
 ) -> tuple[
-    RuntimeLocalIngressRoute,
+    ModelRuntimeLocalIngressRoute,
     list[dict[str, object]],
     list[float],
     list[dict[str, object]],

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -23,14 +23,14 @@ from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
 from omnibase_infra.runtime.runtime_host_process import RuntimeHostProcess
-from omnibase_infra.runtime.runtime_local_ingress import RuntimeLocalIngressRoute
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
 
 pytestmark = pytest.mark.unit
 
 
-def _route() -> RuntimeLocalIngressRoute:
-    return RuntimeLocalIngressRoute(
+def _route() -> ModelRuntimeLocalIngressRoute:
+    return ModelRuntimeLocalIngressRoute(
         node_name="node_session_orchestrator",
         contract_name="session_orchestrator",
         command_topic="onex.cmd.omnimarket.session-orchestrator-start.v1",
@@ -41,9 +41,9 @@ def _route() -> RuntimeLocalIngressRoute:
     )
 
 
-def _route_with_failure_terminal() -> RuntimeLocalIngressRoute:
+def _route_with_failure_terminal() -> ModelRuntimeLocalIngressRoute:
     route = _route()
-    return RuntimeLocalIngressRoute(
+    return ModelRuntimeLocalIngressRoute(
         node_name=route.node_name,
         contract_name=route.contract_name,
         command_topic=route.command_topic,
@@ -58,9 +58,9 @@ def _route_with_failure_terminal() -> RuntimeLocalIngressRoute:
     )
 
 
-def _route_with_plural_only_terminal() -> RuntimeLocalIngressRoute:
+def _route_with_plural_only_terminal() -> ModelRuntimeLocalIngressRoute:
     route = _route()
-    return RuntimeLocalIngressRoute(
+    return ModelRuntimeLocalIngressRoute(
         node_name=route.node_name,
         contract_name=route.contract_name,
         command_topic=route.command_topic,
@@ -198,7 +198,7 @@ class _FakeKafkaTransport:
 
     def __init__(
         self,
-        route: RuntimeLocalIngressRoute,
+        route: ModelRuntimeLocalIngressRoute,
         consumers: list[_FakeAIOKafkaConsumer],
         *,
         terminal_topic: str | None = None,

--- a/tests/unit/services/eval/test_metric_collector.py
+++ b/tests/unit/services/eval/test_metric_collector.py
@@ -9,7 +9,10 @@ from datetime import UTC, datetime
 
 import pytest
 
-from omnibase_infra.services.eval.metric_collector import MetricCollector, MetricEvent
+from omnibase_infra.services.eval.metric_collector import (
+    MetricCollector,
+    ModelMetricEvent,
+)
 
 
 @pytest.fixture
@@ -25,8 +28,8 @@ def _make_event(
     metric_name: str = "latency_ms",
     metric_value: float = 100.0,
     timestamp: datetime | None = None,
-) -> MetricEvent:
-    return MetricEvent(
+) -> ModelMetricEvent:
+    return ModelMetricEvent(
         topic="onex.evt.test.v1",
         correlation_id=correlation_id,
         timestamp=timestamp or datetime(2026, 1, 1, 0, 30, tzinfo=UTC),


### PR DESCRIPTION
## Summary

- Converts 11 boundary models (crossing module boundaries) from `@dataclass` to Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True/False)` as appropriate
- Annotates 42 internal-only dataclasses with `# internal-dataclass-ok: <reason>` — these hold runtime infrastructure objects (asyncio.Task, Callable, AIOKafkaConsumer, type[BaseModel]), use `asdict()` for JSON serialization, or are strictly module-internal with no cross-module exposure
- Updates `RuntimeLocalIngressRoute.replace()` usages to `model_copy(update={})`
- Adds repo-local deploy-gate contract `contracts/OMN-12184.yaml`

## Converted boundary models
- `ModelInfisicalSecretResult`, `ModelInfisicalBatchResult` (adapter → infra boundary)
- `ModelResetActionResult`, `ModelDemoResetReport`, `ModelDemoResetConfig` (CLI layer)
- `ModelHandshakeCheckResult`, `ModelHandshakeResult` (runtime/plugin protocol — used across nodes + runtime)
- `ModelPluginDiscoveryEntry`, `ModelPluginDiscoveryReport` (runtime discovery)
- `ModelTopicSpec` (topics/infra — 122+ cross-module usages)
- `MetricEvent`, `EvalRegressionResult`, `ModelGraphMutation` (service layer)
- `RuntimeLocalIngressRoute` (runtime ↔ node boundary — used in runtime_host_process, node_invocation_adapter, service_pattern_b_broker)

## Not converted (annotated internal-dataclass-ok)
- `ModelDomainPluginConfig` — holds `ModelONEXContainer`, `InMemoryEventBus|KafkaEventBus`, `MessageDispatchEngine` (TYPE_CHECKING imports, circular-import risk)
- `ModelDomainPluginResult` — contains `Callable[[], Awaitable[None]]` unsubscribe callbacks
- `PreparedWiring`, `PreparedContractWiring` — dispatcher callables, runtime wiring state
- `RequestResponseInstanceState` — `asyncio.Task`, `asyncio.Future`, `AIOKafkaConsumer`
- `StrippedEntryPointDist`, `StripEntryPointReport` — script-internal, uses `dataclasses.asdict()` for JSON output
- 36 others — module-internal helpers, validator findings, diagnostics accumulators

## Evidence

Evidence-Ticket: OMN-12184
Evidence-Source: OCC#1688

## Test plan
- [x] All 736 targeted unit tests pass (`tests/unit/cli/`, `tests/unit/adapters/`, `tests/unit/runtime/`)
- [x] All imports verified clean
- [x] `uv run ruff format && ruff check --fix` passes with no errors
- [x] `uv run python scripts/validation/check_topic_literals.py --baseline scripts/validation/topic_literal_baseline.txt`
- [x] `uv run pytest tests/unit/cli/test_service_demo_reset.py -q`

OMN-12184