### PR TITLE
fix(OMN-12245): register full onex dispatch topics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.37.1"
+version = "0.37.2"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1460,6 +1460,45 @@ def _message_type_keys_from_topic(topic: str) -> tuple[str, ...]:
     return tuple(dict.fromkeys(keys))
 
 
+def _topics_for_handler_entry(
+    contract: ModelDiscoveredContract,
+    entry: ModelHandlerRoutingEntry,
+) -> tuple[str, ...]:
+    """Return subscribe topics that can be deterministically assigned to entry."""
+    if contract.event_bus is None:
+        return ()
+
+    topics = contract.event_bus.subscribe_topics
+    event_type_alias = entry.event_type.strip() if entry.event_type else ""
+    if event_type_alias:
+        matched = tuple(
+            topic
+            for topic in topics
+            if topic == event_type_alias
+            or _derive_event_type_alias_from_topic(topic) == event_type_alias
+        )
+        return matched
+
+    if entry.event_model is None:
+        return topics
+
+    if len(topics) == 1:
+        return topics
+
+    return ()
+
+
+def _message_type_keys_for_handler_entry(
+    contract: ModelDiscoveredContract,
+    entry: ModelHandlerRoutingEntry,
+) -> tuple[str, ...]:
+    """Return topic-derived dispatcher keys scoped to one handler entry."""
+    keys: list[str] = []
+    for topic in _topics_for_handler_entry(contract, entry):
+        keys.extend(_message_type_keys_from_topic(topic))
+    return tuple(dict.fromkeys(keys))
+
+
 def _strict_dispatcher_coverage_enabled() -> bool:
     """Return True when strict orchestrator dispatcher coverage is enabled."""
     return os.environ.get(_STRICT_DISPATCHER_COVERAGE_ENV, "").lower() in (
@@ -2384,14 +2423,9 @@ def _prepare_handler_wiring(
     event_type_alias = entry.event_type.strip() if entry.event_type else ""
     if event_type_alias:
         message_types = (message_types or set()) | {event_type_alias}
-    if contract.event_bus:
-        topic_message_types = {
-            message_type
-            for topic in contract.event_bus.subscribe_topics
-            for message_type in _message_type_keys_from_topic(topic)
-        }
-        if topic_message_types:
-            message_types = (message_types or set()).union(topic_message_types)
+    topic_message_types = set(_message_type_keys_for_handler_entry(contract, entry))
+    if topic_message_types:
+        message_types = (message_types or set()).union(topic_message_types)
 
     handler_cls = _import_handler_class(handler_ref.module, handler_ref.name)
 
@@ -2551,7 +2585,7 @@ def _prepare_handler_wiring(
     route_ids: list[str] = []
     routes: list[ModelDispatchRoute] = []
     if contract.event_bus:
-        for topic in contract.event_bus.subscribe_topics:
+        for topic in _topics_for_handler_entry(contract, entry):
             route_id = _derive_route_id(contract.name, handler_key, topic)
             topic_pattern = _derive_topic_pattern_from_topic(topic)
 

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1449,6 +1449,17 @@ def _derive_event_type_alias_from_topic(topic: str) -> str | None:
     return None
 
 
+def _message_type_keys_from_topic(topic: str) -> tuple[str, ...]:
+    """Return dispatch message-type keys accepted for a contract topic."""
+    keys: list[str] = []
+    alias = _derive_event_type_alias_from_topic(topic)
+    if alias is not None:
+        keys.append(alias)
+    if topic.startswith("onex."):
+        keys.append(topic)
+    return tuple(dict.fromkeys(keys))
+
+
 def _strict_dispatcher_coverage_enabled() -> bool:
     """Return True when strict orchestrator dispatcher coverage is enabled."""
     return os.environ.get(_STRICT_DISPATCHER_COVERAGE_ENV, "").lower() in (
@@ -2373,14 +2384,14 @@ def _prepare_handler_wiring(
     event_type_alias = entry.event_type.strip() if entry.event_type else ""
     if event_type_alias:
         message_types = (message_types or set()) | {event_type_alias}
-    elif contract.event_bus:
-        topic_aliases = {
-            alias
+    if contract.event_bus:
+        topic_message_types = {
+            message_type
             for topic in contract.event_bus.subscribe_topics
-            if (alias := _derive_event_type_alias_from_topic(topic)) is not None
+            for message_type in _message_type_keys_from_topic(topic)
         }
-        if topic_aliases:
-            message_types = (message_types or set()).union(topic_aliases)
+        if topic_message_types:
+            message_types = (message_types or set()).union(topic_message_types)
 
     handler_cls = _import_handler_class(handler_ref.module, handler_ref.name)
 

--- a/tests/integration/test_handler_event_type_alias_integration.py
+++ b/tests/integration/test_handler_event_type_alias_integration.py
@@ -106,7 +106,11 @@ def test_registration_emits_alias_matching_dispatch_engine_normalization() -> No
             container=None,
         )
 
-    assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}, (
+    assert prepared.message_types == {
+        "ModelFooCommand",
+        "platform.foo-start",
+        "onex.cmd.platform.foo-start.v1",
+    }, (
         "Registration must emit the stripped alias so the dispatch engine's "
         ".strip()-normalized wire event_type matches. Drift here reintroduces "
         "the OMN-9215 DLQ-everything bug."
@@ -163,4 +167,8 @@ def test_alias_absent_falls_back_to_class_name_and_topic_derived_alias() -> None
             container=None,
         )
 
-    assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+    assert prepared.message_types == {
+        "ModelFooCommand",
+        "platform.foo-start",
+        "onex.cmd.platform.foo-start.v1",
+    }

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -51,6 +51,7 @@ def _make_contract_with_event_type_alias(
     event_type_alias: str | None,
     message_category: str | None = None,
     node_name: str = "node_local",
+    subscribe_topic: str = "onex.cmd.platform.foo-start.v1",
 ) -> ModelDiscoveredContract:
     event_model = ModelHandlerRef(name=event_model_name, module="fake.models")
     entry_kwargs: dict[str, object] = {
@@ -71,7 +72,7 @@ def _make_contract_with_event_type_alias(
         entry_point_name=node_name,
         package_name="test-pkg",
         event_bus=ModelEventBusWiring(
-            subscribe_topics=("onex.cmd.platform.foo-start.v1",),
+            subscribe_topics=(subscribe_topic,),
             publish_topics=(),
         ),
         handler_routing=ModelHandlerRouting(
@@ -142,7 +143,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_types_strips_whitespace_from_event_type_alias(self) -> None:
@@ -177,7 +182,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_types_omits_alias_when_only_whitespace(self) -> None:
@@ -213,7 +222,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_category_overrides_contract_first_topic_category(self) -> None:
@@ -268,6 +281,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
             event_type_alias="platform.node-heartbeat",
             message_category="EVENT",
             node_name="node_registration_orchestrator",
+            subscribe_topic="onex.evt.platform.node-heartbeat.v1",
         )
         entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
         handler_cls = _make_zero_arg_handler_cls()
@@ -295,6 +309,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {
             "ModelNodeHeartbeatEvent",
             "platform.node-heartbeat",
+            "onex.evt.platform.node-heartbeat.v1",
         }
         assert (
             prepared.resolution_outcome
@@ -335,7 +350,53 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
+
+    @pytest.mark.unit
+    def test_message_types_include_full_onex_topic_for_canonical_envelopes(
+        self,
+    ) -> None:
+        """Canonical envelopes preserve the full topic in ``event_type``.
+
+        Projection consumers receive ``ModelEventEnvelope.event_type`` as
+        ``onex.evt.<producer>.<event>.v1`` when publishers emit canonical
+        envelopes. Dispatcher registration must include that exact wire key in
+        addition to the older dot-path alias.
+        """
+        contract = _make_contract_with_event_type_alias(
+            event_model_name="ModelTaskDelegatedEvent",
+            event_type_alias=None,
+            subscribe_topic="onex.evt.omniclaude.task-delegated.v1",
+        )
+        entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
+        handler_cls = _make_zero_arg_handler_cls()
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=handler_cls,
+        ):
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+
+        assert prepared.message_types == {
+            "ModelTaskDelegatedEvent",
+            "omniclaude.task-delegated",
+            "onex.evt.omniclaude.task-delegated.v1",
+        }
 
 
 class TestContractDiscoveryParsesEventType:

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -398,6 +398,81 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
             "onex.evt.omniclaude.task-delegated.v1",
         }
 
+    @pytest.mark.unit
+    def test_topic_derived_keys_are_scoped_to_matching_handler_entry(self) -> None:
+        """Multi-handler contracts must not register every handler for every topic."""
+        heartbeat_entry = ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name="HandlerNodeHeartbeat", module="fake.module"),
+            event_model=ModelHandlerRef(
+                name="ModelNodeHeartbeatEvent",
+                module="fake.models",
+            ),
+            event_type="platform.node-heartbeat",
+        )
+        introspection_entry = ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(
+                name="HandlerNodeIntrospected",
+                module="fake.module",
+            ),
+            event_model=ModelHandlerRef(
+                name="ModelNodeIntrospectionEvent",
+                module="fake.models",
+            ),
+            event_type="platform.node-introspection",
+        )
+        contract = ModelDiscoveredContract(
+            name="node_registration_orchestrator",
+            node_type="ORCHESTRATOR_GENERIC",
+            contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+            contract_path=Path("/fake/contract.yaml"),
+            entry_point_name="node_registration_orchestrator",
+            package_name="test-pkg",
+            event_bus=ModelEventBusWiring(
+                subscribe_topics=(
+                    "onex.evt.platform.node-introspection.v1",
+                    "onex.evt.platform.node-heartbeat.v1",
+                ),
+                publish_topics=(),
+            ),
+            handler_routing=ModelHandlerRouting(
+                routing_strategy="payload_type_match",
+                handlers=(introspection_entry, heartbeat_entry),
+            ),
+        )
+        handler_cls = _make_zero_arg_handler_cls()
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=handler_cls,
+        ):
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=heartbeat_entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+
+        assert prepared.message_types == {
+            "ModelNodeHeartbeatEvent",
+            "platform.node-heartbeat",
+            "onex.evt.platform.node-heartbeat.v1",
+        }
+        assert "platform.node-introspection" not in prepared.message_types
+        assert "onex.evt.platform.node-introspection.v1" not in prepared.message_types
+        assert prepared.route_ids == [
+            (
+                "route.auto.node_registration_orchestrator."
+                "HandlerNodeHeartbeat.onex_evt_platform_node_heartbeat_v1"
+            )
+        ]
+
 
 class TestContractDiscoveryParsesEventType:
     """End-to-end check: YAML `event_type:` survives parsing onto the model."""

--- a/uv.lock
+++ b/uv.lock
@@ -2159,7 +2159,7 @@ dependencies = [
 [[package]]
 name = "onex-change-control"
 version = "0.5.0"
-source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main#ad054ca0bdeb7c9c7031755e5e4ec5333d7c863f" }
+source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main#308a4d09c88b9a328ae5ec24042c336604fe8d0c" }
 dependencies = [
     { name = "colorama" },
     { name = "omnibase-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.37.1"
+version = "0.37.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- register full `onex.*.v1` subscribe topics as dispatch `message_types` alongside dot-path aliases
- preserve existing class-name and alias routing while accepting canonical `ModelEventEnvelope.event_type` values
- bump `omnibase-infra` to `0.37.2` for the follow-up runtime hotfix release

## Verification
- `uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/integration/test_handler_event_type_alias_integration.py tests/unit/runtime/auto_wiring/test_wiring.py tests/integration/envelope_routing/test_projection_topic_extraction.py tests/integration/projectors/test_handler_wiring_projection_dispatch.py -q` -> 58 passed
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/integration/test_handler_event_type_alias_integration.py` -> passed
- `git diff --check` -> clean

## Runtime Evidence
Stability `.201` on `0.37.1` proved package identity and tier escalation code, then exposed the remaining dispatcher miss: canonical publish to `onex.evt.omniclaude.task-delegated.v1` with `ModelEventEnvelope.event_type` set to the full topic went to DLQ because auto-wiring only registered `omniclaude.task-delegated`.

This PR adds the missing full-topic key and a regression for that exact `task-delegated` envelope case. Post-merge, the manual sweep will rebuild/redeploy `.201` and rerun the projection DB proof.


Evidence-Ticket: OMN-12245
Evidence-Source: OCC#1785
hotfix-evidence: OCC-1785
backmerge: #1774

