### PR TITLE
fix(OMN-12618): preserve generated runtime image build

### DIFF
--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import time
+import tomllib
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from types import ModuleType
@@ -340,6 +341,33 @@ def _compose_env() -> dict[str, str]:
     for key, value in defaults.items():
         env.setdefault(key, value)
     return env
+
+
+def _env_with_repo_pythonpath(env: Mapping[str, str]) -> dict[str, str]:
+    """Return env with this deploy repo's src path first on PYTHONPATH."""
+    repo_src = f"{REPO_DIR}/src"
+    current = env.get("PYTHONPATH", "")
+    return {
+        **env,
+        "PYTHONPATH": f"{repo_src}:{current}" if current else repo_src,
+    }
+
+
+def _runtime_version_from_pyproject(repo_dir: str = REPO_DIR) -> str:
+    """Return the runtime package version stamped into rebuilt images."""
+    pyproject = Path(repo_dir) / "pyproject.toml"
+    if not pyproject.is_file():
+        pyproject = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        version = str(data["project"]["version"]).strip()
+    except (FileNotFoundError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        raise RuntimeError(
+            f"Could not resolve RUNTIME_VERSION from {pyproject}"
+        ) from exc
+    if not version:
+        raise RuntimeError(f"Empty RUNTIME_VERSION in {pyproject}")
+    return version
 
 
 def _runtime_health_passed(result: subprocess.CompletedProcess) -> bool:
@@ -691,7 +719,12 @@ class DeployExecutor:
             COMPOSE_FILE,
         ]
 
-        result = _run(cmd, timeout=timeout, cwd=REPO_DIR, env=_compose_env())
+        result = _run(
+            cmd,
+            timeout=timeout,
+            cwd=REPO_DIR,
+            env=_env_with_repo_pythonpath(_compose_env()),
+        )
         if result.returncode != 0:
             logger.warning(
                 "compose_gen returned non-zero (exit=%d) — continuing with existing compose file. stderr: %s",
@@ -1024,6 +1057,7 @@ class DeployExecutor:
         import datetime
 
         build_date = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        runtime_version = _runtime_version_from_pyproject()
 
         cmd = [
             "docker",
@@ -1041,6 +1075,8 @@ class DeployExecutor:
             f"VCS_REF={git_sha}",
             "--build-arg",
             f"BUILD_DATE={build_date}",
+            "--build-arg",
+            f"RUNTIME_VERSION={runtime_version}",
             "--build-arg",
             f"OMNIBASE_COMPAT_REF={compat_ref}",
             "--build-arg",

--- a/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
@@ -120,6 +120,30 @@ class TestComposeGen:
             f"Expected --output {COMPOSE_FILE!r}, got {cmd[output_idx]!r}"
         )
 
+    def test_compose_gen_prefers_repo_src_on_pythonpath(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """compose_gen must not import catalog code from a stale canonical clone."""
+        from deploy_agent.executor import REPO_DIR
+
+        executor = DeployExecutor()
+        captured_env: dict[str, str] = {}
+        monkeypatch.setenv("PYTHONPATH", "/stale/canonical/src")
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_env.update(kwargs["env"])
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(["core", "runtime"], _noop_phase_update)
+
+        assert captured_env["PYTHONPATH"].split(":")[:2] == [
+            f"{REPO_DIR}/src",
+            "/stale/canonical/src",
+        ]
+
     def test_compose_gen_succeeds_on_catalog_cli_failure(self) -> None:
         """compose_gen must not raise even when the catalog CLI exits non-zero (non-fatal)."""
         executor = DeployExecutor()

--- a/scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py
@@ -193,6 +193,7 @@ def test_workspace_build_passes_build_date_and_vcs_ref(
 
     build_cmd = captured_cmds[0]
     assert "VCS_REF=deadbeef" in build_cmd
+    assert "RUNTIME_VERSION=0.38.0" in build_cmd
     assert any(a.startswith("BUILD_DATE=") for a in build_cmd)
 
 

--- a/src/omnibase_infra/docker/catalog/generator.py
+++ b/src/omnibase_infra/docker/catalog/generator.py
@@ -9,6 +9,27 @@ from __future__ import annotations
 from omnibase_infra.docker.catalog.enum_infra_layer import EnumInfraLayer
 from omnibase_infra.docker.catalog.resolver import ResolvedStack
 
+_RUNTIME_IMAGE_BUILD_SERVICE = "omninode-runtime"
+
+
+def _runtime_image_build() -> dict[str, object]:
+    """Return the canonical build stanza for the shared runtime image."""
+    return {
+        "context": "..",
+        "dockerfile": "docker/Dockerfile.runtime",
+        "args": {
+            "BUILD_SOURCE": "${BUILD_SOURCE:-release}",
+            "EXPECTED_BUILD_SOURCE": "${EXPECTED_BUILD_SOURCE:-release}",
+            "OMNI_HOME": "${OMNI_HOME:-}",
+            "RUNTIME_VERSION": "${RUNTIME_VERSION:-0.1.0}",
+            "BUILD_DATE": "${BUILD_DATE:-}",
+            "VCS_REF": "${VCS_REF:-}",
+            "GIT_SHA": "${GIT_SHA:-unknown}",
+            "RUNTIME_SOURCE_HASH": "${RUNTIME_SOURCE_HASH:-unknown}",
+            "COMPOSE_PROJECT": "${COMPOSE_PROJECT:-omnibase-infra}",
+        },
+    }
+
 
 def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
     """Generate a docker-compose dict from a resolved stack."""
@@ -21,6 +42,8 @@ def generate_compose(resolved: ResolvedStack) -> dict[str, object]:
 
         # Image
         svc["image"] = manifest.image
+        if name == _RUNTIME_IMAGE_BUILD_SERVICE and manifest.image == "runtime:latest":
+            svc["build"] = _runtime_image_build()
 
         # Container name
         if manifest.container_name:

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -46,6 +46,23 @@ def test_generated_compose_preserves_depends_on_conditions() -> None:
 
 
 @pytest.mark.unit
+def test_generated_runtime_compose_preserves_runtime_image_build() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+
+    build = compose["services"]["omninode-runtime"]["build"]
+    assert build["context"] == ".."
+    assert build["dockerfile"] == "docker/Dockerfile.runtime"
+    assert build["args"]["BUILD_SOURCE"] == "${BUILD_SOURCE:-release}"
+    assert build["args"]["EXPECTED_BUILD_SOURCE"] == "${EXPECTED_BUILD_SOURCE:-release}"
+    assert build["args"]["OMNI_HOME"] == "${OMNI_HOME:-}"
+    assert build["args"]["GIT_SHA"] == "${GIT_SHA:-unknown}"
+    assert build["args"]["VCS_REF"] == "${VCS_REF:-}"
+    assert build["args"]["BUILD_DATE"] == "${BUILD_DATE:-}"
+
+
+@pytest.mark.unit
 def test_generated_compose_preserves_redpanda_ulimits() -> None:
     resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
     resolved = resolver.resolve(bundles=["core"])


### PR DESCRIPTION
## Summary
- restore the runtime image build stanza in catalog-generated compose for omninode-runtime
- force deploy-agent compose generation to import the staged repo source before any ambient PYTHONPATH clone
- add regression coverage for generated build metadata and stale PYTHONPATH protection

## Verification
- PYTHONPATH=src uv run pytest tests/unit/infra/test_catalog_generator.py -q
- PYTHONPATH=src uv run pytest scripts/deploy-agent/tests/unit/test_executor_compose_gen.py scripts/deploy-agent/tests/unit/test_executor_build_source.py scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py -q
- PYTHONPATH=src uv run python -m omnibase_infra.docker.catalog.cli generate runtime --output /tmp/omn12618.generated.yml

## Runtime safety
This changes deploy-agent/catalog build metadata only. Stability and prod are untouched until dev proves a newly built image with baked provenance.

Evidence-Source: OCC#2130
Evidence-Ticket: OMN-12618