### PR TITLE
chore(release)(OMN-12765): bump omnibase_infra to v0.38.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.38.1"
+version = "0.38.2"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.38.1"
+version = "0.38.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- Bump omnibase_infra package version to v0.38.2 after OMN-12765 main promotion.
- Keep uv.lock editable package metadata aligned.

## Verification
- git diff --check
- pyproject/uv.lock version consistency check

Source ticket: OMN-12765