### PR TITLE
feat(OMN-8904): Wave B — machine-class overlay profiles and seed-infisical extension

### DIFF
--- a/config/infisical_projects.yaml
+++ b/config/infisical_projects.yaml
@@ -1,0 +1,59 @@
+# infisical_projects.yaml — Infisical project registry (OMN-8904 — Wave B)
+#
+# Authoritative list of Infisical project names and their purposes.
+# Project UUIDs are populated after the projects are created in the live
+# Infisical instance on 192.168.86.201:8880.
+#
+# To create the projects and fill in the IDs:
+#   1. Ensure Infisical is reachable: curl -fsS http://192.168.86.201:8880/api/status
+#   2. Run: uv run python scripts/seed-infisical.py --machine-class mac-dev --dry-run
+#      (lists what would be seeded; use --execute to actually seed)
+#   3. After creation, populate the project_id fields below with the UUIDs
+#      returned by `infisical projects list` or the Infisical API.
+#
+# version: 1.0 (OMN-8904)
+# Reload required: increment minor when adding projects, major on schema changes.
+version: "1.0"
+# Shared platform project — all secrets in /shared/<transport>/ live here.
+# This is the project referenced by INFISICAL_PROJECT_ID in bootstrap .env files
+# on all machine classes. It is the source of truth for platform-wide secrets.
+shared:
+  name: onex-platform
+  description: >
+    Shared platform secrets. All keys in shared_key_registry.yaml are seeded here under /shared/<transport>/. This project is the default for all services.
+
+  # project_id: FILL_IN_AFTER_INFISICAL_CREATION
+  # To retrieve: infisical projects list | grep onex-platform
+# Machine-class projects — machine-class-specific config overrides.
+# Secrets here are NOT the same as shared secrets. They contain addressing and
+# logging overrides that differ per machine class (see config/overlays/).
+machine_classes:
+  - name: mac-dev
+    description: >
+      Developer Macs (Mac Studio, MacBook). Host-side port addressing, debug logging, host-exposed Kafka/Postgres/Valkey ports. See config/overlays/mac-dev.yaml.
+
+    infisical_path_prefix: /machine-class/mac-dev/
+    overlay_file: config/overlays/mac-dev.yaml
+    # project_id: FILL_IN_AFTER_INFISICAL_CREATION
+  - name: linux-server
+    description: >
+      .201 Linux AI server. Docker-internal service DNS, container-side Kafka/Postgres/Valkey addresses. Ephemeral /run/omnibase/runtime.env written by `onex init`. See config/overlays/linux-server.yaml.
+
+    infisical_path_prefix: /machine-class/linux-server/
+    overlay_file: config/overlays/linux-server.yaml
+    # project_id: FILL_IN_AFTER_INFISICAL_CREATION
+  - name: cloud-k8s
+    description: >
+      Kubernetes cluster (onex-dev). k8s service DNS. Secrets injected via InfisicalSecret CRDs — no host-side bootstrap file. Reference implementation for target state. See config/overlays/cloud-k8s.yaml.
+
+    infisical_path_prefix: /machine-class/cloud-k8s/
+    overlay_file: config/overlays/cloud-k8s.yaml
+    # project_id: FILL_IN_AFTER_INFISICAL_CREATION
+
+# Note on project scoping:
+#   Shared secrets (/shared/<transport>/) are visible to ALL machine classes.
+#   Machine-class secrets (/machine-class/<class>/) are scoped to that class only.
+#   At runtime, config resolution priority is (highest to lowest):
+#     1. /services/<repo>/<transport>/ — per-service override
+#     2. /machine-class/<class>/       — machine-class override
+#     3. /shared/<transport>/          — platform-wide default

--- a/config/overlays/cloud-k8s.yaml
+++ b/config/overlays/cloud-k8s.yaml
@@ -1,0 +1,50 @@
+# cloud-k8s machine-class overlay profile (OMN-8904 — Wave B)
+#
+# Reference implementation for the Kubernetes / onex-dev cluster.
+# k8s is the reference implementation for the target state of the bootstrap plan —
+# it already uses the Infisical operator (`secrets.infisical.com/v1alpha1` CRDs)
+# with NO host-side .env file. This overlay documents the pattern.
+#
+# Unlike mac-dev and linux-server, this overlay is NOT applied by `onex init`.
+# Secrets are injected via InfisicalSecret CRDs (see k8s/infisical/ manifests).
+# The overlay exists here for:
+#   1. Documentation — shows the k8s address/port conventions for reference
+#   2. Infisical machine-class project structure — seed-infisical.py can seed
+#      machine-class-specific secrets to /machine-class/cloud-k8s/ so k8s
+#      InfisicalSecret CRDs can reference them
+#
+# Semantics: see config/overlays/mac-dev.yaml header for full field descriptions.
+#
+# Infisical project: "cloud-k8s" (see config/infisical_projects.yaml for project IDs)
+#
+# version: 1.0 (OMN-8904)
+version: "1.0"
+machine_class: cloud-k8s
+description: >
+  Kubernetes cluster (onex-dev). Secrets are injected by the Infisical operator via InfisicalSecret CRDs — no host-side bootstrap file required. This overlay documents the k8s service DNS conventions and serves as the seed target for the /machine-class/cloud-k8s/ Infisical path.
+
+infisical_path: /machine-class/cloud-k8s/
+overrides:
+  # Database — k8s service DNS (postgres service in the same namespace)
+  POSTGRES_HOST: "postgres.default.svc.cluster.local"
+  POSTGRES_PORT: "5432"
+  # Kafka — k8s service DNS for Redpanda
+  KAFKA_BOOTSTRAP_SERVERS: "redpanda.default.svc.cluster.local:9092"
+  # Valkey — k8s service DNS
+  VALKEY_HOST: "valkey.default.svc.cluster.local"
+  VALKEY_PORT: "6379"
+  # Qdrant — k8s service DNS
+  QDRANT_HOST: "qdrant.default.svc.cluster.local"
+  QDRANT_PORT: "6333"
+  # Logging — info level for cluster runtime
+  LOG_LEVEL: "INFO"
+  # Runtime health endpoints — k8s ingress / internal service
+  ONEX_RUNTIME_URL: "http://omninode-runtime.default.svc.cluster.local:8085"
+  ONEX_EFFECTS_URL: "http://runtime-effects.default.svc.cluster.local:8086"
+
+# k8s bootstrap pattern (reference):
+#   The Infisical operator reads INFISICAL_PROJECT_ID and credentials from a
+#   Kubernetes Secret (not a host .env file). InfisicalSecret CRDs are defined
+#   at k8s/infisical/onex-runtime-infisical-secret.yaml.
+#   No per-pod host-side env file is needed — this is the target state for all
+#   machine classes (Wave D for mac-dev and linux-server).

--- a/config/overlays/linux-server.yaml
+++ b/config/overlays/linux-server.yaml
@@ -1,0 +1,51 @@
+# linux-server machine-class overlay profile (OMN-8904 — Wave B)
+#
+# Applied by `onex init --profile linux-server` on the .201 Linux AI server (192.168.86.201).
+# Contains Docker-internal service DNS and container-side addressing for the production
+# infra runtime lane. Services communicate via Docker bridge network, not host-side ports.
+#
+# Semantics: see config/overlays/mac-dev.yaml header for full field descriptions.
+#
+# Infisical project: "linux-server" (see config/infisical_projects.yaml for project IDs)
+#
+# version: 1.0 (OMN-8904)
+version: "1.0"
+machine_class: linux-server
+description: >
+  .201 Linux AI server (Ubuntu, Docker). ONEX runtime containers communicate via Docker bridge network using internal service DNS. The host-side environment provides only bootstrap vars; all secrets are resolved from Infisical. Docker Compose reads from /run/omnibase/runtime.env (ephemeral file written by `onex init` at startup).
+
+infisical_path: /machine-class/linux-server/
+overrides:
+  # Database — Docker-internal service DNS (prod lane Postgres on port 5432)
+  POSTGRES_HOST: "postgres"
+  POSTGRES_PORT: "5432"
+  # Kafka — Docker-internal Redpanda broker (containers use the internal service name)
+  KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
+  # Valkey — Docker-internal
+  VALKEY_HOST: "valkey"
+  VALKEY_PORT: "6379"
+  # Qdrant — Docker-internal
+  QDRANT_HOST: "qdrant"
+  QDRANT_PORT: "6333"
+  # Logging — info level for server runtime
+  LOG_LEVEL: "INFO"
+  # Runtime health endpoints — prod lane
+  ONEX_RUNTIME_URL: "http://localhost:28085"
+  ONEX_EFFECTS_URL: "http://localhost:28086"
+
+# Config materialization note:
+#   `onex init --profile linux-server` writes a runtime compose env file to
+#   /run/omnibase/runtime.env (ephemeral tmpfs). Docker Compose references this
+#   via env_file: in the generated compose config. This is the only mechanism
+#   by which Infisical-sourced vars reach containers on .201 — shell-session env
+#   alone does not propagate to compose-launched containers (OMN-7350).
+#
+# bootstrap_only vars (always from ~/.omnibase/.env, not seeded into Infisical):
+#   POSTGRES_PASSWORD
+#   KAFKA_BOOTSTRAP_SERVERS  (also in overrides above for reference)
+#   INFISICAL_ADDR
+#   INFISICAL_CLIENT_ID
+#   INFISICAL_CLIENT_SECRET
+#   INFISICAL_PROJECT_ID
+#   INFISICAL_ENCRYPTION_KEY  (.201-only — Infisical server secret)
+#   INFISICAL_AUTH_SECRET     (.201-only — Infisical server secret)

--- a/config/overlays/mac-dev.yaml
+++ b/config/overlays/mac-dev.yaml
@@ -1,0 +1,51 @@
+# mac-dev machine-class overlay profile (OMN-8904 — Wave B)
+#
+# Applied by `onex init --profile mac-dev` on developer Macs (Mac Studio, MacBook).
+# Contains host-side service addresses for local development.
+#
+# Semantics:
+#   machine_class  — canonical identifier used as the Infisical /machine-class/<class>/ path prefix
+#   description    — human-readable description of the machine class
+#   infisical_path — Infisical path prefix where machine-class-specific secrets are stored
+#   overrides      — non-secret config values that differ from the platform-wide shared defaults
+#                    (e.g. host-side addresses vs Docker-internal service DNS)
+#
+# These are NOT secret values. Secrets (passwords, API keys) remain in Infisical /shared/<transport>/.
+# This overlay provides address/port/logging overrides so `onex init` can configure the shell session
+# correctly for the local machine class without requiring per-machine .env edits.
+#
+# Infisical project: "mac-dev" (see config/infisical_projects.yaml for project IDs)
+#
+# version: 1.0 (OMN-8904)
+version: "1.0"
+machine_class: mac-dev
+description: >
+  Developer Mac (Mac Studio M2 Ultra or MacBook). Services run as Docker containers on the local machine. Host-side addressing is used (localhost / 127.0.0.1). Debug logging enabled. Kafka bootstrap is the host-exposed port (not Docker-internal redpanda:9092).
+
+infisical_path: /machine-class/mac-dev/
+overrides:
+  # Database — host-side exposed port (5436 for dev lane, 5432 fallback if running standalone)
+  POSTGRES_HOST: "localhost"
+  POSTGRES_PORT: "5436"
+  # Kafka — host-side exposed port (19092 for dev lane; containers use redpanda:9092 internally)
+  KAFKA_BOOTSTRAP_SERVERS: "localhost:19092"
+  # Valkey — host-side exposed port (16379 for dev lane)
+  VALKEY_HOST: "localhost"
+  VALKEY_PORT: "16379"
+  # Qdrant — host-side
+  QDRANT_HOST: "localhost"
+  QDRANT_PORT: "6333"
+  # Logging — debug level for local development
+  LOG_LEVEL: "DEBUG"
+  # Runtime health endpoints — dev lane
+  ONEX_RUNTIME_URL: "http://localhost:8085"
+  ONEX_EFFECTS_URL: "http://localhost:8086"
+
+# bootstrap_only vars that must always come from ~/.omnibase/.env on this class
+# (never seeded into Infisical — circular bootstrap dep):
+#   POSTGRES_PASSWORD
+#   KAFKA_BOOTSTRAP_SERVERS  (also in overrides above for reference, but sourced from bootstrap file at init)
+#   INFISICAL_ADDR
+#   INFISICAL_CLIENT_ID
+#   INFISICAL_CLIENT_SECRET
+#   INFISICAL_PROJECT_ID

--- a/scripts/seed-infisical.py
+++ b/scripts/seed-infisical.py
@@ -14,6 +14,7 @@ with the expected keys. It is designed to be safe by default:
     - ``--overwrite-existing`` (default: false) -- overwrites existing values
     - ``--import-env FILE`` -- import values from a .env file
     - ``--export`` -- export current Infisical values to stdout
+    - ``--machine-class CLASS`` -- seed machine-class overlay (mac-dev, linux-server, cloud-k8s)
 
 Usage:
     # Dry run (default) -- show what would happen
@@ -32,6 +33,15 @@ Usage:
         --contracts-dir src/omnibase_infra/nodes \\
         --import-env .env \\
         --set-values \\
+        --execute
+
+    # Seed machine-class overlay (OMN-8904)
+    uv run python scripts/seed-infisical.py \\
+        --machine-class mac-dev \\
+        --dry-run
+
+    uv run python scripts/seed-infisical.py \\
+        --machine-class linux-server \\
         --execute
 
 Note:
@@ -491,6 +501,157 @@ def _do_export(*, reveal: bool = False) -> bool:
         adapter.shutdown()
 
 
+_MACHINE_CLASSES = ("mac-dev", "linux-server", "cloud-k8s")
+_CONFIG_DIR = _PROJECT_ROOT / "config"
+_OVERLAYS_DIR = _CONFIG_DIR / "overlays"
+
+
+def _load_machine_class_overlay(machine_class: str) -> dict[str, str]:
+    """Load the overlay YAML for a machine class and return its overrides dict.
+
+    Args:
+        machine_class: One of 'mac-dev', 'linux-server', 'cloud-k8s'.
+
+    Returns:
+        Dict mapping key name to value string from the overlay's ``overrides`` section.
+
+    Raises:
+        SystemExit: If the overlay file is missing or malformed.
+    """
+    try:
+        import yaml
+    except ImportError:
+        logger.exception(
+            "PyYAML is required for machine-class seeding: pip install pyyaml"
+        )
+        raise SystemExit(1) from None
+
+    overlay_path = _OVERLAYS_DIR / f"{machine_class}.yaml"
+    if not overlay_path.exists():
+        logger.error(
+            "Machine-class overlay not found: %s. Expected path: %s",
+            machine_class,
+            overlay_path,
+        )
+        raise SystemExit(1)
+
+    with overlay_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    if not isinstance(data, dict):
+        logger.error("Overlay file %s is not a valid YAML mapping", overlay_path)
+        raise SystemExit(1)
+
+    overrides = data.get("overrides")
+    if not isinstance(overrides, dict):
+        logger.error(
+            "Overlay file %s is missing or has invalid 'overrides' section",
+            overlay_path,
+        )
+        raise SystemExit(1)
+
+    return {str(k): str(v) for k, v in overrides.items()}
+
+
+def _seed_machine_class(
+    machine_class: str,
+    *,
+    create_missing: bool,
+    overwrite_existing: bool,
+    dry_run: bool,
+) -> int:
+    """Seed machine-class overlay values into Infisical.
+
+    Reads ``config/overlays/<machine-class>.yaml``, extracts the ``overrides``
+    section, and seeds each key under ``/machine-class/<class>/`` in Infisical.
+    Only non-secret config values (addresses, ports, log levels) should appear
+    in overlays — secrets belong in ``/shared/<transport>/``.
+
+    Args:
+        machine_class: Target class — 'mac-dev', 'linux-server', or 'cloud-k8s'.
+        create_missing: Create keys absent from Infisical.
+        overwrite_existing: Overwrite keys that already exist.
+        dry_run: If True, print diff without writing.
+
+    Returns:
+        Exit code: 0 on success, 1 on any error.
+    """
+    if machine_class not in _MACHINE_CLASSES:
+        logger.error(
+            "Unknown machine class '%s'. Valid classes: %s",
+            machine_class,
+            ", ".join(_MACHINE_CLASSES),
+        )
+        return 1
+
+    try:
+        overrides = _load_machine_class_overlay(machine_class)
+    except SystemExit:
+        return 1
+
+    infisical_folder = f"/machine-class/{machine_class}/"
+    requirements = [
+        {
+            "key": key,
+            "transport_type": "machine-class",
+            "folder": infisical_folder,
+            "source": f"overlays/{machine_class}.yaml",
+        }
+        for key in overrides
+    ]
+
+    logger.info(
+        "Machine-class overlay '%s': %d keys to seed at %s",
+        machine_class,
+        len(requirements),
+        infisical_folder,
+    )
+
+    _print_diff_summary(
+        requirements,
+        overrides,
+        create_missing=create_missing,
+        set_values=True,
+        overwrite_existing=overwrite_existing,
+    )
+
+    if dry_run:
+        logger.info("Dry run complete. Use --execute to write to Infisical.")
+        return 0
+
+    try:
+        created, updated, skipped, error_count = _do_seed(
+            requirements,
+            overrides,
+            create_missing=create_missing,
+            set_values=True,
+            overwrite_existing=overwrite_existing,
+        )
+    except Exception as exc:
+        try:
+            from omnibase_infra.utils.util_error_sanitization import (
+                sanitize_error_message,
+            )
+
+            _msg = sanitize_error_message(exc)
+        except ImportError:
+            _msg = type(exc).__name__
+        logger.exception("Machine-class seed failed with unhandled error: %s", _msg)
+        return 1
+
+    logger.info(
+        "Machine-class seed complete: %d created, %d updated, %d skipped, %d errors",
+        created,
+        updated,
+        skipped,
+        error_count,
+    )
+    if error_count > 0:
+        logger.error("%d secret(s) failed to process", error_count)
+        return 1
+    return 0
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -584,8 +745,28 @@ def main() -> int:
         default=False,
         help="Show actual secret values in --export output (use with caution)",
     )
+    parser.add_argument(
+        "--machine-class",
+        choices=list(_MACHINE_CLASSES),
+        default=None,
+        help=(
+            "Seed machine-class overlay values into Infisical (OMN-8904). "
+            "Reads config/overlays/<class>.yaml and seeds each override key "
+            "under /machine-class/<class>/ in Infisical. "
+            "Valid classes: " + ", ".join(_MACHINE_CLASSES)
+        ),
+    )
 
     args = parser.parse_args()
+
+    # Handle machine-class overlay seeding (OMN-8904 — Wave B)
+    if args.machine_class is not None:
+        return _seed_machine_class(
+            args.machine_class,
+            create_missing=args.create_missing_keys,
+            overwrite_existing=args.overwrite_existing,
+            dry_run=args.dry_run and not args.execute,
+        )
 
     # Handle export mode
     if args.export:

--- a/tests/unit/config/test_machine_class_overlays.py
+++ b/tests/unit/config/test_machine_class_overlays.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for machine-class overlay profiles (OMN-8904 — Wave B)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OVERLAYS_DIR = REPO_ROOT / "config" / "overlays"
+INFISICAL_PROJECTS = REPO_ROOT / "config" / "infisical_projects.yaml"
+SEED_SCRIPT = REPO_ROOT / "scripts" / "seed-infisical.py"
+
+pytestmark = pytest.mark.unit
+
+EXPECTED_MACHINE_CLASSES = ("mac-dev", "linux-server", "cloud-k8s")
+
+
+# ---------------------------------------------------------------------------
+# Overlay file existence and schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_file_exists(machine_class: str) -> None:
+    path = OVERLAYS_DIR / f"{machine_class}.yaml"
+    assert path.exists(), f"Missing overlay file: {path}"
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_file_valid_yaml(machine_class: str) -> None:
+    path = OVERLAYS_DIR / f"{machine_class}.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{machine_class}.yaml must be a YAML mapping"
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_has_required_fields(machine_class: str) -> None:
+    data = yaml.safe_load(
+        (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+    )
+    for field in ("version", "machine_class", "infisical_path", "overrides"):
+        assert field in data, f"{machine_class}.yaml missing required field: {field}"
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_machine_class_matches_filename(machine_class: str) -> None:
+    data = yaml.safe_load(
+        (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+    )
+    assert data["machine_class"] == machine_class
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_infisical_path_correct(machine_class: str) -> None:
+    data = yaml.safe_load(
+        (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+    )
+    assert data["infisical_path"] == f"/machine-class/{machine_class}/"
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_overrides_non_empty(machine_class: str) -> None:
+    data = yaml.safe_load(
+        (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+    )
+    assert isinstance(data["overrides"], dict) and len(data["overrides"]) > 0
+
+
+@pytest.mark.parametrize("machine_class", EXPECTED_MACHINE_CLASSES)
+def test_overlay_overrides_contain_expected_keys(machine_class: str) -> None:
+    """All overlays must declare: Postgres host, Kafka bootstrap, Valkey host."""
+    data = yaml.safe_load(
+        (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+    )
+    overrides = data["overrides"]
+    for key in ("POSTGRES_HOST", "KAFKA_BOOTSTRAP_SERVERS", "VALKEY_HOST"):
+        assert key in overrides, (
+            f"{machine_class}.yaml missing expected override key: {key}"
+        )
+
+
+def test_overlays_no_secrets() -> None:
+    """Overlay files must not contain secret values."""
+    secret_suffixes = ("_KEY", "_SECRET", "_TOKEN", "_PASSWORD")
+    for machine_class in EXPECTED_MACHINE_CLASSES:
+        data = yaml.safe_load(
+            (OVERLAYS_DIR / f"{machine_class}.yaml").read_text(encoding="utf-8")
+        )
+        overrides = data.get("overrides", {})
+        for key in overrides:
+            for suffix in secret_suffixes:
+                assert not key.upper().endswith(suffix), (
+                    f"{machine_class}.yaml contains likely-secret key '{key}' in overrides. "
+                    "Secrets belong in Infisical /shared/<transport>/, not in overlay files."
+                )
+
+
+# ---------------------------------------------------------------------------
+# infisical_projects.yaml schema
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_projects_file_exists() -> None:
+    assert INFISICAL_PROJECTS.exists(), f"Missing: {INFISICAL_PROJECTS}"
+
+
+def test_infisical_projects_valid_yaml() -> None:
+    data = yaml.safe_load(INFISICAL_PROJECTS.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+
+
+def test_infisical_projects_has_machine_classes() -> None:
+    data = yaml.safe_load(INFISICAL_PROJECTS.read_text(encoding="utf-8"))
+    assert "machine_classes" in data
+    names = {mc["name"] for mc in data["machine_classes"]}
+    for cls in EXPECTED_MACHINE_CLASSES:
+        assert cls in names, f"infisical_projects.yaml missing machine class: {cls}"
+
+
+def test_infisical_projects_overlay_files_exist() -> None:
+    data = yaml.safe_load(INFISICAL_PROJECTS.read_text(encoding="utf-8"))
+    for mc in data["machine_classes"]:
+        overlay_path = REPO_ROOT / mc["overlay_file"]
+        assert overlay_path.exists(), (
+            f"infisical_projects.yaml references non-existent overlay: {mc['overlay_file']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# seed-infisical.py --machine-class loading contract
+# ---------------------------------------------------------------------------
+
+
+def _load_seed_module() -> object:
+    """Import seed-infisical.py as a module."""
+    spec = importlib.util.spec_from_file_location("seed_infisical", str(SEED_SCRIPT))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+def test_load_machine_class_overlay_returns_overrides(tmp_path: Path) -> None:
+    """_load_machine_class_overlay parses an overlay YAML and returns the overrides dict."""
+    fake_overlay_dir = tmp_path / "overlays"
+    fake_overlay_dir.mkdir()
+    (fake_overlay_dir / "mac-dev.yaml").write_text(
+        "version: '1.0'\n"
+        "machine_class: mac-dev\n"
+        "infisical_path: /machine-class/mac-dev/\n"
+        "overrides:\n"
+        "  POSTGRES_HOST: localhost\n"
+        "  KAFKA_BOOTSTRAP_SERVERS: localhost:19092\n",
+        encoding="utf-8",
+    )
+
+    mod = _load_seed_module()
+    original = mod._OVERLAYS_DIR  # type: ignore[attr-defined]
+    mod._OVERLAYS_DIR = fake_overlay_dir  # type: ignore[attr-defined]
+    try:
+        result = mod._load_machine_class_overlay("mac-dev")  # type: ignore[attr-defined]
+    finally:
+        mod._OVERLAYS_DIR = original  # type: ignore[attr-defined]
+
+    assert result["POSTGRES_HOST"] == "localhost"
+    assert result["KAFKA_BOOTSTRAP_SERVERS"] == "localhost:19092"
+
+
+def test_seed_machine_class_dry_run_returns_zero(tmp_path: Path) -> None:
+    """_seed_machine_class dry_run=True returns 0 without touching Infisical."""
+    fake_overlay_dir = tmp_path / "overlays"
+    fake_overlay_dir.mkdir()
+    (fake_overlay_dir / "mac-dev.yaml").write_text(
+        "version: '1.0'\n"
+        "machine_class: mac-dev\n"
+        "infisical_path: /machine-class/mac-dev/\n"
+        "overrides:\n"
+        "  POSTGRES_HOST: localhost\n"
+        "  KAFKA_BOOTSTRAP_SERVERS: localhost:19092\n"
+        "  VALKEY_HOST: localhost\n",
+        encoding="utf-8",
+    )
+
+    mod = _load_seed_module()
+    original = mod._OVERLAYS_DIR  # type: ignore[attr-defined]
+    mod._OVERLAYS_DIR = fake_overlay_dir  # type: ignore[attr-defined]
+    try:
+        rc = mod._seed_machine_class(  # type: ignore[attr-defined]
+            "mac-dev",
+            create_missing=True,
+            overwrite_existing=False,
+            dry_run=True,
+        )
+    finally:
+        mod._OVERLAYS_DIR = original  # type: ignore[attr-defined]
+
+    assert rc == 0
+
+
+def test_seed_machine_class_unknown_class_returns_one(tmp_path: Path) -> None:
+    """_seed_machine_class returns 1 for an unknown machine class."""
+    mod = _load_seed_module()
+    rc = mod._seed_machine_class(  # type: ignore[attr-defined]
+        "nonexistent-class",
+        create_missing=True,
+        overwrite_existing=False,
+        dry_run=True,
+    )
+    assert rc == 1
+
+
+def test_seed_script_cli_machine_class_unknown_exits_nonzero() -> None:
+    """CLI rejects unknown --machine-class value at argparse level."""
+    result = subprocess.run(
+        [sys.executable, str(SEED_SCRIPT), "--machine-class", "bad-class"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## OMN-8904 — Wave B: Machine-Class Overlay Profiles

Part of epic OMN-8860 (Single-source env bootstrap). Wave A (OMN-8769) is Done. This implements Wave B: machine-class overlay profiles and the Infisical seed extension.

## Summary

- `config/overlays/mac-dev.yaml` — host-side port addressing for developer Macs (localhost:19092/5436/16379), debug logging
- `config/overlays/linux-server.yaml` — Docker-internal service DNS for .201 server (redpanda:9092, postgres:5432, valkey:6379)
- `config/overlays/cloud-k8s.yaml` — k8s service DNS reference implementation (cloud-k8s is already the target state via Infisical operator CRDs; documented as reference)
- `config/infisical_projects.yaml` — Infisical project registry scaffold with machine-class entries (project_id fields left as comments pending live Infisical connectivity at 192.168.86.201:8880)
- `scripts/seed-infisical.py` — adds `--machine-class <class>` flag that seeds overlay overrides to `/machine-class/<class>/` in Infisical; `_load_machine_class_overlay` + `_seed_machine_class` helpers

## Tests

30 unit tests covering: overlay schema validation, no-secrets invariant (overlay files must not contain keys ending in _KEY/_SECRET/_TOKEN/_PASSWORD), project registry consistency, and seed dry-run/unknown-class contract.

## dod_evidence

- 30 unit tests passing
- All pre-commit hooks pass
- `seed-infisical.py --machine-class mac-dev --dry-run` exits 0 without Infisical connectivity (dry-run path verified by tests)
- Live Infisical project creation (3 projects: mac-dev, linux-server, cloud-k8s) requires operator action when Infisical is accessible at 192.168.86.201:8880; blocked by infrastructure availability, not by code

Evidence-Source: 8c827c92c4b5ef4343a8e07cd07db8c1b24a32a1

Evidence-Ticket: OMN-8904