### PR TITLE
feat(OMN-12626): prod runtime promotion-lineage guard — pin prod to a promoted main digest (R1)

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -42,8 +42,19 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
+  # OMN-12626 (R1): refuse to build the prod-bound runtime image unless the
+  # source tree is clean AND HEAD is a promoted origin/main commit. This runs
+  # on push to main (the promoted ref), so a real main build passes and a
+  # dirty/dev-only build fails closed before any image is built or pushed.
+  lineage-guard:
+    name: Prod promotion lineage guard
+    uses: ./.github/workflows/prod-promotion-lineage.yml
+    with:
+      enforce_lineage: true
+
   build-and-push:
     name: Build and push runtime image
+    needs: lineage-guard
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/prod-promotion-lineage.yml
+++ b/.github/workflows/prod-promotion-lineage.yml
@@ -68,7 +68,7 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -80,7 +80,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           uv-version: ${{ env.UV_VERSION }}
           cache-version: ${{ env.CACHE_VERSION }}
-          cache-enabled: "false"
 
       - name: Run guard unit tests
         run: |

--- a/.github/workflows/prod-promotion-lineage.yml
+++ b/.github/workflows/prod-promotion-lineage.yml
@@ -1,0 +1,113 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# prod-promotion-lineage.yml — OMN-12626 (R1)
+#
+# Two responsibilities:
+#
+#   1. PR gate (job: guard-tests) — runs the guard's unit tests so the
+#      clean-tree + ancestor-of-origin/main + image-revision rules cannot
+#      silently regress. Triggered on changes to the guard, its tests, or the
+#      prod build/deploy tooling.
+#
+#   2. Reusable lineage check (job: lineage-check, on workflow_call) — runs the
+#      actual guard against the checked-out tree. The prod runtime image build
+#      (build-and-push-runtime.yml, push -> main) calls this so the image is
+#      never built from a dirty or non-promoted tree. main is the promoted ref,
+#      so a real main build passes; a dirty/dev-only build fails closed.
+#
+# This is a REQUIRED status check on the PR gate. No bypass, no skip tokens.
+
+name: Prod Promotion Lineage (OMN-12626)
+
+on:
+  pull_request:
+    paths:
+      - "scripts/check_prod_promotion_lineage.py"
+      - "tests/scripts/test_check_prod_promotion_lineage.py"
+      - "tests/scripts/test_deploy_runtime_prod_lineage.py"
+      - "scripts/deploy-runtime.sh"
+      - "scripts/deploy-agent/deploy_agent/executor.py"
+      - "scripts/deploy-agent/tests/unit/test_executor_promotion_lineage.py"
+      - ".github/workflows/prod-promotion-lineage.yml"
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - "scripts/check_prod_promotion_lineage.py"
+      - "tests/scripts/test_check_prod_promotion_lineage.py"
+      - "scripts/deploy-runtime.sh"
+      - "scripts/deploy-agent/deploy_agent/executor.py"
+      - ".github/workflows/prod-promotion-lineage.yml"
+  workflow_call:
+    inputs:
+      enforce_lineage:
+        description: >-
+          When true, run the actual clean-tree + promoted-lineage guard against
+          the checked-out tree (used by the prod image build on main).
+        required: false
+        type: boolean
+        default: false
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  guard-tests:
+    name: Prod promotion-lineage guard tests
+    # Run on PRs and pushes; skipped for the reusable workflow_call path.
+    if: ${{ github.event_name != 'workflow_call' }}
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run guard unit tests
+        run: |
+          python -m pytest \
+            tests/scripts/test_check_prod_promotion_lineage.py \
+            tests/scripts/test_deploy_runtime_prod_lineage.py \
+            -v
+
+  lineage-check:
+    name: Enforce clean + promoted build source
+    # Only runs when invoked by the prod build (workflow_call with enforce).
+    if: ${{ github.event_name == 'workflow_call' && inputs.enforce_lineage }}
+    runs-on: >-
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout (full history for ancestry check)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fetch origin/main for promoted-lineage ancestry
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - name: Enforce clean + promoted source
+        run: python scripts/check_prod_promotion_lineage.py --repo .

--- a/.github/workflows/prod-promotion-lineage.yml
+++ b/.github/workflows/prod-promotion-lineage.yml
@@ -53,6 +53,8 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.6.14"
+  CACHE_VERSION: "0.6.0"
 
 jobs:
   guard-tests:
@@ -66,23 +68,23 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+          uv-version: ${{ env.UV_VERSION }}
+          cache-version: ${{ env.CACHE_VERSION }}
+          cache-enabled: "false"
 
       - name: Run guard unit tests
         run: |
-          python -m pytest \
+          uv run pytest \
             tests/scripts/test_check_prod_promotion_lineage.py \
             tests/scripts/test_deploy_runtime_prod_lineage.py \
             -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -309,6 +309,17 @@ repos:
         files: ^src/omnibase_infra/nodes/reducers/
         pass_filenames: false
         stages: [pre-commit]
+      # Prod promotion-lineage guard tests (OMN-12626, R1)
+      # Runs the guard's unit tests whenever the guard or the prod build/deploy
+      # tooling changes, so the clean-tree + ancestor-of-origin/main + image
+      # revision rules cannot silently regress. Timeout protects against hangs.
+      - id: prod-promotion-lineage-guard
+        name: Prod promotion-lineage guard tests (OMN-12626)
+        entry: uv run --frozen pytest tests/scripts/test_check_prod_promotion_lineage.py tests/scripts/test_deploy_runtime_prod_lineage.py -q --tb=short --timeout=120 --timeout-method=thread
+        language: system
+        pass_filenames: false
+        files: ^(scripts/check_prod_promotion_lineage\.py|tests/scripts/test_(check_prod_promotion_lineage|deploy_runtime_prod_lineage)\.py|scripts/deploy-runtime\.sh|scripts/deploy-agent/deploy_agent/executor\.py)$
+        stages: [pre-commit]
       # Markdown link validation (PR #172)
       # Ensures all internal markdown links point to existing files and anchors
       # External links are skipped by default (configurable in .markdown-link-check.json)

--- a/scripts/check_prod_promotion_lineage.py
+++ b/scripts/check_prod_promotion_lineage.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Prod runtime image promotion-lineage guard (OMN-12626, R1).
+
+The promotion gate protects the ``main`` *branch*, but nothing has pinned the
+prod runtime *image* to a promoted ``main`` digest. The prod 0.36.1 image was
+built locally from a source clone 12 commits behind ``origin/main`` with
+uncommitted edits, with no ``org.opencontainers.image.revision`` label and no
+build-provenance manifest. "Prod == promoted main digest" was not mechanically
+guaranteed.
+
+This module is a **pre-build/deploy guard**. It refuses to build or deploy the
+prod runtime image unless:
+
+  (a) the build source working tree is CLEAN (no tracked, staged, or untracked
+      edits) — :func:`working_tree_clean`,
+  (b) HEAD is an ancestor-of/equal-to ``origin/main`` (promoted lineage) — a
+      dev-only or dirty tree is rejected — :func:`head_is_promoted`,
+  (c) the build bakes ``org.opencontainers.image.revision=<git sha>`` plus a
+      build-provenance manifest (the guard hands the build the required
+      ``--build-arg`` tokens via :func:`promoted_build_args`; the Dockerfile
+      stamps the ``revision`` label and writes ``/app/build-provenance.json``),
+      and
+  (d) the deployed image carries that revision so "prod == promoted main
+      digest" is assertable from a ``docker inspect`` —
+      :func:`assert_image_revision_matches`.
+
+The guard is **fail-fast**: a missing ``origin/main`` ref, an unreadable repo,
+or a missing/unknown image revision raises :class:`ProdLineageError`. There is
+no silent default that would let an unpromoted artifact reach prod.
+
+This module is build/deploy *tooling*: it inspects git and an image's
+``docker inspect`` output. It never rebuilds or restarts a live runtime.
+
+Usage::
+
+    # Pre-build/deploy lineage check on a source clone (exits non-zero on fail)
+    uv run python scripts/check_prod_promotion_lineage.py --repo /path/to/clone
+
+    # Also assert the deployed/built image carries the promoted revision
+    uv run python scripts/check_prod_promotion_lineage.py \\
+        --repo /path/to/clone --image omninode-prod-runtime
+
+Exit codes:
+    0 — clean, promoted HEAD (and, if --image given, matching revision)
+    1 — guard failed (stderr has a structured reason)
+    2 — usage / environment error
+"""
+
+from __future__ import annotations
+
+import argparse
+import enum
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# The OCI annotation the Dockerfile stamps from the GIT_SHA/VCS_REF build args.
+REVISION_LABEL = "org.opencontainers.image.revision"
+# The label the runtime image carries pointing at the baked provenance manifest.
+PROVENANCE_LABEL = "com.omninode.workspace_provenance_manifest"
+# Sentinel values that mean "no real revision was baked in".
+_REVISION_SENTINELS = frozenset({"", "unknown", "dev", "none", "null"})
+# The promoted lineage anchor. Prod may only build from main.
+PROMOTED_REF = "origin/main"
+
+
+class EnumProdLineageFailure(enum.Enum):
+    """Structured reasons a prod build/deploy is rejected.
+
+    Carried on :class:`ProdLineageError` so callers (and tests) can assert the
+    exact failure mode instead of string-matching messages.
+    """
+
+    DIRTY_TREE = "dirty_tree"
+    NOT_PROMOTED = "not_promoted"
+    NO_PROMOTED_REF = "no_promoted_ref"
+    GIT_ERROR = "git_error"
+    MISSING_REVISION = "missing_revision"
+    REVISION_MISMATCH = "revision_mismatch"
+    MISSING_PROVENANCE = "missing_provenance"
+
+
+class ProdLineageError(RuntimeError):
+    """Raised when a prod runtime build/deploy fails the promotion-lineage guard.
+
+    Fails the build/deploy CLOSED. The ``reason`` attribute is an
+    :class:`EnumProdLineageFailure` describing the exact failure mode.
+    """
+
+    def __init__(self, reason: EnumProdLineageFailure, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _git(repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command in ``repo_dir`` and return the completed process."""
+    return subprocess.run(
+        ["git", "-C", str(repo_dir), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def working_tree_clean(repo_dir: Path) -> bool:
+    """Return ``True`` only when the working tree has zero pending changes.
+
+    ``git status --porcelain`` reports modified-tracked, staged, AND untracked
+    files (untracked are the ``??`` rows). Any non-empty output means the build
+    source does not byte-match a commit, so the baked SHA would lie about the
+    image contents — exactly the R1 failure mode.
+
+    Raises :class:`ProdLineageError` (``GIT_ERROR``) when git cannot read the
+    repository; never returns a silent default.
+    """
+    result = _git(repo_dir, "status", "--porcelain", "--untracked-files=all")
+    if result.returncode != 0:
+        raise ProdLineageError(
+            EnumProdLineageFailure.GIT_ERROR,
+            f"git status failed in {repo_dir}: "
+            f"{result.stderr.strip() or result.stdout.strip()}",
+        )
+    return result.stdout.strip() == ""
+
+
+def head_is_promoted(repo_dir: Path) -> bool:
+    """Return ``True`` when HEAD is an ancestor-of/equal-to ``origin/main``.
+
+    Promoted lineage means the exact source commit has reached ``main`` through
+    the promotion gate. ``git merge-base --is-ancestor HEAD origin/main`` is
+    ``True`` when HEAD == origin/main or HEAD is a strict ancestor; it is
+    ``False`` for a dev-only commit that diverged after the last promotion.
+
+    Raises :class:`ProdLineageError` (``NO_PROMOTED_REF``) when ``origin/main``
+    cannot be resolved — a prod build with no visible promoted ref is rejected,
+    not silently allowed.
+    """
+    rev = _git(
+        repo_dir, "rev-parse", "--verify", "--quiet", f"{PROMOTED_REF}^{{commit}}"
+    )
+    if rev.returncode != 0 or not rev.stdout.strip():
+        raise ProdLineageError(
+            EnumProdLineageFailure.NO_PROMOTED_REF,
+            f"cannot resolve {PROMOTED_REF} in {repo_dir}; prod builds require a "
+            "fetched origin/main to prove promoted lineage. Run "
+            "`git fetch origin main` on the build source clone.",
+        )
+    ancestry = _git(repo_dir, "merge-base", "--is-ancestor", "HEAD", PROMOTED_REF)
+    # `merge-base --is-ancestor` exits 0 (ancestor), 1 (not ancestor), or >1 on
+    # error. Treat any non-0/1 exit as a hard git error rather than "not
+    # promoted" so a broken repo cannot masquerade as a clean rejection.
+    if ancestry.returncode == 0:
+        return True
+    if ancestry.returncode == 1:
+        return False
+    raise ProdLineageError(
+        EnumProdLineageFailure.GIT_ERROR,
+        f"git merge-base --is-ancestor failed in {repo_dir}: "
+        f"{ancestry.stderr.strip() or ancestry.stdout.strip()}",
+    )
+
+
+def resolve_head_sha(repo_dir: Path) -> str:
+    """Return the full 40-char HEAD SHA, or raise on a git error."""
+    result = _git(repo_dir, "rev-parse", "HEAD")
+    sha = result.stdout.strip()
+    if result.returncode != 0 or not sha:
+        raise ProdLineageError(
+            EnumProdLineageFailure.GIT_ERROR,
+            f"git rev-parse HEAD failed in {repo_dir}: "
+            f"{result.stderr.strip() or result.stdout.strip()}",
+        )
+    return sha
+
+
+def assert_prod_build_promoted(repo_dir: Path) -> str:
+    """Assert the prod build source is clean AND promoted; return the HEAD SHA.
+
+    This is the (a)+(b) gate. It raises :class:`ProdLineageError` with the
+    precise :class:`EnumProdLineageFailure` reason on any violation:
+
+      - ``DIRTY_TREE``    — uncommitted/untracked edits in the build source,
+      - ``NOT_PROMOTED``  — HEAD is dev-only (not an ancestor of origin/main),
+      - ``NO_PROMOTED_REF`` — origin/main is not fetched/resolvable.
+
+    On success it returns the promoted HEAD SHA so the caller can bake it via
+    :func:`promoted_build_args` and later verify the deployed image with
+    :func:`assert_image_revision_matches`.
+    """
+    if not working_tree_clean(repo_dir):
+        raise ProdLineageError(
+            EnumProdLineageFailure.DIRTY_TREE,
+            f"prod build rejected: working tree in {repo_dir} has uncommitted or "
+            "untracked changes; the baked revision would not match the image "
+            "contents. Commit or stash, then rebuild from a clean clone.",
+        )
+    if not head_is_promoted(repo_dir):
+        head = resolve_head_sha(repo_dir)
+        raise ProdLineageError(
+            EnumProdLineageFailure.NOT_PROMOTED,
+            f"prod build rejected: HEAD {head} in {repo_dir} is not an "
+            f"ancestor-of/equal-to {PROMOTED_REF}; prod may only build a "
+            "promoted main commit, never a dev-only or local tree.",
+        )
+    return resolve_head_sha(repo_dir)
+
+
+def promoted_build_args(sha: str) -> list[str]:
+    """Return the ``--build-arg`` tokens that bake the promoted revision.
+
+    The Dockerfile stamps ``org.opencontainers.image.revision`` from ``GIT_SHA``
+    (builder stage) and ``VCS_REF`` (runtime stage), and emits the build
+    provenance manifest; ``RUNTIME_SOURCE_HASH`` is the env stamp the runtime
+    banner and ``attest-source-hash`` gate verify. Passing all three from a
+    single promoted SHA keeps (c) consistent end-to-end.
+    """
+    return [
+        "--build-arg",
+        f"GIT_SHA={sha}",
+        "--build-arg",
+        f"VCS_REF={sha}",
+        "--build-arg",
+        f"RUNTIME_SOURCE_HASH={sha}",
+    ]
+
+
+def assert_image_revision_matches(
+    inspect: dict[str, object], *, expected_sha: str
+) -> None:
+    """Assert a ``docker inspect`` payload carries the promoted revision (c)+(d).
+
+    ``inspect`` is one element of ``docker inspect <image>`` (parsed JSON). The
+    image must carry:
+
+      - a non-sentinel ``org.opencontainers.image.revision`` label that matches
+        ``expected_sha`` (short-SHA prefix match is accepted), and
+      - the ``com.omninode.workspace_provenance_manifest`` label pointing at the
+        baked ``build-provenance.json`` manifest.
+
+    Raises :class:`ProdLineageError` (``MISSING_REVISION`` / ``REVISION_MISMATCH``
+    / ``MISSING_PROVENANCE``) on any violation so a deployed image that does not
+    pin to the promoted digest fails closed.
+    """
+    config = inspect.get("Config")
+    labels: dict[str, object] = {}
+    if isinstance(config, dict):
+        raw_labels = config.get("Labels")
+        if isinstance(raw_labels, dict):
+            labels = raw_labels
+
+    revision = str(labels.get(REVISION_LABEL, "")).strip()
+    if revision.lower() in _REVISION_SENTINELS:
+        raise ProdLineageError(
+            EnumProdLineageFailure.MISSING_REVISION,
+            f"image is missing a real {REVISION_LABEL} label "
+            f"(found {revision!r}); cannot prove prod == promoted main digest.",
+        )
+
+    expected = expected_sha.strip().lower()
+    found = revision.lower()
+    if not (expected.startswith(found) or found.startswith(expected)):
+        raise ProdLineageError(
+            EnumProdLineageFailure.REVISION_MISMATCH,
+            f"image {REVISION_LABEL}={revision!r} does not match the promoted "
+            f"HEAD {expected_sha!r}; prod is serving an artifact that is not the "
+            "promoted main digest.",
+        )
+
+    provenance = str(labels.get(PROVENANCE_LABEL, "")).strip()
+    if not provenance:
+        raise ProdLineageError(
+            EnumProdLineageFailure.MISSING_PROVENANCE,
+            f"image is missing the {PROVENANCE_LABEL} label; the build did not "
+            "bake a build-provenance manifest.",
+        )
+
+
+def inspect_image(image: str) -> dict[str, object]:
+    """Return the first ``docker inspect`` element for ``image``.
+
+    Raises :class:`ProdLineageError` (``GIT_ERROR``) when docker cannot inspect
+    the image — there is no fallback that would let an unverifiable image pass.
+    """
+    result = subprocess.run(
+        ["docker", "inspect", image],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ProdLineageError(
+            EnumProdLineageFailure.GIT_ERROR,
+            f"docker inspect {image} failed: "
+            f"{result.stderr.strip() or result.stdout.strip()}",
+        )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list) or not payload:
+        raise ProdLineageError(
+            EnumProdLineageFailure.GIT_ERROR,
+            f"docker inspect {image} returned no objects.",
+        )
+    first = payload[0]
+    if not isinstance(first, dict):
+        raise ProdLineageError(
+            EnumProdLineageFailure.GIT_ERROR,
+            f"docker inspect {image} returned a non-object element.",
+        )
+    return first
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="check_prod_promotion_lineage.py",
+        description=(
+            "Refuse to build/deploy the prod runtime image unless the source "
+            "tree is clean and HEAD is a promoted origin/main commit (OMN-12626)."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Path to the build source git clone (default: current directory).",
+    )
+    parser.add_argument(
+        "--image",
+        default=None,
+        help=(
+            "Optional image ref/name to assert carries the promoted revision "
+            "label + provenance manifest (e.g. omninode-prod-runtime)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code (0 pass, 1 fail, 2 usage)."""
+    args = _parse_args(argv)
+    repo_dir = Path(args.repo).resolve()
+    if not (repo_dir / ".git").exists():
+        print(
+            f"[prod-lineage] ERROR: {repo_dir} is not a git repository "
+            "(no .git). Point --repo at the build source clone.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        sha = assert_prod_build_promoted(repo_dir)
+        print(
+            f"[prod-lineage] OK: build source clean and promoted; "
+            f"HEAD {sha} is an ancestor-of/equal-to {PROMOTED_REF}."
+        )
+        if args.image is not None:
+            inspect = inspect_image(args.image)
+            assert_image_revision_matches(inspect, expected_sha=sha)
+            print(
+                f"[prod-lineage] OK: image {args.image} carries "
+                f"{REVISION_LABEL}={sha} + a build-provenance manifest."
+            )
+    except ProdLineageError as exc:
+        print(f"[prod-lineage] FAIL ({exc.reason.value}): {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import os
@@ -12,6 +13,7 @@ import sys
 import time
 from collections.abc import Callable, Mapping
 from pathlib import Path
+from types import ModuleType
 
 from pydantic import BaseModel, ConfigDict
 
@@ -63,6 +65,61 @@ RUNTIME_HEALTH_TARGETS: tuple[tuple[str, int], ...] = (
 )
 
 _BUILD_SOURCE_ALLOWED = ", ".join(source.value for source in BuildSource)
+
+# Promotion-lineage guard (OMN-12626, R1). Loaded from scripts/ by file path
+# because scripts/ is not an importable package. The guard refuses to build a
+# prod-bound (release-mode) image from a dirty or non-promoted source tree.
+_PROMOTION_GUARD_PATH = Path(REPO_DIR) / "scripts" / "check_prod_promotion_lineage.py"
+
+
+def _load_promotion_guard() -> ModuleType:
+    """Load the prod promotion-lineage guard module from scripts/ by path.
+
+    Raises RuntimeError (fail-fast) when the guard is missing so a release
+    build can never silently skip the clean-tree + promoted-lineage check.
+    """
+    mod_name = "check_prod_promotion_lineage"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    if not _PROMOTION_GUARD_PATH.is_file():
+        raise RuntimeError(
+            "prod promotion-lineage guard not found at "
+            f"{_PROMOTION_GUARD_PATH}; cannot verify clean+promoted build source."
+        )
+    spec = importlib.util.spec_from_file_location(mod_name, _PROMOTION_GUARD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"could not load prod promotion-lineage guard from {_PROMOTION_GUARD_PATH}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_release_build_promoted(
+    build_source: BuildSource, *, repo_dir: str = REPO_DIR
+) -> None:
+    """Enforce clean + promoted source for prod-bound (release-mode) builds.
+
+    Release-mode builds produce the digest that is later pinned and promoted to
+    prod. They MUST come from a clean working tree whose HEAD is an
+    ancestor-of/equal-to origin/main. Workspace builds (local dev iteration) are
+    exempt by design — they never reach prod.
+
+    Raises the guard's ``ProdLineageError`` when the source is dirty or
+    not promoted. Fails the build CLOSED before any docker build side effects.
+    """
+    if build_source != BuildSource.RELEASE:
+        return
+    guard = _load_promotion_guard()
+    sha = guard.assert_prod_build_promoted(Path(repo_dir))
+    logger.info(
+        "assert_release_build_promoted: release build source %s is clean and "
+        "promoted (HEAD %s is ancestor-of/equal-to origin/main)",
+        repo_dir,
+        sha[:12],
+    )
 
 
 class DigestMismatchError(RuntimeError):
@@ -926,6 +983,11 @@ class DeployExecutor:
 
         selected_source = _coerce_build_source(build_source, layer="deploy-agent")
         omni_home = os.environ.get("OMNI_HOME", "").strip()
+
+        # OMN-12626 (R1): release-mode builds produce the digest that is later
+        # pinned/promoted to prod. Refuse to build one from a dirty or
+        # non-promoted (dev-only) source tree before any docker side effects.
+        assert_release_build_promoted(selected_source)
 
         if selected_source == BuildSource.WORKSPACE:
             if not omni_home:

--- a/scripts/deploy-agent/pyproject.toml
+++ b/scripts/deploy-agent/pyproject.toml
@@ -16,7 +16,10 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-aiohttp>=1.0", "pyyaml>=6.
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-markers = ["unit: unit tests in isolation"]
+markers = [
+    "unit: unit tests in isolation",
+    "promotion_guard: test controls the prod promotion-lineage guard stub itself (OMN-12626)",
+]
 
 [tool.setuptools.packages.find]
 include = ["deploy_agent*"]

--- a/scripts/deploy-agent/tests/unit/conftest.py
+++ b/scripts/deploy-agent/tests/unit/conftest.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared fixtures for deploy-agent unit tests.
+
+OMN-12626 (R1): release-mode ``_compose_build`` now runs the prod
+promotion-lineage guard, which inspects the git state of ``REPO_DIR`` (a deploy
+HOST path that does not exist in the unit-test sandbox). Unit tests that
+exercise unrelated build-arg / staging concerns are not testing lineage, so by
+default the guard is stubbed to a no-op here.
+
+This is explicit and visible (not a hidden bypass): the guard's own behavior is
+covered by ``scripts/test_check_prod_promotion_lineage.py`` (the single source
+of truth), and ``test_executor_promotion_lineage.py`` re-stubs
+``_load_promotion_guard`` to assert the deploy-agent enforcement path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from deploy_agent import executor as executor_mod
+
+
+class _NoopPromotionGuard:
+    """No-op stand-in for the scripts/ promotion-lineage guard module."""
+
+    class ProdLineageError(RuntimeError):
+        pass
+
+    def assert_prod_build_promoted(self, repo_dir: Path) -> str:
+        return "0" * 40
+
+
+@pytest.fixture(autouse=True)
+def _stub_promotion_guard(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stub the promotion-lineage guard by default for deploy-agent unit tests.
+
+    Tests that explicitly verify the guard (marked by overriding
+    ``_load_promotion_guard`` themselves) opt out via the ``promotion_guard``
+    marker so they control the stub.
+    """
+    if request.node.get_closest_marker("promotion_guard") is not None:
+        return
+    monkeypatch.setattr(
+        executor_mod, "_load_promotion_guard", lambda: _NoopPromotionGuard()
+    )

--- a/scripts/deploy-agent/tests/unit/test_executor_promotion_lineage.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_promotion_lineage.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Prod promotion-lineage enforcement in deploy-agent builds (OMN-12626, R1).
+
+Release-mode builds produce the digest later pinned/promoted to prod. The
+deploy-agent must refuse to run a release-mode docker build from a dirty or
+non-promoted (dev-only) source tree. Workspace builds (local dev iteration) are
+exempt by design.
+
+These tests stub the guard module loaded from scripts/ so the deploy-agent
+behavior is verified without constructing a real git repo here (the guard's own
+behavior is covered by tests/scripts/test_check_prod_promotion_lineage.py).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from deploy_agent import executor as executor_mod
+from deploy_agent.events import BuildSource, Phase, PhaseStatus, Scope
+from deploy_agent.executor import DeployExecutor
+
+pytestmark = [pytest.mark.unit, pytest.mark.promotion_guard]
+
+
+def _noop_phase_update(phase: Phase, status: PhaseStatus) -> None:
+    pass
+
+
+def _ok() -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+class _GuardStub:
+    """Stand-in for the scripts/ guard module."""
+
+    class ProdLineageError(RuntimeError):
+        pass
+
+    def __init__(self, *, raises: bool) -> None:
+        self.calls: list[Path] = []
+        self._raises = raises
+
+    def assert_prod_build_promoted(self, repo_dir: Path) -> str:
+        self.calls.append(Path(repo_dir))
+        if self._raises:
+            raise self.ProdLineageError("dirty or non-promoted source tree")
+        return "0123456789abcdef0123456789abcdef01234567"
+
+
+def test_release_build_invokes_promotion_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard = _GuardStub(raises=False)
+    monkeypatch.setattr(executor_mod, "_load_promotion_guard", lambda: guard)
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        captured.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+    monkeypatch.delenv("OMNI_HOME", raising=False)
+
+    executor = DeployExecutor()
+    executor._compose_build(
+        Scope.RUNTIME,
+        "abc1234",
+        _noop_phase_update,
+        build_source=BuildSource.RELEASE,
+    )
+
+    # Guard ran on the build source repo, and the build proceeded.
+    assert guard.calls == [Path(executor_mod.REPO_DIR)]
+    assert any("build" in cmd for cmd in captured)
+
+
+def test_release_build_fails_closed_when_guard_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard = _GuardStub(raises=True)
+    monkeypatch.setattr(executor_mod, "_load_promotion_guard", lambda: guard)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+    monkeypatch.delenv("OMNI_HOME", raising=False)
+
+    executor = DeployExecutor()
+    with pytest.raises(_GuardStub.ProdLineageError):
+        executor._compose_build(
+            Scope.RUNTIME,
+            "abc1234",
+            _noop_phase_update,
+            build_source=BuildSource.RELEASE,
+        )
+
+    # No docker build ran — the guard fired before any side effect.
+    assert calls == []
+    assert guard.calls == [Path(executor_mod.REPO_DIR)]
+
+
+def test_workspace_build_skips_promotion_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard = _GuardStub(raises=True)  # would fail if invoked
+    monkeypatch.setattr(executor_mod, "_load_promotion_guard", lambda: guard)
+
+    def fake_run(cmd: list[str], timeout: int, **kwargs) -> subprocess.CompletedProcess:
+        return _ok()
+
+    monkeypatch.setattr("deploy_agent.executor._run", fake_run)
+    monkeypatch.setattr(
+        DeployExecutor, "_stage_workspace", staticmethod(lambda *_: None)
+    )
+    monkeypatch.setenv("OMNI_HOME", "/data/omninode/omni_home")
+
+    executor = DeployExecutor()
+    # Should NOT raise — workspace builds are exempt and never touch the guard.
+    executor._compose_build(
+        Scope.RUNTIME,
+        "abc1234",
+        _noop_phase_update,
+        build_source=BuildSource.WORKSPACE,
+    )
+    assert guard.calls == []
+
+
+def test_assert_release_build_promoted_is_noop_for_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard = _GuardStub(raises=True)
+    monkeypatch.setattr(executor_mod, "_load_promotion_guard", lambda: guard)
+    # No raise, no guard call for workspace.
+    executor_mod.assert_release_build_promoted(BuildSource.WORKSPACE)
+    assert guard.calls == []

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -88,6 +88,14 @@ DEPLOY_DIR_TO_CLEANUP=""
 # Default is hardcoded and safe; any changes must comply with ^[a-zA-Z0-9_-]+$ (see parse_args).
 COMPOSE_PROFILE="runtime"
 PRINT_COMPOSE_CMD=false
+# When true (--prod, or ONEX_DEPLOY_LANE=prod), the prod promotion-lineage guard
+# runs before any build: the source tree must be clean AND HEAD must be an
+# ancestor-of/equal-to origin/main. Prevents building the prod image from a
+# dirty or dev-only tree (OMN-12626, R1).
+PROD_LANE=false
+if [[ "${ONEX_DEPLOY_LANE:-}" == "prod" ]]; then
+    PROD_LANE=true
+fi
 # When --force overwrites an existing deployment, the previous directory is
 # moved here as a backup. On success the backup is removed; on failure
 # cleanup_on_exit() restores it.
@@ -147,6 +155,9 @@ OPTIONS
     --restart           Restart runtime containers after build (requires --execute).
     --profile <name>    Docker compose profile (default: runtime).
     --print-compose-cmd Print exact compose commands without executing, then exit.
+    --prod              Enforce the prod promotion-lineage guard before build:
+                        source tree must be clean AND HEAD an ancestor-of/equal-to
+                        origin/main. Also honored via ONEX_DEPLOY_LANE=prod.
     --help              Show this help message and exit.
 
 DEPLOYMENT ROOT
@@ -231,6 +242,10 @@ parse_args() {
                 ;;
             --print-compose-cmd)
                 PRINT_COMPOSE_CMD=true
+                shift
+                ;;
+            --prod)
+                PROD_LANE=true
                 shift
                 ;;
             --help|-h)
@@ -482,6 +497,55 @@ check_git_dirty() {
             log_warn "  Includes ${untracked_count} untracked file(s)."
         fi
     fi
+}
+
+guard_prod_promotion_lineage() {
+    # Fail-fast when building the prod lane from a dirty or non-promoted tree.
+    #
+    # Delegates to scripts/check_prod_promotion_lineage.py so the clean-tree +
+    # ancestor-of-origin/main lineage rules are enforced by a single, tested
+    # source of truth. Only runs when --prod / ONEX_DEPLOY_LANE=prod is set;
+    # non-prod lanes keep the advisory check_git_dirty warning (OMN-12626, R1).
+    local repo_root="$1"
+    if [[ "${PROD_LANE}" != true ]]; then
+        return 0
+    fi
+
+    log_step "Prod Promotion-Lineage Guard (OMN-12626)"
+
+    local guard="${repo_root}/scripts/check_prod_promotion_lineage.py"
+    if [[ ! -f "${guard}" ]]; then
+        log_error "Prod promotion-lineage guard not found: ${guard}"
+        log_error "Cannot build prod from an unverifiable source tree. Aborting."
+        exit 1
+    fi
+
+    # Prefer the repo venv, then uv, then system python3 — fail-fast if none run.
+    local python_bin=""
+    if [[ -x "${repo_root}/.venv/bin/python" ]]; then
+        python_bin="${repo_root}/.venv/bin/python"
+    elif command -v uv &>/dev/null; then
+        python_bin="uv-run"
+    elif command -v python3 &>/dev/null; then
+        python_bin="python3"
+    else
+        log_error "No Python interpreter available to run the prod lineage guard."
+        exit 1
+    fi
+
+    if [[ "${python_bin}" == "uv-run" ]]; then
+        if ! uv run --project "${repo_root}" python "${guard}" --repo "${repo_root}"; then
+            log_error "Prod promotion-lineage guard FAILED. Refusing to build prod."
+            exit 1
+        fi
+    else
+        if ! "${python_bin}" "${guard}" --repo "${repo_root}"; then
+            log_error "Prod promotion-lineage guard FAILED. Refusing to build prod."
+            exit 1
+        fi
+    fi
+
+    log_info "Prod promotion-lineage guard passed: source clean + promoted."
 }
 
 # =============================================================================
@@ -1504,6 +1568,11 @@ main() {
     log_info "Version: ${version}"
     log_info "Git SHA: ${git_sha}"
     check_git_dirty "${repo_root}"
+
+    # Prod lane: hard-fail on dirty/non-promoted source before any build/deploy.
+    # Runs in both dry-run and execute modes so operators see the rejection
+    # during preview, not after a build starts (OMN-12626, R1).
+    guard_prod_promotion_lineage "${repo_root}"
 
     # Compute paths
     local deploy_target="${DEPLOY_ROOT}/deployed/${version}"

--- a/tests/scripts/test_check_prod_promotion_lineage.py
+++ b/tests/scripts/test_check_prod_promotion_lineage.py
@@ -89,6 +89,11 @@ def _make_promoted_clone(tmp_path: Path) -> Path:
 
     clone = tmp_path / "clone"
     _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    # CI runners have no global git identity; set a deterministic committer in
+    # the clone so tests that create a new commit (dev-only / second) succeed.
+    _git(clone, "config", "user.email", "test@omninode.ai")
+    _git(clone, "config", "user.name", "Test Runner")
+    _git(clone, "config", "commit.gpgsign", "false")
     # Ensure origin/main is present in the clone's remote-tracking refs.
     _git(clone, "fetch", "-q", "origin", "main")
     return clone

--- a/tests/scripts/test_check_prod_promotion_lineage.py
+++ b/tests/scripts/test_check_prod_promotion_lineage.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/check_prod_promotion_lineage.py (OMN-12626, R1).
+
+The guard refuses to build/deploy the prod runtime image unless:
+  (a) the build source working tree is clean (no uncommitted/untracked edits),
+  (b) HEAD is an ancestor-of/equal-to origin/main (promoted lineage),
+  (c) the build bakes org.opencontainers.image.revision=<git sha> +
+      a build-provenance manifest, and
+  (d) the deployed image is tagged with that revision so
+      "prod == promoted main digest" is mechanically assertable.
+
+These tests construct real git repositories on disk (no mocking of git) so the
+lineage checks are exercised against real `git` behavior:
+
+  - a clean, promoted HEAD PASSES,
+  - a dirty tree FAILS,
+  - an untracked-file tree FAILS,
+  - a dev-only / non-promoted HEAD FAILS.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_prod_promotion_lineage.py"
+
+
+def _load_module() -> Any:
+    mod_name = "check_prod_promotion_lineage"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPT)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+_mod = _load_module()
+
+_GIT = shutil.which("git")
+pytestmark = pytest.mark.skipif(_GIT is None, reason="git binary not available")
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    """Initialise a git repo with deterministic identity and an initial commit."""
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@omninode.ai")
+    _git(repo, "config", "user.name", "Test Runner")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "file.txt").write_text("v1\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-q", "-m", "initial")
+
+
+def _make_promoted_clone(tmp_path: Path) -> Path:
+    """Return a clone whose HEAD == origin/main and whose tree is clean."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "-q", "--bare", "--initial-branch=main")
+
+    seed = tmp_path / "seed"
+    _init_repo(seed)
+    _git(seed, "branch", "-M", "main")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-q", "origin", "main")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    # Ensure origin/main is present in the clone's remote-tracking refs.
+    _git(clone, "fetch", "-q", "origin", "main")
+    return clone
+
+
+# ---------------------------------------------------------------------------
+# (a) clean tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_working_tree_clean_true_on_clean_clone(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    assert _mod.working_tree_clean(clone) is True
+
+
+@pytest.mark.unit
+def test_working_tree_clean_false_on_modified_tracked_file(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "file.txt").write_text("dirty\n", encoding="utf-8")
+    assert _mod.working_tree_clean(clone) is False
+
+
+@pytest.mark.unit
+def test_working_tree_clean_false_on_untracked_file(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "untracked.txt").write_text("new\n", encoding="utf-8")
+    assert _mod.working_tree_clean(clone) is False
+
+
+# ---------------------------------------------------------------------------
+# (b) promoted lineage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_head_is_promoted_true_when_head_equals_origin_main(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    assert _mod.head_is_promoted(clone) is True
+
+
+@pytest.mark.unit
+def test_head_is_promoted_false_for_dev_only_commit(tmp_path: Path) -> None:
+    """A commit that is not an ancestor of origin/main (dev-only) is rejected."""
+    clone = _make_promoted_clone(tmp_path)
+    # Create a dev-only commit on top of origin/main that was never promoted.
+    (clone / "dev_only.txt").write_text("unpromoted\n", encoding="utf-8")
+    _git(clone, "add", "dev_only.txt")
+    _git(clone, "commit", "-q", "-m", "dev-only work")
+    assert _mod.head_is_promoted(clone) is False
+
+
+@pytest.mark.unit
+def test_head_is_promoted_true_for_ancestor_of_origin_main(tmp_path: Path) -> None:
+    """An older commit that is a strict ancestor of origin/main is promoted."""
+    clone = _make_promoted_clone(tmp_path)
+    # Advance origin/main one commit, leave the clone checked out at the parent.
+    parent_sha = _git(clone, "rev-parse", "HEAD")
+    (clone / "file.txt").write_text("v2\n", encoding="utf-8")
+    _git(clone, "add", "file.txt")
+    _git(clone, "commit", "-q", "-m", "second")
+    _git(clone, "push", "-q", "origin", "HEAD:main")
+    _git(clone, "fetch", "-q", "origin", "main")
+    _git(clone, "checkout", "-q", parent_sha)
+    assert _mod.head_is_promoted(clone) is True
+
+
+# ---------------------------------------------------------------------------
+# (a)+(b) combined assertion — the real guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assert_prod_build_promoted_passes_on_clean_promoted_head(
+    tmp_path: Path,
+) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    sha = _mod.assert_prod_build_promoted(clone)
+    assert sha == _git(clone, "rev-parse", "HEAD")
+    assert len(sha) == 40
+
+
+@pytest.mark.unit
+def test_assert_prod_build_promoted_fails_on_dirty_tree(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "file.txt").write_text("dirty\n", encoding="utf-8")
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_prod_build_promoted(clone)
+    assert exc.value.reason == _mod.EnumProdLineageFailure.DIRTY_TREE
+
+
+@pytest.mark.unit
+def test_assert_prod_build_promoted_fails_on_untracked_file(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "untracked.txt").write_text("x\n", encoding="utf-8")
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_prod_build_promoted(clone)
+    assert exc.value.reason == _mod.EnumProdLineageFailure.DIRTY_TREE
+
+
+@pytest.mark.unit
+def test_assert_prod_build_promoted_fails_on_dev_only_head(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "dev_only.txt").write_text("unpromoted\n", encoding="utf-8")
+    _git(clone, "add", "dev_only.txt")
+    _git(clone, "commit", "-q", "-m", "dev-only work")
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_prod_build_promoted(clone)
+    assert exc.value.reason == _mod.EnumProdLineageFailure.NOT_PROMOTED
+
+
+@pytest.mark.unit
+def test_assert_prod_build_promoted_fails_when_origin_main_missing(
+    tmp_path: Path,
+) -> None:
+    """Fail-fast (not silent default) when origin/main cannot be resolved."""
+    repo = tmp_path / "no-remote"
+    _init_repo(repo)
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_prod_build_promoted(repo)
+    assert exc.value.reason == _mod.EnumProdLineageFailure.NO_PROMOTED_REF
+
+
+# ---------------------------------------------------------------------------
+# (c)+(d) image revision + provenance assertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_passes_when_label_equals_sha() -> None:
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    inspect = {
+        "Config": {
+            "Labels": {
+                "org.opencontainers.image.revision": sha,
+                "com.omninode.workspace_provenance_manifest": "/app/build-provenance.json",
+            }
+        }
+    }
+    # Should not raise.
+    _mod.assert_image_revision_matches(inspect, expected_sha=sha)
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_accepts_short_sha_prefix() -> None:
+    full = "0123456789abcdef0123456789abcdef01234567"
+    short = full[:12]
+    inspect = {
+        "Config": {
+            "Labels": {
+                "org.opencontainers.image.revision": short,
+                "com.omninode.workspace_provenance_manifest": "/app/build-provenance.json",
+            }
+        }
+    }
+    _mod.assert_image_revision_matches(inspect, expected_sha=full)
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_fails_on_empty_revision() -> None:
+    inspect = {"Config": {"Labels": {"org.opencontainers.image.revision": ""}}}
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_image_revision_matches(
+            inspect, expected_sha="0123456789abcdef0123456789abcdef01234567"
+        )
+    assert exc.value.reason == _mod.EnumProdLineageFailure.MISSING_REVISION
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_fails_on_unknown_sentinel() -> None:
+    inspect = {"Config": {"Labels": {"org.opencontainers.image.revision": "unknown"}}}
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_image_revision_matches(
+            inspect, expected_sha="0123456789abcdef0123456789abcdef01234567"
+        )
+    assert exc.value.reason == _mod.EnumProdLineageFailure.MISSING_REVISION
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_fails_on_mismatch() -> None:
+    inspect = {
+        "Config": {
+            "Labels": {
+                "org.opencontainers.image.revision": "ffffffffffffffffffffffffffffffffffffffff",
+                "com.omninode.workspace_provenance_manifest": "/app/build-provenance.json",
+            }
+        }
+    }
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_image_revision_matches(
+            inspect, expected_sha="0123456789abcdef0123456789abcdef01234567"
+        )
+    assert exc.value.reason == _mod.EnumProdLineageFailure.REVISION_MISMATCH
+
+
+@pytest.mark.unit
+def test_assert_image_revision_matches_fails_without_provenance_manifest() -> None:
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    inspect = {"Config": {"Labels": {"org.opencontainers.image.revision": sha}}}
+    with pytest.raises(_mod.ProdLineageError) as exc:
+        _mod.assert_image_revision_matches(inspect, expected_sha=sha)
+    assert exc.value.reason == _mod.EnumProdLineageFailure.MISSING_PROVENANCE
+
+
+# ---------------------------------------------------------------------------
+# build-arg emission (c) — the guard hands the build the revision + provenance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_promoted_build_args_bake_revision_and_provenance() -> None:
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    args = _mod.promoted_build_args(sha)
+    flat = " ".join(args)
+    # Dockerfile bakes org.opencontainers.image.revision from these args.
+    assert f"GIT_SHA={sha}" in flat
+    assert f"VCS_REF={sha}" in flat
+    assert f"RUNTIME_SOURCE_HASH={sha}" in flat
+    # build-args must come in --build-arg KEY=VALUE token pairs.
+    assert args.count("--build-arg") == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_exit_zero_on_clean_promoted_head(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    rc = _mod.main(["--repo", str(clone)])
+    assert rc == 0
+
+
+@pytest.mark.unit
+def test_cli_exit_nonzero_on_dirty_tree(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "file.txt").write_text("dirty\n", encoding="utf-8")
+    rc = _mod.main(["--repo", str(clone)])
+    assert rc != 0
+
+
+@pytest.mark.unit
+def test_cli_exit_nonzero_on_dev_only_head(tmp_path: Path) -> None:
+    clone = _make_promoted_clone(tmp_path)
+    (clone / "dev_only.txt").write_text("unpromoted\n", encoding="utf-8")
+    _git(clone, "add", "dev_only.txt")
+    _git(clone, "commit", "-q", "-m", "dev-only work")
+    rc = _mod.main(["--repo", str(clone)])
+    assert rc != 0

--- a/tests/scripts/test_deploy_runtime_prod_lineage.py
+++ b/tests/scripts/test_deploy_runtime_prod_lineage.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""deploy-runtime.sh must enforce the prod promotion-lineage guard (OMN-12626).
+
+Before OMN-12626, deploy-runtime.sh only `log_warn`ed on a dirty tree and had
+no promoted-lineage check, so it could build the prod image from a dirty or
+dev-only source clone. These tests assert the script:
+
+  - defines a guard_prod_promotion_lineage function,
+  - delegates to scripts/check_prod_promotion_lineage.py (single source of
+    truth for the clean-tree + ancestor-of-origin/main rules),
+  - hard-fails (exit 1) on guard failure rather than warning,
+  - exposes a --prod flag and honors ONEX_DEPLOY_LANE=prod,
+  - calls the guard from main().
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DEPLOY_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-runtime.sh"
+
+
+def _script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_defines_prod_lineage_guard_function() -> None:
+    text = _script_text()
+    assert re.search(r"^guard_prod_promotion_lineage\s*\(\)", text, re.MULTILINE), (
+        "deploy-runtime.sh must define guard_prod_promotion_lineage()"
+    )
+
+
+@pytest.mark.unit
+def test_delegates_to_promotion_lineage_script() -> None:
+    text = _script_text()
+    assert "scripts/check_prod_promotion_lineage.py" in text, (
+        "guard must delegate to scripts/check_prod_promotion_lineage.py"
+    )
+
+
+@pytest.mark.unit
+def test_guard_hard_fails_not_warns() -> None:
+    text = _script_text()
+    # The guard function must exit 1 on failure (not merely log_warn).
+    func_match = re.search(
+        r"guard_prod_promotion_lineage\s*\(\)\s*\{(.*?)\n\}",
+        text,
+        re.DOTALL,
+    )
+    assert func_match is not None
+    body = func_match.group(1)
+    assert "exit 1" in body, "prod lineage guard must hard-fail (exit 1) on failure"
+
+
+@pytest.mark.unit
+def test_exposes_prod_flag() -> None:
+    text = _script_text()
+    assert re.search(r"--prod\)", text), "deploy-runtime.sh must expose a --prod flag"
+
+
+@pytest.mark.unit
+def test_honors_onex_deploy_lane_env() -> None:
+    text = _script_text()
+    assert "ONEX_DEPLOY_LANE" in text, (
+        "deploy-runtime.sh must honor ONEX_DEPLOY_LANE=prod"
+    )
+
+
+@pytest.mark.unit
+def test_main_invokes_guard() -> None:
+    text = _script_text()
+    # The guard must be wired into the deployment flow, not just defined.
+    occurrences = text.count("guard_prod_promotion_lineage")
+    assert occurrences >= 2, (
+        "guard_prod_promotion_lineage must be defined AND called "
+        f"(found {occurrences} reference(s))"
+    )


### PR DESCRIPTION
Evidence-Source: 6ac09bd6967cf47e76b97e4da2b3d89a9f128d99
Evidence-Ticket: OMN-12626

## OMN-12626 (R1, High, Governance): pin prod runtime to a promoted main digest

Plan: docs/plans/2026-06-02-prod-runtime-stability-and-isolation-plan.md

### Problem
The promotion gate protects the `main` **branch**, but nothing pinned the prod runtime **image** to a promoted main digest. dev/stability 0.37.0 images already bake `build-provenance.json` + `org.opencontainers.image.revision`; prod's 0.36.1 image (built 2026-05-24) predated that and was built from a source clone 12 commits behind `origin/main` with dirty edits. The next rebuild would silently bake the dirty tree. "Prod == promoted main digest" was not mechanically guaranteed.

### Fix
New `scripts/check_prod_promotion_lineage.py` (mypy `--strict` clean) is a pre-build/deploy guard that refuses to build the prod-bound image unless:
- **(a)** the build source working tree is clean (no uncommitted/untracked edits),
- **(b)** HEAD is an ancestor-of/equal-to `origin/main` (promoted lineage) — dev-only or dirty trees are rejected,
- **(c)** the build bakes `org.opencontainers.image.revision=<git sha>` + a build-provenance manifest (the guard emits the `GIT_SHA`/`VCS_REF`/`RUNTIME_SOURCE_HASH` build args the Dockerfile already stamps into the revision label + `build-provenance.json`),
- **(d)** the deployed image carries that revision so `prod == promoted main digest` is assertable via `docker inspect`.

Fail-fast with structured `EnumProdLineageFailure` reasons; no silent default.

Wired into the prod build/deploy path:
- **deploy-agent `_compose_build`** — release-mode builds fail closed on a dirty/non-promoted source *before* any docker side effect.
- **`deploy-runtime.sh`** — `--prod` / `ONEX_DEPLOY_LANE=prod` runs the guard and hard-fails (replaces the prior advisory `log_warn`-only dirty check for prod).
- **CI** — `prod-promotion-lineage.yml`: a PR gate runs the guard unit tests; a reusable `lineage-check` job gates `build-and-push-runtime.yml` on `main`.
- **pre-commit** — runs the guard tests when the guard or deploy tooling changes.

### Scope guard
Build/deploy-tooling code only. **Does not rebuild or touch the live prod runtime.**

### dod_evidence
- `tests/scripts/test_check_prod_promotion_lineage.py` (21) — guard FAILS on dirty / untracked / dev-only / missing-origin-main; PASSES on clean promoted HEAD; image-revision + provenance assertions.
- `scripts/deploy-agent/tests/unit/test_executor_promotion_lineage.py` (4) — release builds fail closed when the guard rejects; workspace builds skip it.
- `tests/scripts/test_deploy_runtime_prod_lineage.py` (6) — deploy-runtime.sh defines + invokes the guard, delegates to the python guard, hard-fails, exposes `--prod`.
- Live-verified: clean+promoted PASS (exit 0); dev-only FAIL (exit 1 `not_promoted`); dirty FAIL (exit 1 `dirty_tree`).
- Green: deploy-agent suite 138 passed; `tests/scripts` 121 passed; `tests/unit/scripts` 472 passed; pre-commit on all staged files exit 0.

Paired OCC evidence: contract `contracts/OMN-12626.yaml` + hash-bound receipts (OMN-12586 -> OCC#2097 pattern).