### PR TITLE
fix(OMN-12716): codify qwen vllm tool parser unit

### DIFF
--- a/deploy/systemd/vllm-gpu0-qwen-coder.service
+++ b/deploy/systemd/vllm-gpu0-qwen-coder.service
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# vllm-gpu0-qwen-coder.service — Qwen coder model-serving unit for .201.
+#
+# Install on the model-serving host:
+#   sudo cp deploy/systemd/vllm-gpu0-qwen-coder.service /etc/systemd/system/vllm-gpu0.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now vllm-gpu0.service
+#
+# The auto-tool-choice and qwen3_coder parser flags are required for SEA ADK
+# tool-calling runs. Without them, local OpenAI-compatible ADK calls can fail
+# with HTTP 400 even though plain chat completions pass.
+
+[Unit]
+Description=vLLM API - Qwen3.6-35B-A3B GPTQ-Int4 (RTX 5090, 128K)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=jonah
+Group=jonah
+Environment=CUDA_DEVICE_ORDER=PCI_BUS_ID
+Environment=CUDA_VISIBLE_DEVICES=0
+EnvironmentFile=-/etc/vllm/env
+WorkingDirectory=/opt/vllm
+ExecStart=/opt/vllm/venv/bin/python -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --model /data/inference/hf-cache/Qwen3.6-35B-A3B-GPTQ-Int4 \
+    --served-model-name Qwen3.6-35B-A3B \
+    --tensor-parallel-size 1 \
+    --max-model-len 131072 \
+    --max-num-seqs 4 \
+    --gpu-memory-utilization 0.92 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --trust-remote-code
+Restart=on-failure
+RestartSec=10
+LimitMEMLOCK=infinity
+LimitNOFILE=65535
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/ci/test_vllm_qwen_coder_service_unit.py
+++ b/tests/ci/test_vllm_qwen_coder_service_unit.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 SERVICE_PATH = Path("deploy/systemd/vllm-gpu0-qwen-coder.service")
 
 
+@pytest.mark.unit
 def test_qwen_coder_vllm_unit_declares_tool_call_parser_flags() -> None:
     service = SERVICE_PATH.read_text(encoding="utf-8")
 
@@ -16,6 +19,7 @@ def test_qwen_coder_vllm_unit_declares_tool_call_parser_flags() -> None:
     assert "--tool-call-parser qwen3_coder" in service
 
 
+@pytest.mark.unit
 def test_qwen_coder_vllm_unit_preserves_stability_endpoint_identity() -> None:
     service = SERVICE_PATH.read_text(encoding="utf-8")
 

--- a/tests/ci/test_vllm_qwen_coder_service_unit.py
+++ b/tests/ci/test_vllm_qwen_coder_service_unit.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression guard for the Qwen coder vLLM systemd unit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SERVICE_PATH = Path("deploy/systemd/vllm-gpu0-qwen-coder.service")
+
+
+def test_qwen_coder_vllm_unit_declares_tool_call_parser_flags() -> None:
+    service = SERVICE_PATH.read_text(encoding="utf-8")
+
+    assert "--enable-auto-tool-choice" in service
+    assert "--tool-call-parser qwen3_coder" in service
+
+
+def test_qwen_coder_vllm_unit_preserves_stability_endpoint_identity() -> None:
+    service = SERVICE_PATH.read_text(encoding="utf-8")
+
+    assert "--port 8000" in service
+    assert "--served-model-name Qwen3.6-35B-A3B" in service
+    assert "--max-model-len 131072" in service


### PR DESCRIPTION
## Summary
- add a checked-in systemd unit for the .201 Qwen coder vLLM service
- preserve the ADK-required `--enable-auto-tool-choice` and `--tool-call-parser qwen3_coder` flags
- add a CI guard so the served model, port, context length, and tool parser flags do not drift

## Evidence
- `uv run ruff check tests/ci/test_vllm_qwen_coder_service_unit.py --fix`
- `uv run pytest tests/ci/test_vllm_qwen_coder_service_unit.py -q` -> 2 passed
- live hotpatch proof: SEA `--agent` correlation `f6859ca4-e2ad-46ea-bd14-4eaab5ae81f2` returned PASS and `{"is_healthy": true}`
- direct delegation proof: correlation `39cba6ae-68d0-4690-8238-fcdda82f3890`, model `Qwen3.6-27B-MTP-IQ4_XS.gguf`, content `healthy=true`

Evidence-Ticket: OMN-12716
Evidence-Source: OCC#2199