### PR TITLE
fix(OMN-12597): re-sync vendored savings node migration to canonical omnimarket source

### DIFF
--- a/contracts/OMN-12597.yaml
+++ b/contracts/OMN-12597.yaml
@@ -1,0 +1,43 @@
+# OMN-12597 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-12597
+title: "Re-sync vendored omnimarket savings node migration to its canonical source"
+summary: >
+  Follow-up to OMN-12559 (PR #1820). The vendored copy of node_projection_savings 076_create_delegation_savings_projection_view.sql diverged from its canonical owner in omnimarket: the COALESCE argument order on the latency_ms projection column was swapped (vendored had COALESCE(latency_ms, delegation_latency_ms); omnimarket source has COALESCE(delegation_latency_ms, latency_ms)). omnimarket owns the node migration, so the vendored copy must mirror the source 1:1. This re-syncs the vendored file via scripts/sync-node-migrations.sh so the drift guard passes and the savings view prefers the delegation-specific latency column as the node intends. Proven by the auto-discovery test suite, including the drift guard test_sync_check_reports_in_sync which previously FAILED when the local omnimarket source was resolvable.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Auto-discovery suite passes, including the vendored-tree drift guard."
+    command: "OMNI_HOME=$OMNI_HOME uv run pytest tests/unit/migrations/test_node_migration_discovery.py -q"
+  - kind: ci
+    description: "Vendored node migrations stay in sync with the omnimarket source (drift guard)."
+    command: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - kind: manual
+    description: "Deploy-gate proof: migration SQL re-sync only; the next migrate image build carries the corrected vendored file. No live deploy performed pre-merge."
+    command: "deploy-gate: no live deploy performed pre-merge; next migrate image build (Dockerfile.migrate COPY is recursive) carries the re-synced nodes/ subtree"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-discovery-tests
+    description: "Node-migration auto-discovery suite passes (8/8), including the drift guard that was failing pre-fix."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "OMNI_HOME=$OMNI_HOME uv run pytest tests/unit/migrations/test_node_migration_discovery.py -q"
+  - id: dod-vendor-sync
+    description: "Vendored node migration is in sync with omnimarket origin/dev after re-sync."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - id: dod-deploy-gate
+    description: "No pre-merge live deploy required; the next migrate image build carries the re-synced vendored node migration."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy-gate: no live deploy performed pre-merge; next migrate image build carries the re-synced nodes/ subtree"

--- a/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
@@ -42,7 +42,7 @@ event_sessions AS (
         COALESCE(tokens_input, 0)::int AS prompt_tokens,
         COALESCE(tokens_output, 0)::int AS completion_tokens,
         NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
-        COALESCE(latency_ms, delegation_latency_ms)::int AS latency_ms,
+        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
         COALESCE(created_at, timestamp) AS created_at,
         prompt_text,
         response_text


### PR DESCRIPTION
## OMN-12597: re-sync vendored omnimarket savings node migration to its canonical source

Implements OMN-12597 (parent OMN-12588). Follow-up to OMN-12559 / PR #1820 (now merged).

### What this fixes
PR #1820 introduced auto-discovery of omnimarket node-owned migrations (vendored under `docker/migrations/forward/nodes/<node>/`). The vendored copy of `node_projection_savings/076_create_delegation_savings_projection_view.sql` was NOT a verbatim copy of the canonical omnimarket source: the `COALESCE` argument order on the `latency_ms` projection column was swapped.

- **omnimarket source (canonical owner, dev HEAD, file unchanged since PR #1005/OMN-12489):** `COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms`
- **vendored infra copy (PR #1820):** `COALESCE(latency_ms, delegation_latency_ms)::int AS latency_ms`

omnimarket owns its node migrations, so the vendored copy must mirror the source 1:1. The savings view should prefer the delegation-specific `delegation_latency_ms` first, as the node intends.

This was caught by the auto-discovery drift guard `tests/unit/migrations/test_node_migration_discovery.py::TestVendoredTreeMatchesSource::test_sync_check_reports_in_sync`, which FAILED (1 of 8) when the local omnimarket source was resolvable. In CI the guard skips (no omnimarket checkout) — only `--check` against a resolvable source surfaces it, which is why #1820 went green with the drift latent.

### What changed
- **`docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql`**: re-synced via `scripts/sync-node-migrations.sh` (one line: `COALESCE` argument order restored to match omnimarket).
- **`contracts/OMN-12597.yaml`**: deploy-gate contract.

### Known limitation (not introduced here)
`run-forward-migrations.sh` tracks node migrations by `migration_id` only (`checksum='applied-by-runner'`, a literal), so an environment that already applied `node:node_projection_savings:076_...` will SKIP re-apply and keep the old view definition until manually refreshed. This is the OMN-12559 runner design, not a regression in this PR. The corrected SQL is picked up on every clean clone / fresh deploy (`CREATE OR REPLACE VIEW`), which is the durable source-of-truth fix OMN-12597 requires.

### dod_evidence
- Auto-discovery suite green after re-sync: `OMNI_HOME=$OMNI_HOME uv run pytest tests/unit/migrations/test_node_migration_discovery.py -q` → **8 passed** (was 1 failed / 7 passed pre-fix, the failure being the vendored-tree drift guard).
- Migration unit + sequence validator suite: `uv run pytest tests/unit/migrations/ tests/ci/test_validate_migration_sequence.py -q` → **35 passed**.
- Drift guard direct: `OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check` → in sync.
- `pre-commit run --files <changed>`: clean (ONEX Node Migration Vendor Sync Check, ONEX Contract Validation, Writer-Migration Coupling Check all pass).

Parent-PR landing proof for OMN-12597 AC#1 (infra#1820 merged): `gh pr view 1820 --json state,mergedAt` → `{"state":"MERGED","mergedAt":"2026-06-02T13:22:04Z"}`, merge commit `d64b7f8198862b172f4a7e1d2f147876a700d4b6` on `dev`. Auto-discovery test (AC#2): `tests/unit/migrations/test_node_migration_discovery.py` + `tests/integration/migrations/test_node_migration_discovery_applies.py`.

Contract: `contracts/OMN-12597.yaml` (in-repo, deploy-gate).

Deploy-gate: no live deploy performed pre-merge; the next migrate image build (Dockerfile.migrate COPY is recursive) carries the re-synced `nodes/` subtree.

Evidence-Ticket: OMN-12597
Evidence-Source: OCC#2093

Plan: docs/plans/2026-06-02-system-stability-delegation-sea-recovery-plan.md

