### PR TITLE
fix(OMN-12763): pin runtime core to overlay contract fix

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "4fceb0a3ef3e965c25df49151f518062",
+  "identity_digest": "3983ac30e350d4ee4757801bc9a4ca0e",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "84472db719e00b9b709d36de",
+  "shared_env_digest": "637cdf47b773dd163d8d965f",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,9 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-12727: bump core pin to dev HEAD (f587bbb4, OMN-12663/OMN-12676)
-# which widens bifrost delegation tier literals and carries inference API key refs.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "f587bbb4bd7f8db10a178dab546bdcef5c7136fd" }
+# OMN-12763: bump core pin to dev HEAD (c7d6b5ec, OMN-12762)
+# which accepts quality-gate DoD overlay criteria in delegation wire requests.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -2076,7 +2076,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.44.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd#f587bbb4bd7f8db10a178dab546bdcef5c7136fd" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06#c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=f587bbb4bd7f8db10a178dab546bdcef5c7136fd" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
## Summary
- update the runtime image omnibase-core git pin to the merged OMN-12762 core commit
- refresh uv.lock so workspace/release builds resolve the same core DTO that accepts quality-gate overlay DoD criteria

## Verification
- `uv lock` -> resolved omnibase-core v0.44.0 from `f587bbb4` to `c7d6b5ec`
- `uv run python` DTO probe: `ModelDelegationRequest(... quality_contract_mode="replace_task_class", acceptance_criteria=("compiles_without_errors", "final_artifact_only"))` accepted
- `git diff --check` -> pass

## Integration
This unblocks trustworthy dev runtime SEA/direct delegation proof after OMN-12762. Without this pin update, rebuilt runtime images still carry the old core request DTO.

Evidence-Source: fada8ff755f87b665d4e51cba24c9acf34fc0890
Evidence-Ticket: OMN-12763


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal core dependency to a newer revision to keep components current.
  * Refreshed runner lockfile digests to align with updated builds and ensure consistent environment pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->