### PR TITLE
fix(OMN-12531): pass Kafka API version to Pattern B terminal consumer

### DIFF
--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -188,6 +188,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 import os
 import random
@@ -639,6 +640,20 @@ class EventBusKafka(
 
         return kwargs
 
+    def _build_client_version_kwargs(
+        self, client_cls: type[object]
+    ) -> dict[str, object]:
+        """Build optional aiokafka client-version kwargs."""
+        if self._config.api_version is None:
+            return {}
+        try:
+            parameters = inspect.signature(client_cls.__init__).parameters
+        except (TypeError, ValueError):
+            return {}
+        if "api_version" not in parameters:
+            return {}
+        return {"api_version": self._config.api_version}
+
     async def start(self) -> None:
         """Start the event bus and connect to Kafka.
 
@@ -676,6 +691,7 @@ class EventBusKafka(
                     enable_idempotence=self._config.enable_idempotence,
                     max_request_size=self._config.max_request_size,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
+                    **self._build_client_version_kwargs(AIOKafkaProducer),
                     **self._build_auth_kwargs(),
                 )
 
@@ -1012,6 +1028,7 @@ class EventBusKafka(
                 enable_idempotence=self._config.enable_idempotence,
                 max_request_size=self._config.max_request_size,
                 retry_backoff_ms=self._config.reconnect_backoff_ms,
+                **self._build_client_version_kwargs(AIOKafkaProducer),
                 **self._build_auth_kwargs(),
             )
 
@@ -1749,6 +1766,7 @@ class EventBusKafka(
             heartbeat_interval_ms=self._config.heartbeat_interval_ms,
             max_poll_interval_ms=self._config.max_poll_interval_ms,
             retry_backoff_ms=self._config.reconnect_backoff_ms,
+            **self._build_client_version_kwargs(AIOKafkaConsumer),
             **self._build_auth_kwargs(),
         )
 
@@ -1875,6 +1893,7 @@ class EventBusKafka(
                     heartbeat_interval_ms=self._config.heartbeat_interval_ms,
                     max_poll_interval_ms=self._config.max_poll_interval_ms,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
+                    **self._build_client_version_kwargs(AIOKafkaConsumer),
                     **self._build_auth_kwargs(),
                 )
 

--- a/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
+++ b/src/omnibase_infra/event_bus/models/config/model_kafka_event_bus_config.py
@@ -218,6 +218,13 @@ class ModelKafkaEventBusConfig(BaseModel):
         description="Kafka bootstrap servers (host:port format, comma-separated for multiple)",
         min_length=1,
     )
+    api_version: str | None = Field(
+        default=None,
+        description=(
+            "Optional explicit aiokafka API version, for example '2.8.0'. "
+            "When unset, aiokafka auto-negotiates the broker version."
+        ),
+    )
     environment: str = Field(
         default="local",
         description=(
@@ -766,6 +773,31 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         return v.strip()
 
+    @field_validator("api_version", mode="before")
+    @classmethod
+    def validate_api_version(cls, v: object) -> str | None:
+        """Validate optional aiokafka API version override."""
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            v = str(v)
+        value = v.strip()
+        if not value:
+            return None
+        if not re.match(r"^\d+\.\d+\.\d+$", value):
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.KAFKA,
+                operation="validate_config",
+                target_name="kafka_config",
+            )
+            raise ProtocolConfigurationError(
+                "api_version must use '<major>.<minor>.<patch>' format",
+                context=context,
+                parameter="api_version",
+                value=value,
+            )
+        return value
+
     @field_validator("environment", mode="before")
     @classmethod
     def validate_environment(cls, v: object) -> str:
@@ -843,6 +875,7 @@ class ModelKafkaEventBusConfig(BaseModel):
 
         env_mappings: dict[str, str] = {
             "KAFKA_BOOTSTRAP_SERVERS": "bootstrap_servers",
+            "KAFKA_API_VERSION": "api_version",
             "KAFKA_TIMEOUT_SECONDS": "timeout_seconds",
             "KAFKA_ENVIRONMENT": "environment",
             "KAFKA_MAX_RETRY_ATTEMPTS": "max_retry_attempts",

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -258,6 +259,7 @@ class RuntimePatternBBroker:
             heartbeat_interval_ms=getattr(config, "heartbeat_interval_ms", 15000),
             max_poll_interval_ms=getattr(config, "max_poll_interval_ms", 300000),
             retry_backoff_ms=getattr(config, "reconnect_backoff_ms", 2000),
+            **self._direct_kafka_client_version_kwargs(AIOKafkaConsumer),
             **self._direct_kafka_auth_kwargs(),
         )
 
@@ -365,6 +367,21 @@ class RuntimePatternBBroker:
             build_auth_kwargs,
         )()
         return dict(auth_kwargs or {})
+
+    def _direct_kafka_client_version_kwargs(
+        self, client_cls: type[object]
+    ) -> dict[str, object]:
+        config = getattr(self._kafka_event_bus(), "config", SimpleNamespace())
+        api_version = getattr(config, "api_version", None)
+        if api_version is None:
+            return {}
+        try:
+            parameters = inspect.signature(client_cls.__init__).parameters
+        except (TypeError, ValueError):
+            return {}
+        if "api_version" not in parameters:
+            return {}
+        return {"api_version": api_version}
 
     def _kafka_bootstrap_servers(self) -> str:
         bootstrap_servers = getattr(  # noqa: B009

--- a/tests/unit/event_bus/test_kafka_config_api_version.py
+++ b/tests/unit/event_bus/test_kafka_config_api_version.py
@@ -20,9 +20,7 @@ class TestKafkaApiVersionConfig:
     """Verify explicit aiokafka API version config is typed and plumbed."""
 
     def test_api_version_defaults_to_auto_negotiation(self) -> None:
-        config = ModelKafkaEventBusConfig(
-            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS
-        )
+        config = ModelKafkaEventBusConfig(bootstrap_servers=_TEST_BOOTSTRAP_SERVERS)
 
         assert config.api_version is None
 
@@ -108,9 +106,7 @@ class TestKafkaApiVersionConfig:
 
     @pytest.mark.asyncio
     async def test_producer_omits_api_version_when_unset(self) -> None:
-        config = ModelKafkaEventBusConfig(
-            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS
-        )
+        config = ModelKafkaEventBusConfig(bootstrap_servers=_TEST_BOOTSTRAP_SERVERS)
         bus = EventBusKafka(config=config)
 
         with patch(

--- a/tests/unit/event_bus/test_kafka_config_api_version.py
+++ b/tests/unit/event_bus/test_kafka_config_api_version.py
@@ -12,13 +12,17 @@ from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
 from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
 
+_TEST_BOOTSTRAP_SERVERS = "localhost:19092"
+
 
 @pytest.mark.unit
 class TestKafkaApiVersionConfig:
     """Verify explicit aiokafka API version config is typed and plumbed."""
 
     def test_api_version_defaults_to_auto_negotiation(self) -> None:
-        config = ModelKafkaEventBusConfig()
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS
+        )
 
         assert config.api_version is None
 
@@ -42,7 +46,10 @@ class TestKafkaApiVersionConfig:
 
     def test_invalid_api_version_fails_closed(self) -> None:
         with pytest.raises(ProtocolConfigurationError, match="api_version"):
-            ModelKafkaEventBusConfig(api_version="2.8")
+            ModelKafkaEventBusConfig(
+                bootstrap_servers=_TEST_BOOTSTRAP_SERVERS,
+                api_version="2.8",
+            )
 
     def test_api_version_kwargs_omitted_when_aiokafka_does_not_support_them(
         self,
@@ -51,7 +58,10 @@ class TestKafkaApiVersionConfig:
             def __init__(self, *, bootstrap_servers: str) -> None:
                 self.bootstrap_servers = bootstrap_servers
 
-        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS,
+            api_version="2.8.0",
+        )
         bus = EventBusKafka(config=config)
 
         assert bus._build_client_version_kwargs(ClientWithoutApiVersion) == {}
@@ -64,7 +74,10 @@ class TestKafkaApiVersionConfig:
                 self.bootstrap_servers = bootstrap_servers
                 self.api_version = api_version
 
-        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS,
+            api_version="2.8.0",
+        )
         bus = EventBusKafka(config=config)
 
         assert bus._build_client_version_kwargs(ClientWithApiVersion) == {
@@ -75,7 +88,10 @@ class TestKafkaApiVersionConfig:
     async def test_producer_omits_api_version_when_installed_aiokafka_lacks_support(
         self,
     ) -> None:
-        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS,
+            api_version="2.8.0",
+        )
         bus = EventBusKafka(config=config)
 
         with patch(
@@ -92,7 +108,9 @@ class TestKafkaApiVersionConfig:
 
     @pytest.mark.asyncio
     async def test_producer_omits_api_version_when_unset(self) -> None:
-        config = ModelKafkaEventBusConfig()
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS
+        )
         bus = EventBusKafka(config=config)
 
         with patch(
@@ -111,7 +129,10 @@ class TestKafkaApiVersionConfig:
     async def test_consumer_omits_api_version_when_installed_aiokafka_lacks_support(
         self,
     ) -> None:
-        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        config = ModelKafkaEventBusConfig(
+            bootstrap_servers=_TEST_BOOTSTRAP_SERVERS,
+            api_version="2.8.0",
+        )
         bus = EventBusKafka(config=config)
         mock_consumer = MagicMock()
         mock_consumer.start = AsyncMock()

--- a/tests/unit/event_bus/test_kafka_config_api_version.py
+++ b/tests/unit/event_bus/test_kafka_config_api_version.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for EventBusKafka aiokafka API version configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.errors import ProtocolConfigurationError
+from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
+
+
+@pytest.mark.unit
+class TestKafkaApiVersionConfig:
+    """Verify explicit aiokafka API version config is typed and plumbed."""
+
+    def test_api_version_defaults_to_auto_negotiation(self) -> None:
+        config = ModelKafkaEventBusConfig()
+
+        assert config.api_version is None
+
+    def test_api_version_can_be_set_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_API_VERSION", "2.8.0")
+
+        config = ModelKafkaEventBusConfig.default()
+
+        assert config.api_version == "2.8.0"
+
+    def test_blank_api_version_env_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_API_VERSION", "   ")
+
+        config = ModelKafkaEventBusConfig.default()
+
+        assert config.api_version is None
+
+    def test_invalid_api_version_fails_closed(self) -> None:
+        with pytest.raises(ProtocolConfigurationError, match="api_version"):
+            ModelKafkaEventBusConfig(api_version="2.8")
+
+    def test_api_version_kwargs_omitted_when_aiokafka_does_not_support_them(
+        self,
+    ) -> None:
+        class ClientWithoutApiVersion:
+            def __init__(self, *, bootstrap_servers: str) -> None:
+                self.bootstrap_servers = bootstrap_servers
+
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        assert bus._build_client_version_kwargs(ClientWithoutApiVersion) == {}
+
+    def test_api_version_kwargs_present_when_aiokafka_supports_them(self) -> None:
+        class ClientWithApiVersion:
+            def __init__(
+                self, *, bootstrap_servers: str, api_version: str = "auto"
+            ) -> None:
+                self.bootstrap_servers = bootstrap_servers
+                self.api_version = api_version
+
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        assert bus._build_client_version_kwargs(ClientWithApiVersion) == {
+            "api_version": "2.8.0"
+        }
+
+    @pytest.mark.asyncio
+    async def test_producer_omits_api_version_when_installed_aiokafka_lacks_support(
+        self,
+    ) -> None:
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+
+            await bus.start()
+
+        assert "api_version" not in mock_producer_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_producer_omits_api_version_when_unset(self) -> None:
+        config = ModelKafkaEventBusConfig()
+        bus = EventBusKafka(config=config)
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+
+            await bus.start()
+
+        assert "api_version" not in mock_producer_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_consumer_omits_api_version_when_installed_aiokafka_lacks_support(
+        self,
+    ) -> None:
+        config = ModelKafkaEventBusConfig(api_version="2.8.0")
+        bus = EventBusKafka(config=config)
+        mock_consumer = MagicMock()
+        mock_consumer.start = AsyncMock()
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaProducer"
+        ) as mock_producer_cls:
+            mock_producer = MagicMock()
+            mock_producer.start = AsyncMock()
+            mock_producer.stop = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            await bus.start()
+
+        with patch(
+            "omnibase_infra.event_bus.event_bus_kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ) as mock_consumer_cls:
+            await bus.subscribe(
+                "test-topic", on_message=AsyncMock(), group_id="test-group"
+            )
+
+        assert "api_version" not in mock_consumer_cls.call_args.kwargs

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -99,8 +99,15 @@ class _FakeAIOKafkaConsumer:
     topic_partitions_by_topic: ClassVar[dict[str, set[int]] | None] = None
     require_metadata_refresh: ClassVar[bool] = False
 
-    def __init__(self, *topics: object, **kwargs: object) -> None:
+    def __init__(
+        self,
+        *topics: object,
+        api_version: str | None = None,
+        **kwargs: object,
+    ) -> None:
         self.topics = topics
+        if api_version is not None:
+            kwargs["api_version"] = api_version
         self.kwargs = kwargs
         self._client = _FakeAIOKafkaClient(self)
         self.messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
@@ -193,6 +200,7 @@ class _FakeKafkaTransport:
         heartbeat_interval_ms=15000,
         max_poll_interval_ms=300000,
         reconnect_backoff_ms=2000,
+        api_version="2.8.0",
     )
     _bootstrap_servers = "pattern-b-test-broker"
 
@@ -408,6 +416,7 @@ async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
     assert result.status == "completed"
     assert result.payload == {"status": "complete", "dispatch_count": 5}
     assert created_consumers[0].kwargs["group_id"] is None
+    assert created_consumers[0].kwargs["api_version"] == "2.8.0"
     assert created_consumers[0].assigned_partitions
     assert created_consumers[0].stopped is True
 


### PR DESCRIPTION
## Summary
- Pass the typed Kafka `api_version` config into the direct Pattern B terminal `AIOKafkaConsumer` path.
- Keeps the direct terminal consumer aligned with OMN-12523/EventBusKafka bootstrap behavior so stability runtime dispatch does not stall before worker command publication.
- Includes the OMN-12523 Kafka API version context because `dev` does not contain it yet.

## Verification
- `uv run pytest tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/event_bus/test_kafka_config_api_version.py -q` -> 28 passed
- `uv run ruff check src/omnibase_infra/runtime/service_pattern_b_broker.py tests/unit/runtime/test_service_pattern_b_broker.py tests/unit/event_bus/test_kafka_config_api_version.py`
- `git diff --check`
- Stability dogfood: live `coderabbit_triage` request with OMN-12523 patched infra reaches Kafka but reproduces `.201:39092` group-coordinator heartbeat churn, matching OMN-12531 runtime class.

## Evidence
Evidence-Ticket: OMN-12531
Evidence-Source: OCC#1975

## Deploy Gate
- Stability/dev runtime impact only; no production deploy requested.
- Post-merge validation: rerun Codex Pattern B request against `.201` with `KAFKA_API_VERSION=2.8.0` and verify terminal event on the route completion topic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `api_version` configuration for Kafka clients to control the Kafka API version
  * Configurable via `KAFKA_API_VERSION` environment variable or configuration setting
  * Includes validation for version format with rejection of invalid values
  * Automatically applied when supported by the Kafka client library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->