### PR TITLE
fix(OMN-12433): github.com egress healthcheck for CI runner image

### DIFF
--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -58,12 +58,17 @@ x-runner-base: &runner-base
     - /var/run/docker.sock:/var/run/docker.sock
     - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
     - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+    - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
   group_add:
     - "984" # Match host Docker socket GID for DinD access
+  # OMN-12433: healthcheck proves BOTH the listener is alive AND github.com is
+  # reachable. The old pgrep-only check passed while runners were silently
+  # disconnected from GitHub (lost egress), letting dead runners stay in the
+  # pool and wedge the merge queue. timeout covers the curl --max-time 8.
   healthcheck:
-    test: ["CMD-SHELL", "pgrep -f Runner.Listener > /dev/null"]
+    test: ["CMD-SHELL", "/usr/local/bin/healthcheck.sh"]
     interval: 30s
-    timeout: 10s
+    timeout: 12s
     retries: 3
     start_period: 120s
   logging:
@@ -82,6 +87,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-1-creds:/home/runner/.runner-creds
   omninode-runner-2:
     !!merge <<: *runner-base
@@ -93,6 +99,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-2-creds:/home/runner/.runner-creds
   omninode-runner-3:
     !!merge <<: *runner-base
@@ -104,6 +111,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-3-creds:/home/runner/.runner-creds
   omninode-runner-4:
     !!merge <<: *runner-base
@@ -115,6 +123,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-4-creds:/home/runner/.runner-creds
   omninode-runner-5:
     !!merge <<: *runner-base
@@ -126,6 +135,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-5-creds:/home/runner/.runner-creds
   omninode-runner-6:
     !!merge <<: *runner-base
@@ -137,6 +147,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-6-creds:/home/runner/.runner-creds
   omninode-runner-7:
     !!merge <<: *runner-base
@@ -148,6 +159,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-7-creds:/home/runner/.runner-creds
   omninode-runner-8:
     !!merge <<: *runner-base
@@ -159,6 +171,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-8-creds:/home/runner/.runner-creds
   omninode-runner-9:
     !!merge <<: *runner-base
@@ -170,6 +183,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-9-creds:/home/runner/.runner-creds
   omninode-runner-10:
     !!merge <<: *runner-base
@@ -181,6 +195,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-10-creds:/home/runner/.runner-creds
   omninode-runner-11:
     !!merge <<: *runner-base
@@ -192,6 +207,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-11-creds:/home/runner/.runner-creds
   omninode-runner-12:
     !!merge <<: *runner-base
@@ -203,6 +219,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-12-creds:/home/runner/.runner-creds
   omninode-runner-13:
     !!merge <<: *runner-base
@@ -214,6 +231,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-13-creds:/home/runner/.runner-creds
   omninode-runner-14:
     !!merge <<: *runner-base
@@ -225,6 +243,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-14-creds:/home/runner/.runner-creds
   omninode-runner-15:
     !!merge <<: *runner-base
@@ -237,6 +256,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-15-creds:/home/runner/.runner-creds
   omninode-runner-16:
     !!merge <<: *runner-base
@@ -249,6 +269,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-16-creds:/home/runner/.runner-creds
   omninode-runner-17:
     !!merge <<: *runner-base
@@ -261,6 +282,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-17-creds:/home/runner/.runner-creds
   omninode-runner-18:
     !!merge <<: *runner-base
@@ -273,6 +295,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-18-creds:/home/runner/.runner-creds
   omninode-runner-19:
     !!merge <<: *runner-base
@@ -285,6 +308,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-19-creds:/home/runner/.runner-creds
   omninode-runner-20:
     !!merge <<: *runner-base
@@ -297,6 +321,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-20-creds:/home/runner/.runner-creds
 volumes:
   runner-1-creds:

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -107,7 +107,8 @@ RUN mkdir -p /home/runner/.runner-creds && chown runner:runner /home/runner/.run
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY runner-job-started.sh /usr/local/bin/runner-job-started.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/runner-job-started.sh
+COPY healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/runner-job-started.sh /usr/local/bin/healthcheck.sh
 
 # Install gosu for privilege de-escalation in entrypoint.
 # The entrypoint starts as root to fix Docker socket GID, then drops to runner.

--- a/docker/runners/healthcheck.sh
+++ b/docker/runners/healthcheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Docker healthcheck for the GitHub Actions runner container (OMN-12433).
+#
+# The old healthcheck only ran `pgrep -f Runner.Listener`. That passes even when
+# the listener has silently lost its connection to github.com - the exact failure
+# that left ~9 runners "Up (healthy)" in Docker while offline in the GitHub pool,
+# wedging the merge queue. This check additionally proves github.com egress so a
+# runner that cannot reach GitHub is marked unhealthy and removed from rotation.
+set -u
+
+# 1. Listener process must be alive (runner agent running at all).
+if ! pgrep -f Runner.Listener >/dev/null 2>&1; then
+  echo "unhealthy: Runner.Listener not running"
+  exit 1
+fi
+
+# 2. github.com must be reachable. A connected listener with no in-flight job is
+#    expected; an egress fault that drops the GitHub connection is what we catch.
+#    Use a short-timeout unauthenticated request. This proves network egress
+#    without requiring an API token.
+if ! curl -fsS --max-time 8 -o /dev/null https://github.com/; then
+  echo "unhealthy: github.com egress unreachable"
+  exit 1
+fi
+
+echo "healthy: listener up, github.com reachable"
+exit 0

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -75,3 +77,54 @@ def test_runner_scripts_do_not_embed_legacy_count() -> None:
 
     assert "RUNNER_COUNT=10" not in deploy_script
     assert "EXPECTED_RUNNERS=10" not in monitor_script
+
+
+def test_runner_healthcheck_probes_github_egress() -> None:
+    """OMN-12433: the runner healthcheck must verify github.com egress.
+
+    A pgrep-only healthcheck passes while a runner has silently lost its
+    connection to GitHub (egress fault), letting dead runners stay "healthy"
+    in Docker and wedge the merge queue. The healthcheck script must prove both
+    the listener is alive AND github.com is reachable.
+    """
+    script = (REPO_ROOT / "docker" / "runners" / "healthcheck.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "pgrep -f Runner.Listener" in script
+    assert "--max-time" in script
+    curl_commands = [
+        shlex.split(line.removeprefix("if ! ").removesuffix("; then").strip())
+        for line in script.splitlines()
+        if line.startswith("if ! curl ")
+    ]
+    assert len(curl_commands) == 1
+    endpoint = urlsplit(curl_commands[0][-1])
+    assert (endpoint.scheme, endpoint.netloc, endpoint.path) == (
+        "https",
+        "github.com",
+        "/",
+    )
+
+
+def test_runner_compose_healthcheck_uses_egress_script() -> None:
+    """OMN-12433: every runner service must run the egress healthcheck script,
+    not the old pgrep-only test, and mount the script into the container."""
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker" / "docker-compose.runners.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    base_test = compose["x-runner-base"]["healthcheck"]["test"]
+    assert base_test == ["CMD-SHELL", "/usr/local/bin/healthcheck.sh"]
+
+    hc_mount = "./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro"
+    for name, definition in compose["services"].items():
+        if not re.fullmatch(r"omninode-runner-\d+", name):
+            continue
+        # Per-service volumes override the anchor (YAML lists don't deep-merge),
+        # so each runner must mount the healthcheck script explicitly.
+        assert hc_mount in definition["volumes"], f"{name} missing healthcheck mount"
+        # No runner may regress to the bare pgrep-only healthcheck.
+        resolved_test = definition.get("healthcheck", {}).get("test", base_test)
+        assert resolved_test == ["CMD-SHELL", "/usr/local/bin/healthcheck.sh"]


### PR DESCRIPTION
## Summary

Durable fix for the 2026-05-29 CI wedge. The runner Docker healthcheck was `pgrep -f Runner.Listener` only — it passed even when a runner had silently lost its connection to github.com. That let ~9 of 20 runners sit "Up (healthy)" in Docker while OFFLINE in the GitHub pool, starving the merge queue and blocking #1789/#1781/#1782.

- New `docker/runners/healthcheck.sh`: requires BOTH the `Runner.Listener` process AND a short-timeout (`--max-time 8`) github.com reachability probe. A runner that loses egress now goes unhealthy and is removed from rotation instead of accepting jobs it will fail.
- Wired into the runner `Dockerfile` (baked) and mounted into every runner service in `docker-compose.runners.yml` (so already-deployed runners pick it up on recreate, no rebuild required). Anchor + 20 services = 21 mounts.
- Regression tests in `tests/unit/observability/runner_health/test_runner_fleet_config.py` assert the script probes github.com and every runner service uses the egress healthcheck (not bare pgrep).

## Proof

- `bash -n` + `shellcheck` clean on healthcheck.sh.
- `tests/unit/observability/runner_health/test_runner_fleet_config.py`: 6 passed (incl. 2 new). Broader `tests/unit/observability/` + compose tests: 151 passed.
- Compose YAML parses; all 20 runner services resolve `healthcheck.test: [CMD-SHELL, /usr/local/bin/healthcheck.sh]` and mount the script.

Context: this is the durable companion to OMN-12432 (the uv git-auth fix). Both address the same .201 runner-egress fault — OMN-12432 stops it failing git fetches, OMN-12433 stops a degraded runner from silently staying in the pool.

## Test plan

- [ ] CI green on this branch
- [ ] On deploy/recreate, a runner that loses github.com egress transitions to unhealthy (manual/observed)

Evidence-Source: OCC#1888
Evidence-Ticket: OMN-12433

OMN-12433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security scanning now runs CodeQL using a repo-level config that targets source, scripts, and tests while excluding CI metadata.

* **Improvements**
  * Runner healthchecks strengthened to verify listener liveness and outbound connectivity; healthcheck script deployed to runners and images.
  * CI workflows: increased timeouts for long jobs, added preinstall/retry logic for heavy dependencies, and pinned scanning steps to use explicit actions.
  * CI setup action supports authenticated git fetches via a token and increases uv sync retry default.

* **Tests**
  * Added regression and unit tests validating CodeQL workflow, authenticated fetch behavior, healthchecks, and CI retry/timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->