### PR TITLE
fix(OMN-12516): require Infisical Redis auth in catalog

### DIFF
--- a/docker/catalog/services/infisical.yaml
+++ b/docker/catalog/services/infisical.yaml
@@ -5,11 +5,12 @@ layer: infrastructure
 container_name: omnibase-infra-infisical
 required_env:
   - POSTGRES_PASSWORD
+  - INFISICAL_REDIS_URL
   - INFISICAL_ENCRYPTION_KEY
   - INFISICAL_AUTH_SECRET
 hardcoded_env:
   DB_CONNECTION_URI: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/infisical?sslmode=disable'
-  REDIS_URL: 'redis://valkey:6379'
+  REDIS_URL: '${INFISICAL_REDIS_URL:?INFISICAL_REDIS_URL must be set in ~/.omnibase/.env}'
   ENCRYPTION_KEY: '${INFISICAL_ENCRYPTION_KEY}'
   AUTH_SECRET: '${INFISICAL_AUTH_SECRET}'
   TELEMETRY_ENABLED: 'false'

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -179,19 +180,20 @@ def _run_compose_config(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _compose_config_json() -> dict:
+def _compose_config_json() -> dict[str, Any]:
     result = _run_compose_config("--format", "json")
 
     rendered_config = json.loads(result.stdout)
     assert isinstance(rendered_config, dict)
-    return rendered_config
+    return cast("dict[str, Any]", rendered_config)
 
 
-def _published_ports(service_config: dict) -> set[str]:
-    return {str(port["published"]) for port in service_config.get("ports", [])}
+def _published_ports(service_config: dict[str, Any]) -> set[str]:
+    ports = cast("list[dict[str, Any]]", service_config.get("ports", []))
+    return {str(port["published"]) for port in ports}
 
 
-def _label_value(service_config: dict, key: str) -> str | None:
+def _label_value(service_config: dict[str, Any], key: str) -> str | None:
     labels = service_config.get("labels", {})
     if isinstance(labels, dict):
         value = labels.get(key)

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -109,7 +109,7 @@ COMPOSE_RENDER_ENV = {
     "INFISICAL_AUTH_SECRET": "render-only-infisical-auth-secret",
     "INFISICAL_DB_CONNECTION_URI": "postgresql://postgres:postgres@postgres:5432/infisical",
     "INFISICAL_ENCRYPTION_KEY": "render-only-infisical-encryption-key-32",
-    "INFISICAL_REDIS_URL": "redis://valkey:6379",
+    "INFISICAL_REDIS_URL": "redis://:render-only-valkey-password@valkey:6379",
     "GITHUB_TOKEN": "render-only-github-token",
     "LINEAR_API_KEY": "render-only-linear-api-key",
     "LLM_CODER_FAST_URL": _http_url("llm-coder-fast.invalid"),

--- a/tests/unit/docker/test_infisical_first_config.py
+++ b/tests/unit/docker/test_infisical_first_config.py
@@ -16,6 +16,9 @@ from pathlib import Path
 import pytest
 import yaml
 
+from omnibase_infra.docker.catalog.generator import generate_compose
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+
 # Project root: tests/unit/docker/ -> tests/unit/ -> tests/ -> project_root
 _PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 _CATALOG_DIR = _PROJECT_ROOT / "docker" / "catalog"
@@ -103,6 +106,42 @@ class TestInfisicalInCoreBundle:
             assert var in required, (
                 f"{var} must be in core bundle's inject_required_env"
             )
+
+    def test_infisical_catalog_requires_authenticated_redis_url(
+        self, service_manifests: dict[str, dict[str, object]]
+    ) -> None:
+        """Infisical must not be generated with an unauthenticated Valkey URL."""
+        infisical = service_manifests["infisical"]
+        required_env = set(infisical.get("required_env", []))
+        hardcoded_env = infisical.get("hardcoded_env", {})
+
+        assert "INFISICAL_REDIS_URL" in required_env
+        assert hardcoded_env.get("REDIS_URL") == (
+            "${INFISICAL_REDIS_URL:"
+            "?INFISICAL_REDIS_URL must be set in ~/.omnibase/.env}"
+        )
+        assert hardcoded_env.get("REDIS_URL") != "redis://valkey:6379"
+
+    def test_generated_core_compose_uses_infisical_redis_url_source(self) -> None:
+        """Generated compose must map Infisical REDIS_URL from INFISICAL_REDIS_URL."""
+        resolver = CatalogResolver(catalog_dir=str(_CATALOG_DIR))
+        compose = generate_compose(resolver.resolve(["core"]))
+
+        services = compose["services"]
+        assert isinstance(services, dict)
+        infisical = services["infisical"]
+        assert isinstance(infisical, dict)
+        environment = infisical["environment"]
+        assert isinstance(environment, dict)
+
+        assert environment["REDIS_URL"] == (
+            "${INFISICAL_REDIS_URL:"
+            "?INFISICAL_REDIS_URL must be set in ~/.omnibase/.env}"
+        )
+        assert environment["INFISICAL_REDIS_URL"] == (
+            "${INFISICAL_REDIS_URL:"
+            "?INFISICAL_REDIS_URL must be set in ~/.omnibase/.env}"
+        )
 
 
 class TestNoDbUrlInRequiredEnv:

--- a/tests/unit/docker/test_infisical_first_config.py
+++ b/tests/unit/docker/test_infisical_first_config.py
@@ -12,6 +12,7 @@ Validates that:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -42,27 +43,29 @@ _DOCKER_INTERNAL_HOST = "postgres:5432"
 
 
 @pytest.fixture(scope="module")
-def bundles() -> dict[str, object]:
+def bundles() -> dict[str, Any]:
     """Load bundle definitions."""
     with open(_BUNDLES_PATH) as f:
-        return yaml.safe_load(f)
+        return cast("dict[str, Any]", yaml.safe_load(f))
 
 
 @pytest.fixture(scope="module")
-def service_manifests() -> dict[str, dict[str, object]]:
+def service_manifests() -> dict[str, dict[str, Any]]:
     """Load all service catalog YAMLs."""
-    manifests: dict[str, dict[str, object]] = {}
+    manifests: dict[str, dict[str, Any]] = {}
     for yaml_file in _SERVICES_DIR.glob("*.yaml"):
         with open(yaml_file) as f:
-            data = yaml.safe_load(f)
-        manifests[data["name"]] = data
+            data = cast("dict[str, Any]", yaml.safe_load(f))
+        name = data["name"]
+        assert isinstance(name, str)
+        manifests[name] = data
     return manifests
 
 
 class TestInfisicalInCoreBundle:
     """Verify Infisical is part of the core bundle."""
 
-    def test_infisical_in_core_services(self, bundles: dict[str, object]) -> None:
+    def test_infisical_in_core_services(self, bundles: dict[str, Any]) -> None:
         """Infisical must be listed in the core bundle's services."""
         core = bundles["core"]
         assert isinstance(core, dict)
@@ -72,7 +75,7 @@ class TestInfisicalInCoreBundle:
             "It was moved from the secrets bundle in OMN-5831."
         )
 
-    def test_valkey_in_core_services(self, bundles: dict[str, object]) -> None:
+    def test_valkey_in_core_services(self, bundles: dict[str, Any]) -> None:
         """Valkey must be in core because Infisical depends on it."""
         core = bundles["core"]
         assert isinstance(core, dict)
@@ -81,7 +84,7 @@ class TestInfisicalInCoreBundle:
             "Valkey must be in the core bundle because Infisical depends on it."
         )
 
-    def test_core_injects_infisical_env(self, bundles: dict[str, object]) -> None:
+    def test_core_injects_infisical_env(self, bundles: dict[str, Any]) -> None:
         """Core bundle must inject INFISICAL_ADDR for runtime services."""
         core = bundles["core"]
         assert isinstance(core, dict)
@@ -92,7 +95,7 @@ class TestInfisicalInCoreBundle:
         )
 
     def test_core_requires_infisical_bootstrap_vars(
-        self, bundles: dict[str, object]
+        self, bundles: dict[str, Any]
     ) -> None:
         """Core bundle must require Infisical bootstrap credentials."""
         core = bundles["core"]
@@ -108,7 +111,7 @@ class TestInfisicalInCoreBundle:
             )
 
     def test_infisical_catalog_requires_authenticated_redis_url(
-        self, service_manifests: dict[str, dict[str, object]]
+        self, service_manifests: dict[str, dict[str, Any]]
     ) -> None:
         """Infisical must not be generated with an unauthenticated Valkey URL."""
         infisical = service_manifests["infisical"]
@@ -148,7 +151,7 @@ class TestNoDbUrlInRequiredEnv:
     """Verify no runtime service has DB URL/DSN vars in required_env."""
 
     def test_no_db_url_in_required_env(
-        self, service_manifests: dict[str, dict[str, object]]
+        self, service_manifests: dict[str, dict[str, Any]]
     ) -> None:
         """DB URL vars must be in hardcoded_env, not required_env."""
         violations: list[str] = []
@@ -171,7 +174,7 @@ class TestDbUrlsUseDockerInternal:
     """Verify hardcoded DB URLs use Docker-internal addresses."""
 
     def test_hardcoded_db_urls_use_internal_host(
-        self, service_manifests: dict[str, dict[str, object]]
+        self, service_manifests: dict[str, dict[str, Any]]
     ) -> None:
         """All hardcoded DB URL values must reference postgres:5432."""
         violations: list[str] = []

--- a/tests/unit/infra/test_canary_bundle.py
+++ b/tests/unit/infra/test_canary_bundle.py
@@ -133,6 +133,7 @@ def test_canary_bundle_required_env_subset_of_core_baseline() -> None:
             "INFISICAL_PROJECT_ID",
             "INFISICAL_ENCRYPTION_KEY",
             "INFISICAL_AUTH_SECRET",
+            "INFISICAL_REDIS_URL",
         }
     )
     unexpected = resolved.required_env - _EXPECTED_CANARY_ENV


### PR DESCRIPTION
## Summary

- require `INFISICAL_REDIS_URL` in the Infisical catalog service
- render Infisical `REDIS_URL` from the authenticated host env source instead of hardcoding `redis://valkey:6379`
- add focused manifest/generated-compose coverage and update stability render env to use an authenticated Valkey URL

## Recovery Context

`.201` currently has `omnibase-infra-infisical` restart-looping with `NOAUTH Authentication required`. The host env already has an authenticated `INFISICAL_REDIS_URL`, but catalog-generated compose emitted unauthenticated `REDIS_URL=redis://valkey:6379`.

## Verification

- `uv run pytest tests/unit/docker/test_infisical_first_config.py -q` -> 9 passed
- `uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py -q` -> 6 passed
- `PYTHONPATH=src uv run python -m omnibase_infra.docker.catalog.cli validate core` -> pass
- `PYTHONPATH=src uv run python -m omnibase_infra.docker.catalog.cli generate core --output /tmp/omn-12516-compose.yml` -> generated Infisical `REDIS_URL` and `INFISICAL_REDIS_URL` from `${INFISICAL_REDIS_URL:?…}`
- `uv run ruff format --check tests/unit/docker/test_infisical_first_config.py tests/integration/infra/test_stability_test_runtime_compose_render.py` -> pass
- `uv run ruff check tests/unit/docker/test_infisical_first_config.py tests/integration/infra/test_stability_test_runtime_compose_render.py` -> pass
- YAML parse check for `docker/catalog/services/infisical.yaml` -> pass
Evidence-Source: cc57ca6566f171a09ed460350b9ff6ddaa03f92f
Evidence-Ticket: OMN-12516