### PR TITLE
fix(OMN-12627): vendor registration projection migrations

### DIFF
--- a/contracts/OMN-12627.yaml
+++ b/contracts/OMN-12627.yaml
@@ -1,0 +1,48 @@
+# OMN-12627 contract file for omnibase_infra deploy-gate.
+schema_version: "1.0.0"
+ticket_id: OMN-12627
+title: "Vendor node_service_registry owner migrations into the infra forward set"
+summary: >
+  Adds omnimarket node_projection_registration to the node-owned migration
+  allowlist and vendors its idempotent node_service_registry migrations into
+  docker/migrations/forward/nodes/. The forward migration runner applies these
+  under canonical namespaced ids node:node_projection_registration:<file>, so a
+  clean runtime/migration image can create the missing prod table without an
+  undocumented hand-created table.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Unit tests prove node_projection_registration migrations are vendored and selected by the sync allowlist."
+    command: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket uv run pytest tests/unit/migrations/test_node_migration_discovery.py -q"
+  - kind: ci
+    description: "Vendored node migrations stay in sync with omnimarket source."
+    command: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - kind: manual
+    description: "Prod DB apply remains gated; this PR only makes the canonical migration path available."
+    command: "deploy-gate: no prod DB mutation or runtime redeploy performed by this PR; apply node:node_projection_registration:* via the approved lane migration runner during the gated runtime sync window"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-registration-vendor-test
+    description: "Focused unit test verifies node_projection_registration migrations are vendored and allowlisted."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket uv run pytest tests/unit/migrations/test_node_migration_discovery.py -q"
+  - id: dod-vendor-sync
+    description: "Vendored node migration tree is in sync with the omnimarket source tree."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - id: dod-no-prod-mutation
+    description: "The autonomous PR does not mutate prod; prod table creation is deferred to the approved migration/deploy window."
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy-gate: no prod DB mutation or runtime redeploy performed by this PR; gated apply will record schema_migrations rows for node:node_projection_registration:0000_create_node_service_registry.sql and node:node_projection_registration:0001_add_heartbeat_columns.sql"

--- a/docker/migrations/forward/nodes/.synced-nodes
+++ b/docker/migrations/forward/nodes/.synced-nodes
@@ -18,3 +18,7 @@ node_projection_delegation
 # Savings dashboard read view only. The savings_estimates base table is already
 # owned by infra's flat migration 074; we vendor just the OMN-12489 view here.
 node_projection_savings:076_*
+
+# Registration projection read model. Prod currently lacks node_service_registry;
+# vendor the node-owned, idempotent migrations so the forward runner owns the fix.
+node_projection_registration

--- a/docker/migrations/forward/nodes/node_projection_delegation/0011_delegation_event_projection_versions.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0011_delegation_event_projection_versions.sql
@@ -1,0 +1,11 @@
+-- OMN-12606: stamp materializer provenance on delegation_events rows.
+--
+-- The reducer/orchestrator completion path materializes a fresh terminal
+-- delegation event directly into delegation_events (no operator backfill,
+-- May 31 finding). Each materialized row records the projection schema
+-- contract version and the reducer logic version so the proof packet can
+-- attribute a fresh row to a known materializer (OMN-12488 acceptance-extension).
+
+ALTER TABLE delegation_events
+    ADD COLUMN IF NOT EXISTS projection_version TEXT NOT NULL DEFAULT '1.0.0',
+    ADD COLUMN IF NOT EXISTS reducer_version TEXT NOT NULL DEFAULT '1.0.0';

--- a/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
+++ b/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
@@ -1,0 +1,29 @@
+-- OMN-10079: Create the node registration projection table.
+-- OMN-11012 ownership: omnimarket.nodes.node_projection_registration is the
+-- DDL owner for node_service_registry. Do not add a duplicate CREATE TABLE
+-- migration for this table in omnibase_infra.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS node_service_registry (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_name TEXT UNIQUE NOT NULL,
+  service_url TEXT NOT NULL DEFAULT '',
+  service_type TEXT,
+  health_status TEXT DEFAULT 'unknown',
+  last_health_check TIMESTAMPTZ,
+  last_heartbeat_at TIMESTAMPTZ,
+  uptime_seconds BIGINT DEFAULT 0,
+  health_check_interval_seconds INT DEFAULT 60,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  projected_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_health_status
+  ON node_service_registry (health_status);
+
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_last_heartbeat_at
+  ON node_service_registry (last_heartbeat_at);

--- a/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
+++ b/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS node_service_registry (
   health_status TEXT DEFAULT 'unknown',
   last_health_check TIMESTAMPTZ,
   last_heartbeat_at TIMESTAMPTZ,
-  uptime_seconds BIGINT DEFAULT 0,
+  uptime_seconds BIGINT NOT NULL DEFAULT 0,
   health_check_interval_seconds INT DEFAULT 60,
   metadata JSONB DEFAULT '{}'::jsonb,
   is_active BOOLEAN DEFAULT true,

--- a/docker/migrations/forward/nodes/node_projection_registration/0001_add_heartbeat_columns.sql
+++ b/docker/migrations/forward/nodes/node_projection_registration/0001_add_heartbeat_columns.sql
@@ -1,0 +1,19 @@
+-- OMN-8693: Add last_heartbeat_at and uptime_seconds columns to node_service_registry.
+--
+-- last_heartbeat_at: updated on every periodic heartbeat event (every 60s per node)
+-- uptime_seconds:    node uptime reported by the heartbeat emitter
+-- health_status now supports 'stale' in addition to healthy/degraded/unhealthy/unknown
+
+ALTER TABLE node_service_registry
+  ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS uptime_seconds BIGINT NOT NULL DEFAULT 0;
+
+-- Backfill: treat existing rows' last_health_check as the initial heartbeat time
+UPDATE node_service_registry
+SET last_heartbeat_at = last_health_check
+WHERE last_heartbeat_at IS NULL
+  AND last_health_check IS NOT NULL;
+
+-- Create index for stale-detection queries (WHERE last_heartbeat_at < NOW() - INTERVAL '5 min')
+CREATE INDEX IF NOT EXISTS idx_node_service_registry_last_heartbeat_at
+  ON node_service_registry (last_heartbeat_at);

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -44,6 +44,12 @@ SAVINGS_VIEW = (
     / "node_projection_savings"
     / "076_create_delegation_savings_projection_view.sql"
 )
+REGISTRATION_CREATE = (
+    NODES_DIR / "node_projection_registration" / "0000_create_node_service_registry.sql"
+)
+REGISTRATION_HEARTBEAT = (
+    NODES_DIR / "node_projection_registration" / "0001_add_heartbeat_columns.sql"
+)
 
 pytestmark = pytest.mark.unit
 
@@ -81,6 +87,23 @@ class TestVendoredViewMigrations:
         assert "0008_generation_events.sql" in files
         assert "0010_create_delegation_dashboard_projection_views.sql" in files
 
+    def test_registration_projection_migrations_vendored(self) -> None:
+        """The node_service_registry owner migrations are vendored durably."""
+        assert REGISTRATION_CREATE.is_file(), (
+            "node_service_registry create migration must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_registration/"
+        )
+        assert REGISTRATION_HEARTBEAT.is_file(), (
+            "node_service_registry heartbeat-column migration must be vendored "
+            "beside the create migration"
+        )
+
+        create_sql = REGISTRATION_CREATE.read_text(encoding="utf-8")
+        heartbeat_sql = REGISTRATION_HEARTBEAT.read_text(encoding="utf-8")
+        assert "CREATE TABLE IF NOT EXISTS node_service_registry" in create_sql
+        assert "ADD COLUMN IF NOT EXISTS last_heartbeat_at" in heartbeat_sql
+        assert "ADD COLUMN IF NOT EXISTS uptime_seconds" in heartbeat_sql
+
 
 class TestNamespacedDiscoveryWiring:
     """run-forward-migrations.sh applies node migrations under namespaced ids."""
@@ -115,6 +138,7 @@ class TestSyncedNodesAllowlist:
         content = SYNCED_NODES.read_text(encoding="utf-8")
         assert "node_projection_delegation" in content
         assert "node_projection_savings" in content
+        assert "node_projection_registration" in content
 
 
 def _resolve_omnimarket_src() -> Path | None:

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -101,6 +101,7 @@ class TestVendoredViewMigrations:
         create_sql = REGISTRATION_CREATE.read_text(encoding="utf-8")
         heartbeat_sql = REGISTRATION_HEARTBEAT.read_text(encoding="utf-8")
         assert "CREATE TABLE IF NOT EXISTS node_service_registry" in create_sql
+        assert "uptime_seconds BIGINT NOT NULL DEFAULT 0" in create_sql
         assert "ADD COLUMN IF NOT EXISTS last_heartbeat_at" in heartbeat_sql
         assert "ADD COLUMN IF NOT EXISTS uptime_seconds" in heartbeat_sql
 


### PR DESCRIPTION
## Summary

Vendors the `node_projection_registration` node-owned migrations into `omnibase_infra`'s namespaced forward-migration tree so `node_service_registry` is created through the canonical migration runner instead of an undocumented table hand-create.

This is OMN-12627 Facet A only. The prod DB apply remains gated and is handled during the approved runtime sync window.

## Changes

- Adds `node_projection_registration` to `docker/migrations/forward/nodes/.synced-nodes`
- Vendors:
  - `node_projection_registration/0000_create_node_service_registry.sql`
  - `node_projection_registration/0001_add_heartbeat_columns.sql`
- Hardens the vendored clean-create schema so `uptime_seconds` is created `NOT NULL DEFAULT 0`, matching the heartbeat migration intent
- Resyncs existing allowlisted delegation projection drift: `node_projection_delegation/0011_delegation_event_projection_versions.sql`
- Pins unit assertions for the registration migration vendoring path
- Adds repo-local deploy/evidence contract `contracts/OMN-12627.yaml`

## Verification

- `uv run pytest tests/unit/migrations/test_node_migration_discovery.py tests/integration/test_auto_wiring_real_manifest.py::test_real_manifest_wiring_has_no_failures tests/integration/runtime/test_runtime_boot_clean.py::test_wire_from_manifest_main_profile_no_crash -q` -> 10 passed, 1 skipped
- `uv run ruff format --check tests/unit/migrations/test_node_migration_discovery.py tests/unit/runtime/test_handler_wiring_resolver_integration.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py`
- `uv run ruff check tests/unit/migrations/test_node_migration_discovery.py tests/unit/runtime/test_handler_wiring_resolver_integration.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py`

Evidence-Ticket: OMN-12627
Evidence-Source: OCC#2115