### PR TITLE
ci(OMN-12542): add merge queue janitor

### DIFF
--- a/scripts/ci/merge_queue_janitor.py
+++ b/scripts/ci/merge_queue_janitor.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cancel superseded GitHub merge-queue workflow runs.
+
+The janitor is intentionally conservative: it only considers ``merge_group``
+runs, preserves the newest run for each live queue ref/workflow pair, and
+defaults to dry-run mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ACTIVE_RUN_STATUSES = frozenset({"queued", "in_progress", "waiting", "pending"})
+
+
+@dataclass(frozen=True)
+class WorkflowRun:
+    run_id: int
+    event: str
+    head_branch: str
+    workflow_name: str
+    status: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class CancellationCandidate:
+    run_id: int
+    head_branch: str
+    workflow_name: str
+    reason: str
+    preserved_run_id: int | None = None
+
+
+def determine_cancellations(
+    *, live_queue_refs: set[str], active_runs: list[WorkflowRun]
+) -> list[CancellationCandidate]:
+    """Return merge-group runs that are safe to cancel."""
+    candidates: list[CancellationCandidate] = []
+    grouped: dict[tuple[str, str], list[WorkflowRun]] = {}
+
+    for run in active_runs:
+        if run.event != "merge_group" or run.status not in ACTIVE_RUN_STATUSES:
+            continue
+        if not _is_live_queue_ref(run.head_branch, live_queue_refs):
+            candidates.append(
+                CancellationCandidate(
+                    run_id=run.run_id,
+                    head_branch=run.head_branch,
+                    workflow_name=run.workflow_name,
+                    reason="stale_queue_ref",
+                )
+            )
+            continue
+        grouped.setdefault((run.head_branch, run.workflow_name), []).append(run)
+
+    for (_head_branch, _workflow_name), runs in grouped.items():
+        if len(runs) < 2:
+            continue
+        newest = max(runs, key=_run_sort_key)
+        for run in runs:
+            if run.run_id == newest.run_id:
+                continue
+            candidates.append(
+                CancellationCandidate(
+                    run_id=run.run_id,
+                    head_branch=run.head_branch,
+                    workflow_name=run.workflow_name,
+                    reason="older_duplicate_workflow_for_live_ref",
+                    preserved_run_id=newest.run_id,
+                )
+            )
+
+    return sorted(candidates, key=lambda candidate: candidate.run_id)
+
+
+def _is_live_queue_ref(head_branch: str, live_queue_refs: set[str]) -> bool:
+    return head_branch in live_queue_refs or any(
+        head_branch.startswith(live_ref) for live_ref in live_queue_refs
+    )
+
+
+def _run_sort_key(run: WorkflowRun) -> tuple[str, int]:
+    return (run.created_at, run.run_id)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def fetch_live_queue_refs(owner: str, repo: str, branch: str) -> set[str]:
+    query = """
+query($owner: String!, $repo: String!, $branch: String!) {
+  repository(owner: $owner, name: $repo) {
+    mergeQueue(branch: $branch) {
+      entries(first: 100) {
+        nodes {
+          pullRequest {
+            number
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    payload = _run_gh_json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"repo={repo}",
+            "-f",
+            f"branch={branch}",
+            "-f",
+            f"query={query}",
+        ]
+    )
+    nodes = payload["data"]["repository"]["mergeQueue"]["entries"]["nodes"]
+    return {
+        f"gh-readonly-queue/{branch}/pr-{node['pullRequest']['number']}-"
+        for node in nodes
+        if node.get("pullRequest")
+    }
+
+
+def fetch_active_runs(owner: str, repo: str, limit: int) -> list[WorkflowRun]:
+    payload = _run_gh_json(
+        [
+            "run",
+            "list",
+            "--repo",
+            f"{owner}/{repo}",
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,event,headBranch,workflowName,status,createdAt,updatedAt",
+        ]
+    )
+    return [
+        WorkflowRun(
+            run_id=int(item["databaseId"]),
+            event=item["event"],
+            head_branch=item["headBranch"],
+            workflow_name=item["workflowName"],
+            status=item["status"],
+            created_at=item["createdAt"],
+            updated_at=item["updatedAt"],
+        )
+        for item in payload
+        if item["status"] in ACTIVE_RUN_STATUSES
+    ]
+
+
+def cancel_run(owner: str, repo: str, run_id: int) -> None:
+    subprocess.run(
+        ["gh", "run", "cancel", str(run_id), "--repo", f"{owner}/{repo}"],
+        check=True,
+    )
+
+
+def write_report(
+    *,
+    path: Path,
+    owner: str,
+    repo: str,
+    branch: str,
+    apply: bool,
+    live_queue_refs: set[str],
+    candidates: list[CancellationCandidate],
+) -> None:
+    report = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "repository": f"{owner}/{repo}",
+        "branch": branch,
+        "mode": "apply" if apply else "dry-run",
+        "live_queue_refs": sorted(live_queue_refs),
+        "cancellations": [asdict(candidate) for candidate in candidates],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--owner", default="OmniNode-ai")
+    parser.add_argument("--repo", default="omnibase_infra")
+    parser.add_argument("--branch", default="dev")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Cancel candidates. Omit for dry-run mode.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="Optional JSON report path.",
+    )
+    args = parser.parse_args(argv)
+
+    live_queue_refs = fetch_live_queue_refs(args.owner, args.repo, args.branch)
+    active_runs = fetch_active_runs(args.owner, args.repo, args.limit)
+    candidates = determine_cancellations(
+        live_queue_refs=live_queue_refs,
+        active_runs=active_runs,
+    )
+
+    if not candidates:
+        print("[merge-queue-janitor] no superseded merge_group runs found")
+    for candidate in candidates:
+        print(
+            "[merge-queue-janitor] "
+            f"{'cancel' if args.apply else 'would-cancel'} "
+            f"run={candidate.run_id} workflow={candidate.workflow_name!r} "
+            f"ref={candidate.head_branch!r} reason={candidate.reason}"
+        )
+        if args.apply:
+            cancel_run(args.owner, args.repo, candidate.run_id)
+
+    if args.report:
+        write_report(
+            path=args.report,
+            owner=args.owner,
+            repo=args.repo,
+            branch=args.branch,
+            apply=args.apply,
+            live_queue_refs=live_queue_refs,
+            candidates=candidates,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/ci/test_merge_queue_janitor.py
+++ b/tests/unit/scripts/ci/test_merge_queue_janitor.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from scripts.ci.merge_queue_janitor import WorkflowRun, determine_cancellations
+
+
+def _run(
+    run_id: int,
+    *,
+    ref: str = "gh-readonly-queue/dev/pr-1-head",
+    workflow: str = "CI",
+    event: str = "merge_group",
+    status: str = "in_progress",
+    created_at: str | None = None,
+) -> WorkflowRun:
+    return WorkflowRun(
+        run_id=run_id,
+        event=event,
+        head_branch=ref,
+        workflow_name=workflow,
+        status=status,
+        created_at=created_at or f"2026-05-31T10:{run_id:02d}:00Z",
+        updated_at=created_at or f"2026-05-31T10:{run_id:02d}:30Z",
+    )
+
+
+def test_marks_stale_queue_refs_for_cancellation() -> None:
+    candidates = determine_cancellations(
+        live_queue_refs={"gh-readonly-queue/dev/pr-2-"},
+        active_runs=[_run(1, ref="gh-readonly-queue/dev/pr-1-head")],
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].run_id == 1
+    assert candidates[0].reason == "stale_queue_ref"
+
+
+def test_preserves_newest_duplicate_for_same_live_ref_and_workflow() -> None:
+    candidates = determine_cancellations(
+        live_queue_refs={"gh-readonly-queue/dev/pr-1-"},
+        active_runs=[
+            _run(10, workflow="CI", created_at="2026-05-31T10:10:00Z"),
+            _run(11, workflow="CI", created_at="2026-05-31T10:11:00Z"),
+            _run(12, workflow="Receipt Gate", created_at="2026-05-31T10:09:00Z"),
+        ],
+    )
+
+    assert [candidate.run_id for candidate in candidates] == [10]
+    assert candidates[0].reason == "older_duplicate_workflow_for_live_ref"
+    assert candidates[0].preserved_run_id == 11
+
+
+def test_ignores_non_merge_group_and_completed_runs() -> None:
+    candidates = determine_cancellations(
+        live_queue_refs={"gh-readonly-queue/dev/pr-1-"},
+        active_runs=[
+            _run(1, event="pull_request"),
+            _run(2, status="completed"),
+            _run(3, workflow="CI"),
+        ],
+    )
+
+    assert candidates == []


### PR DESCRIPTION
## Summary
- add a conservative merge queue janitor for superseded merge_group runs
- preserve newest live run per queue ref/workflow and cancel stale refs only in --apply mode
- emit optional JSON report for durable evidence

## Verification
- uv run ruff format scripts/ci/merge_queue_janitor.py tests/unit/scripts/ci/test_merge_queue_janitor.py
- uv run ruff check scripts/ci/merge_queue_janitor.py tests/unit/scripts/ci/test_merge_queue_janitor.py
- uv run pytest tests/unit/scripts/ci/test_merge_queue_janitor.py -q
- python scripts/ci/merge_queue_janitor.py --apply --report /tmp/omn-12542-janitor-apply.json cancelled superseded run 26710622335 and preserved newer run 26710739111

Evidence-Source: OCC#1991
Evidence-Ticket: OMN-12542