### PR TITLE
feat(OMN-12573): re-point runtime-rebuild CI to node_redeploy (redeploy-start.v1)

### DIFF
--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -3,20 +3,30 @@
 #
 # runtime-rebuild-trigger.yml
 #
-# Triggers a deploy-agent rebuild when a PR that touches runtime code merges
-# to main. Closes the 6-day deploy gap (OMN-7963 / pr_review_bot failure class).
+# Triggers a runtime redeploy when a PR that touches runtime code merges to
+# dev or main. Closes the 6-day deploy gap (OMN-7963 / pr_review_bot failure
+# class).
+#
+# CI publishes onex.cmd.omnimarket.redeploy-start.v1 (consumed by node_redeploy),
+# NOT onex.cmd.deploy.rebuild-requested.v1 directly. node_redeploy owns the
+# deploy lifecycle (lane policy, digest pinning, readiness, rollback) and is the
+# sole emitter of the deploy-agent rebuild command (OMN-12573, blocker B1).
+#
+# The triggering base branch decides the runtime lane (dev -> dev lane, main ->
+# stability-test lane) and the merge commit SHA is the ref node_redeploy
+# rebuilds — there is no hardcoded origin/main.
 #
 # Trigger conditions (evaluated by scripts/trigger_rebuild_on_merge.py):
 #   - PR had the "runtime_change" label, OR
 #   - Any changed file matches src/omnimarket/** or src/omnibase_infra/nodes/**
 #
-# Ticket: OMN-8917
+# Tickets: OMN-8917 (original auto-trigger), OMN-12573 (re-point to node_redeploy)
 #
 # Required GitHub Secrets:
 #   KAFKA_BOOTSTRAP_SERVERS    -- e.g. pkc-xxx.us-east-1.aws.confluent.cloud:9092
 #   KAFKA_SASL_USERNAME        -- Confluent Cloud API key (or SASL username)
 #   KAFKA_SASL_PASSWORD        -- Confluent Cloud API secret (or SASL password)
-#   DEPLOY_AGENT_HMAC_SECRET   -- HMAC secret for signing rebuild commands
+#   DEPLOY_AGENT_HMAC_SECRET   -- HMAC secret for signing redeploy commands
 
 name: Runtime Rebuild Trigger
 
@@ -29,7 +39,7 @@ on:
 
 jobs:
   trigger-rebuild:
-    name: Trigger Deploy Agent Rebuild
+    name: Trigger node_redeploy Start
     if: github.event.pull_request.merged == true
     runs-on: >-
       ${{
@@ -59,8 +69,8 @@ jobs:
         run: |
           pip install --quiet confluent-kafka click
 
-      - name: Trigger rebuild if runtime change detected
-        # All potentially attacker-controlled inputs (labels, head_ref) are
+      - name: Trigger node_redeploy if runtime change detected
+        # All potentially attacker-controlled inputs (labels, base_ref, sha) are
         # passed through environment variables to prevent shell injection.
         env:
           KAFKA_BOOTSTRAP_SERVERS: ${{ secrets.KAFKA_BOOTSTRAP_SERVERS }}
@@ -70,9 +80,14 @@ jobs:
           PR_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # The triggering base branch decides the runtime lane; the merge
+          # commit SHA is the exact ref node_redeploy rebuilds.
+          PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           python scripts/trigger_rebuild_on_merge.py \
             --changed-files "$PR_CHANGED_FILES" \
             --labels "$PR_LABELS" \
-            --git-ref "origin/main" \
+            --base-branch "$PR_BASE_BRANCH" \
+            --source-sha "$PR_MERGE_SHA" \
             --requested-by "gha/omnibase_infra/pr-$PR_NUMBER"

--- a/scripts/trigger_rebuild_on_merge.py
+++ b/scripts/trigger_rebuild_on_merge.py
@@ -4,15 +4,26 @@
 
 # trigger_rebuild_on_merge.py
 #
-# Publishes onex.cmd.deploy.rebuild-requested.v1 when a merged PR contains
-# runtime changes. Called from the runtime-rebuild-trigger GHA workflow on
-# push to main.
+# Publishes onex.cmd.omnimarket.redeploy-start.v1 (consumed by node_redeploy)
+# when a merged PR contains runtime changes. Called from the
+# runtime-rebuild-trigger GHA workflow on PR merge to dev or main.
+#
+# node_redeploy owns the deployment lifecycle (lane policy, digest pinning,
+# readiness, rollback) and is the SOLE emitter of
+# onex.cmd.deploy.rebuild-requested.v1 to the deploy agent. CI publishes a typed
+# start command only; it never talks to the deploy agent directly.
 #
 # Triggers when:
 #   - PR had the "runtime_change" label, OR
 #   - Any changed file matches src/omnimarket/** or src/omnibase_infra/nodes/**
 #
-# Ticket: OMN-8917
+# Lane policy (the triggering ref decides the lane — no hardcoded origin/main):
+#   - merge to dev  -> runtime_lane=dev,            source_branch=dev
+#   - merge to main -> runtime_lane=stability-test, source_branch=main
+#     (dev->main promotion proves the stability lane; prod deploys the
+#      stability-proven digest later via node_redeploy, not from CI)
+#
+# Tickets: OMN-8917 (original auto-trigger), OMN-12573 (re-point to node_redeploy)
 #
 # Required environment variables (when not --dry-run):
 #   KAFKA_BOOTSTRAP_SERVERS   -- broker address(es), e.g. host:9092
@@ -24,7 +35,8 @@
 #   python scripts/trigger_rebuild_on_merge.py \
 #     --changed-files "src/omnimarket/nodes/foo/handler.py,README.md" \
 #     --labels "runtime_change,bug" \
-#     --git-ref "origin/main" \
+#     --base-branch "dev" \
+#     --source-sha "<merge_commit_sha>" \
 #     [--dry-run]
 
 from __future__ import annotations
@@ -40,7 +52,9 @@ from datetime import UTC, datetime
 
 import click
 
-TOPIC = "onex.cmd.deploy.rebuild-requested.v1"
+# CI publishes the node_redeploy start command; node_redeploy is the sole
+# emitter of the deploy-agent rebuild command downstream.
+TOPIC = "onex.cmd.omnimarket.redeploy-start.v1"
 
 _RUNTIME_PATH_PATTERNS = [
     "src/omnimarket/*",
@@ -48,6 +62,15 @@ _RUNTIME_PATH_PATTERNS = [
 ]
 
 _RUNTIME_LABEL = "runtime_change"
+
+# Maps the merged PR's base branch to a node_redeploy runtime lane. Values match
+# deploy_agent.events.EnumRuntimeLane (dev | stability-test | prod). prod is not
+# triggerable from CI: production deploys the stability-proven digest through
+# node_redeploy's promotion gate, never from a merge event.
+_BASE_BRANCH_LANES: dict[str, str] = {
+    "dev": "dev",
+    "main": "stability-test",
+}
 
 
 def should_trigger(changed_files: list[str], labels: list[str]) -> bool:
@@ -61,31 +84,53 @@ def should_trigger(changed_files: list[str], labels: list[str]) -> bool:
     return False
 
 
-def _sign_envelope(envelope: dict, secret: str) -> dict:
+def lane_for_base_branch(base_branch: str) -> str:
+    """Map a merged PR's base branch to a node_redeploy runtime lane.
+
+    Fails closed on unmapped branches: a misconfigured trigger must not silently
+    pick a default lane and rebuild the wrong runtime.
+    """
+    lane = _BASE_BRANCH_LANES.get(base_branch)
+    if lane is None:
+        allowed = ", ".join(sorted(_BASE_BRANCH_LANES))
+        msg = (
+            f"No runtime lane mapping for base branch {base_branch!r}; "
+            f"allowed base branches: {allowed}"
+        )
+        raise ValueError(msg)
+    return lane
+
+
+def _sign_envelope(envelope: dict[str, object], secret: str) -> dict[str, object]:
     body_dict = {k: v for k, v in envelope.items() if k != "_signature"}
     body = json.dumps(body_dict, sort_keys=True, separators=(",", ":")).encode()
     signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return {**envelope, "_signature": signature}
 
 
-def publish_rebuild_event(
+def publish_redeploy_start_event(
     bootstrap_servers: str,
     username: str,
     password: str,
     hmac_secret: str,
-    git_ref: str,
+    runtime_lane: str,
+    source_branch: str,
+    source_sha: str,
     correlation_id: str,
     requested_by: str,
 ) -> None:
-    """Publish a signed rebuild-requested event to Kafka via SASL_SSL."""
-    from confluent_kafka import Producer  # type: ignore[import-untyped]
+    """Publish a signed redeploy-start command to node_redeploy via SASL_SSL."""
+    from confluent_kafka import Producer
 
     envelope = {
         "correlation_id": correlation_id,
         "requested_by": requested_by,
-        "scope": "runtime",
-        "services": [],
-        "git_ref": git_ref,
+        "runtime_lane": runtime_lane,
+        "source_branch": source_branch,
+        "source_sha": source_sha,
+        # dev dogfoods OCC drafting; stability gates on readiness before prod.
+        "requires_occ": True,
+        "requires_readiness_gate": runtime_lane != "dev",
         "requested_at": datetime.now(UTC).isoformat(),
     }
     signed = _sign_envelope(envelope, hmac_secret)
@@ -101,13 +146,13 @@ def publish_rebuild_event(
 
     delivery_error: BaseException | None = None
 
-    def _on_delivery(err: object, _msg: object) -> None:  # type: ignore[misc]
+    def _on_delivery(err: object, _msg: object) -> None:
         nonlocal delivery_error
         if err is not None:
             delivery_error = RuntimeError(str(err))
 
     message = json.dumps(signed, default=str).encode("utf-8")
-    key = f"gha-rebuild/{correlation_id}".encode()
+    key = f"gha-redeploy/{correlation_id}".encode()
 
     producer.produce(
         topic=TOPIC,
@@ -133,14 +178,19 @@ def publish_rebuild_event(
     help="Comma-separated list of PR label names",
 )
 @click.option(
-    "--git-ref",
-    default="origin/main",
-    help="Git ref to rebuild (default: origin/main)",
+    "--base-branch",
+    required=True,
+    help="Merged PR base branch (dev | main) — decides the runtime lane",
+)
+@click.option(
+    "--source-sha",
+    required=True,
+    help="Merge commit SHA of the triggering PR (the ref node_redeploy rebuilds)",
 )
 @click.option(
     "--requested-by",
     default="gha-runtime-rebuild-trigger",
-    help="Identifier for who is requesting the rebuild",
+    help="Identifier for who is requesting the redeploy",
 )
 @click.option(
     "--correlation-id",
@@ -156,15 +206,17 @@ def publish_rebuild_event(
 def main(
     changed_files: str,
     labels: str,
-    git_ref: str,
+    base_branch: str,
+    source_sha: str,
     requested_by: str,
     correlation_id: str,
     dry_run: bool,
 ) -> None:
-    """Publish rebuild-requested event if PR contains runtime changes.
+    """Publish a node_redeploy start command if a PR contains runtime changes.
 
-    Triggers when PR had runtime_change label OR changed files match
-    src/omnimarket/** or src/omnibase_infra/nodes/**.
+    Triggers when PR had the runtime_change label OR changed files match
+    src/omnimarket/** or src/omnibase_infra/nodes/**. The triggering base branch
+    decides the runtime lane; the merge SHA is the ref node_redeploy rebuilds.
     """
     files: list[str] = (
         [f.strip() for f in changed_files.split(",") if f.strip()]
@@ -177,6 +229,8 @@ def main(
 
     corr_id = correlation_id or str(uuid.uuid4())
 
+    runtime_lane = lane_for_base_branch(base_branch)
+
     if not should_trigger(files, label_list):
         click.echo(
             "No rebuild trigger: no runtime_change label or runtime path changes detected."
@@ -184,8 +238,9 @@ def main(
         sys.exit(0)
 
     click.echo(
-        f"Rebuild triggered: git_ref={git_ref} correlation_id={corr_id} "
-        f"labels={label_list} files_matched={[f for f in files if any(f.startswith(p.rstrip('*')) for p in _RUNTIME_PATH_PATTERNS)]}"
+        f"Redeploy triggered: runtime_lane={runtime_lane} source_branch={base_branch} "
+        f"source_sha={source_sha} correlation_id={corr_id} labels={label_list} "
+        f"files_matched={[f for f in files if any(f.startswith(p.rstrip('*')) for p in _RUNTIME_PATH_PATTERNS)]}"
     )
 
     if dry_run:
@@ -208,12 +263,14 @@ def main(
         sys.exit(1)
 
     try:
-        publish_rebuild_event(
+        publish_redeploy_start_event(
             bootstrap_servers=bootstrap_servers,
             username=username,
             password=password,
             hmac_secret=hmac_secret,
-            git_ref=git_ref,
+            runtime_lane=runtime_lane,
+            source_branch=base_branch,
+            source_sha=source_sha,
             correlation_id=corr_id,
             requested_by=requested_by,
         )
@@ -221,7 +278,7 @@ def main(
         click.echo(f"Delivery error: {exc}", err=True)
         sys.exit(1)
 
-    click.echo(f"Published rebuild-requested to {TOPIC} (correlation_id={corr_id})")
+    click.echo(f"Published redeploy-start to {TOPIC} (correlation_id={corr_id})")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_trigger_redeploy_start.py
+++ b/tests/scripts/test_trigger_redeploy_start.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/trigger_rebuild_on_merge.py re-point to node_redeploy.
+
+OMN-12573 (blocker B1): CI must publish ``onex.cmd.omnimarket.redeploy-start.v1``
+(consumed by ``node_redeploy``) carrying the triggering lane + ref — not
+``onex.cmd.deploy.rebuild-requested.v1`` directly, and not a hardcoded
+``origin/main``. ``node_redeploy`` remains the sole emitter of
+``onex.cmd.deploy.rebuild-requested.v1`` to the deploy agent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "trigger_rebuild_on_merge.py"
+
+REDEPLOY_START_TOPIC = "onex.cmd.omnimarket.redeploy-start.v1"
+REBUILD_REQUESTED_TOPIC = "onex.cmd.deploy.rebuild-requested.v1"
+
+
+def _load_trigger_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "trigger_rebuild_on_merge", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["trigger_rebuild_on_merge"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def trigger_module() -> Any:
+    return _load_trigger_module()
+
+
+class _CapturingProducer:
+    """Fake confluent-kafka Producer capturing the published topic + payload."""
+
+    last: _CapturingProducer | None = None
+
+    def __init__(self, config: dict[str, object]) -> None:
+        self.config = config
+        self.produced: list[dict[str, Any]] = []
+        _CapturingProducer.last = self
+
+    def produce(
+        self,
+        topic: str,
+        key: bytes,
+        value: bytes,
+        on_delivery: Any,
+    ) -> None:
+        self.produced.append(
+            {
+                "topic": topic,
+                "key": key,
+                "payload": json.loads(value.decode("utf-8")),
+            }
+        )
+        on_delivery(None, None)
+
+    def flush(self, timeout: float) -> int:
+        return 0
+
+
+def _code_lines(source: str) -> str:
+    """Return source with comment lines stripped (operative code only).
+
+    Comments legitimately reference the deploy-agent topic to explain *why* CI
+    must not publish it; the guarantee under test is that no code path actually
+    targets it.
+    """
+    return "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+@pytest.mark.unit
+def test_topic_constant_is_redeploy_start_not_rebuild_requested(
+    trigger_module: Any,
+) -> None:
+    """The script must publish to node_redeploy, not the deploy agent directly."""
+    assert trigger_module.TOPIC == REDEPLOY_START_TOPIC
+    # node_redeploy is the SOLE emitter of rebuild-requested to the deploy agent;
+    # this script must not publish that topic from any code path.
+    code = _code_lines(SCRIPT_PATH.read_text())
+    assert REBUILD_REQUESTED_TOPIC not in code
+
+
+@pytest.mark.unit
+def test_lane_for_base_branch_maps_dev_and_main(trigger_module: Any) -> None:
+    """dev merges deploy the dev lane; main (promotion) merges the stability lane."""
+    assert trigger_module.lane_for_base_branch("dev") == "dev"
+    assert trigger_module.lane_for_base_branch("main") == "stability-test"
+
+
+@pytest.mark.unit
+def test_lane_for_base_branch_rejects_unknown(trigger_module: Any) -> None:
+    """Unknown base branches must fail closed (no silent default lane)."""
+    with pytest.raises(ValueError, match="release"):
+        trigger_module.lane_for_base_branch("release")
+
+
+@pytest.mark.unit
+def test_publish_redeploy_start_carries_triggering_lane_and_ref(
+    trigger_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Payload carries the actual lane/ref/sha, never a hardcoded origin/main."""
+    import types
+
+    fake_confluent = types.SimpleNamespace(Producer=_CapturingProducer)
+    monkeypatch.setitem(sys.modules, "confluent_kafka", fake_confluent)
+
+    trigger_module.publish_redeploy_start_event(
+        bootstrap_servers="broker:9092",
+        username="user",
+        password="secret",
+        hmac_secret="hmac-secret",
+        runtime_lane="dev",
+        source_branch="dev",
+        source_sha="abc123",
+        correlation_id="corr-123",
+        requested_by="gha/omnibase_infra/pr-42",
+    )
+
+    producer = _CapturingProducer.last
+    assert producer is not None
+    assert len(producer.produced) == 1
+    msg = producer.produced[0]
+
+    assert msg["topic"] == REDEPLOY_START_TOPIC
+    payload = msg["payload"]
+    assert payload["runtime_lane"] == "dev"
+    assert payload["source_branch"] == "dev"
+    assert payload["source_sha"] == "abc123"
+    # No hardcoded origin/main anywhere in the payload.
+    assert "origin/main" not in json.dumps(payload)
+    # HMAC signature is still applied.
+    assert "_signature" in payload
+
+
+@pytest.mark.unit
+def test_cli_publishes_redeploy_start_with_main_lane(
+    trigger_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end CLI: a main-base trigger publishes the stability-test lane."""
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker:9092")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "user")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "secret")
+    monkeypatch.setenv("DEPLOY_AGENT_HMAC_SECRET", "hmac-secret")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_publish(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(trigger_module, "publish_redeploy_start_event", _fake_publish)
+
+    result = CliRunner().invoke(
+        trigger_module.main,
+        [
+            "--changed-files",
+            "src/omnibase_infra/nodes/node_runtime_sweep/handler.py",
+            "--base-branch",
+            "main",
+            "--source-sha",
+            "deadbeef",
+            "--correlation-id",
+            "corr-xyz",
+            "--requested-by",
+            "gha/omnibase_infra/pr-7",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["runtime_lane"] == "stability-test"
+    assert captured["source_branch"] == "main"
+    assert captured["source_sha"] == "deadbeef"
+
+
+@pytest.mark.unit
+def test_cli_dry_run_reports_lane_and_ref(
+    trigger_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dry-run prints the resolved lane/ref and does not publish."""
+
+    def _explode(**_kwargs: Any) -> None:
+        raise AssertionError("dry-run must not publish")
+
+    monkeypatch.setattr(trigger_module, "publish_redeploy_start_event", _explode)
+
+    result = CliRunner().invoke(
+        trigger_module.main,
+        [
+            "--changed-files",
+            "src/omnimarket/nodes/foo/handler.py",
+            "--base-branch",
+            "dev",
+            "--source-sha",
+            "cafe",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "runtime_lane=dev" in result.output
+    assert "source_sha=cafe" in result.output
+
+
+@pytest.mark.unit
+def test_workflow_passes_triggering_lane_and_ref_not_origin_main() -> None:
+    """The GHA workflow must hand the script the real base branch + merge SHA."""
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "runtime-rebuild-trigger.yml"
+    ).read_text()
+    code = _code_lines(workflow)
+    # The hardcoded git ref is gone from the operative invocation.
+    assert "--git-ref" not in code
+    assert "origin/main" not in code
+    # The script receives the merged PR's base branch and merge SHA.
+    assert "--base-branch" in code
+    assert "github.event.pull_request.base.ref" in code
+    assert "--source-sha" in code
+    assert "github.event.pull_request.merge_commit_sha" in code

--- a/tests/unit/scripts/test_pr_merged_rebuild_trigger.py
+++ b/tests/unit/scripts/test_pr_merged_rebuild_trigger.py
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Unit tests for scripts/trigger_rebuild_on_merge.py [OMN-8917].
+"""Unit tests for scripts/trigger_rebuild_on_merge.py [OMN-8917, OMN-12573].
 
 Tests assert path-based and label-based trigger logic with mocked Kafka publish.
+OMN-12573 re-points the script to publish the node_redeploy start command
+(onex.cmd.omnimarket.redeploy-start.v1) carrying the triggering lane + ref,
+instead of the deploy-agent rebuild command with a hardcoded origin/main.
 """
 
 from __future__ import annotations
@@ -98,43 +101,40 @@ class TestRebuildTriggerLogic:
 
 
 @pytest.mark.unit
-class TestRebuildTriggerPublish:
-    """Unit tests for publish_rebuild_event() Kafka call shape."""
+class TestRedeployStartPublish:
+    """Unit tests for publish_redeploy_start_event() Kafka call shape (OMN-12573).
+
+    CI publishes the node_redeploy start command, not the deploy-agent rebuild
+    command directly.
+    """
 
     def setup_method(self) -> None:
         self.mod = _import_trigger_module()
 
-    def test_publish_calls_producer_with_correct_topic(self) -> None:
-        """publish_rebuild_event should produce to onex.cmd.deploy.rebuild-requested.v1."""
+    def test_publish_calls_producer_with_redeploy_start_topic(self) -> None:
+        """publish_redeploy_start_event publishes onex.cmd.omnimarket.redeploy-start.v1."""
         mock_producer = MagicMock()
         mock_producer.flush.return_value = None
 
-        with patch.dict(
-            "os.environ",
-            {
-                "KAFKA_BOOTSTRAP_SERVERS": "broker:9092",
-                "KAFKA_SASL_USERNAME": "user",
-                "KAFKA_SASL_PASSWORD": "pass",
-                "DEPLOY_AGENT_HMAC_SECRET": "testsecret",
-            },
-        ):
-            with patch("confluent_kafka.Producer", return_value=mock_producer):
-                self.mod.publish_rebuild_event(
-                    bootstrap_servers="broker:9092",
-                    username="user",
-                    password="pass",
-                    hmac_secret="testsecret",
-                    git_ref="origin/main",
-                    correlation_id="test-corr-id",
-                    requested_by="gha-trigger",
-                )
+        with patch("confluent_kafka.Producer", return_value=mock_producer):
+            self.mod.publish_redeploy_start_event(
+                bootstrap_servers="broker:9092",
+                username="user",
+                password="pass",
+                hmac_secret="testsecret",
+                runtime_lane="dev",
+                source_branch="dev",
+                source_sha="abc123",
+                correlation_id="test-corr-id",
+                requested_by="gha-trigger",
+            )
 
         mock_producer.produce.assert_called_once()
         call_kwargs = mock_producer.produce.call_args
-        assert call_kwargs.kwargs["topic"] == "onex.cmd.deploy.rebuild-requested.v1"
+        assert call_kwargs.kwargs["topic"] == "onex.cmd.omnimarket.redeploy-start.v1"
 
     def test_publish_event_payload_shape(self) -> None:
-        """Published payload must include scope=runtime and git_ref."""
+        """Payload carries the triggering lane + ref, never a hardcoded origin/main."""
         import json
 
         mock_producer = MagicMock()
@@ -147,27 +147,32 @@ class TestRebuildTriggerPublish:
         mock_producer.flush.return_value = None
 
         with patch("confluent_kafka.Producer", return_value=mock_producer):
-            self.mod.publish_rebuild_event(
+            self.mod.publish_redeploy_start_event(
                 bootstrap_servers="broker:9092",
                 username="user",
                 password="pass",
                 hmac_secret="testsecret",
-                git_ref="origin/main",
+                runtime_lane="stability-test",
+                source_branch="main",
+                source_sha="deadbeef",
                 correlation_id="test-corr-id",
                 requested_by="gha-trigger",
             )
 
         assert captured_value, "produce was not called"
         payload = json.loads(captured_value[0])
-        assert payload["scope"] == "runtime"
-        assert payload["git_ref"] == "origin/main"
+        assert payload["runtime_lane"] == "stability-test"
+        assert payload["source_branch"] == "main"
+        assert payload["source_sha"] == "deadbeef"
+        assert payload["requires_readiness_gate"] is True
+        assert "origin/main" not in json.dumps(payload)
         assert "correlation_id" in payload
         assert "_signature" in payload
 
 
 @pytest.mark.unit
-class TestRebuildTriggerCLI:
-    """CLI integration tests using --dry-run flag."""
+class TestRedeployStartCLI:
+    """CLI integration tests using --dry-run flag (OMN-12573)."""
 
     def test_dry_run_no_trigger_exits_zero(self) -> None:
         """--dry-run with no matching files or labels should exit 0 without publishing."""
@@ -179,8 +184,10 @@ class TestRebuildTriggerCLI:
                 "README.md,docs/plans/foo.md",
                 "--labels",
                 "",
-                "--git-ref",
-                "origin/main",
+                "--base-branch",
+                "dev",
+                "--source-sha",
+                "abc123",
                 "--dry-run",
             ],
             capture_output=True,
@@ -191,8 +198,8 @@ class TestRebuildTriggerCLI:
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert "no rebuild trigger" in result.stdout.lower()
 
-    def test_dry_run_with_runtime_change_label(self) -> None:
-        """--dry-run with runtime_change label should report trigger without publishing."""
+    def test_dry_run_with_runtime_change_label_reports_dev_lane(self) -> None:
+        """--dry-run with runtime_change label reports the dev lane and ref."""
         result = subprocess.run(
             [
                 sys.executable,
@@ -201,8 +208,10 @@ class TestRebuildTriggerCLI:
                 "",
                 "--labels",
                 "runtime_change",
-                "--git-ref",
-                "origin/main",
+                "--base-branch",
+                "dev",
+                "--source-sha",
+                "abc123",
                 "--dry-run",
             ],
             capture_output=True,
@@ -211,13 +220,11 @@ class TestRebuildTriggerCLI:
             check=False,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        assert (
-            "rebuild triggered" in result.stdout.lower()
-            or "dry-run" in result.stdout.lower()
-        )
+        assert "runtime_lane=dev" in result.stdout
+        assert "source_sha=abc123" in result.stdout
 
-    def test_dry_run_with_omnimarket_path(self) -> None:
-        """--dry-run with omnimarket src path should report trigger."""
+    def test_dry_run_with_main_base_reports_stability_lane(self) -> None:
+        """--dry-run with omnimarket src path and main base reports the stability lane."""
         result = subprocess.run(
             [
                 sys.executable,
@@ -226,8 +233,10 @@ class TestRebuildTriggerCLI:
                 "src/omnimarket/nodes/foo/handler.py",
                 "--labels",
                 "",
-                "--git-ref",
-                "origin/main",
+                "--base-branch",
+                "main",
+                "--source-sha",
+                "deadbeef",
                 "--dry-run",
             ],
             capture_output=True,
@@ -236,7 +245,29 @@ class TestRebuildTriggerCLI:
             check=False,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        assert (
-            "rebuild triggered" in result.stdout.lower()
-            or "dry-run" in result.stdout.lower()
+        assert "runtime_lane=stability-test" in result.stdout
+        assert "source_sha=deadbeef" in result.stdout
+
+    def test_unknown_base_branch_fails(self) -> None:
+        """An unmapped base branch must fail closed (no silent default lane)."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-files",
+                "src/omnimarket/nodes/foo/handler.py",
+                "--labels",
+                "",
+                "--base-branch",
+                "release",
+                "--source-sha",
+                "abc123",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
         )
+        assert result.returncode != 0
+        assert "release" in (result.stdout + result.stderr)


### PR DESCRIPTION
## Summary

Blocker **B1** of `docs/plans/2026-06-01-node-based-runtime-deployment-occ-tdd.md`. Today CI bypasses `node_redeploy` and hardcodes the rebuild ref: `runtime-rebuild-trigger.yml` runs `scripts/trigger_rebuild_on_merge.py` which publishes `onex.cmd.deploy.rebuild-requested.v1` **directly** to the deploy agent with `--git-ref "origin/main"` **unconditionally** — so a `dev` trigger still rebuilds `main`.

This PR re-points CI so `node_redeploy` owns the deploy lifecycle (lane policy, digest pinning, readiness, rollback):

1. CI now publishes `onex.cmd.omnimarket.redeploy-start.v1` (consumed by `node_redeploy`), not `rebuild-requested.v1` directly.
2. The triggering **base branch + merge SHA** are passed through, not a hardcoded `origin/main`. The base branch decides the runtime lane: `dev` -> `dev` lane, `main` (promotion) -> `stability-test` lane. Lane values match `deploy_agent.events.EnumRuntimeLane` (from OMN-12572).
3. `node_redeploy` remains the **sole** emitter of `onex.cmd.deploy.rebuild-requested.v1` to the deploy agent — this script never publishes that topic from any code path.

`prod` is intentionally not triggerable from a merge event: production deploys the stability-proven digest via `node_redeploy`'s promotion gate (later phases of the plan), never from CI.

## Stacking

Stacked on **OMN-12572** (`jonah/omn-12572-deploy-agent-lane-digest`, B2 — deploy-agent `runtime_lane` + `image_digest`). The lane vocabulary the redeploy-start payload uses (`dev` / `stability-test` / `prod`) is the `EnumRuntimeLane` introduced there. Base will retarget to `dev` once OMN-12572 lands.

## Scope

`omnibase_infra` only (CI workflow + the infra-side trigger script that `actions/checkout` + `python scripts/trigger_rebuild_on_merge.py` actually invokes). `omnimarket/scripts/trigger_rebuild_on_merge.py` is a separate copy not invoked by this workflow; consuming the new `redeploy-start.v1` lane/ref fields in `node_redeploy.ModelRedeployCommand` is downstream omnimarket work (Phase 2 of the plan), tracked separately. `scripts/deploy-trigger.py` (a manual operator tool, not CI-wired) is left unchanged.

## dod_evidence (OMN-12573)

DoD bullets and how each is satisfied:
- **CI publishes `onex.cmd.omnimarket.redeploy-start.v1` with the triggering lane/ref** — `TOPIC = "onex.cmd.omnimarket.redeploy-start.v1"`; `publish_redeploy_start_event` emits `runtime_lane` / `source_branch` / `source_sha`. Workflow passes `--base-branch "$PR_BASE_BRANCH"` / `--source-sha "$PR_MERGE_SHA"`.
- **No hardcoded `origin/main`; a `dev` trigger rebuilds the `dev` ref** — `--git-ref "origin/main"` removed from the workflow; `lane_for_base_branch` maps `dev`->`dev`, `main`->`stability-test`, and fails closed on unmapped branches.
- **`node_redeploy` is the sole emitter of `rebuild-requested.v1`** — the script no longer publishes that topic from any code path (asserted by `test_topic_constant_is_redeploy_start_not_rebuild_requested`).
- **Test proving the workflow publishes `redeploy-start.v1` with the correct ref/lane** — `tests/scripts/test_trigger_redeploy_start.py` (TDD-first, 7 tests) + updated `tests/unit/scripts/test_pr_merged_rebuild_trigger.py`.

Commands run (from the worktree):
```
uv run ruff format scripts/... tests/...            -> clean (files unchanged)
uv run ruff check scripts/... tests/...             -> All checks passed
uv run mypy scripts/trigger_rebuild_on_merge.py     -> 0 errors (repo config)
uv run pytest tests/scripts/ tests/unit/scripts/ tests/ci/test_topic_parity.py
                                                     -> 563 passed
uv run pytest tests/redeploy/ tests/scripts/ tests/unit/scripts/
                                                     -> 561 passed
pre-commit run --files <4 changed files>            -> all hooks Passed (clean)
```

Note: the full `uv run pytest tests/ -m unit` run was killed by a sandbox resource/timeout limit (exit 143), not a test failure. The change is isolated to one script, one workflow, and two test files (no `src/` changes), so the scripts/redeploy/ci/topic-parity suites above are the load-bearing coverage and are green.

Files changed:
- `.github/workflows/runtime-rebuild-trigger.yml`
- `scripts/trigger_rebuild_on_merge.py`
- `tests/scripts/test_trigger_redeploy_start.py` (new)
- `tests/unit/scripts/test_pr_merged_rebuild_trigger.py`