### PR TITLE
chore(OMN-12667): bump zone-filter workflow ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   # .evidence/), heavy jobs (test-parallel, migration-integration) skip, while
   # lint, validators, contract gates, and receipt-gate callers still run.
   zone-filter:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/zone-filter.yml@296431f68a7431b9a98cd3661c6a2e05d1a18e45
+    uses: OmniNode-ai/omnibase_core/.github/workflows/zone-filter.yml@a1e73fff25a05ccb37cbb92d9c91754c59d808c0
     with:
       python-version: "3.12"
 


### PR DESCRIPTION
Ticket: OMN-12667

Evidence-Source: e4897be094cc268ae6f0bedde58580cdda0e70ea
Evidence-Ticket: OMN-12667

## Summary
- Replaces Dependabot PR #1853 with a ticketed branch for Receipt Gate compatibility.
- Bumps the reusable zone-filter workflow reference in `.github/workflows/ci.yml` to `a1e73fff25a05ccb37cbb92d9c91754c59d808c0`.

## Verification
- `uv run python -c 'from pathlib import Path; import yaml; data=yaml.safe_load(Path(".github/workflows/ci.yml").read_text()); assert data["jobs"]["zone-filter"]["uses"].endswith("@a1e73fff25a05ccb37cbb92d9c91754c59d808c0"); print(data["jobs"]["zone-filter"]["uses"])'`\n- `grep -n 'zone-filter.yml@a1e73fff25a05ccb37cbb92d9c91754c59d808c0' .github/workflows/ci.yml`\n- Central OCC evidence merged in OmniNode-ai/onex_change_control#2144 (`e4897be094cc268ae6f0bedde58580cdda0e70ea`)\n\nSupersedes: #1853