### PR TITLE
fix(OMN-12245): route projection envelope topics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.37.0"
+version = "0.37.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -729,6 +729,10 @@ def _extract_projection_topic(envelope: object) -> str:
         value = _materialized_dispatch_trace_value(envelope, "topic")
     else:
         value = getattr(envelope, "topic", None)
+        if not value:
+            event_type = getattr(envelope, "event_type", None)
+            if isinstance(event_type, str) and event_type.startswith("onex."):
+                value = event_type
     return str(value).strip() if value else ""
 
 

--- a/tests/integration/envelope_routing/test_projection_topic_extraction.py
+++ b/tests/integration/envelope_routing/test_projection_topic_extraction.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for projection route topic extraction."""
+
+from __future__ import annotations
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _extract_projection_topic
+
+
+def test_projection_topic_uses_onex_event_type_when_envelope_topic_is_absent() -> None:
+    envelope = ModelEventEnvelope[dict[str, str]](
+        event_type="onex.evt.omniclaude.task-delegated.v1",
+        payload={"correlation_id": "runtime-proof"},
+    )
+
+    assert _extract_projection_topic(envelope) == envelope.event_type

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -23,6 +23,7 @@ from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _derive_route_id,
     _derive_topic_pattern_from_topic,
     _detect_duplicate_topics,
+    _extract_projection_topic,
     _make_dispatch_callback,
     wire_from_manifest,
 )
@@ -137,6 +138,29 @@ class TestDeriveMessageCategory:
 
     def test_unknown_defaults_to_event(self) -> None:
         assert _derive_message_category("onex.unknown.platform.test.v1") == "event"
+
+
+class TestExtractProjectionTopic:
+    @pytest.mark.unit
+    def test_model_event_envelope_uses_event_type_topic(self) -> None:
+        envelope = ModelEventEnvelope[dict[str, str]](
+            payload={"correlation_id": "release-proof"},
+            event_type="onex.evt.omniclaude.task-delegated.v1",
+        )
+
+        assert (
+            _extract_projection_topic(envelope)
+            == "onex.evt.omniclaude.task-delegated.v1"
+        )
+
+    @pytest.mark.unit
+    def test_model_event_envelope_ignores_non_topic_event_type(self) -> None:
+        envelope = ModelEventEnvelope[dict[str, str]](
+            payload={"correlation_id": "release-proof"},
+            event_type="omnimarket.task-delegated",
+        )
+
+        assert _extract_projection_topic(envelope) == ""
 
 
 class TestDeriveIds:

--- a/uv.lock
+++ b/uv.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.37.0"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- route projection callbacks using ModelEventEnvelope.event_type when it carries the ONEX topic
- keep non-topic event_type aliases ignored for projection topic extraction
- bump omnibase_infra to 0.37.1 for the release hotfix
- add integration coverage for projection envelope topic extraction

## Verification
- uv run pytest tests/unit/runtime/auto_wiring/test_wiring.py tests/integration/envelope_routing/test_projection_topic_extraction.py -q
- uv run ruff format src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_wiring.py tests/integration/envelope_routing/test_projection_topic_extraction.py
- uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_wiring.py tests/integration/envelope_routing/test_projection_topic_extraction.py

Evidence-Ticket: OMN-12245
Evidence-Source: OCC#1779
hotfix-evidence: OCC-1779
backmerge: #1773