### PR TITLE
ci(OMN-12736): harden migration freeze checkout timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,13 +302,18 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 5
+    # OMN-12736: merge_group queue refs can spend several minutes in checkout on
+    # self-hosted runners. Keep the freeze gate strict, but give checkout enough
+    # room to finish before the script runs.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
+        timeout-minutes: 10
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          fetch-tags: false
 
       - name: Check migration freeze
         run: ./scripts/check_migration_freeze.sh --ci

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -53,15 +53,19 @@ def _runs_on_expression(job: dict[str, Any]) -> str:
     return str(runs_on)
 
 
-def test_migration_freeze_uses_shallow_checkout_for_merge_group() -> None:
+def test_migration_freeze_checkout_is_bounded_for_merge_group() -> None:
     workflow = _load_yaml(CI_WORKFLOW)
     job = workflow["jobs"]["migration-freeze"]
     steps = job["steps"]
 
+    assert job["timeout-minutes"] == 15
+
     checkout_step = next(
         step for step in steps if step.get("uses") == "actions/checkout@v6"
     )
+    assert checkout_step["timeout-minutes"] == 10
     assert checkout_step["with"]["fetch-depth"] == 2
+    assert checkout_step["with"]["fetch-tags"] is False
 
     freeze_step = next(
         step for step in steps if step.get("name") == "Check migration freeze"


### PR DESCRIPTION
## Summary
- OMN-12736: harden the `Migration Freeze Check` merge_group path after run 27058639824 / job 79867549855 spent the full 5m budget in `actions/checkout@v6` fetching `gh-readonly-queue/dev/pr-1881` and skipped the freeze script.
- Raise the migration-freeze job timeout from 5m to 15m.
- Bound the checkout step at 10m, keep shallow `fetch-depth: 2`, and make `fetch-tags: false` explicit. The freeze script remains unchanged and required.
- Extend focused CI workflow resilience coverage for the new timeout/fetch settings.

## Verification
- `uv run pytest tests/ci/test_ci_workflow_resilience.py -q`
- `uv run ruff format --check tests/ci/test_ci_workflow_resilience.py`
- `uv run ruff check tests/ci/test_ci_workflow_resilience.py`
- `git diff --check`

## Evidence

OMN-12736

Evidence-Source: OCC#2254

Evidence-Ticket: OMN-12736

This is a CI-only workflow-hardening change (`.github/workflows` + focused CI resilience test); it ships no runtime contract, node, handler, topic, or migration. The Evidence-Source above (OCC#2254, merged to OCC main at e3a7974c) carries the OMN-12736 contract; the Receipt Gate (OMN-10419) resolves the merged OCC PR to its merge commit on OCC main.

## Notes
- No merge or deploy performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI job timeout configurations and checkout behavior for improved stability.

* **Tests**
  * Updated CI resilience test suite to validate timeout settings and checkout parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



