### PR TITLE
test(OMN-12585): node24-capable + non-downgrade runner image rollout gate

### DIFF
--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -127,6 +127,37 @@ jobs:
           '
           echo "Runner image build smoke PASSED: identity bound + prebuilt env baked."
 
+      # OMN-12585: assert the baked runner can execute node24 actions
+      # (actions/checkout@v6, used 73x across workflows). The OMN-12567 image
+      # pinned RUNNER_VERSION=2.323.0, which predates node24 execution support
+      # (landed in actions/runner 2.327.0); rolling it to the live fleet (2.334.0)
+      # downgraded the runner and broke "Set up job" with `'using: node24' is not
+      # supported`. A build-only smoke never caught this because PR CI runs on the
+      # OLD fleet, not the NEW image's runner version. Here we inspect the NEW
+      # image directly: the runner ships its bundled node24 under externals/node24
+      # only at >= 2.327, so its presence is a direct, version-agnostic
+      # node24-capability proof.
+      - name: Assert baked runner is node24-capable
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint bash "${SMOKE_TAG}" -lc '
+            set -euo pipefail
+            node24="${RUNNER_HOME}/externals/node24/bin/node"
+            if [[ ! -x "${node24}" ]]; then
+              echo "::error::baked runner has no executable node24 at ${node24}; it cannot run node24 actions (actions/checkout@v6). RUNNER_VERSION is too old (< 2.327.0)."
+              echo "externals dir contents:"
+              ls -la "${RUNNER_HOME}/externals" 2>/dev/null || echo "no externals dir"
+              exit 1
+            fi
+            ver="$("${node24}" --version)"
+            echo "baked runner node24 present: ${node24} (${ver})"
+            case "${ver}" in
+              v24.*) : ;;
+              *) echo "::error::externals/node24 reports ${ver}, expected v24.x"; exit 1 ;;
+            esac
+          '
+          echo "node24 capability PASSED: the baked runner can execute node24 actions."
+
       - name: Cleanup throwaway image
         if: always()
         run: |

--- a/docs/ci/versioned-runner-image-rollout-checklist.md
+++ b/docs/ci/versioned-runner-image-rollout-checklist.md
@@ -37,11 +37,22 @@ contract must be proven on a **freshly recreated** runner.
 - [ ] Run the validation script on the freshly recreated runner and confirm
       `RESULT: GREEN`:
       `scripts/ci/validate_runner_image.sh --json`.
+- [ ] **node24 capability canary (OMN-12585) — REQUIRED before fleet rollout.**
+      Dispatch a job onto the *recreated* runner that uses `actions/checkout@v6`
+      (a `using: node24` action) and confirm "Set up job" + "Checkout code" pass.
+      A build-only smoke is **insufficient**: PR CI runs on the OLD fleet, so it
+      never exercises the NEW image's runner version against a node24 action. This
+      is the exact gap that let OMN-12567 ship a `2.323.0` runner that broke
+      org-wide CI with `'using: node24' is not supported`. The baked runner must
+      bundle `externals/node24` (present only at runner `>= 2.327.0`); the
+      build-smoke workflow asserts this statically, but the deployed-runner
+      checkout@v6 job is the live proof.
 - [ ] Confirm at least one real CI job ran green on the recreated runner and the
       job's startup evidence shows the bound `runner_image_identity` (from the
       `emit-runner-identity` action) matching the committed lock.
 
-Only after this gate is green does the fleet rollout below begin.
+Only after this gate (including the node24 canary) is green does the fleet
+rollout below begin.
 
 ## Per-repo migration steps
 
@@ -125,9 +136,28 @@ exits non-zero on any required failure:
 It is a **read-only** assertion — it never recreates, restarts, or registers a
 runner. Recreation is a separate, operator-run live runtime step.
 
+## RUNNER_VERSION floor gate (OMN-12585)
+
+Independent of the runner-side validation above, two static invariants on the
+baked `RUNNER_VERSION` are enforced as a **unit gate on every PR**
+(`tests/ci/test_runner_image_node24_floor.py`) and re-asserted by the
+build-smoke workflow:
+
+1. **node24-capable** — `RUNNER_VERSION >= 2.327.0` (node24 execution support;
+   actions/runner#3940). Below this, `actions/checkout@v6` fails at "Set up job".
+2. **non-downgrade** — `RUNNER_VERSION >= 2.334.0` (the live fleet). Bumping the
+   fleet forward means raising `LIVE_FLEET_FLOOR` in that test in the same change.
+
+The Dockerfile `ARG`, the SHA256 comment, and the lock `runner_version` must all
+agree, so a partial bump (version updated, checksum or lock stale) also fails the
+gate. This is "enforcement, not detection": the regression that let a `2.323.0`
+runner reach the fleet had no gate — now it cannot merge green.
+
 ## Acceptance (OMN-12568)
 
 - One repo (`omnibase_infra`) runs green on the versioned image **after fresh
   runner recreation** — proven by `validate_runner_image.sh` returning
   `RESULT: GREEN` on the recreated runner plus a green CI run.
+- A `actions/checkout@v6` (node24) job runs green on the recreated runner before
+  fleet rollout (OMN-12585).
 - This rollout checklist exists with explicit opt-outs noted (this document).

--- a/tests/ci/test_runner_image_node24_floor.py
+++ b/tests/ci/test_runner_image_node24_floor.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Rollout gate: the runner image RUNNER_VERSION must be node24-capable and must
+not downgrade the live fleet (OMN-12585).
+
+Background. The OMN-12567 versioned runner image pinned
+``ARG RUNNER_VERSION=2.323.0`` while the live fleet ran ``2.334.0``. Rolling that
+image to the fleet *downgraded* the GitHub Actions runner, and ``2.323.0`` cannot
+execute ``node24`` actions (``actions/checkout@v6``, used 73x across workflows).
+It fails at "Set up job" with ``'using: node24' is not supported``. node24
+execution support landed in actions/runner ``2.327.0`` (actions/runner#3940).
+
+The OMN-12584 build-smoke proves the image *builds*, but it runs on whatever
+runner picks up the PR (the OLD fleet), so it never exercises the NEW image's
+runner version against a node24 action. No gate asserted the baked
+``RUNNER_VERSION`` was node24-capable or not a downgrade — this regression merged
+green. This test is that gate, enforced as a unit check on every PR (and the
+build-smoke workflow / pre-commit run it before the runner image can ship).
+
+Two invariants, both load-bearing:
+
+* **node24 capability** — ``RUNNER_VERSION >= 2.327.0`` so the baked runner can
+  execute ``node24`` actions.
+* **non-downgrade vs the live fleet** — ``RUNNER_VERSION >= 2.334.0`` so rolling
+  the image to the fleet never rolls the runner backward.
+
+The Dockerfile ``ARG``, the SHA256 comment, and the lock ``runner_version`` must
+all agree, so a partial bump (version updated but checksum stale, or lock not
+regenerated) also fails here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_DOCKERFILE = REPO_ROOT / "docker" / "runners" / "Dockerfile"
+LOCK_FILE = REPO_ROOT / "docker" / "runners" / "runner-image.lock.json"
+
+# node24 *execution* support landed in actions/runner 2.327.0 (actions/runner
+# #3940). Below this, `actions/checkout@v6` (using: node24) fails at "Set up job".
+NODE24_FLOOR = (2, 327, 0)
+
+# The live self-hosted fleet runs 2.334.0 (verified 2026-06-02, OMN-12585). The
+# baked image must never downgrade the fleet's runner. Raise this floor whenever
+# the fleet is rolled forward to a newer runner.
+LIVE_FLEET_FLOOR = (2, 334, 0)
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def _parse(version: str) -> tuple[int, int, int]:
+    """Parse a dotted ``major.minor.patch`` runner version into a comparable tuple."""
+    match = _VERSION_RE.match(version.strip())
+    assert match is not None, f"unparseable runner version: {version!r}"
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _fmt(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _dockerfile_runner_version() -> str:
+    source = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+    match = re.search(r"^ARG RUNNER_VERSION=(\S+)\s*$", source, re.MULTILINE)
+    assert match is not None, "ARG RUNNER_VERSION not found in runner Dockerfile"
+    return match.group(1)
+
+
+def _lock_runner_version() -> str:
+    data = json.loads(LOCK_FILE.read_text(encoding="utf-8"))
+    version = data.get("runner_version")
+    assert isinstance(version, str) and version, "lock missing runner_version"
+    return version
+
+
+def test_dockerfile_runner_version_is_node24_capable() -> None:
+    """The baked runner must be able to execute node24 actions (>= 2.327.0)."""
+    version = _parse(_dockerfile_runner_version())
+    assert version >= NODE24_FLOOR, (
+        f"RUNNER_VERSION {_fmt(version)} predates node24 execution support "
+        f"({_fmt(NODE24_FLOOR)}); actions/checkout@v6 (using: node24) would fail "
+        "at 'Set up job' with \"'using: node24' is not supported\""
+    )
+
+
+def test_dockerfile_runner_version_does_not_downgrade_live_fleet() -> None:
+    """The baked runner must not roll the live fleet backward (>= 2.334.0)."""
+    version = _parse(_dockerfile_runner_version())
+    assert version >= LIVE_FLEET_FLOOR, (
+        f"RUNNER_VERSION {_fmt(version)} is a downgrade from the live fleet "
+        f"({_fmt(LIVE_FLEET_FLOOR)}); rolling this image to the fleet would "
+        "downgrade the runner — the exact OMN-12585 regression"
+    )
+
+
+def test_lock_runner_version_matches_dockerfile() -> None:
+    """The lock's runner_version must track the Dockerfile ARG.
+
+    The runner version is part of the bound image identity, so a mismatch means
+    the lock was not regenerated after the bump — the baked binding would not
+    describe the runner actually installed.
+    """
+    docker_version = _dockerfile_runner_version()
+    lock_version = _lock_runner_version()
+    assert docker_version == lock_version, (
+        f"Dockerfile RUNNER_VERSION {docker_version!r} != lock runner_version "
+        f"{lock_version!r}; run scripts/ci/runner_image_identity.py --mode generate"
+    )
+
+
+def test_lock_runner_version_is_node24_capable_and_not_a_downgrade() -> None:
+    """The same floors apply to the lock-recorded runner version."""
+    version = _parse(_lock_runner_version())
+    assert version >= NODE24_FLOOR, (
+        f"lock runner_version {_fmt(version)} predates node24 support "
+        f"({_fmt(NODE24_FLOOR)})"
+    )
+    assert version >= LIVE_FLEET_FLOOR, (
+        f"lock runner_version {_fmt(version)} downgrades the live fleet "
+        f"({_fmt(LIVE_FLEET_FLOOR)})"
+    )
+
+
+def test_runner_sha256_comment_tracks_runner_version() -> None:
+    """The SHA256 comment must name the same version as the ARG.
+
+    The Dockerfile verifies the downloaded runner tarball against a pinned
+    RUNNER_SHA256. The comment naming the version that checksum belongs to must
+    track the ARG, or a version bump with a stale checksum (wrong file) slips
+    through: the build would fail the sha256 check, but only at image-build time.
+    This static check catches the inconsistency earlier and unambiguously.
+    """
+    source = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+    version = _dockerfile_runner_version()
+    assert f"actions-runner-linux-x64-{version}.tar.gz" in source, (
+        f"runner Dockerfile SHA256 comment does not reference "
+        f"actions-runner-linux-x64-{version}.tar.gz; update the checksum + "
+        "comment in lockstep with RUNNER_VERSION"
+    )
+    # A non-empty pinned checksum must be present.
+    assert re.search(r"^ENV RUNNER_SHA256=[0-9a-f]{64}\s*$", source, re.MULTILINE), (
+        "runner Dockerfile must pin a 64-hex-char RUNNER_SHA256"
+    )


### PR DESCRIPTION
Evidence-Ticket: OMN-12585
Evidence-Source: deb2d828b8ea1c023e8bf851229ba35733f5bb17

## OMN-12585: node24-capable + non-downgrade runner image rollout gate

Stacked on #1835 (OMN-12583). Base branch is `jonah/omn-12583-runner-node24`; this PR's diff is **only the regression gate** that #1835 does not include.

### Context
The OMN-12567 runner image pinned `RUNNER_VERSION=2.323.0` — a downgrade from the live 2.334.0 fleet. 2.323.0 cannot execute `node24` actions (`actions/checkout@v6`, used 73x), failing at "Set up job" with `'using: node24' is not supported`. node24 execution support landed in actions/runner **2.327.0** (actions/runner#3940). A post-deploy integration test on .201 caught it; the fleet was rolled back, then #1835 (OMN-12583) bumped the image to **2.334.0 (image v5)** and deployed it live to .201 (48/48 healthy).

**#1835 ships the fix; this PR ships the gate that #1835 lacks** — the regression that let a 2.323.0 runner reach the fleet had no gate. "Enforcement, not detection."

### Gate (the only files this PR adds, on top of #1835's image v5)
1. **tests/ci/test_runner_image_node24_floor.py** (NEW) — asserts the baked `RUNNER_VERSION` is node24-capable (`>= 2.327.0`) AND not a downgrade (`>= 2.334.0`), and that the Dockerfile ARG, the SHA256 comment, and the lock `runner_version` all agree (a partial bump fails the gate).
2. **.github/workflows/runner-image-build-smoke.yml** — adds a node24-capability assertion inspecting the built image for an executable `externals/node24/bin/node` (present only at runner `>= 2.327`). A build-only smoke is insufficient: PR CI runs on the OLD fleet, never the NEW image's runner version.
3. **docs/ci/versioned-runner-image-rollout-checklist.md** — requires a deployed-runner `actions/checkout@v6` (node24) canary green BEFORE fleet rollout (OMN-12568 checklist); documents the RUNNER_VERSION floor gate.

### Proof
Non-destructive `omninode-runner:next` rebuild on .201 (from the 2.334.0 tree) confirmed: `externals/node24/bin/node` = **v24.15.0** (the capability 2.323.0 lacked), identity matches lock, `validate_runner_image.py` = **RESULT: GREEN**. Live `:latest` + 48-runner fleet untouched (no recreate/restart/retag). Evidence in `.onex_state/evidence/OMN-12585/`.

Local gates: ruff/mypy clean; `tests/ci/` green (gate + identity + validate); pre-commit clean on the 3 gate files.

### OCC pairing
OCC PR #2068 (contract `OMN-12585.yaml` + PASS receipts, verifier≠runner, contract_sha256 per OMN-10421) merged to OCC dev at `deb2d828`.
