### PR TITLE
chore(OMN-12816): normalize infra main promotion conflicts

### DIFF
--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 #
 # OMN-12243: Block PRs targeting main unless they are promotion PRs
-# from dev with a promotion receipt.
-# OMN-12477: Removed the hotfix/* bypass — main accepts only dev promotions.
+# from dev with a promotion receipt, or hotfix PRs with evidence and
+# a backmerge link.
 
 name: Main target guard
 
@@ -49,11 +49,35 @@ jobs:
 
             echo "::error::PR is from dev but is missing a promotion receipt."
             echo "::error::Add a line matching: promotion-receipt: OCC-<number>"
-            echo "::error::Retarget this PR to dev; main accepts only promotion PRs."
+            echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
             exit 1
           fi
 
-          echo "::error::PRs targeting main must come from dev."
+          if [[ "${HEAD_REF}" == hotfix/* ]]; then
+            MISSING=()
+
+            if ! echo "${PR_BODY}" | grep -qE 'hotfix-evidence:[[:space:]]*OCC-[0-9]+'; then
+              MISSING+=("hotfix-evidence: OCC-<number>")
+            fi
+
+            if ! echo "${PR_BODY}" | grep -qE 'backmerge:[[:space:]]*#[0-9]+'; then
+              MISSING+=("backmerge: #<pr-number>")
+            fi
+
+            if [[ "${#MISSING[@]}" -eq 0 ]]; then
+              echo "::notice::Hotfix PR from '${HEAD_REF}' with valid hotfix evidence and backmerge. Allowed."
+              exit 0
+            fi
+
+            echo "::error::Hotfix PR from '${HEAD_REF}' is missing required fields:"
+            for field in "${MISSING[@]}"; do
+              echo "::error::  - ${field}"
+            done
+            echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
+            exit 1
+          fi
+
+          echo "::error::PRs targeting main must come from dev or hotfix/*."
           echo "::error::Head ref '${HEAD_REF}' is not permitted to target main directly."
-          echo "::error::Retarget this PR to dev; main accepts only promotion PRs."
+          echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
           exit 1

--- a/tests/integration/runtime/test_llm_inference_contract_runtime_bus.py
+++ b/tests/integration/runtime/test_llm_inference_contract_runtime_bus.py
@@ -69,7 +69,7 @@ def _contract(
     return ModelDiscoveredContract(
         name="node_llm_inference_effect",
         node_type="EFFECT_GENERIC",
-        contract_version=ModelContractVersion(major=1, minor=4, patch=1),
+        contract_version=ModelContractVersion(major=1, minor=4, patch=0),
         contract_path=effective_contract_path,
         entry_point_name="node_llm_inference_effect",
         package_name="omnibase_infra",


### PR DESCRIPTION
## Summary
Normalizes the two add/add conflict points left by the squash-based main backmerge so the authoritative `dev -> main` OMN-12816 promotion can merge through the required guard path.

Evidence-Source: OCC#2322
Evidence-Ticket: OMN-12816
Evidence-Refresh: 2026-06-08T07:44:00Z

## Details
- Keeps the proven OMN-12816 runtime `extra_body` implementation and contract version bump intact.
- Aligns `.github/workflows/main-target-guard.yml` with current `main` to remove the policy-only add/add conflict.
- Aligns the synthetic integration test contract-version fixture with current `main` to remove the add/add conflict; runtime contract `contract.yaml` still merges to patch `1`.

## Verification
- `uv run pytest tests/integration/runtime/test_llm_inference_contract_runtime_bus.py tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py -q` — 83 passed, 1 skipped
- `git diff --check` — PASS
- `git merge-tree --write-tree origin/main HEAD` — PASS

## Promotion impact
This PR exists only to make #1905 mergeable after #1906 was squash-merged by the queue. It does not change the runtime payload path proven on stability-test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch protection workflow to allow hotfix PRs targeting main with required documentation and backmerge references
  * Updated LLM inference contract version in integration tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->