### PR TITLE
ci(OMN-12535): harden sibling compat installs

### DIFF
--- a/.github/workflows/check-sibling-compat.yml
+++ b/.github/workflows/check-sibling-compat.yml
@@ -17,6 +17,8 @@ env:
   UV_VERSION: "0.6.14"
   PYTHON_VERSION: "3.12"
   CACHE_VERSION: "0.6.0"
+  UV_HTTP_TIMEOUT: "600"
+  UV_TORCH_BACKEND: cpu
 
 jobs:
   sibling-compat:
@@ -66,11 +68,8 @@ jobs:
           cache-enabled: "false"
           cache-key-prefix: uv-sibling-compat
           lock-file-path: 'omnibase_infra/**/uv.lock'
-          skip-install: 'true'
-
-      - name: Install omnibase_infra dev dependencies
-        working-directory: omnibase_infra
-        run: uv sync
+          working-directory: omnibase_infra
+          install-args: ""
 
       - name: Validate sibling repo compatibility (OMN-4315)
         working-directory: omnibase_infra
@@ -87,9 +86,20 @@ jobs:
           echo "Override: omnibase-compat @ file://$(pwd)/../omnibase_compat"
           echo ""
           echo "Dry-run install of siblings with full transitive deps..."
-          uv pip install --overrides /tmp/sibling-overrides.txt \
+          attempt=1
+          max_attempts=5
+          until uv pip install --torch-backend cpu --overrides /tmp/sibling-overrides.txt \
             -e ../omniintelligence \
-            --dry-run
+            --dry-run; do
+            status=$?
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::uv pip install sibling dry-run failed after ${attempt} attempt(s)"
+              exit "${status}"
+            fi
+            echo "::warning::uv pip install sibling dry-run attempt ${attempt}/${max_attempts} failed with exit ${status}; retrying in 10s"
+            attempt=$((attempt + 1))
+            sleep 10
+          done
           echo ""
           echo "PASS: Sibling repos are compatible with current omnibase_infra."
           echo ""

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -22,6 +22,9 @@ OMNI_STANDARDS_WORKFLOW = (
 SECURITY_SCAN_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security-scan.yml"
 CHECK_HANDSHAKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "check-handshake.yml"
 CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
+CHECK_SIBLING_COMPAT_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "check-sibling-compat.yml"
+)
 SETUP_PYTHON_UV_ACTION = (
     REPO_ROOT / ".github" / "actions" / "setup-python-uv" / "action.yml"
 )
@@ -191,9 +194,7 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
     )
     assert setup_step["with"]["cache-enabled"] == "false"
 
-    sibling_workflow = _load_yaml(
-        REPO_ROOT / ".github" / "workflows" / "check-sibling-compat.yml"
-    )
+    sibling_workflow = _load_yaml(CHECK_SIBLING_COMPAT_WORKFLOW)
     setup_step = next(
         step
         for step in sibling_workflow["jobs"]["sibling-compat"]["steps"]
@@ -292,6 +293,54 @@ def test_architecture_handshake_has_checkout_retry_timeout_budget() -> None:
     job = workflow["jobs"]["check-handshake"]
 
     assert job["timeout-minutes"] >= 10
+
+
+def test_sibling_compat_routes_uv_sync_through_retrying_setup_action() -> None:
+    workflow = _load_yaml(CHECK_SIBLING_COMPAT_WORKFLOW)
+    assert workflow["env"]["UV_HTTP_TIMEOUT"] == "600"
+    assert workflow["env"]["UV_TORCH_BACKEND"] == "cpu"
+
+    steps = workflow["jobs"]["sibling-compat"]["steps"]
+    setup_step = next(
+        step
+        for step in steps
+        if step.get("uses") == "./omnibase_infra/.github/actions/setup-python-uv"
+    )
+
+    assert setup_step["with"]["cache-enabled"] == "false"
+    assert setup_step["with"]["working-directory"] == "omnibase_infra"
+    assert setup_step["with"]["install-args"] == ""
+    assert setup_step["with"].get("skip-install") != "true"
+    assert not any(
+        step.get("name") == "Install omnibase_infra dev dependencies" for step in steps
+    )
+    assert not any(step.get("run") == "uv sync" for step in steps)
+
+
+def test_sibling_compat_dry_run_retries_transient_download_failures() -> None:
+    workflow = _load_yaml(CHECK_SIBLING_COMPAT_WORKFLOW)
+    steps = workflow["jobs"]["sibling-compat"]["steps"]
+    install_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Validate sibling repo compatibility (OMN-4315)"
+    )
+
+    run_script = install_step["run"]
+    assert "max_attempts=5" in run_script
+    assert (
+        "until uv pip install --torch-backend cpu --overrides "
+        "/tmp/sibling-overrides.txt" in run_script
+    )
+    assert "--dry-run; do" in run_script
+    assert (
+        'echo "::warning::uv pip install sibling dry-run attempt '
+        "${attempt}/${max_attempts} failed" in run_script
+    )
+    assert (
+        'echo "::error::uv pip install sibling dry-run failed after '
+        '${attempt} attempt(s)"' in run_script
+    )
 
 
 def test_setup_python_uv_retries_uv_sync_and_logs_transport_settings() -> None:


### PR DESCRIPTION
## Summary
- route Sibling Compat dependency install through the retrying setup-python-uv action
- set long uv HTTP timeout and CPU torch backend at workflow level
- retry the sibling dry-run install to survive transient dependency download timeouts

## Verification
- uv run pytest tests/ci/test_ci_workflow_resilience.py -q
- uv run ruff format --check tests/ci/test_ci_workflow_resilience.py
- uv run ruff check tests/ci/test_ci_workflow_resilience.py
- git diff --check

Linear: OMN-12535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow with improved retry mechanisms for dependency compatibility checks, increasing reliability when encountering transient issues.

* **Tests**
  * Added regression tests to verify CI workflow resilience and error handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1982
Evidence-Ticket: OMN-12535

