### PR TITLE
fix(OMN-12618): add runtime error triage upsert index

### DIFF
--- a/docker/migrations/forward/084_add_runtime_error_triage_open_suppressed_unique.sql
+++ b/docker/migrations/forward/084_add_runtime_error_triage_open_suppressed_unique.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- MIGRATION: Add runtime_error_triage partial uniqueness for incident upsert
+-- =============================================================================
+-- Ticket: OMN-12618
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   The runtime error triage handler upserts active incidents with:
+--     ON CONFLICT (fingerprint) WHERE incident_state IN ('open', 'suppressed')
+--
+--   PostgreSQL requires a matching unique or exclusion constraint for that
+--   conflict target. Migration 055 created only non-unique indexes, causing
+--   runtime triage writes to fail at deploy time.
+--
+-- IDEMPOTENCY:
+--   - CREATE UNIQUE INDEX IF NOT EXISTS is safe to re-run.
+--   - CONCURRENTLY avoids taking a long write lock on the live triage table.
+--
+-- ROLLBACK:
+--   See rollback/rollback_084_add_runtime_error_triage_open_suppressed_unique.sql
+-- =============================================================================
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_runtime_error_triage_active_fingerprint
+    ON public.runtime_error_triage (fingerprint)
+    WHERE incident_state IN ('open', 'suppressed');

--- a/docker/migrations/rollback/rollback_084_add_runtime_error_triage_open_suppressed_unique.sql
+++ b/docker/migrations/rollback/rollback_084_add_runtime_error_triage_open_suppressed_unique.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- ROLLBACK: Drop runtime_error_triage active fingerprint uniqueness
+-- =============================================================================
+-- Ticket: OMN-12618
+--
+-- WARNING:
+--   Dropping this index makes the runtime error triage handler's active
+--   incident upsert invalid again.
+-- =============================================================================
+
+DROP INDEX CONCURRENTLY IF EXISTS public.uq_runtime_error_triage_active_fingerprint;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:6f4891be982289898e5cf47ded9921e301136041df1a2859a3e5f4487532d46f
-generated_at: 2026-05-26T02:17:06Z
-migration_file_count: 69
+sha256:d887aceeeaca141904e97bb17eb8205df8bf5bca05b7e9da17f8d8ec0c3acaa4
+generated_at: 2026-06-03T20:02:52Z
+migration_file_count: 70


### PR DESCRIPTION
## Summary
- add migration 084 for the partial unique index required by runtime_error_triage active incident upserts
- add rollback migration for the index
- restamp schema migration fingerprint

## Why
Dev redeploy correlation 048ea264-c43f-478f-898f-3b2f5289cc60 restarted runtime/effects, but runtime logs showed asyncpg InvalidColumnReferenceError because handler_runtime_error_triage uses ON CONFLICT (fingerprint) WHERE incident_state IN ('open', 'suppressed') without a matching unique index.

## Verification
- uv run python scripts/check_schema_fingerprint.py stamp --dry-run
- uv run python scripts/check_schema_fingerprint.py verify
- uv run pytest tests/unit/nodes/test_handler_runtime_error_triage.py -q
- uv run pytest tests/unit/runtime/test_migration_sentinel.py -q

## Runtime safety
Migration uses CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS and does not recreate runtime containers or brokers.

Evidence-Source: OCC#2128
Evidence-Ticket: OMN-12618