### PR TITLE
fix(OMN-12672): cap a2a-sdk below v1

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "efa8e7cba714f4c4b39479944f0e01f5",
+  "identity_digest": "7edfaaf04d50354ec5b3e222a60affe6",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "5ce96de6f0cf8e512923cabf",
+  "shared_env_digest": "0ab26bd57b082b9bd83c1837",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "7edfaaf04d50354ec5b3e222a60affe6",
+  "identity_digest": "37fdee0d8f3f91a39a178c781903f487",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "0ab26bd57b082b9bd83c1837",
+  "shared_env_digest": "daa2bec0def377549641f459",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = [
     "pydantic-settings>=2.2.1,<3.0.0", # Settings management
     "jsonschema>=4.20.0,<5.0.0", # JSON schema validation
     "watchdog>=4.0.0", # Filesystem event monitoring (HandlerContractFileWatcher, OMN-3940)
-    "a2a-sdk>=0.3.4,<1.1.0", # Real A2A client/server protocol support for remote-agent invocation
+    "a2a-sdk>=0.3.4,<1.2.0", # Real A2A client/server protocol support for remote-agent invocation
     # Security: CVE-2026-32597 (HIGH) - PyJWT <2.12.0 accepts unknown `crit` header extensions.
     # Transitive dependency (via mcp/httpx/authlib). Explicitly declared to enforce minimum version.
     "pyjwt>=2.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = [
     "pydantic-settings>=2.2.1,<3.0.0", # Settings management
     "jsonschema>=4.20.0,<5.0.0", # JSON schema validation
     "watchdog>=4.0.0", # Filesystem event monitoring (HandlerContractFileWatcher, OMN-3940)
-    "a2a-sdk>=0.3.4,<1.2.0", # Real A2A client/server protocol support for remote-agent invocation
+    "a2a-sdk>=0.3.4,<1.0.0", # Real A2A client/server protocol support for remote-agent invocation
     # Security: CVE-2026-32597 (HIGH) - PyJWT <2.12.0 accepts unknown `crit` header extensions.
     # Transitive dependency (via mcp/httpx/authlib). Explicitly declared to enforce minimum version.
     "pyjwt>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2091,7 +2091,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.4,<1.1.0" },
+    { name = "a2a-sdk", specifier = ">=0.3.4,<1.2.0" },
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiokafka", specifier = ">=0.11.0,<0.15.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2091,7 +2091,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.4,<1.2.0" },
+    { name = "a2a-sdk", specifier = ">=0.3.4,<1.0.0" },
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiokafka", specifier = ">=0.11.0,<0.15.0" },


### PR DESCRIPTION
## Summary
- supersedes Dependabot #1854 with a compatibility-safe owner branch
- caps `a2a-sdk` at `>=0.3.4,<1.0.0` after CodeRabbit flagged v1.x API incompatibility risk
- refreshes root `uv.lock` metadata and runner image identity

## Evidence
Evidence-Ticket: OMN-12672
Evidence-Source: c9c304f27d142ec6f39163fecacc84f328e56411

Local verification:
- `uv lock --check`
- `uv run python - <<PY ... importlib.metadata.version("a2a-sdk") ... PY` -> `a2a-sdk 0.3.26`
- `uv run pytest tests/unit/nodes/node_remote_agent_invoke_effect/test_handler_a2a_task.py tests/integration/test_remote_agent_invoke_effect_contract.py tests/integration/test_remote_agent_invoke_runtime_discovery.py -q` -> `23 passed`
- `python3 scripts/ci/runner_image_identity.py --mode verify` -> `v5 37fdee0d8f3f91a39a178c781903f487`
- `git diff --check HEAD~2..HEAD`
- `runner-image-build-smoke` passed for the corrected head

## Notes
- The resolved `a2a-sdk` version remains `0.3.26` in the current lock.
- Central OCC contract and PASS receipts are merged in onex_change_control commit `c9c304f27d142ec6f39163fecacc84f328e56411`.
- No runtime deploy/restart or `.201` mutation is included.
