### PR TITLE
fix(OMN-12727): update core pin for delegation routing

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "d8528f4dda24f9e6627c8d06124d3dcc",
+  "identity_digest": "5a0ff559831c179ba9cb093707ad1178",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "4481208c7395297955f861c8",
+  "shared_env_digest": "2fffb3749d606e3cfe03774d",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.43.0,<0.44.0",
+    "omnibase-core>=0.44.0,<0.45.0",
     "omnibase-spi>=0.22.0,<0.23.0",
     # ============================================================================
     # External Dependency Security Guidance
@@ -164,14 +164,14 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.43.0,<0.44.0",
+    "omnibase-core>=0.44.0,<0.45.0",
     "omnibase-spi>=0.22.0,<0.23.0",
 ]
 
 [tool.uv.sources]
-# OMN-12623: bump core pin to dev HEAD (a1e73fff, OMN-12621 #1191) which adds
-# ModelTopicMigrationContract/ModelTopicSchemaBinding consumed by the migration executor.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "a1e73fff25a05ccb37cbb92d9c91754c59d808c0" }
+# OMN-12727: bump core pin to dev HEAD (f587bbb4, OMN-12663/OMN-12676)
+# which widens bifrost delegation tier literals and carries inference API key refs.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "f587bbb4bd7f8db10a178dab546bdcef5c7136fd" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,8 +175,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.43.0",
-        max_version="0.44.0",
+        min_version="0.44.0",
+        max_version="0.45.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=a1e73fff25a05ccb37cbb92d9c91754c59d808c0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -2075,8 +2075,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.43.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=a1e73fff25a05ccb37cbb92d9c91754c59d808c0#a1e73fff25a05ccb37cbb92d9c91754c59d808c0" }
+version = "0.44.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd#f587bbb4bd7f8db10a178dab546bdcef5c7136fd" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=a1e73fff25a05ccb37cbb92d9c91754c59d808c0" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- update omnibase-core pin to f587bbb4 / 0.44.0 so runtime images include the bifrost delegation tier literal fix
- adjust infra dependency bounds and lockfile to match the fixed core version

## Runtime evidence
- dev-lane delegation correlation 19320699-25af-4e5e-a498-82abcfe2bd7f reached routing but failed with: No tier has a configured endpoint for task_type='test'
- rendered /app/data/delegation/bifrost_delegation.yaml contains local endpoints and test routing rule
- direct container load failed because old omnibase-core rejected cheap_cloud, cheap_frontier, and cli_agents tier values

## Verification
- uv lock --upgrade-package omnibase-core
- uv run python tier literal sanity check for local/frontier_api/cheap_cloud/cheap_frontier/cli_agents
- uv run pytest tests/unit/runtime/test_render_bifrost_delegation_contract.py tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py tests/unit/runtime/test_node_subscription_wiring.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core library dependency to version 0.44.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#2212
Evidence-Ticket: OMN-12727