### PR TITLE
fix(OMN-12522): retry Kafka cold bootstrap

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -203,6 +203,7 @@ from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from aiokafka.abc import AbstractTokenProvider
 from aiokafka.errors import (
     InvalidPartitionsError,
+    KafkaConnectionError,
     KafkaError,
     UnknownTopicOrPartitionError,
 )
@@ -488,6 +489,98 @@ class EventBusKafka(
         # Gated by ENABLE_CONSUMER_HEALTH_EMITTER env var
         self._health_emitter: ConsumerHealthEmitter | None = None
 
+    def _build_producer(self) -> AIOKafkaProducer:
+        """Build a producer from the current immutable config snapshot."""
+        return AIOKafkaProducer(
+            bootstrap_servers=self._bootstrap_servers,
+            acks=self._config.acks_aiokafka,
+            enable_idempotence=self._config.enable_idempotence,
+            max_request_size=self._config.max_request_size,
+            retry_backoff_ms=self._config.reconnect_backoff_ms,
+            **self._build_auth_kwargs(),
+        )
+
+    def _build_consumer(
+        self,
+        topic: str,
+        *,
+        effective_group_id: str,
+        resolved_group_instance_id: str | None,
+    ) -> AIOKafkaConsumer:
+        """Build a consumer from the current immutable config snapshot."""
+        return AIOKafkaConsumer(
+            topic,
+            bootstrap_servers=self._bootstrap_servers,
+            group_id=effective_group_id,
+            group_instance_id=resolved_group_instance_id,
+            auto_offset_reset=self._config.auto_offset_reset,
+            enable_auto_commit=self._config.enable_auto_commit,
+            session_timeout_ms=self._config.session_timeout_ms,
+            heartbeat_interval_ms=self._config.heartbeat_interval_ms,
+            max_poll_interval_ms=self._config.max_poll_interval_ms,
+            retry_backoff_ms=self._config.reconnect_backoff_ms,
+            **self._build_auth_kwargs(),
+        )
+
+    async def _stop_producer_quietly(
+        self, producer: AIOKafkaProducer | None, *, reason: str
+    ) -> None:
+        if producer is None:
+            return
+        try:
+            await producer.stop()
+        except Exception as cleanup_err:  # noqa: BLE001 — boundary cleanup only
+            logger.warning(
+                "Cleanup failed for Kafka producer stop during %s: %s",
+                reason,
+                cleanup_err,
+                exc_info=True,
+            )
+
+    async def _start_producer_with_retry(self, correlation_id: UUID) -> None:
+        """Start the producer, retrying transient cold-bootstrap failures.
+
+        Redpanda can accept TCP while a metadata bootstrap request times out or
+        returns ``KafkaConnectionError`` under topic/group pressure. Startup now
+        uses the same bus-level retry budget as publish operations instead of
+        failing the whole runtime on the first cold-bootstrap miss.
+        """
+        attempts = self._max_retry_attempts + 1
+        backoff = max(0.001, self._retry_backoff_base)
+        last_error: BaseException | None = None
+
+        for attempt in range(1, attempts + 1):
+            producer = self._build_producer()
+            self._producer = producer
+            try:
+                await asyncio.wait_for(
+                    producer.start(),
+                    timeout=self._timeout_seconds,
+                )
+                return
+            except (TimeoutError, KafkaConnectionError) as exc:
+                last_error = exc
+                self._producer = None
+                await self._stop_producer_quietly(producer, reason="bootstrap retry")
+                if attempt >= attempts:
+                    raise
+                logger.warning(
+                    "Kafka producer bootstrap failed on attempt %d/%d; retrying in %.3fs",
+                    attempt,
+                    attempts,
+                    backoff,
+                    extra={
+                        "environment": self._environment,
+                        "correlation_id": str(correlation_id),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 10.0)
+
+        if last_error is not None:
+            raise last_error
+
     # =========================================================================
     # Factory Methods
     # =========================================================================
@@ -668,20 +761,7 @@ class EventBusKafka(
                 )
 
             try:
-                # Apply producer configuration from config model
-                self._producer = AIOKafkaProducer(
-                    bootstrap_servers=self._bootstrap_servers,
-                    acks=self._config.acks_aiokafka,
-                    enable_idempotence=self._config.enable_idempotence,
-                    max_request_size=self._config.max_request_size,
-                    retry_backoff_ms=self._config.reconnect_backoff_ms,
-                    **self._build_auth_kwargs(),
-                )
-
-                await asyncio.wait_for(
-                    self._producer.start(),
-                    timeout=self._timeout_seconds,
-                )
+                await self._start_producer_with_retry(correlation_id)
 
                 self._started = True
                 self._shutdown = False
@@ -1736,19 +1816,10 @@ class EventBusKafka(
         )
         resolved_group_instance_id = self._resolve_group_instance_id(effective_group_id)
 
-        # Apply consumer configuration from config model
-        consumer = AIOKafkaConsumer(
+        consumer = self._build_consumer(
             topic,
-            bootstrap_servers=self._bootstrap_servers,
-            group_id=effective_group_id,
-            group_instance_id=resolved_group_instance_id,
-            auto_offset_reset=self._config.auto_offset_reset,
-            enable_auto_commit=self._config.enable_auto_commit,
-            session_timeout_ms=self._config.session_timeout_ms,
-            heartbeat_interval_ms=self._config.heartbeat_interval_ms,
-            max_poll_interval_ms=self._config.max_poll_interval_ms,
-            retry_backoff_ms=self._config.reconnect_backoff_ms,
-            **self._build_auth_kwargs(),
+            effective_group_id=effective_group_id,
+            resolved_group_instance_id=resolved_group_instance_id,
         )
 
         # Redpanda (and Kafka) can return UnknownTopicOrPartitionError or
@@ -1771,6 +1842,8 @@ class EventBusKafka(
             asyncio.get_event_loop().time() + self._timeout_seconds
         )
         metadata_retry_backoff = 2.0  # seconds; doubles each attempt, capped at 10s
+        bootstrap_attempt = 0
+        bootstrap_retry_backoff = max(0.001, self._retry_backoff_base)
 
         while True:
             try:
@@ -1856,22 +1929,71 @@ class EventBusKafka(
 
                 # Recreate consumer for the next attempt — a consumer that failed
                 # start() cannot be restarted.
-                consumer = AIOKafkaConsumer(
+                consumer = self._build_consumer(
                     topic,
-                    bootstrap_servers=self._bootstrap_servers,
-                    group_id=effective_group_id,
-                    group_instance_id=resolved_group_instance_id,
-                    auto_offset_reset=self._config.auto_offset_reset,
-                    enable_auto_commit=self._config.enable_auto_commit,
-                    session_timeout_ms=self._config.session_timeout_ms,
-                    heartbeat_interval_ms=self._config.heartbeat_interval_ms,
-                    max_poll_interval_ms=self._config.max_poll_interval_ms,
-                    retry_backoff_ms=self._config.reconnect_backoff_ms,
-                    **self._build_auth_kwargs(),
+                    effective_group_id=effective_group_id,
+                    resolved_group_instance_id=resolved_group_instance_id,
+                )
+
+            except KafkaConnectionError as e:
+                bootstrap_attempt += 1
+                try:
+                    await consumer.stop()
+                except Exception as cleanup_err:  # noqa: BLE001
+                    logger.debug(
+                        "Cleanup after KafkaConnectionError (topic=%s): %s",
+                        topic,
+                        cleanup_err,
+                    )
+
+                if bootstrap_attempt > self._max_retry_attempts:
+                    self._pending_consumer_keys.discard(consumer_key)
+                    context = ModelInfraErrorContext.with_correlation(
+                        correlation_id=correlation_id,
+                        transport_type=EnumInfraTransportType.KAFKA,
+                        operation="start_consumer",
+                        target_name=f"kafka.{topic}",
+                    )
+                    logger.exception(
+                        f"Failed to start consumer for topic {topic}: {e}",
+                        extra={
+                            "topic": topic,
+                            "group_id": group_id,
+                            "correlation_id": str(correlation_id),
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                            "servers": sanitized_servers,
+                        },
+                    )
+                    raise InfraConnectionError(
+                        f"Failed to start consumer for topic {topic}: {e}",
+                        context=context,
+                        topic=topic,
+                        servers=sanitized_servers,
+                    ) from e
+
+                logger.warning(
+                    "Kafka consumer bootstrap failed for %s on attempt %d/%d; "
+                    "retrying in %.3fs",
+                    topic,
+                    bootstrap_attempt,
+                    self._max_retry_attempts + 1,
+                    bootstrap_retry_backoff,
+                    extra={
+                        "topic": topic,
+                        "group_id": group_id,
+                        "correlation_id": str(correlation_id),
+                    },
+                )
+                await asyncio.sleep(bootstrap_retry_backoff)
+                bootstrap_retry_backoff = min(bootstrap_retry_backoff * 2, 10.0)
+                consumer = self._build_consumer(
+                    topic,
+                    effective_group_id=effective_group_id,
+                    resolved_group_instance_id=resolved_group_instance_id,
                 )
 
             except TimeoutError as e:
-                self._pending_consumer_keys.discard(consumer_key)
                 # Clean up consumer on failure to prevent resource leak
                 try:
                     await consumer.stop()
@@ -1883,6 +2005,31 @@ class EventBusKafka(
                         exc_info=True,
                     )
 
+                bootstrap_attempt += 1
+                if bootstrap_attempt <= self._max_retry_attempts:
+                    logger.warning(
+                        "Kafka consumer bootstrap timed out for %s on attempt %d/%d; "
+                        "retrying in %.3fs",
+                        topic,
+                        bootstrap_attempt,
+                        self._max_retry_attempts + 1,
+                        bootstrap_retry_backoff,
+                        extra={
+                            "topic": topic,
+                            "group_id": group_id,
+                            "correlation_id": str(correlation_id),
+                        },
+                    )
+                    await asyncio.sleep(bootstrap_retry_backoff)
+                    bootstrap_retry_backoff = min(bootstrap_retry_backoff * 2, 10.0)
+                    consumer = self._build_consumer(
+                        topic,
+                        effective_group_id=effective_group_id,
+                        resolved_group_instance_id=resolved_group_instance_id,
+                    )
+                    continue
+
+                self._pending_consumer_keys.discard(consumer_key)
                 # Propagate timeout error to surface startup failures (differentiate from connection errors)
                 timeout_ctx = ModelTimeoutErrorContext(
                     transport_type=EnumInfraTransportType.KAFKA,

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -493,6 +493,7 @@ class EventBusKafka(
         """Build a producer from the current immutable config snapshot."""
         return AIOKafkaProducer(
             bootstrap_servers=self._bootstrap_servers,
+            api_version=self._config.api_version,
             acks=self._config.acks_aiokafka,
             enable_idempotence=self._config.enable_idempotence,
             max_request_size=self._config.max_request_size,
@@ -511,6 +512,7 @@ class EventBusKafka(
         return AIOKafkaConsumer(
             topic,
             bootstrap_servers=self._bootstrap_servers,
+            api_version=self._config.api_version,
             group_id=effective_group_id,
             group_instance_id=resolved_group_instance_id,
             auto_offset_reset=self._config.auto_offset_reset,

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -178,6 +178,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
     Attributes:
         bootstrap_servers: Kafka bootstrap servers (host:port format)
+        api_version: Kafka broker API version for aiokafka ("auto" or x.y[.z])
         environment: Environment identifier for consumer groups and logging
         timeout_seconds: Timeout for Kafka operations in seconds
         max_retry_attempts: Maximum retry attempts for publish operations
@@ -230,6 +231,16 @@ class ModelKafkaEventBusConfig(BaseModel):
         description="Timeout for Kafka operations in seconds",
         ge=1,
         le=300,
+    )
+    api_version: str = Field(
+        default="auto",
+        description=(
+            "Kafka broker API version passed to aiokafka. Use 'auto' for "
+            "aiokafka version probing, or pin a broker-compatible version "
+            "such as '2.8.0' to skip the all-topic MetadataRequest used by "
+            "auto-detection on large clusters."
+        ),
+        pattern=r"^(auto|\d+\.\d+(?:\.\d+)?)$",
     )
 
     # Retry configuration
@@ -821,6 +832,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         Environment variables are mapped as follows:
             - KAFKA_BOOTSTRAP_SERVERS -> bootstrap_servers
+            - KAFKA_API_VERSION -> api_version
             - KAFKA_TIMEOUT_SECONDS -> timeout_seconds
             - KAFKA_ENVIRONMENT -> environment
             - KAFKA_MAX_RETRY_ATTEMPTS -> max_retry_attempts
@@ -843,6 +855,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         env_mappings: dict[str, str] = {
             "KAFKA_BOOTSTRAP_SERVERS": "bootstrap_servers",
+            "KAFKA_API_VERSION": "api_version",
             "KAFKA_TIMEOUT_SECONDS": "timeout_seconds",
             "KAFKA_ENVIRONMENT": "environment",
             "KAFKA_MAX_RETRY_ATTEMPTS": "max_retry_attempts",
@@ -974,7 +987,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         if overrides:
             # Exclude computed field to avoid validation error
-            current_data = self.model_dump(exclude={"acks_aiokafka"})  # noqa: model-dump-bare
+            current_data = self.model_dump(exclude={"acks_aiokafka"})
             current_data.update(overrides)
             return ModelKafkaEventBusConfig(**current_data)
 
@@ -992,6 +1005,7 @@ class ModelKafkaEventBusConfig(BaseModel):
         """
         base_config = cls(
             bootstrap_servers="localhost:19092",  # fallback-ok: local-dev default factory
+            api_version="auto",
             environment="local",
             timeout_seconds=30,
             max_retry_attempts=3,

--- a/tests/unit/event_bus/test_kafka_bootstrap_retry.py
+++ b/tests/unit/event_bus/test_kafka_bootstrap_retry.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kafka cold-bootstrap retry coverage for EventBusKafka."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiokafka.errors import KafkaConnectionError
+
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+
+
+def _retry_config() -> ModelKafkaEventBusConfig:
+    return ModelKafkaEventBusConfig(
+        bootstrap_servers="localhost:19092",
+        timeout_seconds=1,
+        max_retry_attempts=1,
+        retry_backoff_base=0.001,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_producer_start_retries_kafka_connection_error() -> None:
+    bus = EventBusKafka(config=_retry_config())
+
+    first_producer = MagicMock()
+    first_producer.start = AsyncMock(side_effect=KafkaConnectionError())
+    first_producer.stop = AsyncMock()
+
+    second_producer = MagicMock()
+    second_producer.start = AsyncMock()
+    second_producer.stop = AsyncMock()
+
+    with (
+        patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+            side_effect=[first_producer, second_producer],
+        ) as producer_cls,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await bus.start()
+
+    assert producer_cls.call_count == 2
+    first_producer.stop.assert_awaited_once()
+    second_producer.start.assert_awaited_once()
+    assert bus._producer is second_producer
+
+    await bus.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consumer_start_retries_kafka_connection_error() -> None:
+    bus = EventBusKafka(config=_retry_config())
+
+    producer = MagicMock()
+    producer.start = AsyncMock()
+    producer.stop = AsyncMock()
+
+    with patch(
+        "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+        return_value=producer,
+    ):
+        await bus.start()
+
+    first_consumer = MagicMock()
+    first_consumer.start = AsyncMock(side_effect=KafkaConnectionError())
+    first_consumer.stop = AsyncMock()
+
+    second_consumer = MagicMock()
+    second_consumer.start = AsyncMock()
+    second_consumer.stop = AsyncMock()
+
+    with (
+        patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+            side_effect=[first_consumer, second_consumer],
+        ) as consumer_cls,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await bus.subscribe(
+            "onex.evt.omnimarket.pattern-b-dispatch-completed.v1",
+            on_message=AsyncMock(),
+            group_id="codex-adapter-bootstrap-retry",
+        )
+
+    assert consumer_cls.call_count == 2
+    first_consumer.stop.assert_awaited_once()
+    second_consumer.start.assert_awaited_once()
+
+    await bus.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consumer_start_retries_timeout_error() -> None:
+    bus = EventBusKafka(config=_retry_config())
+
+    producer = MagicMock()
+    producer.start = AsyncMock()
+    producer.stop = AsyncMock()
+
+    with patch(
+        "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer",
+        return_value=producer,
+    ):
+        await bus.start()
+
+    first_consumer = MagicMock()
+    first_consumer.start = AsyncMock(side_effect=TimeoutError())
+    first_consumer.stop = AsyncMock()
+
+    second_consumer = MagicMock()
+    second_consumer.start = AsyncMock()
+    second_consumer.stop = AsyncMock()
+
+    with (
+        patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+            side_effect=[first_consumer, second_consumer],
+        ) as consumer_cls,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await bus.subscribe(
+            "onex.evt.omnimarket.pattern-b-dispatch-completed.v1",
+            on_message=AsyncMock(),
+            group_id="codex-adapter-bootstrap-timeout-retry",
+        )
+
+    assert consumer_cls.call_count == 2
+    first_consumer.stop.assert_awaited_once()
+    second_consumer.start.assert_awaited_once()
+
+    await bus.close()

--- a/tests/unit/event_bus/test_kafka_bootstrap_retry.py
+++ b/tests/unit/event_bus/test_kafka_bootstrap_retry.py
@@ -13,9 +13,19 @@ from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
 from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
 
 
+@pytest.mark.unit
+def test_kafka_api_version_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_API_VERSION", "2.8.0")
+
+    config = ModelKafkaEventBusConfig.default()
+
+    assert config.api_version == "2.8.0"
+
+
 def _retry_config() -> ModelKafkaEventBusConfig:
     return ModelKafkaEventBusConfig(
         bootstrap_servers="localhost:19092",
+        api_version="2.8.0",
         timeout_seconds=1,
         max_retry_attempts=1,
         retry_backoff_base=0.001,
@@ -45,6 +55,7 @@ async def test_producer_start_retries_kafka_connection_error() -> None:
         await bus.start()
 
     assert producer_cls.call_count == 2
+    assert producer_cls.call_args_list[0].kwargs["api_version"] == "2.8.0"
     first_producer.stop.assert_awaited_once()
     second_producer.start.assert_awaited_once()
     assert bus._producer is second_producer
@@ -89,6 +100,7 @@ async def test_consumer_start_retries_kafka_connection_error() -> None:
         )
 
     assert consumer_cls.call_count == 2
+    assert consumer_cls.call_args_list[0].kwargs["api_version"] == "2.8.0"
     first_consumer.stop.assert_awaited_once()
     second_consumer.start.assert_awaited_once()
 
@@ -132,6 +144,7 @@ async def test_consumer_start_retries_timeout_error() -> None:
         )
 
     assert consumer_cls.call_count == 2
+    assert consumer_cls.call_args_list[0].kwargs["api_version"] == "2.8.0"
     first_consumer.stop.assert_awaited_once()
     second_consumer.start.assert_awaited_once()
 


### PR DESCRIPTION
## Summary
- retry EventBusKafka producer bootstrap on transient aiokafka TimeoutError/KafkaConnectionError
- retry response consumer bootstrap on TimeoutError/KafkaConnectionError with fresh consumer instances
- add focused unit coverage for producer and consumer cold-bootstrap retries

## Evidence
- ruff format/check passed for changed files
- uv run pytest tests/unit/event_bus/test_kafka_bootstrap_retry.py tests/unit/event_bus/test_kafka_timeout_kwargs.py tests/unit/event_bus/test_kafka_static_group_membership.py tests/integration/event_bus/test_kafka_invalid_partitions_retry_integration.py -q -> 22 passed
- live patched adapter against 192.168.86.201:39092 exercised retry path but exhausted producer bootstrap while independent rpk cluster info from this host also timed out; .201 Redpanda reports ready/healthy and internal docker exec rpk succeeds, so remaining live blocker is the stability external listener/network path, not session_orchestrator dispatch code

## Runtime note
No production mutation. Stability/client hotpatch can use this branch or rebuilt omnibase_infra package; 19092 should not be used for stability dogfood, use 39092.