### PR TITLE
fix(OMN-12424): force fresh git wheel for moving-ref ONEX deps in Dockerfile.runtime

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -235,13 +235,24 @@ COPY scripts/runtime_build/compute_workspace_provenance.py /workspace/compute_wo
 # branch ever runs; the other branch's install artifacts never enter the image.
 ARG OMNIBASE_COMPAT_REF="c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1"
 ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1.tar.gz"
-# OMN-10728: ONEX_CHANGE_CONTROL_REF must be the full commit SHA so that the
-# install URL itself changes when main advances — this busts the uv cache mount
-# (keyed on URL, not on resolved HEAD) and forces a fresh fetch.
+# onex_change_control tracks the moving `main` branch (default).
 ARG ONEX_CHANGE_CONTROL_REF=main
 # OMN-12195: default branch is dev, not main — use dev to avoid stale SHA from
 # Docker's git cache resolving @main to an older commit.
 ARG OMNIMARKET_REF=dev
+#
+# OMN-12424: uv keys its git source cache on the *resolved commit* for a moving
+# ref (`@dev` / `@main`), so a plain rebuild — even `docker build --no-cache`,
+# which busts Docker layer cache but NOT the `type=cache` BuildKit mount below —
+# can reinstall a stale wheel from a previous commit of dev/main. (OMN-10728's
+# SHA-pin theory was wrong: the install URL `@dev` does not change when dev
+# advances, so the cache is never invalidated.) Pinning to a fixed SHA would fix
+# staleness but defeats the whole point of tracking the moving branch, so each
+# release-mode git install passes `--refresh-package <name>`: uv re-resolves and
+# re-fetches *only* that package's git source on every build while reusing the
+# cache for all other packages. The result: every rebuild always installs the
+# current HEAD of the tracked branch. omnibase_compat is a SHA-pinned immutable
+# tarball, so it needs no refresh.
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     set -eu; \
@@ -258,9 +269,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     else \
         uv pip install --no-deps \
             "https://github.com/OmniNode-ai/omnibase_compat/archive/${OMNIBASE_COMPAT_REF}.tar.gz"; \
-        uv pip install --no-deps \
+        uv pip install --no-deps --refresh-package onex-change-control \
             "git+https://github.com/OmniNode-ai/onex_change_control.git@${ONEX_CHANGE_CONTROL_REF}#egg=onex-change-control"; \
-        uv pip install --no-deps \
+        uv pip install --no-deps --refresh-package omnimarket \
             "git+https://github.com/OmniNode-ai/omnimarket.git@${OMNIMARKET_REF}#egg=omnimarket"; \
     fi
 

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -242,8 +242,8 @@ ARG ONEX_CHANGE_CONTROL_REF=main
 ARG OMNIMARKET_REF=dev
 #
 # OMN-12424: uv keys its git source cache on the *resolved commit* for a moving
-# ref (`@dev` / `@main`), so a plain rebuild — even `docker build --no-cache`,
-# which busts Docker layer cache but NOT the `type=cache` BuildKit mount below —
+# ref (`@dev` / `@main`), so a plain rebuild - even `docker build --no-cache`,
+# which busts Docker layer cache but NOT the `type=cache` BuildKit mount below -
 # can reinstall a stale wheel from a previous commit of dev/main. (OMN-10728's
 # SHA-pin theory was wrong: the install URL `@dev` does not change when dev
 # advances, so the cache is never invalidated.) Pinning to a fixed SHA would fix

--- a/tests/scripts/test_dockerfile_runtime_git_refresh.py
+++ b/tests/scripts/test_dockerfile_runtime_git_refresh.py
@@ -47,6 +47,7 @@ def dockerfile_text() -> str:
     return re.sub(r"\\\n\s*", " ", raw)
 
 
+@pytest.mark.unit
 def test_dockerfile_runtime_exists() -> None:
     assert _DOCKERFILE.is_file()
 
@@ -55,6 +56,7 @@ def test_dockerfile_runtime_exists() -> None:
     ("repo_slug", "refresh_name"),
     sorted(_MOVING_REF_GIT_PACKAGES.items()),
 )
+@pytest.mark.unit
 def test_moving_ref_git_install_uses_refresh_package(
     dockerfile_text: str, repo_slug: str, refresh_name: str
 ) -> None:
@@ -76,6 +78,7 @@ def test_moving_ref_git_install_uses_refresh_package(
     )
 
 
+@pytest.mark.unit
 def test_no_moving_ref_git_install_without_refresh(dockerfile_text: str) -> None:
     """No release-mode git+ install of a tracked moving-ref package may omit refresh.
 

--- a/tests/scripts/test_dockerfile_runtime_git_refresh.py
+++ b/tests/scripts/test_dockerfile_runtime_git_refresh.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression test for OMN-12424.
+
+`Dockerfile.runtime` installs the cross-repo ONEX packages onex_change_control
+and omnimarket from *moving* git refs (`@main` / `@dev`) under a persistent
+BuildKit uv cache mount (`--mount=type=cache,target=/root/.cache/uv`).
+
+uv keys its git source cache on the resolved commit for the URL, and the URL
+itself does not change when the moving branch advances. Therefore a rebuild —
+even `docker build --no-cache`, which busts Docker layer cache but not the
+BuildKit cache mount — can reinstall a stale wheel from a previous commit of
+dev/main. This silently shipped pre-#988 omnimarket code during the OMN-12420
+redeploy.
+
+The fix: every release-mode git install of a moving-ref ONEX package must pass
+`--refresh-package <name>` so uv re-fetches that package's git source on every
+build. This test pins that invariant so the fix cannot regress.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "docker" / "Dockerfile.runtime"
+
+# Moving-ref git-sourced ONEX packages installed in release mode, mapped to the
+# `--refresh-package` name uv expects (the distribution name, hyphenated).
+# omnibase_compat is intentionally excluded: it is installed from a SHA-pinned,
+# immutable archive tarball and therefore needs no refresh.
+_MOVING_REF_GIT_PACKAGES: dict[str, str] = {
+    "onex_change_control": "onex-change-control",
+    "omnimarket": "omnimarket",
+}
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    assert _DOCKERFILE.is_file(), f"missing {_DOCKERFILE}"
+    raw = _DOCKERFILE.read_text(encoding="utf-8")
+    # Collapse shell line continuations so a single `uv pip install` statement
+    # that spans `\`-continued physical lines is matchable on one logical line.
+    return re.sub(r"\\\n\s*", " ", raw)
+
+
+def test_dockerfile_runtime_exists() -> None:
+    assert _DOCKERFILE.is_file()
+
+
+@pytest.mark.parametrize(
+    ("repo_slug", "refresh_name"),
+    sorted(_MOVING_REF_GIT_PACKAGES.items()),
+)
+def test_moving_ref_git_install_uses_refresh_package(
+    dockerfile_text: str, repo_slug: str, refresh_name: str
+) -> None:
+    """Each moving-ref git install line must carry the matching --refresh-package."""
+    # Find the `uv pip install ... git+https://...<repo_slug>.git@... ` install
+    # line (a single logical line may span backslash continuations; the source
+    # keeps each install on one physical `uv pip install ...` statement).
+    pattern = re.compile(
+        r"uv pip install[^\n]*--refresh-package\s+"
+        + re.escape(refresh_name)
+        + r"[^\n]*git\+https://github\.com/OmniNode-ai/"
+        + re.escape(repo_slug)
+        + r"\.git@",
+    )
+    assert pattern.search(dockerfile_text), (
+        f"release-mode git install of {repo_slug} must pass "
+        f"--refresh-package {refresh_name} (OMN-12424): a moving @dev/@main ref "
+        f"under the uv cache mount otherwise ships stale wheels on rebuild."
+    )
+
+
+def test_no_moving_ref_git_install_without_refresh(dockerfile_text: str) -> None:
+    """No release-mode git+ install of a tracked moving-ref package may omit refresh.
+
+    Guards against someone adding a new `git+...@dev`/`@main` ONEX install that
+    reintroduces the staleness bug.
+    """
+    git_install_re = re.compile(
+        r"git\+https://github\.com/OmniNode-ai/([A-Za-z0-9_\-]+)\.git@",
+    )
+    for match in git_install_re.finditer(dockerfile_text):
+        repo_slug = match.group(1)
+        if repo_slug not in _MOVING_REF_GIT_PACKAGES:
+            continue
+        # Look back to the start of this `uv pip install` statement and forward
+        # to the URL; the whole statement must contain --refresh-package.
+        stmt_start = dockerfile_text.rfind("uv pip install", 0, match.start())
+        assert stmt_start != -1, (
+            f"git install of {repo_slug} not preceded by a uv pip install statement"
+        )
+        statement = dockerfile_text[stmt_start : match.end()]
+        assert "--refresh-package" in statement, (
+            f"git install of moving-ref package {repo_slug} is missing "
+            f"--refresh-package (OMN-12424)."
+        )

--- a/tests/scripts/test_dockerfile_runtime_git_refresh.py
+++ b/tests/scripts/test_dockerfile_runtime_git_refresh.py
@@ -7,9 +7,9 @@ and omnimarket from *moving* git refs (`@main` / `@dev`) under a persistent
 BuildKit uv cache mount (`--mount=type=cache,target=/root/.cache/uv`).
 
 uv keys its git source cache on the resolved commit for the URL, and the URL
-itself does not change when the moving branch advances. Therefore a rebuild —
+itself does not change when the moving branch advances. Therefore a rebuild -
 even `docker build --no-cache`, which busts Docker layer cache but not the
-BuildKit cache mount — can reinstall a stale wheel from a previous commit of
+BuildKit cache mount - can reinstall a stale wheel from a previous commit of
 dev/main. This silently shipped pre-#988 omnimarket code during the OMN-12420
 redeploy.
 


### PR DESCRIPTION
## Summary

Fixes OMN-12424: runtime Docker rebuilds silently ship **stale** cross-repo code.

`Dockerfile.runtime` installs `onex_change_control@main` and `omnimarket@dev` via `uv pip install "git+...@<branch>"` under a persistent BuildKit uv cache mount (`--mount=type=cache,target=/root/.cache/uv`). uv keys its git source cache on the **resolved commit for the URL**, and the URL (`@dev`/`@main`) does not change when the branch advances. Docker `--no-cache` busts the layer cache but **not** the `type=cache` mount — so a rebuild can reinstall a wheel built from a *previous* commit of dev/main.

This is what masked the OMN-12420 fix during the stability-test redeploy: the rebuilt image still contained the pre-#988 `node_dod_verify` contract (`runtime_sha_verify` present, no `event_model`), the container came up `healthy` on stale code, and `node_dod_verify` still failed to emit a terminal event.

## Fix

Pass `--refresh-package <name>` on each release-mode moving-ref git install (`onex-change-control`, `omnimarket`). uv re-resolves and re-fetches **only** those packages' git sources on every build while reusing the cache for everything else, so a rebuild always installs current branch HEAD. `omnibase_compat` is a SHA-pinned immutable tarball and needs no refresh.

Chose `--refresh-package` over SHA-pinning the refs deliberately: pinning to a fixed SHA would also fix staleness but defeats moving-`dev` tracking (the whole point of these installs is "pick up latest merged nodes on every rebuild"). The earlier OMN-10728 comment claiming a SHA-in-URL busts the cache was incorrect — `@dev` is constant, so nothing invalidated the cache.

## Test

Adds `tests/scripts/test_dockerfile_runtime_git_refresh.py` pinning the invariant: every moving-ref `git+...` ONEX install in `Dockerfile.runtime` must carry `--refresh-package`. Fails if a new moving-ref install omits it. (4 tests, all pass.)

## Verification (durable proof)

Rebuilt the stability-test runtime images from this Dockerfile and ran the mandatory image pre-check **before** any container run:

```
docker run --rm --entrypoint sh <image>:latest -c \
  'grep -c OMN-12420 /app/.venv/lib/python3.12/site-packages/omnimarket/nodes/node_dod_verify/contract.yaml'
# => 1   (pre-fix image returned 0)
```

`runtime_sha_verify` operation removed, `event_model` present — i.e. the rebuild now provably contains the merged change. Full trace in `omni_home/docs/diagnosis-dod-verify-no-terminal-event.md` (2026-05-29 sections).

> Note: the end-to-end on-bus `node_dod_verify` verification surfaced a **separate, unrelated** boot-blocker in current omnimarket dev (`HandlerModelRouter` auto-wiring `TypeError`) that prevents the runtime kernel from booting on current dev — out of scope for this PR. Tracked separately; this PR's fix is independently proven by the image pre-check.

Evidence-Ticket: OMN-12424
Evidence-Source: OCC#1871

Closes OMN-12424.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime build configuration to improve handling of git-based dependencies in release mode, ensuring proper package refresh across rebuilds.

* **Tests**
  * Added regression tests to validate git dependency resolution behavior in Docker builds, preventing future issues with moving-ref packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->