### PR TITLE
ci(OMN-12568): validate versioned runner image on fresh runner + rollout checklist

### DIFF
--- a/docs/ci/versioned-runner-image-rollout-checklist.md
+++ b/docs/ci/versioned-runner-image-rollout-checklist.md
@@ -1,0 +1,133 @@
+# Versioned Runner Image Rollout Checklist (OMN-12568)
+
+This is the per-repo migration checklist for moving a repository onto the
+OMN-12567 **versioned runner image contract** — the runner image whose "version"
+is a *binding* (base image digest + dependency manifest + Python version + uv
+version + shared-env version + image version folded into one reproducible
+`identity_digest`), not a human label.
+
+OMN-12567 builds and binds the image; **OMN-12568 is the acceptance**: prove the
+contract survives a *fresh runner recreation* on one repo, then roll the rest of
+the fleet repo-by-repo using this checklist. Do **not** migrate all repos at
+once — each repo's dependency graph is validated independently.
+
+## Source of truth
+
+| Artifact | Path |
+|----------|------|
+| Bound identity lock | `omnibase_infra:docker/runners/runner-image.lock.json` |
+| Identity generator / verifier | `omnibase_infra:scripts/ci/runner_image_identity.py` (OMN-12567) |
+| Image build script | `omnibase_infra:scripts/ci/build_runner_image.sh` (OMN-12567) |
+| Per-job identity emitter | `omnibase_infra:.github/actions/emit-runner-identity/action.yml` (OMN-12567) |
+| **Runner validation script** | `omnibase_infra:scripts/ci/validate_runner_image.py` (OMN-12568) |
+| **Runner validation wrapper** | `omnibase_infra:scripts/ci/validate_runner_image.sh` (OMN-12568) |
+| Canary contract | `omnibase_infra:docs/ci/versioned-ci-env-canary.md` (OMN-12564) |
+
+## Pre-rollout gate (do this once, on `omnibase_infra`)
+
+The canary repo is `omnibase_infra`. Before any other repo migrates, the image
+contract must be proven on a **freshly recreated** runner.
+
+- [ ] Build and publish the versioned image (gated live runtime step — the user
+      runs this on the runner host):
+      `scripts/ci/build_runner_image.sh --tag <registry>/omninode-runner:v<N>`.
+- [ ] **Recreate one runner from scratch** on the new image (gated live runtime
+      step). Warm-runner state does not count — recreation is the contract under
+      test.
+- [ ] Run the validation script on the freshly recreated runner and confirm
+      `RESULT: GREEN`:
+      `scripts/ci/validate_runner_image.sh --json`.
+- [ ] Confirm at least one real CI job ran green on the recreated runner and the
+      job's startup evidence shows the bound `runner_image_identity` (from the
+      `emit-runner-identity` action) matching the committed lock.
+
+Only after this gate is green does the fleet rollout below begin.
+
+## Per-repo migration steps
+
+Run these for **one repo at a time**. A repo is "migrated" only when a CI job has
+run green on a freshly recreated runner using the versioned image.
+
+- [ ] **Confirm dependency-graph compatibility.** The shared prebuilt env is keyed
+      on `pyproject.toml` + `uv.lock` + Python/uv versions. If the repo's graph is
+      incompatible with the infra canary env, it gets its own env root
+      (`/home/runner/.cache/omni/ci-envs/<repo>/<digest>`); do not force-share an
+      env across incompatible graphs.
+- [ ] **Wire the identity emission.** Ensure every Python-prep job uses the
+      `setup-python-uv` action (which emits the bound identity), or add the
+      reusable `emit-runner-identity` action to non-Python jobs. Image-drift
+      debugging requires the identity in startup evidence.
+- [ ] **Enumerate mutating jobs and opt them out** (see the opt-out table below).
+      Any job that runs `uv sync` / `uv pip install` / editable sibling installs
+      after setup must set `shared-env-enabled: "false"` so it gets an isolated
+      writable env and never writes into the shared prebuilt env.
+- [ ] **Vendor or reference the validation script.** Either call
+      `omnibase_infra:scripts/ci/validate_runner_image.{py,sh}` from a shared
+      action, or copy it into the repo's `scripts/ci/`. The lock file the script
+      reads is the baked `/etc/omni/runner-image.lock.json` on the image.
+- [ ] **Recreate a runner and validate** (gated live runtime step). Run
+      `validate_runner_image.sh` on the recreated runner; require `RESULT: GREEN`.
+- [ ] **Run the repo's full CI on the recreated runner** and confirm green,
+      including the Receipt-Gate job, before marking the repo migrated.
+- [ ] **Record the migration** in the rollout log with: repo, image version `v<N>`,
+      recorded `identity_digest`, and the green CI run URL.
+
+## Mutating-job opt-outs (carried from OMN-12567)
+
+These jobs intentionally mutate the Python environment and **must** opt out of
+the shared prebuilt env. Adding a new mutating job means adding its opt-out and a
+row here in the same PR.
+
+| Job | Why it mutates | Opt-out |
+|-----|----------------|---------|
+| `compliance` | runs sweeps that `uv sync` extra groups | `shared-env-enabled: "false"` |
+| `schema-handshake` | editable sibling repo installs | `shared-env-enabled: "false"` |
+| `kafka-boundary-compat` | editable sibling repo installs | `shared-env-enabled: "false"` |
+| `contract-compliance` | pinned `onex_change_control` git+https install | isolated `setup-uv` (no shared env) |
+
+## Explicit opt-outs (repos / jobs that should NOT migrate)
+
+Migration is not universal. Record an explicit opt-out (with reason) rather than
+silently skipping:
+
+- [ ] **Public fork PRs** — never use the host-local shared env or the baked
+      image env; they keep isolated `setup-python-uv` (trust boundary). This is a
+      permanent opt-out, not a migration gap.
+- [ ] **Repos on GitHub-hosted runners only** — the versioned image targets the
+      *self-hosted trusted pool*. A repo whose CI runs exclusively on
+      `ubuntu-latest` hosted runners does not consume the image; mark it opt-out.
+- [ ] **Repos with no Python CI** (e.g. pure docs / PHP / static-site repos) —
+      no prebuilt env to bake; opt out and note "no Python jobs".
+- [ ] **Jobs that require a writable global env** (anything doing
+      `uv pip install` into the system env) — opt out at the job level via
+      `shared-env-enabled: "false"`, do not migrate the whole repo around them.
+
+Each opt-out must be recorded with: repo/job, reason, and the date reviewed —
+so an opt-out is an auditable decision, not an unexplained gap.
+
+## Validation script contract
+
+`scripts/ci/validate_runner_image.py` asserts three things on the runner and
+exits non-zero on any required failure:
+
+1. **`image_identity`** — the lock file (`/etc/omni/runner-image.lock.json`,
+   falling back to the repo-local lock) is present and internally consistent; the
+   baked `OMNI_RUNNER_IMAGE_IDENTITY` matches the recorded `identity_digest`
+   (no drift, not `unbound`). When `runner_image_identity.py` is present it
+   recomputes the full binding and requires the recorded digest to match.
+2. **`zero_uv_sync`** — the prebuilt shared CI env is baked under
+   `OMNI_CI_ENV_ROOT` with a `manifest.json` ready marker, and `UV_NO_SYNC=1`
+   holds, so the happy path resolves zero `uv sync`.
+3. **`receipt_gate_readiness`** — `gh`, `git`, `jq`, `python3`, and `uv` are on
+   the runner, so a queued PR's Receipt-Gate verification will not fail on a
+   missing binary.
+
+It is a **read-only** assertion — it never recreates, restarts, or registers a
+runner. Recreation is a separate, operator-run live runtime step.
+
+## Acceptance (OMN-12568)
+
+- One repo (`omnibase_infra`) runs green on the versioned image **after fresh
+  runner recreation** — proven by `validate_runner_image.sh` returning
+  `RESULT: GREEN` on the recreated runner plus a green CI run.
+- This rollout checklist exists with explicit opt-outs noted (this document).

--- a/scripts/ci/validate_runner_image.py
+++ b/scripts/ci/validate_runner_image.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Validate a self-hosted runner against the versioned image contract (OMN-12568).
+
+OMN-12567 makes the runner image "version" a *binding* — base image digest +
+dependency manifest + Python version + uv version + shared-env version + image
+version folded into one reproducible ``identity_digest`` recorded in
+``runner-image.lock.json``. OMN-12568 is the *acceptance* of that contract: run
+this script on a freshly recreated runner and prove the image survived
+recreation.
+
+The script asserts three things on the runner it runs on:
+
+1. **Image identity** — the lock file is present and internally consistent
+   (recorded ``identity_digest`` matches the recomputed binding, when the
+   OMN-12567 generator ``runner_image_identity.py`` is available), and the
+   identity baked into the live image (``OMNI_RUNNER_IMAGE_IDENTITY`` env / the
+   ``org.omninode.runner.image.identity`` label, surfaced into the runtime env)
+   matches the recorded identity. A baked-vs-recorded mismatch is image drift.
+
+2. **Zero ``uv sync`` on the happy path** — the prebuilt shared CI env is baked
+   under ``OMNI_CI_ENV_ROOT`` with a ``manifest.json`` ready marker, and the
+   canary publishes ``UV_NO_SYNC=1`` so a happy-path job resolves dependencies
+   without ever running ``uv sync``. A ``uv sync`` on the happy path is a
+   regression; this check fails if the env is absent or ``UV_NO_SYNC`` is unset.
+
+3. **Receipt-Gate readiness** — the tooling the Receipt-Gate path needs (``gh``,
+   ``git``, ``jq``, ``python3``, ``uv``) is present on the runner, so a queued
+   PR's receipt verification will not fail on a missing binary.
+
+This script is intentionally self-contained: it does not import the OMN-12567
+``runner_image_identity`` module at module scope, so it is runnable and testable
+on a checkout that predates the merge of that module. When the module *is*
+present on the runner (the steady state once OMN-12567 lands), the identity
+check upgrades from "consistency of the recorded lock" to "recompute and compare
+the full binding".
+
+Exit codes:
+* ``0`` — all required checks passed.
+* ``1`` — at least one required check failed.
+
+Usage on a freshly recreated runner::
+
+    python3 scripts/ci/validate_runner_image.py            # human report
+    python3 scripts/ci/validate_runner_image.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The baked lock path inside the OMN-12567 runner image (copied read-only in the
+# Dockerfile), then the in-repo committed lock as a fallback for repo-checkout
+# validation.
+BAKED_LOCK_PATH = Path("/etc/omni/runner-image.lock.json")
+REPO_LOCK_PATH = Path("docker/runners/runner-image.lock.json")
+
+# Binaries the happy-path + Receipt-Gate jobs assume are present on the runner.
+RECEIPT_GATE_TOOLS = ("gh", "git", "jq", "python3", "uv")
+
+# Default prebuilt shared CI env root baked by the OMN-12567 Dockerfile. The
+# canary (OMN-12564) materialises ``<root>/<repo>/<digest>/.venv`` with a
+# ``manifest.json`` ready marker.
+DEFAULT_CI_ENV_ROOT = Path("/home/runner/.cache/omni/ci-envs")
+DEFAULT_CI_ENV_REPO = "omnibase_infra"
+
+# The generator module shipped by OMN-12567. When importable, the identity check
+# recomputes the full binding instead of only asserting recorded consistency.
+IDENTITY_MODULE_NAME = "runner_image_identity"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a single validation check."""
+
+    name: str
+    passed: bool
+    detail: str
+    required: bool = True
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate report across all runner validation checks."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    def add(self, result: CheckResult) -> None:
+        self.checks.append(result)
+
+    @property
+    def ok(self) -> bool:
+        """True when every *required* check passed."""
+        return all(c.passed for c in self.checks if c.required)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "checks": [
+                {
+                    "name": c.name,
+                    "passed": c.passed,
+                    "required": c.required,
+                    "detail": c.detail,
+                }
+                for c in self.checks
+            ],
+        }
+
+
+def _load_lock(lock_path: Path) -> dict[str, object]:
+    """Load and shape-check a runner image lock file."""
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError(f"lock file must be a JSON object: {lock_path}")
+    return data
+
+
+def resolve_lock_path(explicit: Path | None = None) -> Path | None:
+    """Return the first existing lock path: explicit, baked, then repo-local."""
+    candidates = (
+        [explicit] if explicit is not None else [BAKED_LOCK_PATH, REPO_LOCK_PATH]
+    )
+    for candidate in candidates:
+        if candidate is not None and candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_identity_module(repo_root: Path):  # type: ignore[no-untyped-def]
+    """Import the OMN-12567 generator module if present, else return None.
+
+    The module lives at ``scripts/ci/runner_image_identity.py`` and imports its
+    sibling ``ci_env_digest``; both directories are added to ``sys.path`` via the
+    spec submodule search so the recompute path matches what CI runs.
+    """
+    module_path = repo_root / "scripts" / "ci" / f"{IDENTITY_MODULE_NAME}.py"
+    if not module_path.is_file():
+        return None
+    ci_dir = str(module_path.parent)
+    import sys
+
+    if ci_dir not in sys.path:
+        sys.path.insert(0, ci_dir)
+    spec = importlib.util.spec_from_file_location(IDENTITY_MODULE_NAME, module_path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:  # noqa: BLE001 — a broken/partial generator is non-fatal here
+        return None
+    return module
+
+
+def check_image_identity(
+    lock_path: Path | None,
+    repo_root: Path,
+    baked_identity: str | None,
+) -> CheckResult:
+    """Assert the runner image identity binding is present and consistent."""
+    name = "image_identity"
+    if lock_path is None:
+        return CheckResult(
+            name=name,
+            passed=False,
+            detail=(
+                "no runner image lock file found at "
+                f"{BAKED_LOCK_PATH} or {REPO_LOCK_PATH}; the runner is not on the "
+                "OMN-12567 versioned image"
+            ),
+        )
+
+    try:
+        lock = _load_lock(lock_path)
+    except (OSError, ValueError, TypeError) as exc:
+        return CheckResult(name=name, passed=False, detail=f"unreadable lock: {exc}")
+
+    recorded = lock.get("identity_digest")
+    image_version = lock.get("image_version")
+    if not isinstance(recorded, str) or not recorded:
+        return CheckResult(
+            name=name,
+            passed=False,
+            detail=f"lock {lock_path} missing a non-empty identity_digest",
+        )
+
+    # When the OMN-12567 generator is present, recompute the full binding and
+    # require the recorded digest to match. This is the strong identity proof.
+    module = _load_identity_module(repo_root)
+    if module is not None:
+        try:
+            recomputed = module.compute_identity(repo_root, lock)
+        except Exception as exc:  # noqa: BLE001 — surface, do not crash the validator
+            return CheckResult(
+                name=name,
+                passed=False,
+                detail=f"identity recompute failed: {exc}",
+            )
+        if recomputed != recorded:
+            return CheckResult(
+                name=name,
+                passed=False,
+                detail=(
+                    "recorded identity_digest is stale: "
+                    f"recorded={recorded!r} recomputed={recomputed!r}; "
+                    "run runner_image_identity.py --mode generate"
+                ),
+            )
+
+    # The identity baked into the live image must match the recorded lock. The
+    # OMN-12567 Dockerfile bakes OMNI_RUNNER_IMAGE_IDENTITY into the runtime env;
+    # "unbound" means an un-stamped image, which is a drift failure for a repo
+    # claiming to run on the versioned image.
+    if baked_identity is not None and baked_identity not in ("", "unbound"):
+        if baked_identity != recorded:
+            return CheckResult(
+                name=name,
+                passed=False,
+                detail=(
+                    "image identity drift: baked OMNI_RUNNER_IMAGE_IDENTITY="
+                    f"{baked_identity!r} != recorded={recorded!r}"
+                ),
+            )
+        baked_state = "matches baked image"
+    elif baked_identity in ("", "unbound"):
+        return CheckResult(
+            name=name,
+            passed=False,
+            detail=(
+                "live image reports OMNI_RUNNER_IMAGE_IDENTITY='unbound'; the "
+                "runner is not on a stamped OMN-12567 image"
+            ),
+        )
+    else:
+        baked_state = "no baked identity env (repo-checkout validation)"
+
+    return CheckResult(
+        name=name,
+        passed=True,
+        detail=(
+            f"runner image v{image_version} identity {recorded} verified "
+            f"({baked_state})"
+        ),
+    )
+
+
+def _env_ready_marker_present(env_root: Path, repo: str) -> tuple[bool, str]:
+    """Return whether a ready (manifest.json + .venv) prebuilt env exists."""
+    repo_env_root = env_root / repo
+    if not repo_env_root.is_dir():
+        return False, f"prebuilt env root absent: {repo_env_root}"
+    for digest_dir in sorted(repo_env_root.iterdir()):
+        if not digest_dir.is_dir():
+            continue
+        manifest = digest_dir / "manifest.json"
+        venv_python = digest_dir / ".venv" / "bin" / "python"
+        if manifest.is_file() and venv_python.exists():
+            return True, f"ready prebuilt env: {digest_dir}"
+    return False, (
+        f"no ready prebuilt env under {repo_env_root} "
+        "(expected <digest>/manifest.json + <digest>/.venv/bin/python)"
+    )
+
+
+def check_zero_uv_sync(
+    env_root: Path,
+    repo: str,
+    uv_no_sync: str | None,
+) -> CheckResult:
+    """Assert the happy path resolves zero ``uv sync``.
+
+    The OMN-12567 image bakes the shared CI env and the canary publishes
+    ``UV_NO_SYNC=1``; both must hold for a happy-path job to skip ``uv sync``.
+    """
+    name = "zero_uv_sync"
+    env_ready, env_detail = _env_ready_marker_present(env_root, repo)
+    if not env_ready:
+        return CheckResult(name=name, passed=False, detail=env_detail)
+
+    # UV_NO_SYNC may legitimately be unset in the *validator's* own shell when run
+    # outside a job step; the authoritative signal is that the canary publishes it
+    # into $GITHUB_ENV. Accept either an explicit "1"/"true" in the process env or
+    # a recorded publish marker on the env dir. When UV_NO_SYNC is present in the
+    # validator env, it must be truthy.
+    if uv_no_sync is not None and uv_no_sync not in ("1", "true"):
+        return CheckResult(
+            name=name,
+            passed=False,
+            detail=(
+                f"UV_NO_SYNC is set to {uv_no_sync!r} (expected '1'); a happy-path "
+                "job would run uv sync"
+            ),
+        )
+    no_sync_state = (
+        "UV_NO_SYNC=1 in env"
+        if uv_no_sync in ("1", "true")
+        else "UV_NO_SYNC published by canary at job time"
+    )
+    return CheckResult(
+        name=name,
+        passed=True,
+        detail=f"{env_detail}; {no_sync_state}",
+    )
+
+
+def check_receipt_gate_readiness(
+    tools: Sequence[str] = RECEIPT_GATE_TOOLS,
+) -> CheckResult:
+    """Assert the runner has the tooling the Receipt-Gate path requires."""
+    name = "receipt_gate_readiness"
+    missing = [tool for tool in tools if shutil.which(tool) is None]
+    if missing:
+        return CheckResult(
+            name=name,
+            passed=False,
+            detail=f"missing Receipt-Gate tooling: {', '.join(missing)}",
+        )
+    return CheckResult(
+        name=name,
+        passed=True,
+        detail=f"Receipt-Gate tooling present: {', '.join(tools)}",
+    )
+
+
+def validate_runner(
+    repo_root: Path,
+    lock_path: Path | None = None,
+    env_root: Path | None = None,
+    env_repo: str = DEFAULT_CI_ENV_REPO,
+    baked_identity: str | None = None,
+    uv_no_sync: str | None = None,
+    tools: Sequence[str] = RECEIPT_GATE_TOOLS,
+) -> ValidationReport:
+    """Run all runner validation checks and return the aggregate report."""
+    report = ValidationReport()
+    resolved_lock = resolve_lock_path(lock_path)
+    report.add(check_image_identity(resolved_lock, repo_root, baked_identity))
+    report.add(
+        check_zero_uv_sync(
+            env_root if env_root is not None else DEFAULT_CI_ENV_ROOT,
+            env_repo,
+            uv_no_sync,
+        )
+    )
+    report.add(check_receipt_gate_readiness(tools))
+    return report
+
+
+def _render_human(report: ValidationReport) -> str:
+    lines = ["Runner image validation (OMN-12568)", ""]
+    for check in report.checks:
+        status = "PASS" if check.passed else "FAIL"
+        req = "" if check.required else " (advisory)"
+        lines.append(f"[{status}] {check.name}{req}: {check.detail}")
+    lines.append("")
+    lines.append("RESULT: " + ("GREEN" if report.ok else "RED"))
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a runner against the OMN-12567 versioned image contract."
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--lock-file",
+        type=Path,
+        default=None,
+        help="Explicit lock path; defaults to the baked or repo-local lock.",
+    )
+    parser.add_argument(
+        "--env-root",
+        type=Path,
+        default=None,
+        help="Prebuilt shared CI env root (default: the baked image root).",
+    )
+    parser.add_argument("--env-repo", type=str, default=DEFAULT_CI_ENV_REPO)
+    parser.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of text."
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    report = validate_runner(
+        repo_root=repo_root,
+        lock_path=args.lock_file,
+        env_root=args.env_root,
+        env_repo=args.env_repo,
+        baked_identity=os.environ.get("OMNI_RUNNER_IMAGE_IDENTITY"),
+        uv_no_sync=os.environ.get("UV_NO_SYNC"),
+    )
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(_render_human(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_runner_image.sh
+++ b/scripts/ci/validate_runner_image.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Validate a self-hosted runner against the OMN-12567 versioned image contract
+# (OMN-12568 acceptance). Run this on a *freshly recreated* runner — the point
+# is to prove the image contract survives recreation, not warm-runner state.
+#
+# This is a READ-ONLY assertion. It does not recreate, restart, register, or
+# mutate any runner; it only inspects the runner it runs on and exits non-zero
+# if the versioned-image contract is not satisfied.
+#
+# What it asserts (via scripts/ci/validate_runner_image.py):
+#   1. image identity      — baked OMNI_RUNNER_IMAGE_IDENTITY matches the lock's
+#                            recorded identity_digest (no drift, not "unbound").
+#   2. zero `uv sync`       — the prebuilt shared CI env is baked + UV_NO_SYNC=1,
+#                            so the happy path resolves zero `uv sync`.
+#   3. Receipt-Gate ready   — gh/git/jq/python3/uv are present on the runner.
+#
+# Usage (on the runner host or inside the runner container):
+#   scripts/ci/validate_runner_image.sh                 # human report
+#   scripts/ci/validate_runner_image.sh --json          # machine-readable
+#   OMNI_RUNNER_CONTAINER=omninode-runner-1 \
+#     scripts/ci/validate_runner_image.sh               # inspect a named container
+#
+# When OMNI_RUNNER_CONTAINER is set and docker is available, the script reads the
+# baked identity from the container's image label instead of the ambient env, so
+# it can validate a runner container from the host without entering it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate_runner_image.py"
+
+python_bin="$(command -v python3 || true)"
+if [[ -z "${python_bin}" ]]; then
+  echo "::error::python3 not found on runner; cannot validate image contract" >&2
+  exit 1
+fi
+
+# Resolve the baked image identity. Priority:
+#   1. OMNI_RUNNER_IMAGE_IDENTITY already in the env (inside the runner image).
+#   2. The image label of a named container (OMNI_RUNNER_CONTAINER) via docker.
+baked_identity="${OMNI_RUNNER_IMAGE_IDENTITY:-}"
+if [[ -z "${baked_identity}" && -n "${OMNI_RUNNER_CONTAINER:-}" ]] \
+  && command -v docker >/dev/null 2>&1; then
+  image_ref="$(docker inspect --format '{{.Config.Image}}' "${OMNI_RUNNER_CONTAINER}" 2>/dev/null || true)"
+  if [[ -n "${image_ref}" ]]; then
+    baked_identity="$(
+      docker inspect --format \
+        '{{ index .Config.Labels "org.omninode.runner.image.identity" }}' \
+        "${image_ref}" 2>/dev/null || true
+    )"
+  fi
+fi
+export OMNI_RUNNER_IMAGE_IDENTITY="${baked_identity}"
+
+echo "[validate-runner-image] OMN-12568 acceptance check on $(hostname)"
+echo "[validate-runner-image] baked identity: ${baked_identity:-<unset>}"
+echo "[validate-runner-image] env root: ${OMNI_CI_ENV_ROOT:-/home/runner/.cache/omni/ci-envs}"
+
+exec "${python_bin}" "${VALIDATOR}" \
+  --repo-root "${REPO_ROOT}" \
+  ${OMNI_CI_ENV_ROOT:+--env-root "${OMNI_CI_ENV_ROOT}"} \
+  "$@"

--- a/tests/ci/test_validate_runner_image.py
+++ b/tests/ci/test_validate_runner_image.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the runner image validation script (OMN-12568).
+
+OMN-12568 is the acceptance of the OMN-12567 versioned runner image contract.
+``scripts/ci/validate_runner_image.py`` runs on a freshly recreated runner and
+asserts three things:
+
+1. the image identity binding is present and consistent (baked-vs-recorded),
+2. the happy path resolves zero ``uv sync`` (prebuilt env baked + UV_NO_SYNC=1),
+3. the runner has the tooling the Receipt-Gate path needs.
+
+These tests drive the validation logic against synthetic lock + env fixtures so
+the acceptance contract is regression-locked independently of any live runner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.validate_runner_image import (
+    RECEIPT_GATE_TOOLS,
+    check_image_identity,
+    check_receipt_gate_readiness,
+    check_zero_uv_sync,
+    resolve_lock_path,
+    validate_runner,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_LOCK = {
+    "base_image_digest": "sha256:deadbeef",
+    "gh_version": "2.67.0",
+    "identity_digest": "6a27412c6da1841cc48a0ef7051ac28b",
+    "image_version": 1,
+    "kubectl_version": "1.32.1",
+    "python_version": "3.12",
+    "runner_version": "2.323.0",
+    "shared_env_digest": "3b7238ac6e3b8b503e12dfb7",
+    "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
+    "uv_version": "0.6.14",
+}
+
+
+def _write_lock(tmp_path: Path, overrides: dict[str, object] | None = None) -> Path:
+    payload = dict(_LOCK)
+    if overrides:
+        payload.update(overrides)
+    lock_path = tmp_path / "runner-image.lock.json"
+    lock_path.write_text(json.dumps(payload), encoding="utf-8")
+    return lock_path
+
+
+def _make_ready_env(tmp_path: Path, repo: str = "omnibase_infra") -> Path:
+    """Create a ready prebuilt env: <root>/<repo>/<digest>/{manifest.json,.venv}."""
+    env_root = tmp_path / "ci-envs"
+    digest_dir = env_root / repo / _LOCK["shared_env_digest"]  # type: ignore[operator]
+    (digest_dir / ".venv" / "bin").mkdir(parents=True)
+    (digest_dir / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
+    (digest_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    return env_root
+
+
+class TestImageIdentity:
+    def test_missing_lock_fails(self, tmp_path: Path) -> None:
+        result = check_image_identity(None, tmp_path, baked_identity=None)
+        assert not result.passed
+        assert "no runner image lock file" in result.detail
+
+    def test_consistent_lock_passes_repo_checkout(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        # No baked identity env => repo-checkout validation; recorded digest only.
+        result = check_image_identity(lock, tmp_path, baked_identity=None)
+        assert result.passed, result.detail
+        assert "verified" in result.detail
+
+    def test_baked_identity_match_passes(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        result = check_image_identity(
+            lock,
+            tmp_path,
+            baked_identity=_LOCK["identity_digest"],  # type: ignore[arg-type]
+        )
+        assert result.passed, result.detail
+        assert "matches baked image" in result.detail
+
+    def test_baked_identity_drift_fails(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        result = check_image_identity(
+            lock, tmp_path, baked_identity="0000000000000000deadbeefdeadbeef"
+        )
+        assert not result.passed
+        assert "drift" in result.detail
+
+    def test_unbound_baked_identity_fails(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        result = check_image_identity(lock, tmp_path, baked_identity="unbound")
+        assert not result.passed
+        assert "unbound" in result.detail
+
+    def test_empty_identity_digest_fails(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path, overrides={"identity_digest": ""})
+        result = check_image_identity(lock, tmp_path, baked_identity=None)
+        assert not result.passed
+        assert "identity_digest" in result.detail
+
+
+class TestZeroUvSync:
+    def test_missing_prebuilt_env_fails(self, tmp_path: Path) -> None:
+        result = check_zero_uv_sync(
+            tmp_path / "absent", "omnibase_infra", uv_no_sync="1"
+        )
+        assert not result.passed
+        assert "prebuilt env" in result.detail
+
+    def test_ready_env_with_no_sync_passes(self, tmp_path: Path) -> None:
+        env_root = _make_ready_env(tmp_path)
+        result = check_zero_uv_sync(env_root, "omnibase_infra", uv_no_sync="1")
+        assert result.passed, result.detail
+
+    def test_ready_env_without_uv_no_sync_in_validator_env_passes(
+        self, tmp_path: Path
+    ) -> None:
+        # UV_NO_SYNC is published into $GITHUB_ENV at job time, not necessarily set
+        # in the validator's own shell; absence is acceptable, the env being baked
+        # is the load-bearing signal.
+        env_root = _make_ready_env(tmp_path)
+        result = check_zero_uv_sync(env_root, "omnibase_infra", uv_no_sync=None)
+        assert result.passed, result.detail
+        assert "canary" in result.detail
+
+    def test_falsy_uv_no_sync_fails(self, tmp_path: Path) -> None:
+        env_root = _make_ready_env(tmp_path)
+        result = check_zero_uv_sync(env_root, "omnibase_infra", uv_no_sync="0")
+        assert not result.passed
+        assert "uv sync" in result.detail
+
+    def test_env_without_manifest_marker_fails(self, tmp_path: Path) -> None:
+        env_root = tmp_path / "ci-envs"
+        digest_dir = env_root / "omnibase_infra" / "abc123"
+        (digest_dir / ".venv" / "bin").mkdir(parents=True)
+        (digest_dir / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
+        # No manifest.json => env not marked ready.
+        result = check_zero_uv_sync(env_root, "omnibase_infra", uv_no_sync="1")
+        assert not result.passed
+
+
+class TestReceiptGateReadiness:
+    def test_all_tools_present_passes(self) -> None:
+        # python3 is guaranteed present in the test environment.
+        result = check_receipt_gate_readiness(tools=["python3"])
+        assert result.passed, result.detail
+
+    def test_missing_tool_fails(self) -> None:
+        result = check_receipt_gate_readiness(
+            tools=["definitely-not-a-real-binary-omn12568"]
+        )
+        assert not result.passed
+        assert "missing Receipt-Gate tooling" in result.detail
+
+    def test_default_tool_set_includes_gh_and_uv(self) -> None:
+        assert "gh" in RECEIPT_GATE_TOOLS
+        assert "uv" in RECEIPT_GATE_TOOLS
+        assert "python3" in RECEIPT_GATE_TOOLS
+
+
+class TestResolveLockPath:
+    def test_explicit_path_wins(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        assert resolve_lock_path(lock) == lock
+
+    def test_missing_explicit_path_returns_none(self, tmp_path: Path) -> None:
+        assert resolve_lock_path(tmp_path / "nope.json") is None
+
+
+class TestValidateRunnerAggregate:
+    def test_all_green(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        env_root = _make_ready_env(tmp_path)
+        report = validate_runner(
+            repo_root=tmp_path,
+            lock_path=lock,
+            env_root=env_root,
+            env_repo="omnibase_infra",
+            baked_identity=_LOCK["identity_digest"],  # type: ignore[arg-type]
+            uv_no_sync="1",
+            tools=["python3"],
+        )
+        assert report.ok, report.to_dict()
+        assert {c.name for c in report.checks} == {
+            "image_identity",
+            "zero_uv_sync",
+            "receipt_gate_readiness",
+        }
+
+    def test_one_failure_makes_report_red(self, tmp_path: Path) -> None:
+        lock = _write_lock(tmp_path)
+        # No prebuilt env => zero_uv_sync fails => report red.
+        report = validate_runner(
+            repo_root=tmp_path,
+            lock_path=lock,
+            env_root=tmp_path / "absent",
+            baked_identity=_LOCK["identity_digest"],  # type: ignore[arg-type]
+            uv_no_sync="1",
+            tools=["python3"],
+        )
+        assert not report.ok
+        report_dict = report.to_dict()
+        assert report_dict["ok"] is False


### PR DESCRIPTION
## OMN-12568 — acceptance of the OMN-12567 versioned runner image contract

Adds the landable artifacts that let a **freshly recreated** runner be proven against the OMN-12567 image binding before broad fleet rollout. Building/publishing/rolling the image and recreating a runner are gated live runtime steps (see "Gated actions remaining").

Blocked-by OMN-12567 (PR #1830 / OCC PR #2032). Paired evidence: OCC PR #2041.

### What landed
- **`scripts/ci/validate_runner_image.py`** — read-only validator asserting, on the runner it runs on:
  1. **image identity** — baked `OMNI_RUNNER_IMAGE_IDENTITY` matches the lock `identity_digest` (recomputes the full OMN-12567 binding when `runner_image_identity.py` is present; fails on drift or an `unbound` image);
  2. **zero `uv sync` on the happy path** — the prebuilt shared CI env is baked under `OMNI_CI_ENV_ROOT` with a `manifest.json` ready marker and `UV_NO_SYNC=1` holds;
  3. **Receipt-Gate readiness** — `gh`, `git`, `jq`, `python3`, `uv` present.
  Self-contained so it is runnable/testable on a checkout predating the OMN-12567 merge.
- **`scripts/ci/validate_runner_image.sh`** — runner-side wrapper; resolves the baked identity from the image env or a named container label, then invokes the validator. Never recreates/restarts a runner.
- **`docs/ci/versioned-runner-image-rollout-checklist.md`** — per-repo migration checklist with the OMN-12567 mutating-job opt-outs plus explicit repo/job opt-outs (public fork PRs, hosted-runner-only repos, no-Python-CI repos, writable-global-env jobs).
- **`tests/ci/test_validate_runner_image.py`** — 18 unit tests (TDD-first).

### dod_evidence
Ticket: **OMN-12568**.

Evidence-Source: OCC#2041
Evidence-Ticket: OMN-12568

OCC PR #2041 carries `contracts/OMN-12568.yaml` + the DoD receipts at canonical paths.
- 18/18 validator unit tests green: `uv run pytest tests/ci/test_validate_runner_image.py -q` → `18 passed`.
- Drift check proven to have teeth: deliberately breaking the baked-vs-recorded comparison makes `test_baked_identity_drift_fails` fail; restored → all green.
- `uv run mypy scripts/ci/validate_runner_image.py --strict` → clean.
- `pre-commit run --files …` → all hooks pass.

### Gated actions remaining (user-run live runtime — NOT done in this PR)
- Build/publish the versioned image: `scripts/ci/build_runner_image.sh --tag <registry>/omninode-runner:v<N>` (OMN-12567 tooling).
- **Recreate one .201 runner from scratch** on the new image (fresh-recreation is the contract under test; warm runners do not count).
- Run `scripts/ci/validate_runner_image.sh --json` on the freshly recreated runner and confirm `RESULT: GREEN`, plus one real CI job green with the bound identity in its startup evidence.