### PR TITLE
fix(OMN-12755): preserve workspace root in deploy-runtime

### DIFF
--- a/contracts/OMN-12755.yaml
+++ b/contracts/OMN-12755.yaml
@@ -1,0 +1,59 @@
+# OMN-12755 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-12755"
+title: "Fix deploy-runtime workspace OMNI_HOME propagation"
+summary: >-
+  deploy-runtime.sh preserves an operator-supplied OMNI_HOME across
+  ~/.omnibase/.env sourcing, stages workspace sibling repos from that root when
+  BUILD_SOURCE=workspace, and passes BUILD_SOURCE, EXPECTED_BUILD_SOURCE, and
+  OMNI_HOME as explicit Dockerfile build args.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused deploy-runtime workspace build command and env precedence regressions pass"
+    command: >-
+      uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_deploy_runtime_no_env_file.py -q
+  - kind: "tests"
+    description: "deploy-runtime shell syntax is valid"
+    command: "bash -n scripts/deploy-runtime.sh"
+  - kind: "tests"
+    description: "Touched Python test file passes ruff"
+    command: "uv run ruff check tests/scripts/test_deploy_runtime_build_context.py"
+  - kind: "manual"
+    description: "Post-merge runtime deployment should be run with BUILD_SOURCE=workspace to verify staging and image provenance"
+    command: >-
+      BUILD_SOURCE=workspace OMNI_HOME=/data/omninode/omni_home bash scripts/deploy-runtime.sh --execute --force
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-focused-tests"
+    description: "Focused deploy-runtime workspace build command and env precedence regressions pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_deploy_runtime_no_env_file.py -q
+  - id: "dod-shell-syntax"
+    description: "deploy-runtime shell syntax is valid"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "bash -n scripts/deploy-runtime.sh"
+  - id: "dod-ruff"
+    description: "Touched Python test file passes ruff"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run ruff check tests/scripts/test_deploy_runtime_build_context.py"
+  - id: "dod-post-merge-deploy"
+    description: "Post-merge workspace-mode runtime deploy validates staging and image provenance"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          BUILD_SOURCE=workspace OMNI_HOME=/data/omninode/omni_home bash scripts/deploy-runtime.sh --execute --force, then inspect image build args/provenance for the operator workspace root

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -31,10 +31,15 @@ set -euo pipefail
 # shellcheck source=/dev/null
 SCRIPT_DIR_FOR_ENV="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_FOR_ENV="$(cd "${SCRIPT_DIR_FOR_ENV}/.." && pwd)"
+OPERATOR_OMNI_HOME="${OMNI_HOME:-}"
 set -a
 source "${REPO_ROOT_FOR_ENV}/docker/runtime-policy.env"
 source "${HOME}/.omnibase/.env"
 set +a
+if [[ -n "${OPERATOR_OMNI_HOME}" ]]; then
+    export OMNI_HOME="${OPERATOR_OMNI_HOME}"
+fi
+unset OPERATOR_OMNI_HOME
 
 # =============================================================================
 # Constants
@@ -486,6 +491,76 @@ read_repo_ref_or_main() {
     else
         echo "main"
     fi
+}
+
+resolve_build_source() {
+    # Resolve the selected Dockerfile dependency source.
+    echo "${BUILD_SOURCE:-release}"
+}
+
+resolve_expected_build_source() {
+    # Default the Dockerfile assertion to the selected source. This preserves
+    # release-mode behavior while allowing BUILD_SOURCE=workspace without
+    # requiring operators to set a second env var by hand.
+    local build_source="$1"
+    echo "${EXPECTED_BUILD_SOURCE:-${build_source}}"
+}
+
+validate_build_source_config() {
+    # Validate build-source selector agreement before staging or Docker build.
+    local build_source expected_build_source omni_home
+    build_source="$(resolve_build_source)"
+    expected_build_source="$(resolve_expected_build_source "${build_source}")"
+    omni_home="${OMNI_HOME:-}"
+
+    case "${build_source}" in
+        workspace|release) ;;
+        *)
+            log_error "Invalid BUILD_SOURCE='${build_source}'; expected workspace or release."
+            exit 64
+            ;;
+    esac
+
+    case "${expected_build_source}" in
+        workspace|release) ;;
+        *)
+            log_error "Invalid EXPECTED_BUILD_SOURCE='${expected_build_source}'; expected workspace or release."
+            exit 64
+            ;;
+    esac
+
+    if [[ "${build_source}" != "${expected_build_source}" ]]; then
+        log_error "BUILD_SOURCE selector mismatch: BUILD_SOURCE='${build_source}' EXPECTED_BUILD_SOURCE='${expected_build_source}'."
+        exit 64
+    fi
+
+    if [[ "${build_source}" == "workspace" && -z "${omni_home}" ]]; then
+        log_error "BUILD_SOURCE=workspace requires OMNI_HOME before staging or build."
+        exit 64
+    fi
+}
+
+stage_workspace_if_needed() {
+    # Populate workspace/sibling-repos/ from the operator-selected OMNI_HOME so
+    # Dockerfile.runtime can install exact local sibling repo contents.
+    local repo_root="$1"
+    local build_source omni_home stage_script
+    build_source="$(resolve_build_source)"
+    if [[ "${build_source}" != "workspace" ]]; then
+        return 0
+    fi
+
+    omni_home="${OMNI_HOME:-}"
+    stage_script="${repo_root}/scripts/runtime_build/stage_workspace.sh"
+    if [[ ! -f "${stage_script}" ]]; then
+        log_error "Workspace staging script not found: ${stage_script}"
+        log_error "Cannot proceed with BUILD_SOURCE=workspace."
+        exit 1
+    fi
+
+    log_step "Stage Workspace Sibling Repos"
+    log_cmd "OMNI_HOME=${omni_home} bash ${stage_script}"
+    (cd "${repo_root}" && OMNI_HOME="${omni_home}" bash "${stage_script}")
 }
 
 check_git_dirty() {
@@ -1027,6 +1102,8 @@ if spec and spec.origin:
     # 5. Runtime build context paths required by docker/Dockerfile.runtime.
     # Release-mode builds still COPY these paths, even when sibling repos are
     # represented only by the committed .gitkeep placeholder.
+    stage_workspace_if_needed "${repo_root}"
+
     log_info "Syncing runtime build context..."
     mkdir -p "${deploy_target}/scripts" "${deploy_target}/workspace"
     log_cmd "rsync -a --delete scripts/runtime_build/ -> deployed"
@@ -1270,6 +1347,10 @@ build_images() {
     local build_date
     build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     local omni_home="${OMNI_HOME:-}"
+    local build_source
+    build_source="$(resolve_build_source)"
+    local expected_build_source
+    expected_build_source="$(resolve_expected_build_source "${build_source}")"
     local compat_ref="main"
     local omnimarket_ref="dev"
     local occ_ref="main"
@@ -1295,12 +1376,16 @@ build_images() {
         --build-arg "BUILD_DATE=${build_date}"
         --build-arg "RUNTIME_SOURCE_HASH=${git_sha}"
         --build-arg "COMPOSE_PROJECT=${compose_project}"
+        --build-arg "BUILD_SOURCE=${build_source}"
+        --build-arg "EXPECTED_BUILD_SOURCE=${expected_build_source}"
+        --build-arg "OMNI_HOME=${omni_home}"
         --build-arg "OMNIBASE_COMPAT_REF=${compat_ref}"
         --build-arg "OMNIMARKET_REF=${omnimarket_ref}"
         --build-arg "ONEX_CHANGE_CONTROL_REF=${occ_ref}"
     )
 
     log_info "Building images with VCS_REF=${git_sha} RUNTIME_SOURCE_HASH=${git_sha} COMPOSE_PROJECT=${compose_project}..."
+    log_info "Build source: BUILD_SOURCE=${build_source} EXPECTED_BUILD_SOURCE=${expected_build_source} OMNI_HOME=${omni_home}"
     log_info "Plugin refs: OMNIBASE_COMPAT_REF=${compat_ref} OMNIMARKET_REF=${omnimarket_ref} ONEX_CHANGE_CONTROL_REF=${occ_ref}"
     log_info "Build timeout: ${build_timeout}s (set DOCKER_BUILD_TIMEOUT_SECONDS to override)"
     log_cmd "${cmd[*]}"
@@ -1487,6 +1572,19 @@ print_compose_commands() {
     local compose_project="$2"
     local git_sha="$3"
     local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local omni_home="${OMNI_HOME:-}"
+    local build_source
+    build_source="$(resolve_build_source)"
+    local expected_build_source
+    expected_build_source="$(resolve_expected_build_source "${build_source}")"
+    local compat_ref="main"
+    local omnimarket_ref="dev"
+    local occ_ref="main"
+    if [[ -n "${omni_home}" ]]; then
+        compat_ref="$(read_repo_ref_or_main "${omni_home}/omnibase_compat")"
+        omnimarket_ref="$(read_repo_ref_or_main "${omni_home}/omnimarket")"
+        occ_ref="$(read_repo_ref_or_main "${omni_home}/onex_change_control")"
+    fi
 
     log_step "Compose Commands"
 
@@ -1503,9 +1601,12 @@ print_compose_commands() {
     log_info "    --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \\"
     log_info "    --build-arg RUNTIME_SOURCE_HASH=${git_sha} \\"
     log_info "    --build-arg COMPOSE_PROJECT=${compose_project} \\"
-    log_info "    --build-arg OMNIBASE_COMPAT_REF=\${OMNIBASE_COMPAT_REF:-main} \\"
-    log_info "    --build-arg OMNIMARKET_REF=\${OMNIMARKET_REF:-dev} \\"
-    log_info "    --build-arg ONEX_CHANGE_CONTROL_REF=\${ONEX_CHANGE_CONTROL_REF:-main}"
+    log_info "    --build-arg BUILD_SOURCE=${build_source} \\"
+    log_info "    --build-arg EXPECTED_BUILD_SOURCE=${expected_build_source} \\"
+    log_info "    --build-arg OMNI_HOME=${omni_home} \\"
+    log_info "    --build-arg OMNIBASE_COMPAT_REF=${compat_ref} \\"
+    log_info "    --build-arg OMNIMARKET_REF=${omnimarket_ref} \\"
+    log_info "    --build-arg ONEX_CHANGE_CONTROL_REF=${occ_ref}"
     log_info ""
     log_info "Restart runtime services:"
     log_info "  docker compose \\"
@@ -1638,6 +1739,7 @@ main() {
     log_info "Version: ${version}"
     log_info "Git SHA: ${git_sha}"
     check_git_dirty "${repo_root}"
+    validate_build_source_config
 
     # Prod lane: hard-fail on dirty/non-promoted source before any build/deploy.
     # Runs in both dry-run and execute modes so operators see the rejection

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -354,11 +354,14 @@ validate_prerequisites() {
     # Check that all required external commands and Docker Compose version are available.
     log_step "Validate Prerequisites"
 
-    check_command rsync   "file synchronization"
     check_command docker  "container runtime"
-    check_command jq      "JSON processing"
     check_command git     "version control"
-    check_command curl    "deployment verification"
+
+    if [[ "${PRINT_COMPOSE_CMD}" == false ]]; then
+        check_command rsync   "file synchronization"
+        check_command jq      "JSON processing"
+        check_command curl    "deployment verification"
+    fi
 
     check_compose_version
 }

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -29,3 +31,114 @@ def test_deploy_runtime_syncs_runtime_dockerfile_copy_sources() -> None:
 
     assert '"${repo_root}/workspace/sibling-repos/"' in deploy_script
     assert '"${repo_root}/scripts/runtime_build/"' in deploy_script
+
+
+def _init_git_repo(path: Path, marker: str) -> str:
+    path.mkdir(parents=True)
+    (path / "marker.txt").write_text(marker, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "add", "marker.txt"], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=deploy-runtime-test",
+            "-c",
+            "user.email=deploy-runtime-test@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+        ],
+        cwd=path,
+        check=True,
+    )
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_fake_docker(bin_dir: Path) -> None:
+    docker = bin_dir / "docker"
+    docker.write_text(
+        """#!/usr/bin/env sh
+set -eu
+if [ "$1" = "compose" ] && [ "$2" = "version" ] && [ "$3" = "--short" ]; then
+  printf '2.27.0\\n'
+  exit 0
+fi
+printf 'unexpected docker invocation: %s\\n' "$*" >&2
+exit 1
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+
+@pytest.mark.unit
+def test_workspace_printed_build_command_uses_operator_omni_home(
+    tmp_path: Path,
+) -> None:
+    """Operator OMNI_HOME must survive ~/.omnibase/.env during workspace builds."""
+    operator_home = tmp_path / "operator" / "omni_home"
+    env_home_root = tmp_path / "env-file" / "omni_home"
+    operator_omnimarket_sha = _init_git_repo(
+        operator_home / "omnimarket", "operator-root"
+    )
+    env_omnimarket_sha = _init_git_repo(env_home_root / "omnimarket", "env-root")
+
+    home = tmp_path / "home"
+    omnibase_dir = home / ".omnibase"
+    omnibase_dir.mkdir(parents=True)
+    (omnibase_dir / ".env").write_text(
+        f"INFRA_HOST=127.0.0.1\nOMNI_HOME={env_home_root}\n",
+        encoding="utf-8",
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "BUILD_SOURCE": "workspace",
+            "HOME": str(home),
+            "OMNI_HOME": str(operator_home),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+        }
+    )
+    env.pop("EXPECTED_BUILD_SOURCE", None)
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "--print-compose-cmd"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert f"--build-arg OMNI_HOME={operator_home}" in result.stdout
+    assert "--build-arg BUILD_SOURCE=workspace" in result.stdout
+    assert "--build-arg EXPECTED_BUILD_SOURCE=workspace" in result.stdout
+    assert f"--build-arg OMNIMARKET_REF={operator_omnimarket_sha}" in result.stdout
+    assert env_omnimarket_sha not in result.stdout
+
+
+@pytest.mark.unit
+def test_deploy_runtime_stages_workspace_and_passes_omni_home_arg() -> None:
+    """Workspace mode must stage sibling repos and pass OMNI_HOME to Dockerfile."""
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'stage_workspace_if_needed "${repo_root}"' in deploy_script
+    assert '--build-arg "BUILD_SOURCE=${build_source}"' in deploy_script
+    assert (
+        '--build-arg "EXPECTED_BUILD_SOURCE=${expected_build_source}"' in deploy_script
+    )
+    assert '--build-arg "OMNI_HOME=${omni_home}"' in deploy_script


### PR DESCRIPTION
## Summary
- preserve operator-supplied `OMNI_HOME` after sourcing `~/.omnibase/.env` so workspace staging/ref capture use the requested root
- validate `BUILD_SOURCE` / `EXPECTED_BUILD_SOURCE` before staging or build
- stage workspace sibling repos during `deploy-runtime.sh --execute` when `BUILD_SOURCE=workspace`
- pass `BUILD_SOURCE`, `EXPECTED_BUILD_SOURCE`, and `OMNI_HOME` as explicit Docker build args and print the resolved args via `--print-compose-cmd`

## Evidence
- `bash -n scripts/deploy-runtime.sh`
- `uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_deploy_runtime_no_env_file.py -q`
- `uv run ruff check tests/scripts/test_deploy_runtime_build_context.py`
- `uv run validate-yaml contracts/OMN-12755.yaml`
- `git diff --check`

## Deploy note
Post-merge workspace-mode runtime validation should run `BUILD_SOURCE=workspace OMNI_HOME=/data/omninode/omni_home bash scripts/deploy-runtime.sh --execute --force` and inspect image provenance/build args for the operator workspace root.

No dashboard changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment script now supports configurable build sources (workspace and release modes), allowing operators to deploy from workspace using `BUILD_SOURCE=workspace`.

* **Tests**
  * Added test coverage for workspace deployment validation and build source configuration handling.

* **Chores**
  * Added deployment contract specifying requirements and validation steps for the new build source workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#2244

Evidence-Ticket: OMN-12755