### PR TITLE
feat(OMN-12816): additive extra_body passthrough on ModelLlmInferenceRequest

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT
 # OMN-8735: handler constructor compliance refactor (2026-04-15)
 # OMN-8735 follow-up: HandlerLlmCliSubprocess null-guard compliance (2026-04-16)
+# OMN-12816: additive extra_body passthrough — provider-specific request-body
+#   fields (e.g. chat_template_kwargs.enable_thinking) merged in _build_payload
+#   without overriding declared fields (2026-06-07)
 # Copyright (c) 2026 OmniNode Team
 #
 # ONEX Node Contract
@@ -17,7 +20,7 @@ node_name: "node_llm_inference_effect"
 contract_version:
   major: 1
   minor: 4
-  patch: 0
+  patch: 1
 node_version:
   major: 0
   minor: 1
@@ -39,7 +42,7 @@ runtime_profiles:
 input_model:
   name: "ModelLlmInferenceRequest"
   module: "omnibase_infra.models.llm"
-  description: "Input model containing LLM inference parameters, routing configuration, optional direct endpoint_url override, and optional EnumUsageSource-backed compute usage provenance."
+  description: "Input model containing LLM inference parameters, routing configuration, optional direct endpoint_url override, optional EnumUsageSource-backed compute usage provenance, and an optional additive extra_body map for provider-specific request-body fields (OMN-12816, e.g. chat_template_kwargs.enable_thinking)."
 output_model:
   name: "ModelLlmInferenceResponse"
   module: "omnibase_infra.models.llm"

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -562,6 +562,14 @@ class HandlerLlmOpenaiCompatible:
         if request.tool_choice is not None:
             payload["tool_choice"] = _serialize_tool_choice(request.tool_choice)
 
+        # OMN-12816: provider-specific body fields (e.g. chat_template_kwargs to
+        # disable Qwen reasoning). Declared payload fields win — extra_body only
+        # fills keys the typed schema did not already set, so it can never
+        # silently override model/messages/max_tokens/etc.
+        for key, value in request.extra_body.items():
+            if key not in payload:
+                payload[key] = value
+
         return payload
 
     # ── HTTP execution with auth ─────────────────────────────────────────

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
@@ -163,6 +163,18 @@ class ModelLlmInferenceRequest(BaseModel):
             "(e.g. ``X-ONEX-Signature``). Keys and values must be ASCII strings."
         ),
     )
+    extra_body: dict[str, JsonType] = Field(
+        default_factory=dict,
+        repr=False,
+        description=(
+            "Provider-specific JSON fields merged into the request body, for "
+            "inference parameters the typed schema does not model directly. "
+            "Example: ``{'chat_template_kwargs': {'enable_thinking': False}}`` to "
+            "suppress reasoning output on Qwen vLLM backends (OMN-12816). Default "
+            "empty so existing callers are unaffected; declared payload fields take "
+            "precedence over identically-named ``extra_body`` keys."
+        ),
+    )
     timeout_seconds: float = Field(
         default=30.0,
         ge=1.0,

--- a/tests/integration/runtime/test_llm_inference_contract_runtime_bus.py
+++ b/tests/integration/runtime/test_llm_inference_contract_runtime_bus.py
@@ -69,7 +69,7 @@ def _contract(
     return ModelDiscoveredContract(
         name="node_llm_inference_effect",
         node_type="EFFECT_GENERIC",
-        contract_version=ModelContractVersion(major=1, minor=4, patch=0),
+        contract_version=ModelContractVersion(major=1, minor=4, patch=1),
         contract_path=effective_contract_path,
         entry_point_name="node_llm_inference_effect",
         package_name="omnibase_infra",

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
@@ -281,6 +281,40 @@ class TestBuildPayload:
         assert "tools" not in payload
         assert "tool_choice" not in payload
 
+    def test_extra_body_default_adds_nothing(self) -> None:
+        """OMN-12816: default empty extra_body adds no keys (no behavior change)."""
+        request = _make_chat_request()
+        payload = HandlerLlmOpenaiCompatible._build_payload(request)
+        assert "chat_template_kwargs" not in payload
+        # Only the expected base keys are present for a minimal request.
+        assert set(payload.keys()) == {"model", "messages"}
+
+    def test_extra_body_merged_into_payload(self) -> None:
+        """OMN-12816: extra_body fields are merged into the POST body verbatim."""
+        request = ModelLlmInferenceRequest(
+            base_url="http://localhost:8000",
+            model="Qwen3.6-35B-A3B",
+            operation_type=EnumLlmOperationType.CHAT_COMPLETION,
+            messages=({"role": "user", "content": "Hello"},),
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+        )
+        payload = HandlerLlmOpenaiCompatible._build_payload(request)
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_extra_body_cannot_override_declared_fields(self) -> None:
+        """OMN-12816: declared payload fields win over identically-named extra_body keys."""
+        request = ModelLlmInferenceRequest(
+            base_url="http://localhost:8000",
+            model="real-model",
+            operation_type=EnumLlmOperationType.CHAT_COMPLETION,
+            messages=({"role": "user", "content": "Hello"},),
+            max_tokens=128,
+            extra_body={"model": "spoofed", "max_tokens": 1},
+        )
+        payload = HandlerLlmOpenaiCompatible._build_payload(request)
+        assert payload["model"] == "real-model"
+        assert payload["max_tokens"] == 128
+
     def test_chat_payload_with_system_prompt(self) -> None:
         """system_prompt is prepended as a system message."""
         request = _make_chat_request(system_prompt="You are a helpful assistant.")


### PR DESCRIPTION
Evidence-Source: OCC#2318
Evidence-Ticket: OMN-12816

## OMN-12816 — extra_body passthrough (determinism layer foundation)

Adds an ADDITIVE `extra_body: dict[str, JsonType]` (default `{}`) to `ModelLlmInferenceRequest` and merges it into `HandlerLlmOpenaiCompatible._build_payload`. Lets a caller pass provider-specific body fields the typed schema does not model — specifically `chat_template_kwargs: {enable_thinking: false}` to suppress Qwen reasoning output (the SEA generation determinism fix: attempt_count=2 → 1).

### Safety
- ADDITIVE: default empty → zero behavior change for existing callers (incl. the delegation chain).
- Declared payload fields take precedence: extra_body only fills keys the typed schema did not set, so it can never override model/messages/max_tokens/etc.

### Evidence
- 3 new unit tests (default adds nothing; extra_body merged; cannot override declared fields)
- node_llm_inference_effect suite 460 pass; mypy --strict + ruff + pre-commit clean

Paired omnimarket PR (omn-12816-enable-thinking) consumes this field via the generation contract. Shared-core-contract change → hostile review must converge before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional provider-specific request body fields in LLM inference requests, enabling injection of additional fields without overriding declared configuration parameters.

* **Tests**
  * Added unit tests validating provider-specific field injection and field precedence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->