### PR TITLE
fix(OMN-12534): register topic event type dispatchers

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1475,6 +1475,13 @@ def _derive_event_type_alias_from_topic(topic: str) -> str | None:
     return None
 
 
+def _literal_event_type_aliases_from_topics(
+    subscribe_topics: tuple[str, ...],
+) -> set[str]:
+    """Return literal wire-topic aliases accepted as envelope event_type keys."""
+    return {topic.strip() for topic in subscribe_topics if topic.strip()}
+
+
 def _strict_dispatcher_coverage_enabled() -> bool:
     """Return True when strict orchestrator dispatcher coverage is enabled."""
     return os.environ.get(_STRICT_DISPATCHER_COVERAGE_ENV, "").lower() in (
@@ -2397,12 +2404,16 @@ def _prepare_handler_wiring(
     # Strip surrounding whitespace so registration matches the dispatch-engine
     # normalization (message_dispatch_engine.py normalizes via .strip()).
     event_type_alias = entry.event_type.strip() if entry.event_type else ""
+    subscribe_topics = contract.event_bus.subscribe_topics if contract.event_bus else ()
+    literal_topic_aliases = _literal_event_type_aliases_from_topics(subscribe_topics)
+    if literal_topic_aliases:
+        message_types = (message_types or set()).union(literal_topic_aliases)
     if event_type_alias:
         message_types = (message_types or set()) | {event_type_alias}
     elif contract.event_bus:
         topic_aliases = {
             alias
-            for topic in contract.event_bus.subscribe_topics
+            for topic in subscribe_topics
             if (alias := _derive_event_type_alias_from_topic(topic)) is not None
         }
         if topic_aliases:

--- a/tests/integration/test_handler_event_type_alias_integration.py
+++ b/tests/integration/test_handler_event_type_alias_integration.py
@@ -13,6 +13,10 @@ command missed the dispatcher lookup and fell through to DLQ.
 This integration test asserts the two-sided symmetry between registration
 and dispatch as a single contract — if either side drifts, this fails.
 
+The registration surface also includes each literal subscribed topic as a
+compatibility key for envelopes that already carry the ONEX topic in
+``event_type``.
+
 Unit coverage for the individual sides lives at:
     tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
 
@@ -106,10 +110,15 @@ def test_registration_emits_alias_matching_dispatch_engine_normalization() -> No
             container=None,
         )
 
-    assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}, (
+    assert prepared.message_types == {
+        "ModelFooCommand",
+        "platform.foo-start",
+        "onex.cmd.platform.foo-start.v1",
+    }, (
         "Registration must emit the stripped alias so the dispatch engine's "
-        ".strip()-normalized wire event_type matches. Drift here reintroduces "
-        "the OMN-9215 DLQ-everything bug."
+        ".strip()-normalized wire event_type matches, while retaining the literal "
+        "subscribed topic compatibility key. Drift here reintroduces the OMN-9215 "
+        "DLQ-everything bug."
     )
 
     # Symmetry check: dispatch-engine normalization of the wire value.
@@ -163,4 +172,8 @@ def test_alias_absent_falls_back_to_class_name_and_topic_derived_alias() -> None
             container=None,
         )
 
-    assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+    assert prepared.message_types == {
+        "ModelFooCommand",
+        "platform.foo-start",
+        "onex.cmd.platform.foo-start.v1",
+    }

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -11,8 +11,8 @@ on-wire ``event_type`` and every command routed to DLQ.
 
 This test proves:
   1. ``ModelHandlerRoutingEntry`` accepts an optional ``event_type`` alias.
-  2. ``_prepare_handler_wiring`` includes both the class name AND the
-     ``event_type`` alias in ``PreparedWiring.message_types``.
+  2. ``_prepare_handler_wiring`` includes the class name, the ``event_type``
+     alias, and literal subscribe topics in ``PreparedWiring.message_types``.
 """
 
 from __future__ import annotations
@@ -115,7 +115,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         """When event_type alias is declared, BOTH keys index the dispatcher.
 
         Before OMN-9215 dispatcher-key fix: message_types == {"ModelFooCommand"}.
-        After: message_types == {"ModelFooCommand", "platform.foo-start"}.
+        After: message_types includes class, semantic alias, and wire topic.
         This lets a publisher's wire-level event_type resolve to the registered
         handler (primary lookup path) AND keeps the class-name fallback working.
         """
@@ -142,7 +142,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_types_strips_whitespace_from_event_type_alias(self) -> None:
@@ -177,7 +181,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_types_omits_alias_when_only_whitespace(self) -> None:
@@ -213,7 +221,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
     @pytest.mark.unit
     def test_message_category_overrides_contract_first_topic_category(self) -> None:
@@ -295,6 +307,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {
             "ModelNodeHeartbeatEvent",
             "platform.node-heartbeat",
+            "onex.cmd.platform.foo-start.v1",
         }
         assert (
             prepared.resolution_outcome
@@ -335,7 +348,11 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
                 event_bus=None,
                 container=None,
             )
-        assert prepared.message_types == {"ModelFooCommand", "platform.foo-start"}
+        assert prepared.message_types == {
+            "ModelFooCommand",
+            "platform.foo-start",
+            "onex.cmd.platform.foo-start.v1",
+        }
 
 
 class TestContractDiscoveryParsesEventType:

--- a/tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py
+++ b/tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py
@@ -126,16 +126,25 @@ async def test_strict_coverage_accepts_contract_event_type_alias(
         ),
     )
 
+    engine = MessageDispatchEngine()
     with patch(
         "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
         return_value=FakeHandler,
     ):
-        report = await wire_from_manifest(manifest, MessageDispatchEngine())
+        report = await wire_from_manifest(manifest, engine)
 
     assert report.total_wired == 1
     assert report.results[0].dispatchers_registered == (
         "dispatcher.auto.pr_lifecycle_orchestrator.HandlerPrLifecycleOrchestrator",
     )
+    dispatcher = engine._dispatchers[
+        "dispatcher.auto.pr_lifecycle_orchestrator.HandlerPrLifecycleOrchestrator"
+    ]
+    assert dispatcher.message_types == {
+        "ModelPrLifecycleStartCommand",
+        START_ALIAS,
+        START_TOPIC,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- register literal subscribe topics as dispatcher `message_types` during auto-wiring
- preserve existing class-name, explicit `event_type`, and topic-derived alias dispatch keys
- add regression coverage for the PR lifecycle start topic that routed to DLQ on `.201`

## Evidence

- `.201` runtime dogfood before fix: command `onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1` was consumed, then DLQ'd with `No dispatcher found for category 'command' and message type 'onex.cmd.omnimarket.pr-lifecycle-orchestrator-start.v1'`
- `uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py -q` -> `16 passed`
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_orchestrator_dispatcher_coverage.py` -> pass
- `uv run pytest tests/unit/runtime/auto_wiring -q` -> `239 passed`
- `git diff --check` -> pass

## OCC

Evidence-Source: OCC#1981
Evidence-Ticket: OMN-12534

## Runtime validation

Post-merge validation target: redeploy/hotpatch `.201` runtime-effects and rerun live `pr_lifecycle_orchestrator` Pattern B request; expected terminal event on `onex.evt.omnimarket.pr-lifecycle-orchestrator-completed.v1`.