### PR TITLE
fix(OMN-12523): configure kafka client api version

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -188,6 +188,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 import os
 import random
@@ -638,6 +639,20 @@ class EventBusKafka(
 
         return kwargs
 
+    def _build_client_version_kwargs(
+        self, client_cls: type[object]
+    ) -> dict[str, object]:
+        """Build optional aiokafka client-version kwargs."""
+        if self._config.api_version is None:
+            return {}
+        try:
+            parameters = inspect.signature(client_cls.__init__).parameters
+        except (TypeError, ValueError):
+            return {}
+        if "api_version" not in parameters:
+            return {}
+        return {"api_version": self._config.api_version}
+
     async def start(self) -> None:
         """Start the event bus and connect to Kafka.
 
@@ -675,6 +690,7 @@ class EventBusKafka(
                     enable_idempotence=self._config.enable_idempotence,
                     max_request_size=self._config.max_request_size,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
+                    **self._build_client_version_kwargs(AIOKafkaProducer),
                     **self._build_auth_kwargs(),
                 )
 
@@ -1011,6 +1027,7 @@ class EventBusKafka(
                 enable_idempotence=self._config.enable_idempotence,
                 max_request_size=self._config.max_request_size,
                 retry_backoff_ms=self._config.reconnect_backoff_ms,
+                **self._build_client_version_kwargs(AIOKafkaProducer),
                 **self._build_auth_kwargs(),
             )
 
@@ -1748,6 +1765,7 @@ class EventBusKafka(
             heartbeat_interval_ms=self._config.heartbeat_interval_ms,
             max_poll_interval_ms=self._config.max_poll_interval_ms,
             retry_backoff_ms=self._config.reconnect_backoff_ms,
+            **self._build_client_version_kwargs(AIOKafkaConsumer),
             **self._build_auth_kwargs(),
         )
 
@@ -1867,6 +1885,7 @@ class EventBusKafka(
                     heartbeat_interval_ms=self._config.heartbeat_interval_ms,
                     max_poll_interval_ms=self._config.max_poll_interval_ms,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
+                    **self._build_client_version_kwargs(AIOKafkaConsumer),
                     **self._build_auth_kwargs(),
                 )
 

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -218,6 +218,13 @@ class ModelKafkaEventBusConfig(BaseModel):
         description="Kafka bootstrap servers (host:port format, comma-separated for multiple)",
         min_length=1,
     )
+    api_version: str | None = Field(
+        default=None,
+        description=(
+            "Optional explicit aiokafka API version, for example '2.8.0'. "
+            "When unset, aiokafka auto-negotiates the broker version."
+        ),
+    )
     environment: str = Field(
         default="local",
         description=(
@@ -766,6 +773,31 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         return v.strip()
 
+    @field_validator("api_version", mode="before")
+    @classmethod
+    def validate_api_version(cls, v: object) -> str | None:
+        """Validate optional aiokafka API version override."""
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            v = str(v)
+        value = v.strip()
+        if not value:
+            return None
+        if not re.match(r"^\d+\.\d+\.\d+$", value):
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.KAFKA,
+                operation="validate_config",
+                target_name="kafka_config",
+            )
+            raise ProtocolConfigurationError(
+                "api_version must use '<major>.<minor>.<patch>' format",
+                context=context,
+                parameter="api_version",
+                value=value,
+            )
+        return value
+
     @field_validator("environment", mode="before")
     @classmethod
     def validate_environment(cls, v: object) -> str:
@@ -843,6 +875,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         env_mappings: dict[str, str] = {
             "KAFKA_BOOTSTRAP_SERVERS": "bootstrap_servers",
+            "KAFKA_API_VERSION": "api_version",
             "KAFKA_TIMEOUT_SECONDS": "timeout_seconds",
             "KAFKA_ENVIRONMENT": "environment",
             "KAFKA_MAX_RETRY_ATTEMPTS": "max_retry_attempts",

--- a/tests/unit/event_bus/test_kafka_config_api_version.py
+++ b/tests/unit/event_bus/test_kafka_config_api_version.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for EventBusKafka aiokafka API version configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.errors import ProtocolConfigurationError
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+
+
+@pytest.mark.unit
+class TestKafkaApiVersionConfig:
+    """Verify explicit aiokafka API version config is typed and plumbed."""
+
+    def test_api_version_defaults_to_auto_negotiation(self) -> None:
+        config = ModelKafkaEventBusConfig()
+
+        assert config.api_version is None
+
+    def test_api_version_can_be_set_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_API_VERSION", "2.8.0")
+
+        config = ModelKafkaEventBusConfig.default()
+
+        assert config.api_version == "2.8.0"
+
+    def test_blank_api_version_env_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_API_VERSION", "   ")
+
+        config = ModelKafkaEventBusConfig.default()
+
+        assert config.api_version is None
+
+    def test_invalid_api_version_fails_closed(self) -> None:
+        with pytest.raises(ProtocolConfigurationError, match="api_version"):
+            ModelKafkaEventBusConfig(api_version="2.8")
+
+    def test_api_version_kwargs_omitted_when_aiokafka_does_not_support_them(
+        self,
+    ) -> None:
+        class ClientWithoutApiVersion:
+            def __init__(self, *, bootstrap_servers: str) -> None:
+                self.bootstrap_servers = bootstrap_servers
+
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        assert bus._build_client_version_kwargs(ClientWithoutApiVersion) == {}
+
+    def test_api_version_kwargs_present_when_aiokafka_supports_them(self) -> None:
+        class ClientWithApiVersion:
+            def __init__(
+                self, *, bootstrap_servers: str, api_version: str = "auto"
+            ) -> None:
+                self.bootstrap_servers = bootstrap_servers
+                self.api_version = api_version
+
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        assert bus._build_client_version_kwargs(ClientWithApiVersion) == {
+            "api_version": "2.8.0"
+        }
+
+    @pytest.mark.asyncio
+    async def test_producer_omits_api_version_when_installed_aiokafka_lacks_support(
+        self,
+    ) -> None:
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+
+            await bus.start()
+
+        assert "api_version" not in mock_producer_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_producer_omits_api_version_when_unset(self) -> None:
+        config = ModelKafkaEventBusConfig()
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+
+            await bus.start()
+
+        assert "api_version" not in mock_producer_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_consumer_omits_api_version_when_installed_aiokafka_lacks_support(
+        self,
+    ) -> None:
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+        mock_consumer = MagicMock()
+        mock_consumer.start = AsyncMock()
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            await bus.start()
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ) as mock_consumer_cls:
+            await bus.subscribe(
+                "test-topic", on_message=AsyncMock(), group_id="test-group"
+            )
+
+        assert "api_version" not in mock_consumer_cls.call_args.kwargs


### PR DESCRIPTION
## Summary
- Add typed `ModelKafkaEventBusConfig.api_version` with `KAFKA_API_VERSION` env override.
- Pass `api_version` to aiokafka producer/consumer constructors only when the installed aiokafka version supports that kwarg.
- Keep default behavior unchanged when `KAFKA_API_VERSION` is unset.

## Verification
- `uv run ruff check src/omnibase_infra/event_bus/event_bus_kafka.py src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py tests/unit/event_bus/test_kafka_config_api_version.py`
- `uv run pytest tests/unit/event_bus/test_kafka_config_api_version.py tests/unit/event_bus/test_kafka_producer_max_request_size.py tests/unit/event_bus/test_kafka_timeout_kwargs.py -q` -> 18 passed
- Live proof from `omnimarket` with OMN-12523 worktree first on `PYTHONPATH`: `KAFKA_BOOTSTRAP_SERVERS=192.168.86.201:39092 KAFKA_API_VERSION=2.8.0 KAFKA_TIMEOUT_SECONDS=8` started `EventBusKafka` in 0.03s.

## Follow-up
- OMN-12524 tracks the separate terminal-result delivery bug found after bootstrap was fixed: runtime publishes and adapter group consumes `session-orchestrator-completed`, but the CLI still times out.

Evidence-Ticket: OMN-12523
Evidence-Source: OCC#1954