### PR TITLE
fix(OMN-12448): bound consumer-startup concurrency + retry-then-raise in EventBusKafka

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -14,7 +14,6 @@ on:
 env:
   PYTHON_VERSION: "3.12"
   UV_VERSION: "0.8.3"
-  UV_HTTP_TIMEOUT: "600"
   REPO_NAME: "omnibase_infra"
   UV_HTTP_TIMEOUT: "600"
   # OMN-12564 canary: trusted self-hosted CI uses the same immutable

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -14,6 +14,7 @@ on:
 env:
   PYTHON_VERSION: "3.12"
   UV_VERSION: "0.8.3"
+  UV_HTTP_TIMEOUT: "600"
   REPO_NAME: "omnibase_infra"
   UV_HTTP_TIMEOUT: "600"
   # OMN-12564 canary: trusted self-hosted CI uses the same immutable
@@ -51,6 +52,8 @@ jobs:
           cache-key-prefix: uv-type-safety
           install-args: --all-extras
           github-token: ${{ secrets.CROSS_REPO_PAT || github.token }}
+          sync-attempts: "3"
+          sync-retry-delay-seconds: "10"
 
       - name: Run MyPy type checking
         run: |
@@ -83,6 +86,8 @@ jobs:
           cache-key-prefix: uv-type-union
           install-args: --all-extras
           github-token: ${{ secrets.CROSS_REPO_PAT || github.token }}
+          sync-attempts: "3"
+          sync-retry-delay-seconds: "10"
 
       - name: Check for Optional/Union usage (PEP 604)
         run: uv run ruff check src/ --select UP007,UP006

--- a/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
+++ b/src/omnibase_infra/event_bus/configs/kafka_event_bus_config.yaml
@@ -67,6 +67,13 @@ circuit_breaker_reset_timeout: ${KAFKA_CIRCUIT_BREAKER_RESET_TIMEOUT:-30.0}
 
 # Sleep interval in seconds between consumer poll iterations
 consumer_sleep_interval: ${KAFKA_CONSUMER_SLEEP_INTERVAL:-0.1}
+# Cold-start consumer concurrency (OMN-12448). Contract-config only — no env
+# override — so a runtime subscribing to hundreds of topics throttles the burst
+# of consumer-group joins instead of stampeding the broker group coordinator.
+# Max consumer-group starts in flight during start_consuming().
+consumer_start_concurrency: 32
+# Retry passes for a transiently-failing consumer start before aborting boot.
+consumer_start_max_retries: 3
 # Where to start reading messages when no committed offset exists
 # Options: "earliest" (beginning), "latest" (end of topic)
 auto_offset_reset: "${KAFKA_AUTO_OFFSET_RESET:-latest}"

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -2344,18 +2344,45 @@ class EventBusKafka(
                         self._pending_consumer_keys.add(consumer_key)
                         topics_to_start.append((topic, group_id))
 
-        # Start all consumers concurrently — wall-clock time becomes the
-        # slowest single consumer rather than the sum of all N consumers.
-        # return_exceptions=True lets every consumer attempt to start; we
-        # collect failures and re-raise the first one after all have settled
-        # so a single bad topic does not starve the rest.
+        # Start consumers concurrently but bounded (OMN-12448). An unbounded
+        # gather over hundreds of group-joins stampedes the broker group
+        # coordinator on cold start; tail latency then blows the per-consumer
+        # start timeout. A single failure aborting the whole boot crash-loops
+        # the runtime — and each failed boot leaves half-formed groups that make
+        # the next boot slower. So: cap in-flight starts at
+        # consumer_start_concurrency and retry a transiently-failing start up to
+        # consumer_start_max_retries times before letting it fail the boot.
         if topics_to_start:
+            semaphore = asyncio.Semaphore(self._config.consumer_start_concurrency)
+            max_retries = self._config.consumer_start_max_retries
+
+            async def _start_bounded(topic: str, group_id: str) -> BaseException | None:
+                async with semaphore:
+                    last_error: BaseException | None = None
+                    for attempt in range(max_retries + 1):
+                        try:
+                            await self._start_consumer_for_topic_unlocked(
+                                topic, group_id
+                            )
+                            return None
+                        except BaseException as exc:  # noqa: BLE001 — boundary: collected, re-raised after retries exhausted
+                            last_error = exc
+                            if attempt >= max_retries:
+                                break
+                            # Every failure path discards the pending-key
+                            # reservation; re-reserve it before retrying so the
+                            # next attempt is not treated as a duplicate.
+                            self._pending_consumer_keys.add((topic, group_id))
+                            # Yield so other in-flight starts make progress and
+                            # the coordinator settles before we retry.
+                            await asyncio.sleep(0)
+                    return last_error
+
             results = await asyncio.gather(
                 *[
-                    self._start_consumer_for_topic_unlocked(topic, group_id)
+                    _start_bounded(topic, group_id)
                     for topic, group_id in topics_to_start
-                ],
-                return_exceptions=True,
+                ]
             )
             errors = [r for r in results if isinstance(r, BaseException)]
             if errors:

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -2356,16 +2356,16 @@ class EventBusKafka(
             semaphore = asyncio.Semaphore(self._config.consumer_start_concurrency)
             max_retries = self._config.consumer_start_max_retries
 
-            async def _start_bounded(topic: str, group_id: str) -> BaseException | None:
+            async def _start_bounded(topic: str, group_id: str) -> Exception | None:
                 async with semaphore:
-                    last_error: BaseException | None = None
+                    last_error: Exception | None = None
                     for attempt in range(max_retries + 1):
                         try:
                             await self._start_consumer_for_topic_unlocked(
                                 topic, group_id
                             )
                             return None
-                        except BaseException as exc:  # noqa: BLE001 — boundary: collected, re-raised after retries exhausted
+                        except Exception as exc:  # noqa: BLE001 — boundary: collected, re-raised after retries exhausted
                             last_error = exc
                             if attempt >= max_retries:
                                 break
@@ -2384,7 +2384,7 @@ class EventBusKafka(
                     for topic, group_id in topics_to_start
                 ]
             )
-            errors = [r for r in results if isinstance(r, BaseException)]
+            errors = [r for r in results if isinstance(r, Exception)]
             if errors:
                 raise errors[0]
 

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -2365,7 +2365,11 @@ class EventBusKafka(
                                 topic, group_id
                             )
                             return None
-                        except Exception as exc:  # noqa: BLE001 — boundary: collected, re-raised after retries exhausted
+                        except (
+                            InfraConnectionError,
+                            InfraTimeoutError,
+                            InfraUnavailableError,
+                        ) as exc:
                             last_error = exc
                             if attempt >= max_retries:
                                 break

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -268,6 +268,30 @@ class ModelKafkaEventBusConfig(BaseModel):
         le=10.0,
     )
 
+    # Consumer cold-start concurrency (OMN-12448). Bounds the burst of
+    # consumer-group joins during start_consuming() so a runtime subscribing to
+    # hundreds of topics does not stampede the broker's group coordinator and
+    # blow the per-consumer start timeout. Contract-config only — deliberately
+    # not exposed as an env override.
+    consumer_start_concurrency: int = Field(
+        default=32,
+        description=(
+            "Maximum consumer-group starts in flight during start_consuming(). "
+            "Caps the cold-start burst on the broker group coordinator."
+        ),
+        ge=1,
+        le=1024,
+    )
+    consumer_start_max_retries: int = Field(
+        default=3,
+        description=(
+            "Retry passes for a transiently-failing consumer start before "
+            "aborting boot. 0 disables retries."
+        ),
+        ge=0,
+        le=10,
+    )
+
     # Kafka producer settings
     acks: EnumKafkaAcks = Field(
         default=EnumKafkaAcks.ALL,

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -489,6 +489,30 @@ def test_architecture_handshake_has_checkout_retry_timeout_budget() -> None:
     assert job["timeout-minutes"] >= 10
 
 
+def test_omni_standards_jobs_use_retrying_uv_install() -> None:
+    workflow = _load_yaml(OMNI_STANDARDS_WORKFLOW)
+
+    assert workflow["env"]["UV_HTTP_TIMEOUT"] == "600"
+
+    for job_name in ("type-safety", "type-union-check"):
+        steps = workflow["jobs"][job_name]["steps"]
+        setup_step = next(
+            step
+            for step in steps
+            if step.get("uses") == "./.github/actions/setup-python-uv"
+        )
+
+        assert setup_step["with"]["python-version"] == "${{ env.PYTHON_VERSION }}"
+        assert setup_step["with"]["uv-version"] == "${{ env.UV_VERSION }}"
+        assert setup_step["with"]["cache-enabled"] == "false"
+        assert setup_step["with"]["install-args"] == "--all-extras"
+        assert setup_step["with"]["sync-attempts"] == "3"
+        assert setup_step["with"]["sync-retry-delay-seconds"] == "10"
+        assert not any(
+            step.get("run") == "uv sync --no-cache --all-extras" for step in steps
+        )
+
+
 def test_setup_python_uv_retries_uv_sync_and_logs_transport_settings() -> None:
     action = _load_yaml(SETUP_PYTHON_UV_ACTION)
 

--- a/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
+++ b/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from omnibase_infra.errors import InfraConnectionError
 from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
 from omnibase_infra.event_bus.models import ModelEventMessage
 from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
@@ -223,7 +224,7 @@ async def test_start_consuming_retries_transient_failure_without_aborting_boot()
         if topic == flaky and attempts[topic] == 1:
             # Mirror the real failure path: pending key discarded before raising.
             bus._pending_consumer_keys.discard((topic, group_id))
-            raise RuntimeError("transient group-join timeout")
+            raise InfraConnectionError("transient group-join timeout")
         bus._group_consumers[(topic, group_id)] = AsyncMock()
         bus._pending_consumer_keys.discard((topic, group_id))
 
@@ -258,7 +259,7 @@ async def test_start_consuming_raises_after_retries_exhausted() -> None:
         attempts[topic] = attempts.get(topic, 0) + 1
         if topic == broken:
             bus._pending_consumer_keys.discard((topic, group_id))
-            raise RuntimeError("permanent group-join failure")
+            raise InfraConnectionError("permanent group-join failure")
         bus._group_consumers[(topic, group_id)] = AsyncMock()
         bus._pending_consumer_keys.discard((topic, group_id))
 
@@ -272,7 +273,7 @@ async def test_start_consuming_raises_after_retries_exhausted() -> None:
             ("service", "sub-ok", _handler),
         ]
 
-    with pytest.raises(RuntimeError, match="permanent group-join failure"):
+    with pytest.raises(InfraConnectionError, match="permanent group-join failure"):
         await bus.start_consuming()
 
     # Initial attempt + max_retries retries.

--- a/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
+++ b/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
@@ -141,3 +141,139 @@ async def test_start_consuming_starts_distinct_consumers_in_parallel() -> None:
     assert len(started) == 3
     assert len(set(started)) == 3
     assert max_active_starts > 1
+
+
+# ---------------------------------------------------------------------------
+# OMN-12448: bounded consumer-startup concurrency + retry-then-raise.
+# Unbounded asyncio.gather over ~870 group-joins stampedes the broker's group
+# coordinator; one slow join blowing the timeout aborts the whole boot, which
+# crash-loops the runtime. start_consuming must cap in-flight starts and retry
+# transient failures before failing the boot.
+# ---------------------------------------------------------------------------
+
+
+def _make_bus_tuned(concurrency: int, max_retries: int) -> EventBusKafka:
+    return EventBusKafka(
+        config=ModelKafkaEventBusConfig(
+            bootstrap_servers="localhost:19092",
+            environment="test",
+            consumer_start_concurrency=concurrency,
+            consumer_start_max_retries=max_retries,
+        )
+    )
+
+
+async def _drive_start_consuming(bus: EventBusKafka) -> None:
+    """Run start_consuming to completion of the startup fan-out, then stop."""
+    task = asyncio.create_task(bus.start_consuming())
+    await asyncio.sleep(0.2)
+    await bus.shutdown()
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_start_consuming_caps_in_flight_consumer_starts() -> None:
+    """In-flight consumer starts must never exceed consumer_start_concurrency."""
+    concurrency = 4
+    total = 20
+    bus = _make_bus_tuned(concurrency=concurrency, max_retries=3)
+    bus._started = True
+
+    active = 0
+    max_active = 0
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.02)
+        bus._group_consumers[(topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((topic, group_id))
+        active -= 1
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    async with bus._lock:
+        for idx in range(total):
+            bus._subscribers[f"onex.evt.omnibase-infra.bound-{idx}.v1"] = [
+                ("service", f"sub-{idx}", _handler),
+            ]
+
+    await _drive_start_consuming(bus)
+
+    assert bus._start_consumer_for_topic_unlocked.await_count == total
+    assert max_active <= concurrency
+
+
+@pytest.mark.asyncio
+async def test_start_consuming_retries_transient_failure_without_aborting_boot() -> (
+    None
+):
+    """A consumer that fails once then succeeds must not abort the boot."""
+    bus = _make_bus_tuned(concurrency=4, max_retries=2)
+    bus._started = True
+
+    attempts: dict[str, int] = {}
+    flaky = "onex.evt.omnibase-infra.flaky.v1"
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        attempts[topic] = attempts.get(topic, 0) + 1
+        if topic == flaky and attempts[topic] == 1:
+            # Mirror the real failure path: pending key discarded before raising.
+            bus._pending_consumer_keys.discard((topic, group_id))
+            raise RuntimeError("transient group-join timeout")
+        bus._group_consumers[(topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((topic, group_id))
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    async with bus._lock:
+        bus._subscribers[flaky] = [("service", "sub-flaky", _handler)]
+        bus._subscribers["onex.evt.omnibase-infra.healthy.v1"] = [
+            ("service", "sub-healthy", _handler),
+        ]
+
+    # Must NOT raise — the flaky consumer recovers on retry.
+    await _drive_start_consuming(bus)
+
+    assert attempts[flaky] == 2
+    assert (flaky, "service.__t." + flaky) not in bus._pending_consumer_keys
+
+
+@pytest.mark.asyncio
+async def test_start_consuming_raises_after_retries_exhausted() -> None:
+    """A consumer that always fails raises only after max_retries are spent."""
+    max_retries = 2
+    bus = _make_bus_tuned(concurrency=4, max_retries=max_retries)
+    bus._started = True
+
+    attempts: dict[str, int] = {}
+    broken = "onex.evt.omnibase-infra.broken.v1"
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        attempts[topic] = attempts.get(topic, 0) + 1
+        if topic == broken:
+            bus._pending_consumer_keys.discard((topic, group_id))
+            raise RuntimeError("permanent group-join failure")
+        bus._group_consumers[(topic, group_id)] = AsyncMock()
+        bus._pending_consumer_keys.discard((topic, group_id))
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    async with bus._lock:
+        bus._subscribers[broken] = [("service", "sub-broken", _handler)]
+        bus._subscribers["onex.evt.omnibase-infra.ok.v1"] = [
+            ("service", "sub-ok", _handler),
+        ]
+
+    with pytest.raises(RuntimeError, match="permanent group-join failure"):
+        await bus.start_consuming()
+
+    # Initial attempt + max_retries retries.
+    assert attempts[broken] == max_retries + 1

--- a/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
+++ b/tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py
@@ -277,3 +277,28 @@ async def test_start_consuming_raises_after_retries_exhausted() -> None:
 
     # Initial attempt + max_retries retries.
     assert attempts[broken] == max_retries + 1
+
+
+@pytest.mark.asyncio
+async def test_start_consuming_does_not_retry_cancellation() -> None:
+    """Cancellation must propagate instead of being treated as a Kafka start retry."""
+    bus = _make_bus_tuned(concurrency=4, max_retries=2)
+    bus._started = True
+
+    cancelled = "onex.evt.omnibase-infra.cancelled.v1"
+
+    async def fake_start(topic: str, group_id: str) -> None:
+        bus._pending_consumer_keys.discard((topic, group_id))
+        raise asyncio.CancelledError
+
+    bus._start_consumer_for_topic_unlocked = AsyncMock(  # type: ignore[method-assign]
+        side_effect=fake_start
+    )
+
+    async with bus._lock:
+        bus._subscribers[cancelled] = [("service", "sub-cancelled", _handler)]
+
+    with pytest.raises(asyncio.CancelledError):
+        await bus.start_consuming()
+
+    assert bus._start_consumer_for_topic_unlocked.await_count == 1


### PR DESCRIPTION
## Summary

`EventBusKafka.start_consuming()` started **all** consumer groups in one unbounded `asyncio.gather` and aborted the entire boot if any single start failed (`if errors: raise errors[0]`).

On cold start a runtime subscribing to ~870 topics stampedes redpanda's group coordinator; tail latency blows the per-consumer start timeout, the single failure raises, and the runtime crash-loops. **Observed on the `.201` dev lane: `omninode-runtime` restarted 296 times** on `InfraTimeoutError ONEX_CORE_092: Timeout starting consumer for onex.cmd.omnimarket.dispatch-queue-drain.v1 after 30s`. Each failed boot leaves half-formed groups mid-rebalance, making the next boot slower — a self-sustaining loop. stability-test/prod only avoid this because they completed one clean cold-start and now just heartbeat (`restarts=0`).

This is the direct follow-up to OMN-11975 (which introduced the unbounded gather) and OMN-10954 (which only made one specific consumer non-fatal).

## Change

- Cap in-flight consumer starts at `config.consumer_start_concurrency` (default **32**) via a semaphore.
- Retry a transiently-failing start up to `config.consumer_start_max_retries` (default **3**) passes before letting it fail the boot; re-reserve the pending-consumer key between attempts (every failure path discards it).
- **Contracts only — no new env vars.** New fields live on `ModelKafkaEventBusConfig` + `kafka_event_bus_config.yaml` and are deliberately excluded from the `KAFKA_*` env-override map. Per-lane tuning is via contract overlay, not env.

Defaults preserve existing parallelism (32 ≥ the small fan-outs in existing tests); the cap only bites at scale, exactly where the stampede happens. Fixes cold-start robustness platform-wide, not just the dev lane.

## Testing / dod_evidence (OMN-12595, OMN-12448)

Landing ticket: OMN-12595 (Land infra#1795 bounded consumer startup + retry-then-raise). Implementation ticket: OMN-12448.

TDD — failing tests written first (`tests/integration/event_bus/test_kafka_concurrent_subscribe_startup.py`):
- `test_start_consuming_caps_in_flight_consumer_starts` — in-flight starts never exceed the configured cap (20 topics, cap 4) under startup pressure.
- `test_start_consuming_retries_transient_failure_without_aborting_boot` — a consumer that fails once then succeeds does not abort the boot.
- `test_start_consuming_raises_after_retries_exhausted` — the retry-then-raise path: an always-failing consumer raises only after `max_retries + 1` attempts under startup pressure.
- `test_start_consuming_does_not_retry_cancellation` — cancellation propagates and is not treated as a Kafka start retry.

Local results (rebased onto current `dev`):
- 7/7 in that file pass (4 new + 3 existing OMN-11975 tests).
- `tests/unit/event_bus tests/integration/event_bus tests/ci/test_ci_workflow_resilience.py`: 664 passed, 26 skipped. (34 errors are pre-existing/environmental — `test_adapter_protocol_event_publisher_kafka.py` needs a live broker at localhost:19092; `KafkaConnectionError: Unable to bootstrap`, identical on clean `dev`.)
- `ruff format` + `ruff check`: clean. `mypy --strict` on changed source: clean. Scoped `pre-commit run --files <changed>`: all hooks pass (Topic Naming Lint, Topic Enum Drift, AI-slop, architecture, contract validation included).

Related: OMN-11975, OMN-10954

Plan: docs/plans/2026-06-02-system-stability-delegation-sea-recovery-plan.md

Evidence-Source: OCC#1906
Evidence-Ticket: OMN-12448
