### PR TITLE
fix(OMN-12749): invoke typed local runtime handlers

### DIFF
--- a/src/omnibase_infra/runtime/runtime_local_adapter.py
+++ b/src/omnibase_infra/runtime/runtime_local_adapter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 __all__ = ["LocalRuntimeBusAdapter"]
 
 import asyncio
+import inspect
 import json
 import logging
 import time
@@ -31,7 +32,9 @@ logger = logging.getLogger(__name__)
 class LocalRuntimeBusAdapter:
     """Wraps an ONEX handler with event bus serialization/deserialization.
 
-    Handlers are invoked with **model.model_dump() as kwargs.
+    Typed handlers are invoked with the validated input model as the sole
+    request object. Legacy handlers that explicitly accept **kwargs are invoked
+    with model.model_dump() as kwargs.
     Results are serialized to JSON and published to the output topic.
     Correlation IDs are preserved across input -> output.
 
@@ -88,15 +91,14 @@ class LocalRuntimeBusAdapter:
         start = time.monotonic()
         try:
             handle_method = self.handler.handle
-            model_kwargs = input_model.model_dump(mode="json")
-            if asyncio.iscoroutinefunction(handle_method):
-                maybe_result = handle_method(**model_kwargs)
+            maybe_result = _invoke_handle_method(handle_method, input_model)
+            if inspect.isawaitable(maybe_result):
                 awaitable_result: Awaitable[object] = cast(
                     "Awaitable[object]", maybe_result
                 )
                 result = await awaitable_result
             else:
-                result = handle_method(**model_kwargs)
+                result = maybe_result
         except Exception:  # fallback-ok: local runtime adapter records handler failure and continues shutdown
             elapsed = time.monotonic() - start
             logger.exception(
@@ -151,3 +153,54 @@ class LocalRuntimeBusAdapter:
             )
             if self.on_error:
                 self.on_error()
+
+
+def _invoke_handle_method(
+    handle_method: Callable[..., object],
+    input_model: BaseModel,
+) -> object:
+    """Invoke a local-runtime handler using its declared calling convention."""
+    try:
+        signature = inspect.signature(handle_method)
+    except (TypeError, ValueError):
+        return handle_method(input_model)
+
+    parameters = tuple(signature.parameters.values())
+    if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in parameters):
+        return handle_method(**input_model.model_dump(mode="json"))
+
+    positional_parameters = tuple(
+        param
+        for param in parameters
+        if param.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    )
+    if len(positional_parameters) == 0:
+        return handle_method()
+
+    if len(positional_parameters) == 1 and _parameter_expects_model(
+        positional_parameters[0],
+        type(input_model),
+    ):
+        return handle_method(input_model)
+
+    return handle_method(**input_model.model_dump(mode="json"))
+
+
+def _parameter_expects_model(
+    parameter: inspect.Parameter,
+    input_model_cls: type[BaseModel],
+) -> bool:
+    """Return True when a single handle parameter expects the request model."""
+    if parameter.name in {"request", "payload", "event", "input_model"}:
+        return True
+
+    annotation = parameter.annotation
+    return (
+        isinstance(annotation, type)
+        and issubclass(annotation, BaseModel)
+        and issubclass(input_model_cls, annotation)
+    )

--- a/tests/unit/runtime/test_runtime_local_execution.py
+++ b/tests/unit/runtime/test_runtime_local_execution.py
@@ -188,6 +188,42 @@ def _make_sync_handler(
     return _Handler()
 
 
+def _make_async_typed_handler(
+    output: MockOutput | None = None,
+    error: Exception | None = None,
+) -> Any:
+    """Return an object with an async typed ``handle(request)`` method."""
+
+    class _Handler:
+        calls: list[MockInput] = []
+
+        async def handle(self, request: MockInput) -> MockOutput | None:
+            self.calls.append(request)
+            if error is not None:
+                raise error
+            return output
+
+    return _Handler()
+
+
+def _make_sync_typed_handler(
+    output: MockOutput | None = None,
+    error: Exception | None = None,
+) -> Any:
+    """Return an object with a sync typed ``handle(request)`` method."""
+
+    class _Handler:
+        calls: list[MockInput] = []
+
+        def handle(self, request: MockInput) -> MockOutput | None:
+            self.calls.append(request)
+            if error is not None:
+                raise error
+            return output
+
+    return _Handler()
+
+
 def _input_bytes(correlation_id: str = "cid-1", name: str = "alice") -> bytes:
     return (
         MockInput(correlation_id=correlation_id, name=name).model_dump_json().encode()
@@ -196,8 +232,8 @@ def _input_bytes(correlation_id: str = "cid-1", name: str = "alice") -> bytes:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_adapter_async_handler() -> None:
-    """Adapter deserializes message, calls async handler, publishes result."""
+async def test_adapter_async_kwargs_handler() -> None:
+    """Adapter deserializes message, calls legacy async kwargs handler."""
     expected_output = MockOutput(correlation_id="cid-1", result="ok")
     handler = _make_async_handler(output=expected_output)
     bus = MockBus()
@@ -212,7 +248,6 @@ async def test_adapter_async_handler() -> None:
     msg = MockMessage(value=_input_bytes())
     await adapter.on_message(msg)
 
-    # Handler was called with deserialized kwargs
     assert len(handler.calls) == 1
     assert handler.calls[0]["correlation_id"] == "cid-1"
     assert handler.calls[0]["name"] == "alice"
@@ -228,8 +263,8 @@ async def test_adapter_async_handler() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_adapter_sync_handler() -> None:
-    """Adapter works with sync handlers too."""
+async def test_adapter_sync_kwargs_handler() -> None:
+    """Adapter works with legacy sync kwargs handlers too."""
     expected_output = MockOutput(correlation_id="cid-2", result="sync-ok")
     handler = _make_sync_handler(output=expected_output)
     bus = MockBus()
@@ -249,6 +284,60 @@ async def test_adapter_sync_handler() -> None:
     assert len(bus.published) == 1
     published_data = json.loads(bus.published[0][2])
     assert published_data["result"] == "sync-ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_async_typed_handler() -> None:
+    """Adapter calls async typed handlers with the validated request model."""
+    expected_output = MockOutput(correlation_id="cid-typed", result="typed-ok")
+    handler = _make_async_typed_handler(output=expected_output)
+    bus = MockBus()
+    adapter = LocalRuntimeBusAdapter(
+        handler=handler,
+        handler_name="test-async-typed",
+        input_model_cls=MockInput,
+        output_topic="out.topic",
+        bus=bus,
+    )
+
+    msg = MockMessage(value=_input_bytes(correlation_id="cid-typed", name="ada"))
+    await adapter.on_message(msg)
+
+    assert len(handler.calls) == 1
+    assert isinstance(handler.calls[0], MockInput)
+    assert handler.calls[0].correlation_id == "cid-typed"
+    assert handler.calls[0].name == "ada"
+    assert len(bus.published) == 1
+    published_data = json.loads(bus.published[0][2])
+    assert published_data["result"] == "typed-ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_sync_typed_handler() -> None:
+    """Adapter calls sync typed handlers with the validated request model."""
+    expected_output = MockOutput(correlation_id="cid-sync-typed", result="typed-sync")
+    handler = _make_sync_typed_handler(output=expected_output)
+    bus = MockBus()
+    adapter = LocalRuntimeBusAdapter(
+        handler=handler,
+        handler_name="test-sync-typed",
+        input_model_cls=MockInput,
+        output_topic="out.topic",
+        bus=bus,
+    )
+
+    msg = MockMessage(value=_input_bytes(correlation_id="cid-sync-typed", name="grace"))
+    await adapter.on_message(msg)
+
+    assert len(handler.calls) == 1
+    assert isinstance(handler.calls[0], MockInput)
+    assert handler.calls[0].correlation_id == "cid-sync-typed"
+    assert handler.calls[0].name == "grace"
+    assert len(bus.published) == 1
+    published_data = json.loads(bus.published[0][2])
+    assert published_data["result"] == "typed-sync"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- fix `LocalRuntimeBusAdapter` to call typed `handle(request)` handlers with the validated Pydantic input model
- preserve legacy `handle(**kwargs)` and named-field handler compatibility
- add regression coverage for async/sync typed handlers and legacy kwargs handlers

## Why
`/onex:delegate` was failing before LLM work with `TypeError: HandlerDelegateSkill.handle() got an unexpected keyword argument 'prompt'` because the adapter splatted validated request fields into a typed handler.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_local_execution.py -q` -> 42 passed
- `uv run pytest tests/unit/runtime/test_runtime_local_execution.py tests/unit/runtime/test_handler_wiring_resolver_integration.py tests/unit/runtime/test_container_wiring.py -q` -> 80 passed
- `uv run ruff format src/omnibase_infra/runtime/runtime_local_adapter.py tests/unit/runtime/test_runtime_local_execution.py && uv run ruff check src/omnibase_infra/runtime/runtime_local_adapter.py tests/unit/runtime/test_runtime_local_execution.py`
- `git diff --check`
- Cross-repo smoke: real `HandlerDelegateSkill` + fake dispatch port through `LocalRuntimeBusAdapter` published a completed typed response

## Evidence
Evidence-Source: OCC#2235
Evidence-Ticket: OMN-12749

## Runtime note
No deploy/restart/runtime mutation was performed. Live `/onex:delegate` verification requires approved runtime refresh/deploy.