### PR TITLE
fix(OMN-12501): quarantine Protocol handler declarations

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
+++ b/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
@@ -25,9 +25,14 @@ class EnumQuarantineReason(str, Enum):
       container-resolved dependency, which is incompatible with runtime-managed
       async boot. Follow-up: convert the handler or its dependency to async-safe
       construction.
+    - ``PROTOCOL_HANDLER_DECLARATION``: contract handler routing points at a
+      ``typing.Protocol`` interface rather than a concrete handler class.
+      Follow-up: change the contract to reference the concrete handler and keep
+      Protocols in dependency/interface declarations.
     """
 
     ASYNC_INCOMPATIBLE = "async_incompatible"
+    PROTOCOL_HANDLER_DECLARATION = "protocol_handler_declaration"
 
 
 __all__ = ["EnumQuarantineReason"]

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -185,6 +185,11 @@ def _is_async_incompat_runtime_error(exc: BaseException) -> bool:
     return False
 
 
+def _is_protocol_handler_class(handler_cls: type) -> bool:
+    """Return True when a handler routing entry points at a Protocol class."""
+    return bool(getattr(handler_cls, "_is_protocol", False))
+
+
 async def _async_resolve_from_container(
     container: object,
     handler_cls: type,
@@ -2434,25 +2439,27 @@ def _prepare_handler_wiring(
         ownership_query=ownership_query,
     )
 
-    def _quarantine_prepared(exc: BaseException) -> PreparedWiring:
-        """Return a containment-only PreparedWiring for an async-incompat handler.
+    def _quarantine_prepared(
+        *,
+        reason: EnumQuarantineReason,
+        detail: str,
+    ) -> PreparedWiring:
+        """Return a containment-only PreparedWiring for a known bad handler.
 
-        OMN-9457: the handler's constructor raised ``RuntimeError: asyncio.run()
-        cannot be called from a running event loop``. We deterministically
-        contain it — no dispatcher / route registration — and surface it on the
-        wiring report so follow-up migration is visible rather than
-        partially-broken runtime state.
+        Known containment-worthy declaration/construction failures are
+        surfaced in the wiring report instead of partially registering a broken
+        dispatcher. Resolver Step-6 constructor exhaustion TypeError remains
+        boot-fatal outside these explicit reasons.
         """
-        detail = _sanitize_exc(exc)
         logger.warning(
-            "Auto-wiring: quarantining async-incompatible handler %s.%s "
-            "(contract=%s, package=%s): %s. Runtime-effects boot will "
-            "continue; convert the handler to async-safe construction to "
-            "re-enable it.",
+            "Auto-wiring: quarantining handler %s.%s "
+            "(contract=%s, package=%s, reason=%s): %s. Runtime-effects boot "
+            "will continue; follow-up migration required.",
             handler_ref.module,
             handler_ref.name,
             contract.name,
             contract.package_name,
+            reason.value,
             detail,
         )
         return PreparedWiring(
@@ -2463,8 +2470,8 @@ def _prepare_handler_wiring(
             handler_name=handler_ref.name,
             handler_module=handler_ref.module,
             resolution_outcome=EnumHandlerResolutionOutcome.UNRESOLVABLE,
-            skip_reason=f"quarantined:{EnumQuarantineReason.ASYNC_INCOMPATIBLE.value}",
-            quarantine_reason=EnumQuarantineReason.ASYNC_INCOMPATIBLE,
+            skip_reason=f"quarantined:{reason.value}",
+            quarantine_reason=reason,
             quarantine_detail=detail,
         )
 
@@ -2496,12 +2503,26 @@ def _prepare_handler_wiring(
         )
         try:
             resolution = resolver.resolve(ctx)
+        except TypeError as exc:
+            # OMN-12501: Protocol interfaces are non-instantiable by design.
+            # They are invalid as handler_routing targets, but should be
+            # reported as contract migration work rather than crashing
+            # runtime-effects boot under the generic resolver TypeError path.
+            if _is_protocol_handler_class(handler_cls):
+                return _quarantine_prepared(
+                    reason=EnumQuarantineReason.PROTOCOL_HANDLER_DECLARATION,
+                    detail=_sanitize_exc(exc),
+                )
+            raise
         except RuntimeError as exc:
             # OMN-9457: deterministic containment for handlers whose
             # construction path calls asyncio.run() inside runtime-managed
             # async boot. Any other RuntimeError propagates unchanged.
             if _is_async_incompat_runtime_error(exc):
-                return _quarantine_prepared(exc)
+                return _quarantine_prepared(
+                    reason=EnumQuarantineReason.ASYNC_INCOMPATIBLE,
+                    detail=_sanitize_exc(exc),
+                )
             raise
 
     # _early_category was computed up-front so the quarantine sentinel could

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
@@ -217,7 +217,8 @@ class _HandlerAsyncIncompatInInitWithWrap:
 class _HandlerProtocolDeclaration(Protocol):
     """Invalid handler_routing target: interface, not concrete handler."""
 
-    async def handle(self, envelope: object) -> None: ...
+    async def handle(self, envelope: object) -> None:
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
@@ -34,6 +34,7 @@ These tests cover:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Protocol
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -213,6 +214,12 @@ class _HandlerAsyncIncompatInInitWithWrap:
         return None
 
 
+class _HandlerProtocolDeclaration(Protocol):
+    """Invalid handler_routing target: interface, not concrete handler."""
+
+    async def handle(self, envelope: object) -> None: ...
+
+
 # ---------------------------------------------------------------------------
 # wire_from_manifest quarantine tests
 # ---------------------------------------------------------------------------
@@ -315,6 +322,43 @@ async def test_wrapped_async_incompat_is_quarantined() -> None:
     assert (
         report.quarantined_handlers[0].reason is EnumQuarantineReason.ASYNC_INCOMPATIBLE
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_handler_declaration_is_quarantined_not_boot_fatal() -> None:
+    """A Protocol handler reference is invalid contract wiring, not Step-6 exhaustion."""
+    contract = _make_contract(
+        node_name="node_protocol_handler",
+        handler_entries=(("fake.module", "_HandlerProtocolDeclaration"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=_HandlerProtocolDeclaration,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 0
+    assert report.total_wired == 0
+    assert report.total_skipped == 1
+    assert report.total_quarantined == 1
+    q = report.quarantined_handlers[0]
+    assert q.handler_name == "_HandlerProtocolDeclaration"
+    assert q.handler_module == "fake.module"
+    assert q.contract_name == "node_protocol_handler"
+    assert q.reason is EnumQuarantineReason.PROTOCOL_HANDLER_DECLARATION
+    assert "Protocol" in q.detail
+
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.SKIPPED
+    assert result.reason == "all handlers quarantined"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add a Protocol-specific auto-wiring quarantine reason for invalid handler_routing targets
- Convert Protocol-instantiation TypeError into a visible quarantine entry while preserving resolver TypeError fail-fast for normal constructor exhaustion
- Add regression coverage proving Protocol handler declarations do not crash runtime-effects boot

## Verification
- env -u PYTHONPATH uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py -q
- env -u PYTHONPATH uv run ruff check src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
- env -u PYTHONPATH uv run ruff format --check src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_async_incompat_quarantine.py
- env -u PYTHONPATH uv run mypy src/ --strict
- env -u PYTHONPATH uv run ruff check src/ --select UP007,UP006
- git diff --check

## Runtime note
This addresses the .201 stability runtime refresh blocker where refreshed runtime-effects boot hit `TypeError: Protocols cannot be instantiated` during auto-wiring.

Evidence-Source: cfefacca9b91447a0e91e88c265f05710114e255
Evidence-Ticket: OMN-12501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Handler routing to protocol interfaces is now detected and gracefully quarantined rather than causing boot failures.

* **Tests**
  * Added coverage for protocol handler quarantine behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_infra/pull/1800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->