### PR TITLE
ci(OMN-12816): use branch-aware receipt policy for promotions

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -30,3 +30,16 @@ permissions:
 jobs:
   verify:
     uses: OmniNode-ai/omnibase_core/.github/workflows/receipt-gate.yml@main
+    with:
+      branch-policy-mode: >-
+        ${{
+          github.event.pull_request.base.ref == 'main'
+          && 'main-release'
+          || github.event.merge_group.base_ref == 'refs/heads/main'
+          && 'main-release'
+          || github.event.pull_request.base.ref == 'dev'
+          && 'dev-preflight'
+          || github.event.merge_group.base_ref == 'refs/heads/dev'
+          && 'dev-preflight'
+          || 'legacy'
+        }}

--- a/tests/ci/test_receipt_gate_install_guard.py
+++ b/tests/ci/test_receipt_gate_install_guard.py
@@ -72,6 +72,19 @@ class TestCallReceiptGateDelegation:
         assert perms.get("contents") == "read"
         assert perms.get("pull-requests") == "read"
 
+    def test_caller_sets_branch_aware_policy_mode(self) -> None:
+        workflow = _load_yaml(CALL_RECEIPT_GATE)
+        verify_job = workflow["jobs"]["verify"]
+        with_block = verify_job.get("with", {})
+
+        policy_expr = with_block.get("branch-policy-mode", "")
+        assert "main-release" in policy_expr
+        assert "dev-preflight" in policy_expr
+        assert "github.event.pull_request.base.ref == 'main'" in policy_expr
+        assert "github.event.merge_group.base_ref == 'refs/heads/main'" in policy_expr
+        assert "github.event.pull_request.base.ref == 'dev'" in policy_expr
+        assert "github.event.merge_group.base_ref == 'refs/heads/dev'" in policy_expr
+
 
 class TestReceiptGateInstallSafeguards:
     """The reusable receipt-gate.yml from omnibase_core must have install safeguards.


### PR DESCRIPTION
## Summary

Wires the omnibase_core receipt-gate branch policy input in the omnibase_infra caller so:

- PRs and merge groups targeting `main` use `main-release`.
- PRs and merge groups targeting `dev` use `dev-preflight`.
- Other cases fall back to `legacy`.

This fixes the OMN-12816 dev-to-main promotion path where #1905 is correctly headed from `dev`, but legacy identity binding rejects `branch=dev` despite central `main-release` policy explicitly allowing promotion PRs from `dev` with merged OCC evidence.

## Verification

- `uv run pytest tests/ci/test_receipt_gate_install_guard.py::TestCallReceiptGateDelegation -q`
- `uv run ruff check tests/ci/test_receipt_gate_install_guard.py`
- `uv run ruff format --check tests/ci/test_receipt_gate_install_guard.py`
- `git diff --check`
- Receipt Gate rerun passed against merged OCC #2325 (`e04bbe1994d76f4dc9b8e64cf13b43b7e8d6f482`)

## Local Note

- Full local `tests/ci/test_receipt_gate_install_guard.py` currently has one pre-existing failure against the local omnibase_core clone install-step text; the new delegation class passes and CI skips local-clone-only safeguards when the canonical sibling clone is absent.

Evidence-Ticket: OMN-12816
Evidence-Source: OCC#2325
Evidence-Refresh: 2026-06-08T10:01:00Z