### PR TITLE
fix(OMN-12724): respect runtime profile ownership for subscriptions

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -28,6 +28,9 @@ node_type: "EFFECT_GENERIC"
 description: >
   LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence for local-model compute attribution using the shared EnumUsageSource vocabulary.
 
+runtime_profiles:
+  - effects
+
 # Strongly typed I/O models
 # Note: These models live in the shared omnibase_infra.models.llm package.
 # They are shared across all LLM inference handlers (OpenAI-compatible)

--- a/src/omnibase_infra/runtime/auto_wiring/profile_ownership.py
+++ b/src/omnibase_infra/runtime/auto_wiring/profile_ownership.py
@@ -10,6 +10,8 @@ from the primary runtime.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_infra.runtime.auto_wiring.models import (
@@ -25,6 +27,47 @@ def _normalize_runtime_profile(value: object) -> str:
     if not profile:
         raise ValueError("runtime_profile cannot be blank")
     return profile
+
+
+def extract_runtime_profiles_from_contract(
+    raw_contract: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Return normalized runtime-profile ownership declared by raw contract YAML."""
+    profiles_raw = raw_contract.get("runtime_profiles")
+    descriptor_raw = raw_contract.get("descriptor")
+    if profiles_raw is None and isinstance(descriptor_raw, Mapping):
+        profiles_raw = descriptor_raw.get("runtime_profiles")
+
+    if profiles_raw is None:
+        return ()
+    if isinstance(profiles_raw, str):
+        raw_values = (profiles_raw,)
+    elif isinstance(profiles_raw, (list, tuple)):
+        raw_values = tuple(profiles_raw)
+    else:
+        raise TypeError("runtime_profiles must be a string or sequence of strings")
+
+    profiles: list[str] = []
+    for raw in raw_values:
+        profiles.append(_normalize_runtime_profile(raw))
+    return tuple(dict.fromkeys(profiles))
+
+
+def runtime_profile_owns_contract(
+    raw_contract: Mapping[str, object],
+    runtime_profile: str,
+) -> bool:
+    """Return whether runtime_profile owns a raw contract's subscriptions.
+
+    Contracts without ``runtime_profiles`` default to ``main`` ownership. This
+    mirrors auto-wiring ownership filtering for legacy runtime-host subscription
+    paths that operate on raw contract dictionaries.
+    """
+    normalized_profile = _normalize_runtime_profile(runtime_profile)
+    runtime_profiles = extract_runtime_profiles_from_contract(raw_contract)
+    if runtime_profiles:
+        return normalized_profile in runtime_profiles
+    return normalized_profile == "main"
 
 
 class ModelRuntimeProfileOwnershipResult(BaseModel):
@@ -81,5 +124,7 @@ def filter_manifest_for_runtime_profile(
 
 __all__ = [
     "ModelRuntimeProfileOwnershipResult",
+    "extract_runtime_profiles_from_contract",
     "filter_manifest_for_runtime_profile",
+    "runtime_profile_owns_contract",
 ]

--- a/src/omnibase_infra/runtime/runtime_host_process.py
+++ b/src/omnibase_infra/runtime/runtime_host_process.py
@@ -102,6 +102,9 @@ from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchRe
 from omnibase_infra.models.runtime.model_resolved_dependencies import (
     ModelResolvedDependencies,
 )
+from omnibase_infra.runtime.auto_wiring.profile_ownership import (
+    runtime_profile_owns_contract,
+)
 from omnibase_infra.runtime.batch_response_publisher import BatchResponsePublisher
 from omnibase_infra.runtime.constants_security import (
     TRUSTED_HANDLER_NAMESPACE_PREFIXES,
@@ -595,6 +598,18 @@ def _baseline_subscription_wiring_disabled(runtime_profile: str | None = None) -
     return runtime_profile.strip().lower() != "main"
 
 
+def _raw_contract_owned_by_runtime_profile(
+    raw_contract: object,
+    runtime_profile: str | None = None,
+) -> bool:
+    """Return whether raw contract subscriptions are owned by runtime_profile."""
+    if not isinstance(raw_contract, dict):
+        return True
+    if runtime_profile is None:
+        runtime_profile = os.environ.get("RUNTIME_PROFILE", "main")
+    return runtime_profile_owns_contract(raw_contract, runtime_profile)
+
+
 def _discover_package_node_contracts(package_root: Path) -> list[dict[str, object]]:
     """Discover node contracts from the installed package tree.
 
@@ -633,6 +648,7 @@ async def _wire_package_node_subscriptions(
     contracts: list[dict[str, object]],
     event_bus_wiring: EventBusSubcontractWiring,
     already_wired_names: set[str],
+    runtime_profile: str | None = None,
 ) -> tuple[int, int, int]:
     """Wire Kafka subscriptions for package-discovered node contracts.
 
@@ -671,6 +687,16 @@ async def _wire_package_node_subscriptions(
                 "node=%s consumer_purpose=%s",
                 node_name,
                 event_bus_section.get("consumer_purpose"),
+            )
+            continue
+
+        if not _raw_contract_owned_by_runtime_profile(contract, runtime_profile):
+            skipped_no_topics += 1
+            logger.info(
+                "RuntimeHostProcess: skipping Kafka subscription for "
+                "runtime-profile-owned contract node=%s profile=%s",
+                node_name,
+                runtime_profile or os.environ.get("RUNTIME_PROFILE", "main"),
             )
             continue
 
@@ -3592,6 +3618,14 @@ class RuntimeHostProcess:
         event_bus_data = descriptor.contract_config.get("event_bus")
         if not event_bus_data or not isinstance(event_bus_data, dict):
             return
+        if not _raw_contract_owned_by_runtime_profile(descriptor.contract_config):
+            logger.info(
+                "Skipping live handler subscription for runtime-profile-owned "
+                "contract: node=%s profile=%s",
+                node_name,
+                os.environ.get("RUNTIME_PROFILE", "main"),
+            )
+            return
         if _requires_raw_event_projection_wiring(event_bus_data):
             logger.info(
                 "Skipping live handler subscription for raw projection consumer: "
@@ -5756,6 +5790,14 @@ class RuntimeHostProcess:
                 if isinstance(raw_contract, dict)
                 else None
             )
+            if not _raw_contract_owned_by_runtime_profile(raw_contract):
+                logger.info(
+                    "Skipping event_bus subcontract wiring for "
+                    "runtime-profile-owned contract: handler=%s profile=%s",
+                    descriptor.name or handler_type,
+                    os.environ.get("RUNTIME_PROFILE", "main"),
+                )
+                continue
             if _requires_raw_event_projection_wiring(raw_event_bus):
                 logger.info(
                     "Skipping event_bus subcontract wiring for raw projection consumer: "
@@ -5871,6 +5913,7 @@ class RuntimeHostProcess:
             contracts=contracts,
             event_bus_wiring=self._event_bus_wiring,
             already_wired_names=already_wired,
+            runtime_profile=os.environ.get("RUNTIME_PROFILE", "main"),
         )
 
         logger.info(

--- a/tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py
+++ b/tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py
@@ -18,6 +18,10 @@ from omnibase_infra.runtime.auto_wiring.models import (
     ModelContractVersion,
     ModelDiscoveredContract,
 )
+from omnibase_infra.runtime.auto_wiring.profile_ownership import (
+    extract_runtime_profiles_from_contract,
+    runtime_profile_owns_contract,
+)
 
 
 def _contract(
@@ -68,6 +72,37 @@ def test_contract_runtime_profiles_select_single_owner() -> None:
         "main_only"
     ]
     assert main_result.skipped_contracts == ("effects_only",)
+
+
+def test_raw_contract_runtime_profile_ownership_defaults_to_main() -> None:
+    raw_contract = {
+        "name": "node_delegation_orchestrator",
+        "event_bus": {
+            "subscribe_topics": [
+                "onex.cmd.omnibase-infra.delegation-request.v1",
+            ],
+        },
+    }
+
+    assert extract_runtime_profiles_from_contract(raw_contract) == ()
+    assert runtime_profile_owns_contract(raw_contract, "main") is True
+    assert runtime_profile_owns_contract(raw_contract, "effects") is False
+
+
+def test_raw_contract_runtime_profile_ownership_reads_descriptor_metadata() -> None:
+    raw_contract = {
+        "name": "node_delegation_quality_gate_effect",
+        "descriptor": {"runtime_profiles": [" Effects ", "effects"]},
+        "event_bus": {
+            "subscribe_topics": [
+                "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1",
+            ],
+        },
+    }
+
+    assert extract_runtime_profiles_from_contract(raw_contract) == ("effects",)
+    assert runtime_profile_owns_contract(raw_contract, "effects") is True
+    assert runtime_profile_owns_contract(raw_contract, "main") is False
 
 
 def test_runtime_profiles_are_normalized_and_deduplicated() -> None:
@@ -145,3 +180,34 @@ def test_github_pr_poller_is_owned_by_effects_runtime_profile() -> None:
     ]
     assert main_result.manifest.contracts == ()
     assert main_result.skipped_contracts == ("node_github_pr_poller_effect",)
+
+
+def test_llm_inference_effect_is_owned_by_effects_runtime_profile() -> None:
+    contract_path = (
+        Path(__file__).resolve().parents[4]
+        / "src"
+        / "omnibase_infra"
+        / "nodes"
+        / "node_llm_inference_effect"
+        / "contract.yaml"
+    )
+
+    manifest = discover_contracts_from_paths([contract_path])
+
+    assert manifest.total_errors == 0
+    contract = manifest.contracts[0]
+    assert contract.name == "node_llm_inference_effect"
+    assert contract.runtime_profiles == ("effects",)
+    assert contract.event_bus is not None
+    assert contract.event_bus.subscribe_topics == (
+        "onex.cmd.omnibase-infra.llm-inference-request.v1",
+    )
+
+    effects_result = filter_manifest_for_runtime_profile(manifest, "effects")
+    main_result = filter_manifest_for_runtime_profile(manifest, "main")
+
+    assert [item.name for item in effects_result.manifest.contracts] == [
+        "node_llm_inference_effect"
+    ]
+    assert main_result.manifest.contracts == ()
+    assert main_result.skipped_contracts == ("node_llm_inference_effect",)

--- a/tests/unit/runtime/test_node_subscription_wiring.py
+++ b/tests/unit/runtime/test_node_subscription_wiring.py
@@ -253,6 +253,82 @@ class TestPackageNodeSubscriptionWiring:
         assert skipped_no_topics == 2
 
     @pytest.mark.asyncio
+    async def test_package_wiring_respects_runtime_profile_ownership(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """Secondary runtimes must not subscribe to main-owned delegation workflow topics."""
+        orchestrator = (
+            tmp_path / "nodes" / "node_delegation_orchestrator" / "contract.yaml"
+        )
+        orchestrator.parent.mkdir(parents=True)
+        orchestrator.write_text(
+            textwrap.dedent("""\
+            name: "node_delegation_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.delegation-request.v1"
+            """)
+        )
+
+        effect = tmp_path / "nodes" / "node_llm_inference_effect" / "contract.yaml"
+        effect.parent.mkdir(parents=True)
+        effect.write_text(
+            textwrap.dedent("""\
+            name: "node_llm_inference_effect"
+            node_type: "EFFECT_GENERIC"
+            runtime_profiles:
+              - effects
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.llm-inference-request.v1"
+            """)
+        )
+
+        from omnibase_infra.runtime.runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        wired, _, skipped_no_topics = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+            runtime_profile="effects",
+        )
+
+        assert wired == 1
+        assert skipped_no_topics == 1
+        wired_names = {c["node_name"] for c in mock_event_bus_wiring._wire_calls}
+        assert "node_delegation_orchestrator" not in wired_names
+        assert "node_llm_inference_effect" in wired_names
+
+        mock_event_bus_wiring._wire_calls.clear()
+        mock_event_bus_wiring.wire_subscriptions.reset_mock()
+
+        wired, _, skipped_no_topics = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+            runtime_profile="main",
+        )
+
+        assert wired == 1
+        assert skipped_no_topics == 1
+        wired_names = {c["node_name"] for c in mock_event_bus_wiring._wire_calls}
+        assert "node_delegation_orchestrator" in wired_names
+        assert "node_llm_inference_effect" not in wired_names
+
+    @pytest.mark.asyncio
     async def test_raw_projection_consumer_purpose_not_wired(
         self, tmp_path: Path, mock_event_bus_wiring: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- apply runtime profile ownership filtering to raw runtime-host subscription paths
- mark node_llm_inference_effect as effects runtime-owned
- add regression coverage proving effects skips main-owned delegation workflow topics and main skips effects-owned LLM inference topics

## Live Failure Context

Observed during the 2026-06-05 dev-runtime delegation proof. Correlation b29b9532-df6a-45e4-8024-04461604d3cc completed useful pytest output, but emitted duplicate inference responses, duplicate quality results, and duplicate completed events because both omninode-runtime and omninode-runtime-effects consumed delegation workflow topics.

## Verification

- uv run pytest tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py tests/unit/runtime/test_node_subscription_wiring.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/auto_wiring/test_wiring_subscribe.py tests/unit/runtime/auto_wiring/test_plugin_managed_subscription.py -q -> 88 passed
- uv run ruff check src/omnibase_infra/runtime/auto_wiring/profile_ownership.py src/omnibase_infra/runtime/runtime_host_process.py tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py tests/unit/runtime/test_node_subscription_wiring.py -> passed

Refs OMN-12724

Evidence-Source: fa346609063f237721566746f2168c4890122091
Evidence-Ticket: OMN-12724