### PR TITLE
fix(OMN-6664): clean up non-standard noqa suppressions in omnibase_infra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ line-ending = "auto"
 # Matches omnibase_core settings for consistency across ONEX ecosystem
 select = ["E", "F", "W", "C90", "I", "N", "UP", "YTT", "S", "BLE", "FBT", "B", "A", "COM", "C4", "DTZ", "T10", "EM", "EXE", "ISC", "ICN", "G", "INP", "PIE", "T20", "PT", "Q", "RSE", "RET", "SLF", "SIM", "TID", "TCH", "ARG", "PTH", "ERA", "PD", "PGH", "PL", "TRY", "NPY", "RUF"]
 # Custom pre-commit hook codes — registered so ruff doesn't warn about unknown noqa directives
-external = ["model-dump-bare", "ONEX-PATTERN-PARAMS", "arch-topic-naming"]
+external = ["model-dump-bare", "ONEX-PATTERN-PARAMS", "arch-topic-naming", "onex-pattern-validation", "topic-naming-lint"]
 ignore = [
     # UP007 (Union[X, Y] -> X | Y) is NOT ignored — PEP 604 syntax enforced
     "S101",      # Allow assert statements in tests

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/persistence/remote_task_state_repository.py
@@ -241,8 +241,8 @@ class RemoteTaskStateRepository(MixinPostgresOpExecutor):
         self,
         task_id: UUID,
         *,
-        correlation_id: "UUID | None" = None,  # noqa: UP037
-    ) -> "list[dict[str, ModelSchemaValue]] | None":  # noqa: UP037
+        correlation_id: UUID | None = None,
+    ) -> list[dict[str, ModelSchemaValue]] | None:
         row = await self._run_checked(
             correlation_id=correlation_id or uuid4(),
             op_name="get_last_emitted_artifact_payload",
@@ -261,7 +261,7 @@ class RemoteTaskStateRepository(MixinPostgresOpExecutor):
         task_id: UUID,
         payload: list[dict[str, ModelSchemaValue]],
         *,
-        correlation_id: "UUID | None" = None,  # noqa: UP037
+        correlation_id: UUID | None = None,
     ) -> None:
         op_correlation_id = correlation_id or uuid4()
 

--- a/src/omnibase_infra/services/cost_api/snapshot_cache.py
+++ b/src/omnibase_infra/services/cost_api/snapshot_cache.py
@@ -10,9 +10,9 @@ from typing import Final
 
 SnapshotPayload = Mapping[str, object]
 
-TOPIC_COST_SUMMARY: Final[str] = "onex.snapshot.projection.cost.summary.v1"  # noqa: RUF100  # noqa: topic-naming-lint
-TOPIC_COST_BY_REPO: Final[str] = "onex.snapshot.projection.cost.by_repo.v1"  # noqa: RUF100  # noqa: topic-naming-lint
-TOPIC_COST_TOKEN_USAGE: Final[str] = "onex.snapshot.projection.cost.token_usage.v1"  # noqa: RUF100  # noqa: topic-naming-lint
+TOPIC_COST_SUMMARY: Final[str] = "onex.snapshot.projection.cost.summary.v1"  # noqa: topic-naming-lint
+TOPIC_COST_BY_REPO: Final[str] = "onex.snapshot.projection.cost.by_repo.v1"  # noqa: topic-naming-lint
+TOPIC_COST_TOKEN_USAGE: Final[str] = "onex.snapshot.projection.cost.token_usage.v1"  # noqa: topic-naming-lint
 
 _LATEST: dict[tuple[str, str], dict[str, object]] = {}
 

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_handle_async_dispatch.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_handle_async_dispatch.py
@@ -85,6 +85,7 @@ class _HandlerWithoutHandle:
     def execute(self, payload: object) -> object:
         return {"from": "execute"}
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Registers `onex-pattern-validation` and `topic-naming-lint` as ruff `external` codes so they do not trigger `RUF100` unused-noqa findings
- Removes redundant quoted annotations in `remote_task_state_repository.py`
- Normalizes malformed double-noqa lines in `cost_api/snapshot_cache.py`
- Rebases the branch onto current `dev` and applies the ruff formatting delta from the PR merge ref

## Verification

- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/omnibase_infra`
- [x] `uv run python -m pytest tests/unit/runtime/auto_wiring/test_handler_wiring_handle_async_dispatch.py -q`

Evidence-Source: OCC#1805
Evidence-Ticket: OMN-6664