### PR TITLE
fix(OMN-12632): adapt drain-proof lag observer to aiokafka 0.13.0 admin (no list_offsets)

### DIFF
--- a/src/omnibase_infra/migration/__init__.py
+++ b/src/omnibase_infra/migration/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Topic-migration runtime services (OMN-12623): lag observation + drain-proof gate."""
 
+from omnibase_infra.migration.adapter_kafka_admin_lag import AdapterKafkaAdminLag
 from omnibase_infra.migration.service_consumer_lag_observer import (
     ServiceConsumerLagObserver,
 )
@@ -11,6 +12,7 @@ from omnibase_infra.migration.service_drain_proof_gate import (
 )
 
 __all__ = [
+    "AdapterKafkaAdminLag",
     "ModelDrainProofDecision",
     "ServiceConsumerLagObserver",
     "ServiceDrainProofGate",

--- a/src/omnibase_infra/migration/adapter_kafka_admin_lag.py
+++ b/src/omnibase_infra/migration/adapter_kafka_admin_lag.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Admin adapter that supplies the lag surface aiokafka 0.13.0 omits (OMN-12632).
+
+The pinned ``aiokafka==0.13.0`` ``AIOKafkaAdminClient`` exposes
+``list_consumer_group_offsets`` but has **no** ``list_offsets`` method, so
+``ServiceConsumerLagObserver`` — which needs both committed offsets and
+per-partition log-end offsets — crashes with ``AttributeError`` against the real
+runtime admin. CI never caught it because the unit tests stubbed
+``list_offsets`` onto a fake admin (OMN-12623).
+
+This adapter satisfies the full :class:`ProtocolKafkaAdminLike` surface by
+delegating every committed-offset / group method to the real admin and serving
+``list_offsets`` (log-end / high-water marks) through an
+``AIOKafkaConsumer.end_offsets`` call, which *does* exist on 0.13.0. The observer
+is wired to this adapter rather than a raw ``AIOKafkaAdminClient``, so the lag
+path works against the pinned client.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from omnibase_infra.migration.protocols.protocol_kafka_lag_consumer import (
+        ProtocolKafkaLagConsumer,
+    )
+    from omnibase_infra.protocols.protocol_kafka_admin_like import (
+        ProtocolKafkaAdminLike,
+    )
+
+# aiokafka's log-end / high-water-mark request sentinel.
+_OFFSET_LATEST = -1
+
+
+class AdapterKafkaAdminLag:
+    """``ProtocolKafkaAdminLike`` over a real admin plus a consumer for log-end offsets.
+
+    Committed offsets and group lifecycle delegate to ``admin``; log-end offsets
+    (``list_offsets``) are served via ``consumer.end_offsets`` because the pinned
+    ``AIOKafkaAdminClient`` (0.13.0) has no ``list_offsets`` of its own.
+    """
+
+    def __init__(
+        self,
+        admin: ProtocolKafkaAdminLike,
+        consumer: ProtocolKafkaLagConsumer,
+    ) -> None:
+        self._admin = admin
+        self._consumer = consumer
+
+    async def start(self) -> None:
+        await self._admin.start()
+
+    async def stop(self) -> None:
+        await self._admin.stop()
+
+    async def close(self) -> None:
+        await self._admin.close()
+
+    async def list_consumer_groups(
+        self, broker_ids: Sequence[int] | None = None
+    ) -> Sequence[tuple[str, str | None]]:
+        return await self._admin.list_consumer_groups(broker_ids)
+
+    async def describe_consumer_groups(
+        self,
+        group_ids: Sequence[str],
+        group_coordinator_id: int | None = None,
+        include_authorized_operations: bool = False,
+    ) -> list[object]:
+        return await self._admin.describe_consumer_groups(
+            group_ids,
+            group_coordinator_id=group_coordinator_id,
+            include_authorized_operations=include_authorized_operations,
+        )
+
+    async def list_consumer_group_offsets(
+        self,
+        group_id: str,
+        group_coordinator_id: int | None = None,
+        partitions: Sequence[object] | None = None,
+    ) -> Mapping[object, object]:
+        return await self._admin.list_consumer_group_offsets(
+            group_id,
+            group_coordinator_id=group_coordinator_id,
+            partitions=partitions,
+        )
+
+    async def list_offsets(
+        self,
+        topic_partitions: Mapping[object, int],
+    ) -> Mapping[object, object]:
+        """Serve per-partition log-end offsets via the consumer's ``end_offsets``.
+
+        Only the high-water-mark request (``_OFFSET_LATEST``) is supported — that
+        is the sole shape :class:`ServiceConsumerLagObserver` issues. Any other
+        timestamp/offset target is rejected rather than silently mis-served,
+        because ``end_offsets`` cannot resolve arbitrary timestamps.
+        """
+        unsupported = [
+            tp for tp, target in topic_partitions.items() if target != _OFFSET_LATEST
+        ]
+        if unsupported:
+            raise ValueError(
+                "AdapterKafkaAdminLag.list_offsets only serves log-end "
+                f"(LATEST/{_OFFSET_LATEST}) requests via end_offsets; got "
+                f"non-LATEST targets for {unsupported!r}"
+            )
+        partitions = list(topic_partitions.keys())
+        return await self._consumer.end_offsets(partitions)
+
+
+__all__ = ["AdapterKafkaAdminLag"]

--- a/src/omnibase_infra/migration/protocols/__init__.py
+++ b/src/omnibase_infra/migration/protocols/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural protocols for the topic-migration lag surface (OMN-12632)."""
+
+from omnibase_infra.migration.protocols.protocol_kafka_lag_consumer import (
+    ProtocolKafkaLagConsumer,
+)
+
+__all__ = ["ProtocolKafkaLagConsumer"]

--- a/src/omnibase_infra/migration/protocols/protocol_kafka_lag_consumer.py
+++ b/src/omnibase_infra/migration/protocols/protocol_kafka_lag_consumer.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Minimal consumer protocol for log-end offset lookups (OMN-12632).
+
+Captures only the ``AIOKafkaConsumer.end_offsets`` surface that
+:class:`AdapterKafkaAdminLag` needs to serve ``list_offsets``. Declared
+structurally so the adapter avoids a hard ``aiokafka`` import at parse time and
+so tests can supply a fake mirroring the real 0.13.0 consumer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Protocol
+
+
+class ProtocolKafkaLagConsumer(Protocol):
+    """Subset of ``AIOKafkaConsumer`` used to read per-partition log-end offsets."""
+
+    async def end_offsets(self, partitions: Iterable[object]) -> Mapping[object, int]:
+        """Return the log-end (high-water-mark) offset for each TopicPartition."""
+        ...
+
+
+__all__ = ["ProtocolKafkaLagConsumer"]

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -107,6 +107,7 @@ _SENSITIVE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _STRICT_DISPATCHER_COVERAGE_ENV = "ONEX_STRICT_DISPATCHER_COVERAGE"
+_TOPIC_MIGRATION_EXECUTOR_DEPS = frozenset({"provisioner", "drain_proof_gate"})
 
 
 def _sanitize_exc(exc: BaseException) -> str:
@@ -1387,8 +1388,45 @@ def _should_skip_sync_container_resolution(handler_cls: type) -> bool:
     """
     required_params = _required_handler_init_params(handler_cls)
     return not required_params or required_params <= frozenset(
-        {"event_bus", "dispatch_port"}
+        {"event_bus", "dispatch_port", "provisioner", "drain_proof_gate"}
     )
+
+
+def _contracts_root_for_runtime_dependencies() -> Path:
+    raw = os.environ.get("ONEX_CONTRACTS_DIR")
+    if raw:
+        return Path(raw)
+    return Path(__file__).resolve().parents[2] / "nodes"
+
+
+def _build_topic_migration_executor_dependencies() -> dict[str, object]:
+    """Build concrete collaborators for HandlerTopicMigrationExecutor.
+
+    The handler declares these as required constructor services. Materializing
+    them here keeps generic resolver Step 2 deterministic while preserving the
+    handler's strict constructor contract.
+    """
+    from aiokafka import AIOKafkaAdminClient, AIOKafkaConsumer
+
+    from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+    from omnibase_infra.migration.adapter_kafka_admin_lag import AdapterKafkaAdminLag
+    from omnibase_infra.migration.service_consumer_lag_observer import (
+        ServiceConsumerLagObserver,
+    )
+    from omnibase_infra.migration.service_drain_proof_gate import ServiceDrainProofGate
+
+    bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]  # ONEX_EXCLUDE: env
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap_servers)
+    consumer = AIOKafkaConsumer(bootstrap_servers=bootstrap_servers)
+    lag_admin = AdapterKafkaAdminLag(admin, consumer)
+    observer = ServiceConsumerLagObserver(lag_admin)
+    return {
+        "provisioner": TopicProvisioner(
+            bootstrap_servers=bootstrap_servers,
+            contracts_root=_contracts_root_for_runtime_dependencies(),
+        ),
+        "drain_proof_gate": ServiceDrainProofGate(observer),
+    }
 
 
 def _handler_requires_delegation_dispatch_port(handler_cls: type) -> bool:
@@ -1437,11 +1475,6 @@ def _materialize_known_handler_dependencies(
     required_params = _required_handler_init_params(handler_cls)
     if not required_params and not requires_delegation_port:
         return materialized_explicit_dependencies
-    if not (
-        required_params.intersection({"container", "ownership_query", "dispatch_port"})
-        or ("dispatch_port" in constructor_params and requires_delegation_port)
-    ):
-        return materialized_explicit_dependencies
     available = {
         name: value
         for name, value in (
@@ -1451,6 +1484,14 @@ def _materialize_known_handler_dependencies(
         )
         if value is not None
     }
+    if required_params.issubset(_TOPIC_MIGRATION_EXECUTOR_DEPS):
+        available.update(_build_topic_migration_executor_dependencies())
+    if not (
+        required_params.intersection({"container", "ownership_query", "dispatch_port"})
+        or ("dispatch_port" in constructor_params and requires_delegation_port)
+        or required_params.issubset(_TOPIC_MIGRATION_EXECUTOR_DEPS)
+    ):
+        return materialized_explicit_dependencies
     if "dispatch_port" in constructor_params and requires_delegation_port:
         # Pure Kafka delegation chain (OMN-12294): the delegate-skill handler
         # dispatches via the Kafka-backed RuntimeDelegationDispatchPort. The

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1406,7 +1406,8 @@ def _build_topic_migration_executor_dependencies() -> dict[str, object]:
     them here keeps generic resolver Step 2 deterministic while preserving the
     handler's strict constructor contract.
     """
-    from aiokafka import AIOKafkaAdminClient, AIOKafkaConsumer
+    from aiokafka import AIOKafkaConsumer
+    from aiokafka.admin import AIOKafkaAdminClient
 
     from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
     from omnibase_infra.migration.adapter_kafka_admin_lag import AdapterKafkaAdminLag

--- a/tests/integration/envelope_routing/test_projection_topic_extraction.py
+++ b/tests/integration/envelope_routing/test_projection_topic_extraction.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Integration coverage for projection route topic extraction."""
 
 from __future__ import annotations

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -161,6 +161,10 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolKafkaReplayConsumer": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_replay_consumer.py",
     "ProtocolOffsetAndTimestamp": "nodes/node_kafka_replay_compute/protocols/protocol_offset_and_timestamp.py",
     "ProtocolTopicPartition": "nodes/node_kafka_replay_compute/protocols/protocol_topic_partition.py",
+    # [RUNTIME] OMN-12632 narrows the AIOKafkaConsumer.end_offsets surface so
+    # AdapterKafkaAdminLag can serve log-end offsets the pinned aiokafka 0.13.0
+    # admin omits, without a hard aiokafka import at parse time.
+    "ProtocolKafkaLagConsumer": "migration/protocols/protocol_kafka_lag_consumer.py",
     # [NODE] OMN-11573 narrows the GitHubHttpClient surface used by the PR
     # poller so handler tests can inject a deterministic triage adapter.
     "ProtocolGitHubTriageClient": "nodes/node_github_pr_poller_effect/handlers/handler_github_api_poll.py",

--- a/tests/unit/event_bus/test_kafka_config_api_version.py
+++ b/tests/unit/event_bus/test_kafka_config_api_version.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
 """Tests for EventBusKafka aiokafka API version configuration."""
 
 from __future__ import annotations

--- a/tests/unit/migration/test_consumer_group_lag.py
+++ b/tests/unit/migration/test_consumer_group_lag.py
@@ -19,6 +19,7 @@ from omnibase_core.models.contracts.model_topic_schema_binding import (
     ModelTopicSchemaBinding,
 )
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_infra.migration.adapter_kafka_admin_lag import AdapterKafkaAdminLag
 from omnibase_infra.migration.models.model_consumer_group_lag import (
     ModelConsumerGroupLag,
 )
@@ -59,15 +60,16 @@ class _FakeOffset:
 
 
 class _FakeAdmin:
-    """In-memory ProtocolKafkaAdminLike for committed/end offsets."""
+    """In-memory admin mirroring the aiokafka 0.13.0 surface.
 
-    def __init__(
-        self,
-        committed: dict[_FakeTopicPartition, int],
-        end: dict[_FakeTopicPartition, int],
-    ) -> None:
+    Intentionally has NO ``list_offsets`` — that method does not exist on the
+    pinned ``AIOKafkaAdminClient`` (OMN-12632). Stubbing it here was the masking
+    that hid the production crash; log-end offsets are served by the consumer via
+    :class:`AdapterKafkaAdminLag` instead.
+    """
+
+    def __init__(self, committed: dict[_FakeTopicPartition, int]) -> None:
         self._committed = committed
-        self._end = end
 
     async def start(self) -> None:  # pragma: no cover - protocol shape
         return None
@@ -87,8 +89,24 @@ class _FakeAdmin:
     async def list_consumer_group_offsets(self, group_id, **kwargs):
         return {tp: _FakeOffset(off) for tp, off in self._committed.items()}
 
-    async def list_offsets(self, topic_partitions):
-        return {tp: _FakeOffset(self._end[tp]) for tp in topic_partitions}
+
+class _FakeConsumer:
+    """In-memory consumer mirroring ``AIOKafkaConsumer.end_offsets`` (0.13.0)."""
+
+    def __init__(self, end: dict[_FakeTopicPartition, int]) -> None:
+        self._end = end
+
+    async def end_offsets(self, partitions):
+        return {tp: self._end[tp] for tp in partitions}
+
+
+def _observer(
+    committed: dict[_FakeTopicPartition, int],
+    end: dict[_FakeTopicPartition, int],
+) -> ServiceConsumerLagObserver:
+    """Build an observer over the adapter, mirroring the real wired surface."""
+    adapter = AdapterKafkaAdminLag(_FakeAdmin(committed), _FakeConsumer(end))
+    return ServiceConsumerLagObserver(adapter)
 
 
 def _binding(topic: str, major: int) -> ModelTopicSchemaBinding:
@@ -179,11 +197,10 @@ def test_group_lag_empty_is_not_drained() -> None:
 async def test_observer_computes_lag_from_committed_and_end() -> None:
     tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
     tp1 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 1)
-    admin = _FakeAdmin(
+    observer = _observer(
         committed={tp0: 10, tp1: 7},
         end={tp0: 10, tp1: 12},
     )
-    observer = ServiceConsumerLagObserver(admin)
     lag = await observer.observe("dev.orders.order-placed.consume.v1")
     assert lag.total_lag == 5
     assert lag.lag_for_topic("onex.evt.orders.order-placed.v1") == 5
@@ -192,8 +209,7 @@ async def test_observer_computes_lag_from_committed_and_end() -> None:
 @pytest.mark.asyncio
 async def test_observer_normalizes_negative_committed_to_zero() -> None:
     tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
-    admin = _FakeAdmin(committed={tp0: -1}, end={tp0: 4})
-    observer = ServiceConsumerLagObserver(admin)
+    observer = _observer(committed={tp0: -1}, end={tp0: 4})
     lag = await observer.observe("g")
     assert lag.total_lag == 4
 
@@ -206,8 +222,7 @@ async def test_observer_normalizes_negative_committed_to_zero() -> None:
 @pytest.mark.asyncio
 async def test_gate_blocks_retirement_while_lag_remains() -> None:
     tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
-    admin = _FakeAdmin(committed={tp0: 3}, end={tp0: 5})
-    gate = ServiceDrainProofGate(ServiceConsumerLagObserver(admin))
+    gate = ServiceDrainProofGate(_observer(committed={tp0: 3}, end={tp0: 5}))
     decision = await gate.evaluate(_migration_contract())
     assert decision.retirement_allowed is False
     assert decision.residual_lag == 2
@@ -216,8 +231,7 @@ async def test_gate_blocks_retirement_while_lag_remains() -> None:
 @pytest.mark.asyncio
 async def test_gate_allows_retirement_after_drain_proof() -> None:
     tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
-    admin = _FakeAdmin(committed={tp0: 5}, end={tp0: 5})
-    gate = ServiceDrainProofGate(ServiceConsumerLagObserver(admin))
+    gate = ServiceDrainProofGate(_observer(committed={tp0: 5}, end={tp0: 5}))
     decision = await gate.evaluate(_migration_contract())
     assert decision.retirement_allowed is True
     assert decision.residual_lag == 0
@@ -225,8 +239,7 @@ async def test_gate_allows_retirement_after_drain_proof() -> None:
 
 @pytest.mark.asyncio
 async def test_gate_blocks_when_no_offsets_observed() -> None:
-    admin = _FakeAdmin(committed={}, end={})
-    gate = ServiceDrainProofGate(ServiceConsumerLagObserver(admin))
+    gate = ServiceDrainProofGate(_observer(committed={}, end={}))
     decision = await gate.evaluate(_migration_contract())
     # Absence of evidence is not proof of drain.
     assert decision.retirement_allowed is False
@@ -237,8 +250,7 @@ async def test_gate_blocks_when_group_has_offsets_but_not_on_old_topic() -> None
     # The group commits offsets on an UNRELATED topic but nothing on old_topic.
     # Global non-emptiness must not be mistaken for old-topic drain proof.
     other = _FakeTopicPartition("onex.evt.orders.order-shipped.v1", 0)
-    admin = _FakeAdmin(committed={other: 5}, end={other: 5})
-    gate = ServiceDrainProofGate(ServiceConsumerLagObserver(admin))
+    gate = ServiceDrainProofGate(_observer(committed={other: 5}, end={other: 5}))
     decision = await gate.evaluate(_migration_contract())
     assert decision.retirement_allowed is False
     assert "no committed offsets" in decision.reason
@@ -246,8 +258,7 @@ async def test_gate_blocks_when_group_has_offsets_but_not_on_old_topic() -> None
 
 @pytest.mark.asyncio
 async def test_gate_allows_when_drain_proof_opted_out() -> None:
-    admin = _FakeAdmin(committed={}, end={})
-    gate = ServiceDrainProofGate(ServiceConsumerLagObserver(admin))
+    gate = ServiceDrainProofGate(_observer(committed={}, end={}))
     # An opt-out contract still requires OLD_TOPIC_DRAINED cutover criterion only
     # when drain_proof_required is True; build a valid opt-out contract.
     contract = ModelTopicMigrationContract(

--- a/tests/unit/migration/test_lag_adapter_list_offsets.py
+++ b/tests/unit/migration/test_lag_adapter_list_offsets.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression: lag observation against the real aiokafka 0.13.0 admin surface (OMN-12632).
+
+The merged OMN-12623 unit tests stubbed ``list_offsets`` onto a fake admin, which
+masked the production crash: ``aiokafka==0.13.0``'s ``AIOKafkaAdminClient`` has
+**no** ``list_offsets`` method, so ``ServiceConsumerLagObserver.observe`` raised
+``AttributeError`` against the real runtime admin (found by the live .201 proof of
+OMN-12623).
+
+These tests deliberately use a fake admin that mirrors the 0.13.0 surface —
+``list_consumer_group_offsets`` exists, ``list_offsets`` does **not** — so the
+missing method cannot be hidden. ``test_observer_crashes_on_raw_0_13_0_admin``
+pins the buggy behavior; the remaining tests prove :class:`AdapterKafkaAdminLag`
+restores lag observation by serving log-end offsets through the consumer's
+``end_offsets`` (which 0.13.0 *does* provide).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.migration.adapter_kafka_admin_lag import AdapterKafkaAdminLag
+from omnibase_infra.migration.service_consumer_lag_observer import (
+    ServiceConsumerLagObserver,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTopicPartition:
+    """TopicPartition-like key with .topic/.partition, hashable."""
+
+    def __init__(self, topic: str, partition: int) -> None:
+        self.topic = topic
+        self.partition = partition
+
+    def __hash__(self) -> int:
+        return hash((self.topic, self.partition))
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, _FakeTopicPartition)
+            and other.topic == self.topic
+            and other.partition == self.partition
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"_FakeTopicPartition({self.topic!r}, {self.partition})"
+
+
+class _FakeOffsetAndMetadata:
+    """Committed-offset value exposing .offset, as the real admin returns."""
+
+    def __init__(self, offset: int) -> None:
+        self.offset = offset
+
+
+class _FakeAiokafka0130Admin:
+    """Mirrors the aiokafka 0.13.0 admin surface: it has NO ``list_offsets``.
+
+    Crucially this class does not define ``list_offsets`` — attribute access for
+    it raises ``AttributeError`` exactly like the pinned ``AIOKafkaAdminClient``,
+    so any code that calls ``admin.list_offsets`` is provably broken.
+    """
+
+    def __init__(self, committed: dict[_FakeTopicPartition, int]) -> None:
+        self._committed = committed
+
+    async def start(self) -> None:  # pragma: no cover - protocol shape
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover
+        return None
+
+    async def close(self) -> None:  # pragma: no cover
+        return None
+
+    async def list_consumer_groups(self, broker_ids=None):  # pragma: no cover
+        return []
+
+    async def describe_consumer_groups(self, group_ids, **kwargs):  # pragma: no cover
+        return []
+
+    async def list_consumer_group_offsets(self, group_id, **kwargs):
+        return {tp: _FakeOffsetAndMetadata(off) for tp, off in self._committed.items()}
+
+
+class _FakeAiokafka0130Consumer:
+    """Mirrors the aiokafka 0.13.0 consumer surface: ``end_offsets`` returns ints."""
+
+    def __init__(self, end: dict[_FakeTopicPartition, int]) -> None:
+        self._end = end
+        self.requested: list[_FakeTopicPartition] | None = None
+
+    async def end_offsets(self, partitions):
+        self.requested = list(partitions)
+        return {tp: self._end[tp] for tp in self.requested}
+
+
+@pytest.mark.asyncio
+async def test_observer_crashes_on_raw_0_13_0_admin() -> None:
+    """The pre-fix wiring (observer over a raw 0.13.0 admin) must crash.
+
+    This is the regression the merged tests masked by stubbing ``list_offsets``.
+    Without that stub, ``observe`` hits the missing method.
+    """
+    tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
+    admin = _FakeAiokafka0130Admin(committed={tp0: 3})
+    observer = ServiceConsumerLagObserver(admin)
+    with pytest.raises(AttributeError, match="list_offsets"):
+        await observer.observe("dev.orders.order-placed.consume.v1")
+
+
+@pytest.mark.asyncio
+async def test_adapter_serves_lag_via_consumer_end_offsets() -> None:
+    """Observer wired to the adapter computes lag against the 0.13.0 surface."""
+    tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
+    tp1 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 1)
+    admin = _FakeAiokafka0130Admin(committed={tp0: 10, tp1: 7})
+    consumer = _FakeAiokafka0130Consumer(end={tp0: 10, tp1: 12})
+
+    adapter = AdapterKafkaAdminLag(admin, consumer)
+    observer = ServiceConsumerLagObserver(adapter)
+    lag = await observer.observe("dev.orders.order-placed.consume.v1")
+
+    assert lag.total_lag == 5
+    assert lag.lag_for_topic("onex.evt.orders.order-placed.v1") == 5
+    # The adapter must query log-end for exactly the committed partitions.
+    assert consumer.requested is not None
+    assert set(consumer.requested) == {tp0, tp1}
+
+
+@pytest.mark.asyncio
+async def test_adapter_committed_offsets_delegate_to_real_admin() -> None:
+    """Committed offsets stay on the admin's ``list_consumer_group_offsets``."""
+    tp0 = _FakeTopicPartition("onex.evt.orders.order-placed.v1", 0)
+    admin = _FakeAiokafka0130Admin(committed={tp0: 4})
+    consumer = _FakeAiokafka0130Consumer(end={tp0: 9})
+
+    adapter = AdapterKafkaAdminLag(admin, consumer)
+    committed = await adapter.list_consumer_group_offsets("g")
+    assert committed[tp0].offset == 4
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_non_latest_offset_request() -> None:
+    """Only the LATEST (log-end) request shape is serviceable via end_offsets."""
+    tp0 = _FakeTopicPartition("t.v1", 0)
+    admin = _FakeAiokafka0130Admin(committed={tp0: 0})
+    consumer = _FakeAiokafka0130Consumer(end={tp0: 0})
+
+    adapter = AdapterKafkaAdminLag(admin, consumer)
+    with pytest.raises(ValueError, match="LATEST"):
+        await adapter.list_offsets({tp0: 12345})

--- a/tests/unit/nodes/node_dlq_replay_effect/__init__.py
+++ b/tests/unit/nodes/node_dlq_replay_effect/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/test_handler_wiring_resolver_integration.py
+++ b/tests/unit/runtime/test_handler_wiring_resolver_integration.py
@@ -309,6 +309,59 @@ class TestPrepareHandlerWiringDelegatesToResolver:
         )
 
     @pytest.mark.unit
+    def test_topic_migration_executor_deps_materialized(self) -> None:
+        """Runtime materializes topic-migration executor collaborators."""
+        contract = _make_contract(handler_name="HandlerTopicMigrationExecutor")
+        entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
+
+        class HandlerTopicMigrationExecutor:
+            def __init__(self, provisioner: object, drain_proof_gate: object) -> None:
+                self.provisioner = provisioner
+                self.drain_proof_gate = drain_proof_gate
+
+            async def handle(self, envelope: object) -> None:
+                return None
+
+        fake_provisioner = object()
+        fake_gate = object()
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+
+        with (
+            patch(
+                "omnibase_infra.runtime.auto_wiring.handler_wiring."
+                "_import_handler_class",
+                return_value=HandlerTopicMigrationExecutor,
+            ),
+            patch(
+                "omnibase_infra.runtime.auto_wiring.handler_wiring."
+                "_build_topic_migration_executor_dependencies",
+                return_value={
+                    "provisioner": fake_provisioner,
+                    "drain_proof_gate": fake_gate,
+                },
+            ),
+        ):
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+
+        assert prepared.is_skip is False
+        assert (
+            prepared.resolution_outcome
+            is EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
+        )
+        assert prepared.dispatcher is not None
+
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_wire_from_manifest_threads_materialized_deps_to_resolver(
         self,

--- a/tests/unit/runtime/test_handler_wiring_resolver_integration.py
+++ b/tests/unit/runtime/test_handler_wiring_resolver_integration.py
@@ -42,6 +42,7 @@ from omnibase_core.services.service_local_handler_ownership_query import (
 )
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _assert_is_ownership_query,
+    _build_topic_migration_executor_dependencies,
     _prepare_handler_wiring,
     wire_from_manifest,
 )
@@ -360,6 +361,23 @@ class TestPrepareHandlerWiringDelegatesToResolver:
             is EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
         )
         assert prepared.dispatcher is not None
+
+    @pytest.mark.unit
+    def test_topic_migration_executor_builder_uses_admin_namespace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned aiokafka exposes AIOKafkaAdminClient from aiokafka.admin."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+        with (
+            patch("aiokafka.admin.AIOKafkaAdminClient") as admin_cls,
+            patch("aiokafka.AIOKafkaConsumer") as consumer_cls,
+        ):
+            deps = _build_topic_migration_executor_dependencies()
+
+        admin_cls.assert_called_once_with(bootstrap_servers="localhost:9092")
+        consumer_cls.assert_called_once_with(bootstrap_servers="localhost:9092")
+        assert set(deps) == {"provisioner", "drain_proof_gate"}
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## OMN-12632 — drain-proof lag observation crashes on aiokafka 0.13.0

Epic OMN-12618. Follow-up to OMN-12623, found by its live .201 stability-test proof (2026-06-03).

### Bug
`ServiceConsumerLagObserver.observe()` calls `admin.list_offsets(...)` (declared on `ProtocolKafkaAdminLike`), but the pinned `aiokafka==0.13.0` `AIOKafkaAdminClient` has **no** `list_offsets` method. Against the real runtime admin the drain-proof gate raised:

```
AttributeError: 'AIOKafkaAdminClient' object has no attribute 'list_offsets'
```

So the lag/drain-proof gate — the largest net-new piece of OMN-12623 — was **non-functional in the deployed runtime**. CI missed it because the admin client was **mocked**, and the fake admin stubbed `list_offsets` into existence. (0.13.0 also lacks `delete_consumer_groups`.)

Verified surface on the pinned client:
```
admin has list_offsets: False
admin has list_consumer_group_offsets: True
consumer has end_offsets: True
```

### Current vs target
- **Current:** drain-proof gate crashes on the first live `observe()` against `AIOKafkaAdminClient` 0.13.0.
- **Target:** lag observation works against the real pinned client, with a test that would have caught it.

### Fix (lower-risk adapter, no aiokafka bump)
- `src/omnibase_infra/migration/adapter_kafka_admin_lag.py` — `AdapterKafkaAdminLag` implements the full `ProtocolKafkaAdminLike` surface. Committed offsets delegate to the real admin's `list_consumer_group_offsets`; per-partition log-end offsets (`list_offsets`) are served via `AIOKafkaConsumer.end_offsets()` (which 0.13.0 provides). Non-LATEST offset requests are rejected, not silently mis-served.
- `ServiceConsumerLagObserver` is constructed over the adapter, **never** a raw `AIOKafkaAdminClient`.
- `src/omnibase_infra/migration/protocols/protocol_kafka_lag_consumer.py` — minimal `ProtocolKafkaLagConsumer` (just `end_offsets`), registered in the protocol-ownership allowlist.

### TDD — failing-before captured
New regression test `tests/unit/migration/test_lag_adapter_list_offsets.py` exercises `observe()` against a fake mirroring the real 0.13.0 surface (admin has `list_consumer_group_offsets` but **NO** `list_offsets`; consumer has `end_offsets`).

Failing-before (production crash reproduced against the real pinned surface):
```
aiokafka admin has list_offsets: False
RawAdmin (0.13.0-shaped) has list_offsets: False
FAILING-BEFORE AttributeError: 'RawAdmin' object has no attribute 'list_offsets'
```

Passing-after:
```
tests/unit/migration/test_lag_adapter_list_offsets.py ....  [4 passed]
```

The OMN-12623 migration tests (`tests/unit/migration/test_consumer_group_lag.py`) were refactored to **drop the `list_offsets` stub that masked the bug**, routing log-end offsets through a fake consumer via the adapter instead.

### dod_evidence
- Unit suite: `uv run pytest tests/unit/ -n auto -q` → `20120 passed, 15 skipped`. The one failure is the pre-existing ONEX Node Migration Vendor Sync drift against the locally-checked-out omnimarket clone (this PR touches zero files under `docker/migrations/`; CI vendors from the pinned source).
- Migration regression suite: `16 passed` (incl. `test_observer_crashes_on_raw_0_13_0_admin`).
- `uv run mypy src/omnibase_infra/migration/ --strict` → clean.
- ruff format + check pass; pre-commit passes for the committed files.
- Live .201 stability-test lag re-proof: **PENDING operator-approved .201 run** (HARD GATE — no .201 redeploy/restart performed). Method recorded in the OCC receipt `dod-live-lag-reproof-method`.
- Live integration evidence (T4): `omni_home/docs/tracking/2026-06-03-omn12618-live-integration-evidence.md`.

Evidence-Source: OCC#2114
Evidence-Ticket: OMN-12632