### PR TITLE
ci(OMN-12564): disable OCC cache save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,8 +1120,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
-          cache-dependency-glob: 'onex_change_control/uv.lock'
+          enable-cache: false
 
       - name: Install onex_change_control
         working-directory: onex_change_control

--- a/docs/ci/versioned-ci-env-canary.md
+++ b/docs/ci/versioned-ci-env-canary.md
@@ -54,6 +54,9 @@ Public fork PRs do not use the host-local environment and keep isolated setup.
   PR's `pyproject.toml` without polluting clean-root checks.
 - Build the shared env with bounded retries because a single transient git or
   wheel fetch failure would otherwise poison every job waiting on the digest.
+- Do not enable `setup-uv` cache save for direct jobs that intentionally run
+  `uv sync --no-cache`; the post-job cache upload can outlive the actual check
+  and cancel merge-group CI while adding no useful reuse.
 - Do not replace a real workspace `.venv`; the canary only manages the checkout
   `.venv` when it is absent or already a symlink to a shared env.
 - Keep the `uv` wrapper narrow: only plain `uv run <tool> ...` is redirected to

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -370,6 +370,12 @@ def test_contract_compliance_uv_sync_is_bounded_and_retried() -> None:
         checkout_occ["with"]["token"] == "${{ secrets.CROSS_REPO_PAT || github.token }}"
     )
 
+    setup_uv = next(
+        step for step in steps if step.get("uses") == "astral-sh/setup-uv@v7"
+    )
+    assert setup_uv["with"]["enable-cache"] is False
+    assert "cache-dependency-glob" not in setup_uv["with"]
+
     install_step = next(
         step for step in steps if step.get("name") == "Install onex_change_control"
     )


### PR DESCRIPTION
## Summary
- disables setup-uv cache save for the direct onex_change_control contract-compliance job
- keeps the bounded/retried uv sync path, but avoids the post-job cache upload that cancelled merge-group CI after the actual check had completed
- documents the operating rule for direct uv sync --no-cache jobs

Evidence-Ticket: OMN-12564
Evidence-Source: OCC#2021

## Verification
- uv run pytest tests/ci/test_ci_workflow_resilience.py tests/ci/test_reusable_runtime_boot_schema.py -q
- uv run ruff check tests/ci/test_ci_workflow_resilience.py
- uv run ruff format --check tests/ci/test_ci_workflow_resilience.py
- git diff --check origin/dev..HEAD