### PR TITLE
chore(OMN-12668): bump upload-artifact action

### DIFF
--- a/.github/workflows/omnigate.yml
+++ b/.github/workflows/omnigate.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload decision artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: omnigate-decision
           path: /tmp/omnigate-decision.json


### PR DESCRIPTION
Ticket: OMN-12668

Evidence-Source: 351519491fb775f18d62b397f8d2ece9622d219f
Evidence-Ticket: OMN-12668

## Summary
- Replaces Dependabot PR #1852 with a ticketed branch for Receipt Gate compatibility.
- Bumps `actions/upload-artifact` from `v4` to `v7` in `.github/workflows/omnigate.yml`.

## Verification
- YAML parse/assertion confirmed the only upload-artifact ref is `actions/upload-artifact@v7`.
- Central OCC evidence merged in OmniNode-ai/onex_change_control#2145 (`351519491fb775f18d62b397f8d2ece9622d219f`).

Supersedes: #1852