### PR TITLE
fix(OMN-12522): advertise stability broker on connected network

### DIFF
--- a/contracts/OMN-12522.yaml
+++ b/contracts/OMN-12522.yaml
@@ -1,0 +1,61 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-12522"
+title: "Advertise stability Redpanda on the connected network"
+summary: >-
+  Require the stability-test Redpanda external listener to advertise a
+  connected-network address so authorized off-LAN operators can complete Kafka
+  metadata bootstrap instead of being redirected to a LAN-only broker address.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - protocols
+evidence_requirements:
+  - kind: "tests"
+    description: "Stability runtime lane static and compose render tests pass"
+    command: >-
+      env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
+  - kind: "ci"
+    description: "Touched stability runtime tests pass ruff checks"
+    command: >-
+      env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
+  - kind: "manual"
+    description: "Stability compose render requires and advertises the connected-network broker host"
+    command: >-
+      env STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key GITHUB_TOKEN=test-github-token ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 LLM_ENDPOINT_CIDR_ALLOWLIST=192.168.86.0/24 LOCAL_LLM_SHARED_SECRET=render-only-local-llm-secret OMNI_HOME=/data/omninode/omni_home ONEX_INFRA_HOST=100.109.203.94 ONEX_INFRA_USER=jonah docker compose --env-file docker/runtime-policy.env -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
+  - kind: "manual"
+    description: "Post-merge .201 stability Redpanda metadata advertises the connected-network endpoint"
+    command: >-
+      deploy approval required: set STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 on .201, recreate/restart the stability Redpanda lane, then verify `kcat -L -b 100.109.203.94:39092` reports broker 0 at 100.109.203.94:39092
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-stability-lane-tests"
+    description: "Stability runtime lane static and compose render tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q
+  - id: "dod-ruff-check"
+    description: "Touched stability runtime tests pass ruff checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py
+  - id: "dod-compose-connected-advertise"
+    description: "Stability compose render requires and advertises the connected-network broker host"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          env STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 POSTGRES_PASSWORD=test VALKEY_PASSWORD=test LINEAR_API_KEY=test-linear-api-key GITHUB_TOKEN=test-github-token ONEX_REGISTRATION_AUTO_ACK=true ONEX_SERVICE_CLIENT_SECRET=test-service-secret LLM_CODER_URL=http://llm-coder.test:8000 LLM_CODER_FAST_URL=http://llm-coder-fast.test:8001 LLM_EMBEDDING_URL=http://llm-embed.test:8100 LLM_DEEPSEEK_R1_URL=http://llm-r1.test:8101 LLM_ENDPOINT_CIDR_ALLOWLIST=192.168.86.0/24 LOCAL_LLM_SHARED_SECRET=render-only-local-llm-secret OMNI_HOME=/data/omninode/omni_home ONEX_INFRA_HOST=100.109.203.94 ONEX_INFRA_USER=jonah docker compose --env-file docker/runtime-policy.env -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet
+  - id: "dod-live-metadata"
+    description: "Post-merge .201 stability Redpanda metadata advertises the connected-network endpoint"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          deploy approval required: set STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 on .201, recreate/restart the stability Redpanda lane, then verify `kcat -L -b 100.109.203.94:39092` reports broker 0 at 100.109.203.94:39092

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -38,11 +38,11 @@ services:
       - --kafka-addr
       - internal://0.0.0.0:9092,external://0.0.0.0:19092
       - --advertise-kafka-addr
-      - internal://redpanda:9092,external://${REDPANDA_ADVERTISE_HOST:-localhost}:${STABILITY_TEST_REDPANDA_EXTERNAL_PORT:-39092}
+      - internal://redpanda:9092,external://${STABILITY_TEST_REDPANDA_ADVERTISE_HOST:?STABILITY_TEST_REDPANDA_ADVERTISE_HOST must be a connected-network address reachable by all stability-test operators}:${STABILITY_TEST_REDPANDA_EXTERNAL_PORT:-39092}
       - --pandaproxy-addr
       - internal://0.0.0.0:8082,external://0.0.0.0:18082
       - --advertise-pandaproxy-addr
-      - internal://redpanda:8082,external://${REDPANDA_ADVERTISE_HOST:-localhost}:${STABILITY_TEST_REDPANDA_PANDAPROXY_PORT:-28082}
+      - internal://redpanda:8082,external://${STABILITY_TEST_REDPANDA_ADVERTISE_HOST:?STABILITY_TEST_REDPANDA_ADVERTISE_HOST must be a connected-network address reachable by all stability-test operators}:${STABILITY_TEST_REDPANDA_PANDAPROXY_PORT:-28082}
       - --schema-registry-addr
       - internal://0.0.0.0:8081,external://0.0.0.0:18081
       - --rpc-addr

--- a/docs/runbooks/stability-test-runtime-lane.md
+++ b/docs/runbooks/stability-test-runtime-lane.md
@@ -66,11 +66,39 @@ the two-phase runtime build plan into a concrete runtime lane:
   - `omnibase-infra-stability-test-network`
   - `omnibase-infra-stability-test-omnimemory-network`
 
+## Connected-Network Kafka Access
+
+The stability-test Redpanda external listener must advertise one address that is
+reachable by every authorized stability-test operator. Do not advertise
+`localhost` or a LAN-only address such as `192.168.86.201` for this lane: Kafka
+clients bootstrap on the supplied broker, then reconnect to the broker address
+returned in metadata.
+
+On `.201`, use the Tailscale address or a stable MagicDNS name as the
+stability-test advertise host:
+
+```bash
+export STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94
+export STABILITY_TEST_REDPANDA_EXTERNAL_PORT=39092
+```
+
+Operators should then bootstrap with the same connected-network endpoint:
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=100.109.203.94:39092
+kcat -L -b "$KAFKA_BOOTSTRAP_SERVERS" | sed -n '1,5p'
+```
+
+The metadata must report broker `0` at the connected-network host and port. If
+it reports `localhost` or `192.168.86.201`, off-LAN clients can open the TCP port
+but fail when Kafka redirects them to the advertised broker address.
+
 ## Validation Only
 
 Render the config only:
 
 ```bash
+STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 \
 docker compose \
   -f docker/docker-compose.infra.yml \
   -f docker/docker-compose.stability-test.yml \
@@ -85,6 +113,7 @@ List the rendered services and confirm the stability-test runtime services are
 present:
 
 ```bash
+STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 \
 docker compose \
   -f docker/docker-compose.infra.yml \
   -f docker/docker-compose.stability-test.yml \

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -125,7 +125,7 @@ COMPOSE_RENDER_ENV = {
     "ONEX_INFRA_USER": "jonah",
     "ONEX_SERVICE_CLIENT_SECRET": "render-only-client-secret",
     "POSTGRES_PASSWORD": "postgres",
-    "REDPANDA_ADVERTISE_HOST": "localhost",
+    "STABILITY_TEST_REDPANDA_ADVERTISE_HOST": "100.109.203.94",
     "STABILITY_TEST_POSTGRES_EXTERNAL_PORT": "15436",
     "STABILITY_TEST_VALKEY_EXTERNAL_PORT": "26379",
     "STABILITY_TEST_REDPANDA_ADMIN_PORT": "29644",
@@ -390,7 +390,9 @@ def test_stability_lane_render_does_not_expose_production_ports_or_services() ->
         assert published_ports.isdisjoint(PRODUCTION_PUBLISHED_PORTS)
 
     redpanda_command = " ".join(services["redpanda"]["command"])
-    assert "localhost:39092" in redpanda_command
+    assert "100.109.203.94:39092" in redpanda_command
+    assert "100.109.203.94:28082" in redpanda_command
+    assert "192.168.86.201:39092" not in redpanda_command
     assert "localhost:19092" not in redpanda_command
 
     partition_cap_command = "\n".join(services["redpanda-partition-cap"]["command"])

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -240,6 +240,18 @@ def test_stability_lane_runtime_ports_override_production_bindings() -> None:
 
 
 @pytest.mark.unit
+def test_stability_lane_redpanda_requires_connected_network_advertise_host() -> None:
+    overlay = _load_overlay()
+    redpanda_command = " ".join(overlay["services"]["redpanda"]["command"])
+
+    assert "STABILITY_TEST_REDPANDA_ADVERTISE_HOST" in redpanda_command
+    assert "${REDPANDA_ADVERTISE_HOST" not in redpanda_command
+    assert "localhost:${STABILITY_TEST_REDPANDA_EXTERNAL_PORT" not in redpanda_command
+    assert "localhost:${STABILITY_TEST_REDPANDA_PANDAPROXY_PORT" not in redpanda_command
+    assert "reachable by all stability-test operators" in redpanda_command
+
+
+@pytest.mark.unit
 def test_stability_lane_sets_redpanda_partition_capacity_before_runtime() -> None:
     overlay = _load_overlay()
     services = overlay["services"]


### PR DESCRIPTION
Evidence-Source: ab9f901531e2e0f47c1cac2af9eb78d20d49ae4b
Evidence-Ticket: OMN-12522

## Summary

Fixes the stability-test Redpanda external listener contract so it cannot silently advertise `localhost` or a LAN-only broker address for connected operators.

Current live failure mode confirmed on 2026-06-02:

- TCP succeeds to `100.109.203.94:39092`.
- `.201` Tailscale IP is `100.109.203.94`.
- `kcat -L -b 100.109.203.94:39092` currently reports broker metadata as `broker 0 at 192.168.86.201:39092`.

That means off-LAN/Tailscale clients can open the bootstrap port, then Kafka redirects them to a LAN-only address they cannot route. This is an advertised-listener bug, not a macOS Local Network grant issue for connected remote operators.

## Changes

- Require `STABILITY_TEST_REDPANDA_ADVERTISE_HOST` in `docker/docker-compose.stability-test.yml` for Redpanda Kafka + Pandaproxy advertised addresses.
- Update stability lane render tests to prove the broker advertises `100.109.203.94:39092` and does not advertise `192.168.86.201:39092`.
- Document connected-network Kafka bootstrap/metadata proof in the stability-test runbook.
- Add repo-local `contracts/OMN-12522.yaml` with static, compose render, and post-merge metadata evidence requirements.

## Verification

- `env -u PYTHONPATH uv run pytest tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q` → 25 passed
- `env -u PYTHONPATH uv run ruff format --check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py && env -u PYTHONPATH uv run ruff check tests/unit/infra/test_stability_test_runtime_lane.py tests/integration/infra/test_stability_test_runtime_compose_render.py` → passed
- `env -u PYTHONPATH uv run python scripts/validate.py contracts` → passed
- `env STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94 ... docker compose --env-file docker/runtime-policy.env -f docker/docker-compose.infra.yml -f docker/docker-compose.stability-test.yml --profile runtime config --quiet` → passed

## Runtime note

This PR does not restart or mutate `.201`.

Post-merge/live closeout requires approval to set `STABILITY_TEST_REDPANDA_ADVERTISE_HOST=100.109.203.94` on `.201` and recreate/restart the stability Redpanda lane. Then verify:

```bash
kcat -L -b 100.109.203.94:39092 | sed -n '1,4p'
```

Expected metadata: broker 0 at `100.109.203.94:39092`.