### PR TITLE
fix(OMN-12725): preflight runtime projection schema

### DIFF
--- a/docker/catalog/services/forward-migration.yaml
+++ b/docker/catalog/services/forward-migration.yaml
@@ -9,6 +9,7 @@ hardcoded_env:
   POSTGRES_HOST: postgres
   POSTGRES_PORT: '5432'
   POSTGRES_DB: omnibase_infra
+  NODE_POSTGRES_DB: omnidash_analytics
   MIGRATIONS_DIR: /migrations/forward
 operational_defaults:
   POSTGRES_USER: postgres

--- a/docker/catalog/services/migration-gate.yaml
+++ b/docker/catalog/services/migration-gate.yaml
@@ -9,6 +9,8 @@ hardcoded_env:
   POSTGRES_HOST: postgres
   POSTGRES_PORT: '5432'
   POSTGRES_DB: omnibase_infra
+  NODE_POSTGRES_DB: omnidash_analytics
+  REQUIRED_PROJECTION_TABLES: delegation_events node_service_registry
 operational_defaults:
   POSTGRES_USER: postgres
 ports: null

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -573,6 +573,7 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: "5432"
       POSTGRES_DB: omnibase_infra
+      NODE_POSTGRES_DB: omnidash_analytics
       MIGRATIONS_DIR: /migrations/forward
     volumes:
       - ../scripts/run-forward-migrations.sh:/run-forward-migrations.sh:ro
@@ -617,6 +618,8 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: "5432"
       POSTGRES_DB: omnibase_infra
+      NODE_POSTGRES_DB: omnidash_analytics
+      REQUIRED_PROJECTION_TABLES: "delegation_events node_service_registry"
     # Stay alive so healthcheck can run; no actual workload.
     entrypoint: ["sh", "-c", "while true; do sleep 3600; done"]
     volumes:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -108,6 +108,8 @@ services:
     container_name: omninode-prod-runtime
     restart: unless-stopped
     depends_on:
+      migration-gate:
+        condition: service_healthy
       intelligence-migration:
         condition: service_completed_successfully
       redpanda-partition-cap:
@@ -142,6 +144,9 @@ services:
   runtime-effects:
     container_name: omninode-prod-runtime-effects
     restart: unless-stopped
+    depends_on:
+      migration-gate:
+        condition: service_healthy
     environment:
       OMNIMEMORY_ENABLED: ${PROD_RUNTIME_EFFECTS_OMNIMEMORY_ENABLED:?runtime policy contract must set PROD_RUNTIME_EFFECTS_OMNIMEMORY_ENABLED}
       OMNIMEMORY_MEMGRAPH_HOST: ${PROD_RUNTIME_EFFECTS_OMNIMEMORY_MEMGRAPH_HOST?runtime policy contract must set PROD_RUNTIME_EFFECTS_OMNIMEMORY_MEMGRAPH_HOST}
@@ -184,6 +189,9 @@ services:
   runtime-worker:
     container_name: omninode-prod-runtime-worker
     restart: unless-stopped
+    depends_on:
+      migration-gate:
+        condition: service_healthy
     environment:
       OMNIMEMORY_ENABLED: ${PROD_RUNTIME_WORKER_OMNIMEMORY_ENABLED:?runtime policy contract must set PROD_RUNTIME_WORKER_OMNIMEMORY_ENABLED}
       OMNIMEMORY_MEMGRAPH_HOST: ${PROD_RUNTIME_WORKER_OMNIMEMORY_MEMGRAPH_HOST?runtime policy contract must set PROD_RUNTIME_WORKER_OMNIMEMORY_MEMGRAPH_HOST}

--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -89,6 +89,8 @@ services:
     container_name: omninode-stability-test-runtime
     restart: unless-stopped
     depends_on:
+      migration-gate:
+        condition: service_healthy
       intelligence-migration:
         condition: service_completed_successfully
       redpanda-partition-cap:
@@ -130,6 +132,9 @@ services:
   runtime-effects:
     container_name: omninode-stability-test-runtime-effects
     restart: unless-stopped
+    depends_on:
+      migration-gate:
+        condition: service_healthy
     environment:
       OMNIMEMORY_ENABLED: ${STABILITY_TEST_RUNTIME_EFFECTS_OMNIMEMORY_ENABLED:?runtime policy contract must set STABILITY_TEST_RUNTIME_EFFECTS_OMNIMEMORY_ENABLED}
       OMNIMEMORY_MEMGRAPH_HOST: ${STABILITY_TEST_RUNTIME_EFFECTS_OMNIMEMORY_MEMGRAPH_HOST?runtime policy contract must set STABILITY_TEST_RUNTIME_EFFECTS_OMNIMEMORY_MEMGRAPH_HOST}
@@ -179,6 +184,9 @@ services:
   runtime-worker:
     container_name: omninode-stability-test-runtime-worker
     restart: unless-stopped
+    depends_on:
+      migration-gate:
+        condition: service_healthy
     environment:
       OMNIMEMORY_ENABLED: ${STABILITY_TEST_RUNTIME_WORKER_OMNIMEMORY_ENABLED:?runtime policy contract must set STABILITY_TEST_RUNTIME_WORKER_OMNIMEMORY_ENABLED}
       OMNIMEMORY_MEMGRAPH_HOST: ${STABILITY_TEST_RUNTIME_WORKER_OMNIMEMORY_MEMGRAPH_HOST?runtime policy contract must set STABILITY_TEST_RUNTIME_WORKER_OMNIMEMORY_MEMGRAPH_HOST}

--- a/docker/migrations/forward/nodes/.synced-nodes
+++ b/docker/migrations/forward/nodes/.synced-nodes
@@ -15,9 +15,10 @@
 # generation_events), additive columns, and the dashboard read views (0010).
 node_projection_delegation
 
-# Savings dashboard read view only. The savings_estimates base table is already
-# owned by infra's flat migration 074; we vendor just the OMN-12489 view here.
-node_projection_savings:076_*
+# Savings dashboard projection: base table, additive columns, and the
+# OMN-12489 read view. Node-owned migrations apply to omnidash_analytics,
+# not the infra database that carries the historical flat 074 migration.
+node_projection_savings
 
 # Registration projection read model. Prod currently lacks node_service_registry;
 # vendor the node-owned, idempotent migrations so the forward runner owns the fix.

--- a/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
+++ b/docker/migrations/forward/nodes/node_projection_registration/0000_create_node_service_registry.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS node_service_registry (
   health_status TEXT DEFAULT 'unknown',
   last_health_check TIMESTAMPTZ,
   last_heartbeat_at TIMESTAMPTZ,
-  uptime_seconds BIGINT NOT NULL DEFAULT 0,
+  uptime_seconds BIGINT DEFAULT 0,
   health_check_interval_seconds INT DEFAULT 60,
   metadata JSONB DEFAULT '{}'::jsonb,
   is_active BOOLEAN DEFAULT true,

--- a/docker/migrations/forward/nodes/node_projection_savings/074_create_savings_estimates.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/074_create_savings_estimates.sql
@@ -1,0 +1,42 @@
+-- OMN-10340: deterministic savings estimate projection table.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS savings_estimates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_timestamp TIMESTAMPTZ NOT NULL,
+    session_id TEXT NOT NULL,
+    model_local TEXT NOT NULL,
+    model_cloud_baseline TEXT NOT NULL,
+    local_cost_usd NUMERIC(18, 6) NOT NULL CHECK (local_cost_usd >= 0),
+    cloud_cost_usd NUMERIC(18, 6) NOT NULL CHECK (cloud_cost_usd >= 0),
+    savings_usd NUMERIC(18, 6) NOT NULL,
+    repo_name TEXT,
+    machine_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT savings_estimates_amounts_match
+        CHECK (savings_usd = cloud_cost_usd - local_cost_usd)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_savings_estimates_identity
+    ON savings_estimates (
+        session_id,
+        event_timestamp,
+        model_local,
+        model_cloud_baseline
+    );
+
+CREATE OR REPLACE FUNCTION refresh_savings_estimates_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_savings_estimates_updated_at ON savings_estimates;
+CREATE TRIGGER trg_savings_estimates_updated_at
+    BEFORE UPDATE ON savings_estimates
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_savings_estimates_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_savings/075_add_savings_estimates_updated_at.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/075_add_savings_estimates_updated_at.sql
@@ -1,0 +1,4 @@
+-- OMN-11299: repair existing savings_estimates projections missing updated_at.
+
+ALTER TABLE savings_estimates
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/scripts/check_migrations_complete.sh
+++ b/scripts/check_migrations_complete.sh
@@ -16,6 +16,8 @@
 #   POSTGRES_HOST     (default: localhost)
 #   POSTGRES_PORT     (default: 5432)
 #   POSTGRES_DB       (default: omnibase_infra)
+#   NODE_POSTGRES_DB  (default: omnidash_analytics)
+#   REQUIRED_PROJECTION_TABLES (default: delegation_events node_service_registry)
 
 set -e
 
@@ -23,14 +25,24 @@ PGUSER="${POSTGRES_USER:-postgres}"
 PGHOST="${POSTGRES_HOST:?POSTGRES_HOST required}"
 PGPORT="${POSTGRES_PORT:-5432}"
 PGDB="${POSTGRES_DB:-omnibase_infra}"
+NODE_PGDB="${NODE_POSTGRES_DB:-omnidash_analytics}"
+REQUIRED_PROJECTION_TABLES="${REQUIRED_PROJECTION_TABLES:-delegation_events node_service_registry}"
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
 result=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
   -tAc "SELECT migrations_complete FROM public.db_metadata WHERE id = TRUE" 2>/dev/null)
 
-if [ "$result" = "t" ]; then
-  exit 0
-else
+if [ "$result" != "t" ]; then
   exit 1
 fi
+
+for table_name in $REQUIRED_PROJECTION_TABLES; do
+  table_exists=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$NODE_PGDB" \
+    -tAc "SELECT to_regclass('public.${table_name}') IS NOT NULL" 2>/dev/null)
+  if [ "$table_exists" != "t" ]; then
+    exit 1
+  fi
+done
+
+exit 0

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -64,6 +64,14 @@ RUNTIME_HEALTH_TARGETS: tuple[tuple[str, int], ...] = (
     ("omninode-runtime", 8085),
     ("runtime-effects", 8086),
 )
+RUNTIME_MIGRATION_SERVICES: tuple[str, ...] = (
+    "forward-migration",
+    "migration-gate",
+)
+REQUIRED_PROJECTION_TABLES: tuple[str, ...] = (
+    "delegation_events",
+    "node_service_registry",
+)
 
 _BUILD_SOURCE_ALLOWED = ", ".join(source.value for source in BuildSource)
 
@@ -1104,6 +1112,8 @@ class DeployExecutor:
         config = lane_config_for(lane)
         profile = "core" if scope == Scope.CORE else "runtime"
         requested_services = _requested_services_for_up(scope, services)
+        if scope == Scope.RUNTIME:
+            self._ensure_runtime_migrations_ready(lane=lane, timeout=timeout)
         cmd = [
             "docker",
             "compose",
@@ -1189,6 +1199,68 @@ class DeployExecutor:
 
         on_phase_update(phase, PhaseStatus.SUCCESS)
 
+    def _ensure_runtime_migrations_ready(
+        self,
+        *,
+        lane: EnumRuntimeLane = EnumRuntimeLane.DEV,
+        timeout: int = 300,
+    ) -> None:
+        """Run bounded migration services before a runtime-only restart.
+
+        Runtime deploys intentionally use ``--no-deps`` so compose cannot walk
+        into core infra and recreate Postgres/Redpanda/Valkey. The migration
+        one-shots are not core infra; they are the boot-order contract that
+        applies pending projection DDL and exposes the migration health gate.
+        """
+        config = lane_config_for(lane)
+        base_cmd = [
+            "docker",
+            "compose",
+            *_compose_file_args(lane),
+            "-p",
+            config.compose_project,
+            "--profile",
+            "runtime",
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+        ]
+        for service in RUNTIME_MIGRATION_SERVICES:
+            cmd = [*base_cmd, service]
+            result = _run(cmd, timeout=timeout, env=_compose_env())
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Runtime migration preflight failed for {service}: "
+                    f"{result.stderr.strip() or result.stdout.strip()}"
+                )
+            ok, stuck = verify_containers_up([service], timeout_s=120, lane=lane)
+            if not ok:
+                raise RuntimeError(
+                    f"Runtime migration preflight did not satisfy {service}: {stuck}"
+                )
+        for table_name in REQUIRED_PROJECTION_TABLES:
+            result = _run(
+                [
+                    "docker",
+                    "exec",
+                    config.postgres_container,
+                    "psql",
+                    "-U",
+                    "postgres",
+                    "-d",
+                    "omnidash_analytics",
+                    "-tAc",
+                    f"SELECT to_regclass('public.{table_name}') IS NOT NULL",
+                ],
+                timeout=timeout,
+            )
+            if result.stdout.strip() != "t":
+                raise RuntimeError(
+                    "Runtime migration preflight failed: missing "
+                    f"omnidash_analytics.{table_name}"
+                )
+
     def verify(
         self,
         on_phase_update: PhaseCallback,
@@ -1249,30 +1321,31 @@ class DeployExecutor:
                 )
             )
 
-        # Check psql registration count
-        result = _run(
-            [
-                "docker",
-                "exec",
-                lane_config_for(lane).postgres_container,
-                "psql",
-                "-U",
-                "postgres",
-                "-d",
-                "omnibase_infra",
-                "-tAc",
-                "SELECT to_regclass('public.node_service_registry') IS NOT NULL",
-            ],
-            timeout=timeout,
-        )
-        checks.append(
-            ModelHealthCheck(
-                service="postgres",
-                endpoint="node_service_registry exists",
-                status="pass" if result.stdout.strip() == "t" else "fail",
-                latency_ms=0,
+        # Check projection tables in the database used by runtime DB injection.
+        for table_name in REQUIRED_PROJECTION_TABLES:
+            result = _run(
+                [
+                    "docker",
+                    "exec",
+                    lane_config_for(lane).postgres_container,
+                    "psql",
+                    "-U",
+                    "postgres",
+                    "-d",
+                    "omnidash_analytics",
+                    "-tAc",
+                    f"SELECT to_regclass('public.{table_name}') IS NOT NULL",
+                ],
+                timeout=timeout,
             )
-        )
+            checks.append(
+                ModelHealthCheck(
+                    service="postgres",
+                    endpoint=f"omnidash_analytics.{table_name} exists",
+                    status="pass" if result.stdout.strip() == "t" else "fail",
+                    latency_ms=0,
+                )
+            )
 
         # Runtime health endpoint checks.
         #

--- a/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
@@ -36,6 +36,16 @@ def _ok() -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
+def _is_projection_table_check(cmd: list[str]) -> bool:
+    return (
+        "omnidash_analytics" in cmd
+        and any(
+            f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
+            for table in ("delegation_events", "node_service_registry")
+        )
+    )
+
+
 class TestLaneConfig:
     def test_dev_lane_matches_legacy_module_constants(self) -> None:
         cfg = lane_config_for(EnumRuntimeLane.DEV)
@@ -85,6 +95,7 @@ class TestComposeUpLaneSelection:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(executor, "_ensure_runtime_migrations_ready"),
             patch(
                 "deploy_agent.executor.verify_containers_up", return_value=(True, [])
             ),
@@ -117,6 +128,7 @@ class TestComposeUpLaneSelection:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(executor, "_ensure_runtime_migrations_ready"),
             patch(
                 "deploy_agent.executor.verify_containers_up", return_value=(True, [])
             ),
@@ -146,6 +158,7 @@ class TestComposeUpLaneSelection:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(executor, "_ensure_runtime_migrations_ready"),
             patch(
                 "deploy_agent.executor.verify_containers_up", return_value=(True, [])
             ),
@@ -184,7 +197,7 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            if _is_projection_table_check(cmd):
                 assert "omnibase-infra-stability-test-postgres" in cmd
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="t\n", stderr=""
@@ -218,7 +231,7 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            if _is_projection_table_check(cmd):
                 assert "omnibase-infra-prod-postgres" in cmd
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="t\n", stderr=""
@@ -253,7 +266,7 @@ class TestVerifyLaneHealthTargets:
         ) -> subprocess.CompletedProcess:
             if cmd[:2] == ["docker", "ps"]:
                 return _ok()
-            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+            if _is_projection_table_check(cmd):
                 assert "omnibase-infra-postgres" in cmd
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="t\n", stderr=""

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
@@ -48,6 +48,16 @@ def _health_payload(
     )
 
 
+def _is_projection_table_check(cmd: list[str]) -> bool:
+    return (
+        "omnidash_analytics" in cmd
+        and any(
+            f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
+            for table in ("delegation_events", "node_service_registry")
+        )
+    )
+
+
 def test_verify_probes_runtime_health_ports_only() -> None:
     executor = DeployExecutor()
     captured_cmds: list[list[str]] = []
@@ -58,7 +68,7 @@ def test_verify_probes_runtime_health_ports_only() -> None:
         captured_cmds.append(cmd)
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+        if _is_projection_table_check(cmd):
             return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload())
@@ -100,7 +110,7 @@ def test_verify_accepts_runtime_health_when_config_prefetch_skipped() -> None:
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+        if _is_projection_table_check(cmd):
             return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(
@@ -134,7 +144,7 @@ def test_verify_fails_postgres_check_when_node_service_registry_missing() -> Non
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+        if _is_projection_table_check(cmd):
             return _completed(cmd, stdout="f\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload())
@@ -146,7 +156,7 @@ def test_verify_fails_postgres_check_when_node_service_registry_missing() -> Non
         checks = executor.verify(on_phase_update=_noop_phase_update)
 
     status_by_endpoint = {check.endpoint: check.status for check in checks}
-    assert status_by_endpoint["node_service_registry exists"] == "fail"
+    assert status_by_endpoint["omnidash_analytics.node_service_registry exists"] == "fail"
 
 
 def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:
@@ -157,7 +167,7 @@ def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+        if _is_projection_table_check(cmd):
             return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload())
@@ -184,7 +194,7 @@ def test_verify_fails_runtime_health_when_process_not_running() -> None:
     ) -> subprocess.CompletedProcess:
         if cmd[:2] == ["docker", "ps"]:
             return _completed(cmd)
-        if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+        if _is_projection_table_check(cmd):
             return _completed(cmd, stdout="t\n")
         if "http://localhost:8085/health" in cmd:
             return _completed(cmd, stdout=_health_payload(is_running=False))

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
@@ -96,6 +96,7 @@ class TestRuntimeScopeComposeUp:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(executor, "_ensure_runtime_migrations_ready"),
             patch(
                 "deploy_agent.executor.verify_containers_up",
                 return_value=(True, []),
@@ -147,6 +148,7 @@ class TestRuntimeScopeComposeUp:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch.object(executor, "_ensure_runtime_migrations_ready"),
             patch(
                 "deploy_agent.executor.verify_containers_up",
                 return_value=(True, []),
@@ -251,3 +253,60 @@ class TestCoreAndFullScopeComposeUp:
         mock_verify.assert_called_once_with(
             requested, timeout_s=120, lane=EnumRuntimeLane.DEV
         )
+
+    def test_runtime_scope_runs_migration_preflight_before_runtime_services(
+        self,
+    ) -> None:
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+        verified: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            if "SELECT to_regclass('public.delegation_events') IS NOT NULL" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="t\n", stderr=""
+                )
+            if "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="t\n", stderr=""
+                )
+            return _ok()
+
+        def fake_verify(
+            services: list[str], timeout_s: int = 120, **kwargs: object
+        ) -> tuple[bool, list[str]]:
+            verified.append(services)
+            return True, []
+
+        with (
+            patch("deploy_agent.executor._run", side_effect=fake_run),
+            patch("deploy_agent.executor.verify_containers_up", side_effect=fake_verify),
+        ):
+            executor._compose_up(
+                Phase.RUNTIME,
+                Scope.RUNTIME,
+                [],
+                _noop_phase_update,
+            )
+
+        assert captured_cmds[0][-1] == "forward-migration"
+        assert "--no-deps" in captured_cmds[0]
+        assert captured_cmds[1][-1] == "migration-gate"
+        assert "--no-deps" in captured_cmds[1]
+        assert any(
+            "SELECT to_regclass('public.delegation_events') IS NOT NULL" in cmd
+            and "omnidash_analytics" in cmd
+            for cmd in captured_cmds
+        )
+        assert any(
+            "SELECT to_regclass('public.node_service_registry') IS NOT NULL" in cmd
+            and "omnidash_analytics" in cmd
+            for cmd in captured_cmds
+        )
+        assert captured_cmds[-1][-len(services_for_scope(Scope.RUNTIME)) :] == (
+            services_for_scope(Scope.RUNTIME)
+        )
+        assert verified[:2] == [["forward-migration"], ["migration-gate"]]

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -65,6 +65,14 @@ readonly RUNTIME_SERVICES=(
     intelligence-api
     omninode-contract-resolver
 )
+readonly RUNTIME_MIGRATION_SERVICES=(
+    forward-migration
+    migration-gate
+)
+readonly REQUIRED_PROJECTION_TABLES=(
+    delegation_events
+    node_service_registry
+)
 
 # Minimum Docker Compose version (nested variable expansion support)
 readonly MIN_COMPOSE_VERSION="2.20"
@@ -1299,6 +1307,54 @@ build_images() {
 # Restart -- bring up runtime services only
 # =============================================================================
 
+run_runtime_migration_preflight() {
+    # Run bounded migration services before --no-deps runtime restarts.
+    local deploy_target="$1"
+    local compose_project="$2"
+    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+
+    log_step "Runtime Migration Preflight"
+
+    for service in "${RUNTIME_MIGRATION_SERVICES[@]}"; do
+        local cmd=(
+            docker compose
+            -p "${compose_project}"
+            -f "${compose_file}"
+            --profile "${COMPOSE_PROFILE}"
+            up -d --no-deps --force-recreate
+            "${service}"
+        )
+        log_info "Refreshing migration service: ${service}"
+        log_cmd "${cmd[*]}"
+        "${cmd[@]}"
+        if [[ "${service}" == "forward-migration" ]]; then
+            local wait_cmd=(docker wait omnibase-forward-migration)
+            log_cmd "${wait_cmd[*]}"
+            if [[ "$("${wait_cmd[@]}")" != "0" ]]; then
+                log_error "forward-migration did not complete successfully."
+                return 1
+            fi
+        fi
+    done
+
+    for table_name in "${REQUIRED_PROJECTION_TABLES[@]}"; do
+        local check_cmd=(
+            docker exec omnibase-infra-postgres
+            psql
+            -U postgres
+            -d omnidash_analytics
+            -tAc
+            "SELECT to_regclass('public.${table_name}') IS NOT NULL"
+        )
+        log_info "Checking projection table: omnidash_analytics.${table_name}"
+        log_cmd "${check_cmd[*]}"
+        if [[ "$("${check_cmd[@]}")" != "t" ]]; then
+            log_error "Missing projection table omnidash_analytics.${table_name}; aborting runtime restart."
+            return 1
+        fi
+    done
+}
+
 restart_services() {
     # Restart runtime containers via docker compose up --force-recreate.
     local deploy_target="$1"
@@ -1640,6 +1696,7 @@ main() {
 
     # Phase 11: Restart (optional)
     if [[ "${RESTART}" == true ]]; then
+        run_runtime_migration_preflight "${deploy_target}" "${compose_project}"
         restart_services "${deploy_target}" "${compose_project}"
     fi
 

--- a/scripts/run-forward-migrations.sh
+++ b/scripts/run-forward-migrations.sh
@@ -39,6 +39,7 @@
 #   POSTGRES_DB       (default: omnibase_infra)
 #   MIGRATIONS_DIR    (default: /migrations/forward)
 #   NODE_MIGRATIONS_DIR (default: ${MIGRATIONS_DIR}/nodes)
+#   NODE_POSTGRES_DB  (default: POSTGRES_DB; compose sets omnidash_analytics)
 
 set -e
 
@@ -48,6 +49,7 @@ PGPORT="${POSTGRES_PORT:-5432}"
 PGDB="${POSTGRES_DB:-omnibase_infra}"
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-/migrations/forward}"
 NODE_MIGRATIONS_DIR="${NODE_MIGRATIONS_DIR:-${MIGRATIONS_DIR}/nodes}"
+NODE_PGDB="${NODE_POSTGRES_DB:-${PGDB}}"
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
@@ -113,7 +115,18 @@ NODE_APPLIED=0
 NODE_SKIPPED=0
 
 if [ -d "${NODE_MIGRATIONS_DIR}" ]; then
-  echo "[forward-migration] Scanning ${NODE_MIGRATIONS_DIR} for node-owned migrations..."
+  echo "[forward-migration] Ensuring schema_migrations table exists in node projection database ${NODE_PGDB}..."
+
+  psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$NODE_PGDB" -c "
+CREATE TABLE IF NOT EXISTS public.schema_migrations (
+    migration_id TEXT PRIMARY KEY,
+    applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    checksum     TEXT NOT NULL,
+    source_set   TEXT NOT NULL
+);
+"
+
+  echo "[forward-migration] Scanning ${NODE_MIGRATIONS_DIR} for node-owned migrations in ${NODE_PGDB}..."
 
   # Iterate node directories in sorted order for deterministic application.
   for node_dir in $(ls -d "${NODE_MIGRATIONS_DIR}"/*/ 2>/dev/null | sort); do
@@ -128,7 +141,7 @@ if [ -d "${NODE_MIGRATIONS_DIR}" ]; then
       filename=$(basename "$migration_file")
       migration_id="node:${node_name}:${filename}"
 
-      already_applied=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+      already_applied=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$NODE_PGDB" \
         -tAc "SELECT 1 FROM public.schema_migrations WHERE migration_id = '${migration_id}'" 2>/dev/null || true)
 
       if [ "$already_applied" = "1" ]; then
@@ -139,10 +152,10 @@ if [ -d "${NODE_MIGRATIONS_DIR}" ]; then
 
       echo "[forward-migration]   apply ${migration_id}..."
 
-      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$NODE_PGDB" \
         -v ON_ERROR_STOP=1 -f "$migration_file"
 
-      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
+      psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$NODE_PGDB" \
         -c "INSERT INTO public.schema_migrations (migration_id, checksum, source_set)
             VALUES ('${migration_id}', 'applied-by-runner', 'node')
             ON CONFLICT (migration_id) DO NOTHING;"

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -300,6 +300,11 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
         ]
         == "service_completed_successfully"
     )
+    for service_name in REQUIRED_RUNTIME_SERVICES:
+        assert (
+            services[service_name]["depends_on"]["migration-gate"]["condition"]
+            == "service_healthy"
+        )
     assert services["redpanda-partition-cap"]["depends_on"]["redpanda"][
         "condition"
     ] == ("service_healthy")

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -80,6 +80,20 @@ def test_generated_compose_preserves_one_shot_semantics() -> None:
     fm = compose["services"]["forward-migration"]
     assert fm["restart"] == "no"
     assert "healthcheck" not in fm  # one-shot entries have no healthcheck
+    assert fm["environment"]["NODE_POSTGRES_DB"] == "omnidash_analytics"
+
+
+@pytest.mark.unit
+def test_generated_migration_gate_requires_projection_tables() -> None:
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+    gate = compose["services"]["migration-gate"]
+    assert gate["environment"]["NODE_POSTGRES_DB"] == "omnidash_analytics"
+    assert (
+        gate["environment"]["REQUIRED_PROJECTION_TABLES"]
+        == "delegation_events node_service_registry"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -276,6 +276,11 @@ def test_stability_lane_sets_redpanda_partition_capacity_before_runtime() -> Non
         ]
         == "service_completed_successfully"
     )
+    for service_name in RUNTIME_SERVICES:
+        assert (
+            services[service_name]["depends_on"]["migration-gate"]["condition"]
+            == "service_healthy"
+        )
     assert (
         services["omninode-runtime"]["depends_on"]["intelligence-migration"][
             "condition"

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -44,6 +44,12 @@ SAVINGS_VIEW = (
     / "node_projection_savings"
     / "076_create_delegation_savings_projection_view.sql"
 )
+SAVINGS_CREATE = (
+    NODES_DIR / "node_projection_savings" / "074_create_savings_estimates.sql"
+)
+SAVINGS_UPDATED_AT = (
+    NODES_DIR / "node_projection_savings" / "075_add_savings_estimates_updated_at.sql"
+)
 REGISTRATION_CREATE = (
     NODES_DIR / "node_projection_registration" / "0000_create_node_service_registry.sql"
 )
@@ -71,6 +77,13 @@ class TestVendoredViewMigrations:
         assert SAVINGS_VIEW.is_file(), (
             "savings projection view must be vendored under "
             "docker/migrations/forward/nodes/node_projection_savings/"
+        )
+        assert SAVINGS_CREATE.is_file(), (
+            "savings_estimates base table must be vendored with the savings view "
+            "because node-owned migrations apply to omnidash_analytics"
+        )
+        assert SAVINGS_UPDATED_AT.is_file(), (
+            "savings_estimates additive columns must be vendored with the savings view"
         )
         sql = SAVINGS_VIEW.read_text(encoding="utf-8")
         assert "CREATE OR REPLACE VIEW projection_delegation_savings" in sql
@@ -101,7 +114,7 @@ class TestVendoredViewMigrations:
         create_sql = REGISTRATION_CREATE.read_text(encoding="utf-8")
         heartbeat_sql = REGISTRATION_HEARTBEAT.read_text(encoding="utf-8")
         assert "CREATE TABLE IF NOT EXISTS node_service_registry" in create_sql
-        assert "uptime_seconds BIGINT NOT NULL DEFAULT 0" in create_sql
+        assert "uptime_seconds BIGINT DEFAULT 0" in create_sql
         assert "ADD COLUMN IF NOT EXISTS last_heartbeat_at" in heartbeat_sql
         assert "ADD COLUMN IF NOT EXISTS uptime_seconds" in heartbeat_sql
 
@@ -121,6 +134,11 @@ class TestNamespacedDiscoveryWiring:
         # numeric collision with the flat docker/<filename> sequence.
         assert 'migration_id="node:${node_name}:${filename}"' in script
         assert "source_set" in script
+
+    def test_runner_applies_node_migrations_to_projection_database(self) -> None:
+        script = RUNNER.read_text(encoding="utf-8")
+        assert 'NODE_PGDB="${NODE_POSTGRES_DB:-${PGDB}}"' in script
+        assert '-d "$NODE_PGDB"' in script
 
     def test_runner_flat_and_node_ids_are_distinct_namespaces(self) -> None:
         """The flat sequence and node sequence use different id prefixes."""

--- a/tests/unit/runtime/test_migration_sentinel.py
+++ b/tests/unit/runtime/test_migration_sentinel.py
@@ -91,6 +91,15 @@ class TestHealthcheckScript:
             "Healthcheck must query db_metadata.migrations_complete"
         )
 
+    def test_healthcheck_requires_projection_tables(self) -> None:
+        """Runtime gate must prove projection tables in omnidash_analytics."""
+        content = HEALTHCHECK_SCRIPT.read_text()
+        assert "NODE_POSTGRES_DB" in content
+        assert "REQUIRED_PROJECTION_TABLES" in content
+        assert "delegation_events" in content
+        assert "node_service_registry" in content
+        assert "to_regclass" in content
+
     def test_healthcheck_uses_psql(self) -> None:
         """Script must use psql to query PostgreSQL."""
         content = HEALTHCHECK_SCRIPT.read_text()
@@ -140,4 +149,12 @@ class TestDockerComposeIntegration:
         content = COMPOSE_FILE.read_text()
         assert "check_migrations_complete.sh" in content, (
             "migration-gate must mount check_migrations_complete.sh"
+        )
+
+    def test_forward_migration_targets_projection_database(self) -> None:
+        content = COMPOSE_FILE.read_text()
+        assert "NODE_POSTGRES_DB: omnidash_analytics" in content
+        assert (
+            'REQUIRED_PROJECTION_TABLES: "delegation_events node_service_registry"'
+            in content
         )


### PR DESCRIPTION
## Summary
- Apply node-owned forward migrations to the runtime projection database omnidash_analytics instead of only omnibase_infra.
- Require delegation_events and node_service_registry in the migration gate and runtime deploy preflight before runtime startup.
- Preserve migration-gate dependencies in stability/prod runtime overlays and vendor missing savings projection base migrations for clean projection DB application.

## Verification
- bash -n scripts/deploy-runtime.sh && sh -n scripts/run-forward-migrations.sh && sh -n scripts/check_migrations_complete.sh
- uv run ruff check on changed Python source and test files: passed
- OMNI_HOME=/Users/jonah/Code/omni_home uv run pytest focused migration/runtime deploy suite: 65 passed

## Notes
- No live .201 mutation was performed in this PR. This is the durable fix for the dev projection schema blocker discovered during delegation integration.

Evidence-Source: fa346609063f237721566746f2168c4890122091
Evidence-Ticket: OMN-12725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration gate health checks to ensure all required projection tables are validated before runtime services start.
  * Introduced savings estimates tracking capability with automatic timestamp management.

* **Bug Fixes**
  * Made uptime seconds column nullable in node service registry.

* **Chores**
  * Enhanced migration validation to support separate node projection database.
  * Updated runtime service startup dependencies to wait for migration completion.
  * Improved migration preflight verification for required projection tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->