### PR TITLE
fix(OMN-12584): runner-image prebuilt-env bake fails on uv cache EACCES + add build smoke gate

### DIFF
--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-12584: Build-smoke gate for the versioned self-hosted runner image.
+#
+# Why this exists: the OMN-12567 runner image (docker/runners/Dockerfile) merged
+# green but had NEVER been built. Its prebuilt-env bake stage failed with an
+# EACCES because the runner user could not create its uv cache under the
+# root-owned /home/runner/.cache. No CI job built docker/runners/Dockerfile, so a
+# non-building image passed every check. This workflow closes that gap:
+# "enforcement, not detection" — when a PR touches the runner image inputs, we
+# actually build the image (through the prebuilt-env bake stage that broke) so a
+# non-building runner image can never merge green again.
+#
+# Bounded: build only, no push, no fleet recreate, no retag of :latest. The
+# throwaway tag is local-only and discarded.
+
+name: Runner Image Build Smoke
+
+on:
+  pull_request:
+    branches: [main, dev, develop]
+    paths:
+      - 'docker/runners/**'
+      - 'scripts/ci/build_runner_image.sh'
+      - 'scripts/ci/runner_image_identity.py'
+      - 'scripts/ci/ensure_ci_env.sh'
+      - 'scripts/ci/ci_env_digest.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/runner-image-build-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: runner-image-build-smoke-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  runner-image-build-smoke:
+    name: runner-image-build-smoke
+    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker jobs default to self-hosted
+    # omnibase-ci; public forks default to ubuntu-latest.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    # The prebuilt-env bake runs `uv sync --frozen --all-extras --all-groups`,
+    # which dominates the build. 30 min gives a comfortable buffer for a cold
+    # cache; a warm self-hosted cache completes in a few minutes.
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Verify Docker socket access
+        run: |
+          if ! docker info > /dev/null 2>&1; then
+            echo "::error::Docker daemon is not accessible. On self-hosted runners, ensure the runner user is in the docker group and /var/run/docker.sock is bind-mounted."
+            ls -la /var/run/docker.sock 2>/dev/null || echo "Socket not found"
+            echo "Current user: $(whoami) (uid=$(id -u), groups=$(id -Gn))"
+            exit 1
+          fi
+          echo "Docker daemon accessible"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Build the versioned runner image to a throwaway local tag. This runs the
+      # exact production path: build_runner_image.sh first verifies the bound
+      # identity (runner_image_identity.py --mode verify, so lock drift fails
+      # here too), stages the prebuilt-env context, then `docker build`s through
+      # the prebuilt-env bake stage — the stage that broke in OMN-12567. No push,
+      # no fleet contact. The image is local-only and removed afterward.
+      - name: Build runner image (smoke, no push)
+        run: |
+          set -euo pipefail
+          SMOKE_TAG="omninode-runner:smoke-${{ github.run_id }}"
+          echo "Building ${SMOKE_TAG} from docker/runners/Dockerfile (build-only, no push)"
+          bash scripts/ci/build_runner_image.sh --tag "${SMOKE_TAG}"
+          echo "SMOKE_TAG=${SMOKE_TAG}" >> "${GITHUB_ENV}"
+
+      # Prove the prebuilt-env bake actually produced a ready shared CI env and
+      # the bound identity was baked (not "unbound"). A build that "succeeds" but
+      # skips the bake would not satisfy the OMN-12567 contract.
+      - name: Assert baked identity + prebuilt env present
+        run: |
+          set -euo pipefail
+          LOCK_IDENTITY="$(python3 -c 'import json;print(json.load(open("docker/runners/runner-image.lock.json"))["identity_digest"])')"
+          BAKED_LABEL="$(docker inspect --format '{{ index .Config.Labels "org.omninode.runner.image.identity" }}' "${SMOKE_TAG}")"
+          echo "lock identity_digest:  ${LOCK_IDENTITY}"
+          echo "baked image label:     ${BAKED_LABEL}"
+          if [[ "${BAKED_LABEL}" != "${LOCK_IDENTITY}" ]]; then
+            echo "::error::baked identity label '${BAKED_LABEL}' != lock identity_digest '${LOCK_IDENTITY}'"
+            exit 1
+          fi
+          if [[ -z "${BAKED_LABEL}" || "${BAKED_LABEL}" == "unbound" ]]; then
+            echo "::error::runner image identity is unbound"
+            exit 1
+          fi
+          # The prebuilt-env bake must have materialised a ready env (manifest.json
+          # + .venv/bin/python) — this is the EACCES-class regression guard.
+          docker run --rm --entrypoint bash "${SMOKE_TAG}" -lc '
+            set -euo pipefail
+            ready=0
+            for d in "${OMNI_CI_ENV_ROOT}"/omnibase_infra/*/; do
+              if [[ -f "${d}manifest.json" && -x "${d}.venv/bin/python" ]]; then
+                echo "ready prebuilt env: ${d}"
+                ready=1
+              fi
+            done
+            if [[ "${ready}" -ne 1 ]]; then
+              echo "::error::no ready prebuilt CI env baked under ${OMNI_CI_ENV_ROOT}/omnibase_infra"
+              exit 1
+            fi
+          '
+          echo "Runner image build smoke PASSED: identity bound + prebuilt env baked."
+
+      - name: Cleanup throwaway image
+        if: always()
+        run: |
+          docker image rm "${SMOKE_TAG:-}" 2>/dev/null || true

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -149,8 +149,18 @@ RUN chmod 0444 /etc/omni/runner-image.lock.json
 COPY prebuilt-env-context/pyproject.toml /opt/omni/prebuilt/pyproject.toml
 COPY prebuilt-env-context/uv.lock /opt/omni/prebuilt/uv.lock
 COPY prebuilt-env-context/ci/ /opt/omni/prebuilt/scripts/ci/
-RUN mkdir -p "${OMNI_CI_ENV_ROOT}/omnibase_infra" \
-    && chown -R runner:runner /opt/omni/prebuilt "${OMNI_CI_ENV_ROOT}"
+# OMN-12584: chown the *whole* runner cache dir, not only the ci-envs subtree.
+# `mkdir -p "${OMNI_CI_ENV_ROOT}/omnibase_infra"` runs as root and creates the
+# parent /home/runner/.cache owned by root:root. The bake step below runs the
+# shared-env build as USER runner, and uv writes its cache to its default
+# ~/.cache/uv = /home/runner/.cache/uv. If only the ci-envs subtree is
+# runner-owned, that uv-cache mkdir fails with EACCES and the prebuilt-env bake
+# (the core of the OMN-12567 image contract) never completes. Widening the chown
+# to /home/runner/.cache fixes the bake. This is identity-neutral: the Dockerfile
+# is not part of the runner_image_identity binding, so runner-image.lock.json's
+# identity_digest is unchanged.
+RUN mkdir -p "${OMNI_CI_ENV_ROOT}/omnibase_infra" /home/runner/.cache \
+    && chown -R runner:runner /opt/omni/prebuilt /home/runner/.cache
 USER runner
 RUN cd /opt/omni/prebuilt \
     && OMNI_CI_ENV_ROOT="${OMNI_CI_ENV_ROOT}" \


### PR DESCRIPTION
## OMN-12584 — runner image prebuilt-env bake never built (uv cache EACCES)

Fixes the OMN-12567 versioned runner image, which **had never built**. `docker/runners/Dockerfile`'s prebuilt-env bake step crashed:

```
uv sync → failed to create directory `/home/runner/.cache/uv`: Permission denied (os error 13)
```

### Root cause (deterministically reproduced on .201, linux/amd64)
`mkdir -p ${OMNI_CI_ENV_ROOT}/omnibase_infra` runs as root and creates the parent `/home/runner/.cache` as **root:root**. The following `chown -R runner:runner /opt/omni/prebuilt ${OMNI_CI_ENV_ROOT}` only chowns the `omni/ci-envs` subtree, **not the parent** `.cache`. After `USER runner`, `uv sync` writes its cache to the default `~/.cache/uv` = `/home/runner/.cache/uv`, which the runner user cannot create under the root-owned parent → EACCES. `ensure_ci_env.sh` never sets `UV_CACHE_DIR`/`UV_NO_CACHE`.

### Fix (primary, identity-neutral)
Widen the existing chown to cover `/home/runner/.cache` before `USER runner`. The Dockerfile is **not** part of the `runner_image_identity` binding, so `docker/runners/runner-image.lock.json`'s `identity_digest` is **unchanged** (`231ae5fa883556778e9db274f1d5f83b`, confirmed via `runner_image_identity.py --mode verify`). No `--mode generate`, no lock edit.

### Fix (enforcement — why CI missed it)
No CI job built `docker/runners/Dockerfile` — the OMN-12567 identity tests are static lock/label assertions, so a non-building image merged green. New `runner-image-build-smoke.yml`: on a PR touching `docker/runners/**` or the runner-image scripts, **actually build the image** through the prebuilt-env bake stage (the stage that broke) to a throwaway tag (no push, no fleet contact), then assert the baked identity == lock identity_digest and a ready prebuilt env exists. A non-building runner image can no longer merge green. "Enforcement, not detection."

### Proof (non-destructive, on .201)
- From-scratch `docker build --no-cache` of `docker/runners/Dockerfile` **SUCCEEDS**; prebuilt-env bake completes (no EACCES).
- Candidate `omninode-runner:next` identity LABEL == lock `identity_digest` == `231ae5fa883556778e9db274f1d5f83b`.
- `scripts/ci/validate_runner_image.py` against the candidate: **RESULT: GREEN** (image_identity, zero_uv_sync, receipt_gate_readiness all PASS).
- Live 48-runner fleet and `omninode-runner:latest` (`d6372168c7ac`) **untouched** — no recreate/restart/retag.

Evidence: `.onex_state/evidence/OMN-12567/` (build1-FAILED→build2-SUCCESS, validator-RESULT.json) and `.onex_state/evidence/OMN-12584/` (build-nocache-SUCCESS.log, rebuild-validation.txt).

### dod_evidence
- OMN-12584
- Defect-before: `.onex_state/evidence/OMN-12567/build1-FAILED.log` (EACCES, exit 1)
- Fix-after: `.onex_state/evidence/OMN-12584/build-nocache-SUCCESS.log` (from-scratch GREEN) + `rebuild-validation.txt` (validator GREEN, identity match)
- CI-didn't-catch-it rationale: no build of `docker/runners/Dockerfile` in CI; now closed by `runner-image-build-smoke.yml`.

Head: `23e473016b82ef1eaa0b37b3705fe3090aca5f09`

Evidence-Ticket: OMN-12584
Evidence-Source: OCC#2061