### PR TITLE
chore(release)(OMN-12765): bump omnibase_infra to v0.38.3

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "fd552e30b04bc6c94648015aaf61a485",
+  "identity_digest": "c68f428c0086620d5190d127e6de73a0",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "ebf34dd246440901a9deaa72",
+  "shared_env_digest": "882244b1d89b9eba03fa1b95",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_infra"
-version = "0.38.2"
+version = "0.38.3"
 description = "ONEX Infrastructure - Service integration and database infrastructure tools"
 authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 license = {text = "MIT"}

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -28,5 +28,5 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    assert lock["identity_digest"] == "fd552e30b04bc6c94648015aaf61a485"
-    assert lock["shared_env_digest"] == "ebf34dd246440901a9deaa72"
+    assert lock["identity_digest"] == "c68f428c0086620d5190d127e6de73a0"
+    assert lock["shared_env_digest"] == "882244b1d89b9eba03fa1b95"

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.38.2"
+version = "0.38.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Evidence-Ticket: OMN-12765
Evidence-Source: OCC#2283
hotfix-evidence: OCC-12765
backmerge: #1901

## Summary
- Bump omnibase_infra package version to v0.38.3 after the OMN-12765 dev integration promotion landed on main.
- Keep uv.lock editable package metadata aligned.

## Verification
- git diff --check
- pyproject/uv.lock version consistency check

Source ticket: OMN-12765
Evidence-Refresh: OCC#2283-clean
