### PR TITLE
fix(OMN-12536): preserve catalog runtime tmpfs

### DIFF
--- a/contracts/OMN-12536.yaml
+++ b/contracts/OMN-12536.yaml
@@ -1,0 +1,37 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-12536"
+title: "Preserve runtime tmpfs in catalog-generated compose"
+summary: "Catalog-driven runtime compose renders the runtime-owned local ingress tmpfs so generated deploys do not crash when binding /run/onex-runtime."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused catalog and runtime socket checks prove tmpfs is loaded and rendered."
+    command: "uv run pytest tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_renders_local_ingress_tmpfs tests/integration/test_catalog_extra_networks.py::test_generate_compose_default_network_not_overwritten_as_external tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs -q"
+  - kind: "manual"
+    description: ".201 dev runtime proof after hotpatch: runtime main is healthy and Pattern-B broker is stable with zero lag."
+    command: "deploy: docker inspect omninode-runtime --format '{{json .HostConfig.Tmpfs}}' && curl -sf http://127.0.0.1:8085/health && docker exec omnibase-infra-redpanda rpk group describe pattern-b-broker-onex-cmd-omnimarket-pattern-b-dispatch-v1.__t.onex.cmd.omnimarket.pattern-b-dispatch.v1 --brokers redpanda:9092"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-focused-tests"
+    description: "Focused catalog and runtime socket checks pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_renders_local_ingress_tmpfs tests/integration/test_catalog_extra_networks.py::test_generate_compose_default_network_not_overwritten_as_external tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs -q"
+  - id: "dod-expanded-nondocker-tests"
+    description: "Expanded non-Docker catalog checks pass."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_memgraph_bundle_injects_env tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_without_memgraph_excludes_memory_env tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_renders_local_ingress_tmpfs tests/integration/test_catalog_roundtrip.py::test_catalog_tracing_bundle_injects_otel_env tests/integration/test_catalog_extra_networks.py tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs -q"
+  - id: "dod-runtime-hotpatch-proof"
+    description: ".201 dev runtime restored the runtime-owned socket tmpfs and Pattern-B broker membership."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker inspect omninode-runtime --format '{{json .HostConfig.Tmpfs}}' includes /run/onex-runtime; /health reports status=healthy, runtime_attached=true, local_ingress.running=true; rpk group describe pattern-b-broker-onex-cmd-omnimarket-pattern-b-dispatch-v1.__t.onex.cmd.omnimarket.pattern-b-dispatch.v1 reports Stable, MEMBERS=1, TOTAL-LAG=0"

--- a/contracts/OMN-12536.yaml
+++ b/contracts/OMN-12536.yaml
@@ -34,4 +34,14 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "docker inspect omninode-runtime --format '{{json .HostConfig.Tmpfs}}' includes /run/onex-runtime; /health reports status=healthy, runtime_attached=true, local_ingress.running=true; rpk group describe pattern-b-broker-onex-cmd-omnimarket-pattern-b-dispatch-v1.__t.onex.cmd.omnimarket.pattern-b-dispatch.v1 reports Stable, MEMBERS=1, TOTAL-LAG=0"
+        check_value: >-
+          tmpfs="$(docker inspect omninode-runtime --format '{{json .HostConfig.Tmpfs}}')"
+          && printf '%s\n' "$tmpfs" | grep -F /run/onex-runtime
+          && curl -sf http://127.0.0.1:8085/health
+          | python -c 'import json, sys; data = json.load(sys.stdin); assert data["status"] == "healthy"; assert data["runtime_attached"] is True; assert data["local_ingress"]["running"] is True'
+          && docker exec omnibase-infra-redpanda rpk group describe pattern-b-broker-onex-cmd-omnimarket-pattern-b-dispatch-v1.__t.onex.cmd.omnimarket.pattern-b-dispatch.v1 --brokers redpanda:9092
+          > /tmp/omn-12536-rpk-group.txt
+          && cat /tmp/omn-12536-rpk-group.txt
+          && grep -F Stable /tmp/omn-12536-rpk-group.txt
+          && grep -E 'MEMBERS[[:space:]]+1|MEMBERS=1' /tmp/omn-12536-rpk-group.txt
+          && grep -E 'TOTAL-LAG[[:space:]]+0|TOTAL-LAG=0' /tmp/omn-12536-rpk-group.txt

--- a/docker/catalog/services/omninode-runtime.yaml
+++ b/docker/catalog/services/omninode-runtime.yaml
@@ -58,6 +58,8 @@ volumes:
   - runtime_logs:/app/logs
   - runtime_data:/app/data
   - ../contracts:/app/contracts:ro
+tmpfs:
+  - /run/onex-runtime:uid=1000,gid=1000,mode=0770
 depends_on:
   - service: migration-gate
     condition: service_healthy

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -60,6 +60,10 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
                 if not vol_name.startswith(".") and not vol_name.startswith("/"):
                     all_volumes.add(vol_name)
 
+        # Tmpfs mounts
+        if manifest.tmpfs:
+            svc["tmpfs"] = list(manifest.tmpfs)
+
         # Networks
         networks: list[str] = ["omnibase-infra-network"]
         if manifest.extra_networks:

--- a/src/omnibase_infra/docker/catalog/manifest_schema.py
+++ b/src/omnibase_infra/docker/catalog/manifest_schema.py
@@ -87,6 +87,7 @@ class CatalogManifest:
     ports: PortMapping | None
     healthcheck: HealthCheck | None
     volumes: list[str]
+    tmpfs: list[str]
     depends_on: list[DependsOnEntry]
     # Optional fields with sane defaults
     container_name: str | None = None

--- a/src/omnibase_infra/docker/catalog/manifest_schema.py
+++ b/src/omnibase_infra/docker/catalog/manifest_schema.py
@@ -87,9 +87,9 @@ class CatalogManifest:
     ports: PortMapping | None
     healthcheck: HealthCheck | None
     volumes: list[str]
-    tmpfs: list[str]
     depends_on: list[DependsOnEntry]
     # Optional fields with sane defaults
+    tmpfs: list[str] = field(default_factory=list)
     container_name: str | None = None
     command: str | list[str] | None = None
     restart: str = "unless-stopped"

--- a/src/omnibase_infra/docker/catalog/resolver.py
+++ b/src/omnibase_infra/docker/catalog/resolver.py
@@ -101,6 +101,7 @@ def _load_manifest(path: Path) -> CatalogManifest:
         ports=ports,
         healthcheck=healthcheck,
         volumes=raw.get("volumes", []),
+        tmpfs=raw.get("tmpfs", []),
         depends_on=depends_on,
         container_name=raw.get("container_name"),
         command=raw.get("command"),

--- a/tests/integration/test_catalog_extra_networks.py
+++ b/tests/integration/test_catalog_extra_networks.py
@@ -117,6 +117,7 @@ def test_generate_compose_default_network_not_overwritten_as_external() -> None:
         ports=None,
         healthcheck=None,
         volumes=[],
+        tmpfs=[],
         depends_on=[],
         extra_networks=["omnibase-infra-network"],  # reserved name in extra_networks
     )

--- a/tests/integration/test_catalog_roundtrip.py
+++ b/tests/integration/test_catalog_roundtrip.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from omnibase_infra.docker.catalog.generator import generate_compose
 from omnibase_infra.docker.catalog.resolver import CatalogResolver
 
 REPO_ROOT = str(Path(__file__).parent.parent.parent)
@@ -184,6 +185,19 @@ def test_catalog_runtime_without_memgraph_excludes_memory_env() -> None:
         assert not key.startswith("OMNIMEMORY_"), (
             f"Unexpected OMNIMEMORY var '{key}' in runtime-only stack"
         )
+
+
+@pytest.mark.integration
+def test_catalog_runtime_renders_local_ingress_tmpfs() -> None:
+    """Generated runtime compose must preserve the runtime-owned socket tmpfs."""
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    stack = resolver.resolve(["runtime"])
+    compose = generate_compose(stack)
+    services = compose["services"]
+    assert isinstance(services, dict)
+
+    runtime_service = services["omninode-runtime"]
+    assert runtime_service["tmpfs"] == ["/run/onex-runtime:uid=1000,gid=1000,mode=0770"]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Fixes OMN-12536 by preserving the runtime-owned local ingress tmpfs in catalog-generated compose output.

- Adds typed `tmpfs` support to catalog manifests, resolver, and generator.
- Declares `/run/onex-runtime:uid=1000,gid=1000,mode=0770` on `docker/catalog/services/omninode-runtime.yaml`.
- Adds focused catalog coverage so generated runtime compose keeps the tmpfs.
- Adds repo-local deploy evidence contract `contracts/OMN-12536.yaml`.

## Runtime evidence

Manual .201 dev-runtime hotpatch restored the missing tmpfs in generated compose and recreated only `omninode-runtime`.

Observed proof:
- `docker inspect omninode-runtime --format '{{json .HostConfig.Tmpfs}}'` includes `/run/onex-runtime`.
- `curl -sf http://127.0.0.1:8085/health` reports `status=healthy`, `runtime_attached=true`, `local_ingress.running=true`.
- `rpk group describe pattern-b-broker-onex-cmd-omnimarket-pattern-b-dispatch-v1.__t.onex.cmd.omnimarket.pattern-b-dispatch.v1` reports `STATE Stable`, `MEMBERS 1`, `TOTAL-LAG 0`.

## Verification

- `uv run ruff format src/omnibase_infra/docker/catalog/manifest_schema.py src/omnibase_infra/docker/catalog/resolver.py src/omnibase_infra/docker/catalog/generator.py tests/integration/test_catalog_roundtrip.py tests/integration/test_catalog_extra_networks.py`
- `uv run ruff check src/omnibase_infra/docker/catalog/manifest_schema.py src/omnibase_infra/docker/catalog/resolver.py src/omnibase_infra/docker/catalog/generator.py tests/integration/test_catalog_roundtrip.py tests/integration/test_catalog_extra_networks.py`
- `uv run pytest tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_renders_local_ingress_tmpfs tests/integration/test_catalog_extra_networks.py::test_generate_compose_default_network_not_overwritten_as_external tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs -q`
- `uv run pytest tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_memgraph_bundle_injects_env tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_without_memgraph_excludes_memory_env tests/integration/test_catalog_roundtrip.py::test_catalog_runtime_renders_local_ingress_tmpfs tests/integration/test_catalog_roundtrip.py::test_catalog_tracing_bundle_injects_otel_env tests/integration/test_catalog_extra_networks.py tests/unit/docker/test_docker_security.py::TestDockerComposeSecurity::test_runtime_socket_uses_owned_tmpfs -q`
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`

Known local limitation: the Docker-start integration test in `tests/integration/test_catalog_roundtrip.py` cannot run on this workstation because the local Docker daemon is unavailable.

Evidence-Ticket: OMN-12536

Evidence-Source: OCC#1983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring temporary filesystem (tmpfs) mounts in Docker services through the catalog manifest.
  * Services can now declare tmpfs mount points with customizable permissions and ownership settings.
  * The omninode-runtime service now includes a tmpfs mount for secure runtime storage with appropriate access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->