### PR TITLE
fix(OMN-12720): publish inference validation failures

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -33,6 +33,7 @@ import re
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -108,6 +109,9 @@ _SENSITIVE_PATTERN = re.compile(
 )
 _STRICT_DISPATCHER_COVERAGE_ENV = "ONEX_STRICT_DISPATCHER_COVERAGE"
 _TOPIC_MIGRATION_EXECUTOR_DEPS = frozenset({"provisioner", "drain_proof_gate"})
+_DELEGATION_INFERENCE_INTENT_MODULE = "omnibase_core.models.delegation.wire"
+_DELEGATION_INFERENCE_INTENT_NAME = "ModelInferenceIntent"
+_DELEGATION_INFERENCE_INTENT_DISCRIMINATOR = "llm_inference"
 
 
 def _sanitize_exc(exc: BaseException) -> str:
@@ -189,6 +193,26 @@ def _is_async_incompat_runtime_error(exc: BaseException) -> bool:
 def _is_protocol_handler_class(handler_cls: type) -> bool:
     """Return True when a handler routing entry points at a Protocol class."""
     return bool(getattr(handler_cls, "_is_protocol", False))
+
+
+def _is_delegation_inference_intent_ref(event_model: ModelHandlerRef) -> bool:
+    """Return True for the canonical delegation inference-intent wire model."""
+    return (
+        event_model.module == _DELEGATION_INFERENCE_INTENT_MODULE
+        and event_model.name == _DELEGATION_INFERENCE_INTENT_NAME
+    )
+
+
+def _payload_value(payload: object, key: str) -> object:
+    if isinstance(payload, Mapping):
+        return payload.get(key)
+    return getattr(payload, key, None)
+
+
+def _payload_claims_delegation_inference_intent(payload: object) -> bool:
+    """Return True when a raw payload declares the inference-intent discriminator."""
+    intent = _payload_value(payload, "intent")
+    return intent == _DELEGATION_INFERENCE_INTENT_DISCRIMINATOR
 
 
 async def _async_resolve_from_container(
@@ -413,12 +437,23 @@ def _make_dispatch_callback(
             return _normalize_handler_result(raw_result, envelope, None)
 
         payload = _extract_dispatch_payload(envelope)
-        model_cls = _import_event_model_class(event_model)
-        typed_payload = (
-            payload
-            if isinstance(payload, model_cls)
-            else model_cls.model_validate(payload)
-        )
+        try:
+            model_cls = _import_event_model_class(event_model)
+            typed_payload = (
+                payload
+                if isinstance(payload, model_cls)
+                else model_cls.model_validate(payload)
+            )
+        except Exception as exc:
+            failure_result = _build_inference_intent_validation_failure_result(
+                event_model=event_model,
+                envelope=envelope,
+                payload=payload,
+                exc=exc,
+            )
+            if failure_result is not None:
+                return failure_result
+            raise
         if _handler_accepts_event_envelope(
             cast("Callable[..., object]", handle_method)
         ):
@@ -464,17 +499,88 @@ def _make_payload_type_matcher(
 
     def _matches(payload: object) -> bool:
         if not cached_model_cls:
-            cached_model_cls.append(_import_event_model_class(event_model))
+            try:
+                cached_model_cls.append(_import_event_model_class(event_model))
+            except Exception:
+                if _is_delegation_inference_intent_ref(
+                    event_model
+                ) and _payload_claims_delegation_inference_intent(payload):
+                    return True
+                raise
         model_cls = cached_model_cls[0]
         if isinstance(payload, model_cls):
             return True
         try:
             model_cls.model_validate(payload)
         except Exception:  # noqa: BLE001 — validation failure means "not my type"
+            if _is_delegation_inference_intent_ref(
+                event_model
+            ) and _payload_claims_delegation_inference_intent(payload):
+                return True
             return False
         return True
 
     return _matches
+
+
+def _build_inference_intent_validation_failure_result(
+    *,
+    event_model: ModelHandlerRef,
+    envelope: object,
+    payload: object,
+    exc: BaseException,
+) -> ModelDispatchResult | None:
+    """Build a correlated inference-response error for pre-handler validation misses.
+
+    Delegation's inference effect publishes ``ModelInferenceResponseData`` for
+    provider/runtime failures inside ``HandlerInferenceIntent.handle()``. Payload
+    validation and event-model import happen before that handler is called, so
+    this boundary maps only canonical ``ModelInferenceIntent`` load/validation
+    failures to the same response shape. The delegation orchestrator then handles
+    it through its normal inference-error path instead of leaving the caller to
+    wait for a timeout.
+    """
+    if not _is_delegation_inference_intent_ref(event_model):
+        return None
+    if not _payload_claims_delegation_inference_intent(payload):
+        return None
+
+    from omnibase_core.models.delegation.wire import ModelInferenceResponseData
+    from omnibase_infra.enums import EnumDispatchStatus
+    from omnibase_infra.models.dispatch.model_dispatch_result import (
+        ModelDispatchResult,
+    )
+
+    correlation_candidate = _extract_dispatch_correlation_id(envelope, payload)
+    correlation_id = _coerce_uuid_or_none(correlation_candidate)
+    if correlation_id is None:
+        return None
+
+    model_value = _payload_value(payload, "model")
+    model_used = model_value if isinstance(model_value, str) else ""
+    error_message = (
+        "ModelInferenceIntent validation failed before "
+        f"HandlerInferenceIntent.handle(): {_sanitize_exc(exc)}"
+    )
+    response = ModelInferenceResponseData(
+        correlation_id=correlation_id,
+        content="",
+        model_used=model_used,
+        llm_call_id="",
+        latency_ms=0,
+        error_message=error_message,
+    )
+    now = datetime.now(UTC)
+    return ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic=_extract_dispatch_topic(envelope),
+        message_type=event_model.name,
+        started_at=now,
+        completed_at=now,
+        output_count=1,
+        output_events=[response],
+        correlation_id=correlation_id,
+    )
 
 
 def _import_event_model_class(event_model: ModelHandlerRef) -> type[BaseModel]:

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py
@@ -57,7 +57,7 @@ def _invalid_inference_payload(correlation_id: UUID) -> dict[str, object]:
         "system_prompt": "",
         "prompt": "produce a short result",
         "max_tokens": 128,
-        "temperature": 0.3,
+        "temperature": 99.0,
         "timeout_seconds": 30.0,
         "correlation_id": str(correlation_id),
         "api_key": None,
@@ -119,7 +119,7 @@ async def test_invalid_inference_intent_returns_correlated_error_response() -> N
     assert response.model_used == "qwen-test"
     assert response.content == ""
     assert "ModelInferenceIntent validation failed" in response.error_message
-    assert "api_key" in response.error_message
+    assert "temperature" in response.error_message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for inference-intent validation failures.
+
+Malformed delegation ``ModelInferenceIntent`` payloads used to be rejected by
+auto-wiring before ``HandlerInferenceIntent.handle()`` could return its normal
+``ModelInferenceResponseData(error_message=...)`` failure surface. That left the
+delegation workflow waiting for a terminal event until the caller timed out.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from omnibase_core.models.delegation.wire import ModelInferenceResponseData
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _make_dispatch_callback,
+    _make_payload_type_matcher,
+)
+from omnibase_infra.runtime.auto_wiring.models import ModelHandlerRef
+from omnibase_infra.runtime.service_dispatch_result_applier import (
+    DispatchResultApplier,
+)
+
+pytestmark = pytest.mark.unit
+
+_INFERENCE_RESPONSE_TOPIC = "onex.evt.omnibase-infra.inference-response.v1"
+
+
+class _MustNotRunInferenceHandler:
+    def __init__(self) -> None:
+        self.called = False
+
+    def handle(self, payload: object) -> object:
+        self.called = True
+        raise AssertionError("validation failures must not call the handler")
+
+
+def _inference_event_model_ref() -> ModelHandlerRef:
+    return ModelHandlerRef(
+        name="ModelInferenceIntent",
+        module="omnibase_core.models.delegation.wire",
+    )
+
+
+def _invalid_inference_payload(correlation_id: UUID) -> dict[str, object]:
+    return {
+        "intent": "llm_inference",
+        "base_url": "http://127.0.0.1:8001",
+        "model": "qwen-test",
+        "system_prompt": "",
+        "prompt": "produce a short result",
+        "max_tokens": 128,
+        "temperature": 0.3,
+        "timeout_seconds": 30.0,
+        "correlation_id": str(correlation_id),
+        "api_key": None,
+    }
+
+
+def _envelope(
+    *,
+    correlation_id: UUID,
+    payload: dict[str, object],
+) -> ModelEventEnvelope[object]:
+    return ModelEventEnvelope[object](
+        payload=payload,
+        correlation_id=correlation_id,
+        envelope_timestamp=datetime.now(UTC),
+        event_type="ModelInferenceIntent",
+        payload_type="ModelInferenceIntent",
+        source_tool="test-handler-wiring",
+    )
+
+
+def test_inference_intent_matcher_accepts_claimed_but_invalid_payload() -> None:
+    matcher = _make_payload_type_matcher(_inference_event_model_ref())
+    correlation_id = UUID("00000000-0000-0000-0000-000000000127")
+
+    assert matcher(_invalid_inference_payload(correlation_id)) is True
+    assert (
+        matcher({"intent": "routing_reducer", "correlation_id": str(correlation_id)})
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_inference_intent_returns_correlated_error_response() -> None:
+    correlation_id = UUID("00000000-0000-0000-0000-000000001270")
+    handler = _MustNotRunInferenceHandler()
+    callback = _make_dispatch_callback(
+        handler,  # type: ignore[arg-type]
+        event_model=_inference_event_model_ref(),
+    )
+
+    result = await callback(
+        _envelope(
+            correlation_id=correlation_id,
+            payload=_invalid_inference_payload(correlation_id),
+        )
+    )
+
+    assert handler.called is False
+    assert result is not None
+    assert result.status is EnumDispatchStatus.SUCCESS
+    assert result.correlation_id == correlation_id
+    assert result.output_count == 1
+    assert len(result.output_events) == 1
+
+    response = result.output_events[0]
+    assert isinstance(response, ModelInferenceResponseData)
+    assert response.correlation_id == correlation_id
+    assert response.model_used == "qwen-test"
+    assert response.content == ""
+    assert "ModelInferenceIntent validation failed" in response.error_message
+    assert "api_key" in response.error_message
+
+
+@pytest.mark.asyncio
+async def test_invalid_inference_intent_error_response_publishes_to_inference_topic() -> (
+    None
+):
+    correlation_id = UUID("00000000-0000-0000-0000-000000012700")
+    callback = _make_dispatch_callback(
+        _MustNotRunInferenceHandler(),  # type: ignore[arg-type]
+        event_model=_inference_event_model_ref(),
+    )
+    result = await callback(
+        _envelope(
+            correlation_id=correlation_id,
+            payload=_invalid_inference_payload(correlation_id),
+        )
+    )
+    assert result is not None
+
+    bus = AsyncMock()
+    applier = DispatchResultApplier(
+        event_bus=bus,
+        output_topic="onex.evt.omnibase-infra.delegation-completed.v1",
+        output_topic_map={"InferenceResponseData": _INFERENCE_RESPONSE_TOPIC},
+    )
+
+    await applier.apply(result, correlation_id=correlation_id)
+
+    bus.publish_envelope.assert_awaited_once()
+    call_kwargs = bus.publish_envelope.call_args.kwargs
+    assert call_kwargs["topic"] == _INFERENCE_RESPONSE_TOPIC
+    assert call_kwargs["envelope"].correlation_id == correlation_id
+    assert isinstance(call_kwargs["envelope"].payload, ModelInferenceResponseData)


### PR DESCRIPTION
Evidence-Ticket: OMN-12720

## Summary
- route malformed canonical ModelInferenceIntent payloads that carry intent=llm_inference through the inference handler dispatcher instead of dropping them as no-dispatcher
- convert pre-handler ModelInferenceIntent schema/import validation failures into correlated ModelInferenceResponseData(error_message=...) dispatch output
- add regression coverage for matcher selection, correlated error response construction, and inference-response topic publication

## Verification
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py -q
- uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_payload_type_matcher.py tests/unit/runtime/test_dispatch_result_applier_topic_routing.py -q
- uv run pytest tests/unit/runtime/auto_wiring -q
- uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_handler_wiring_inference_intent_failure.py
- uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict

## Notes
- Provider/runtime errors inside HandlerInferenceIntent.handle() remain untouched and still publish through the existing handler-owned ModelInferenceResponseData path.

Evidence-Source: OCC#2207
