### PR TITLE
fix(OMN-12489): wire stability projection dependencies

### DIFF
--- a/docker/catalog/services/projection-api.yaml
+++ b/docker/catalog/services/projection-api.yaml
@@ -5,6 +5,7 @@ layer: runtime
 container_name: omnimarket-projection-api
 required_env:
   - POSTGRES_PASSWORD
+  - OMNIDASH_ANALYTICS_DB_URL
 hardcoded_env:
   OMNIBASE_INFRA_DB_URL: 'postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/omnibase_infra'
   OTEL_SERVICE_NAME: omnimarket-projection-api

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -327,6 +327,17 @@ def test_stability_lane_runtime_socket_uses_owned_tmpfs() -> None:
 
 
 @pytest.mark.integration
+def test_stability_projection_api_has_separate_infra_and_analytics_dsns() -> None:
+    rendered_config = _compose_config_json()
+    environment = rendered_config["services"]["projection-api"]["environment"]
+
+    assert environment["ONEX_ENVIRONMENT"] == "stability-test"
+    assert environment["KAFKA_ENVIRONMENT"] == "stability-test"
+    assert environment["OMNIBASE_INFRA_DB_URL"].endswith("/omnibase_infra")
+    assert environment["OMNIDASH_ANALYTICS_DB_URL"].endswith("/omnidash_analytics")
+
+
+@pytest.mark.integration
 def test_stability_lane_render_inherits_failing_runtime_healthcheck() -> None:
     rendered_config = _compose_config_json()
     services = rendered_config["services"]


### PR DESCRIPTION
## Summary
- require OMNIDASH_ANALYTICS_DB_URL for projection-api catalog rendering
- assert stability projection API keeps separate infra and analytics DSNs
- rebase note: current dev already carries the newer omnibase_compat pin (`4d887307...`), so the stale `8fee6a...` pin/allowlist change was dropped from this branch

## Runtime evidence
- stability projection API must read omnidash_analytics for delegation_events while retaining omnibase_infra for entrypoint fingerprinting

## Verification
- uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py::test_stability_projection_api_has_separate_infra_and_analytics_dsns -q
- uv run ruff format tests/integration/infra/test_stability_test_runtime_compose_render.py
- uv run ruff check tests/integration/infra/test_stability_test_runtime_compose_render.py
- git diff --check origin/dev...HEAD

Evidence-Source: 65a1474b6d95e508db43aeed6a7743dc4e41c482
Evidence-Ticket: OMN-12489