### PR TITLE
fix(OMN-12582): reconcile runner-fleet compose/config to live 48-runner fleet

### DIFF
--- a/config/runner_fleet.yaml
+++ b/config/runner_fleet.yaml
@@ -7,8 +7,11 @@ github_org: OmniNode-ai
 runner_host: 192.168.86.201
 runner_group: omnibase-ci
 runner_name_prefix: omninode-runner
-expected_count: 14
-burst_count: 20
+# Reconciled to the live .201 fleet (OMN-12582): 48 always-on steady-state
+# runners, matching the hand-scaled live compose. All 48 are steady (no burst
+# profiles), so burst_count == expected_count (no separate burst tier).
+expected_count: 48
+burst_count: 48
 # Docker subnet-pool alerting (OMN-12566). The runner host's default address
 # pool can subnet a bounded number of networks before `docker network create`
 # fails with "all predefined address pools have been fully subnetted". Alert at

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -1,10 +1,10 @@
 # docker-compose.runners.yml
 # OmniNode self-hosted GitHub Actions runners
-# Ticket: OMN-3276 / Epic: OMN-3273 | Scaled: OMN-3714
+# Ticket: OMN-3276 / Epic: OMN-3273 | Scaled: OMN-3714 | Reconciled to live 48: OMN-12582
 #
-# Runs the configured steady-state runner fleet; burst runners are profile-gated.
-# The steady-state and burst counts are owned by config/runner_fleet.yaml.
-# Each runner registers with GitHub org OmniNode-ai in the 'omnibase-ci' runner group.
+# Runs the full steady-state runner fleet. The fleet count is owned by
+# config/runner_fleet.yaml (expected_count). Each runner registers with GitHub
+# org OmniNode-ai in the 'omnibase-ci' runner group.
 #
 # Prerequisites:
 #   - Build the runner image first (OMN-3275):
@@ -34,13 +34,15 @@
 # Verify: cat /proc/sys/fs/inotify/max_user_watches
 #
 # Resource allocation per runner (RTX 5090 host with ample RAM):
-#   mem_limit: 6g     - 84 GB steady across 14 runners; 120 GB only with the burst profile
+#   mem_limit: 6g     - per-runner memory limit (not a reservation); 48 runners
+#                       share the host's 91 GB, peak usage ~21 GB observed live
 #   memswap_limit: 12g - bounded swap headroom for large CI spikes
-#   cpus: "2.0"       — 28 vCPUs steady; 40 vCPUs only with the burst profile
-#   pids_limit: 4096  — prevents fork bombs from runaway test processes
+#   cpus: "2.0"       - per-runner CFS quota (not a reservation); 48 runners
+#                       share the host's 32 vCPUs (over-subscription tolerated)
+#   pids_limit: 4096  - prevents fork bombs from runaway test processes
 #
 # NOTE: mem_limit/cpus/pids_limit are Compose v2 top-level resource keys.
-# Do NOT use deploy.resources — those are Swarm-only and silently ignored here.
+# Do NOT use deploy.resources - those are Swarm-only and silently ignored here.
 x-runner-base: &runner-base
   image: omninode-runner:latest
   restart: unless-stopped
@@ -247,7 +249,6 @@ services:
       - runner-14-creds:/home/runner/.runner-creds
   omninode-runner-15:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-15
     environment:
       !!merge <<: *runner-env
@@ -260,7 +261,6 @@ services:
       - runner-15-creds:/home/runner/.runner-creds
   omninode-runner-16:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-16
     environment:
       !!merge <<: *runner-env
@@ -273,7 +273,6 @@ services:
       - runner-16-creds:/home/runner/.runner-creds
   omninode-runner-17:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-17
     environment:
       !!merge <<: *runner-env
@@ -286,7 +285,6 @@ services:
       - runner-17-creds:/home/runner/.runner-creds
   omninode-runner-18:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-18
     environment:
       !!merge <<: *runner-env
@@ -299,7 +297,6 @@ services:
       - runner-18-creds:/home/runner/.runner-creds
   omninode-runner-19:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-19
     environment:
       !!merge <<: *runner-env
@@ -312,7 +309,6 @@ services:
       - runner-19-creds:/home/runner/.runner-creds
   omninode-runner-20:
     !!merge <<: *runner-base
-    profiles: ["burst"]
     container_name: omninode-runner-20
     environment:
       !!merge <<: *runner-env
@@ -323,6 +319,342 @@ services:
       - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
       - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
       - runner-20-creds:/home/runner/.runner-creds
+  omninode-runner-21:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-21
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-21
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-21-creds:/home/runner/.runner-creds
+  omninode-runner-22:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-22
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-22
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-22-creds:/home/runner/.runner-creds
+  omninode-runner-23:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-23
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-23
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-23-creds:/home/runner/.runner-creds
+  omninode-runner-24:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-24
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-24
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-24-creds:/home/runner/.runner-creds
+  omninode-runner-25:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-25
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-25
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-25-creds:/home/runner/.runner-creds
+  omninode-runner-26:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-26
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-26
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-26-creds:/home/runner/.runner-creds
+  omninode-runner-27:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-27
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-27
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-27-creds:/home/runner/.runner-creds
+  omninode-runner-28:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-28
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-28
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-28-creds:/home/runner/.runner-creds
+  omninode-runner-29:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-29
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-29
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-29-creds:/home/runner/.runner-creds
+  omninode-runner-30:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-30
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-30-creds:/home/runner/.runner-creds
+  omninode-runner-31:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-31
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-31
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-31-creds:/home/runner/.runner-creds
+  omninode-runner-32:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-32
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-32
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-32-creds:/home/runner/.runner-creds
+  omninode-runner-33:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-33
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-33
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-33-creds:/home/runner/.runner-creds
+  omninode-runner-34:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-34
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-34
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-34-creds:/home/runner/.runner-creds
+  omninode-runner-35:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-35
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-35
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-35-creds:/home/runner/.runner-creds
+  omninode-runner-36:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-36
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-36
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-36-creds:/home/runner/.runner-creds
+  omninode-runner-37:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-37
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-37
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-37-creds:/home/runner/.runner-creds
+  omninode-runner-38:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-38
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-38
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-38-creds:/home/runner/.runner-creds
+  omninode-runner-39:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-39
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-39
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-39-creds:/home/runner/.runner-creds
+  omninode-runner-40:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-40
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-40
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-40-creds:/home/runner/.runner-creds
+  omninode-runner-41:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-41
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-41
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-41-creds:/home/runner/.runner-creds
+  omninode-runner-42:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-42
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-42
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-42-creds:/home/runner/.runner-creds
+  omninode-runner-43:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-43
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-43
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-43-creds:/home/runner/.runner-creds
+  omninode-runner-44:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-44
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-44
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-44-creds:/home/runner/.runner-creds
+  omninode-runner-45:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-45
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-45
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-45-creds:/home/runner/.runner-creds
+  omninode-runner-46:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-46
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-46
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-46-creds:/home/runner/.runner-creds
+  omninode-runner-47:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-47
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-47
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-47-creds:/home/runner/.runner-creds
+  omninode-runner-48:
+    !!merge <<: *runner-base
+    container_name: omninode-runner-48
+    environment:
+      !!merge <<: *runner-env
+      RUNNER_NAME: omninode-runner-48
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runners/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./runners/runner-job-started.sh:/usr/local/bin/runner-job-started.sh:ro
+      - ./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro
+      - runner-48-creds:/home/runner/.runner-creds
 volumes:
   runner-1-creds:
     name: omninode-runner-1-creds
@@ -364,3 +696,59 @@ volumes:
     name: omninode-runner-19-creds
   runner-20-creds:
     name: omninode-runner-20-creds
+  runner-21-creds:
+    name: omninode-runner-21-creds
+  runner-22-creds:
+    name: omninode-runner-22-creds
+  runner-23-creds:
+    name: omninode-runner-23-creds
+  runner-24-creds:
+    name: omninode-runner-24-creds
+  runner-25-creds:
+    name: omninode-runner-25-creds
+  runner-26-creds:
+    name: omninode-runner-26-creds
+  runner-27-creds:
+    name: omninode-runner-27-creds
+  runner-28-creds:
+    name: omninode-runner-28-creds
+  runner-29-creds:
+    name: omninode-runner-29-creds
+  runner-30-creds:
+    name: omninode-runner-30-creds
+  runner-31-creds:
+    name: omninode-runner-31-creds
+  runner-32-creds:
+    name: omninode-runner-32-creds
+  runner-33-creds:
+    name: omninode-runner-33-creds
+  runner-34-creds:
+    name: omninode-runner-34-creds
+  runner-35-creds:
+    name: omninode-runner-35-creds
+  runner-36-creds:
+    name: omninode-runner-36-creds
+  runner-37-creds:
+    name: omninode-runner-37-creds
+  runner-38-creds:
+    name: omninode-runner-38-creds
+  runner-39-creds:
+    name: omninode-runner-39-creds
+  runner-40-creds:
+    name: omninode-runner-40-creds
+  runner-41-creds:
+    name: omninode-runner-41-creds
+  runner-42-creds:
+    name: omninode-runner-42-creds
+  runner-43-creds:
+    name: omninode-runner-43-creds
+  runner-44-creds:
+    name: omninode-runner-44-creds
+  runner-45-creds:
+    name: omninode-runner-45-creds
+  runner-46-creds:
+    name: omninode-runner-46-creds
+  runner-47-creds:
+    name: omninode-runner-47-creds
+  runner-48-creds:
+    name: omninode-runner-48-creds

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -85,6 +85,7 @@ SYNC_PATHS=(
     "docker/runners/entrypoint.sh"
     "docker/runners/runner-job-started.sh"
     "docker/runners/runner-monitor.sh"
+    "docker/runners/healthcheck.sh"
     "docker/docker-compose.runners.yml"
 )
 
@@ -194,6 +195,7 @@ rsync_artifacts() {
         "${REPO_ROOT}/docker/runners/entrypoint.sh" \
         "${REPO_ROOT}/docker/runners/runner-job-started.sh" \
         "${REPO_ROOT}/docker/runners/runner-monitor.sh" \
+        "${REPO_ROOT}/docker/runners/healthcheck.sh" \
         "${RUNNER_HOST}:${RUNNER_HOST_DIR}/docker/runners/"
 
     # Sync compose file into docker/

--- a/tests/unit/observability/runner_health/test_runner_fleet_config.py
+++ b/tests/unit/observability/runner_health/test_runner_fleet_config.py
@@ -24,8 +24,10 @@ def test_runner_fleet_config_loads_from_repo_config() -> None:
     assert config.github_org == "OmniNode-ai"
     assert config.runner_group == "omnibase-ci"
     assert config.runner_name_prefix == "omninode-runner"
-    assert config.expected_count == 14
-    assert config.burst_count == 20
+    # OMN-12582: reconciled to the live .201 fleet of 48 always-on steady-state
+    # runners (no burst tier), so burst_count == expected_count.
+    assert config.expected_count == 48
+    assert config.burst_count == 48
 
 
 def test_runner_compose_matches_configured_count() -> None:
@@ -128,3 +130,58 @@ def test_runner_compose_healthcheck_uses_egress_script() -> None:
         # No runner may regress to the bare pgrep-only healthcheck.
         resolved_test = definition.get("healthcheck", {}).get("test", base_test)
         assert resolved_test == ["CMD-SHELL", "/usr/local/bin/healthcheck.sh"]
+
+
+def test_runner_compose_reconciled_to_live_48_fleet() -> None:
+    """OMN-12582: the repo compose must match the proven live .201 fleet of 48
+    always-on steady-state runners, so `deploy-runners.sh` cannot orphan-remove
+    live runners 21-48 (which would drop the org CI fleet 48->20 and trigger an
+    outage). All 48 runners are steady (no burst profiles) and each mounts the
+    OMN-12433 egress healthcheck script.
+    """
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker" / "docker-compose.runners.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    runner_services = {
+        name: definition
+        for name, definition in compose["services"].items()
+        if re.fullmatch(r"omninode-runner-\d+", name)
+    }
+    assert len(runner_services) == 48, "expected exactly 48 runner services"
+    # Contiguous runner-1 .. runner-48, no gaps.
+    indices = sorted(int(name.rsplit("-", 1)[1]) for name in runner_services)
+    assert indices == list(range(1, 49))
+
+    hc_mount = "./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro"
+    for name, definition in runner_services.items():
+        # All 48 are steady-state: no burst profile gating any runner.
+        assert "profiles" not in definition, f"{name} unexpectedly profile-gated"
+        assert hc_mount in definition["volumes"], f"{name} missing healthcheck mount"
+        assert definition["volumes"][-1] == (
+            f"runner-{name.rsplit('-', 1)[1]}-creds:/home/runner/.runner-creds"
+        )
+
+    # A backing named volume exists for each of the 48 runners.
+    volume_names = {
+        name for name in compose["volumes"] if re.fullmatch(r"runner-\d+-creds", name)
+    }
+    assert len(volume_names) == 48
+
+
+def test_deploy_ships_healthcheck_script_to_host() -> None:
+    """OMN-12582: the compose bind-mounts ./runners/healthcheck.sh, so the deploy
+    rsync MUST ship that file to the host. Without it the bind mount resolves to
+    an empty path on the host and every runner's healthcheck breaks. This guards
+    the latent gap where OMN-12433 added the mount but deploy never synced the
+    artifact.
+    """
+    deploy_script = (REPO_ROOT / "scripts" / "deploy-runners.sh").read_text(
+        encoding="utf-8"
+    )
+    # Declared in the SYNC_PATHS manifest (drives the dry-run log).
+    assert '"docker/runners/healthcheck.sh"' in deploy_script
+    # And in the real rsync invocation that ships into docker/runners/.
+    assert '"${REPO_ROOT}/docker/runners/healthcheck.sh" \\' in deploy_script


### PR DESCRIPTION
## OMN-12582: Reconcile runner-fleet compose/config to the live 48-runner fleet

Closes part of OMN-12504; unblocks the OMN-12567/12568 versioned-runner-image rollout.

### Problem (verified on .201, 2026-06-02)
The live `.201` runner fleet was hand-scaled to **48 always-on runners** but never reconciled back to the `omnibase_infra` repo source of truth:
- `config/runner_fleet.yaml` → `expected_count: 14`, `burst_count: 20`
- `docker/docker-compose.runners.yml` → **20** runner services
- Live `.201` fleet → **48** runners (all running, no burst profiles)

`scripts/deploy-runners.sh` rsyncs the **repo** compose over the host copy then runs `docker compose up -d --build --force-recreate --remove-orphans`. With the repo at 20 services, `--remove-orphans` would **tear down live runners 21–48 (48→20 org-CI outage)**.

### Fix (repo follows the proven live reality)
- **`config/runner_fleet.yaml`**: `expected_count` 14→48, `burst_count` 20→48. The live fleet runs all 48 as steady-state with no burst tier, so `burst_count == expected_count`.
- **`docker/docker-compose.runners.yml`**: 20→48 steady services (no burst profiles). Each per-service block is **byte-identical to the live fleet** except for the per-runner `./runners/healthcheck.sh:/usr/local/bin/healthcheck.sh:ro` mount, which the repo intentionally adds (OMN-12433). The live compose still carries the older `pgrep`-only healthcheck and lacks the mount; this PR keeps the repo's newer egress healthcheck rather than regressing to the live pgrep-only check. Header comments updated to reflect the 48-runner resource reality (limits, not reservations).
- **`scripts/deploy-runners.sh`**: add `docker/runners/healthcheck.sh` to `SYNC_PATHS` and the rsync invocation. The compose has bind-mounted `./runners/healthcheck.sh` since OMN-12433 but deploy never shipped the artifact, so the mount would resolve to an empty host path. This fixes that latent gap, making the reconciled deploy safe.

`healthcheck.sh` already exists in the repo (OMN-12433 #1792) and is `COPY`ed into the image by the Dockerfile; no new artifact is introduced. Image ref stays `omninode-runner:latest` (the OMN-12567 versioned-image bump is a separate concern).

### Structural diff vs live (all 48 blocks)
The only per-service delta across all 48 services is the addition of the healthcheck.sh mount. All names, container_names, env, creds volumes, docker.sock + entrypoint/job-started mounts are identical to live. No host-specific junk, no image/env/label drift.

### dod_evidence

**1. `deploy-runners.sh --dry-run` targets 48 runners (no rsync, no recreate):**
```
[deploy-runners] Target host: 192.168.86.201 | Org: OmniNode-ai | Group: omnibase-ci
[deploy-runners] Runner count: 48 | Compose file: docker/docker-compose.runners.yml
[deploy-runners] [DRY RUN MODE] No remote commands will be executed.
```
`RUNNER_COUNT=48` confirms the reconciled config drives the deploy to 48 runners. (The dry-run then aborts at the GitHub registration-token fetch because the local `gh` token lacks `admin:org` scope — this is an environment limitation that occurs *before* any rsync/recreate; no host state was touched.)

**2. No-orphan proof (reconciled compose service set vs live running containers):**
```
Reconciled repo compose defines 48 runner services
Live .201 running containers: 48
Live containers NOT in reconciled compose (would be ORPHAN-REMOVED): NONE
Compose services NOT currently running (would be CREATED): NONE
Counterfactual — OLD origin/dev 20-service compose would orphan-remove 28 live runners: runner-21 .. runner-48
```

**3. Regression tests (TDD — fail on the old 20/14 state, pass on 48/48):**
```
uv run pytest tests/unit/observability/runner_health/test_runner_fleet_config.py \
              tests/integration/observability/test_runner_fleet_config_contract.py -q
10 passed
```
New/updated assertions: `expected_count==48`, exactly 48 contiguous steady services each mounting the egress healthcheck, 48 backing creds volumes, and `deploy-runners.sh` ships `healthcheck.sh`.

### Gates
- `uv run ruff format` / `ruff check`: clean
- `uv run mypy --strict` (changed test): clean
- `bash -n scripts/deploy-runners.sh`: syntax OK
- `pre-commit run --files <changed>`: all hooks Passed/Skipped (no failures)
- `docker compose -f docker/docker-compose.runners.yml config`: 48 services parse

### Prohibitions honored
No real `deploy-runners.sh` run, no recreate/restart of any `.201` runner, no live-fleet mutation. Repo PR only.

Evidence-Source: 424ee6e7da55160a705e8636c1559b034ccb9244
Evidence-Ticket: OMN-12582