### PR TITLE
fix(OMN-12726): sync runtime build context for deploy

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -904,6 +904,8 @@ show_preview() {
     log_info "  src/omnibase_infra/  $(count_files "${repo_root}/src/omnibase_infra") files"
     log_info "  contracts/           $(count_files "${repo_root}/contracts") files"
     log_info "  docker/              $(count_files "${repo_root}/docker") files"
+    log_info "  scripts/runtime_build/ $(count_files "${repo_root}/scripts/runtime_build") files"
+    log_info "  workspace/sibling-repos/ $(count_files "${repo_root}/workspace/sibling-repos") files"
 
     # .env strategy
     if [[ -d "${deploy_target}" && -f "${deploy_target}/docker/.env" ]]; then
@@ -1022,7 +1024,19 @@ if spec and spec.origin:
         --exclude='/overrides/' \
         "${repo_root}/docker/" "${deploy_target}/docker/"
 
-    # 5. Migration scripts (bind-mounted by docker-compose.infra.yml)
+    # 5. Runtime build context paths required by docker/Dockerfile.runtime.
+    # Release-mode builds still COPY these paths, even when sibling repos are
+    # represented only by the committed .gitkeep placeholder.
+    log_info "Syncing runtime build context..."
+    mkdir -p "${deploy_target}/scripts" "${deploy_target}/workspace"
+    log_cmd "rsync -a --delete scripts/runtime_build/ -> deployed"
+    rsync -a --delete \
+        "${repo_root}/scripts/runtime_build/" "${deploy_target}/scripts/runtime_build/"
+    log_cmd "rsync -a --delete workspace/sibling-repos/ -> deployed"
+    rsync -a --delete \
+        "${repo_root}/workspace/sibling-repos/" "${deploy_target}/workspace/sibling-repos/"
+
+    # 6. Migration scripts (bind-mounted by docker-compose.infra.yml)
     log_info "Syncing migration scripts..."
     mkdir -p "${deploy_target}/scripts"
     rsync -a \

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deploy-runtime regression coverage for Docker build context paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-runtime.sh"
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.runtime"
+
+
+@pytest.mark.unit
+def test_deploy_runtime_syncs_runtime_dockerfile_copy_sources() -> None:
+    """deploy-runtime.sh must ship paths copied by Dockerfile.runtime."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    required_sources = (
+        "workspace/sibling-repos/",
+        "scripts/runtime_build/compute_workspace_provenance.py",
+    )
+    for source in required_sources:
+        assert source in dockerfile
+
+    assert '"${repo_root}/workspace/sibling-repos/"' in deploy_script
+    assert '"${repo_root}/scripts/runtime_build/"' in deploy_script


### PR DESCRIPTION
## Summary
- sync `scripts/runtime_build/` into the stable deployed runtime context
- sync `workspace/sibling-repos/` so release-mode Dockerfile COPY sources exist
- add a regression test tying Dockerfile runtime COPY sources to deploy-runtime sync paths

## Verification
- `bash -n scripts/deploy-runtime.sh`
- `uv run ruff check tests/scripts/test_deploy_runtime_build_context.py`
- `uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_deploy_runtime_no_env_file.py tests/scripts/test_dockerfile_runtime_git_refresh.py -q`

## Runtime impact
This fixes a clean dev-lane runtime rebuild blocker. No live deploy or restart was performed by this PR.

Evidence-Source: OCC#2214
Evidence-Ticket: OMN-12726