### PR TITLE
fix(OMN-12734): clear contract resolver bifrost path

### DIFF
--- a/docker/catalog/services/contract-resolver.yaml
+++ b/docker/catalog/services/contract-resolver.yaml
@@ -24,6 +24,8 @@ hardcoded_env:
   KEYCLOAK_ADMIN_URL: http://keycloak:8080
   OTEL_SERVICE_NAME: omninode-contract-resolver
   CONTRACT_RESOLVER_PORT: '8091'
+catalog_env:
+  BIFROST_CONTRACT_PATH: ''
 operational_defaults:
   POSTGRES_USER: postgres
   ONEX_LOG_LEVEL: INFO

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1136,6 +1136,9 @@ services:
     environment:
       !!merge <<: *runtime-env
       OTEL_SERVICE_NAME: omninode-contract-resolver
+      # Contract resolver does not mount /app/data, so it must not render the
+      # Bifrost delegation contract into the shared runtime data path.
+      BIFROST_CONTRACT_PATH: ""
       CORS_ORIGINS: ${CONTRACT_RESOLVER_CORS_ORIGINS:-http://localhost:3000,http://localhost:3001,http://localhost:8085}
       CONTRACT_RESOLVER_PORT: "8091"
       ONEX_LOG_LEVEL: ${ONEX_LOG_LEVEL:-INFO}

--- a/tests/integration/test_runtime_sub_bundle_cli.py
+++ b/tests/integration/test_runtime_sub_bundle_cli.py
@@ -63,13 +63,20 @@ def _run_cli(
     args: list[str], *, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Invoke the catalog CLI with the given args and return the CompletedProcess."""
+    run_env = dict(os.environ if env is None else env)
+    existing_pythonpath = run_env.get("PYTHONPATH", "")
+    pythonpath_parts = [str(REPO_ROOT / "src"), str(REPO_ROOT)]
+    if existing_pythonpath:
+        pythonpath_parts.append(existing_pythonpath)
+    run_env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
     return subprocess.run(
         [*_CLI, *args],
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
         check=False,
-        env=env,
+        env=run_env,
     )
 
 
@@ -111,6 +118,25 @@ def test_generate_runtime_core_declares_seven_services(tmp_path: Path) -> None:
         f"runtime-core compose is missing services: {sorted(missing)}. "
         f"Full service set: {sorted(services)}"
     )
+
+
+@pytest.mark.integration
+def test_generate_runtime_core_clears_contract_resolver_bifrost_path(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "runtime-core.yml"
+    result = _generate_to("runtime-core", output)
+    assert result.returncode == 0, f"generate failed: {result.stderr}"
+
+    compose = _load_compose(output)
+    services = compose["services"]
+    assert isinstance(services, dict)
+    contract_resolver = services["omninode-contract-resolver"]
+    assert isinstance(contract_resolver, dict)
+    environment = contract_resolver["environment"]
+    assert isinstance(environment, dict)
+
+    assert environment["BIFROST_CONTRACT_PATH"] == ""
 
 
 @pytest.mark.integration

--- a/tests/unit/infra/test_catalog_completeness.py
+++ b/tests/unit/infra/test_catalog_completeness.py
@@ -18,6 +18,7 @@ COMPOSE_FILE = (
 BUNDLES_FILE = (
     Path(__file__).resolve().parents[3] / "docker" / "catalog" / "bundles.yaml"
 )
+CONTRACT_RESOLVER_MANIFEST = CATALOG_DIR / "contract-resolver.yaml"
 
 # The compose uses 'omninode-contract-resolver' but the manifest is named
 # 'contract-resolver' for brevity. This mapping handles that.
@@ -68,6 +69,31 @@ def test_no_entry_has_empty_default_env() -> None:
             assert var, f"{manifest['name']}: empty string in required_env"
         for var, val in manifest.get("hardcoded_env", {}).items():
             assert val != "", f"{manifest['name']}: {var} has empty hardcoded value"
+
+
+@pytest.mark.unit
+def test_contract_resolver_catalog_clears_bifrost_contract_path() -> None:
+    with open(CONTRACT_RESOLVER_MANIFEST) as f:
+        manifest = yaml.safe_load(f)
+
+    assert manifest["catalog_env"]["BIFROST_CONTRACT_PATH"] == ""
+
+
+@pytest.mark.unit
+def test_no_data_http_runtime_services_clear_bifrost_contract_path() -> None:
+    content = COMPOSE_FILE.read_text().replace("!!merge ", "")
+    compose = yaml.safe_load(content)
+    services = compose["services"]
+
+    for service_name in ("projection-api", "omninode-contract-resolver"):
+        service = services[service_name]
+        volume_targets = {
+            volume.split(":")[1]
+            for volume in service.get("volumes", [])
+            if isinstance(volume, str) and ":" in volume
+        }
+        assert "/app/data" not in volume_targets
+        assert service["environment"]["BIFROST_CONTRACT_PATH"] == ""
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Evidence-Source: OCC#2218
Evidence-Ticket: OMN-12734

## Summary
- Clear `BIFROST_CONTRACT_PATH` for `omninode-contract-resolver` in `docker-compose.infra.yml` so the service does not try to render Bifrost delegation config into `/app/data` without a data mount.
- Add the same explicit override to the contract-resolver catalog manifest via `catalog_env`.
- Add regression coverage for the hand-authored compose source and generated runtime-core catalog output.

## Runtime impact
This preserves the live dev-lane hotpatch in durable infra sources. It changes only contract-resolver startup env by disabling Bifrost contract rendering for that no-data-volume HTTP bridge. No live restart was performed from this PR.

## Verification
- `PYTHONPATH="$PWD/src:$PWD${PYTHONPATH:+:$PYTHONPATH}" uv run pytest tests/unit/infra/test_catalog_completeness.py tests/integration/test_runtime_sub_bundle_cli.py -q`
  - Result: 11 passed, 1 xpassed
- `env ... docker compose --env-file docker/runtime-policy.env -f docker/docker-compose.infra.yml --profile runtime config --format json`
  - Verified `omninode-contract-resolver.environment.BIFROST_CONTRACT_PATH == ""`
- `uv run ruff format tests/unit/infra/test_catalog_completeness.py tests/integration/test_runtime_sub_bundle_cli.py`
- `uv run ruff check tests/unit/infra/test_catalog_completeness.py tests/integration/test_runtime_sub_bundle_cli.py`
- `git diff --check`

## OCC Evidence
- https://github.com/OmniNode-ai/onex_change_control/pull/2218

## Post-merge validation
- Redeploy dev lane without manual compose edits.
- Recreate `omninode-contract-resolver` from the rendered deployed compose.
- Verify `http://127.0.0.1:8091/health` remains ok and the service no longer logs Bifrost delegation render failures.

Linear: OMN-12734