### PR TITLE
fix(OMN-12618): read workspace provenance metadata

### DIFF
--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -1088,20 +1088,6 @@ class DeployExecutor:
         result = _run(cmd, timeout=timeout, env=_compose_env())
         if result.returncode != 0:
             raise RuntimeError(f"Docker compose build failed: {result.stderr}")
-        if scope == Scope.RUNTIME:
-            tag_result = _run(
-                [
-                    "docker",
-                    "tag",
-                    "omnibase-infra-omninode-runtime:latest",
-                    "runtime:latest",
-                ],
-                timeout=30,
-            )
-            if tag_result.returncode != 0:
-                raise RuntimeError(
-                    f"Docker runtime image tag failed: {tag_result.stderr}"
-                )
 
     def _compose_up(
         self,

--- a/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_cache_bust.py
@@ -62,6 +62,28 @@ class TestCacheBust:
             f"Expected --build-arg GIT_SHA={git_sha}, got {git_sha_arg!r}"
         )
 
+    def test_runtime_build_does_not_retag_from_project_image(self) -> None:
+        """Runtime build must not overwrite runtime:latest from a stale project tag."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _make_ok_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor._compose_build(Scope.RUNTIME, "abc1234", _noop_phase_update)
+
+        assert ["docker", "tag"] not in [cmd[:2] for cmd in captured_cmds]
+        assert not any(
+            cmd[:2] == ["docker", "tag"]
+            and "omnibase-infra-omninode-runtime:latest" in cmd
+            and "runtime:latest" in cmd
+            for cmd in captured_cmds
+        )
+
     def test_compose_build_called_before_compose_up_in_rebuild_scope(self) -> None:
         """rebuild_scope must call _compose_build before _compose_up so images are fresh."""
         executor = DeployExecutor()

--- a/scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py
@@ -50,6 +50,35 @@ def test_provenance_script_exists() -> None:
     )
 
 
+def test_provenance_script_reads_direct_url_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "compute_workspace_provenance_direct_url_test", str(PROVENANCE_SCRIPT)
+    )
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+
+    mock_dist = MagicMock()
+    mock_dist.read_text.return_value = json.dumps(
+        {"url": "file:///workspace/sibling-repos/omnimarket"}
+    )
+    monkeypatch.setattr(
+        mod.importlib.metadata,
+        "distribution",
+        lambda _: mock_dist,
+    )
+
+    assert mod._installed_direct_url("omnimarket") == {
+        "url": "file:///workspace/sibling-repos/omnimarket"
+    }
+    mock_dist.read_text.assert_called_once_with("direct_url.json")
+
+
 # ---------------------------------------------------------------------------
 # _stage_workspace helper
 # ---------------------------------------------------------------------------

--- a/scripts/runtime_build/compute_workspace_provenance.py
+++ b/scripts/runtime_build/compute_workspace_provenance.py
@@ -63,10 +63,10 @@ def _installed_direct_url(dist_name: str) -> dict | None:
         dist = importlib.metadata.distribution(dist_name)
     except importlib.metadata.PackageNotFoundError:
         return None
-    direct_url_file = dist.locate_file("direct_url.json")
-    if not Path(str(direct_url_file)).exists():
+    direct_url_text = dist.read_text("direct_url.json")
+    if direct_url_text is None:
         return None
-    return json.loads(Path(str(direct_url_file)).read_text(encoding="utf-8"))
+    return json.loads(direct_url_text)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- read PEP 610 direct_url.json through importlib metadata read_text instead of locate_file
- add a focused provenance metadata regression test

## Verification
- PYTHONPATH=src uv run pytest scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py -q
- PYTHONPATH=src uv run ruff format scripts/runtime_build/compute_workspace_provenance.py scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py
- PYTHONPATH=src uv run ruff check scripts/runtime_build/compute_workspace_provenance.py scripts/deploy-agent/tests/unit/test_executor_workspace_provenance.py

Evidence-Source: OCC#2135
Evidence-Ticket: OMN-12618