### PR TITLE
chore(release)(OMN-12245): bump omnibase_infra to v0.38.1

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "5a0ff559831c179ba9cb093707ad1178",
+  "identity_digest": "4fceb0a3ef3e965c25df49151f518062",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "2fffb3749d606e3cfe03774d",
+  "shared_env_digest": "84472db719e00b9b709d36de",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.38.0"
+version = "0.38.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -309,7 +309,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {
             "ModelNodeHeartbeatEvent",
             "platform.node-heartbeat",
-            "onex.cmd.platform.foo-start.v1",
+            "onex.evt.platform.node-heartbeat.v1",
         }
         assert (
             prepared.resolution_outcome

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.38.0"
+version = "0.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Evidence-Ticket: OMN-12245
Evidence-Source: OCC#2229
hotfix-evidence: OCC-2229
backmerge: #1887

Bumps omnibase_infra main release metadata to v0.38.1 because v0.38.0 already exists off the current main release head.

Verification:
- uv lock refreshed with package version v0.38.1
- runner image identity lock regenerated after uv.lock change
- targeted local pytest: runner image identity checks and generic direct handler dispatcher event-topic expectation (`3 passed`)
- Central OCC receipt: onex_change_control#2229
- Backmerge companion: omnibase_infra#1887