### PR TITLE
auto-ship(omnibase_infra): rescue uncommitted changes [omnibase_infra]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -137,7 +137,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 20
 
@@ -214,7 +214,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -235,7 +235,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -267,7 +267,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -300,7 +300,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 5
 
@@ -323,7 +323,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -356,7 +356,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -400,7 +400,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # The drift scan is short, but self-hosted post-job cache/archive cleanup
     # has exceeded 5 minutes under runner pressure.
@@ -470,7 +470,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 45
 
@@ -582,7 +582,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -614,7 +614,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
 
@@ -646,7 +646,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -678,7 +678,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - uses: actions/checkout@v6
@@ -724,7 +724,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
@@ -763,7 +763,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     outputs:
       is_full_suite: ${{ steps.detect.outputs.is_full_suite }}
@@ -847,7 +847,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 15
     strategy:
@@ -929,7 +929,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -991,7 +991,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
@@ -1050,7 +1050,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     needs: [test-parallel, detect-changes]
     if: always()
@@ -1082,7 +1082,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@main
@@ -1102,7 +1102,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 20
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
@@ -1173,7 +1173,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     # OMN-9120: runtime-boot-smoke runs as an advisory check during the compose-mode
     # boot stabilization period. It is intentionally NOT in `needs` so a smoke-test
@@ -1273,7 +1273,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 45
 
@@ -1376,7 +1376,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - uses: actions/checkout@v6
@@ -1406,7 +1406,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
     services:
@@ -1573,7 +1573,7 @@ jobs:
         (github.event_name == 'pull_request' &&
          github.event.pull_request.head.repo.full_name != github.repository)
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -83,7 +83,6 @@ jobs:
       ONEX_EVENT_BUS_TYPE: "kafka"
       POSTGRES_DATABASE: "omnibase_infra"
       LLM_ENDPOINT_CIDR_ALLOWLIST: "10.0.0.0/8"
-      DOCKER_COMPOSE_VERSION: "v2.40.3"
 
     steps:
       - name: Validate mode input
@@ -148,23 +147,6 @@ jobs:
           # rpk is executed via `docker exec` against the compose-managed
           # omnibase-infra-redpanda container, so a host-level rpk install is
           # unnecessary in compose mode.
-
-      - name: Install Docker Compose plugin (compose mode)
-        if: inputs.mode == 'compose'
-        run: |
-          set -euo pipefail
-          if docker compose version >/dev/null 2>&1; then
-            docker compose version
-            exit 0
-          fi
-
-          plugin_dir="${HOME}/.docker/cli-plugins"
-          mkdir -p "${plugin_dir}"
-          curl -fsSL \
-            "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
-            -o "${plugin_dir}/docker-compose"
-          chmod +x "${plugin_dir}/docker-compose"
-          docker compose version
 
       - name: Resolve Docker Compose command
         if: inputs.mode == 'compose'
@@ -245,28 +227,6 @@ jobs:
           REDPANDA_PANDAPROXY_PORT="${REDPANDA_PANDAPROXY_PORT}" \
             "${compose_cmd[@]}" -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml up -d postgres redpanda
 
-          capture_compose_infra_diagnostics() {
-            {
-              echo "== docker compose ps =="
-              "${compose_cmd[@]}" -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml ps || true
-              echo
-              echo "== postgres inspect health =="
-              docker inspect --format '{{json .State.Health}}' "${OMNIBASE_INFRA_POSTGRES_CONTAINER}" || true
-              echo
-              echo "== redpanda inspect health =="
-              docker inspect --format '{{json .State.Health}}' "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" || true
-              echo
-              echo "== redpanda cluster health =="
-              docker exec "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" rpk cluster health --brokers redpanda:9092 || true
-              echo
-              echo "== redpanda cluster info =="
-              docker exec "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" rpk cluster info --brokers redpanda:9092 || true
-              echo
-              echo "== redpanda logs tail =="
-              docker logs --tail 200 "${OMNIBASE_INFRA_REDPANDA_CONTAINER}" || true
-            } > compose_infra_diagnostics.txt 2>&1 || true
-          }
-
           # Self-hosted CI runners run inside Docker containers that share the
           # host Docker daemon via /var/run/docker.sock. Port bindings on the
           # host (localhost:$POSTGRES_PORT, localhost:$KAFKA_PORT) are NOT reachable from the
@@ -300,7 +260,7 @@ jobs:
           # Redpanda's single-node dev-container can keep `rpk cluster health`
           # false longer than the broker API is unavailable; runtime boot only
           # needs Kafka API reachability, so probe topic listing explicitly.
-          for i in $(seq 1 150); do
+          for i in $(seq 1 90); do
             pg_ok=false
             kafka_ok=false
             if docker exec "${OMNIBASE_INFRA_POSTGRES_CONTAINER}" pg_isready -U postgres >/dev/null 2>&1; then
@@ -317,8 +277,7 @@ jobs:
             sleep 1
           done
           if ! $pg_ok || ! $kafka_ok; then
-            capture_compose_infra_diagnostics
-            echo "::error::compose services not healthy after 150s — pg=${pg_ok} kafka=${kafka_ok}"
+            echo "::error::compose services not healthy after 90s — pg=${pg_ok} kafka=${kafka_ok}"
             exit 1
           fi
 
@@ -708,9 +667,6 @@ jobs:
           if [[ ! -f startup_logs.txt ]]; then
             : > startup_logs.txt
           fi
-          if [[ ! -f compose_infra_diagnostics.txt ]]; then
-            : > compose_infra_diagnostics.txt
-          fi
           active_fresh_raw='${{ steps.pg_liveness.outputs.active_fresh_registrations }}'
           if [[ -z "$active_fresh_raw" ]]; then
             active_fresh_raw='0'
@@ -725,7 +681,6 @@ jobs:
             --arg active_fresh "${active_fresh_raw}" \
             --rawfile rpk_groups rpk_groups.txt \
             --rawfile startup_logs startup_logs.txt \
-            --rawfile compose_infra_diagnostics compose_infra_diagnostics.txt \
             '{
               mode: $mode,
               runtime_host: $runtime_host,
@@ -736,8 +691,7 @@ jobs:
               effects_health: $effects_health[0],
               active_fresh_registrations: ($active_fresh | tonumber),
               rpk_groups: $rpk_groups,
-              startup_logs: $startup_logs,
-              compose_infra_diagnostics: $compose_infra_diagnostics
+              startup_logs: $startup_logs
             }' > smoke-result.json
 
       - name: Upload smoke-result.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -309,17 +309,6 @@ repos:
         files: ^src/omnibase_infra/nodes/reducers/
         pass_filenames: false
         stages: [pre-commit]
-      # Prod promotion-lineage guard tests (OMN-12626, R1)
-      # Runs the guard's unit tests whenever the guard or the prod build/deploy
-      # tooling changes, so the clean-tree + ancestor-of-origin/main + image
-      # revision rules cannot silently regress. Timeout protects against hangs.
-      - id: prod-promotion-lineage-guard
-        name: Prod promotion-lineage guard tests (OMN-12626)
-        entry: uv run --frozen pytest tests/scripts/test_check_prod_promotion_lineage.py tests/scripts/test_deploy_runtime_prod_lineage.py -q --tb=short --timeout=120 --timeout-method=thread
-        language: system
-        pass_filenames: false
-        files: ^(scripts/check_prod_promotion_lineage\.py|tests/scripts/test_(check_prod_promotion_lineage|deploy_runtime_prod_lineage)\.py|scripts/deploy-runtime\.sh|scripts/deploy-agent/deploy_agent/executor\.py)$
-        stages: [pre-commit]
       # Markdown link validation (PR #172)
       # Ensures all internal markdown links point to existing files and anchors
       # External links are skipped by default (configurable in .markdown-link-check.json)

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -443,8 +443,6 @@ ENV PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:$PATH" \
     # Python path for module resolution
     PYTHONPATH=/app/src \
-    # Workspace root used by ONEX probe and repo-sync nodes inside the runtime
-    OMNI_HOME=/app \
     # Runtime profile selection (all | minimal | kafka | secrets)
     RUNTIME_PROFILE=all \
     # Contract configuration directory
@@ -477,10 +475,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     curl \
     # GitHub CLI for runtime-owned PR lifecycle inventory and merge gates
     gh \
-    # git is required by gh and session health repo probes.
-    # SSH supports runtime-owned host/session probes.
-    git \
-    openssh-client \
     # CA certificates for HTTPS connections
     ca-certificates \
     # Tini - minimal init system for proper signal handling as PID 1
@@ -489,10 +483,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     tini \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
-
-# Runtime session health probes invoke uv-owned commands such as golden-chain
-# checks. Keep uv in the final image as an explicit runtime tool.
-COPY --from=uv-bin /uv /uvx /usr/local/bin/
 
 # Security: upgrade setuptools in the runtime base image to clear CVE-2025-47273.
 # The builder venv already has the patched wheel. Copy it into system
@@ -508,10 +498,6 @@ RUN groupadd --gid 1000 omniinfra && \
     useradd --uid 1000 --gid omniinfra --shell /bin/bash --create-home omniinfra
 
 WORKDIR /app
-
-# Install uv in the final runtime image for ONEX runtime-owned validators and
-# golden-chain probes that shell out through the same pinned uv binary as builds.
-COPY --from=uv-bin /uv /uvx /usr/local/bin/
 
 # Copy virtual environment from builder stage with runtime ownership.
 # This contains all installed Python packages

--- a/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql
@@ -42,7 +42,7 @@ event_sessions AS (
         COALESCE(tokens_input, 0)::int AS prompt_tokens,
         COALESCE(tokens_output, 0)::int AS completion_tokens,
         NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
-        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
+        COALESCE(latency_ms, delegation_latency_ms)::int AS latency_ms,
         COALESCE(created_at, timestamp) AS created_at,
         prompt_text,
         response_text

--- a/docker/runners/Dockerfile
+++ b/docker/runners/Dockerfile
@@ -89,7 +89,6 @@ exec curl \
   --retry-delay 5 \
   --retry-max-time 300 \
   --retry-connrefused \
-  --retry-all-errors \
   "$@"
 EOF
 
@@ -108,11 +107,8 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y \
     && ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
 
 # Install uv
-RUN tmp_dir="$(mktemp -d)" \
-    && omni-curl -o "${tmp_dir}/uv.tar.gz" \
-        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
-    && tar -xzf "${tmp_dir}/uv.tar.gz" -C /usr/local/bin --strip-components=1 uv-x86_64-unknown-linux-gnu/uv \
-    && rm -rf "${tmp_dir}" \
+RUN omni-curl "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=1 uv-x86_64-unknown-linux-gnu/uv \
     && chmod +x /usr/local/bin/uv
 
 # Install Docker CLI (no daemon — socket mounted at runtime)
@@ -128,11 +124,8 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI
-RUN tmp_dir="$(mktemp -d)" \
-    && omni-curl -o "${tmp_dir}/gh.tar.gz" \
-        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    && tar -xzf "${tmp_dir}/gh.tar.gz" -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh" \
-    && rm -rf "${tmp_dir}" \
+RUN omni-curl "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh" \
     && chmod +x /usr/local/bin/gh
 
 # Install kubectl

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "0714d55f119bb6f6b3e635d63555bab7",
+  "identity_digest": "326a57a805df85a1031a67d5b54e523c",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "ddb03ed6fefbf435478e723e",
+  "shared_env_digest": "68031c296386aa953ebf53e7",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ dev = [
     "ruff>=0.14.7,<0.16.0",  # Ruff handles both formatting and linting (replaces black + isort)
     "types-pyyaml>=6.0.12.20250822,<7.0.0",
     "pre-commit>=4.3.0,<5.0.0",
-    "deepdiff>=8.0.0,<9.0.0",  # OMN-12623: direct use in tests/replay topic-migration equivalence harness
 
     # Test infrastructure dependencies
     "locust>=2.31.8,<3.0.0",  # Load testing framework for postgres adapter tests
@@ -169,9 +168,8 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-12623: bump core pin to dev HEAD (a1e73fff, OMN-12621 #1191) which adds
-# ModelTopicMigrationContract/ModelTopicSchemaBinding consumed by the migration executor.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "a1e73fff25a05ccb37cbb92d9c91754c59d808c0" }
+# Release v0.38.0: pin core to the paired v0.43.0 release PR head until the tag is published.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "4ffca7643294fcad4f9654f4d1839ca8002b4454" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]
@@ -483,7 +481,6 @@ node_decision_store_effect = "omnibase_infra.nodes.node_decision_store_effect"
 node_decision_store_query_compute = "omnibase_infra.nodes.node_decision_store_query_compute"
 node_delta_bundle_effect = "omnibase_infra.nodes.node_delta_bundle_effect"
 node_delta_metrics_effect = "omnibase_infra.nodes.node_delta_metrics_effect"
-node_dlq_replay_effect = "omnibase_infra.nodes.node_dlq_replay_effect"
 node_event_bus_wiring_effect = "omnibase_infra.nodes.node_event_bus_wiring_effect"
 node_event_forward_effect = "omnibase_infra.nodes.node_event_forward_effect"
 node_github_pr_poller_effect = "omnibase_infra.nodes.node_github_pr_poller_effect"
@@ -546,8 +543,6 @@ node_setup_orchestrator = "omnibase_infra.nodes.node_setup_orchestrator"
 node_setup_preflight_effect = "omnibase_infra.nodes.node_setup_preflight_effect"
 node_setup_validate_effect = "omnibase_infra.nodes.node_setup_validate_effect"
 node_slack_alerter_effect = "omnibase_infra.nodes.node_slack_alerter_effect"
-node_topic_migration_executor_effect = "omnibase_infra.nodes.node_topic_migration_executor_effect"
-node_topic_migration_projection = "omnibase_infra.nodes.node_topic_migration_projection"
 node_update_plan_reducer = "omnibase_infra.nodes.node_update_plan_reducer"
 node_validation_adjudicator = "omnibase_infra.nodes.node_validation_adjudicator"
 node_validation_executor = "omnibase_infra.nodes.node_validation_executor"

--- a/src/omnibase_infra/event_bus/event_bus_kafka.py
+++ b/src/omnibase_infra/event_bus/event_bus_kafka.py
@@ -188,7 +188,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import inspect
 import logging
 import os
 import random
@@ -640,20 +639,6 @@ class EventBusKafka(
 
         return kwargs
 
-    def _build_client_version_kwargs(
-        self, client_cls: type[object]
-    ) -> dict[str, object]:
-        """Build optional aiokafka client-version kwargs."""
-        if self._config.api_version is None:
-            return {}
-        try:
-            parameters = inspect.signature(client_cls.__init__).parameters
-        except (TypeError, ValueError):
-            return {}
-        if "api_version" not in parameters:
-            return {}
-        return {"api_version": self._config.api_version}
-
     async def start(self) -> None:
         """Start the event bus and connect to Kafka.
 
@@ -691,7 +676,6 @@ class EventBusKafka(
                     enable_idempotence=self._config.enable_idempotence,
                     max_request_size=self._config.max_request_size,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
-                    **self._build_client_version_kwargs(AIOKafkaProducer),
                     **self._build_auth_kwargs(),
                 )
 
@@ -1028,7 +1012,6 @@ class EventBusKafka(
                 enable_idempotence=self._config.enable_idempotence,
                 max_request_size=self._config.max_request_size,
                 retry_backoff_ms=self._config.reconnect_backoff_ms,
-                **self._build_client_version_kwargs(AIOKafkaProducer),
                 **self._build_auth_kwargs(),
             )
 
@@ -1766,7 +1749,6 @@ class EventBusKafka(
             heartbeat_interval_ms=self._config.heartbeat_interval_ms,
             max_poll_interval_ms=self._config.max_poll_interval_ms,
             retry_backoff_ms=self._config.reconnect_backoff_ms,
-            **self._build_client_version_kwargs(AIOKafkaConsumer),
             **self._build_auth_kwargs(),
         )
 
@@ -1893,7 +1875,6 @@ class EventBusKafka(
                     heartbeat_interval_ms=self._config.heartbeat_interval_ms,
                     max_poll_interval_ms=self._config.max_poll_interval_ms,
                     retry_backoff_ms=self._config.reconnect_backoff_ms,
-                    **self._build_client_version_kwargs(AIOKafkaConsumer),
                     **self._build_auth_kwargs(),
                 )
 
@@ -2363,51 +2344,20 @@ class EventBusKafka(
                         self._pending_consumer_keys.add(consumer_key)
                         topics_to_start.append((topic, group_id))
 
-        # Start consumers concurrently but bounded (OMN-12448). An unbounded
-        # gather over hundreds of group-joins stampedes the broker group
-        # coordinator on cold start; tail latency then blows the per-consumer
-        # start timeout. A single failure aborting the whole boot crash-loops
-        # the runtime — and each failed boot leaves half-formed groups that make
-        # the next boot slower. So: cap in-flight starts at
-        # consumer_start_concurrency and retry a transiently-failing start up to
-        # consumer_start_max_retries times before letting it fail the boot.
+        # Start all consumers concurrently — wall-clock time becomes the
+        # slowest single consumer rather than the sum of all N consumers.
+        # return_exceptions=True lets every consumer attempt to start; we
+        # collect failures and re-raise the first one after all have settled
+        # so a single bad topic does not starve the rest.
         if topics_to_start:
-            semaphore = asyncio.Semaphore(self._config.consumer_start_concurrency)
-            max_retries = self._config.consumer_start_max_retries
-
-            async def _start_bounded(topic: str, group_id: str) -> Exception | None:
-                async with semaphore:
-                    last_error: Exception | None = None
-                    for attempt in range(max_retries + 1):
-                        try:
-                            await self._start_consumer_for_topic_unlocked(
-                                topic, group_id
-                            )
-                            return None
-                        except (
-                            InfraConnectionError,
-                            InfraTimeoutError,
-                            InfraUnavailableError,
-                        ) as exc:
-                            last_error = exc
-                            if attempt >= max_retries:
-                                break
-                            # Every failure path discards the pending-key
-                            # reservation; re-reserve it before retrying so the
-                            # next attempt is not treated as a duplicate.
-                            self._pending_consumer_keys.add((topic, group_id))
-                            # Yield so other in-flight starts make progress and
-                            # the coordinator settles before we retry.
-                            await asyncio.sleep(0)
-                    return last_error
-
             results = await asyncio.gather(
                 *[
-                    _start_bounded(topic, group_id)
+                    self._start_consumer_for_topic_unlocked(topic, group_id)
                     for topic, group_id in topics_to_start
-                ]
+                ],
+                return_exceptions=True,
             )
-            errors = [r for r in results if isinstance(r, Exception)]
+            errors = [r for r in results if isinstance(r, BaseException)]
             if errors:
                 raise errors[0]
 

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 DOCKER_BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-build.yml"
-RUNTIME_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.runtime"
 ENV_PARITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "env-parity.yml"
 ARTIFACT_RECONCILIATION_WEBHOOK_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "artifact-reconciliation-webhook.yml"
@@ -34,23 +33,12 @@ CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 SETUP_PYTHON_UV_ACTION = (
     REPO_ROOT / ".github" / "actions" / "setup-python-uv" / "action.yml"
 )
-CHECKOUT_V6_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
-CODEQL_V4_SHA = "dc73d59c2d7bd4f8194098a91219eeee6d8a1719"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
     return loaded
-
-
-def _runs_on_expression(job: dict[str, Any]) -> str:
-    runs_on = job.get("runs-on")
-    if runs_on is None:
-        return ""
-    if isinstance(runs_on, str):
-        return runs_on
-    return str(runs_on)
 
 
 def test_migration_freeze_uses_shallow_checkout_for_merge_group() -> None:
@@ -313,9 +301,6 @@ def test_short_gates_can_disable_uv_cache_cleanup() -> None:
     )
     assert docker_setup_step["with"]["cache-enabled"] == "false"
     assert docker_setup_step["with"]["cache-version"] == "docker"
-    assert docker_setup_step["with"]["cache-key-prefix"] == "uv-docker"
-    assert docker_setup_step["with"]["shared-env-enabled"] == "true"
-    assert docker_setup_step["with"]["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
 
 
 def test_shared_ci_env_scripts_are_digest_keyed_and_read_only() -> None:
@@ -417,29 +402,6 @@ def test_contract_compliance_uv_sync_is_bounded_and_retried() -> None:
     assert "uv sync onex_change_control failed after" in run_script
 
 
-def test_merge_group_and_docker_workflows_have_runner_pool_overrides() -> None:
-    ci_workflow = _load_yaml(CI_WORKFLOW)
-    for job_name, job in ci_workflow["jobs"].items():
-        expression = _runs_on_expression(job)
-        if "self-hosted" not in expression:
-            continue
-
-        assert "OMNI_PUBLIC_PR_RUNS_ON_JSON" in expression, job_name
-        assert "OMNI_REQUIRED_CI_RUNS_ON_JSON" in expression, job_name
-        assert "OMNI_TRUSTED_CI_RUNS_ON_JSON" in expression, job_name
-        assert "github.event_name == 'merge_group'" in expression, job_name
-
-    docker_workflow = _load_yaml(DOCKER_BUILD_WORKFLOW)
-    for job_name, job in docker_workflow["jobs"].items():
-        expression = _runs_on_expression(job)
-        if "self-hosted" not in expression:
-            continue
-
-        assert "OMNI_PUBLIC_PR_RUNS_ON_JSON" in expression, job_name
-        assert "OMNI_DOCKER_CI_RUNS_ON_JSON" in expression, job_name
-        assert "OMNI_TRUSTED_CI_RUNS_ON_JSON" in expression, job_name
-
-
 def test_cross_repo_ci_jobs_use_retrying_uv_install() -> None:
     ci_workflow = _load_yaml(CI_WORKFLOW)
     for job_name in ("topic-drift-check", "schema-handshake"):
@@ -527,101 +489,11 @@ def test_architecture_handshake_has_checkout_retry_timeout_budget() -> None:
     assert job["timeout-minutes"] >= 10
 
 
-def test_retrying_uv_action_defaults_to_cpu_torch_backend() -> None:
-    action_text = SETUP_PYTHON_UV_ACTION.read_text(encoding="utf-8")
-    assert 'export UV_TORCH_BACKEND="${UV_TORCH_BACKEND:-cpu}"' in action_text
-    assert "UV_TORCH_BACKEND=${UV_TORCH_BACKEND:-<unset>}" in action_text
-
-
-def test_docker_integration_uses_retrying_uv_setup_action() -> None:
-    docker_workflow = _load_yaml(DOCKER_BUILD_WORKFLOW)
-    steps = docker_workflow["jobs"]["docker-integration-tests"]["steps"]
-
-    setup_step = next(
-        step
-        for step in steps
-        if step.get("uses") == "./.github/actions/setup-python-uv"
-    )
-    assert setup_step["name"] == "Setup Python and uv"
-    assert setup_step["with"]["cache-enabled"] == "false"
-    assert setup_step["with"]["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
-    assert not any(
-        step.get("run")
-        == "uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi"
-        for step in steps
-    )
-
-
-def test_runtime_plugin_dependency_install_retries_package_index_flakes() -> None:
-    dockerfile = RUNTIME_DOCKERFILE.read_text(encoding="utf-8")
-
-    assert "UV_HTTP_TIMEOUT=600" in dockerfile
-    assert "UV_RETRY_ATTEMPTS=8" in dockerfile
-    assert "cat > /usr/local/bin/uv-with-retry" in dockerfile
-    assert "uv-with-retry pip install \\" in dockerfile
-    assert "uv $* attempt ${attempt}/${max_attempts} failed" in dockerfile
-
-
-def test_runtime_dockerfile_retries_builder_uv_sync_transport_flakes() -> None:
-    dockerfile = RUNTIME_DOCKERFILE.read_text(encoding="utf-8")
-
-    assert "git config --global http.version HTTP/1.1" in dockerfile
-    assert "UV_HTTP_TIMEOUT=600" in dockerfile
-    assert "UV_RETRY_ATTEMPTS=8" in dockerfile
-    assert "uv-with-retry sync --no-dev --no-install-project" in dockerfile
-    assert "uv-with-retry sync --no-dev" in dockerfile
-    assert "uv $* attempt ${attempt}/${max_attempts} failed" in dockerfile
-
-
-def test_runtime_dockerfile_retries_torch_cpu_index_transport_flakes() -> None:
-    dockerfile = RUNTIME_DOCKERFILE.read_text(encoding="utf-8")
-
-    assert "https://download.pytorch.org/whl/cpu" in dockerfile
-    assert (
-        "uv-with-retry pip install torch --index-url https://download.pytorch.org/whl/cpu"
-        in dockerfile
-    )
-    assert (
-        'uv-with-retry pip install --no-deps "torch>=2.6.0,<3.0.0" --index-url https://download.pytorch.org/whl/cpu'
-        in dockerfile
-    )
-    assert "UV_RETRY_ATTEMPTS=8" in dockerfile
-
-
-def test_omni_standards_jobs_use_retrying_uv_install() -> None:
-    workflow = _load_yaml(OMNI_STANDARDS_WORKFLOW)
-
-    assert workflow["env"]["UV_HTTP_TIMEOUT"] == "600"
-
-    for job_name in ("type-safety", "type-union-check"):
-        steps = workflow["jobs"][job_name]["steps"]
-        setup_step = next(
-            step
-            for step in steps
-            if step.get("uses") == "./.github/actions/setup-python-uv"
-        )
-
-        assert setup_step["with"]["python-version"] == "${{ env.PYTHON_VERSION }}"
-        assert setup_step["with"]["uv-version"] == "${{ env.UV_VERSION }}"
-        assert setup_step["with"]["cache-enabled"] == "false"
-        assert setup_step["with"]["install-args"] == "--all-extras"
-        assert setup_step["with"]["sync-attempts"] == "3"
-        assert setup_step["with"]["sync-retry-delay-seconds"] == "10"
-        assert not any(
-            step.get("run") == "uv sync --no-cache --all-extras" for step in steps
-        )
-
-
 def test_setup_python_uv_retries_uv_sync_and_logs_transport_settings() -> None:
     action = _load_yaml(SETUP_PYTHON_UV_ACTION)
 
     assert action["inputs"]["sync-attempts"]["default"] == "5"
     assert action["inputs"]["sync-retry-delay-seconds"]["default"] == "10"
-
-    setup_step = next(
-        step for step in action["runs"]["steps"] if step.get("name") == "Set up Python"
-    )
-    assert setup_step["uses"] == "actions/setup-python@v6"
 
     install_step = next(
         step
@@ -786,37 +658,22 @@ def test_codeql_uses_repo_config_that_ignores_github_metadata() -> None:
     workflow = _load_yaml(SECURITY_SCAN_WORKFLOW)
     config = _load_yaml(CODEQL_CONFIG)
 
-    checkout_step = next(
-        step
-        for step in workflow["jobs"]["codeql"]["steps"]
-        if step.get("name") == "Checkout repository"
-    )
-    assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_V6_SHA}"
-    assert checkout_step["with"]["persist-credentials"] is False
-
     init_step = next(
         step
         for step in workflow["jobs"]["codeql"]["steps"]
         if step.get("name") == "Initialize CodeQL"
     )
-    assert init_step["uses"] == f"github/codeql-action/init@{CODEQL_V4_SHA}"
+    assert init_step["uses"] == "github/codeql-action/init@v4"
     assert init_step["with"]["languages"] == "python"
     assert init_step["with"]["queries"] == "security-and-quality"
     assert init_step["with"]["config-file"] == "./.github/codeql/codeql-config.yml"
-
-    autobuild_step = next(
-        step
-        for step in workflow["jobs"]["codeql"]["steps"]
-        if step.get("name") == "Autobuild"
-    )
-    assert autobuild_step["uses"] == f"github/codeql-action/autobuild@{CODEQL_V4_SHA}"
 
     analyze_step = next(
         step
         for step in workflow["jobs"]["codeql"]["steps"]
         if step.get("name") == "Perform CodeQL Analysis"
     )
-    assert analyze_step["uses"] == f"github/codeql-action/analyze@{CODEQL_V4_SHA}"
+    assert analyze_step["uses"] == "github/codeql-action/analyze@v4"
     assert analyze_step["with"]["category"] == "/language:python"
     assert analyze_step["with"]["upload"] == "never"
     assert analyze_step["with"]["wait-for-processing"] is False

--- a/tests/ci/test_runner_image_node24_floor.py
+++ b/tests/ci/test_runner_image_node24_floor.py
@@ -163,10 +163,7 @@ def test_runner_image_external_downloads_are_retried() -> None:
     assert "--http1.1" in source
     assert "--retry 5" in source
     assert "--retry-connrefused" in source
-    assert "--retry-all-errors" in source
     assert "--retry-max-time 300" in source
-    assert 'omni-curl "https://github.com/astral-sh/uv' not in source
-    assert 'omni-curl "https://github.com/cli/cli' not in source
 
     download_urls = (
         "github.com/astral-sh/uv",


### PR DESCRIPTION
## Auto-shipped by node_dirty_canonical_sweep (OMN-7466)

Dirty files were detected in the canonical omni_home clone and rescued to this worktree before the next `git pull` could discard them.

### Files
- `.github/workflows/ci.yml`
- `.github/workflows/reusable-runtime-boot.yml`
- `.pre-commit-config.yaml`
- `contracts/OMN-12559.yaml`
- `docker/Dockerfile.migrate`
- `docker/Dockerfile.runtime`
- `docker/migrations/forward/nodes/.synced-nodes`
- `docker/migrations/forward/nodes/node_projection_delegation/0007_delegation_events.sql`
- `docker/migrations/forward/nodes/node_projection_delegation/0008_generation_events.sql`
- `docker/migrations/forward/nodes/node_projection_delegation/0009_delegate_skill_projection_metrics.sql`
- `docker/migrations/forward/nodes/node_projection_delegation/0010_create_delegation_dashboard_projection_views.sql`
- `docker/migrations/forward/nodes/node_projection_savings/076_create_delegation_savings_projection_view.sql`
- `docker/runners/Dockerfile`
- `docker/runners/runner-image.lock.json`
- `pyproject.toml`
- `scripts/ci/merge_queue_janitor.py`
- `scripts/run-forward-migrations.sh`
- `scripts/sync-node-migrations.sh`
- `scripts/validation/validate_migration_sequence.py`
- `src/omnibase_infra/event_bus/event_bus_kafka.py`
- `src/omnibase_infra/event_bus/service_topic_manager.py`
- `tests/ci/test_ci_workflow_resilience.py`
- `tests/ci/test_runner_image_node24_floor.py`
- `tests/ci/test_validate_migration_sequence.py`
- `tests/integration/event_bus/test_kafka_invalid_partitions_retry_integration.py`
- `tests/integration/migrations/__init__.py`
- `tests/integration/migrations/test_node_migration_discovery_applies.py`
- `tests/unit/event_bus/test_service_topic_manager.py`
- `tests/unit/migrations/__init__.py`
- `tests/unit/migrations/test_node_migration_discovery.py`
- `tests/unit/scripts/ci/test_merge_queue_janitor.py`

**Review and merge or close.** This PR was created automatically by the dirty-canonical sweep cron.