### PR TITLE
feat(OMN-12378): add Repowise freshness receipt

### DIFF
--- a/docs/runbooks/repowise-freshness-receipt.md
+++ b/docs/runbooks/repowise-freshness-receipt.md
@@ -66,7 +66,7 @@ python3 "$OMNI_HOME/omnibase_infra/scripts/emit_repowise_freshness_receipt.py" \
 
 ### File location
 
-```
+```text
 $OMNI_HOME/.onex_state/repowise-sync/freshness-<ISO8601-timestamp>.json
 ```
 

--- a/docs/runbooks/repowise-freshness-receipt.md
+++ b/docs/runbooks/repowise-freshness-receipt.md
@@ -1,0 +1,149 @@
+# Repowise Freshness Receipt
+
+**Ticket:** OMN-12378
+**Script:** `scripts/emit_repowise_freshness_receipt.py`
+
+## Purpose
+
+The Repowise freshness-receipt script reads `.repowise-workspace.yaml` and
+live git HEAD SHAs to emit a per-repo receipt showing index age, stale status,
+and any failure flags (no index, mismatched HEAD).
+
+This receipt provides a durable audit trail that binds Repowise index metadata
+to exact git state, so tech-debt findings can cite the repository SHAs and
+freshness state that produced them.
+
+## When to Run
+
+Run **manually after `pull-all.sh`** to capture the post-sync freshness state,
+and again after a Repowise reindex to confirm the index is current.
+
+> **Follow-up (OMN-12368):** No automated closeout flow yet wires this script.
+> Invoke it manually until the OMN-12368 closeout flow adopts it as an automatic
+> post-reindex step.
+
+## Prerequisites
+
+- `git` on PATH
+- `$OMNI_HOME` set (or pass `--omni-home`)
+- `.repowise-workspace.yaml` present at the omni_home root
+
+The script is **stdlib-only** — no venv or `uv` required.
+
+## Invocation
+
+### Basic (use `$OMNI_HOME`)
+
+```bash
+python3 "$OMNI_HOME/omnibase_infra/scripts/emit_repowise_freshness_receipt.py"
+```
+
+### With explicit omni-home
+
+```bash
+python3 /path/to/omnibase_infra/scripts/emit_repowise_freshness_receipt.py \
+  --omni-home /path/to/omni_home
+```
+
+### Machine-readable output only
+
+```bash
+python3 "$OMNI_HOME/omnibase_infra/scripts/emit_repowise_freshness_receipt.py" \
+  --json-only
+```
+
+Prints the path to the written JSON receipt and suppresses the human-readable
+summary table.
+
+### Custom output path
+
+```bash
+python3 "$OMNI_HOME/omnibase_infra/scripts/emit_repowise_freshness_receipt.py" \
+  --out /tmp/my-receipt.json
+```
+
+## Output
+
+### File location
+
+```
+$OMNI_HOME/.onex_state/repowise-sync/freshness-<ISO8601-timestamp>.json
+```
+
+A `latest-freshness.json` symlink is updated in the same directory on each run.
+
+### Receipt schema
+
+```json
+{
+  "run_id": "freshness-20260530T120000Z",
+  "generated_at": "<ISO8601>",
+  "omni_home": "<resolved path>",
+  "repos": [
+    {
+      "alias": "omnibase_core",
+      "path": "omnibase_core",
+      "exists": true,
+      "branch": "main",
+      "head_sha": "abc123def",
+      "indexed_at": "2026-05-29T10:00:00+00:00",
+      "index_age_days": 1.08,
+      "index_head_sha": "abc123def",
+      "stale": false,
+      "no_index": false,
+      "docs_mode": "generated",
+      "failure": null
+    }
+  ],
+  "summary": {
+    "total": 12,
+    "indexed": 11,
+    "stale": 0,
+    "no_index": 1,
+    "failures": 1
+  },
+  "failure_summaries": [
+    "omnistream: never indexed by Repowise"
+  ]
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `alias` | string | Repo alias from `.repowise-workspace.yaml` |
+| `path` | string | Path relative to `omni_home` |
+| `exists` | bool | Whether the repo directory exists on disk |
+| `branch` | string \| null | Current git branch |
+| `head_sha` | string \| null | Live `HEAD` SHA |
+| `indexed_at` | string \| null | ISO8601 timestamp of last Repowise index |
+| `index_age_days` | float \| null | Days since last index |
+| `index_head_sha` | string \| null | `HEAD` SHA at last index |
+| `stale` | bool | `true` when `head_sha != index_head_sha` |
+| `no_index` | bool | `true` when `indexed_at` is missing |
+| `docs_mode` | string | `"generated"`, `"skipped"`, or `"none"` |
+| `failure` | string \| null | Human-readable failure summary, or `null` |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Receipt written successfully |
+| `1` | Fatal error (e.g. `.repowise-workspace.yaml` not found) |
+
+## Typical workflow
+
+```bash
+# 1. Sync all repos to latest main
+bash "$OMNI_HOME/omnibase_infra/scripts/pull-all.sh"
+
+# 2. Trigger Repowise reindex (via Repowise UI or CLI)
+
+# 3. Emit freshness receipt
+python3 "$OMNI_HOME/omnibase_infra/scripts/emit_repowise_freshness_receipt.py"
+
+# 4. Review stale/failure entries
+cat "$OMNI_HOME/.onex_state/repowise-sync/latest-freshness.json" | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); [print(f) for f in d['failure_summaries']]"
+```

--- a/scripts/emit_repowise_freshness_receipt.py
+++ b/scripts/emit_repowise_freshness_receipt.py
@@ -73,10 +73,16 @@ def _load_workspace_repos(omni_home: Path) -> list[dict[str, Any]]:
             continue
         if line and not line.startswith(" ") and not stripped.startswith("- "):
             break
-        if stripped.startswith("- path:"):
+        # Any "- " list item starts a new repo record (order-tolerant).
+        if stripped.startswith("- "):
             if current is not None:
                 repos.append(current)
-            current = {"path": _strip_yaml_scalar(stripped.removeprefix("- path:"))}
+            current = {}
+            # The first key may be inline with the list marker (e.g. "- path: foo").
+            rest = stripped[2:].strip()
+            if rest and ":" in rest:
+                key, value = rest.split(":", 1)
+                current[key.strip()] = _strip_yaml_scalar(value)
             continue
         if current is None or ":" not in stripped:
             continue
@@ -85,7 +91,8 @@ def _load_workspace_repos(omni_home: Path) -> list[dict[str, Any]]:
 
     if current is not None:
         repos.append(current)
-    return repos
+    # Discard entries that lack a path field (malformed YAML blocks).
+    return [r for r in repos if r.get("path") is not None]
 
 
 def _age_days(indexed_at: str | None, now: datetime) -> float | None:
@@ -130,12 +137,17 @@ def emit(omni_home: Path, out_path: Path | None = None) -> dict[str, Any]:
         index_age_days = _age_days(indexed_at, now)
         no_index = indexed_at is None
         stale = bool(head_sha and index_head_sha and head_sha != index_head_sha)
+        # A repo that exists and was indexed but has an unreadable HEAD is an
+        # unknown state — flag it explicitly rather than letting it appear fresh.
+        head_unreadable = exists and not no_index and head_sha is None
 
         failure = None
         if not exists:
             failure = "repo directory not found"
         elif no_index:
             failure = "never indexed by Repowise"
+        elif head_unreadable:
+            failure = "repo exists but git HEAD is unreadable (not a git repo?)"
         elif index_age_days is None:
             failure = f"unparseable indexed_at: {indexed_at}"
         elif stale:

--- a/scripts/emit_repowise_freshness_receipt.py
+++ b/scripts/emit_repowise_freshness_receipt.py
@@ -201,6 +201,7 @@ def emit(omni_home: Path, out_path: Path | None = None) -> dict[str, Any]:
     try:
         latest_path.symlink_to(out_path.name)
     except OSError:
+        # Some filesystems disallow symlinks; the timestamped receipt remains durable.
         pass
     return receipt
 

--- a/scripts/emit_repowise_freshness_receipt.py
+++ b/scripts/emit_repowise_freshness_receipt.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Emit a Repowise workspace freshness receipt.
+
+The receipt binds Repowise index metadata to live git state so tech-debt
+findings can cite the repository SHAs and freshness state that produced them.
+It is stdlib-only because the sync wrapper runs outside project venvs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _run(cmd: list[str], cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _git_branch(repo_dir: Path) -> str | None:
+    return _run(["git", "branch", "--show-current"], repo_dir)
+
+
+def _git_head(repo_dir: Path) -> str | None:
+    return _run(["git", "rev-parse", "HEAD"], repo_dir)
+
+
+def _strip_yaml_scalar(value: str) -> str | None:
+    value = value.strip().strip("'\"")
+    if value in {"", "null", "Null", "NULL", "~"}:
+        return None
+    return value
+
+
+def _load_workspace_repos(omni_home: Path) -> list[dict[str, Any]]:
+    workspace_path = omni_home / ".repowise-workspace.yaml"
+    if not workspace_path.exists():
+        raise FileNotFoundError(f"missing workspace config: {workspace_path}")
+
+    repos: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    in_repos = False
+
+    for raw_line in workspace_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "repos:":
+            in_repos = True
+            continue
+        if not in_repos:
+            continue
+        if line and not line.startswith(" ") and not stripped.startswith("- "):
+            break
+        if stripped.startswith("- path:"):
+            if current is not None:
+                repos.append(current)
+            current = {"path": _strip_yaml_scalar(stripped.removeprefix("- path:"))}
+            continue
+        if current is None or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        current[key.strip()] = _strip_yaml_scalar(value)
+
+    if current is not None:
+        repos.append(current)
+    return repos
+
+
+def _age_days(indexed_at: str | None, now: datetime) -> float | None:
+    if indexed_at is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(indexed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return (now - parsed).total_seconds() / 86400.0
+
+
+def _docs_mode(entry: dict[str, Any]) -> str:
+    docs_mode = entry.get("docs_mode") or entry.get("docs")
+    if docs_mode is not None:
+        return str(docs_mode)
+    if entry.get("indexed_at") is None:
+        return "none"
+    return "generated"
+
+
+def emit(omni_home: Path, out_path: Path | None = None) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    run_id = f"freshness-{now.strftime('%Y%m%dT%H%M%SZ')}"
+    records: list[dict[str, Any]] = []
+    failure_summaries: list[str] = []
+
+    for entry in _load_workspace_repos(omni_home):
+        rel_path = str(entry.get("path") or "")
+        alias = str(entry.get("alias") or rel_path or "omni_home")
+        repo_dir = omni_home if rel_path in {"", "."} else omni_home / rel_path
+        exists = repo_dir.is_dir()
+        branch = _git_branch(repo_dir) if exists else None
+        head_sha = _git_head(repo_dir) if exists else None
+
+        indexed_at = entry.get("indexed_at")
+        index_head_sha = entry.get("last_commit_at_index") or entry.get(
+            "index_head_sha"
+        )
+        index_age_days = _age_days(indexed_at, now)
+        no_index = indexed_at is None
+        stale = bool(head_sha and index_head_sha and head_sha != index_head_sha)
+
+        failure = None
+        if not exists:
+            failure = "repo directory not found"
+        elif no_index:
+            failure = "never indexed by Repowise"
+        elif index_age_days is None:
+            failure = f"unparseable indexed_at: {indexed_at}"
+        elif stale:
+            failure = f"HEAD {head_sha[:9]} != index SHA {str(index_head_sha)[:9]}"
+
+        if failure is not None:
+            failure_summaries.append(f"{alias}: {failure}")
+
+        records.append(
+            {
+                "alias": alias,
+                "path": rel_path,
+                "exists": exists,
+                "branch": branch,
+                "head_sha": head_sha,
+                "indexed_at": indexed_at,
+                "index_age_days": (
+                    round(index_age_days, 2) if index_age_days is not None else None
+                ),
+                "index_head_sha": index_head_sha,
+                "stale": stale,
+                "no_index": no_index,
+                "docs_mode": _docs_mode(entry),
+                "failure": failure,
+            }
+        )
+
+    receipt = {
+        "run_id": run_id,
+        "generated_at": now.isoformat(),
+        "omni_home": str(omni_home),
+        "repos": records,
+        "summary": {
+            "total": len(records),
+            "indexed": sum(1 for record in records if not record["no_index"]),
+            "stale": sum(1 for record in records if record["stale"]),
+            "no_index": sum(1 for record in records if record["no_index"]),
+            "failures": sum(1 for record in records if record["failure"] is not None),
+        },
+        "failure_summaries": failure_summaries,
+    }
+
+    if out_path is None:
+        out_path = omni_home / ".onex_state" / "repowise-sync" / f"{run_id}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+    latest_path = out_path.parent / "latest-freshness.json"
+    if latest_path.exists() or latest_path.is_symlink():
+        latest_path.unlink()
+    try:
+        latest_path.symlink_to(out_path.name)
+    except OSError:
+        pass
+    return receipt
+
+
+def _print_summary(receipt: dict[str, Any], out_path: Path) -> None:
+    summary = receipt["summary"]
+    print(f"Repowise freshness receipt: {receipt['run_id']}")
+    print(f"  total: {summary['total']}")
+    print(f"  indexed: {summary['indexed']}")
+    print(f"  stale: {summary['stale']}")
+    print(f"  no_index: {summary['no_index']}")
+    print(f"  failures: {summary['failures']}")
+    print(f"  receipt: {out_path}")
+    for failure in receipt["failure_summaries"]:
+        print(f"  - {failure}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit Repowise freshness receipt")
+    parser.add_argument(
+        "--omni-home",
+        default=os.environ.get("OMNI_HOME"),
+        help="Path to omni_home. Defaults to $OMNI_HOME, then current directory.",
+    )
+    parser.add_argument("--out", help="Output receipt path.")
+    parser.add_argument("--json-only", action="store_true")
+    args = parser.parse_args()
+
+    omni_home = Path(args.omni_home or ".").expanduser().resolve()
+    out_path = Path(args.out).expanduser().resolve() if args.out else None
+    try:
+        receipt = emit(omni_home=omni_home, out_path=out_path)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    default_out_path = (
+        omni_home / ".onex_state" / "repowise-sync" / f"{receipt['run_id']}.json"
+    )
+    receipt_path = out_path or default_out_path
+    if args.json_only:
+        print(receipt_path)
+    else:
+        _print_summary(receipt, receipt_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emit_repowise_freshness_receipt.py
+++ b/scripts/emit_repowise_freshness_receipt.py
@@ -201,8 +201,7 @@ def emit(omni_home: Path, out_path: Path | None = None) -> dict[str, Any]:
     try:
         latest_path.symlink_to(out_path.name)
     except OSError:
-        # Some filesystems disallow symlinks; the timestamped receipt remains durable.
-        pass
+        latest_path.write_text(out_path.read_text(encoding="utf-8"), encoding="utf-8")
     return receipt
 
 

--- a/scripts/emit_repowise_freshness_receipt.py
+++ b/scripts/emit_repowise_freshness_receipt.py
@@ -201,6 +201,7 @@ def emit(omni_home: Path, out_path: Path | None = None) -> dict[str, Any]:
     try:
         latest_path.symlink_to(out_path.name)
     except OSError:
+        # Some CI/workspace filesystems disallow symlinks; keep latest durable.
         latest_path.write_text(out_path.read_text(encoding="utf-8"), encoding="utf-8")
     return receipt
 

--- a/scripts/repowise_sync_after_pull.sh
+++ b/scripts/repowise_sync_after_pull.sh
@@ -48,7 +48,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-omni_home="${OMNI_HOME:-$(pwd)}"
+omni_home="${OMNI_HOME:-}"
+if [[ -z "$omni_home" ]]; then
+  # Fall back to the directory two levels above this script
+  # (scripts/ → omnibase_infra/ → omni_home/).
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  omni_home="$(cd "$script_dir/../.." && pwd)"
+fi
 workspace_config="$omni_home/.repowise-workspace.yaml"
 state_root="$omni_home/.onex_state/repowise-sync"
 run_id="repowise-sync-$(date -u +%Y%m%dT%H%M%SZ)"
@@ -70,12 +76,23 @@ if ! command -v repowise >/dev/null 2>&1; then
   exit 1
 fi
 
+pull_all_script="$omni_home/omnibase_infra/scripts/pull-all.sh"
+freshness_script="$omni_home/omnibase_infra/scripts/emit_repowise_freshness_receipt.py"
+
+for _required_script in "$pull_all_script" "$freshness_script"; do
+  if [[ ! -f "$_required_script" ]]; then
+    echo "ERROR: required script not found: $_required_script" >&2
+    echo "  Set OMNI_HOME to the omni_home root (parent of omnibase_infra/)." >&2
+    exit 1
+  fi
+done
+
 if [[ "$skip_pull" == false ]]; then
   if [[ "${#repos[@]}" -gt 0 ]]; then
-    OMNI_HOME="$omni_home" bash "$omni_home/omnibase_infra/scripts/pull-all.sh" "${repos[@]}" \
+    OMNI_HOME="$omni_home" bash "$pull_all_script" "${repos[@]}" \
       > "$run_dir/pull-all.log" 2>&1
   else
-    OMNI_HOME="$omni_home" bash "$omni_home/omnibase_infra/scripts/pull-all.sh" \
+    OMNI_HOME="$omni_home" bash "$pull_all_script" \
       > "$run_dir/pull-all.log" 2>&1
   fi
 else
@@ -93,7 +110,7 @@ fi
 repowise status --workspace "$omni_home" > "$run_dir/repowise-status.txt" 2>&1 || true
 repowise doctor --workspace "$omni_home" > "$run_dir/repowise-doctor.txt" 2>&1 || true
 
-python3 "$omni_home/omnibase_infra/scripts/emit_repowise_freshness_receipt.py" \
+python3 "$freshness_script" \
   --omni-home "$omni_home" \
   --out "$freshness_receipt_file" \
   > "$run_dir/freshness-receipt.log" 2>&1

--- a/scripts/repowise_sync_after_pull.sh
+++ b/scripts/repowise_sync_after_pull.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: repowise_sync_after_pull.sh [--skip-pull] [--dry-run] [repo ...]
+
+Pull canonical repos, refresh the Repowise workspace index, and write receipts
+under .onex_state/repowise-sync/.
+EOF
+}
+
+skip_pull=false
+dry_run=false
+repos=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-pull)
+      skip_pull=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      skip_pull=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      repos+=("$@")
+      break
+      ;;
+    -*)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      repos+=("$1")
+      shift
+      ;;
+  esac
+done
+
+omni_home="${OMNI_HOME:-$(pwd)}"
+workspace_config="$omni_home/.repowise-workspace.yaml"
+state_root="$omni_home/.onex_state/repowise-sync"
+run_id="repowise-sync-$(date -u +%Y%m%dT%H%M%SZ)"
+run_dir="$state_root/$run_id"
+receipt_file="$run_dir/receipt.json"
+freshness_receipt_file="$run_dir/freshness-receipt.json"
+
+mkdir -p "$run_dir"
+
+exec > >(tee -a "$run_dir/run.log") 2>&1
+
+if [[ ! -f "$workspace_config" ]]; then
+  echo "ERROR: missing workspace config: $workspace_config" >&2
+  exit 1
+fi
+
+if ! command -v repowise >/dev/null 2>&1; then
+  echo "ERROR: repowise CLI not found on PATH" >&2
+  exit 1
+fi
+
+if [[ "$skip_pull" == false ]]; then
+  if [[ "${#repos[@]}" -gt 0 ]]; then
+    OMNI_HOME="$omni_home" bash "$omni_home/omnibase_infra/scripts/pull-all.sh" "${repos[@]}" \
+      > "$run_dir/pull-all.log" 2>&1
+  else
+    OMNI_HOME="$omni_home" bash "$omni_home/omnibase_infra/scripts/pull-all.sh" \
+      > "$run_dir/pull-all.log" 2>&1
+  fi
+else
+  : > "$run_dir/pull-all.log"
+fi
+
+if [[ "$dry_run" == true ]]; then
+  repowise update --workspace --index-only --dry-run "$omni_home" \
+    > "$run_dir/repowise-update.log" 2>&1
+else
+  repowise update --workspace --index-only "$omni_home" \
+    > "$run_dir/repowise-update.log" 2>&1
+fi
+
+repowise status --workspace "$omni_home" > "$run_dir/repowise-status.txt" 2>&1 || true
+repowise doctor --workspace "$omni_home" > "$run_dir/repowise-doctor.txt" 2>&1 || true
+
+python3 "$omni_home/omnibase_infra/scripts/emit_repowise_freshness_receipt.py" \
+  --omni-home "$omni_home" \
+  --out "$freshness_receipt_file" \
+  > "$run_dir/freshness-receipt.log" 2>&1
+
+jq -n \
+  --arg run_id "$run_id" \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg omni_home "$omni_home" \
+  --arg receipt "$freshness_receipt_file" \
+  --arg log "$run_dir/run.log" \
+  --arg pull_all "$run_dir/pull-all.log" \
+  --arg update "$run_dir/repowise-update.log" \
+  --arg status_file "$run_dir/repowise-status.txt" \
+  --arg doctor "$run_dir/repowise-doctor.txt" \
+  --argjson dry_run "$dry_run" \
+  --argjson skip_pull "$skip_pull" \
+  '{
+    run_id: $run_id,
+    generated_at: $generated_at,
+    omni_home: $omni_home,
+    options: {dry_run: $dry_run, skip_pull: $skip_pull},
+    files: {
+      log: $log,
+      pull_all: $pull_all,
+      repowise_update: $update,
+      repowise_status: $status_file,
+      repowise_doctor: $doctor,
+      repowise_freshness: $receipt
+    }
+  }' > "$receipt_file"
+
+ln -sfn "$run_dir" "$state_root/latest"
+echo "receipt: $receipt_file"
+echo "freshness_receipt: $freshness_receipt_file"

--- a/tests/unit/scripts/test_repowise_freshness_receipt.py
+++ b/tests/unit/scripts/test_repowise_freshness_receipt.py
@@ -65,3 +65,69 @@ def test_emit_repowise_freshness_receipt_reports_stale_and_no_index(
     assert saved["repos"][1]["docs_mode"] == "skipped"
     assert saved["repos"][1]["no_index"] is True
     assert (tmp_path / "latest-freshness.json").is_symlink()
+
+
+def test_order_tolerant_yaml_parsing(tmp_path, monkeypatch):
+    """Parser must handle list items where path is not the first key."""
+    module = _load_module()
+
+    (tmp_path / "repo_c").mkdir()
+    # alias comes before path — order should not matter.
+    (tmp_path / ".repowise-workspace.yaml").write_text(
+        "\n".join(
+            [
+                "repos:",
+                "  - alias: gamma",
+                "    path: repo_c",
+                "    indexed_at: '2026-05-30T00:00:00+00:00'",
+                "    last_commit_at_index: abc123",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "_git_branch", lambda repo_dir: "main")
+    monkeypatch.setattr(module, "_git_head", lambda repo_dir: "abc123")
+
+    out_path = tmp_path / "freshness.json"
+    receipt = module.emit(tmp_path, out_path)
+
+    assert receipt["summary"]["total"] == 1
+    assert receipt["repos"][0]["alias"] == "gamma"
+    assert receipt["repos"][0]["path"] == "repo_c"
+    # Same SHA → not stale.
+    assert receipt["repos"][0]["stale"] is False
+    assert receipt["repos"][0]["failure"] is None
+
+
+def test_head_unreadable_flagged_as_failure(tmp_path, monkeypatch):
+    """A repo that exists and is indexed but has an unreadable HEAD is a failure."""
+    module = _load_module()
+
+    (tmp_path / "repo_d").mkdir()
+    (tmp_path / ".repowise-workspace.yaml").write_text(
+        "\n".join(
+            [
+                "repos:",
+                "  - path: repo_d",
+                "    alias: delta",
+                "    indexed_at: '2026-05-30T00:00:00+00:00'",
+                "    last_commit_at_index: abc123",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "_git_branch", lambda repo_dir: None)
+    monkeypatch.setattr(module, "_git_head", lambda repo_dir: None)
+
+    out_path = tmp_path / "freshness.json"
+    receipt = module.emit(tmp_path, out_path)
+
+    assert receipt["summary"]["failures"] == 1
+    repo = receipt["repos"][0]
+    assert repo["failure"] is not None
+    assert "unreadable" in repo["failure"]
+    assert repo["stale"] is False  # can't determine staleness without HEAD

--- a/tests/unit/scripts/test_repowise_freshness_receipt.py
+++ b/tests/unit/scripts/test_repowise_freshness_receipt.py
@@ -131,3 +131,41 @@ def test_head_unreadable_flagged_as_failure(tmp_path, monkeypatch):
     assert repo["failure"] is not None
     assert "unreadable" in repo["failure"]
     assert repo["stale"] is False  # can't determine staleness without HEAD
+
+
+def test_latest_freshness_falls_back_to_copy_when_symlink_unavailable(
+    tmp_path, monkeypatch
+):
+    module = _load_module()
+
+    (tmp_path / "repo_e").mkdir()
+    (tmp_path / ".repowise-workspace.yaml").write_text(
+        "\n".join(
+            [
+                "repos:",
+                "  - path: repo_e",
+                "    alias: epsilon",
+                "    indexed_at: '2026-05-30T00:00:00+00:00'",
+                "    last_commit_at_index: abc123",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "_git_branch", lambda repo_dir: "main")
+    monkeypatch.setattr(module, "_git_head", lambda repo_dir: "abc123")
+
+    def reject_symlink(self, target):
+        raise OSError("symlinks unavailable")
+
+    monkeypatch.setattr(module.Path, "symlink_to", reject_symlink)
+
+    out_path = tmp_path / "freshness.json"
+    module.emit(tmp_path, out_path)
+
+    latest_path = tmp_path / "latest-freshness.json"
+    assert not latest_path.is_symlink()
+    assert json.loads(latest_path.read_text(encoding="utf-8")) == json.loads(
+        out_path.read_text(encoding="utf-8")
+    )

--- a/tests/unit/scripts/test_repowise_freshness_receipt.py
+++ b/tests/unit/scripts/test_repowise_freshness_receipt.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).parents[3] / "scripts" / "emit_repowise_freshness_receipt.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "emit_repowise_freshness_receipt", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_emit_repowise_freshness_receipt_reports_stale_and_no_index(
+    tmp_path, monkeypatch
+):
+    module = _load_module()
+
+    (tmp_path / "repo_a").mkdir()
+    (tmp_path / "repo_b").mkdir()
+    (tmp_path / ".repowise-workspace.yaml").write_text(
+        "\n".join(
+            [
+                "repos:",
+                "  - path: repo_a",
+                "    alias: alpha",
+                "    indexed_at: '2026-05-29T00:00:00+00:00'",
+                "    last_commit_at_index: oldsha",
+                "  - path: repo_b",
+                "    alias: beta",
+                "    docs_mode: skipped",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "_git_branch", lambda repo_dir: "main")
+    monkeypatch.setattr(module, "_git_head", lambda repo_dir: "newsha")
+
+    out_path = tmp_path / "freshness.json"
+    receipt = module.emit(tmp_path, out_path)
+    saved = json.loads(out_path.read_text(encoding="utf-8"))
+
+    assert receipt == saved
+    assert saved["summary"]["total"] == 2
+    assert saved["summary"]["indexed"] == 1
+    assert saved["summary"]["stale"] == 1
+    assert saved["summary"]["no_index"] == 1
+    assert saved["summary"]["failures"] == 2
+    assert saved["repos"][0]["alias"] == "alpha"
+    assert saved["repos"][0]["head_sha"] == "newsha"
+    assert saved["repos"][0]["index_head_sha"] == "oldsha"
+    assert saved["repos"][0]["stale"] is True
+    assert saved["repos"][1]["docs_mode"] == "skipped"
+    assert saved["repos"][1]["no_index"] is True
+    assert (tmp_path / "latest-freshness.json").is_symlink()


### PR DESCRIPTION
## Summary

Rehomes the orphan Repowise freshness-receipt script from .onex_state/ into
tracked source for durability (OMN-12378).

- Add scripts/emit_repowise_freshness_receipt.py — stdlib-only script that reads .repowise-workspace.yaml and live git HEAD SHAs to emit a per-repo freshness receipt under .onex_state/repowise-sync/
- Add scripts/repowise_sync_after_pull.sh — wrapper that pulls canonical repos, refreshes the Repowise workspace index, and writes receipts
- Add docs/runbooks/repowise-freshness-receipt.md — invocation guide, output schema, field reference
- Add unit test covering stale and never-indexed repo summaries

Follow-up (not in this PR): No automated closeout flow currently wires this
script. It must be invoked manually after pull-all.sh and Repowise reindex
until the OMN-12368 closeout flow adopts it as an automatic post-reindex step.

## Ticket

OMN-12378

Evidence-Ticket: OMN-12378
Evidence-Source: OCC#1936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository freshness tracking tool to monitor indexed repositories for sync status against current git HEAD
  * Added post-pull synchronization workflow script with detailed reporting and logging capabilities

* **Documentation**
  * Added runbook covering freshness receipt emission, usage, output schema, and troubleshooting

* **Tests**
  * Added unit tests for freshness receipt functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->