### PR TITLE
chore: release v0.38.0 (OMN-12561)

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -129,10 +129,32 @@ jobs:
           git config --global http.lowSpeedLimit 0
           git config --global http.lowSpeedTime 999999
           export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+          python - <<'PY' > /tmp/onex-change-control-overrides.txt
+          import tomllib
+          from pathlib import Path
+
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          source = (
+              pyproject.get("tool", {})
+              .get("uv", {})
+              .get("sources", {})
+              .get("omnibase-core")
+          )
+          if isinstance(source, dict) and source.get("git"):
+              ref = source.get("rev") or source.get("tag") or source.get("branch")
+              if ref:
+                  print(f"omnibase-core @ git+{source['git']}@{ref}")
+          PY
+          install_args=(
+            "onex_change_control @ git+https://github.com/OmniNode-ai/onex_change_control.git@08a5194c6e587e8b2256c1f1edde236ad34cd397"
+          )
+          if [ -s /tmp/onex-change-control-overrides.txt ]; then
+            install_args=(--overrides /tmp/onex-change-control-overrides.txt "${install_args[@]}")
+          fi
           attempt=1
           max_attempts=3
           delay=10
-          until uv pip install "onex_change_control @ git+https://github.com/OmniNode-ai/onex_change_control.git@08a5194c6e587e8b2256c1f1edde236ad34cd397"; do
+          until uv pip install "${install_args[@]}"; do
             status=$?
             if [[ "$attempt" -ge "$max_attempts" ]]; then
               echo "::error::uv pip install onex_change_control failed after ${attempt} attempt(s)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.38.0 (2026-05-31)
+
+### Features
+- feat(OMN-12294): drop bridge-backed delegation dispatch, use pure Kafka port (stage 2) (#1779)
+- feat(OMN-9545): remove dead instance-discovery fields from registry API (#1777)
+- feat(OMN-10409): skip Bifrost render for projection API (#1780)
+
+### Bug Fixes
+- fix(OMN-12432): authenticate uv git+https fetches in CI (#1789)
+- fix(OMN-6664): clean up non-standard noqa suppressions (#1778)
+
+### Changed
+- Bumps omnibase-core pin to >=0.43.0,<0.44.0
+- And 33+ additional commits since v0.37.0
+
 ## v0.32.0 (2026-04-03)
 
 ### Features

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "db6a647d50ff3beb7738746d609fd23d",
+  "identity_digest": "231ae5fa883556778e9db274f1d5f83b",
   "image_version": 1,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.323.0",
-  "shared_env_digest": "c197b1adb30bba89b04d033f",
+  "shared_env_digest": "9fe7f01afeb5fb03dadb6f0e",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,8 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# Release v0.37.0: pin to release tags for core v0.42.0 and spi v0.22.0
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
+# Release v0.38.0: pin core to the paired v0.43.0 release PR head until the tag is published.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "4ffca7643294fcad4f9654f4d1839ca8002b4454" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.37.0"
+version = "0.38.0"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.42.0,<0.43.0",
+    "omnibase-core>=0.43.0,<0.44.0",
     "omnibase-spi>=0.22.0,<0.23.0",
     # ============================================================================
     # External Dependency Security Guidance
@@ -163,14 +163,14 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.42.0,<0.43.0",
+    "omnibase-core>=0.43.0,<0.44.0",
     "omnibase-spi>=0.22.0,<0.23.0",
 ]
 
 [tool.uv.sources]
 # Release v0.37.0: pin to release tags for core v0.42.0 and spi v0.22.0
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", tag = "v0.42.0" }
-omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", tag = "v0.22.0" }
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
+omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]
 target-version = "py312"

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,8 +175,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.42.0",
-        max_version="0.43.0",
+        min_version="0.43.0",
+        max_version="0.44.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/uv.lock
+++ b/uv.lock
@@ -9,8 +9,8 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.42.0" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.22.0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
 [[package]]
@@ -1981,7 +1981,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.42.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.42.0#fc211e3648681a79f609c2c153a254baaef682ab" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#875a4ff7c1e7026fe5c619a0125a974ff6d0731b" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -2093,8 +2093,8 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.42.0" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.22.0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.48b0,<0.64" },
@@ -2149,7 +2149,7 @@ dev = [
 [[package]]
 name = "omnibase-spi"
 version = "0.22.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?tag=v0.22.0#c01f70cd14e4b68ee83d20468df87e5ce91bee90" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main#b7bac17636ae53fb4c51f071377a0c93501d0c27" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=4ffca7643294fcad4f9654f4d1839ca8002b4454" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -1980,8 +1980,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.42.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#875a4ff7c1e7026fe5c619a0125a974ff6d0731b" }
+version = "0.43.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=4ffca7643294fcad4f9654f4d1839ca8002b4454#4ffca7643294fcad4f9654f4d1839ca8002b4454" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2093,7 +2093,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=4ffca7643294fcad4f9654f4d1839ca8002b4454" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
chore: release v0.38.0 (OMN-12561)

Bumps omnibase_infra from 0.37.0 to 0.38.0 (minor release).

**Changes on dev since v0.37.0:**
- feat(OMN-12294): drop bridge-backed delegation dispatch, use pure Kafka port (stage 2)
- feat(OMN-9545): remove dead instance-discovery fields from registry API
- fix(OMN-10409): skip Bifrost render for projection API
- fix(OMN-12432): authenticate uv git+https fetches in CI
- And 33+ additional commits

Updates omnibase-core pin to >=0.43.0,<0.44.0 and omnibase-spi to branch=main.

Replacement for draft PR #1822. The original PR head ref lacked an OMN-12561 branch identity and is not safe to undraft/enqueue.

## Evidence-Source
Evidence-Ticket: OMN-12561
Evidence-Source: OCC#2029