### PR TITLE
feat(OMN-12559): auto-discover omnimarket node migrations into infra forward set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1316,6 +1316,25 @@ jobs:
           working-directory: omnibase_infra
           shared-env-enabled: "false"
 
+      - name: Preinstall CPU-only torch for sibling deps
+        working-directory: omnibase_infra
+        run: |
+          set -eu
+          export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+          attempt=1
+          max_attempts=5
+          until uv pip install "torch>=2.6.0,<3.0.0" --index-url https://download.pytorch.org/whl/cpu; do
+            status=$?
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::uv pip install kafka-boundary torch CPU wheel failed after ${attempt} attempt(s)"
+              exit "${status}"
+            fi
+            delay=$((attempt * 10))
+            echo "::warning::uv pip install kafka-boundary torch CPU wheel attempt ${attempt}/${max_attempts} failed with exit ${status}; retrying in ${delay}s"
+            attempt=$((attempt + 1))
+            sleep "${delay}"
+          done
+
       - name: Install sibling repos as editable (boundary test deps)
         working-directory: omnibase_infra
         # Use --overrides to install siblings with their full transitive deps while

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -256,16 +256,17 @@ jobs:
             fi
           fi
 
-          # Wait for both compose services to be healthy via docker exec.
-          # Use docker exec for readiness before selecting the runtime
-          # endpoint surface exposed to the runner.
+          # Wait for both compose services to be usable via docker exec.
+          # Redpanda's single-node dev-container can keep `rpk cluster health`
+          # false longer than the broker API is unavailable; runtime boot only
+          # needs Kafka API reachability, so probe topic listing explicitly.
           for i in $(seq 1 90); do
             pg_ok=false
             kafka_ok=false
             if docker exec "${OMNIBASE_INFRA_POSTGRES_CONTAINER}" pg_isready -U postgres >/dev/null 2>&1; then
               pg_ok=true
             fi
-            if docker exec "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" rpk cluster health >/dev/null 2>&1; then
+            if docker exec "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" rpk topic list --brokers redpanda:9092 >/dev/null 2>&1; then
               kafka_ok=true
             fi
             if $pg_ok && $kafka_ok; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,15 @@ repos:
         pass_filenames: false
         always_run: false
         stages: [pre-commit]
+      # OMN-12559: vendored omnimarket node migrations must stay in sync with
+      # source. Skips silently when omnimarket source is not checked out.
+      - id: onex-check-node-migration-sync
+        name: ONEX Node Migration Vendor Sync Check
+        entry: bash scripts/sync-node-migrations.sh --check
+        language: system
+        pass_filenames: false
+        files: ^(docker/migrations/forward/nodes/|scripts/sync-node-migrations\.sh)
+        stages: [pre-commit]
       # Reject any staged .env file at any path depth (OMN-2476)
       # Uses (^|/)\.env([._-].+)?$ to block root/.env, config/.env, .env.production, .env.staging,
       # .env_local, .env_production, .env-secret, etc. (dot-separated, underscore-separated, and

--- a/contracts/OMN-12559.yaml
+++ b/contracts/OMN-12559.yaml
@@ -3,15 +3,7 @@ schema_version: "1.0.0"
 ticket_id: OMN-12559
 title: "Auto-discover omnimarket node migrations into the infra forward set"
 summary: >
-  Vendors omnimarket projection node migrations into a namespaced location
-  (docker/migrations/forward/nodes/<node>/) and extends run-forward-migrations.sh
-  to auto-discover and apply them under namespaced migration ids
-  (node:<node>:<file>). This reproduces the OMN-12489 delegation dashboard views
-  and savings projection view on a clean clone with NO manual copy and NO manual
-  renumber, eliminating the savings 076 -> 084 renumber-as-operational-pattern.
-  Adds scripts/sync-node-migrations.sh (vendor + drift --check), wires the drift
-  check as a pre-commit hook, and excludes the namespaced subtree from the flat
-  migration-sequence validator so node 076 never collides with infra flat 076.
+  Vendors omnimarket projection node migrations into a namespaced location (docker/migrations/forward/nodes/<node>/) and extends run-forward-migrations.sh to auto-discover and apply them under namespaced migration ids (node:<node>:<file>). This reproduces the OMN-12489 delegation dashboard views and savings projection view on a clean clone with NO manual copy and NO manual renumber, eliminating the savings 076 -> 084 renumber-as-operational-pattern. Adds scripts/sync-node-migrations.sh (vendor + drift --check), wires the drift check as a pre-commit hook, and excludes the namespaced subtree from the flat migration-sequence validator so node 076 never collides with infra flat 076.
 
 is_seam_ticket: false
 interface_change: false
@@ -20,7 +12,7 @@ evidence_requirements:
   - kind: tests
     description: "Discovery applies node-owned migrations and creates the views without manual copy; namespaced ids do not collide with the flat sequence."
     command: "uv run pytest tests/unit/migrations/ tests/integration/migrations/ tests/ci/test_validate_migration_sequence.py -q"
-  - kind: validation
+  - kind: ci
     description: "Vendored node migrations stay in sync with omnimarket source (drift guard)."
     command: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
   - kind: manual

--- a/contracts/OMN-12559.yaml
+++ b/contracts/OMN-12559.yaml
@@ -1,0 +1,57 @@
+# OMN-12559 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-12559
+title: "Auto-discover omnimarket node migrations into the infra forward set"
+summary: >
+  Vendors omnimarket projection node migrations into a namespaced location
+  (docker/migrations/forward/nodes/<node>/) and extends run-forward-migrations.sh
+  to auto-discover and apply them under namespaced migration ids
+  (node:<node>:<file>). This reproduces the OMN-12489 delegation dashboard views
+  and savings projection view on a clean clone with NO manual copy and NO manual
+  renumber, eliminating the savings 076 -> 084 renumber-as-operational-pattern.
+  Adds scripts/sync-node-migrations.sh (vendor + drift --check), wires the drift
+  check as a pre-commit hook, and excludes the namespaced subtree from the flat
+  migration-sequence validator so node 076 never collides with infra flat 076.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Discovery applies node-owned migrations and creates the views without manual copy; namespaced ids do not collide with the flat sequence."
+    command: "uv run pytest tests/unit/migrations/ tests/integration/migrations/ tests/ci/test_validate_migration_sequence.py -q"
+  - kind: validation
+    description: "Vendored node migrations stay in sync with omnimarket source (drift guard)."
+    command: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - kind: manual
+    description: "Deploy-gate proof: migration SQL + runner change only; the next migrate image build carries the node-discovery pass. No live deploy performed pre-merge."
+    command: "deploy-gate: no live deploy performed pre-merge; next migrate image build (Dockerfile.migrate COPY is recursive) carries the nodes/ subtree and discovery runner"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-discovery-tests
+    description: "Node-migration discovery unit + integration + sequence-validator tests pass."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/migrations/ tests/integration/migrations/ tests/ci/test_validate_migration_sequence.py -q"
+  - id: dod-vendor-sync
+    description: "Vendored node migrations are in sync with omnimarket origin/dev."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - id: dod-fresh-clone-repro
+    description: "Clean run of run-forward-migrations.sh against an empty DB creates projection_delegation_summary/model_routing/savings views via namespaced node ids with no manual copy."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "RUN_NODE_MIGRATION_DISCOVERY_TEST=1 OMNIBASE_INFRA_DB_URL=postgresql://postgres:PW@HOST:PORT/omnibase_infra uv run pytest tests/integration/migrations/test_node_migration_discovery_applies.py -q"
+  - id: dod-deploy-gate
+    description: "No pre-merge live deploy required; the next migrate image build carries the discovery runner and vendored node migrations."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy-gate: no live deploy performed pre-merge; next migrate image build carries the nodes/ subtree and discovery runner"

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -10,10 +10,15 @@
 # All migrations (001+) live in docker/migrations/forward/ and
 # docker/migrations/rollback/. There is a single canonical source.
 #
+# Node-owned migrations (OMN-12559): omnimarket projection node migrations are
+# vendored under docker/migrations/forward/nodes/<node>/ and applied by
+# run-forward-migrations.sh under namespaced node:<node>:<file> ids. The COPY
+# below is recursive, so the nodes/ subtree ships in the image automatically.
+#
 # Build context: repo root (docker build -f docker/Dockerfile.migrate .)
 
 FROM alpine:3.19
 
-# Copy all migrations from the canonical location
+# Copy all migrations from the canonical location (recursive — includes nodes/).
 COPY docker/migrations/forward/ /migrations/forward/
 COPY docker/migrations/rollback/ /migrations/rollback/

--- a/docker/migrations/forward/nodes/.synced-nodes
+++ b/docker/migrations/forward/nodes/.synced-nodes
@@ -1,0 +1,20 @@
+# OMN-12559 — omnimarket node migrations vendored into the infra forward set.
+#
+# Each entry selects which node-owned migrations scripts/sync-node-migrations.sh
+# vendors into docker/migrations/forward/nodes/<node>/. The forward-migration
+# runner applies them under namespaced ids (node:<node>:<file>), so they NEVER
+# collide with the flat infra numeric sequence — no manual copy, no renumber.
+#
+# Format:
+#   <node>            vendor ALL of that node's migrations
+#   <node>:<glob>     vendor only files whose basename matches <glob>
+#
+# Run `scripts/sync-node-migrations.sh` after editing, then commit the diff.
+
+# Delegation dashboard projection: base tables (delegation_events,
+# generation_events), additive columns, and the dashboard read views (0010).
+node_projection_delegation
+
+# Savings dashboard read view only. The savings_estimates base table is already
+# owned by infra's flat migration 074; we vendor just the OMN-12489 view here.
+node_projection_savings:076_*

--- a/docker/migrations/forward/nodes/node_projection_delegation/0007_delegation_events.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0007_delegation_events.sql
@@ -1,0 +1,51 @@
+-- OMN-11765: base Postgres table for the delegation projection.
+--
+-- HandlerProjectionDelegation and DelegationProjectionRunner upsert into this
+-- table using correlation_id as the deterministic idempotency key. Later
+-- migrations add or backfill projection-specific metrics.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS delegation_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id TEXT NOT NULL UNIQUE,
+    session_id TEXT,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    task_type TEXT NOT NULL DEFAULT '',
+    delegated_to TEXT NOT NULL DEFAULT '',
+    model_name TEXT NOT NULL DEFAULT '',
+    delegated_by TEXT,
+    quality_gate_passed BOOLEAN NOT NULL DEFAULT FALSE,
+    quality_gates_checked INT NOT NULL DEFAULT 0,
+    quality_gates_failed INT NOT NULL DEFAULT 0,
+    quality_gates_checked_jsonb JSONB,
+    quality_gates_failed_jsonb JSONB,
+    quality_gate_detail TEXT,
+    cost_usd NUMERIC NOT NULL DEFAULT 0,
+    cost_savings_usd NUMERIC NOT NULL DEFAULT 0,
+    delegation_latency_ms INT,
+    latency_ms INT,
+    repo TEXT,
+    is_shadow BOOLEAN NOT NULL DEFAULT FALSE,
+    llm_call_id TEXT,
+    prompt_text TEXT,
+    response_text TEXT,
+    tokens_input INT NOT NULL DEFAULT 0,
+    tokens_output INT NOT NULL DEFAULT 0,
+    tokens_to_compliance INT NOT NULL DEFAULT 0,
+    compliance_attempts INT NOT NULL DEFAULT 1,
+    pricing_manifest_version INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_timestamp
+    ON delegation_events (timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_created_at
+    ON delegation_events (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_task_type
+    ON delegation_events (task_type);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_delegated_to
+    ON delegation_events (delegated_to);

--- a/docker/migrations/forward/nodes/node_projection_delegation/0008_generation_events.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0008_generation_events.sql
@@ -1,0 +1,24 @@
+-- OMN-11184: project generation terminal events into generation_events table.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS generation_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id TEXT UNIQUE NOT NULL,
+    task_description TEXT NOT NULL DEFAULT '',
+    provider TEXT NOT NULL DEFAULT '',
+    model_id TEXT NOT NULL DEFAULT '',
+    endpoint_class TEXT NOT NULL DEFAULT '',
+    attempt_count INT NOT NULL DEFAULT 0,
+    total_latency_e2e_ms INT NOT NULL DEFAULT 0,
+    contract_passed BOOLEAN NOT NULL DEFAULT FALSE,
+    cost_inference_usd NUMERIC(18, 6) NOT NULL DEFAULT 0,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_generation_events_contract_passed
+    ON generation_events (contract_passed);
+
+CREATE INDEX IF NOT EXISTS idx_generation_events_timestamp
+    ON generation_events (timestamp);

--- a/docker/migrations/forward/nodes/node_projection_delegation/0009_delegate_skill_projection_metrics.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0009_delegate_skill_projection_metrics.sql
@@ -1,0 +1,16 @@
+-- OMN-11299: project delegate-skill terminal metrics into dashboard-visible columns.
+
+ALTER TABLE delegation_events
+    ADD COLUMN IF NOT EXISTS quality_gate_detail TEXT,
+    ADD COLUMN IF NOT EXISTS latency_ms INT,
+    ADD COLUMN IF NOT EXISTS tokens_input INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS tokens_output INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS pricing_manifest_version INT NOT NULL DEFAULT 0;
+
+UPDATE delegation_events
+SET latency_ms = delegation_latency_ms
+WHERE latency_ms IS NULL
+  AND delegation_latency_ms IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_tokens_total
+    ON delegation_events ((tokens_input + tokens_output));

--- a/docker/migrations/forward/nodes/node_projection_delegation/0010_create_delegation_dashboard_projection_views.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0010_create_delegation_dashboard_projection_views.sql
@@ -1,0 +1,349 @@
+-- OMN-12489: authoritative dashboard read views for bus-fed delegation projections.
+
+CREATE OR REPLACE VIEW projection_delegation_summary AS
+WITH summary AS (
+    SELECT
+        COUNT(*)::int AS total_events,
+        COALESCE(SUM(CASE WHEN quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS quality_passed_count,
+        COALESCE(SUM(CASE WHEN NOT quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS quality_failed_count,
+        COALESCE(AVG(COALESCE(latency_ms, delegation_latency_ms)), 0)::float
+            AS avg_latency_ms,
+        COALESCE(MAX(EXTRACT(EPOCH FROM created_at)), 0)::float AS latest_event_at,
+        COALESCE(SUM(cost_savings_usd), 0)::float AS total_savings_usd,
+        MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+by_task_type AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object('taskType', task_type, 'count', count)
+            ORDER BY count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT task_type, COUNT(*)::int AS count
+        FROM delegation_events
+        GROUP BY task_type
+    ) t
+),
+by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object('model', delegated_to, 'count', count)
+            ORDER BY count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT delegated_to, COUNT(*)::int AS count
+        FROM delegation_events
+        GROUP BY delegated_to
+    ) t
+)
+SELECT
+    s.total_events AS "totalDelegations",
+    CASE WHEN s.total_events > 0
+        THEN s.quality_passed_count::float / s.total_events
+        ELSE 0
+    END AS "qualityGatePassRate",
+    s.quality_passed_count AS "qualityGatePassed",
+    s.total_events AS "qualityGateTotal",
+    s.total_savings_usd AS "totalSavingsUsd",
+    s.avg_latency_ms AS "avgLatencyMs",
+    s.latest_event_at AS "latestEventAt",
+    s.total_events,
+    s.quality_passed_count,
+    s.quality_failed_count,
+    s.avg_latency_ms,
+    s.latest_event_at,
+    by_task_type.rows AS "byTaskType",
+    by_model.rows AS "byModel",
+    s.latest_projection_updated_at
+FROM summary s
+CROSS JOIN by_task_type
+CROSS JOIN by_model;
+
+CREATE OR REPLACE VIEW projection_delegation_model_routing AS
+WITH grouped AS (
+    SELECT
+        delegated_to AS model_alias,
+        COALESCE(NULLIF(model_name, ''), delegated_to) AS model_name,
+        task_type,
+        COUNT(*)::int AS event_count,
+        COALESCE(SUM(CASE WHEN quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS quality_passed,
+        COALESCE(AVG(COALESCE(latency_ms, delegation_latency_ms)), 0)::float
+            AS avg_latency_ms
+    FROM delegation_events
+    GROUP BY delegated_to, COALESCE(NULLIF(model_name, ''), delegated_to), task_type
+),
+totals AS (
+    SELECT COUNT(*)::int AS total_delegations, MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', model_alias,
+                'total_count', total_count,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN total_count::float / totals.total_delegations ELSE 0 END,
+                'top_task_type', top_task_type,
+                'avg_latency_ms', avg_latency_ms,
+                'qg_pass_rate', CASE WHEN total_count > 0
+                    THEN quality_passed::float / total_count ELSE 0 END,
+                'task_types', task_types
+            )
+            ORDER BY total_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            model_alias,
+            SUM(event_count)::int AS total_count,
+            SUM(quality_passed)::int AS quality_passed,
+            CASE WHEN SUM(event_count) > 0
+                THEN SUM(avg_latency_ms * event_count)::float / SUM(event_count)
+                ELSE 0
+            END AS avg_latency_ms,
+            (array_agg(task_type ORDER BY event_count DESC))[1] AS top_task_type,
+            to_jsonb(array_agg(task_type ORDER BY task_type)) AS task_types
+        FROM grouped
+        GROUP BY model_alias
+    ) m
+    CROSS JOIN totals
+),
+routing_rows AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', g.model_alias,
+                'task_type', g.task_type,
+                'count', g.event_count,
+                'pct_of_model', CASE WHEN model_totals.total_count > 0
+                    THEN g.event_count::float / model_totals.total_count ELSE 0 END,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN g.event_count::float / totals.total_delegations ELSE 0 END
+            )
+            ORDER BY g.event_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM grouped g
+    JOIN (
+        SELECT model_alias, SUM(event_count)::int AS total_count
+        FROM grouped
+        GROUP BY model_alias
+    ) model_totals USING (model_alias)
+    CROSS JOIN totals
+),
+decision_traces AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', id,
+                'correlation_id', correlation_id,
+                'task_type', task_type,
+                'model_name', COALESCE(NULLIF(model_name, ''), delegated_to),
+                'delegated_to', delegated_to,
+                'routing_rule', NULL,
+                'routing_confidence', NULL,
+                'routing_candidates', NULL,
+                'latency_ms', COALESCE(latency_ms, delegation_latency_ms),
+                'quality_gate_passed', quality_gate_passed,
+                'created_at', EXTRACT(EPOCH FROM created_at)
+            )
+            ORDER BY created_at DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            row_number() OVER (ORDER BY created_at DESC)::int AS id,
+            correlation_id,
+            task_type,
+            model_name,
+            delegated_to,
+            latency_ms,
+            delegation_latency_ms,
+            quality_gate_passed,
+            created_at
+        FROM delegation_events
+        ORDER BY created_at DESC
+        LIMIT 20
+    ) traces
+)
+SELECT
+    totals.total_delegations,
+    routing_rows.rows,
+    by_model.rows AS by_model,
+    decision_traces.rows AS decision_traces,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN routing_rows
+CROSS JOIN by_model
+CROSS JOIN decision_traces;
+
+CREATE OR REPLACE VIEW projection_delegation_quality_gate AS
+WITH totals AS (
+    SELECT
+        COUNT(*)::int AS total_checks,
+        COALESCE(SUM(CASE WHEN quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS total_passed,
+        COALESCE(SUM(CASE WHEN NOT quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS total_failed,
+        COALESCE(AVG(NULLIF(tokens_to_compliance, 0)), 0)::float
+            AS avg_tokens_to_compliance,
+        percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY NULLIF(tokens_to_compliance, 0)
+        ) AS median_tokens_to_compliance,
+        COALESCE(AVG(NULLIF(compliance_attempts, 0)), 1)::float
+            AS avg_compliance_attempts,
+        MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+failure_categories AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'category', quality_gate_detail,
+                'count', failed_count,
+                'pct_of_failures', CASE WHEN totals.total_failed > 0
+                    THEN failed_count::float / totals.total_failed ELSE 0 END
+            )
+            ORDER BY failed_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT quality_gate_detail, COUNT(*)::int AS failed_count
+        FROM delegation_events
+        WHERE quality_gate_detail IS NOT NULL
+          AND NOT quality_gate_passed
+        GROUP BY quality_gate_detail
+    ) failures
+    CROSS JOIN totals
+),
+tokens_by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', model_name,
+                'avg_tokens', avg_tokens,
+                'avg_attempts', avg_attempts,
+                'sample_count', sample_count
+            )
+            ORDER BY avg_tokens DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            COALESCE(NULLIF(model_name, ''), delegated_to) AS model_name,
+            COALESCE(AVG(NULLIF(tokens_to_compliance, 0)), 0)::float AS avg_tokens,
+            COALESCE(AVG(NULLIF(compliance_attempts, 0)), 1)::float AS avg_attempts,
+            COUNT(*)::int AS sample_count
+        FROM delegation_events
+        GROUP BY COALESCE(NULLIF(model_name, ''), delegated_to)
+    ) by_model
+)
+SELECT
+    CASE WHEN totals.total_checks > 0
+        THEN totals.total_passed::float / totals.total_checks ELSE 0 END
+        AS overall_pass_rate,
+    totals.total_passed,
+    totals.total_failed,
+    totals.total_checks,
+    totals.total_failed AS escalation_count,
+    CASE WHEN totals.total_checks > 0
+        THEN totals.total_failed::float / totals.total_checks ELSE 0 END
+        AS escalation_rate,
+    jsonb_build_array(jsonb_build_object(
+        'check_type', 'deterministic',
+        'passed', totals.total_passed,
+        'failed', totals.total_failed,
+        'total', totals.total_checks,
+        'pass_rate', CASE WHEN totals.total_checks > 0
+            THEN totals.total_passed::float / totals.total_checks ELSE 0 END
+    )) AS by_check_type,
+    failure_categories.rows AS failure_categories,
+    totals.avg_tokens_to_compliance,
+    totals.median_tokens_to_compliance,
+    totals.avg_compliance_attempts,
+    tokens_by_model.rows AS tokens_to_compliance_by_model,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN failure_categories
+CROSS JOIN tokens_by_model;
+
+CREATE OR REPLACE VIEW projection_delegation_token_usage AS
+WITH model_usage AS (
+    SELECT
+        COALESCE(NULLIF(delegated_to, ''), NULLIF(model_name, ''), 'delegated-runtime')
+            AS model_id,
+        COALESCE(NULLIF(model_name, ''), NULLIF(delegated_to, ''), 'delegated-runtime')
+            AS model_name,
+        COALESCE(SUM(tokens_input), 0)::int AS prompt_tokens,
+        COALESCE(SUM(tokens_output), 0)::int AS completion_tokens,
+        COALESCE(SUM(tokens_input + tokens_output), 0)::int AS total_tokens,
+        COALESCE(SUM(cost_usd), 0)::float AS estimated_cost_usd,
+        CASE
+            WHEN COALESCE(SUM(tokens_input + tokens_output), 0) > 0 THEN 'measured'
+            WHEN COALESCE(SUM(cost_usd), 0) > 0 THEN 'estimated'
+            ELSE 'unknown'
+        END AS usage_source,
+        CASE
+            WHEN COALESCE(SUM(tokens_input + tokens_output), 0) > 0 THEN 'measured'
+            WHEN COALESCE(SUM(cost_usd), 0) > 0 THEN 'estimated'
+            ELSE 'unknown'
+        END AS token_provenance
+    FROM delegation_events
+    GROUP BY COALESCE(NULLIF(delegated_to, ''), NULLIF(model_name, ''), 'delegated-runtime'),
+             COALESCE(NULLIF(model_name, ''), NULLIF(delegated_to, ''), 'delegated-runtime')
+),
+totals AS (
+    SELECT
+        COALESCE(SUM(tokens_input), 0)::int AS total_prompt_tokens,
+        COALESCE(SUM(tokens_output), 0)::int AS total_completion_tokens,
+        COALESCE(SUM(tokens_input + tokens_output), 0)::int AS total_tokens,
+        COALESCE(SUM(cost_usd), 0)::float AS total_estimated_cost_usd,
+        MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(to_jsonb(model_usage) ORDER BY total_tokens DESC),
+        '[]'::jsonb
+    ) AS rows
+    FROM model_usage
+),
+provenance AS (
+    SELECT jsonb_build_object(
+        'measured', COALESCE(SUM(CASE WHEN token_provenance = 'measured' THEN 1 ELSE 0 END), 0),
+        'estimated', COALESCE(SUM(CASE WHEN token_provenance = 'estimated' THEN 1 ELSE 0 END), 0),
+        'unknown', COALESCE(SUM(CASE WHEN token_provenance = 'unknown' THEN 1 ELSE 0 END), 0)
+    ) AS summary
+    FROM model_usage
+)
+SELECT
+    totals.total_prompt_tokens,
+    totals.total_completion_tokens,
+    totals.total_tokens,
+    totals.total_estimated_cost_usd,
+    provenance.summary AS provenance_summary,
+    by_model.rows AS by_model,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN provenance
+CROSS JOIN by_model;

--- a/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
@@ -42,7 +42,7 @@ event_sessions AS (
         COALESCE(tokens_input, 0)::int AS prompt_tokens,
         COALESCE(tokens_output, 0)::int AS completion_tokens,
         NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
-        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
+        COALESCE(latency_ms, delegation_latency_ms)::int AS latency_ms,
         COALESCE(created_at, timestamp) AS created_at,
         prompt_text,
         response_text

--- a/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
@@ -1,0 +1,106 @@
+-- OMN-12489: dashboard savings read view over bus-fed delegation projections.
+
+CREATE OR REPLACE VIEW projection_delegation_savings AS
+WITH savings_sessions AS (
+    SELECT
+        session_id,
+        model_local AS task_type,
+        model_local AS model_name,
+        local_cost_usd::float AS local_cost_usd,
+        cloud_cost_usd::float AS cloud_cost_usd,
+        savings_usd::float AS savings_usd,
+        model_cloud_baseline AS baseline_model,
+        'savings-estimated' AS pricing_manifest_version,
+        'measured' AS savings_method,
+        'savings_estimates' AS usage_source,
+        0::int AS prompt_tokens,
+        0::int AS completion_tokens,
+        NULL::int AS tokens_to_compliance,
+        NULL::int AS latency_ms,
+        created_at,
+        NULL::text AS prompt_text,
+        NULL::text AS response_text
+    FROM savings_estimates
+),
+event_sessions AS (
+    SELECT
+        COALESCE(NULLIF(session_id, ''), NULLIF(correlation_id, ''), id::text)
+            AS session_id,
+        COALESCE(task_type, '') AS task_type,
+        COALESCE(NULLIF(model_name, ''), NULLIF(delegated_to, ''), 'local')
+            AS model_name,
+        COALESCE(cost_usd, 0)::float AS local_cost_usd,
+        (COALESCE(cost_usd, 0) + COALESCE(cost_savings_usd, 0))::float
+            AS cloud_cost_usd,
+        COALESCE(cost_savings_usd, 0)::float AS savings_usd,
+        'claude-opus-4.1' AS baseline_model,
+        pricing_manifest_version::text AS pricing_manifest_version,
+        CASE WHEN COALESCE(cost_savings_usd, 0) > 0
+            THEN 'measured' ELSE 'estimated' END AS savings_method,
+        CASE WHEN COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0) > 0
+            THEN 'measured' ELSE 'unknown' END AS usage_source,
+        COALESCE(tokens_input, 0)::int AS prompt_tokens,
+        COALESCE(tokens_output, 0)::int AS completion_tokens,
+        NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
+        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
+        COALESCE(created_at, timestamp) AS created_at,
+        prompt_text,
+        response_text
+    FROM delegation_events
+),
+combined_sessions AS (
+    SELECT * FROM savings_sessions
+    UNION ALL
+    SELECT event_sessions.*
+    FROM event_sessions
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM savings_sessions
+        WHERE savings_sessions.session_id = event_sessions.session_id
+    )
+),
+limited_sessions AS (
+    SELECT *
+    FROM combined_sessions
+    ORDER BY created_at DESC
+    LIMIT 500
+),
+totals AS (
+    SELECT
+        COALESCE(SUM(savings_usd), 0)::float AS cumulative_savings_usd,
+        COALESCE(SUM(local_cost_usd), 0)::float AS cumulative_local_cost_usd,
+        COALESCE(SUM(cloud_cost_usd), 0)::float AS cumulative_cloud_cost_usd,
+        COUNT(*)::int AS session_count,
+        MAX(created_at) AS latest_projection_updated_at
+    FROM combined_sessions
+),
+sessions AS (
+    SELECT COALESCE(
+        jsonb_agg(to_jsonb(limited_sessions) ORDER BY created_at DESC),
+        '[]'::jsonb
+    ) AS rows
+    FROM limited_sessions
+),
+latest AS (
+    SELECT
+        baseline_model,
+        pricing_manifest_version
+    FROM combined_sessions
+    ORDER BY created_at DESC
+    LIMIT 1
+)
+SELECT
+    totals.cumulative_savings_usd,
+    totals.cumulative_local_cost_usd,
+    totals.cumulative_cloud_cost_usd,
+    COALESCE(latest.baseline_model, 'claude-opus-4.1') AS baseline_model,
+    COALESCE(latest.pricing_manifest_version, 'runtime-delegation-events')
+        AS pricing_manifest_version,
+    totals.session_count,
+    sessions.rows AS sessions,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN sessions
+LEFT JOIN latest ON TRUE;

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -72,6 +72,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
+# Bounded external binary downloads. The runner image build-smoke runs in CI,
+# so one-shot curl calls make the image contract depend on transient CDN/TLS
+# behavior. Force HTTP/1.1 and retry connection/protocol resets with a cap.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN cat >/usr/local/bin/omni-curl <<'EOF' \
+    && chmod +x /usr/local/bin/omni-curl
+#!/usr/bin/env bash
+set -euo pipefail
+exec curl \
+  --http1.1 \
+  --fail \
+  --show-error \
+  --location \
+  --retry 5 \
+  --retry-delay 5 \
+  --retry-max-time 300 \
+  --retry-connrefused \
+  "$@"
+EOF
+
 # Install Python 3.12 via deadsnakes PPA
 RUN add-apt-repository ppa:deadsnakes/ppa -y \
     && apt-get update \
@@ -87,13 +107,13 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y \
     && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
 
 # Install uv
-RUN curl -LsSf "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+RUN omni-curl "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
     | tar -xz -C /usr/local/bin --strip-components=1 uv-x86_64-unknown-linux-gnu/uv \
     && chmod +x /usr/local/bin/uv
 
 # Install Docker CLI (no daemon — socket mounted at runtime)
 RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    && omni-curl https://download.docker.com/linux/ubuntu/gpg \
         | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && chmod a+r /etc/apt/keyrings/docker.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
@@ -104,12 +124,12 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+RUN omni-curl "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
     | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh" \
     && chmod +x /usr/local/bin/gh
 
 # Install kubectl
-RUN curl -fsSLo /usr/local/bin/kubectl \
+RUN omni-curl -o /usr/local/bin/kubectl \
     "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
     && chmod +x /usr/local/bin/kubectl
 
@@ -125,7 +145,7 @@ ENV RUNNER_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d2
 
 RUN mkdir -p "${RUNNER_HOME}" \
     && cd "${RUNNER_HOME}" \
-    && curl -fsSLo runner.tar.gz \
+    && omni-curl -o runner.tar.gz \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
     && echo "${RUNNER_SHA256}  runner.tar.gz" | sha256sum --check --strict \
     && tar xzf runner.tar.gz \
@@ -183,7 +203,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/runner-job-started.sh /
 
 # Install gosu for privilege de-escalation in entrypoint.
 # The entrypoint starts as root to fix Docker socket GID, then drops to runner.
-RUN curl -fsSLo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" \
+RUN omni-curl -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true
 

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "de1d34dd07b9d92f8d3b456642fff6df",
+  "identity_digest": "326a57a805df85a1031a67d5b54e523c",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "5ae3eb4a62f7b59e77394dca",
+  "shared_env_digest": "68031c296386aa953ebf53e7",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Integration tests with controlled table names - S608 false positives
 "tests/integration/runtime/db/test_postgres_repository_runtime_integration.py" = ["S608"]
+# Migration discovery integration test - controlled view/id names (OMN-12559)
+"tests/integration/migrations/test_node_migration_discovery_applies.py" = ["S608"]
 # S106: Hardcoded password in function arg - test fixtures only
 # Production secrets managed via Infisical/Vault (OMN-2287, OMN-2736)
 # T201: Print statements OK in tests

--- a/scripts/run-forward-migrations.sh
+++ b/scripts/run-forward-migrations.sh
@@ -15,6 +15,22 @@
 #
 # Ticket: OMN-4175 (Forward migration runner for warm Postgres volumes)
 #
+# ---------------------------------------------------------------------------
+# Node-owned migration auto-discovery (OMN-12559)
+# ---------------------------------------------------------------------------
+# omnimarket projection nodes ship SQL under
+# src/omnimarket/nodes/<node>/migrations/*.sql. Those files are vendored into
+# this repo under ${MIGRATIONS_DIR}/nodes/<node>/ (kept in sync by
+# scripts/sync-node-migrations.sh) so a clean clone reproduces the views with
+# NO manual copy and NO manual renumber.
+#
+# Each node migration is tracked under a NAMESPACED migration_id of the form
+#   node:<node>:<filename>
+# This is a separate identity space from the flat infra sequence
+# (tracked as docker/<filename>). Because the namespace is distinct, a node
+# migration numbered e.g. 076 NEVER collides with infra's flat 076 file —
+# the renumber-as-operational-pattern is eliminated.
+#
 # Environment:
 #   POSTGRES_USER     (default: postgres)
 #   POSTGRES_PASSWORD (required)
@@ -22,6 +38,7 @@
 #   POSTGRES_PORT     (default: 5432)
 #   POSTGRES_DB       (default: omnibase_infra)
 #   MIGRATIONS_DIR    (default: /migrations/forward)
+#   NODE_MIGRATIONS_DIR (default: ${MIGRATIONS_DIR}/nodes)
 
 set -e
 
@@ -30,6 +47,7 @@ PGHOST="${POSTGRES_HOST:-postgres}"
 PGPORT="${POSTGRES_PORT:-5432}"
 PGDB="${POSTGRES_DB:-omnibase_infra}"
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-/migrations/forward}"
+NODE_MIGRATIONS_DIR="${NODE_MIGRATIONS_DIR:-${MIGRATIONS_DIR}/nodes}"
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
@@ -84,4 +102,57 @@ for migration_file in $(ls "${MIGRATIONS_DIR}"/*.sql | sort); do
   APPLIED=$((APPLIED + 1))
 done
 
-echo "[forward-migration] Complete: ${APPLIED} applied, ${SKIPPED} skipped."
+# ---------------------------------------------------------------------------
+# 3. Auto-discover and apply node-owned migrations (OMN-12559)
+# ---------------------------------------------------------------------------
+# Walk ${NODE_MIGRATIONS_DIR}/<node>/*.sql. Within each node directory files
+# are applied in sorted (lexical) order. Each file is tracked under the
+# namespaced id  node:<node>:<filename>  so the infra numeric sequence is
+# never collided with and no renumber is ever required.
+NODE_APPLIED=0
+NODE_SKIPPED=0
+
+if [ -d "${NODE_MIGRATIONS_DIR}" ]; then
+  echo "[forward-migration] Scanning ${NODE_MIGRATIONS_DIR} for node-owned migrations..."
+
+  # Iterate node directories in sorted order for deterministic application.
+  for node_dir in $(ls -d "${NODE_MIGRATIONS_DIR}"/*/ 2>/dev/null | sort); do
+    node_name=$(basename "$node_dir")
+
+    # Skip directories with no .sql files.
+    if ! ls "${node_dir}"*.sql >/dev/null 2>&1; then
+      continue
+    fi
+
+    for migration_file in $(ls "${node_dir}"*.sql | sort); do
+      filename=$(basename "$migration_file")
+      migration_id="node:${node_name}:${filename}"
+
+      already_applied=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+        -tAc "SELECT 1 FROM public.schema_migrations WHERE migration_id = '${migration_id}'" 2>/dev/null || true)
+
+      if [ "$already_applied" = "1" ]; then
+        echo "[forward-migration]   skip  ${migration_id} (already applied)"
+        NODE_SKIPPED=$((NODE_SKIPPED + 1))
+        continue
+      fi
+
+      echo "[forward-migration]   apply ${migration_id}..."
+
+      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+        -v ON_ERROR_STOP=1 -f "$migration_file"
+
+      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+        -c "INSERT INTO public.schema_migrations (migration_id, checksum, source_set)
+            VALUES ('${migration_id}', 'applied-by-runner', 'node')
+            ON CONFLICT (migration_id) DO NOTHING;"
+
+      echo "[forward-migration]   done  ${migration_id}"
+      NODE_APPLIED=$((NODE_APPLIED + 1))
+    done
+  done
+else
+  echo "[forward-migration] No node migrations dir at ${NODE_MIGRATIONS_DIR} — skipping node discovery."
+fi
+
+echo "[forward-migration] Complete: ${APPLIED} infra applied, ${SKIPPED} infra skipped; ${NODE_APPLIED} node applied, ${NODE_SKIPPED} node skipped."

--- a/scripts/sync-node-migrations.sh
+++ b/scripts/sync-node-migrations.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# sync-node-migrations.sh — Auto-discover omnimarket node-owned migrations and
+# vendor them into omnibase_infra's namespaced forward-migration location.
+#
+# Ticket: OMN-12559
+#
+# WHY THIS EXISTS
+#   omnimarket projection nodes ship SQL under
+#     src/omnimarket/nodes/<node>/migrations/*.sql
+#   The omnibase_infra forward-migration runner only reads
+#     docker/migrations/forward/. Previously, landing a node-owned view in infra
+#   required a manual host copy AND a manual renumber (e.g. savings 076 -> 084)
+#   to dodge a numeric collision with the flat infra sequence. That renumber is
+#   an operational footgun: the view in the source repo and the file in infra
+#   drift, and every new node migration repeats the dance.
+#
+# WHAT IT DOES
+#   Discovers every src/omnimarket/nodes/<node>/migrations/*.sql in the resolved
+#   omnimarket source tree and mirrors it 1:1 into
+#     docker/migrations/forward/nodes/<node>/<file>.sql
+#   The forward-migration runner (run-forward-migrations.sh) applies these under
+#   a NAMESPACED migration_id  node:<node>:<file>  which lives in a separate
+#   identity space from the flat infra sequence — so NO renumber is ever needed.
+#
+#   The vendored files are committed to omnibase_infra so a clean clone
+#   reproduces the views without any manual copy. Re-run this script (and commit
+#   the diff) whenever omnimarket adds or changes a node migration.
+#
+# RESOLUTION ORDER for the omnimarket source tree:
+#   1. $OMNIMARKET_SRC                     (explicit override; repo root)
+#   2. $OMNI_HOME/omnimarket               (canonical clone registry)
+#   3. installed package: python -c 'import omnimarket; print(parent)'
+#
+# NODE SELECTION
+#   Discovery is scoped by the allowlist (one entry per line) in
+#     docker/migrations/forward/nodes/.synced-nodes
+#   Each entry is either:
+#     <node>                 vendor ALL of that node's migrations, or
+#     <node>:<glob>          vendor only files whose basename matches <glob>
+#                            (shell case-glob, e.g. 076_*.sql)
+#   This keeps the vendored tree deterministic: only nodes whose projection
+#   tables/views omnibase_infra is responsible for materializing are pulled in,
+#   and --check stays consistent with what is committed. Add an entry and re-run
+#   to onboard a new node's migrations.
+#
+# USAGE
+#   scripts/sync-node-migrations.sh            # vendor (writes files)
+#   scripts/sync-node-migrations.sh --check    # CI mode: fail if drift exists
+#
+# EXIT CODES
+#   0 — in sync (or vendored successfully)
+#   1 — --check mode and vendored tree differs from source (drift)
+#   2 — could not resolve omnimarket source tree
+
+set -euo pipefail
+
+CHECK_MODE=0
+if [ "${1:-}" = "--check" ]; then
+  CHECK_MODE=1
+fi
+
+# Repo root = parent of this script's directory.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEST_ROOT="${REPO_ROOT}/docker/migrations/forward/nodes"
+SYNCED_NODES_FILE="${DEST_ROOT}/.synced-nodes"
+
+# Load the node allowlist (one node name per line; '#' comments and blanks ok).
+load_synced_nodes() {
+  if [ ! -f "${SYNCED_NODES_FILE}" ]; then
+    echo "[sync-node-migrations] ERROR: missing node allowlist ${SYNCED_NODES_FILE}" >&2
+    exit 2
+  fi
+  grep -vE '^\s*(#|$)' "${SYNCED_NODES_FILE}" | tr -d ' \t'
+}
+
+# Return 0 if (node, filename) is selected by the allowlist.
+# Entries are  <node>  (all files) or  <node>:<glob>  (basename glob match).
+file_is_allowed() {
+  _node="$1"
+  _file="$2"
+  for _entry in ${SYNCED_NODES}; do
+    _entry_node="${_entry%%:*}"
+    if [ "${_entry_node}" != "${_node}" ]; then
+      continue
+    fi
+    if [ "${_entry}" = "${_entry_node}" ]; then
+      # Bare node entry: all files allowed.
+      return 0
+    fi
+    _glob="${_entry#*:}"
+    # shellcheck disable=SC2254
+    case "${_file}" in
+      ${_glob}) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+resolve_omnimarket_src() {
+  if [ -n "${OMNIMARKET_SRC:-}" ] && [ -d "${OMNIMARKET_SRC}/src/omnimarket/nodes" ]; then
+    echo "${OMNIMARKET_SRC}"
+    return 0
+  fi
+  if [ -n "${OMNI_HOME:-}" ] && [ -d "${OMNI_HOME}/omnimarket/src/omnimarket/nodes" ]; then
+    echo "${OMNI_HOME}/omnimarket"
+    return 0
+  fi
+  # Installed package: locate the directory that contains the 'nodes' package.
+  pkg_nodes="$(python3 - <<'PY' 2>/dev/null || true
+import importlib.util
+import pathlib
+
+spec = importlib.util.find_spec("omnimarket")
+if spec and spec.submodule_search_locations:
+    base = pathlib.Path(list(spec.submodule_search_locations)[0])
+    nodes = base / "nodes"
+    if nodes.is_dir():
+        # Echo the repo-root-equivalent: parent of src/omnimarket -> stop at base.
+        print(base)
+PY
+)"
+  if [ -n "${pkg_nodes}" ] && [ -d "${pkg_nodes}/nodes" ]; then
+    # For an installed package, point NODES_DIR directly (no src/ prefix).
+    echo "PKG:${pkg_nodes}"
+    return 0
+  fi
+  return 1
+}
+
+OMK_RESOLVED="$(resolve_omnimarket_src || true)"
+if [ -z "${OMK_RESOLVED}" ]; then
+  # In --check mode (pre-commit / CI), the omnimarket source tree is frequently
+  # not checked out. The vendored files are the durable source of truth and are
+  # validated independently by the migration tests; a drift check is only
+  # meaningful when the source is present. Skip (success) rather than fail so the
+  # gate never produces false negatives on runners without omnimarket.
+  if [ "${CHECK_MODE}" -eq 1 ]; then
+    echo "[sync-node-migrations] omnimarket source not resolvable — skipping drift check." >&2
+    exit 0
+  fi
+  echo "[sync-node-migrations] ERROR: could not resolve omnimarket source tree." >&2
+  echo "  Set OMNIMARKET_SRC=<omnimarket repo root>, or OMNI_HOME=<omni_home>, or pip install omnimarket." >&2
+  exit 2
+fi
+
+case "${OMK_RESOLVED}" in
+  PKG:*)
+    NODES_DIR="${OMK_RESOLVED#PKG:}/nodes"
+    ;;
+  *)
+    NODES_DIR="${OMK_RESOLVED}/src/omnimarket/nodes"
+    ;;
+esac
+
+SYNCED_NODES="$(load_synced_nodes)"
+
+echo "[sync-node-migrations] omnimarket nodes: ${NODES_DIR}"
+echo "[sync-node-migrations] vendoring into:   ${DEST_ROOT}"
+echo "[sync-node-migrations] allowlisted nodes: ${SYNCED_NODES}"
+
+DRIFT=0
+COPIED=0
+
+# Discover every node migration file and mirror it (allowlisted nodes only).
+while IFS= read -r src_file; do
+  # src_file = ${NODES_DIR}/<node>/migrations/<file>.sql
+  node_name="$(basename "$(dirname "$(dirname "${src_file}")")")"
+  filename="$(basename "${src_file}")"
+  if ! file_is_allowed "${node_name}" "${filename}"; then
+    continue
+  fi
+  dest_dir="${DEST_ROOT}/${node_name}"
+  dest_file="${dest_dir}/${filename}"
+
+  if [ "${CHECK_MODE}" -eq 1 ]; then
+    if [ ! -f "${dest_file}" ] || ! cmp -s "${src_file}" "${dest_file}"; then
+      echo "[sync-node-migrations] DRIFT: ${node_name}/${filename}" >&2
+      DRIFT=1
+    fi
+  else
+    mkdir -p "${dest_dir}"
+    if [ ! -f "${dest_file}" ] || ! cmp -s "${src_file}" "${dest_file}"; then
+      cp "${src_file}" "${dest_file}"
+      echo "[sync-node-migrations]   vendored ${node_name}/${filename}"
+      COPIED=$((COPIED + 1))
+    fi
+  fi
+done < <(find "${NODES_DIR}" -type f -path "*/migrations/*.sql" | sort)
+
+if [ "${CHECK_MODE}" -eq 1 ]; then
+  if [ "${DRIFT}" -eq 1 ]; then
+    echo "[sync-node-migrations] node migration vendor tree is OUT OF SYNC with omnimarket." >&2
+    echo "  Run: scripts/sync-node-migrations.sh  then commit the diff." >&2
+    exit 1
+  fi
+  echo "[sync-node-migrations] check: in sync."
+  exit 0
+fi
+
+echo "[sync-node-migrations] done: ${COPIED} file(s) updated."

--- a/scripts/validation/validate_migration_sequence.py
+++ b/scripts/validation/validate_migration_sequence.py
@@ -31,6 +31,22 @@ MIGRATION_DIRS: tuple[str, ...] = (
     "src/omnibase_infra/migrations/forward",
 )
 
+# Subtree(s) that are tracked under a SEPARATE migration-id namespace and
+# therefore do NOT participate in the flat numeric sequence (OMN-12559).
+# Node-owned migrations vendored from omnimarket live under
+# docker/migrations/forward/nodes/<node>/ and are applied by
+# run-forward-migrations.sh under namespaced  node:<node>:<file>  ids. A node
+# migration numbered 076 must NOT be reported as colliding with the flat
+# docker/076_* file — they are distinct identity spaces by design, which is
+# exactly what eliminates the renumber-as-operational-pattern.
+EXCLUDED_SUBTREE_PREFIXES: tuple[str, ...] = ("docker/migrations/forward/nodes/",)
+
+
+def _is_in_excluded_subtree(rel_path: str) -> bool:
+    """True if rel_path lives under a separately-namespaced subtree."""
+    normalized = rel_path.replace("\\", "/")
+    return any(normalized.startswith(prefix) for prefix in EXCLUDED_SUBTREE_PREFIXES)
+
 
 @dataclass
 class DuplicateConflict:
@@ -149,6 +165,9 @@ def validate_migration_sequence(
     # Check whether any staged file is a migration file
     staged_migration_rel: set[str] = set()
     for sp in staged_paths:
+        if _is_in_excluded_subtree(sp):
+            # Namespaced node migrations do not share the flat sequence.
+            continue
         for mdir in MIGRATION_DIRS:
             if sp.startswith((mdir + "/", mdir.replace("/", "\\") + "\\")):
                 seq = extract_sequence_number(Path(sp).name)
@@ -166,11 +185,14 @@ def validate_migration_sequence(
     # (staged files may not yet exist on disk if they were just added)
     seen: dict[int, str] = {}  # seq -> relative path string
 
-    # Gather all .sql files from both migration dirs (filesystem scan)
+    # Gather all .sql files from both migration dirs (filesystem scan).
+    # Files under separately-namespaced subtrees (node migrations) are excluded.
     all_files: list[str] = []
     for mdir in MIGRATION_DIRS:
         for f in _scan_migration_dir(repo_path, mdir):
             rel = str(f.relative_to(repo_path))
+            if _is_in_excluded_subtree(rel):
+                continue
             all_files.append(rel)
 
     # Also include staged paths that are migrations but may not be on disk yet

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -438,22 +438,26 @@ def test_heavy_cross_repo_boundary_installs_retry_and_have_timeout_budget() -> N
         assert "sibling deps failed after" in run_script
 
 
-def test_schema_handshake_uses_cpu_torch_for_sibling_install() -> None:
+def test_heavy_cross_repo_jobs_use_cpu_torch_for_sibling_install() -> None:
     ci_workflow = _load_yaml(CI_WORKFLOW)
-    job = ci_workflow["jobs"]["schema-handshake"]
-    steps = job["steps"]
+    for job_name, label in (
+        ("schema-handshake", "schema-handshake"),
+        ("kafka-boundary-compat", "kafka-boundary"),
+    ):
+        job = ci_workflow["jobs"][job_name]
+        steps = job["steps"]
 
-    assert job["timeout-minutes"] >= 45
+        assert job["timeout-minutes"] >= 45
 
-    torch_step = next(
-        step
-        for step in steps
-        if step.get("name") == "Preinstall CPU-only torch for sibling deps"
-    )
-    torch_script = torch_step["run"]
-    assert "https://download.pytorch.org/whl/cpu" in torch_script
-    assert "schema-handshake torch CPU wheel attempt" in torch_script
-    assert "schema-handshake torch CPU wheel failed after" in torch_script
+        torch_step = next(
+            step
+            for step in steps
+            if step.get("name") == "Preinstall CPU-only torch for sibling deps"
+        )
+        torch_script = torch_step["run"]
+        assert "https://download.pytorch.org/whl/cpu" in torch_script
+        assert f"{label} torch CPU wheel attempt" in torch_script
+        assert f"{label} torch CPU wheel failed after" in torch_script
 
 
 def test_topic_enum_drift_has_install_retry_budget() -> None:

--- a/tests/ci/test_runner_image_node24_floor.py
+++ b/tests/ci/test_runner_image_node24_floor.py
@@ -148,3 +148,34 @@ def test_runner_sha256_comment_tracks_runner_version() -> None:
     assert re.search(r"^ENV RUNNER_SHA256=[0-9a-f]{64}\s*$", source, re.MULTILINE), (
         "runner Dockerfile must pin a 64-hex-char RUNNER_SHA256"
     )
+
+
+def test_runner_image_external_downloads_are_retried() -> None:
+    """External binary downloads must not be one-shot curl calls.
+
+    The runner-image build-smoke runs inside CI and downloads several binaries
+    from GitHub, dl.k8s.io, Docker, and gosu. Transient TLS/protocol failures
+    in those downloads should be retried in the Docker build itself.
+    """
+    source = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "RUN cat >/usr/local/bin/omni-curl" in source
+    assert "--http1.1" in source
+    assert "--retry 5" in source
+    assert "--retry-connrefused" in source
+    assert "--retry-max-time 300" in source
+
+    download_urls = (
+        "github.com/astral-sh/uv",
+        "download.docker.com/linux/ubuntu/gpg",
+        "github.com/cli/cli",
+        "dl.k8s.io/release",
+        "github.com/actions/runner",
+        "github.com/tianon/gosu",
+    )
+    run_blocks = re.findall(
+        r"(?ms)^RUN .*?(?=^RUN |^COPY |^USER |^WORKDIR |^ENTRYPOINT |\\Z)", source
+    )
+    for url in download_urls:
+        block = next(block for block in run_blocks if url in block)
+        assert "omni-curl" in block, f"{url} must use retrying omni-curl"

--- a/tests/ci/test_validate_migration_sequence.py
+++ b/tests/ci/test_validate_migration_sequence.py
@@ -220,6 +220,48 @@ class TestValidateMigrationSequence:
         conflict = result.conflicts[0]
         assert conflict.sequence == 5
 
+    # ── node-namespaced subtree exclusion (OMN-12559) ─────────────────────────
+
+    def test_node_subtree_file_does_not_collide_with_flat_sequence(
+        self, tmp_path: Path
+    ) -> None:
+        """A node migration numbered 076 must NOT collide with flat docker/076.
+
+        Node migrations live under docker/migrations/forward/nodes/<node>/ and
+        are tracked under a separate node:<node>:<file> id space, so they do not
+        participate in the flat numeric sequence — no renumber is ever required.
+        """
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        # Flat infra 076 already exists.
+        _write_sql(docker_dir, "076_add_savings_estimate_provenance.sql")
+        # Vendored node migration also numbered 076, in the namespaced subtree.
+        node_dir = docker_dir / "nodes" / "node_projection_savings"
+        node_dir.mkdir(parents=True)
+        node_file = "076_create_delegation_savings_projection_view.sql"
+        _write_sql(node_dir, node_file)
+        staged_path = f"{DOCKER_MIGRATIONS}/nodes/node_projection_savings/{node_file}"
+        with _mock_staged(tmp_path, [staged_path]):
+            result = validate_migration_sequence(tmp_path)
+        # No conflict: the node 076 is in a separate namespace.
+        assert result.is_valid
+        assert not result.has_staged_migrations
+
+    def test_node_subtree_excluded_even_when_flat_migration_staged(
+        self, tmp_path: Path
+    ) -> None:
+        """Flat staged migration triggers scan, but node subtree files are excluded."""
+        docker_dir, _ = _make_migration_dirs(tmp_path)
+        _write_sql(docker_dir, "090_new_flat.sql")
+        node_dir = docker_dir / "nodes" / "node_projection_savings"
+        node_dir.mkdir(parents=True)
+        # Node file shares seq 090 — must NOT be flagged as a collision.
+        _write_sql(node_dir, "090_node_view.sql")
+        staged_path = f"{DOCKER_MIGRATIONS}/090_new_flat.sql"
+        with _mock_staged(tmp_path, [staged_path]):
+            result = validate_migration_sequence(tmp_path)
+        assert result.is_valid
+        assert result.has_staged_migrations
+
 
 # ── generate_report ───────────────────────────────────────────────────────────
 

--- a/tests/ci/test_validate_migration_sequence.py
+++ b/tests/ci/test_validate_migration_sequence.py
@@ -222,6 +222,7 @@ class TestValidateMigrationSequence:
 
     # ── node-namespaced subtree exclusion (OMN-12559) ─────────────────────────
 
+    @pytest.mark.unit
     def test_node_subtree_file_does_not_collide_with_flat_sequence(
         self, tmp_path: Path
     ) -> None:
@@ -246,6 +247,7 @@ class TestValidateMigrationSequence:
         assert result.is_valid
         assert not result.has_staged_migrations
 
+    @pytest.mark.unit
     def test_node_subtree_excluded_even_when_flat_migration_staged(
         self, tmp_path: Path
     ) -> None:

--- a/tests/integration/migrations/__init__.py
+++ b/tests/integration/migrations/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/integration/migrations/test_node_migration_discovery_applies.py
+++ b/tests/integration/migrations/test_node_migration_discovery_applies.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration test: node-owned migration discovery applies WITHOUT manual copy.
+
+Runs the real ``scripts/run-forward-migrations.sh`` against a reachable
+PostgreSQL, pointed at a temp migrations dir that contains only the savings
+base table (infra flat 074) plus the vendored ``nodes/`` subtree. Asserts that:
+
+  * the runner auto-discovers and applies every node migration,
+  * the OMN-12489 dashboard + savings views exist and are queryable,
+  * each node migration is tracked under a namespaced ``node:<node>:<file>``
+    id (a separate identity space from the flat infra sequence), and
+  * a node migration numbered 076 coexists with infra's flat 076 with NO
+    primary-key collision — proving the renumber-as-operational-pattern is
+    eliminated.
+
+Skips cleanly when ``OMNIBASE_INFRA_DB_URL`` is not configured.
+
+Ticket: OMN-12559
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.util_postgres import PostgresConfig, check_postgres_reachable
+
+# This test mutates the target database (creates and drops views). It is opt-in
+# so it never runs against shared infra by accident. Point it at an ephemeral or
+# dedicated test Postgres and set RUN_NODE_MIGRATION_DISCOVERY_TEST=1.
+OPT_IN_ENV = "RUN_NODE_MIGRATION_DISCOVERY_TEST"
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.postgres,
+    pytest.mark.serial,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FORWARD_DIR = REPO_ROOT / "docker" / "migrations" / "forward"
+NODES_DIR = FORWARD_DIR / "nodes"
+RUNNER = REPO_ROOT / "scripts" / "run-forward-migrations.sh"
+SAVINGS_BASE = FORWARD_DIR / "074_create_savings_estimates.sql"
+INFRA_FLAT_076 = FORWARD_DIR / "076_add_savings_estimate_provenance.sql"
+
+
+def _require_psql() -> str:
+    psql = shutil.which("psql")
+    if psql is None:
+        pytest.skip("psql client not available on PATH")
+    return psql
+
+
+def _require_db() -> PostgresConfig:
+    if os.environ.get(OPT_IN_ENV) != "1":
+        pytest.skip(
+            f"node-migration discovery test is opt-in (mutates DB); "
+            f"set {OPT_IN_ENV}=1 and OMNIBASE_INFRA_DB_URL to a dedicated DB"
+        )
+    config = PostgresConfig.from_env()
+    if not config.is_configured or not check_postgres_reachable(config):
+        pytest.skip(
+            "PostgreSQL not configured/reachable (set OMNIBASE_INFRA_DB_URL "
+            "to a full DSN, e.g. postgresql://postgres:pass@host:5432/db)"
+        )
+    # Authentication probe: a reachable host may still reject credentials.
+    psql = _require_psql()
+    probe = subprocess.run(
+        [
+            psql,
+            "-h",
+            config.host or "127.0.0.1",
+            "-p",
+            str(config.port),
+            "-U",
+            config.user,
+            "-d",
+            config.database,
+            "-tAc",
+            "SELECT 1",
+        ],
+        env={
+            "PGPASSWORD": config.password or "",
+            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        },
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if probe.returncode != 0:
+        pytest.skip(
+            f"PostgreSQL reachable but auth/select failed: {probe.stderr.strip()}"
+        )
+    return config
+
+
+def _psql_env(config: PostgresConfig) -> dict[str, str]:
+    return {
+        "POSTGRES_HOST": config.host or "127.0.0.1",
+        "POSTGRES_PORT": str(config.port),
+        "POSTGRES_USER": config.user,
+        "POSTGRES_PASSWORD": config.password or "",
+        "POSTGRES_DB": config.database,
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+
+
+def _query(psql: str, config: PostgresConfig, sql: str) -> str:
+    result = subprocess.run(
+        [
+            psql,
+            "-h",
+            config.host or "127.0.0.1",
+            "-p",
+            str(config.port),
+            "-U",
+            config.user,
+            "-d",
+            config.database,
+            "-tAc",
+            sql,
+        ],
+        env={
+            "PGPASSWORD": config.password or "",
+            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.serial
+def test_node_migration_discovery_applies_views(tmp_path: Path) -> None:
+    psql = _require_psql()
+    config = _require_db()
+
+    # Isolate this test run in a dedicated schema-equivalent by using a unique
+    # tracking-id namespace is not enough; instead drop the objects we create up
+    # front so re-runs are clean. The views/tables are IF NOT EXISTS / OR REPLACE.
+    for view in (
+        "projection_delegation_savings",
+        "projection_delegation_summary",
+        "projection_delegation_model_routing",
+        "projection_delegation_quality_gate",
+        "projection_delegation_token_usage",
+    ):
+        _query(psql, config, f"DROP VIEW IF EXISTS {view} CASCADE;")
+
+    # Build a temp migrations dir: savings base table (flat 074) + nodes subtree.
+    mig_dir = tmp_path / "forward"
+    mig_dir.mkdir()
+    shutil.copy(SAVINGS_BASE, mig_dir / SAVINGS_BASE.name)
+    shutil.copytree(NODES_DIR, mig_dir / "nodes")
+
+    env = _psql_env(config)
+    env["MIGRATIONS_DIR"] = str(mig_dir)
+
+    run = subprocess.run(
+        ["sh", str(RUNNER)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert run.returncode == 0, f"runner failed:\n{run.stdout}\n{run.stderr}"
+
+    # The runner discovered and applied node migrations.
+    assert "node:node_projection_delegation:" in run.stdout
+    assert "node:node_projection_savings:076" in run.stdout
+
+    # Views exist and are queryable (no manual copy was performed).
+    for view in (
+        "projection_delegation_summary",
+        "projection_delegation_savings",
+        "projection_delegation_model_routing",
+    ):
+        exists = _query(
+            psql, config, f"SELECT 1 FROM pg_views WHERE viewname = '{view}';"
+        )
+        assert exists == "1", f"view {view} was not created by discovery"
+        # Queryable end-to-end.
+        _query(psql, config, f"SELECT count(*) FROM {view};")
+
+    # Namespaced ids are tracked under the node identity space.
+    tracked = _query(
+        psql,
+        config,
+        "SELECT migration_id FROM public.schema_migrations "
+        "WHERE migration_id LIKE 'node:%' ORDER BY migration_id;",
+    )
+    assert (
+        "node:node_projection_savings:076_create_delegation_savings_projection_view.sql"
+        in tracked
+    )
+    assert (
+        "node:node_projection_delegation:0010_create_delegation_dashboard_projection_views.sql"
+        in tracked
+    )
+
+
+@pytest.mark.serial
+def test_node_076_does_not_collide_with_infra_flat_076() -> None:
+    """node:<node>:076 and docker/076_* coexist (distinct PK strings)."""
+    psql = _require_psql()
+    config = _require_db()
+
+    # Apply infra flat 076 directly and record it under the flat id, mirroring
+    # what the flat-sequence loop does.
+    flat_id = f"docker/{INFRA_FLAT_076.name}"
+    node_id = (
+        "node:node_projection_savings:076_create_delegation_savings_projection_view.sql"
+    )
+
+    _query(
+        psql,
+        config,
+        "CREATE TABLE IF NOT EXISTS public.schema_migrations ("
+        "migration_id TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), "
+        "checksum TEXT NOT NULL, source_set TEXT NOT NULL);",
+    )
+
+    # Insert both ids; if they collided on the same PK this would fail.
+    probe = f"collision-probe-{uuid.uuid4().hex[:8]}"
+    _query(
+        psql,
+        config,
+        f"INSERT INTO public.schema_migrations (migration_id, checksum, source_set) "
+        f"VALUES ('{flat_id}', '{probe}', 'docker') ON CONFLICT (migration_id) DO NOTHING;",
+    )
+    _query(
+        psql,
+        config,
+        f"INSERT INTO public.schema_migrations (migration_id, checksum, source_set) "
+        f"VALUES ('{node_id}', '{probe}', 'node') ON CONFLICT (migration_id) DO NOTHING;",
+    )
+
+    both = _query(
+        psql,
+        config,
+        f"SELECT count(*) FROM public.schema_migrations "
+        f"WHERE migration_id IN ('{flat_id}', '{node_id}');",
+    )
+    assert both == "2", (
+        "flat 076 and node 076 must coexist as distinct migration ids "
+        "(no numeric collision, no renumber required)"
+    )

--- a/tests/integration/migrations/test_node_migration_discovery_applies.py
+++ b/tests/integration/migrations/test_node_migration_discovery_applies.py
@@ -49,6 +49,32 @@ NODES_DIR = FORWARD_DIR / "nodes"
 RUNNER = REPO_ROOT / "scripts" / "run-forward-migrations.sh"
 SAVINGS_BASE = FORWARD_DIR / "074_create_savings_estimates.sql"
 INFRA_FLAT_076 = FORWARD_DIR / "076_add_savings_estimate_provenance.sql"
+OMNIBASE_ENV = Path.home() / ".omnibase" / ".env"
+
+
+def _read_omnibase_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not OMNIBASE_ENV.exists():
+        return env
+    for raw_line in OMNIBASE_ENV.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, _, value = line.partition("=")
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        env[key.strip()] = value
+    return env
+
+
+def _merged_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    env = {**os.environ, **_read_omnibase_env()}
+    if overrides:
+        env.update(overrides)
+    return env
 
 
 def _require_psql() -> str:
@@ -59,6 +85,7 @@ def _require_psql() -> str:
 
 
 def _require_db() -> PostgresConfig:
+    os.environ.update(_read_omnibase_env())
     if os.environ.get(OPT_IN_ENV) != "1":
         pytest.skip(
             f"node-migration discovery test is opt-in (mutates DB); "
@@ -86,10 +113,12 @@ def _require_db() -> PostgresConfig:
             "-tAc",
             "SELECT 1",
         ],
-        env={
-            "PGPASSWORD": config.password or "",
-            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
-        },
+        env=_merged_env(
+            {
+                "PGPASSWORD": config.password or "",
+                "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+            }
+        ),
         capture_output=True,
         text=True,
         timeout=15,
@@ -103,14 +132,16 @@ def _require_db() -> PostgresConfig:
 
 
 def _psql_env(config: PostgresConfig) -> dict[str, str]:
-    return {
-        "POSTGRES_HOST": config.host or "127.0.0.1",
-        "POSTGRES_PORT": str(config.port),
-        "POSTGRES_USER": config.user,
-        "POSTGRES_PASSWORD": config.password or "",
-        "POSTGRES_DB": config.database,
-        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
-    }
+    return _merged_env(
+        {
+            "POSTGRES_HOST": config.host or "127.0.0.1",
+            "POSTGRES_PORT": str(config.port),
+            "POSTGRES_USER": config.user,
+            "POSTGRES_PASSWORD": config.password or "",
+            "POSTGRES_DB": config.database,
+            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        }
+    )
 
 
 def _query(psql: str, config: PostgresConfig, sql: str) -> str:
@@ -128,10 +159,12 @@ def _query(psql: str, config: PostgresConfig, sql: str) -> str:
             "-tAc",
             sql,
         ],
-        env={
-            "PGPASSWORD": config.password or "",
-            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
-        },
+        env=_merged_env(
+            {
+                "PGPASSWORD": config.password or "",
+                "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+            }
+        ),
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/unit/migrations/__init__.py
+++ b/tests/unit/migrations/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for node-owned migration auto-discovery (OMN-12559).
+
+These tests are Docker/DB-independent. They prove:
+
+  1. The two OMN-12489 view migrations are vendored durably into the
+     namespaced forward location, so a clean clone reproduces the views
+     with NO manual copy.
+  2. ``run-forward-migrations.sh`` contains the namespaced discovery pass
+     that applies node migrations under ``node:<node>:<file>`` ids — a
+     separate identity space from the flat infra sequence, so a node
+     migration numbered 076 never collides with infra's flat 076 and no
+     renumber is ever required.
+  3. The vendored tree stays in sync with the omnimarket source when the
+     source tree is resolvable (drift guard via sync-node-migrations.sh).
+
+Ticket: OMN-12559
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FORWARD_DIR = REPO_ROOT / "docker" / "migrations" / "forward"
+NODES_DIR = FORWARD_DIR / "nodes"
+RUNNER = REPO_ROOT / "scripts" / "run-forward-migrations.sh"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync-node-migrations.sh"
+SYNCED_NODES = NODES_DIR / ".synced-nodes"
+
+DELEGATION_VIEW = (
+    NODES_DIR
+    / "node_projection_delegation"
+    / "0010_create_delegation_dashboard_projection_views.sql"
+)
+SAVINGS_VIEW = (
+    NODES_DIR
+    / "node_projection_savings"
+    / "076_create_delegation_savings_projection_view.sql"
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestVendoredViewMigrations:
+    """The two OMN-12489 view migrations are durably vendored (no manual copy)."""
+
+    def test_delegation_dashboard_views_vendored(self) -> None:
+        assert DELEGATION_VIEW.is_file(), (
+            "delegation dashboard views must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_delegation/"
+        )
+        sql = DELEGATION_VIEW.read_text(encoding="utf-8")
+        # Authoritative dashboard read views from PR #1005 / OMN-12489.
+        assert "CREATE OR REPLACE VIEW projection_delegation_summary" in sql
+        assert "CREATE OR REPLACE VIEW projection_delegation_model_routing" in sql
+
+    def test_savings_projection_view_vendored(self) -> None:
+        assert SAVINGS_VIEW.is_file(), (
+            "savings projection view must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_savings/"
+        )
+        sql = SAVINGS_VIEW.read_text(encoding="utf-8")
+        assert "CREATE OR REPLACE VIEW projection_delegation_savings" in sql
+
+    def test_delegation_base_tables_vendored_so_views_apply(self) -> None:
+        """Views depend on delegation_events/generation_events base tables.
+
+        Those node-owned base-table migrations must be vendored alongside the
+        views so a clean clone can apply the whole chain.
+        """
+        node_dir = NODES_DIR / "node_projection_delegation"
+        files = {p.name for p in node_dir.glob("*.sql")}
+        assert "0007_delegation_events.sql" in files
+        assert "0008_generation_events.sql" in files
+        assert "0010_create_delegation_dashboard_projection_views.sql" in files
+
+
+class TestNamespacedDiscoveryWiring:
+    """run-forward-migrations.sh applies node migrations under namespaced ids."""
+
+    def test_runner_scans_node_migrations_dir(self) -> None:
+        script = RUNNER.read_text(encoding="utf-8")
+        assert "NODE_MIGRATIONS_DIR" in script
+        # Iterates per-node subdirectories.
+        assert "${NODE_MIGRATIONS_DIR}" in script
+
+    def test_runner_uses_namespaced_migration_id(self) -> None:
+        script = RUNNER.read_text(encoding="utf-8")
+        # The namespaced id form node:<node>:<filename> is what prevents the
+        # numeric collision with the flat docker/<filename> sequence.
+        assert 'migration_id="node:${node_name}:${filename}"' in script
+        assert "source_set" in script
+
+    def test_runner_flat_and_node_ids_are_distinct_namespaces(self) -> None:
+        """The flat sequence and node sequence use different id prefixes."""
+        script = RUNNER.read_text(encoding="utf-8")
+        # Flat infra files are tracked as docker/<filename>.
+        assert 'migration_id="docker/${filename}"' in script
+        # Node files are tracked as node:<node>:<filename>.
+        assert 'migration_id="node:${node_name}:${filename}"' in script
+
+
+class TestSyncedNodesAllowlist:
+    """The allowlist file scopes which node migrations are vendored."""
+
+    def test_allowlist_exists_and_lists_both_nodes(self) -> None:
+        assert SYNCED_NODES.is_file()
+        content = SYNCED_NODES.read_text(encoding="utf-8")
+        assert "node_projection_delegation" in content
+        assert "node_projection_savings" in content
+
+
+def _resolve_omnimarket_src() -> Path | None:
+    """Resolve the omnimarket repo root if available for the drift check."""
+    explicit = os.environ.get("OMNIMARKET_SRC")
+    if explicit and (Path(explicit) / "src/omnimarket/nodes").is_dir():
+        return Path(explicit)
+    omni_home = os.environ.get("OMNI_HOME")
+    if omni_home and (Path(omni_home) / "omnimarket/src/omnimarket/nodes").is_dir():
+        return Path(omni_home) / "omnimarket"
+    return None
+
+
+class TestVendoredTreeMatchesSource:
+    """Vendored node migrations stay in sync with omnimarket (drift guard)."""
+
+    def test_sync_check_reports_in_sync(self) -> None:
+        omk = _resolve_omnimarket_src()
+        if omk is None:
+            pytest.skip(
+                "omnimarket source tree not resolvable "
+                "(set OMNIMARKET_SRC or OMNI_HOME)"
+            )
+        result = subprocess.run(
+            ["bash", str(SYNC_SCRIPT), "--check"],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "OMNIMARKET_SRC": str(omk)},
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            "vendored node migrations are out of sync with omnimarket:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )


### PR DESCRIPTION
## OMN-12559: auto-discover omnimarket node migrations into the infra forward set

Implements OMN-12559.

Addresses the integration gap surfaced by OMN-12489 (PR #1005): omnimarket projection nodes ship SQL under `src/omnimarket/nodes/*/migrations/*.sql`, but the forward-migration runner only read `docker/migrations/forward/`. Landing the delegation/savings views previously needed a manual host copy + a hand-renumber (savings `076 -> 084`) to dodge a numeric collision with the flat infra `076`. This eliminates that renumber-as-operational-pattern.

### What changed
- **Vendored node migrations** under `docker/migrations/forward/nodes/<node>/`, read verbatim from omnimarket `origin/dev` (HEAD `26a343de`): `node_projection_delegation` 0007–0010 (base tables + dashboard views) and `node_projection_savings` 076 (savings view).
- **`scripts/run-forward-migrations.sh`**: new discovery pass walks `forward/nodes/<node>/*.sql` and applies each under a **namespaced** `node:<node>:<file>` `migration_id` — a separate identity space from the flat `docker/<file>` sequence, so a node `076` never collides with infra flat `076`. No renumber required.
- **`scripts/sync-node-migrations.sh`**: auto-discovers + vendors node migrations from an installed/cloned omnimarket (allowlist-scoped via `nodes/.synced-nodes`), with a `--check` drift guard wired as a pre-commit hook (enforcement, not detection).
- **`scripts/validation/validate_migration_sequence.py`**: excludes the namespaced `nodes/` subtree from the flat sequence check.
- **`docker/Dockerfile.migrate`**: COPY is recursive, so the `nodes/` subtree ships in the migrate image automatically.

### dod_evidence (fresh-clone reproduction proof)
- Ran the real `run-forward-migrations.sh` against a throwaway local Postgres pointed at a temp `MIGRATIONS_DIR` (savings base 074 + the `nodes/` subtree). The runner auto-discovered and applied all 5 node migrations under namespaced ids and created `projection_delegation_summary`, `projection_delegation_model_routing`, `projection_delegation_quality_gate`, `projection_delegation_token_usage`, `projection_delegation_savings` — **with no manual copy**. Re-run = all skipped (idempotent). Infra flat `076` and node `076` coexist as distinct `schema_migrations` rows (no collision).
- Tests: `tests/unit/migrations/` + `tests/integration/migrations/` + `tests/ci/test_validate_migration_sequence.py` green. Full unit suite: **19981 passed, 15 skipped**. CI validator suite: 133 passed. The integration test that mutates a DB is opt-in (`RUN_NODE_MIGRATION_DISCOVERY_TEST=1`) and skips by default.
- `pre-commit run --all-files`: clean (also fixed a pre-existing SPDX year violation in `test_handler_wiring_handle_async_dispatch.py`).

Contract: `contracts/OMN-12559.yaml` (in-repo, deploy-gate) and the central OCC contract + receipts (Evidence-Source below).

Deploy-gate: no live deploy performed pre-merge; the next migrate image build carries the `nodes/` subtree and the discovery runner.

Evidence-Ticket: OMN-12559
Evidence-Source: OCC#2080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-discovery and application of node-owned database migrations with namespaced tracking
  * Created delegation events and generation events tables with comprehensive metrics
  * Added dashboard views for delegation summary, model routing, quality gates, token usage, and savings projections

* **Infrastructure/Chores**
  * Added pre-commit hook for migration sync validation
  * Enhanced migration runner to support node migration discovery with proper namespacing
  * Added deployment gate contract for node migration changes

* **Tests**
  * Added integration and unit tests for node migration discovery and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
