### PR TITLE
fix(OMN-12664): preserve full Gemini endpoint path in bifrost gateway

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config_loader_bifrost.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/config_loader_bifrost.py
@@ -75,13 +75,21 @@ def load_bifrost_config_from_env() -> ModelBifrostConfig:
 
     # External backends (only added when API key is configured)
     _add_backend_if_set(backends, "glm", "GLM_BASE_URL")
-    # Gemini uses a well-known base URL; only add when API key is present
+    # Gemini's OpenAI-compatible chat endpoint lives at
+    # /v1beta/openai/chat/completions. The bare origin (or a /v1beta/openai base)
+    # would make the inference handler append /v1/chat/completions and 404. Default
+    # to the complete registered endpoint so the resolved URL carries
+    # /v1beta/openai/chat/completions and is posted verbatim (the gateway routes
+    # full endpoints through endpoint_url). Only add when the API key is present.
     if os.environ.get("GEMINI_API_KEY", "").strip():
         _add_backend_if_set(
             backends,
             "gemini",
             "GEMINI_BASE_URL",
-            default_url="https://generativelanguage.googleapis.com",
+            default_url=(
+                "https://generativelanguage.googleapis.com"
+                "/v1beta/openai/chat/completions"
+            ),
         )
 
     if not backends:

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
@@ -115,6 +115,17 @@ logger = logging.getLogger(__name__)
 # HMAC header name for outbound request authentication.
 _HMAC_HEADER_NAME = "X-ONEX-Signature"
 
+# Path suffixes that mark a configured base_url as an already-complete chat
+# endpoint. When a backend's base_url already terminates in one of these, the
+# OpenAI-compatible path must NOT be appended again (doing so produces a
+# double-versioned 404 like ``…/v1beta/openai/v1/chat/completions``). Such a
+# URL is routed through ``endpoint_url`` so the inference handler posts it
+# as-is. This is a structural check on the URL shape — not a provider sniff.
+_FULL_CHAT_ENDPOINT_SUFFIXES: tuple[str, ...] = (
+    "/chat/completions",
+    "/completions",
+)
+
 
 def _safe_invoke_callback(
     callback: Callable[[ModelBifrostResponse], None] | None,
@@ -768,8 +779,22 @@ class HandlerBifrostGateway:  # ONEX_EXCLUDE: method_count - gateway is a single
                 correlation_id=str(correlation_id),
             )
 
+        # When the backend's configured base_url is already a complete chat
+        # endpoint (e.g. a cloud Gemini OpenAI-compatible URL that ends in
+        # ``/chat/completions``), route it through endpoint_url so the inference
+        # handler posts it verbatim instead of appending the OpenAI path again.
+        # Otherwise keep the legacy base_url path, where the handler appends the
+        # operation-type path exactly once.
+        configured_url = backend_cfg.base_url
+        endpoint_url: str | None = None
+        base_url = configured_url
+        if configured_url.rstrip("/").endswith(_FULL_CHAT_ENDPOINT_SUFFIXES):
+            endpoint_url = configured_url
+            base_url = configured_url
+
         return ModelLlmInferenceRequest(
-            base_url=backend_cfg.base_url,
+            endpoint_url=endpoint_url,
+            base_url=base_url,
             operation_type=request.operation_type,
             model=model_name,
             messages=request.messages,

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_endpoint_preservation.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_bifrost_endpoint_preservation.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-12664 regression: bifrost endpoint-path preservation.
+
+The cloud-tier Gemini path produced a 404 because the bifrost gateway fed the
+backend URL through ``base_url``, so the inference handler appended
+``/v1/chat/completions`` again:
+
+- bare-origin base  → ``https://generativelanguage.googleapis.com/v1/chat/completions``
+- full-path base    → ``https://generativelanguage.googleapis.com/v1beta/openai/v1/chat/completions``
+
+The registered endpoint is
+``https://generativelanguage.googleapis.com/v1beta/openai/chat/completions``.
+
+The fix: when a backend's configured ``base_url`` is already a complete chat
+endpoint, route it through ``endpoint_url`` so ``_build_url`` posts it verbatim.
+Non-endpoint base URLs (local OpenAI-compatible servers, GLM origins) stay on
+the legacy ``base_url`` path and keep getting the OpenAI path appended exactly
+once. These tests fail on the old behavior and pass after the fix.
+
+Related:
+    - OMN-12664: cloud-tier Gemini URL path truncation / double-append 404
+    - OMN-10489: endpoint_url field — post-as-is for contract-complete endpoints
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from omnibase_infra.enums import EnumLlmOperationType
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.handler_bifrost_gateway import (
+    HandlerBifrostGateway,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.model_bifrost_config import (
+    ModelBifrostBackendConfig,
+    ModelBifrostConfig,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.bifrost.model_bifrost_request import (
+    ModelBifrostRequest,
+)
+from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_openai_compatible import (
+    HandlerLlmOpenaiCompatible,
+)
+
+pytestmark = pytest.mark.unit
+
+_CORR = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+_TENANT = UUID("12345678-1234-5678-1234-567812345678")
+_GEMINI_FULL = (
+    "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+)
+_GEMINI_OPENAI_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
+_GEMINI_BARE_ORIGIN = "https://generativelanguage.googleapis.com"
+_LOCAL_BASE = "http://100.109.203.94:8000"
+
+
+def _gateway(backend: ModelBifrostBackendConfig) -> HandlerBifrostGateway:
+    """Build a gateway whose single backend is the one under test."""
+    config = ModelBifrostConfig(
+        backends={backend.backend_id: backend},
+        default_backends=(backend.backend_id,),
+    )
+    return HandlerBifrostGateway(
+        config=config,
+        inference_handler=HandlerLlmOpenaiCompatible(transport=None),
+    )
+
+
+def _chat_request() -> ModelBifrostRequest:
+    return ModelBifrostRequest(
+        operation_type=EnumLlmOperationType.CHAT_COMPLETION,
+        tenant_id=_TENANT,
+        messages=[{"role": "user", "content": "hi"}],
+        correlation_id=_CORR,
+    )
+
+
+def _build_request_for(base_url: str):  # type: ignore[no-untyped-def]
+    backend = ModelBifrostBackendConfig(backend_id="b", base_url=base_url)
+    gateway = _gateway(backend)
+    return gateway._build_inference_request(
+        request=_chat_request(),
+        backend_cfg=backend,
+        correlation_id=_CORR,
+    )
+
+
+@pytest.mark.unit
+def test_full_gemini_endpoint_routes_through_endpoint_url() -> None:
+    """A full /v1beta/openai/chat/completions base routes via endpoint_url."""
+    req = _build_request_for(_GEMINI_FULL)
+    assert req.endpoint_url == _GEMINI_FULL
+    # _build_url must post it verbatim — no second path append.
+    assert HandlerLlmOpenaiCompatible._build_url(req) == _GEMINI_FULL
+
+
+@pytest.mark.unit
+def test_no_double_append_for_full_chat_endpoint() -> None:
+    """Regression: the double-versioned 404 path must NOT be produced."""
+    req = _build_request_for(_GEMINI_FULL)
+    resolved = HandlerLlmOpenaiCompatible._build_url(req)
+    assert resolved != (
+        "https://generativelanguage.googleapis.com/v1beta/openai/v1/chat/completions"
+    )
+    assert "/v1beta/openai/v1/chat/completions" not in resolved
+
+
+@pytest.mark.unit
+def test_gemini_openai_base_is_not_a_full_endpoint() -> None:
+    """A /v1beta/openai base (no /chat/completions) is NOT a full endpoint.
+
+    It stays on the legacy base_url path, where /v1/chat/completions is appended,
+    producing the SECOND 404 variant
+    (``…/v1beta/openai/v1/chat/completions``). This documents why the Gemini
+    default must be the complete registered endpoint, not merely the
+    /v1beta/openai base.
+    """
+    req = _build_request_for(_GEMINI_OPENAI_BASE)
+    # Not a complete chat endpoint → stays on legacy base_url path.
+    assert req.endpoint_url is None
+    resolved = HandlerLlmOpenaiCompatible._build_url(req)
+    # The legacy append does NOT reach the registered endpoint for this base.
+    assert resolved == (
+        "https://generativelanguage.googleapis.com/v1beta/openai/v1/chat/completions"
+    )
+    assert resolved != _GEMINI_FULL
+
+
+@pytest.mark.unit
+def test_gemini_bare_origin_does_not_truncate_path() -> None:
+    """Bare origin appends /v1/chat/completions exactly once (legacy path)."""
+    req = _build_request_for(_GEMINI_BARE_ORIGIN)
+    assert req.endpoint_url is None
+    resolved = HandlerLlmOpenaiCompatible._build_url(req)
+    assert resolved == ("https://generativelanguage.googleapis.com/v1/chat/completions")
+
+
+@pytest.mark.unit
+def test_local_openai_backend_unaffected() -> None:
+    """Non-Gemini local OpenAI-compatible backend keeps legacy base_url path."""
+    req = _build_request_for(_LOCAL_BASE)
+    assert req.endpoint_url is None
+    assert req.base_url == _LOCAL_BASE
+    resolved = HandlerLlmOpenaiCompatible._build_url(req)
+    assert resolved == "http://100.109.203.94:8000/v1/chat/completions"
+
+
+@pytest.mark.unit
+def test_local_full_endpoint_routes_through_endpoint_url() -> None:
+    """A local backend already declaring a full endpoint posts as-is too.
+
+    The detection is structural (URL shape), not provider-specific, so a local
+    server configured with a complete endpoint is handled identically — proving
+    no provider sniff was introduced.
+    """
+    full_local = "http://100.109.203.94:8000/v1/chat/completions"
+    req = _build_request_for(full_local)
+    assert req.endpoint_url == full_local
+    assert HandlerLlmOpenaiCompatible._build_url(req) == full_local
+
+
+@pytest.mark.unit
+def test_trailing_slash_full_endpoint_detected() -> None:
+    """A full endpoint with a trailing slash is still detected as complete."""
+    req = _build_request_for(_GEMINI_FULL + "/")
+    assert req.endpoint_url == _GEMINI_FULL + "/"
+    assert HandlerLlmOpenaiCompatible._build_url(req) == _GEMINI_FULL + "/"

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_config_loader_bifrost.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/bifrost/test_config_loader_bifrost.py
@@ -96,3 +96,61 @@ class TestLoadBifrostConfigFromEnv:
             config = load_bifrost_config_from_env()
         with pytest.raises(Exception):
             config.failover_attempts = 99  # type: ignore[misc]
+
+    def test_gemini_default_carries_v1beta_openai_path(self) -> None:
+        """OMN-12664: Gemini default must be /v1beta/openai/chat/completions.
+
+        The bare origin (``https://generativelanguage.googleapis.com``) makes the
+        inference handler post to ``/v1/chat/completions`` → 404. The resolved
+        default must be the complete registered endpoint carrying
+        ``/v1beta/openai`` so the gateway posts it verbatim.
+        """
+        env = {
+            "LLM_CODER_FAST_URL": "http://192.168.86.201:8001",
+            "GEMINI_API_KEY": "test-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_bifrost_config_from_env()
+        assert "gemini" in config.backends
+        gemini_url = config.backends["gemini"].base_url
+        assert gemini_url == (
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        )
+        # Regression guard against the bare-origin default that produced the 404.
+        assert "/v1beta/openai" in gemini_url
+        assert gemini_url != "https://generativelanguage.googleapis.com"
+
+    def test_gemini_explicit_base_url_override_is_preserved(self) -> None:
+        """An explicit GEMINI_BASE_URL override is used verbatim (no regression)."""
+        env = {
+            "LLM_CODER_FAST_URL": "http://192.168.86.201:8001",
+            "GEMINI_API_KEY": "test-key",
+            "GEMINI_BASE_URL": (
+                "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+            ),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_bifrost_config_from_env()
+        assert config.backends["gemini"].base_url == (
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        )
+
+    def test_gemini_omitted_without_api_key(self) -> None:
+        """Gemini backend is only added when the API key is present (unchanged)."""
+        env = {"LLM_CODER_FAST_URL": "http://192.168.86.201:8001"}
+        with patch.dict(os.environ, env, clear=True):
+            config = load_bifrost_config_from_env()
+        assert "gemini" not in config.backends
+
+    def test_non_gemini_backends_have_no_path_appended(self) -> None:
+        """OMN-12664 regression: local/GLM backends keep their bare base_url."""
+        env = {
+            "LLM_CODER_URL": "http://192.168.86.201:8000",
+            "GLM_BASE_URL": "https://open.bigmodel.cn",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_bifrost_config_from_env()
+        assert config.backends["local-coder-30b"].base_url == (
+            "http://192.168.86.201:8000"
+        )
+        assert config.backends["glm"].base_url == "https://open.bigmodel.cn"


### PR DESCRIPTION
## OMN-12664: Preserve full Gemini endpoint path in bifrost gateway (omnibase_infra side)

Workstream A of `docs/plans/2026-06-03-late-day-contractor-live-path-stabilization.md`. Cross-repo with the omnimarket side.

### Problem
The cloud-tier Gemini call dropped the registered `/v1beta/openai` path and posted to `/v1/chat/completions`, producing a 404. The bifrost gateway fed every backend URL through `ModelLlmInferenceRequest.base_url`, so the OpenAI-compatible handler (`_build_url`) appended `/v1/chat/completions` even when the configured URL was already a complete chat endpoint. Two 404 variants resulted:
- bare-origin base -> `https://generativelanguage.googleapis.com/v1/chat/completions`
- `/v1beta/openai` base -> `https://generativelanguage.googleapis.com/v1beta/openai/v1/chat/completions`

The registered endpoint is `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`.

### Changes
1. `handler_bifrost_gateway.py::_build_inference_request` — when a backend's configured `base_url` is already a complete chat endpoint (ends in `/chat/completions` or `/completions`), route it through `endpoint_url` so `_build_url` posts it verbatim with no second path append. Structural URL-shape check, not a provider sniff. `_build_url` itself is unchanged (it was already correct, OMN-10489).
2. `config_loader_bifrost.py` — the Gemini default now resolves to the full `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions` endpoint instead of the bare origin. Gemini-only; local and GLM backends are untouched and keep their legacy `base_url` append path.

No new router/adapter/module that selects behavior by provider (WS-A acceptance + ONEX_CANONICAL_ARCHITECTURE).

### dod_evidence
**What changed:** 2 source files (`handler_bifrost_gateway.py`, `config_loader_bifrost.py`) + 2 test files.

**Tests (new + updated):**
- `tests/unit/.../bifrost/test_bifrost_endpoint_preservation.py` (new):
  - `test_full_gemini_endpoint_routes_through_endpoint_url` — full endpoint posts verbatim
  - `test_no_double_append_for_full_chat_endpoint` — the `/v1beta/openai/v1/chat/completions` 404 variant is NOT produced
  - `test_gemini_openai_base_is_not_a_full_endpoint` — documents the 2nd 404 variant (why the default must be the complete endpoint)
  - `test_gemini_bare_origin_does_not_truncate_path` — 1st 404 variant via legacy path
  - `test_local_openai_backend_unaffected`, `test_local_full_endpoint_routes_through_endpoint_url`, `test_trailing_slash_full_endpoint_detected` — non-Gemini / structural-detection coverage
- `tests/unit/.../bifrost/test_config_loader_bifrost.py` (updated): Gemini default now carries `/v1beta/openai/chat/completions`; explicit override preserved; non-Gemini backends unchanged.

**Local gates (run in worktree, no -k filter):**
- `uv run pytest tests/unit/nodes/node_llm_inference_effect/` -> 466 passed
- new + config-loader regression tests -> 19 passed
- `uv run ruff format` / `ruff check --fix src/ tests/` -> clean (warnings are pre-existing in unrelated files)
- `uv run mypy <two touched src files> --strict` -> Success, no issues
- `pre-commit run --files <changed files>` -> all hooks Passed
- Full suite `uv run pytest tests/ -m "not slow and not integration and not kafka and not postgres and not consul and not chaos and not performance"` -> 20998 passed, 2 failed. Both failures are pre-existing and unrelated to this change (neither test file is in this PR's diff): `test_node_migration_discovery::test_sync_check_reports_in_sync` (local omnimarket migration vendor drift) and `test_receipt_gate_install_guard` (CI install-script content check).

**Transport-mode / URL proof:** regression tests assert the resolved POST URL via `HandlerLlmOpenaiCompatible._build_url`. For the Gemini full endpoint the resolved URL is `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions` (posted as-is). No live `.201`/runtime mutation was performed (code+PR only per plan).

### Cross-repo
Sibling omnimarket PR: https://github.com/OmniNode-ai/omnimarket/pull/1031


Evidence-Source: OCC#2141
Evidence-Ticket: OMN-12664


<!-- occ re-pinned at 4583e150c -->
