### PR TITLE
fix(OMN-12724): preserve runtime lane profile names

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -28,6 +28,9 @@ node_type: "EFFECT_GENERIC"
 description: >
   LLM inference effect node for provider-agnostic inference operations. Delegates to provider-specific handlers (OpenAI-compatible, GLM, Gemini) via declarative operation routing. Supports chat completions and text completions with tool calling, generation parameters, structured response parsing, and optional GPU usage evidence for local-model compute attribution using the shared EnumUsageSource vocabulary.
 
+runtime_profiles:
+  - effects
+
 # Strongly typed I/O models
 # Note: These models live in the shared omnibase_infra.models.llm package.
 # They are shared across all LLM inference handlers (OpenAI-compatible)

--- a/src/omnibase_infra/runtime/auto_wiring/profile_ownership.py
+++ b/src/omnibase_infra/runtime/auto_wiring/profile_ownership.py
@@ -10,6 +10,8 @@ from the primary runtime.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_infra.runtime.auto_wiring.models import (
@@ -25,6 +27,47 @@ def _normalize_runtime_profile(value: object) -> str:
     if not profile:
         raise ValueError("runtime_profile cannot be blank")
     return profile
+
+
+def extract_runtime_profiles_from_contract(
+    raw_contract: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Return normalized runtime-profile ownership declared by raw contract YAML."""
+    profiles_raw = raw_contract.get("runtime_profiles")
+    descriptor_raw = raw_contract.get("descriptor")
+    if profiles_raw is None and isinstance(descriptor_raw, Mapping):
+        profiles_raw = descriptor_raw.get("runtime_profiles")
+
+    if profiles_raw is None:
+        return ()
+    if isinstance(profiles_raw, str):
+        raw_values = (profiles_raw,)
+    elif isinstance(profiles_raw, (list, tuple)):
+        raw_values = tuple(profiles_raw)
+    else:
+        raise TypeError("runtime_profiles must be a string or sequence of strings")
+
+    profiles: list[str] = []
+    for raw in raw_values:
+        profiles.append(_normalize_runtime_profile(raw))
+    return tuple(dict.fromkeys(profiles))
+
+
+def runtime_profile_owns_contract(
+    raw_contract: Mapping[str, object],
+    runtime_profile: str,
+) -> bool:
+    """Return whether runtime_profile owns a raw contract's subscriptions.
+
+    Contracts without ``runtime_profiles`` default to ``main`` ownership. This
+    mirrors auto-wiring ownership filtering for legacy runtime-host subscription
+    paths that operate on raw contract dictionaries.
+    """
+    normalized_profile = _normalize_runtime_profile(runtime_profile)
+    runtime_profiles = extract_runtime_profiles_from_contract(raw_contract)
+    if runtime_profiles:
+        return normalized_profile in runtime_profiles
+    return normalized_profile == "main"
 
 
 class ModelRuntimeProfileOwnershipResult(BaseModel):
@@ -81,5 +124,7 @@ def filter_manifest_for_runtime_profile(
 
 __all__ = [
     "ModelRuntimeProfileOwnershipResult",
+    "extract_runtime_profiles_from_contract",
     "filter_manifest_for_runtime_profile",
+    "runtime_profile_owns_contract",
 ]

--- a/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
+++ b/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
@@ -69,6 +69,7 @@ class ModelDomainPluginConfig:
             this from runtime config (service name, environment, version).
         kafka_bootstrap_servers: Kafka bootstrap servers string. Used by plugins
             that need direct Kafka access (e.g., snapshot publishing).
+        runtime_profile: Runtime profile selected during kernel bootstrap.
 
     Example:
         ```python
@@ -105,6 +106,10 @@ class ModelDomainPluginConfig:
     # Optional: Kafka bootstrap servers for plugins needing direct Kafka access
     # (e.g., SnapshotPublisher). None when using inmemory event bus.
     kafka_bootstrap_servers: str | None = None
+
+    # Runtime profile selected by the kernel during bootstrap. Domain plugins use
+    # this typed value instead of reading process environment directly.
+    runtime_profile: str = "main"
 
     # Optional: Per-event-type topic routing from contract published_events.
     output_topic_map: dict[str, str] | None = None

--- a/src/omnibase_infra/runtime/runtime_host_process.py
+++ b/src/omnibase_infra/runtime/runtime_host_process.py
@@ -102,6 +102,9 @@ from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchRe
 from omnibase_infra.models.runtime.model_resolved_dependencies import (
     ModelResolvedDependencies,
 )
+from omnibase_infra.runtime.auto_wiring.profile_ownership import (
+    runtime_profile_owns_contract,
+)
 from omnibase_infra.runtime.batch_response_publisher import BatchResponsePublisher
 from omnibase_infra.runtime.constants_security import (
     TRUSTED_HANDLER_NAMESPACE_PREFIXES,
@@ -595,6 +598,18 @@ def _baseline_subscription_wiring_disabled(runtime_profile: str | None = None) -
     return runtime_profile.strip().lower() != "main"
 
 
+def _raw_contract_owned_by_runtime_profile(
+    raw_contract: object,
+    runtime_profile: str | None = None,
+) -> bool:
+    """Return whether raw contract subscriptions are owned by runtime_profile."""
+    if not isinstance(raw_contract, dict):
+        return True
+    if runtime_profile is None:
+        runtime_profile = os.environ.get("RUNTIME_PROFILE", "main")
+    return runtime_profile_owns_contract(raw_contract, runtime_profile)
+
+
 def _discover_package_node_contracts(package_root: Path) -> list[dict[str, object]]:
     """Discover node contracts from the installed package tree.
 
@@ -633,6 +648,7 @@ async def _wire_package_node_subscriptions(
     contracts: list[dict[str, object]],
     event_bus_wiring: EventBusSubcontractWiring,
     already_wired_names: set[str],
+    runtime_profile: str | None = None,
 ) -> tuple[int, int, int]:
     """Wire Kafka subscriptions for package-discovered node contracts.
 
@@ -671,6 +687,16 @@ async def _wire_package_node_subscriptions(
                 "node=%s consumer_purpose=%s",
                 node_name,
                 event_bus_section.get("consumer_purpose"),
+            )
+            continue
+
+        if not _raw_contract_owned_by_runtime_profile(contract, runtime_profile):
+            skipped_no_topics += 1
+            logger.info(
+                "RuntimeHostProcess: skipping Kafka subscription for "
+                "runtime-profile-owned contract node=%s profile=%s",
+                node_name,
+                runtime_profile or os.environ.get("RUNTIME_PROFILE", "main"),
             )
             continue
 
@@ -3592,6 +3618,14 @@ class RuntimeHostProcess:
         event_bus_data = descriptor.contract_config.get("event_bus")
         if not event_bus_data or not isinstance(event_bus_data, dict):
             return
+        if not _raw_contract_owned_by_runtime_profile(descriptor.contract_config):
+            logger.info(
+                "Skipping live handler subscription for runtime-profile-owned "
+                "contract: node=%s profile=%s",
+                node_name,
+                os.environ.get("RUNTIME_PROFILE", "main"),
+            )
+            return
         if _requires_raw_event_projection_wiring(event_bus_data):
             logger.info(
                 "Skipping live handler subscription for raw projection consumer: "
@@ -5756,6 +5790,14 @@ class RuntimeHostProcess:
                 if isinstance(raw_contract, dict)
                 else None
             )
+            if not _raw_contract_owned_by_runtime_profile(raw_contract):
+                logger.info(
+                    "Skipping event_bus subcontract wiring for "
+                    "runtime-profile-owned contract: handler=%s profile=%s",
+                    descriptor.name or handler_type,
+                    os.environ.get("RUNTIME_PROFILE", "main"),
+                )
+                continue
             if _requires_raw_event_projection_wiring(raw_event_bus):
                 logger.info(
                     "Skipping event_bus subcontract wiring for raw projection consumer: "
@@ -5871,6 +5913,7 @@ class RuntimeHostProcess:
             contracts=contracts,
             event_bus_wiring=self._event_bus_wiring,
             already_wired_names=already_wired,
+            runtime_profile=os.environ.get("RUNTIME_PROFILE", "main"),
         )
 
         logger.info(

--- a/src/omnibase_infra/runtime/runtime_profile.py
+++ b/src/omnibase_infra/runtime/runtime_profile.py
@@ -11,6 +11,11 @@ across local-dev / staging / production.
 Profiles:
     local-dev  -- No external dependencies assumed; all optional subsystems
                   disabled by default so the runtime boots offline.
+    main       -- Primary event-orchestration runtime.
+    effects    -- Effect-lane runtime for effect-owned contracts and consumers.
+    workers    -- Worker runtime profile used by the runtime-worker service.
+    projection-api -- Projection API runtime profile.
+    canary     -- Canary runtime profile for isolated contract experiments.
     staging    -- Best-effort mode; prefetcher runs but missing secrets are
                   logged as warnings and boot continues.
     production -- Strict mode; missing required secrets cause a hard failure.
@@ -73,6 +78,25 @@ _PROFILES: dict[str, ModelRuntimeProfile] = {
     # "main" matches the auto-wiring RUNTIME_PROFILE default.
     "main": ModelRuntimeProfile(
         name="main",
+        prefetch_policy="disabled",
+    ),
+    # Runtime lane profiles must preserve identity. Consumers use the resolved
+    # profile name to decide ownership; falling back to "default" can subscribe
+    # secondary runtimes to main-owned workflow topics.
+    "effects": ModelRuntimeProfile(
+        name="effects",
+        prefetch_policy="disabled",
+    ),
+    "workers": ModelRuntimeProfile(
+        name="workers",
+        prefetch_policy="disabled",
+    ),
+    "projection-api": ModelRuntimeProfile(
+        name="projection-api",
+        prefetch_policy="disabled",
+    ),
+    "canary": ModelRuntimeProfile(
+        name="canary",
         prefetch_policy="disabled",
     ),
     "staging": ModelRuntimeProfile(

--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -236,6 +236,20 @@ class DispatchResultApplier:
                 return str(value).encode("utf-8")
         return None
 
+    def _publish_payload_for_output_event(self, event: BaseModel) -> BaseModel:
+        """Return the payload that should be wrapped in the bus envelope.
+
+        Some domain handlers return a topic-bearing domain envelope whose
+        ``payload`` is the actual event payload. The runtime uses the outer model
+        to resolve the topic, but Kafka consumers and projections expect the
+        inner payload as ``ModelEventEnvelope.payload``.
+        """
+        if type(event).__name__ == "ModelDelegationEventEnvelope":
+            inner_payload = getattr(event, "payload", None)
+            if isinstance(inner_payload, BaseModel):
+                return inner_payload
+        return event
+
     def _resolve_output_topic(self, event: BaseModel) -> str:
         """Resolve the output topic for an event using the output_topic_map.
 
@@ -589,6 +603,9 @@ class DispatchResultApplier:
         if result.output_events:
             for idx, output_event in enumerate(result.output_events):
                 try:
+                    publish_payload = self._publish_payload_for_output_event(
+                        output_event
+                    )
                     # Deterministic envelope_id: uuid5(correlation_id, "type:index")
                     # ensures redeliveries produce identical IDs, enabling
                     # downstream consumers to deduplicate at-least-once events.
@@ -600,18 +617,18 @@ class DispatchResultApplier:
                     )
                     output_envelope: ModelEventEnvelope[BaseModel] = ModelEventEnvelope(
                         envelope_id=deterministic_id,
-                        payload=output_event,
+                        payload=publish_payload,
                         correlation_id=effective_correlation_id,
                         envelope_timestamp=self._clock(),
                     )
 
                     # Extract partition key for per-entity ordering.
-                    partition_key = self._resolve_partition_key(output_event)
+                    partition_key = self._resolve_partition_key(publish_payload)
                     if partition_key is not None:
                         logger.debug(
                             "Resolved partition key for output event "
                             "(type=%s, key=%s, correlation_id=%s)",
-                            type(output_event).__name__,
+                            type(publish_payload).__name__,
                             partition_key.decode("utf-8"),
                             str(effective_correlation_id),
                         )

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1989,6 +1989,7 @@ async def bootstrap() -> int:
             dispatch_engine=dispatch_engine,
             node_identity=plugin_node_identity,
             kafka_bootstrap_servers=kafka_bootstrap_servers,
+            runtime_profile=kernel_profile.name,
         )
 
         # Activate plugins using two-pass lifecycle (OMN-2050, OMN-2089)

--- a/tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py
+++ b/tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py
@@ -18,6 +18,10 @@ from omnibase_infra.runtime.auto_wiring.models import (
     ModelContractVersion,
     ModelDiscoveredContract,
 )
+from omnibase_infra.runtime.auto_wiring.profile_ownership import (
+    extract_runtime_profiles_from_contract,
+    runtime_profile_owns_contract,
+)
 
 
 def _contract(
@@ -68,6 +72,37 @@ def test_contract_runtime_profiles_select_single_owner() -> None:
         "main_only"
     ]
     assert main_result.skipped_contracts == ("effects_only",)
+
+
+def test_raw_contract_runtime_profile_ownership_defaults_to_main() -> None:
+    raw_contract = {
+        "name": "node_delegation_orchestrator",
+        "event_bus": {
+            "subscribe_topics": [
+                "onex.cmd.omnibase-infra.delegation-request.v1",
+            ],
+        },
+    }
+
+    assert extract_runtime_profiles_from_contract(raw_contract) == ()
+    assert runtime_profile_owns_contract(raw_contract, "main") is True
+    assert runtime_profile_owns_contract(raw_contract, "effects") is False
+
+
+def test_raw_contract_runtime_profile_ownership_reads_descriptor_metadata() -> None:
+    raw_contract = {
+        "name": "node_delegation_quality_gate_effect",
+        "descriptor": {"runtime_profiles": [" Effects ", "effects"]},
+        "event_bus": {
+            "subscribe_topics": [
+                "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1",
+            ],
+        },
+    }
+
+    assert extract_runtime_profiles_from_contract(raw_contract) == ("effects",)
+    assert runtime_profile_owns_contract(raw_contract, "effects") is True
+    assert runtime_profile_owns_contract(raw_contract, "main") is False
 
 
 def test_runtime_profiles_are_normalized_and_deduplicated() -> None:
@@ -145,3 +180,34 @@ def test_github_pr_poller_is_owned_by_effects_runtime_profile() -> None:
     ]
     assert main_result.manifest.contracts == ()
     assert main_result.skipped_contracts == ("node_github_pr_poller_effect",)
+
+
+def test_llm_inference_effect_is_owned_by_effects_runtime_profile() -> None:
+    contract_path = (
+        Path(__file__).resolve().parents[4]
+        / "src"
+        / "omnibase_infra"
+        / "nodes"
+        / "node_llm_inference_effect"
+        / "contract.yaml"
+    )
+
+    manifest = discover_contracts_from_paths([contract_path])
+
+    assert manifest.total_errors == 0
+    contract = manifest.contracts[0]
+    assert contract.name == "node_llm_inference_effect"
+    assert contract.runtime_profiles == ("effects",)
+    assert contract.event_bus is not None
+    assert contract.event_bus.subscribe_topics == (
+        "onex.cmd.omnibase-infra.llm-inference-request.v1",
+    )
+
+    effects_result = filter_manifest_for_runtime_profile(manifest, "effects")
+    main_result = filter_manifest_for_runtime_profile(manifest, "main")
+
+    assert [item.name for item in effects_result.manifest.contracts] == [
+        "node_llm_inference_effect"
+    ]
+    assert main_result.manifest.contracts == ()
+    assert main_result.skipped_contracts == ("node_llm_inference_effect",)

--- a/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
+++ b/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
@@ -91,7 +91,15 @@ class ModelBaselineIntent(BaseModel):
 class ModelDelegationResult(BaseModel):
     """Stub terminal delegation result payload."""
 
+    correlation_id: str = "cid-123"
     content: str = "done"
+
+
+class ModelDelegationEventEnvelope(BaseModel):
+    """Stub topic-bearing delegation event envelope."""
+
+    topic: str
+    payload: ModelDelegationResult
 
 
 def _make_result(**overrides: object) -> ModelDispatchResult:
@@ -394,6 +402,33 @@ class TestDelegationIntentTopicRouting:
         call_kwargs = mock_bus.publish_envelope.call_args.kwargs
         assert call_kwargs["topic"] == completed_topic
         assert isinstance(call_kwargs["envelope"].payload, ModelDelegationResult)
+
+    @pytest.mark.asyncio
+    async def test_delegation_topic_envelope_publishes_inner_terminal_payload(
+        self,
+    ) -> None:
+        mock_bus = AsyncMock()
+        completed_topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=completed_topic,
+        )
+        terminal_payload = ModelDelegationResult(correlation_id="cid-456")
+        result = _make_result(
+            output_events=[
+                ModelDelegationEventEnvelope(
+                    topic=completed_topic,
+                    payload=terminal_payload,
+                )
+            ],
+        )
+
+        await applier.apply(result)
+
+        mock_bus.publish_envelope.assert_called_once()
+        call_kwargs = mock_bus.publish_envelope.call_args.kwargs
+        assert call_kwargs["topic"] == completed_topic
+        assert call_kwargs["envelope"].payload == terminal_payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_kernel_wiring.py
+++ b/tests/unit/runtime/test_kernel_wiring.py
@@ -71,6 +71,29 @@ class TestKernelDispatchEngineWiring:
         )
 
         assert config.dispatch_engine is engine
+        assert config.runtime_profile == "main"
+
+    @pytest.mark.asyncio
+    async def test_runtime_profile_can_be_set_on_plugin_config(self) -> None:
+        """Verify runtime_profile is passed through typed plugin config."""
+        from uuid import uuid4
+
+        from omnibase_infra.runtime.models import ModelDomainPluginConfig
+
+        bus = EventBusInmemory(environment="test", group="test-kernel")
+        container = MagicMock()
+
+        config = ModelDomainPluginConfig(
+            container=container,
+            event_bus=bus,
+            correlation_id=uuid4(),
+            input_topic="requests",
+            output_topic="responses",
+            consumer_group="onex-test",
+            runtime_profile="effects",
+        )
+
+        assert config.runtime_profile == "effects"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_node_subscription_wiring.py
+++ b/tests/unit/runtime/test_node_subscription_wiring.py
@@ -253,6 +253,82 @@ class TestPackageNodeSubscriptionWiring:
         assert skipped_no_topics == 2
 
     @pytest.mark.asyncio
+    async def test_package_wiring_respects_runtime_profile_ownership(
+        self, tmp_path: Path, mock_event_bus_wiring: MagicMock
+    ) -> None:
+        """Secondary runtimes must not subscribe to main-owned delegation workflow topics."""
+        orchestrator = (
+            tmp_path / "nodes" / "node_delegation_orchestrator" / "contract.yaml"
+        )
+        orchestrator.parent.mkdir(parents=True)
+        orchestrator.write_text(
+            textwrap.dedent("""\
+            name: "node_delegation_orchestrator"
+            node_type: "ORCHESTRATOR_GENERIC"
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.delegation-request.v1"
+            """)
+        )
+
+        effect = tmp_path / "nodes" / "node_llm_inference_effect" / "contract.yaml"
+        effect.parent.mkdir(parents=True)
+        effect.write_text(
+            textwrap.dedent("""\
+            name: "node_llm_inference_effect"
+            node_type: "EFFECT_GENERIC"
+            runtime_profiles:
+              - effects
+            event_bus:
+              version:
+                major: 1
+                minor: 0
+                patch: 0
+              subscribe_topics:
+                - "onex.cmd.omnibase-infra.llm-inference-request.v1"
+            """)
+        )
+
+        from omnibase_infra.runtime.runtime_host_process import (
+            _discover_package_node_contracts,
+            _wire_package_node_subscriptions,
+        )
+
+        contracts = _discover_package_node_contracts(tmp_path)
+        wired, _, skipped_no_topics = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+            runtime_profile="effects",
+        )
+
+        assert wired == 1
+        assert skipped_no_topics == 1
+        wired_names = {c["node_name"] for c in mock_event_bus_wiring._wire_calls}
+        assert "node_delegation_orchestrator" not in wired_names
+        assert "node_llm_inference_effect" in wired_names
+
+        mock_event_bus_wiring._wire_calls.clear()
+        mock_event_bus_wiring.wire_subscriptions.reset_mock()
+
+        wired, _, skipped_no_topics = await _wire_package_node_subscriptions(
+            contracts=contracts,
+            event_bus_wiring=mock_event_bus_wiring,
+            already_wired_names=set(),
+            runtime_profile="main",
+        )
+
+        assert wired == 1
+        assert skipped_no_topics == 1
+        wired_names = {c["node_name"] for c in mock_event_bus_wiring._wire_calls}
+        assert "node_delegation_orchestrator" in wired_names
+        assert "node_llm_inference_effect" not in wired_names
+
+    @pytest.mark.asyncio
     async def test_raw_projection_consumer_purpose_not_wired(
         self, tmp_path: Path, mock_event_bus_wiring: MagicMock
     ) -> None:

--- a/tests/unit/runtime/test_runtime_profile.py
+++ b/tests/unit/runtime/test_runtime_profile.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime profile identity tests."""
+
+from __future__ import annotations
+
+from omnibase_infra.runtime.runtime_profile import load_runtime_profile
+
+
+def test_runtime_lane_profiles_preserve_identity() -> None:
+    """Runtime lane names must not fall back to default."""
+    for profile_name in ("main", "effects", "workers", "projection-api", "canary"):
+        assert load_runtime_profile(profile_name).name == profile_name
+
+
+def test_unknown_runtime_profile_still_falls_back_to_default() -> None:
+    assert load_runtime_profile("unknown-lane").name == "default"


### PR DESCRIPTION
Evidence-Source: OCC#2216
Evidence-Ticket: OMN-12724
Closes OMN-12724

## Summary
- Preserve explicit runtime lane profile names for effects, workers, projection-api, and canary.
- Prevent the effects runtime from falling back to the default profile and starting delegation orchestration consumers.

## Verification
- `uv run ruff format src/omnibase_infra/runtime/runtime_profile.py tests/unit/runtime/test_runtime_profile.py`
- `uv run ruff check src/omnibase_infra/runtime/runtime_profile.py tests/unit/runtime/test_runtime_profile.py`
- `uv run pytest tests/unit/runtime/test_runtime_profile.py tests/unit/runtime/test_kernel_wiring.py tests/unit/runtime/auto_wiring/test_runtime_profile_ownership.py -q`
- `.201` hotpatch import proof: `RUNTIME_PROFILE=effects` loads profile name `effects` and effects logs skip delegation orchestration consumer startup.