### PR TITLE
fix(OMN-12503): require stability runtime health env

### DIFF
--- a/contracts/OMN-12503.yaml
+++ b/contracts/OMN-12503.yaml
@@ -1,0 +1,49 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-12503"
+title: "Add stability runtime ONEX health probe env"
+summary: >-
+  Require ONEX_INFRA_HOST and ONEX_INFRA_USER in the stability-test runtime lane
+  so node_session_orchestrator health, deploy-agent, and observability probes can
+  run inside the deployed runtime process.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Stability runtime compose and lane regression tests pass"
+    command: >-
+      env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
+  - kind: "ci"
+    description: "Touched stability runtime files pass ruff checks"
+    command: >-
+      env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
+  - kind: "manual"
+    description: "Post-merge stability runtime redeploy proves session_orchestrator no longer halts on missing ONEX_INFRA_HOST"
+    command: >-
+      deploy .201 stability runtime from the merged image, then run session_orchestrator dry-run against runtime://omninode-pc/stability-test/main and verify the health gate no longer reports missing ONEX_INFRA_HOST or ONEX_INFRA_USER
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-targeted-tests"
+    description: "Stability runtime compose and lane regression tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
+  - id: "dod-ruff-check"
+    description: "Touched stability runtime tests pass ruff checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
+  - id: "dod-stability-dogfood"
+    description: "Post-merge stability runtime dogfood proves env is present in the deployed runtime process"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          deploy .201 stability runtime from the merged image, then run session_orchestrator dry-run against runtime://omninode-pc/stability-test/main and verify the terminal health report does not include missing ONEX_INFRA_HOST or ONEX_INFRA_USER

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -100,6 +100,8 @@ services:
       KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
+      ONEX_INFRA_HOST: ${ONEX_INFRA_HOST:?session orchestrator health probes require ONEX_INFRA_HOST}
+      ONEX_INFRA_USER: ${ONEX_INFRA_USER:?session orchestrator health probes require ONEX_INFRA_USER}
       ONEX_RUNTIME_ID: stability-test-main
       ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/main
       ONEX_RUNTIME_CAPABILITIES: ${STABILITY_TEST_RUNTIME_MAIN_CAPABILITIES:?runtime policy contract must set STABILITY_TEST_RUNTIME_MAIN_CAPABILITIES}
@@ -130,6 +132,8 @@ services:
       KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
+      ONEX_INFRA_HOST: ${ONEX_INFRA_HOST:?session orchestrator health probes require ONEX_INFRA_HOST}
+      ONEX_INFRA_USER: ${ONEX_INFRA_USER:?session orchestrator health probes require ONEX_INFRA_USER}
       ONEX_RUNTIME_ID: stability-test-effects
       ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/effects
       ONEX_RUNTIME_CAPABILITIES: ${STABILITY_TEST_RUNTIME_EFFECTS_CAPABILITIES:?runtime policy contract must set STABILITY_TEST_RUNTIME_EFFECTS_CAPABILITIES}
@@ -172,6 +176,8 @@ services:
       KAFKA_ENVIRONMENT: stability-test
       ONEX_STATE_ROOT: /app/data/.onex_state_stability_test
       ONEX_BOX_ID: omninode-pc
+      ONEX_INFRA_HOST: ${ONEX_INFRA_HOST:?session orchestrator health probes require ONEX_INFRA_HOST}
+      ONEX_INFRA_USER: ${ONEX_INFRA_USER:?session orchestrator health probes require ONEX_INFRA_USER}
       ONEX_RUNTIME_ID: stability-test-worker
       ONEX_RUNTIME_ADDRESS: runtime://omninode-pc/stability-test/worker
       ONEX_RUNTIME_CAPABILITIES: ${STABILITY_TEST_RUNTIME_WORKER_CAPABILITIES:?runtime policy contract must set STABILITY_TEST_RUNTIME_WORKER_CAPABILITIES}

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -181,7 +182,7 @@ def _run_compose_config(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _compose_config_json() -> dict:
+def _compose_config_json() -> dict[str, Any]:
     result = _run_compose_config("--format", "json")
 
     rendered_config = json.loads(result.stdout)
@@ -189,11 +190,11 @@ def _compose_config_json() -> dict:
     return rendered_config
 
 
-def _published_ports(service_config: dict) -> set[str]:
+def _published_ports(service_config: dict[str, Any]) -> set[str]:
     return {str(port["published"]) for port in service_config.get("ports", [])}
 
 
-def _label_value(service_config: dict, key: str) -> str | None:
+def _label_value(service_config: dict[str, Any], key: str) -> str | None:
     labels = service_config.get("labels", {})
     if isinstance(labels, dict):
         value = labels.get(key)

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -118,6 +118,8 @@ COMPOSE_RENDER_ENV = {
     "LLM_EMBEDDING_URL": _http_url("llm-embedding.invalid"),
     "LLM_ENDPOINT_CIDR_ALLOWLIST": _cidr("192.168.86", "0/24"),
     "LOCAL_LLM_SHARED_SECRET": "render-only-local-llm-secret",
+    "ONEX_INFRA_HOST": "192.0.2.10",
+    "ONEX_INFRA_USER": "render-only-user",
     "ONEX_REGISTRATION_AUTO_ACK": "false",
     "ONEX_SERVICE_CLIENT_SECRET": "render-only-client-secret",
     "POSTGRES_PASSWORD": "postgres",
@@ -243,6 +245,8 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
         assert environment["OMNIMEMORY_MEMGRAPH_HOST"] == ""
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
+        assert environment["ONEX_INFRA_HOST"] == "192.0.2.10"
+        assert environment["ONEX_INFRA_USER"] == "render-only-user"
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
         assert environment["KAFKA_MAX_POLL_INTERVAL_MS"] == "1800000"
         assert "image" not in services[service_name]

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -150,6 +150,14 @@ def test_stability_lane_uses_workspace_selector_and_isolated_groups() -> None:
         assert environment["ONEX_ENVIRONMENT"] == "stability-test"
         assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
         assert environment["ONEX_STATE_ROOT"] == "/app/data/.onex_state_stability_test"
+        assert (
+            environment["ONEX_INFRA_HOST"]
+            == "${ONEX_INFRA_HOST:?session orchestrator health probes require ONEX_INFRA_HOST}"
+        )
+        assert (
+            environment["ONEX_INFRA_USER"]
+            == "${ONEX_INFRA_USER:?session orchestrator health probes require ONEX_INFRA_USER}"
+        )
         assert environment["KAFKA_INSTANCE_ID"].startswith("stability-test-")
         assert environment["KAFKA_MAX_POLL_INTERVAL_MS"] == "1800000"
 

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -73,6 +74,7 @@ def _construct_compose_value(
         return loader.construct_mapping(node)
     if isinstance(node, yaml.SequenceNode):
         return loader.construct_sequence(node)
+    assert isinstance(node, yaml.ScalarNode)
     return loader.construct_scalar(node)
 
 
@@ -83,7 +85,7 @@ class _TestSafeLoader(yaml.SafeLoader):
 _TestSafeLoader.add_constructor("!override", _construct_compose_value)
 
 
-def _load_overlay() -> dict:
+def _load_overlay() -> dict[str, Any]:
     overlay_text = OVERLAY_FILE.read_text(encoding="utf-8")
     overlay = yaml.load(overlay_text, Loader=_TestSafeLoader)  # noqa: S506
     assert isinstance(overlay, dict)
@@ -100,7 +102,7 @@ def _load_runtime_policy_env() -> dict[str, str]:
     return env
 
 
-def _load_base_compose() -> dict:
+def _load_base_compose() -> dict[str, Any]:
     base_text = BASE_COMPOSE_FILE.read_text(encoding="utf-8")
     base = yaml.load(base_text, Loader=yaml.SafeLoader)
     assert isinstance(base, dict)


### PR DESCRIPTION
## Summary
- require ONEX_INFRA_HOST and ONEX_INFRA_USER in all stability-test runtime services
- extend stability lane compose render/unit coverage so the env cannot silently disappear
- add repo-local OMN-12503 DoD contract

## Verification
- env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
- env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
- contract YAML parse: contracts/OMN-12503.yaml OK

Evidence-Ticket: OMN-12503
Evidence-Source: 65c4e8348f3881946ae98566dee1da702376a970