### PR TITLE
chore(release)(OMN-12245): backmerge omnibase_infra v0.38.1 version bump to dev

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "5a0ff559831c179ba9cb093707ad1178",
+  "identity_digest": "4fceb0a3ef3e965c25df49151f518062",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "2fffb3749d606e3cfe03774d",
+  "shared_env_digest": "84472db719e00b9b709d36de",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.38.0"
+version = "0.38.1"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -307,7 +307,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {
             "ModelNodeHeartbeatEvent",
             "platform.node-heartbeat",
-            "onex.evt.platform.node-heartbeat.v1",
+            "onex.cmd.platform.foo-start.v1",
         }
         assert (
             prepared.resolution_outcome

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py
@@ -307,7 +307,7 @@ class TestPrepareHandlerWiringIncludesEventTypeAlias:
         assert prepared.message_types == {
             "ModelNodeHeartbeatEvent",
             "platform.node-heartbeat",
-            "onex.cmd.platform.foo-start.v1",
+            "onex.evt.platform.node-heartbeat.v1",
         }
         assert (
             prepared.resolution_outcome

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.38.0"
+version = "0.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Evidence-Ticket: OMN-12245
Evidence-Source: OCC#2231

Backmerge companion for main release-version PR #1886 so dev retains the v0.38.1 release metadata after main release publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Versioned runner image with prebuilt CI environment for faster and more reliable job execution.
  * Production deployment lineage guard to enforce clean promotion before builds.
  * DLQ message quarantine functionality for non-replayable messages instead of dropping.
  * Machine class configuration overlays for environment-specific deployment settings.
  * Node-owned SQL migration discovery and application.

* **Improvements**
  * Enhanced runtime health monitoring with ONEX health probes.
  * Improved Kafka consumer startup with concurrency control and retries.
  * Extended deployment support for multiple runtime lanes (dev, stability, prod).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->