### PR TITLE
chore(OMN-12669): bump checkout action

### DIFF
--- a/.github/workflows/attest-source-hash.yml
+++ b/.github/workflows/attest-source-hash.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
 

--- a/.github/workflows/omnigate.yml
+++ b/.github/workflows/omnigate.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -32,7 +32,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -34,7 +34,7 @@ CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 SETUP_PYTHON_UV_ACTION = (
     REPO_ROOT / ".github" / "actions" / "setup-python-uv" / "action.yml"
 )
-CHECKOUT_V6_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+CHECKOUT_V6_SHA = "df4cb1c069e1874edd31b4311f1884172cec0e10"
 CODEQL_V4_SHA = "dc73d59c2d7bd4f8194098a91219eeee6d8a1719"
 
 


### PR DESCRIPTION
## Summary
- Replace the Dependabot checkout bump with an owner-tracked OMN-12669 PR.
- Update workflow checkout refs to actions/checkout v6 / current pinned v6 SHA.
- Preserve existing workflow behavior and pinning style.

Supersedes: https://github.com/OmniNode-ai/omnibase_infra/pull/1851

Evidence-Ticket: OMN-12669
Evidence-Source: e530d8f7947676e3e7936f1df4e2be8b76d3d34b

## Verification
- `uv run python - <<PY ...` parsed the three changed workflow YAML files and asserted the expected checkout refs.
- `rg` confirmed the changed workflows reference only `actions/checkout@v6` or `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10`.
- `git diff --check`
- Product PR non-Receipt-Gate CI passed after rerunning a transient cancelled `Infra Node Handler Ownership` job.
- OCC evidence refreshed in onex_change_control#2152 at `e530d8f7947676e3e7936f1df4e2be8b76d3d34b`.

## Rollout
No runtime deploy, restart, or `.201` mutation. CI-only workflow action update.