### PR TITLE
fix(OMN-12618): verify deploy-agent lanes against live runtime state

### DIFF
--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -140,7 +140,7 @@ class ProdStabilityDigestMissingError(RuntimeError):
 
 
 class ModelLaneConfig(BaseModel):
-    """Per-lane compose file(s), compose project, and runtime health targets.
+    """Per-lane compose file(s), compose project, and health targets.
 
     The base ``docker-compose.infra.yml`` is always the first compose file;
     non-dev lanes layer their overlay (``docker-compose.<lane>.yml``) on top so
@@ -152,6 +152,7 @@ class ModelLaneConfig(BaseModel):
     lane: EnumRuntimeLane
     compose_files: tuple[str, ...]
     compose_project: str
+    postgres_container: str
     runtime_health_targets: tuple[tuple[str, int], ...]
 
 
@@ -163,12 +164,14 @@ _LANE_CONFIGS: dict[EnumRuntimeLane, ModelLaneConfig] = {
         lane=EnumRuntimeLane.DEV,
         compose_files=(COMPOSE_FILE,),
         compose_project=COMPOSE_PROJECT,
+        postgres_container="omnibase-infra-postgres",
         runtime_health_targets=RUNTIME_HEALTH_TARGETS,
     ),
     EnumRuntimeLane.STABILITY_TEST: ModelLaneConfig(
         lane=EnumRuntimeLane.STABILITY_TEST,
         compose_files=(COMPOSE_FILE, _STABILITY_OVERLAY),
         compose_project="omnibase-infra-stability-test",
+        postgres_container="omnibase-infra-stability-test-postgres",
         runtime_health_targets=(
             ("omninode-runtime", 18085),
             ("runtime-effects", 18086),
@@ -178,6 +181,7 @@ _LANE_CONFIGS: dict[EnumRuntimeLane, ModelLaneConfig] = {
         lane=EnumRuntimeLane.PROD,
         compose_files=(COMPOSE_FILE, _PROD_OVERLAY),
         compose_project="omnibase-infra-prod",
+        postgres_container="omnibase-infra-prod-postgres",
         runtime_health_targets=(
             ("omninode-runtime", 28085),
             ("runtime-effects", 28086),
@@ -354,7 +358,7 @@ def _runtime_health_passed(result: subprocess.CompletedProcess) -> bool:
     return (
         payload.get("status") == "healthy"
         and details.get("is_running") is True
-        and details.get("config_prefetch_status") == "ok"
+        and details.get("config_prefetch_status") in {"ok", "skipped"}
     )
 
 
@@ -1228,36 +1232,25 @@ class DeployExecutor:
             [
                 "docker",
                 "exec",
-                "postgres",
+                lane_config_for(lane).postgres_container,
                 "psql",
                 "-U",
-                "omninode",
+                "postgres",
                 "-d",
-                "omninode",
+                "omnibase_infra",
                 "-tAc",
-                "SELECT count(*) FROM handler_registry",
+                "SELECT to_regclass('public.node_service_registry') IS NOT NULL",
             ],
             timeout=timeout,
         )
-        try:
-            count = int(result.stdout.strip())
-            checks.append(
-                ModelHealthCheck(
-                    service="postgres",
-                    endpoint="handler_registry count",
-                    status="pass" if count > 0 else "fail",
-                    latency_ms=0,
-                )
+        checks.append(
+            ModelHealthCheck(
+                service="postgres",
+                endpoint="node_service_registry exists",
+                status="pass" if result.stdout.strip() == "t" else "fail",
+                latency_ms=0,
             )
-        except (ValueError, TypeError):
-            checks.append(
-                ModelHealthCheck(
-                    service="postgres",
-                    endpoint="handler_registry count",
-                    status="fail",
-                    latency_ms=0,
-                )
-            )
+        )
 
         # Runtime health endpoint checks.
         #

--- a/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
@@ -40,6 +40,7 @@ class TestLaneConfig:
     def test_dev_lane_matches_legacy_module_constants(self) -> None:
         cfg = lane_config_for(EnumRuntimeLane.DEV)
         assert cfg.compose_project == COMPOSE_PROJECT == "omnibase-infra"
+        assert cfg.postgres_container == "omnibase-infra-postgres"
         assert cfg.compose_files == (COMPOSE_FILE,)
         assert cfg.runtime_health_targets == RUNTIME_HEALTH_TARGETS
         assert cfg.runtime_health_targets == (
@@ -50,6 +51,7 @@ class TestLaneConfig:
     def test_stability_test_lane_config(self) -> None:
         cfg = lane_config_for(EnumRuntimeLane.STABILITY_TEST)
         assert cfg.compose_project == "omnibase-infra-stability-test"
+        assert cfg.postgres_container == "omnibase-infra-stability-test-postgres"
         # overlay must be layered on top of the base infra compose file
         assert cfg.compose_files[0] == COMPOSE_FILE
         assert any("docker-compose.stability-test.yml" in f for f in cfg.compose_files)
@@ -61,6 +63,7 @@ class TestLaneConfig:
     def test_prod_lane_config(self) -> None:
         cfg = lane_config_for(EnumRuntimeLane.PROD)
         assert cfg.compose_project == "omnibase-infra-prod"
+        assert cfg.postgres_container == "omnibase-infra-prod-postgres"
         assert cfg.compose_files[0] == COMPOSE_FILE
         assert any("docker-compose.prod.yml" in f for f in cfg.compose_files)
         assert cfg.runtime_health_targets == (
@@ -181,9 +184,10 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "handler_registry count" in cmd:
+            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+                assert "omnibase-infra-stability-test-postgres" in cmd
                 return subprocess.CompletedProcess(
-                    args=cmd, returncode=0, stdout="4\n", stderr=""
+                    args=cmd, returncode=0, stdout="t\n", stderr=""
                 )
             if (
                 "http://localhost:18085/health" in cmd
@@ -214,9 +218,10 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "handler_registry count" in cmd:
+            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+                assert "omnibase-infra-prod-postgres" in cmd
                 return subprocess.CompletedProcess(
-                    args=cmd, returncode=0, stdout="4\n", stderr=""
+                    args=cmd, returncode=0, stdout="t\n", stderr=""
                 )
             if (
                 "http://localhost:28085/health" in cmd
@@ -248,9 +253,10 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "handler_registry count" in cmd:
+            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+                assert "omnibase-infra-postgres" in cmd
                 return subprocess.CompletedProcess(
-                    args=cmd, returncode=0, stdout="4\n", stderr=""
+                    args=cmd, returncode=0, stdout="t\n", stderr=""
                 )
             if (
                 "http://localhost:8085/health" in cmd

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
@@ -58,8 +58,8 @@ def test_verify_probes_runtime_health_ports_only() -> None:
         captured_cmds.append(cmd)
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "handler_registry count" in cmd:
-            return _completed(cmd, stdout="4\n")
+        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload())
         if "http://localhost:8086/health" in cmd:
@@ -92,6 +92,63 @@ def test_verify_probes_runtime_health_ports_only() -> None:
     }
 
 
+def test_verify_accepts_runtime_health_when_config_prefetch_skipped() -> None:
+    executor = DeployExecutor()
+
+    def fake_run(
+        cmd: list[str], timeout: int, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        if cmd[:2] == ["docker", "ps"]:
+            return _completed(cmd)
+        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            return _completed(cmd, stdout="t\n")
+        if "http://localhost:8085/health" in cmd:
+            return _completed(
+                cmd, stdout=_health_payload(config_prefetch_status="skipped")
+            )
+        if "http://localhost:8086/health" in cmd:
+            return _completed(
+                cmd, stdout=_health_payload(config_prefetch_status="skipped")
+            )
+        return _completed(cmd, returncode=1, stderr=f"unexpected command: {cmd}")
+
+    with patch("deploy_agent.executor._run", side_effect=fake_run):
+        checks = executor.verify(on_phase_update=_noop_phase_update)
+
+    runtime_checks = {
+        check.service: check.status
+        for check in checks
+        if check.service in {"omninode-runtime", "runtime-effects"}
+    }
+    assert runtime_checks == {
+        "omninode-runtime": "pass",
+        "runtime-effects": "pass",
+    }
+
+
+def test_verify_fails_postgres_check_when_node_service_registry_missing() -> None:
+    executor = DeployExecutor()
+
+    def fake_run(
+        cmd: list[str], timeout: int, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        if cmd[:2] == ["docker", "ps"]:
+            return _completed(cmd)
+        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            return _completed(cmd, stdout="f\n")
+        if "http://localhost:8085/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        if "http://localhost:8086/health" in cmd:
+            return _completed(cmd, stdout=_health_payload())
+        return _completed(cmd, returncode=1, stderr=f"unexpected command: {cmd}")
+
+    with patch("deploy_agent.executor._run", side_effect=fake_run):
+        checks = executor.verify(on_phase_update=_noop_phase_update)
+
+    status_by_endpoint = {check.endpoint: check.status for check in checks}
+    assert status_by_endpoint["node_service_registry exists"] == "fail"
+
+
 def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:
     executor = DeployExecutor()
 
@@ -100,8 +157,8 @@ def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "handler_registry count" in cmd:
-            return _completed(cmd, stdout="4\n")
+        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload())
         if "http://localhost:8086/health" in cmd:
@@ -127,8 +184,8 @@ def test_verify_fails_runtime_health_when_process_not_running() -> None:
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "handler_registry count" in cmd:
-            return _completed(cmd, stdout="4\n")
+        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload(is_running=False))
         if "http://localhost:8086/health" in cmd:


### PR DESCRIPTION
Evidence-Source: da7fee5bf2f04c35776eff0891022f61cd2a9c31
Evidence-Ticket: OMN-12618

## Summary
- accept runtime health with config_prefetch_status=skipped as deploy-ready while keeping degraded statuses failed
- verify node_service_registry existence through the selected lane Postgres container instead of hard-coded DB settings
- cover dev, stability-test, and prod lane verification behavior in deploy-agent unit tests

## Verification
- uv run ruff check scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/tests/unit/test_executor_lane_selection.py scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
- uv run pytest scripts/deploy-agent/tests/unit/test_executor_lane_selection.py scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py -q

## Deploy Assessment
- Scope: deploy-agent verification only. It does not change runtime compose services or runtime application behavior.
- Runtime impact: required before node_redeploy can produce accurate dev/stability verification on .201 because live runtime health currently reports config_prefetch_status=skipped and lane Postgres containers are lane-named.
- Bret safety: this is a pre-redeploy gate fix. Stability runtime remains untouched until dev redeploy passes and a stability rollback path is ready.
- Rollback: revert this PR or run deploy-agent from the previous infra SHA; no data migration is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for lane-specific database container configuration across DEV, STABILITY_TEST, and PROD deployment environments.
  * Enhanced runtime health verification to accept config prefetch status as either "ok" or "skipped" (previously only "ok").

* **Tests**
  * Updated tests to verify lane-specific database container assignments and updated health check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->