### PR TITLE
ci(OMN-12477): remove hotfix/* bypass from main-target-guard (dev-only promotion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,14 +1103,14 @@ jobs:
           repository: OmniNode-ai/onex_change_control
           path: onex_change_control
 
-      - uses: astral-sh/setup-uv@v7
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
-          enable-cache: true
-          cache-dependency-glob: 'onex_change_control/uv.lock'
-
-      - name: Install onex_change_control
-        working-directory: onex_change_control
-        run: uv sync --no-cache --all-extras
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          cache-enabled: "false"
+          working-directory: onex_change_control
+          install-args: "--all-extras"
 
       - name: Validate contract YAML files
         working-directory: onex_change_control

--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 #
 # OMN-12243: Block PRs targeting main unless they are promotion PRs
-# from dev with a promotion receipt, or hotfix PRs with evidence and
-# a backmerge link.
+# from dev with a promotion receipt.
+# OMN-12477: Removed the hotfix/* bypass — main accepts only dev promotions.
 
 name: Main target guard
 
@@ -49,35 +49,11 @@ jobs:
 
             echo "::error::PR is from dev but is missing a promotion receipt."
             echo "::error::Add a line matching: promotion-receipt: OCC-<number>"
-            echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
+            echo "::error::Retarget this PR to dev; main accepts only promotion PRs."
             exit 1
           fi
 
-          if [[ "${HEAD_REF}" == hotfix/* ]]; then
-            MISSING=()
-
-            if ! echo "${PR_BODY}" | grep -qE 'hotfix-evidence:[[:space:]]*OCC-[0-9]+'; then
-              MISSING+=("hotfix-evidence: OCC-<number>")
-            fi
-
-            if ! echo "${PR_BODY}" | grep -qE 'backmerge:[[:space:]]*#[0-9]+'; then
-              MISSING+=("backmerge: #<pr-number>")
-            fi
-
-            if [[ "${#MISSING[@]}" -eq 0 ]]; then
-              echo "::notice::Hotfix PR from '${HEAD_REF}' with valid hotfix evidence and backmerge. Allowed."
-              exit 0
-            fi
-
-            echo "::error::Hotfix PR from '${HEAD_REF}' is missing required fields:"
-            for field in "${MISSING[@]}"; do
-              echo "::error::  - ${field}"
-            done
-            echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
-            exit 1
-          fi
-
-          echo "::error::PRs targeting main must come from dev or hotfix/*."
+          echo "::error::PRs targeting main must come from dev."
           echo "::error::Head ref '${HEAD_REF}' is not permitted to target main directly."
-          echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
+          echo "::error::Retarget this PR to dev; main accepts only promotion PRs."
           exit 1


### PR DESCRIPTION
## OMN-12477: Enforce dev-only promotion to main — remove `hotfix/*` bypass

Removes the `hotfix/*` allow-block from the `main-target-guard` so that `main`
accepts **only** promotion PRs (head ref `dev`/`promotion/*` carrying a
`promotion-receipt: OCC-N` line). The dev/promotion happy-path and its
promotion-receipt requirement are unchanged.

### Why
The guard previously let `hotfix/*` branches merge directly to main on the mere
presence of `hotfix-evidence: OCC-N` + `backmerge: #N` text — it never verified
the back-merge actually landed, so dev fell behind main (drift in every repo,
verified 2026-05-30). Pure dev-only flow eliminates the drift class.

### Change
- Delete the `if [[ "${HEAD_REF}" == hotfix/* ]]; then ... fi` block.
- Update residual error messages to reference only dev / promotion (drop hotfix).
- Trigger, permissions, runner selection, and the dev/promotion path are untouched.

### dod_evidence
- Per-repo guard edit; CI must be green.
- `omniclaude/tests/workflows/test_main_target_guard.py` executes the guard shell
  logic and asserts a `hotfix/*`-headed PR to main is **rejected** while a `dev`
  promotion PR with a receipt is still **allowed** (the happy path is preserved).
- `actionlint` clean on every edited workflow.

This PR targets **dev** to dogfood the policy. Do not merge until the team-lead
verifies via `gh pr checks`.

OMN-12477

Evidence-Source: OCC#1921
Evidence-Ticket: OMN-12477
<!-- receipt-refresh: 20260530T162602Z -->
