### PR TITLE
ci(OMN-12583): bump runner image for node24 actions

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -67,15 +67,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        version: ${{ inputs.uv-version }}
-        enable-cache: ${{ inputs.cache-enabled != 'false' }}
     - name: Resolve shared CI env mode
       id: shared_env_mode
       shell: bash
@@ -103,6 +94,17 @@ runs:
         esac
         echo "enabled=${enabled}" >> "$GITHUB_OUTPUT"
         echo "shared CI env enabled: ${enabled}"
+    - name: Set up Python
+      if: steps.shared_env_mode.outputs.enabled != 'true'
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install uv
+      if: steps.shared_env_mode.outputs.enabled != 'true'
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: ${{ inputs.uv-version }}
+        enable-cache: ${{ inputs.cache-enabled != 'false' }}
     - name: Prepare shared CI env
       if: steps.shared_env_mode.outputs.enabled == 'true' && inputs.skip-install != 'true'
       shell: bash

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -43,14 +43,13 @@ jobs:
         with:
           separator: ","
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up CI Python environment
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          pip install --quiet confluent-kafka pydantic click
+          cache-key-prefix: uv-pr-webhook
+          install-args: --frozen
 
       - name: Publish PR webhook event
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -70,7 +69,7 @@ jobs:
           PR_MERGED: ${{ github.event.pull_request.merged }}
           PR_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          python scripts/publish_pr_webhook_event.py \
+          uv run python scripts/publish_pr_webhook_event.py \
             --action "$PR_ACTION" \
             --repo "$PR_REPO" \
             --pr-number "$PR_NUMBER" \

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -49,7 +49,9 @@ jobs:
         with:
           python-version: "3.12"
           cache-key-prefix: uv-pr-webhook
+          cache-enabled: "false"
           install-args: --frozen
+          shared-env-enabled: "true"
 
       - name: Publish PR webhook event
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1570,6 +1570,7 @@ jobs:
           python-version: '3.12'
           skip-install: "true"
           cache-enabled: "false"
+          shared-env-enabled: "true"
       - name: Compute changed Python/Markdown files vs PR base
         id: changed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1564,10 +1564,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: '3.12'
+          skip-install: "true"
+          cache-enabled: "false"
       - name: Compute changed Python/Markdown files vs PR base
         id: changed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,10 +1006,6 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
           cache-enabled: "false"
-          shared-env-enabled: "false"
-
-      - name: Install dependencies
-        run: uv sync --no-cache
 
       - name: Check if onex compliance command exists
         id: check-command

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -275,6 +275,7 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           cache-version: docker
           cache-enabled: "false"
+          shared-env-enabled: "true"
 
       # Run Docker integration tests WITHOUT pytest-xdist (no -n auto)
       # This prevents worker crashes during Docker builds

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,6 +68,7 @@ jobs:
           python-version: "3.12"
           skip-install: "true"
           cache-enabled: "false"
+          shared-env-enabled: "true"
 
       - name: Validate Dockerfile plugin pin ranges
         run: python scripts/check_dockerfile_pins.py --dockerfile docker/Dockerfile.runtime

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,10 +62,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: "3.12"
+          skip-install: "true"
+          cache-enabled: "false"
 
       - name: Validate Dockerfile plugin pin ranges
         run: python scripts/check_dockerfile_pins.py --dockerfile docker/Dockerfile.runtime

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           python-version: "3.12"
           cache-key-prefix: uv-pr-merged-event
+          cache-enabled: "false"
           install-args: --frozen
+          shared-env-enabled: "true"
 
       - name: Publish PR merged event
         # All potentially attacker-controlled inputs (head_ref, author, title)

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -49,14 +49,12 @@ jobs:
         with:
           separator: ","
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          pip install --quiet confluent-kafka pydantic click
+          cache-key-prefix: uv-pr-merged-event
+          install-args: --frozen
 
       - name: Publish PR merged event
         # All potentially attacker-controlled inputs (head_ref, author, title)
@@ -77,7 +75,7 @@ jobs:
           PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
           PR_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          python scripts/publish_pr_merged_event.py \
+          uv run python scripts/publish_pr_merged_event.py \
             --repo "$PR_REPO" \
             --pr-number "$PR_NUMBER" \
             --base-ref "$PR_BASE_REF" \

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -75,6 +75,7 @@ jobs:
           python-version: "3.12"
           skip-install: "true"
           cache-enabled: "false"
+          shared-env-enabled: "true"
 
       # Build the versioned runner image to a throwaway local tag. This runs the
       # exact production path: build_runner_image.sh first verifies the bound

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -127,6 +127,37 @@ jobs:
           '
           echo "Runner image build smoke PASSED: identity bound + prebuilt env baked."
 
+      # OMN-12585: assert the baked runner can execute node24 actions
+      # (actions/checkout@v6, used 73x across workflows). The OMN-12567 image
+      # pinned RUNNER_VERSION=2.323.0, which predates node24 execution support
+      # (landed in actions/runner 2.327.0); rolling it to the live fleet (2.334.0)
+      # downgraded the runner and broke "Set up job" with `'using: node24' is not
+      # supported`. A build-only smoke never caught this because PR CI runs on the
+      # OLD fleet, not the NEW image's runner version. Here we inspect the NEW
+      # image directly: the runner ships its bundled node24 under externals/node24
+      # only at >= 2.327, so its presence is a direct, version-agnostic
+      # node24-capability proof.
+      - name: Assert baked runner is node24-capable
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint bash "${SMOKE_TAG}" -lc '
+            set -euo pipefail
+            node24="${RUNNER_HOME}/externals/node24/bin/node"
+            if [[ ! -x "${node24}" ]]; then
+              echo "::error::baked runner has no executable node24 at ${node24}; it cannot run node24 actions (actions/checkout@v6). RUNNER_VERSION is too old (< 2.327.0)."
+              echo "externals dir contents:"
+              ls -la "${RUNNER_HOME}/externals" 2>/dev/null || echo "no externals dir"
+              exit 1
+            fi
+            ver="$("${node24}" --version)"
+            echo "baked runner node24 present: ${node24} (${ver})"
+            case "${ver}" in
+              v24.*) : ;;
+              *) echo "::error::externals/node24 reports ${ver}, expected v24.x"; exit 1 ;;
+            esac
+          '
+          echo "node24 capability PASSED: the baked runner can execute node24 actions."
+
       - name: Cleanup throwaway image
         if: always()
         run: |

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -69,10 +69,12 @@ jobs:
           fi
           echo "Docker daemon accessible"
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: "3.12"
+          skip-install: "true"
+          cache-enabled: "false"
 
       # Build the versioned runner image to a throwaway local tag. This runs the
       # exact production path: build_runner_image.sh first verifies the bound

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -60,14 +60,12 @@ jobs:
         with:
           separator: ","
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          pip install --quiet confluent-kafka click
+          cache-key-prefix: uv-runtime-rebuild-trigger
+          install-args: --frozen
 
       - name: Trigger node_redeploy if runtime change detected
         # All potentially attacker-controlled inputs (labels, base_ref, sha) are
@@ -85,7 +83,7 @@ jobs:
           PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          python scripts/trigger_rebuild_on_merge.py \
+          uv run python scripts/trigger_rebuild_on_merge.py \
             --changed-files "$PR_CHANGED_FILES" \
             --labels "$PR_LABELS" \
             --base-branch "$PR_BASE_BRANCH" \

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -65,7 +65,9 @@ jobs:
         with:
           python-version: "3.12"
           cache-key-prefix: uv-runtime-rebuild-trigger
+          cache-enabled: "false"
           install-args: --frozen
+          shared-env-enabled: "true"
 
       - name: Trigger node_redeploy if runtime change detected
         # All potentially attacker-controlled inputs (labels, base_ref, sha) are

--- a/docker/docker-compose.runners.yml
+++ b/docker/docker-compose.runners.yml
@@ -8,7 +8,7 @@
 #
 # Prerequisites:
 #   - Build the runner image first (OMN-3275):
-#       docker build -t omninode-runner:latest docker/runners/
+#       scripts/ci/build_runner_image.sh --tag omninode-runner:latest
 #   - Set RUNNER_TOKEN in environment or .env file
 #       Generate at: https://github.com/organizations/OmniNode-ai/settings/actions/runners/new
 #       Token is valid for 1 hour. After registration, entrypoint.sh caches credentials.

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -81,7 +81,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y \
         python3.12-dev \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
-    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
+    && python3.12 -m ensurepip --upgrade \
+    && python3.12 -m pip install --no-cache-dir --upgrade pip \
+    && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip3 \
+    && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
 
 # Install uv
 RUN curl -LsSf "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -83,7 +83,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y \
     && ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
     && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
     && python3.12 -m ensurepip --upgrade \
-    && python3.12 -m pip install --no-cache-dir --upgrade pip \
     && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip3 \
     && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
 

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -9,7 +9,7 @@
 # contract). Build args MUST match docker/runners/runner-image.lock.json — CI
 # verifies the bound identity via scripts/ci/runner_image_identity.py.
 
-ARG RUNNER_VERSION=2.323.0
+ARG RUNNER_VERSION=2.334.0
 ARG GH_VERSION=2.67.0
 ARG KUBECTL_VERSION=1.32.1
 # uv pinned to the shared CI env (canary) version so the image binding is truthful.
@@ -117,8 +117,8 @@ RUN groupadd --gid 1001 runner \
     && usermod -aG docker runner
 
 # Download and SHA256-verify GitHub Actions runner binary
-# SHA256 for actions-runner-linux-x64-2.323.0.tar.gz
-ENV RUNNER_SHA256=0dbc9bf5a58620fc52cb6cc0448abcca964a8d74b5f39773b7afcad9ab691e19
+# SHA256 for actions-runner-linux-x64-2.334.0.tar.gz
+ENV RUNNER_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
 
 RUN mkdir -p "${RUNNER_HOME}" \
     && cd "${RUNNER_HOME}" \

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -151,6 +151,7 @@ RUN chmod 0444 /etc/omni/runner-image.lock.json
 # the env directory ownership matches the runtime user.
 COPY prebuilt-env-context/pyproject.toml /opt/omni/prebuilt/pyproject.toml
 COPY prebuilt-env-context/uv.lock /opt/omni/prebuilt/uv.lock
+COPY prebuilt-env-context/.github/actions/setup-python-uv/action.yml /opt/omni/prebuilt/.github/actions/setup-python-uv/action.yml
 COPY prebuilt-env-context/ci/ /opt/omni/prebuilt/scripts/ci/
 # OMN-12584: chown the *whole* runner cache dir, not only the ci-envs subtree.
 # `mkdir -p "${OMNI_CI_ENV_ROOT}/omnibase_infra"` runs as root and creates the

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,11 +1,11 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "231ae5fa883556778e9db274f1d5f83b",
-  "image_version": 1,
+  "identity_digest": "9f6386c2995542f655d80013fe7bbbed",
+  "image_version": 2,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
-  "runner_version": "2.323.0",
+  "runner_version": "2.334.0",
   "shared_env_digest": "9fe7f01afeb5fb03dadb6f0e",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "c7c55bb2a4eb14956860936b46dabd09",
+  "identity_digest": "de1d34dd07b9d92f8d3b456642fff6df",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "85595366f62a3022dc42d2d2",
+  "shared_env_digest": "5ae3eb4a62f7b59e77394dca",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "41c17bd4924dfce255f728a423a48268",
-  "image_version": 4,
+  "identity_digest": "c7c55bb2a4eb14956860936b46dabd09",
+  "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "9fe7f01afeb5fb03dadb6f0e",
+  "shared_env_digest": "85595366f62a3022dc42d2d2",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,8 +1,8 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "9f6386c2995542f655d80013fe7bbbed",
-  "image_version": 2,
+  "identity_digest": "10c7898208b946bf0591ef5fb6b06db2",
+  "image_version": 3,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,8 +1,8 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "10c7898208b946bf0591ef5fb6b06db2",
-  "image_version": 3,
+  "identity_digest": "41c17bd4924dfce255f728a423a48268",
+  "image_version": 4,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",

--- a/docs/ci/versioned-runner-image-rollout-checklist.md
+++ b/docs/ci/versioned-runner-image-rollout-checklist.md
@@ -37,11 +37,22 @@ contract must be proven on a **freshly recreated** runner.
 - [ ] Run the validation script on the freshly recreated runner and confirm
       `RESULT: GREEN`:
       `scripts/ci/validate_runner_image.sh --json`.
+- [ ] **node24 capability canary (OMN-12585) — REQUIRED before fleet rollout.**
+      Dispatch a job onto the *recreated* runner that uses `actions/checkout@v6`
+      (a `using: node24` action) and confirm "Set up job" + "Checkout code" pass.
+      A build-only smoke is **insufficient**: PR CI runs on the OLD fleet, so it
+      never exercises the NEW image's runner version against a node24 action. This
+      is the exact gap that let OMN-12567 ship a `2.323.0` runner that broke
+      org-wide CI with `'using: node24' is not supported`. The baked runner must
+      bundle `externals/node24` (present only at runner `>= 2.327.0`); the
+      build-smoke workflow asserts this statically, but the deployed-runner
+      checkout@v6 job is the live proof.
 - [ ] Confirm at least one real CI job ran green on the recreated runner and the
       job's startup evidence shows the bound `runner_image_identity` (from the
       `emit-runner-identity` action) matching the committed lock.
 
-Only after this gate is green does the fleet rollout below begin.
+Only after this gate (including the node24 canary) is green does the fleet
+rollout below begin.
 
 ## Per-repo migration steps
 
@@ -125,9 +136,28 @@ exits non-zero on any required failure:
 It is a **read-only** assertion — it never recreates, restarts, or registers a
 runner. Recreation is a separate, operator-run live runtime step.
 
+## RUNNER_VERSION floor gate (OMN-12585)
+
+Independent of the runner-side validation above, two static invariants on the
+baked `RUNNER_VERSION` are enforced as a **unit gate on every PR**
+(`tests/ci/test_runner_image_node24_floor.py`) and re-asserted by the
+build-smoke workflow:
+
+1. **node24-capable** — `RUNNER_VERSION >= 2.327.0` (node24 execution support;
+   actions/runner#3940). Below this, `actions/checkout@v6` fails at "Set up job".
+2. **non-downgrade** — `RUNNER_VERSION >= 2.334.0` (the live fleet). Bumping the
+   fleet forward means raising `LIVE_FLEET_FLOOR` in that test in the same change.
+
+The Dockerfile `ARG`, the SHA256 comment, and the lock `runner_version` must all
+agree, so a partial bump (version updated, checksum or lock stale) also fails the
+gate. This is "enforcement, not detection": the regression that let a `2.323.0`
+runner reach the fleet had no gate — now it cannot merge green.
+
 ## Acceptance (OMN-12568)
 
 - One repo (`omnibase_infra`) runs green on the versioned image **after fresh
   runner recreation** — proven by `validate_runner_image.sh` returning
   `RESULT: GREEN` on the recreated runner plus a green CI run.
+- A `actions/checkout@v6` (node24) job runs green on the recreated runner before
+  fleet rollout (OMN-12585).
 - This rollout checklist exists with explicit opt-outs noted (this document).

--- a/scripts/ci/build_runner_image.sh
+++ b/scripts/ci/build_runner_image.sh
@@ -57,8 +57,11 @@ UV_VERSION="$("${python_bin}" -c \
 echo "[build-runner-image] staging prebuilt env build context..."
 rm -rf "${CONTEXT_DIR}"
 mkdir -p "${CONTEXT_DIR}/ci"
+mkdir -p "${CONTEXT_DIR}/.github/actions/setup-python-uv"
 cp "${REPO_ROOT}/pyproject.toml" "${CONTEXT_DIR}/pyproject.toml"
 cp "${REPO_ROOT}/uv.lock" "${CONTEXT_DIR}/uv.lock"
+cp "${REPO_ROOT}/.github/actions/setup-python-uv/action.yml" \
+  "${CONTEXT_DIR}/.github/actions/setup-python-uv/action.yml"
 cp "${REPO_ROOT}/scripts/ci/ci_env_digest.py" "${CONTEXT_DIR}/ci/ci_env_digest.py"
 cp "${REPO_ROOT}/scripts/ci/ensure_ci_env.sh" "${CONTEXT_DIR}/ci/ensure_ci_env.sh"
 

--- a/scripts/ci/ensure_ci_env.sh
+++ b/scripts/ci/ensure_ci_env.sh
@@ -87,6 +87,7 @@ workspace_venv="${workspace_venv}"
 
 if [[ "\${OMNI_CI_SHARED_UV_RUN_DIRECT:-0}" == "1" && "\${1:-}" == "run" ]]; then
   shift
+  run_args=("\$@")
   if [[ "\${1:-}" == "--" ]]; then
     shift
   fi
@@ -99,6 +100,8 @@ if [[ "\${OMNI_CI_SHARED_UV_RUN_DIRECT:-0}" == "1" && "\${1:-}" == "run" ]]; the
     fi
     exec "\${cmd}" "\$@"
   fi
+
+  exec "\${real_uv}" run "\${run_args[@]}"
 fi
 
 exec "\${real_uv}" "\$@"

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -13,13 +13,14 @@
 #   1. Fetch a fresh GitHub Actions registration token (valid 1 hour)
 #   2. Base64-encode token for safe SSH passing
 #   3. Rsync runner artifacts to 192.168.86.201:~/.omnibase/runners/
-#   4. Deploy via SSH: docker compose up -d --build --force-recreate --remove-orphans
-#   5. Install docker prune cron idempotently (build cache + untagged images, tee)
-#   6. Install runner health monitor cron (Slack alerts on state transitions)
-#   7. Poll GitHub API until the configured runner fleet is online
+#   4. Build the versioned runner image via scripts/ci/build_runner_image.sh
+#   5. Deploy via SSH: docker compose up -d --force-recreate --remove-orphans
+#   6. Install docker prune cron idempotently (build cache + untagged images, tee)
+#   7. Install runner health monitor cron (Slack alerts on state transitions)
+#   8. Poll GitHub API until the configured runner fleet is online
 #      (max 5 min, 15s interval)
-#   8. Retry once with fresh token if poll times out
-#   9. Print stale runner report (offline runners with no host container)
+#   9. Retry once with fresh token if poll times out
+#   10. Print stale runner report (offline runners with no host container)
 #
 # --soft mode (entrypoint-only update, no recreate):
 #   1. Rsync runner artifacts to host
@@ -34,7 +35,8 @@
 #   - SSH access to 192.168.86.201 (key-based, no password prompts)
 #   - rsync installed locally
 #
-# See also: docker/runners/Dockerfile, docker/docker-compose.runners.yml
+# See also: docker/runners/Dockerfile, docker/docker-compose.runners.yml,
+# scripts/ci/build_runner_image.sh
 
 set -euo pipefail
 
@@ -81,12 +83,20 @@ POLL_INTERVAL_SECONDS=15
 # Artifacts to sync to the host (relative to repo root)
 SYNC_PATHS=(
     "${RUNNER_FLEET_CONFIG}"
+    ".github/actions/setup-python-uv/action.yml"
+    "pyproject.toml"
+    "uv.lock"
     "docker/runners/Dockerfile"
+    "docker/runners/runner-image.lock.json"
     "docker/runners/entrypoint.sh"
     "docker/runners/runner-job-started.sh"
     "docker/runners/runner-monitor.sh"
     "docker/runners/healthcheck.sh"
     "docker/docker-compose.runners.yml"
+    "scripts/ci/build_runner_image.sh"
+    "scripts/ci/ci_env_digest.py"
+    "scripts/ci/ensure_ci_env.sh"
+    "scripts/ci/runner_image_identity.py"
 )
 
 # ---------------------------------------------------------------------------
@@ -178,25 +188,44 @@ rsync_artifacts() {
     log "Rsyncing runner artifacts to ${RUNNER_HOST}:${RUNNER_HOST_DIR}/ ..."
 
     # Ensure remote directory structure exists
-    run_ssh "mkdir -p ${RUNNER_HOST_DIR}/config ${RUNNER_HOST_DIR}/docker/runners ${RUNNER_HOST_DIR}/docker"
+    run_ssh "mkdir -p ${RUNNER_HOST_DIR}/config ${RUNNER_HOST_DIR}/docker/runners ${RUNNER_HOST_DIR}/docker ${RUNNER_HOST_DIR}/scripts/ci ${RUNNER_HOST_DIR}/.github/actions/setup-python-uv"
 
     if "${DRY_RUN}"; then
         log "[DRY RUN] rsync ${SYNC_PATHS[*]} -> ${RUNNER_HOST}:${RUNNER_HOST_DIR}/"
         return 0
     fi
 
-    # Sync fleet config, Dockerfile, entrypoint, and monitor.
+    # Sync fleet config, versioned image contract inputs, Dockerfile, entrypoint,
+    # and monitor. The runner image build is contract-bound; do not rely on
+    # whatever files happen to be present on the host from an earlier deploy.
     rsync -av --checksum \
         "${RUNNER_FLEET_CONFIG}" \
         "${RUNNER_HOST}:${RUNNER_HOST_DIR}/config/runner_fleet.yaml"
 
     rsync -av --checksum \
+        "${REPO_ROOT}/pyproject.toml" \
+        "${REPO_ROOT}/uv.lock" \
+        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/"
+
+    rsync -av --checksum \
+        "${REPO_ROOT}/.github/actions/setup-python-uv/action.yml" \
+        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/.github/actions/setup-python-uv/action.yml"
+
+    rsync -av --checksum \
         "${REPO_ROOT}/docker/runners/Dockerfile" \
+        "${REPO_ROOT}/docker/runners/runner-image.lock.json" \
         "${REPO_ROOT}/docker/runners/entrypoint.sh" \
         "${REPO_ROOT}/docker/runners/runner-job-started.sh" \
         "${REPO_ROOT}/docker/runners/runner-monitor.sh" \
         "${REPO_ROOT}/docker/runners/healthcheck.sh" \
         "${RUNNER_HOST}:${RUNNER_HOST_DIR}/docker/runners/"
+
+    rsync -av --checksum \
+        "${REPO_ROOT}/scripts/ci/build_runner_image.sh" \
+        "${REPO_ROOT}/scripts/ci/ci_env_digest.py" \
+        "${REPO_ROOT}/scripts/ci/ensure_ci_env.sh" \
+        "${REPO_ROOT}/scripts/ci/runner_image_identity.py" \
+        "${RUNNER_HOST}:${RUNNER_HOST_DIR}/scripts/ci/"
 
     # Sync compose file into docker/
     rsync -av --checksum \
@@ -216,11 +245,7 @@ deploy_runners() {
 
     local compose_cmd="docker compose -f ${RUNNER_HOST_DIR}/docker/docker-compose.runners.yml"
 
-    if "${SKIP_BUILD}"; then
-        local up_flags="--force-recreate --remove-orphans"
-    else
-        local up_flags="--build --force-recreate --remove-orphans"
-    fi
+    local up_flags="--force-recreate --remove-orphans"
 
     log "Deploying runners on ${RUNNER_HOST} (force-recreate ensures fresh env)..."
 
@@ -234,6 +259,9 @@ deploy_runners() {
         RUNNER_TOKEN=\$(echo '${remote_token_b64}' | base64 -d)
         export RUNNER_TOKEN
         cd ${RUNNER_HOST_DIR}
+        if [ '${SKIP_BUILD}' = 'false' ]; then
+            bash scripts/ci/build_runner_image.sh --tag omninode-runner:latest
+        fi
         ${compose_cmd} up -d ${up_flags}
     "
 
@@ -388,9 +416,9 @@ soft_deploy() {
 
     rsync_artifacts
 
-    # Rebuild the image so future containers (from force-recreate deploys) use it
-    log "Rebuilding runner image on ${RUNNER_HOST}..."
-    run_ssh "cd ${RUNNER_HOST_DIR} && docker build -t omninode-runner:latest docker/runners/"
+    # Rebuild the image so future containers (from force-recreate deploys) use it.
+    log "Rebuilding versioned runner image on ${RUNNER_HOST}..."
+    run_ssh "cd ${RUNNER_HOST_DIR} && bash scripts/ci/build_runner_image.sh --tag omninode-runner:latest"
 
     # Ensure entrypoint is executable on host (docker cp preserves source permissions)
     run_ssh "chmod +x ${RUNNER_HOST_DIR}/docker/runners/entrypoint.sh"
@@ -421,7 +449,11 @@ deploy_with_retry() {
         log "=== Deploy attempt ${attempt} ==="
 
         local token
-        token=$(fetch_registration_token)
+        if "${DRY_RUN}"; then
+            token="dry-run-token"
+        else
+            token=$(fetch_registration_token)
+        fi
         local token_b64
         token_b64=$(encode_token "${token}")
 

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -358,7 +358,11 @@ def test_ci_jobs_that_mutate_python_env_disable_shared_env() -> None:
         for step in ci_workflow["jobs"]["compliance"]["steps"]
         if step.get("uses") == "./.github/actions/setup-python-uv"
     )
-    assert compliance_setup["with"]["shared-env-enabled"] == "false"
+    assert compliance_setup["with"].get("shared-env-enabled") != "false"
+    assert not any(
+        step.get("name") == "Install dependencies"
+        for step in ci_workflow["jobs"]["compliance"]["steps"]
+    )
 
     for job_name in ("schema-handshake", "kafka-boundary-compat"):
         setup_step = next(

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -17,6 +17,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 DOCKER_BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-build.yml"
 ENV_PARITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "env-parity.yml"
+ARTIFACT_RECONCILIATION_WEBHOOK_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "artifact-reconciliation-webhook.yml"
+)
+PR_MERGED_EVENT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-merged-event.yml"
+RUNTIME_REBUILD_TRIGGER_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "runtime-rebuild-trigger.yml"
+)
 OMNI_STANDARDS_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "omni-standards-compliance.yml"
 )
@@ -598,6 +605,40 @@ def test_omni_standards_uv_jobs_use_authenticated_composite_action() -> None:
     assert "max_attempts=3" in install_step["run"]
     assert "until uv pip install" in install_step["run"]
     assert "uv pip install onex_change_control failed after" in install_step["run"]
+
+
+def test_webhook_workflows_use_ci_python_environment() -> None:
+    """Webhook producer jobs must not resolve Python deps outside CI env setup."""
+    workflow_paths = (
+        ARTIFACT_RECONCILIATION_WEBHOOK_WORKFLOW,
+        PR_MERGED_EVENT_WORKFLOW,
+        RUNTIME_REBUILD_TRIGGER_WORKFLOW,
+    )
+
+    for workflow_path in workflow_paths:
+        workflow = _load_yaml(workflow_path)
+        for job in workflow["jobs"].values():
+            steps = job["steps"]
+            setup_steps = [
+                step
+                for step in steps
+                if step.get("uses") == "./.github/actions/setup-python-uv"
+            ]
+            assert setup_steps, f"{workflow_path.name} must use setup-python-uv"
+            assert all(
+                step["with"]["install-args"] == "--frozen" for step in setup_steps
+            )
+
+            run_scripts = [
+                step.get("run", "")
+                for step in steps
+                if isinstance(step.get("run"), str)
+            ]
+            assert not any(
+                re.search(r"(^|\n)\s*(?:python -m )?pip install\b", script)
+                for script in run_scripts
+            ), f"{workflow_path.name} must not run pip install directly"
+            assert any("uv run python scripts/" in script for script in run_scripts)
 
 
 def test_codeql_uses_repo_config_that_ignores_github_metadata() -> None:

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -628,6 +628,10 @@ def test_webhook_workflows_use_ci_python_environment() -> None:
             assert all(
                 step["with"]["install-args"] == "--frozen" for step in setup_steps
             )
+            assert all(step["with"]["cache-enabled"] == "false" for step in setup_steps)
+            assert all(
+                step["with"]["shared-env-enabled"] == "true" for step in setup_steps
+            )
 
             run_scripts = [
                 step.get("run", "")

--- a/tests/ci/test_runner_image_node24_floor.py
+++ b/tests/ci/test_runner_image_node24_floor.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Rollout gate: the runner image RUNNER_VERSION must be node24-capable and must
+not downgrade the live fleet (OMN-12585).
+
+Background. The OMN-12567 versioned runner image pinned
+``ARG RUNNER_VERSION=2.323.0`` while the live fleet ran ``2.334.0``. Rolling that
+image to the fleet *downgraded* the GitHub Actions runner, and ``2.323.0`` cannot
+execute ``node24`` actions (``actions/checkout@v6``, used 73x across workflows).
+It fails at "Set up job" with ``'using: node24' is not supported``. node24
+execution support landed in actions/runner ``2.327.0`` (actions/runner#3940).
+
+The OMN-12584 build-smoke proves the image *builds*, but it runs on whatever
+runner picks up the PR (the OLD fleet), so it never exercises the NEW image's
+runner version against a node24 action. No gate asserted the baked
+``RUNNER_VERSION`` was node24-capable or not a downgrade — this regression merged
+green. This test is that gate, enforced as a unit check on every PR (and the
+build-smoke workflow / pre-commit run it before the runner image can ship).
+
+Two invariants, both load-bearing:
+
+* **node24 capability** — ``RUNNER_VERSION >= 2.327.0`` so the baked runner can
+  execute ``node24`` actions.
+* **non-downgrade vs the live fleet** — ``RUNNER_VERSION >= 2.334.0`` so rolling
+  the image to the fleet never rolls the runner backward.
+
+The Dockerfile ``ARG``, the SHA256 comment, and the lock ``runner_version`` must
+all agree, so a partial bump (version updated but checksum stale, or lock not
+regenerated) also fails here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_DOCKERFILE = REPO_ROOT / "docker" / "runners" / "Dockerfile"
+LOCK_FILE = REPO_ROOT / "docker" / "runners" / "runner-image.lock.json"
+
+# node24 *execution* support landed in actions/runner 2.327.0 (actions/runner
+# #3940). Below this, `actions/checkout@v6` (using: node24) fails at "Set up job".
+NODE24_FLOOR = (2, 327, 0)
+
+# The live self-hosted fleet runs 2.334.0 (verified 2026-06-02, OMN-12585). The
+# baked image must never downgrade the fleet's runner. Raise this floor whenever
+# the fleet is rolled forward to a newer runner.
+LIVE_FLEET_FLOOR = (2, 334, 0)
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def _parse(version: str) -> tuple[int, int, int]:
+    """Parse a dotted ``major.minor.patch`` runner version into a comparable tuple."""
+    match = _VERSION_RE.match(version.strip())
+    assert match is not None, f"unparseable runner version: {version!r}"
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _fmt(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _dockerfile_runner_version() -> str:
+    source = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+    match = re.search(r"^ARG RUNNER_VERSION=(\S+)\s*$", source, re.MULTILINE)
+    assert match is not None, "ARG RUNNER_VERSION not found in runner Dockerfile"
+    return match.group(1)
+
+
+def _lock_runner_version() -> str:
+    data = json.loads(LOCK_FILE.read_text(encoding="utf-8"))
+    version = data.get("runner_version")
+    assert isinstance(version, str) and version, "lock missing runner_version"
+    return version
+
+
+def test_dockerfile_runner_version_is_node24_capable() -> None:
+    """The baked runner must be able to execute node24 actions (>= 2.327.0)."""
+    version = _parse(_dockerfile_runner_version())
+    assert version >= NODE24_FLOOR, (
+        f"RUNNER_VERSION {_fmt(version)} predates node24 execution support "
+        f"({_fmt(NODE24_FLOOR)}); actions/checkout@v6 (using: node24) would fail "
+        "at 'Set up job' with \"'using: node24' is not supported\""
+    )
+
+
+def test_dockerfile_runner_version_does_not_downgrade_live_fleet() -> None:
+    """The baked runner must not roll the live fleet backward (>= 2.334.0)."""
+    version = _parse(_dockerfile_runner_version())
+    assert version >= LIVE_FLEET_FLOOR, (
+        f"RUNNER_VERSION {_fmt(version)} is a downgrade from the live fleet "
+        f"({_fmt(LIVE_FLEET_FLOOR)}); rolling this image to the fleet would "
+        "downgrade the runner — the exact OMN-12585 regression"
+    )
+
+
+def test_lock_runner_version_matches_dockerfile() -> None:
+    """The lock's runner_version must track the Dockerfile ARG.
+
+    The runner version is part of the bound image identity, so a mismatch means
+    the lock was not regenerated after the bump — the baked binding would not
+    describe the runner actually installed.
+    """
+    docker_version = _dockerfile_runner_version()
+    lock_version = _lock_runner_version()
+    assert docker_version == lock_version, (
+        f"Dockerfile RUNNER_VERSION {docker_version!r} != lock runner_version "
+        f"{lock_version!r}; run scripts/ci/runner_image_identity.py --mode generate"
+    )
+
+
+def test_lock_runner_version_is_node24_capable_and_not_a_downgrade() -> None:
+    """The same floors apply to the lock-recorded runner version."""
+    version = _parse(_lock_runner_version())
+    assert version >= NODE24_FLOOR, (
+        f"lock runner_version {_fmt(version)} predates node24 support "
+        f"({_fmt(NODE24_FLOOR)})"
+    )
+    assert version >= LIVE_FLEET_FLOOR, (
+        f"lock runner_version {_fmt(version)} downgrades the live fleet "
+        f"({_fmt(LIVE_FLEET_FLOOR)})"
+    )
+
+
+def test_runner_sha256_comment_tracks_runner_version() -> None:
+    """The SHA256 comment must name the same version as the ARG.
+
+    The Dockerfile verifies the downloaded runner tarball against a pinned
+    RUNNER_SHA256. The comment naming the version that checksum belongs to must
+    track the ARG, or a version bump with a stale checksum (wrong file) slips
+    through: the build would fail the sha256 check, but only at image-build time.
+    This static check catches the inconsistency earlier and unambiguously.
+    """
+    source = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+    version = _dockerfile_runner_version()
+    assert f"actions-runner-linux-x64-{version}.tar.gz" in source, (
+        f"runner Dockerfile SHA256 comment does not reference "
+        f"actions-runner-linux-x64-{version}.tar.gz; update the checksum + "
+        "comment in lockstep with RUNNER_VERSION"
+    )
+    # A non-empty pinned checksum must be present.
+    assert re.search(r"^ENV RUNNER_SHA256=[0-9a-f]{64}\s*$", source, re.MULTILINE), (
+        "runner Dockerfile must pin a 64-hex-char RUNNER_SHA256"
+    )

--- a/tests/unit/runtime/test_policy_registry_performance.py
+++ b/tests/unit/runtime/test_policy_registry_performance.py
@@ -890,28 +890,39 @@ class TestPolicyRegistryPerformanceRegression:
             for patch in range(5)
         ]  # 125 unique versions
 
-        # Cold cache: first parse of each version
+        iterations = 20
+
+        # Cold cache: repeatedly reset and parse each version. Measuring a
+        # single 125-version cold pass is sub-millisecond on CI runners, which
+        # makes the ratio sensitive to timer noise.
         cold_start = time.perf_counter()
-        for v in versions:
-            _ = RegistryPolicy._parse_semver(v)
+        for _ in range(iterations):
+            RegistryPolicy._reset_semver_cache()
+            for v in versions:
+                _ = RegistryPolicy._parse_semver(v)
         cold_time = time.perf_counter() - cold_start
 
-        # Warm cache: repeated parse (should hit cache)
+        # Warm cache: repeated parse of the same versions should hit cache.
+        RegistryPolicy._reset_semver_cache()
+        for v in versions:
+            _ = RegistryPolicy._parse_semver(v)
         warm_start = time.perf_counter()
-        for _ in range(10):  # 10 iterations
+        for _ in range(iterations):
             for v in versions:
                 _ = RegistryPolicy._parse_semver(v)
         warm_time = time.perf_counter() - warm_start
 
-        # Warm should be at least 5x faster due to cache (10 iterations)
+        # Warm should be materially faster due to cache.
         # We expect ~10x speedup since all lookups hit cache
         # Use conservative threshold to avoid flakiness
-        per_iteration_warm = warm_time / 10
-        ratio = per_iteration_warm / cold_time
+        per_iteration_cold = cold_time / iterations
+        per_iteration_warm = warm_time / iterations
+        ratio = per_iteration_warm / per_iteration_cold
 
         assert ratio < 2.0, (
             f"Semver cache not effective. "
-            f"Cold: {cold_time * 1000:.2f}ms, Warm per iteration: {per_iteration_warm * 1000:.2f}ms. "
+            f"Cold per iteration: {per_iteration_cold * 1000:.2f}ms, "
+            f"Warm per iteration: {per_iteration_warm * 1000:.2f}ms. "
             f"Ratio: {ratio:.2f}x (expected < 2.0x). "
             f"This indicates cache regression."
         )


### PR DESCRIPTION
Evidence-Source: OCC#2079
Evidence-Ticket: OMN-12583

## Summary
- bump self-hosted runner binary from 2.323.0 to 2.334.0 so Node 24 actions such as actions/checkout@v6 can load
- update the verified runner tarball SHA256
- provision pip on PATH for workflows that call `pip` directly without downloading pip during image build
- bump the bound runner image lock to image version 5 with regenerated identity `de1d34dd07b9d92f8d3b456642fff6df`
- bake the shared omnibase_infra CI uv environment into the runner image as the canary for durable CI env reuse
- skip setup-python/setup-uv bootstrapping when the baked shared runner env is enabled
- route required lightweight Python setup jobs through the shared setup action with shared env forced on and install skipped
- force Docker integration tests through the shared runner env instead of resolving dependencies again
- preserve `uv run` option-bearing invocations such as `uv run --frozen` in the shared env wrapper
- add a node24-capable/non-downgrade runner floor gate and node24 assertion in runner-image build smoke

## Verification
- `PYTHONPATH=scripts/ci uv run python scripts/ci/runner_image_identity.py --mode generate`
- `PYTHONPATH=scripts/ci uv run python scripts/ci/runner_image_identity.py --mode verify`
- `uv run pytest tests/ci/test_runner_image_node24_floor.py -q` -> `5 passed`
- `uv run pytest tests/scripts/test_run_topic_lint_path_resolution.py -q` -> `5 passed`
- `uv run pre-commit run --files docker/runners/runner-image.lock.json scripts/ci/ensure_ci_env.sh scripts/ci/runner_image_identity.py tests/ci/test_runner_image_node24_floor.py`
- OCC evidence PR open in OmniNode-ai/onex_change_control#2079
- CI proof on this head: pending after refresh to `5849cf7326e2f5947186afa24be14ef4e3d70668`; previous head proved runner-image-build-smoke and Build Runtime Image before the uv wrapper/identity refresh
- live .201 runner fleet previously deployed runner 2.334.0 image v5 with old shared env digest `85595366f62a3022dc42d2d2`; redeploy required after this head if CI/fleet evidence must match refreshed digest `5ae3eb4a62f7b59e77394dca`

CI-Rerun-Deploy-Gate: 2026-06-02T08:18:00Z