### PR TITLE
fix(OMN-12815): post contract endpoint_url verbatim in OpenAI-compatible effect

### DIFF
--- a/contracts/OMN-12627.yaml
+++ b/contracts/OMN-12627.yaml
@@ -3,12 +3,7 @@ schema_version: "1.0.0"
 ticket_id: OMN-12627
 title: "Vendor node_service_registry owner migrations into the infra forward set"
 summary: >
-  Adds omnimarket node_projection_registration to the node-owned migration
-  allowlist and vendors its idempotent node_service_registry migrations into
-  docker/migrations/forward/nodes/. The forward migration runner applies these
-  under canonical namespaced ids node:node_projection_registration:<file>, so a
-  clean runtime/migration image can create the missing prod table without an
-  undocumented hand-created table.
+  Adds omnimarket node_projection_registration to the node-owned migration allowlist and vendors its idempotent node_service_registry migrations into docker/migrations/forward/nodes/. The forward migration runner applies these under canonical namespaced ids node:node_projection_registration:<file>, so a clean runtime/migration image can create the missing prod table without an undocumented hand-created table.
 
 is_seam_ticket: false
 interface_change: false

--- a/contracts/OMN-12631.yaml
+++ b/contracts/OMN-12631.yaml
@@ -3,12 +3,7 @@ schema_version: "1.0.0"
 ticket_id: OMN-12631
 title: "Decouple per-lane Redpanda advertise hosts before prod redeploy"
 summary: >
-  Replaces shared REDPANDA_ADVERTISE_HOST interpolation in runtime lane compose
-  with lane-specific advertise host variables. Dev uses
-  DEV_REDPANDA_ADVERTISE_HOST with a local default; stability-test and prod
-  require explicit STABILITY_TEST_REDPANDA_ADVERTISE_HOST and
-  PROD_REDPANDA_ADVERTISE_HOST values so a future prod broker recreate cannot
-  inherit Bret's tailnet stability advertise address.
+  Replaces shared REDPANDA_ADVERTISE_HOST interpolation in runtime lane compose with lane-specific advertise host variables. Dev uses DEV_REDPANDA_ADVERTISE_HOST with a local default; stability-test and prod require explicit STABILITY_TEST_REDPANDA_ADVERTISE_HOST and PROD_REDPANDA_ADVERTISE_HOST values so a future prod broker recreate cannot inherit Bret's tailnet stability advertise address.
 
 is_seam_ticket: false
 interface_change: false

--- a/contracts/OMN-12682.yaml
+++ b/contracts/OMN-12682.yaml
@@ -3,10 +3,7 @@ schema_version: "1.0.0"
 ticket_id: OMN-12682
 title: "Derive ServiceTopicRegistry defaults from the topic catalog"
 summary: >
-  Replaces ServiceTopicRegistry.from_defaults() embedded onex.* topic
-  literals with references to the provisioned topic suffix catalog. Missing
-  registry topics are promoted into named catalog constants and topic specs so
-  runtime topic resolution and broker provisioning share one authority.
+  Replaces ServiceTopicRegistry.from_defaults() embedded onex.* topic literals with references to the provisioned topic suffix catalog. Missing registry topics are promoted into named catalog constants and topic specs so runtime topic resolution and broker provisioning share one authority.
 
 is_seam_ticket: false
 interface_change: false

--- a/contracts/OMN-12700.yaml
+++ b/contracts/OMN-12700.yaml
@@ -6,11 +6,8 @@ schema_version: "1.0.0"
 ticket_id: OMN-12700
 title: "Emit typed LLM inference response events on the runtime bus"
 summary: >
-  Adds the infra-owned runtime command adapter for
-  onex.cmd.omnibase-infra.llm-inference-request.v1 and emits
-  ModelLlmInferenceResponse as the first-class response event on
-  onex.evt.omnibase-infra.inference-response.v1. Existing llm-call-completed
-  metrics events remain in place for their current consumers.
+  Adds the infra-owned runtime command adapter for onex.cmd.omnibase-infra.llm-inference-request.v1 and emits ModelLlmInferenceResponse as the first-class response event on onex.evt.omnibase-infra.inference-response.v1. Existing llm-call-completed metrics events remain in place for their current consumers.
+
 is_seam_ticket: true
 interface_change: true
 interfaces_touched:

--- a/contracts/OMN-12723.yaml
+++ b/contracts/OMN-12723.yaml
@@ -6,10 +6,8 @@ schema_version: "1.0.0"
 ticket_id: "OMN-12723"
 title: "Bootstrap runtime volume ownership"
 summary: >
-  Starts the runtime image with a bounded root bootstrap phase that repairs
-  fresh Docker named volume ownership for /app/data, /app/data/delegation,
-  /app/logs, and /app/tmp, then re-execs the entrypoint as omniinfra with gosu
-  before schema fingerprinting, Bifrost rendering, or runtime launch.
+  Starts the runtime image with a bounded root bootstrap phase that repairs fresh Docker named volume ownership for /app/data, /app/data/delegation, /app/logs, and /app/tmp, then re-execs the entrypoint as omniinfra with gosu before schema fingerprinting, Bifrost rendering, or runtime launch.
+
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []

--- a/contracts/OMN-12755.yaml
+++ b/contracts/OMN-12755.yaml
@@ -4,10 +4,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-12755"
 title: "Fix deploy-runtime workspace OMNI_HOME propagation"
 summary: >-
-  deploy-runtime.sh preserves an operator-supplied OMNI_HOME across
-  ~/.omnibase/.env sourcing, stages workspace sibling repos from that root when
-  BUILD_SOURCE=workspace, and passes BUILD_SOURCE, EXPECTED_BUILD_SOURCE, and
-  OMNI_HOME as explicit Dockerfile build args.
+  deploy-runtime.sh preserves an operator-supplied OMNI_HOME across ~/.omnibase/.env sourcing, stages workspace sibling repos from that root when BUILD_SOURCE=workspace, and passes BUILD_SOURCE, EXPECTED_BUILD_SOURCE, and OMNI_HOME as explicit Dockerfile build args.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []

--- a/contracts/OMN-12815.yaml
+++ b/contracts/OMN-12815.yaml
@@ -1,0 +1,44 @@
+# OMN-12815 per-repo evidence carrier for omnibase_infra.
+# Canonical ticket contract lives in onex_change_control
+# (contracts/OMN-12815.yaml on OnniNode-ai/onex_change_control).
+# A1 (close-the-loop plan, 2026-06-08): the OpenAI-compatible inference effect
+# posts the contract endpoint_url VERBATIM; all in-code URL construction deleted.
+schema_version: '1.0.0'
+ticket_id: OMN-12815
+title: "A1 — post contract endpoint_url VERBATIM in the OpenAI-compatible effect"
+summary: >
+  HandlerLlmOpenaiCompatible._build_url now returns request.endpoint_url verbatim and fails closed when it is empty/missing. Deleted the legacy base_url + path append branch and the _OPERATION_PATHS map. The effect performs no URL construction; the contract endpoint URL is the single source of the POST URL.
+
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - public_api
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001-build-url-verbatim
+    description: >
+      _build_url returns endpoint_url verbatim and fails closed when absent; _OPERATION_PATHS is removed. Run by a verifier other than the author.
+
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >
+          cd omnibase_infra && ! grep -rn "_OPERATION_PATHS" src/
+
+  - id: dod-002-inference-effect-tests
+    description: Full node_llm_inference_effect test suite passes.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >
+          cd omnibase_infra && uv run pytest tests/unit/nodes/node_llm_inference_effect/ -q --tb=short
+
+  - id: dod-003-contract-file
+    description: Evidence contract file present in repo.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'test -f contracts/OMN-12815.yaml'

--- a/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_lane_selection.py
@@ -37,12 +37,9 @@ def _ok() -> subprocess.CompletedProcess:
 
 
 def _is_projection_table_check(cmd: list[str]) -> bool:
-    return (
-        "omnidash_analytics" in cmd
-        and any(
-            f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
-            for table in ("delegation_events", "node_service_registry")
-        )
+    return "omnidash_analytics" in cmd and any(
+        f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
+        for table in ("delegation_events", "node_service_registry")
     )
 
 

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_health_verify.py
@@ -49,12 +49,9 @@ def _health_payload(
 
 
 def _is_projection_table_check(cmd: list[str]) -> bool:
-    return (
-        "omnidash_analytics" in cmd
-        and any(
-            f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
-            for table in ("delegation_events", "node_service_registry")
-        )
+    return "omnidash_analytics" in cmd and any(
+        f"SELECT to_regclass('public.{table}') IS NOT NULL" in cmd
+        for table in ("delegation_events", "node_service_registry")
     )
 
 
@@ -156,7 +153,9 @@ def test_verify_fails_postgres_check_when_node_service_registry_missing() -> Non
         checks = executor.verify(on_phase_update=_noop_phase_update)
 
     status_by_endpoint = {check.endpoint: check.status for check in checks}
-    assert status_by_endpoint["omnidash_analytics.node_service_registry exists"] == "fail"
+    assert (
+        status_by_endpoint["omnidash_analytics.node_service_registry exists"] == "fail"
+    )
 
 
 def test_verify_fails_runtime_health_when_config_prefetch_degraded() -> None:

--- a/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_runtime_scope.py
@@ -283,7 +283,9 @@ class TestCoreAndFullScopeComposeUp:
 
         with (
             patch("deploy_agent.executor._run", side_effect=fake_run),
-            patch("deploy_agent.executor.verify_containers_up", side_effect=fake_verify),
+            patch(
+                "deploy_agent.executor.verify_containers_up", side_effect=fake_verify
+            ),
         ):
             executor._compose_up(
                 Phase.RUNTIME,

--- a/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_analysis_enrichment.py
@@ -249,6 +249,8 @@ class AdapterCodeAnalysisEnrichment:
 
         request = ModelLlmInferenceRequest(
             base_url=self._base_url,
+            # OMN-12815: post the configured endpoint VERBATIM (no path append).
+            endpoint_url=self._base_url,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             model=self._model,
             messages=({"role": "user", "content": user_message},),

--- a/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
+++ b/src/omnibase_infra/adapters/llm/adapter_code_review_analysis.py
@@ -384,6 +384,8 @@ class AdapterCodeReviewAnalysis:
 
         request = ModelLlmInferenceRequest(
             base_url=self._base_url,
+            # OMN-12815: post the configured endpoint VERBATIM (no path append).
+            endpoint_url=self._base_url,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             model=self._model,
             messages=({"role": "user", "content": user_message},),

--- a/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_documentation_generation.py
@@ -358,6 +358,8 @@ class AdapterDocumentationGeneration:
 
         request = ModelLlmInferenceRequest(
             base_url=self._base_url,
+            # OMN-12815: post the configured endpoint VERBATIM (no path append).
+            endpoint_url=self._base_url,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             model=self._model,
             messages=({"role": "user", "content": user_message},),

--- a/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
+++ b/src/omnibase_infra/adapters/llm/adapter_llm_provider_openai.py
@@ -742,8 +742,13 @@ class AdapterLlmProviderOpenai:
         Returns:
             Infra-layer request ready for handler dispatch.
         """
+        # OMN-12815: the effect posts endpoint_url VERBATIM with no URL
+        # construction. This adapter's configured endpoint (``_base_url``) is the
+        # COMPLETE endpoint; pass it through endpoint_url so the effect posts it
+        # unchanged. No path is appended in code.
         return ModelLlmInferenceRequest(
             base_url=self._base_url,
+            endpoint_url=self._base_url,
             model=request.model_name,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             messages=({"role": "user", "content": request.prompt},),

--- a/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
+++ b/src/omnibase_infra/adapters/llm/adapter_summarization_enrichment.py
@@ -314,6 +314,8 @@ class AdapterSummarizationEnrichment:
 
         request = ModelLlmInferenceRequest(
             base_url=self._base_url,
+            # OMN-12815: post the configured endpoint VERBATIM (no path append).
+            endpoint_url=self._base_url,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             model=self._model,
             messages=({"role": "user", "content": user_message},),

--- a/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
+++ b/src/omnibase_infra/adapters/llm/adapter_test_boilerplate_generation.py
@@ -385,6 +385,8 @@ class AdapterTestBoilerplateGeneration:
 
         request = ModelLlmInferenceRequest(
             base_url=self._base_url,
+            # OMN-12815: post the configured endpoint VERBATIM (no path append).
+            endpoint_url=self._base_url,
             operation_type=EnumLlmOperationType.CHAT_COMPLETION,
             model=self._model,
             messages=({"role": "user", "content": user_message},),

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -33,7 +33,6 @@ description: >
 
 runtime_profiles:
   - effects
-
 # Strongly typed I/O models
 # Note: These models live in the shared omnibase_infra.models.llm package.
 # They are shared across all LLM inference handlers (OpenAI-compatible)

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/bifrost/handler_bifrost_gateway.py
@@ -770,6 +770,9 @@ class HandlerBifrostGateway:  # ONEX_EXCLUDE: method_count - gateway is a single
 
         return ModelLlmInferenceRequest(
             base_url=backend_cfg.base_url,
+            # OMN-12815: the effect posts endpoint_url VERBATIM (no path append).
+            # The bifrost backend config URL is the complete endpoint.
+            endpoint_url=backend_cfg.base_url,
             operation_type=request.operation_type,
             model=model_name,
             messages=request.messages,

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -17,7 +17,7 @@ Architecture:
     - Builds ContractLlmCallMetrics for caller to publish
 
 Handler Responsibilities:
-    - Build URL: use endpoint_url directly when set; fall back to base_url + path
+    - Build URL: post the contract endpoint_url verbatim; no URL construction (OMN-12815)
     - Serialize request fields to OpenAI JSON payload
     - Translate ModelLlmToolChoice to wire format
     - Serialize ModelLlmToolDefinition to wire format
@@ -118,12 +118,6 @@ _FINISH_REASON_MAP: dict[str, EnumLlmFinishReason] = {
     "content_filter": EnumLlmFinishReason.CONTENT_FILTER,
     "tool_calls": EnumLlmFinishReason.TOOL_CALLS,
     "function_call": EnumLlmFinishReason.TOOL_CALLS,
-}
-
-# URL path suffixes for each operation type.
-_OPERATION_PATHS: dict[EnumLlmOperationType, str] = {
-    EnumLlmOperationType.CHAT_COMPLETION: "/v1/chat/completions",
-    EnumLlmOperationType.COMPLETION: "/v1/completions",
 }
 
 # Default connection limits for auth-injected httpx clients.
@@ -465,41 +459,35 @@ class HandlerLlmOpenaiCompatible:
 
     @staticmethod
     def _build_url(request: ModelLlmInferenceRequest) -> str:
-        """Return the URL to POST to for this inference request.
+        """Return the contract ``endpoint_url`` verbatim as the POST URL.
 
-        When ``request.endpoint_url`` is set, it is returned directly — no
-        path is appended. This is the preferred path for contracts that declare
-        the full endpoint URL (e.g. z.ai GLM, Google Gemini).
-
-        When only ``request.base_url`` is set (legacy path), the appropriate
-        path suffix is appended based on ``operation_type``. This preserves
-        backwards compatibility with callers that pre-date ``endpoint_url``.
+        OMN-12815: endpoints are specified COMPLETELY in the contract and are
+        used VERBATIM. The handler performs NO URL construction — no operation
+        path is appended, no base_url is split, no path resolver runs. The
+        POST URL equals ``request.endpoint_url`` exactly. In-code URL
+        construction hardcodes provider path logic in code and is flaky and
+        error-prone; the contract is the single source of the full URL.
 
         Args:
             request: The inference request.
 
         Returns:
-            Full URL string to POST to.
+            ``request.endpoint_url`` unchanged.
 
         Raises:
-            ValueError: If operation_type is not CHAT_COMPLETION or COMPLETION
-                and ``endpoint_url`` is not set (legacy path only).
+            ValueError: If ``endpoint_url`` is empty/missing. Fail-closed —
+                there is no base_url fallback or path construction.
         """
-        # Fast path: contract provides the full URL — use it as-is.
-        if request.endpoint_url is not None:
-            return request.endpoint_url
-
-        # Legacy path: construct URL from base_url + operation type path.
-        path = _OPERATION_PATHS.get(request.operation_type)
-        if path is None:
+        if not request.endpoint_url:
             msg = (
-                f"Unsupported operation type for OpenAI handler: "
-                f"{request.operation_type.value}"
+                "endpoint_url is required and must be the COMPLETE contract "
+                "endpoint URL (OMN-12815). The OpenAI-compatible effect posts "
+                "it verbatim and performs no URL construction; populate the "
+                "complete endpoint_url in the routing authority — there is no "
+                "base_url + path fallback."
             )
             raise ValueError(msg)
-
-        base = request.base_url.rstrip("/")
-        return f"{base}{path}"
+        return request.endpoint_url
 
     # ── Payload building ─────────────────────────────────────────────────
 

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/models/model_llm_inference_request.py
@@ -13,6 +13,8 @@ Related:
     - EnumLlmOperationType: Type of LLM operation (CHAT_COMPLETION, COMPLETION)
     - OMN-2107: Phase 7 OpenAI-compatible inference handler
     - OMN-10489: endpoint_url field — full URL, bypasses base_url + path construction
+    - OMN-12815: endpoint_url is the COMPLETE contract endpoint, posted VERBATIM;
+      the handler performs no URL construction (no base_url + path append).
 """
 
 from __future__ import annotations
@@ -38,17 +40,15 @@ class ModelLlmInferenceRequest(BaseModel):
     fields into the provider-specific wire format.
 
     Attributes:
-        endpoint_url: Full URL to POST to (e.g.
+        endpoint_url: The COMPLETE endpoint URL to POST to (e.g.
             ``"https://api.z.ai/api/coding/paas/v4/chat/completions"``).
-            When set, the handler posts to this URL directly — no path is appended.
-            Takes precedence over ``base_url`` + path construction. Use this field
-            when the contract declares the complete endpoint (preferred for non-OpenAI
-            providers such as z.ai GLM, Google Gemini, etc.).
-        base_url: Base URL of the LLM endpoint (e.g. ``"http://192.168.86.201:8000"``).
-            The handler appends the appropriate path (``/v1/chat/completions`` or
-            ``/v1/completions``) based on ``operation_type``. Ignored when
-            ``endpoint_url`` is set. Retained for backwards compatibility with callers
-            that pre-date ``endpoint_url``.
+            OMN-12815: this is the contract endpoint posted VERBATIM — the handler
+            performs no URL construction and appends no path. Required for every
+            inference call; the routing authority resolves it complete.
+        base_url: Routing/observability label for the LLM endpoint host (e.g.
+            ``"http://192.168.86.201:8000"``). It is NOT used to construct the POST
+            URL — the handler posts ``endpoint_url`` verbatim. Retained as the
+            required routing/metrics field consumed by the metrics publisher.
         operation_type: Type of LLM operation to perform.
         model: Model identifier to use for inference.
         messages: Chat messages for CHAT_COMPLETION operations.
@@ -84,19 +84,18 @@ class ModelLlmInferenceRequest(BaseModel):
         default=None,
         min_length=1,
         description=(
-            "Full URL to POST to. When set, the handler posts to this URL directly "
-            "without appending any path suffix. Takes precedence over base_url + "
-            "operation-type path construction. Use for non-OpenAI providers whose "
-            "contract declares the complete endpoint URL (e.g. z.ai GLM, Google Gemini)."
+            "The COMPLETE contract endpoint URL, posted VERBATIM (OMN-12815). The "
+            "handler performs no URL construction and appends no path. Required for "
+            "every inference call; resolved complete by the routing authority."
         ),
     )
     base_url: str = Field(
         ...,
         min_length=1,
         description=(
-            "Base URL of the LLM endpoint. The handler appends the appropriate path "
-            "(``/v1/chat/completions`` or ``/v1/completions``) based on "
-            "``operation_type``. Ignored when ``endpoint_url`` is set."
+            "Routing/observability label for the LLM endpoint host. NOT used to "
+            "construct the POST URL — the handler posts endpoint_url verbatim "
+            "(OMN-12815). Consumed by the metrics publisher as the endpoint label."
         ),
     )
     operation_type: EnumLlmOperationType = Field(

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -99,9 +99,7 @@ pattern_exemptions:
   - file_pattern: 'model_llm_call_completed_event\.py'
     violation_pattern: "Field 'model_id' should use UUID type instead of str"
     reason: >
-      The omniintelligence llm-call-completed metrics event uses model_id for the
-      provider/model name. Changing this field to UUID would break the existing
-      metrics payload contract and downstream cost aggregation consumers.
+      The omniintelligence llm-call-completed metrics event uses model_id for the provider/model name. Changing this field to UUID would break the existing metrics payload contract and downstream cost aggregation consumers.
 
     documentation:
       - OMN-12700 PR description
@@ -109,9 +107,7 @@ pattern_exemptions:
   - file_pattern: 'model_llm_call_completed_infra_event\.py'
     violation_pattern: "Field 'model_id' should use UUID type instead of str"
     reason: >
-      The infra-local llm-call-completed event mirrors the metrics model_id as an
-      LLM provider/model name. It is not an ONEX entity identifier and must stay a
-      string for compatibility with existing infra projections.
+      The infra-local llm-call-completed event mirrors the metrics model_id as an LLM provider/model name. It is not an ONEX entity identifier and must stay a string for compatibility with existing infra projections.
 
     documentation:
       - OMN-12700 PR description

--- a/tests/integration/adapters/llm/test_adapter_documentation_generation_integration.py
+++ b/tests/integration/adapters/llm/test_adapter_documentation_generation_integration.py
@@ -38,7 +38,19 @@ from omnibase_spi.contracts.delegation.contract_delegated_response import (
 # Endpoint discovery
 # ---------------------------------------------------------------------------
 
-_ENDPOINT_URL: str = os.environ.get("LLM_DEEPSEEK_R1_URL", "http://192.168.86.200:8101")
+_ENDPOINT_HOST: str = (
+    os.environ.get(  # onex-allow-internal-ip: live-integration test endpoint host
+        "LLM_DEEPSEEK_R1_URL", "http://192.168.86.200:8101"
+    )
+)
+# OMN-12815: the effect posts endpoint_url VERBATIM. Configure the adapter with
+# the COMPLETE chat endpoint so the live call hits the right path; health probes
+# still use the host root.
+_ENDPOINT_URL: str = (
+    _ENDPOINT_HOST
+    if _ENDPOINT_HOST.rstrip("/").endswith("/chat/completions")
+    else f"{_ENDPOINT_HOST.rstrip('/')}/v1/chat/completions"
+)
 
 # ---------------------------------------------------------------------------
 # Session-scoped reachability check -- skip entire module if endpoint is down
@@ -55,9 +67,10 @@ def _endpoint_reachable(url: str) -> bool:
 
 
 # Evaluated once at collection time; tests are deselected if endpoint is down.
-_ENDPOINT_AVAILABLE: bool = _endpoint_reachable(_ENDPOINT_URL)
+# Health is probed on the host root, not the complete chat endpoint.
+_ENDPOINT_AVAILABLE: bool = _endpoint_reachable(_ENDPOINT_HOST)
 _SKIP_REASON: str = (
-    f"DeepSeek-R1 endpoint unreachable at {_ENDPOINT_URL} "
+    f"DeepSeek-R1 endpoint unreachable at {_ENDPOINT_HOST} "
     "(set LLM_DEEPSEEK_R1_URL to override)"
 )
 

--- a/tests/integration/test_llm_gpu_usage_evidence_integration.py
+++ b/tests/integration/test_llm_gpu_usage_evidence_integration.py
@@ -55,6 +55,7 @@ def _make_transport() -> MagicMock:
 def _make_request(**overrides: Any) -> ModelLlmInferenceRequest:
     defaults: dict[str, Any] = {
         "base_url": "http://localhost:8000",
+        "endpoint_url": "http://localhost:8000/v1/chat/completions",
         "model": "qwen3-coder-30b-a3b",
         "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
         "messages": ({"role": "user", "content": "Hello"},),

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_gpu_measurement.py
@@ -43,6 +43,7 @@ def _make_transport() -> MagicMock:
 def _make_request(**overrides: Any) -> ModelLlmInferenceRequest:
     defaults: dict[str, Any] = {
         "base_url": "http://localhost:8000",
+        "endpoint_url": "http://localhost:8000/v1/chat/completions",
         "model": "qwen3-coder-30b-a3b",
         "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
         "messages": ({"role": "user", "content": "Hello"},),

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible.py
@@ -98,9 +98,15 @@ def _make_handler(transport: MagicMock | None = None) -> HandlerLlmOpenaiCompati
 
 
 def _make_chat_request(**overrides: Any) -> ModelLlmInferenceRequest:
-    """Build a valid CHAT_COMPLETION request with sensible defaults."""
+    """Build a valid CHAT_COMPLETION request with sensible defaults.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint, posted
+    verbatim. The default supplies the full chat-completions URL; ``base_url``
+    is retained only as the required routing/metrics field.
+    """
     defaults: dict[str, Any] = {
         "base_url": _BASE_URL,
+        "endpoint_url": f"{_BASE_URL}/v1/chat/completions",
         "model": _MODEL,
         "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
         "messages": ({"role": "user", "content": "Hello"},),
@@ -110,9 +116,14 @@ def _make_chat_request(**overrides: Any) -> ModelLlmInferenceRequest:
 
 
 def _make_completion_request(**overrides: Any) -> ModelLlmInferenceRequest:
-    """Build a valid COMPLETION request with sensible defaults."""
+    """Build a valid COMPLETION request with sensible defaults.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint, posted
+    verbatim.
+    """
     defaults: dict[str, Any] = {
         "base_url": _BASE_URL,
+        "endpoint_url": f"{_BASE_URL}/v1/completions",
         "model": _MODEL,
         "operation_type": EnumLlmOperationType.COMPLETION,
         "prompt": "Once upon a time",
@@ -224,73 +235,54 @@ def _make_error_context() -> ModelInfraErrorContext:
 
 @pytest.mark.unit
 class TestBuildUrl:
-    """Tests for HandlerLlmOpenaiCompatible._build_url()."""
+    """Tests for HandlerLlmOpenaiCompatible._build_url() (OMN-12815).
 
-    def test_chat_completion_url(self) -> None:
-        """CHAT_COMPLETION appends /v1/chat/completions."""
-        request = _make_chat_request()
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == f"{_BASE_URL}/v1/chat/completions"
+    Endpoints are COMPLETE in the contract and posted VERBATIM. The handler
+    performs no URL construction: the POST URL equals ``endpoint_url`` exactly
+    for every provider, and a missing ``endpoint_url`` fails closed.
+    """
 
-    def test_completion_url(self) -> None:
-        """COMPLETION appends /v1/completions."""
-        request = _make_completion_request()
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == f"{_BASE_URL}/v1/completions"
-
-    def test_trailing_slash_stripped(self) -> None:
-        """Trailing slash on base_url does not produce double slash."""
-        request = _make_chat_request(base_url="http://host:8000/")
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == "http://host:8000/v1/chat/completions"
-        assert "//" not in url.split("://")[1]
-
-    def test_unsupported_operation_type_raises_value_error(self) -> None:
-        """Unsupported operation_type raises ValueError (legacy path, no endpoint_url)."""
-        # EMBEDDING is not supported by the OpenAI handler
-        # We can't construct a request with EMBEDDING and messages, so test
-        # the static method directly with a mock request.
-        # endpoint_url=None forces the legacy base_url + path construction path.
-        mock_request = MagicMock()
-        mock_request.endpoint_url = None
-        mock_request.operation_type = EnumLlmOperationType.EMBEDDING
-        mock_request.base_url = _BASE_URL
-
-        with pytest.raises(ValueError, match="Unsupported operation type"):
-            HandlerLlmOpenaiCompatible._build_url(mock_request)
-
-    def test_endpoint_url_returned_directly(self) -> None:
-        """When endpoint_url is set, _build_url returns it verbatim — no path appended."""
-        full_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"
+    def test_endpoint_url_returned_verbatim_local(self) -> None:
+        """A complete local endpoint_url is returned exactly — no append/split."""
+        full_url = "http://192.168.86.201:8000/v1/chat/completions"
         request = _make_chat_request(endpoint_url=full_url)
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == full_url
+        assert HandlerLlmOpenaiCompatible._build_url(request) == full_url
 
-    def test_endpoint_url_takes_precedence_over_base_url(self) -> None:
-        """endpoint_url wins even when base_url is also set."""
+    def test_endpoint_url_returned_verbatim_gemini(self) -> None:
+        """A complete Gemini endpoint_url is returned exactly — no append/split."""
         full_url = (
             "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
         )
-        request = _make_chat_request(
-            endpoint_url=full_url,
-            base_url="http://192.168.86.201:8000",
-        )
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == full_url
-        assert "192.168.86.201" not in url
-
-    def test_endpoint_url_none_falls_back_to_base_url_path(self) -> None:
-        """When endpoint_url is None, legacy base_url + path construction is used."""
-        request = _make_chat_request(endpoint_url=None)
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == f"{_BASE_URL}/v1/chat/completions"
-
-    def test_endpoint_url_local_model_full_url(self) -> None:
-        """Full URL for a local model is returned unchanged."""
-        full_url = "http://192.168.86.201:8000/v1/chat/completions"
         request = _make_chat_request(endpoint_url=full_url)
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-        assert url == full_url
+        assert HandlerLlmOpenaiCompatible._build_url(request) == full_url
+
+    def test_endpoint_url_returned_verbatim_openrouter(self) -> None:
+        """A complete OpenRouter endpoint_url is returned exactly — no append/split."""
+        full_url = "https://openrouter.ai/api/v1/chat/completions"
+        request = _make_chat_request(endpoint_url=full_url)
+        assert HandlerLlmOpenaiCompatible._build_url(request) == full_url
+
+    def test_endpoint_url_returned_verbatim_zai(self) -> None:
+        """A complete z.ai endpoint_url is returned exactly — no double-versioning."""
+        full_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        request = _make_chat_request(endpoint_url=full_url)
+        assert HandlerLlmOpenaiCompatible._build_url(request) == full_url
+
+    def test_no_path_appended_to_endpoint_url(self) -> None:
+        """Even a bare base posted as endpoint_url is returned untouched (no append).
+
+        The handler never appends an operation path; completeness is the
+        contract's responsibility, enforced at the routing authority.
+        """
+        bare = "http://host:8000"
+        request = _make_chat_request(endpoint_url=bare)
+        assert HandlerLlmOpenaiCompatible._build_url(request) == bare
+
+    def test_missing_endpoint_url_fails_closed(self) -> None:
+        """A request without endpoint_url fails closed — no base_url fallback."""
+        request = _make_chat_request(endpoint_url=None)
+        with pytest.raises(ValueError, match="endpoint_url is required"):
+            HandlerLlmOpenaiCompatible._build_url(request)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
@@ -6,7 +6,7 @@
 
 Tests cover:
     - Initialization with transport injection
-    - Class-level constants (_FINISH_REASON_MAP, _OPERATION_PATHS)
+    - Class-level constants (_FINISH_REASON_MAP)
     - _build_url() for both operation types and unsupported types
     - _build_payload() for CHAT_COMPLETION and COMPLETION requests
     - _build_empty_response() for empty/malformed provider output
@@ -40,7 +40,6 @@ from omnibase_infra.models.llm import (
 )
 from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_openai_compatible import (
     _FINISH_REASON_MAP,
-    _OPERATION_PATHS,
     HandlerLlmOpenaiCompatible,
     _parse_tool_calls,
     _parse_usage,
@@ -69,6 +68,7 @@ def _make_chat_request(
     *,
     model: str = "gpt-4",
     base_url: str = "http://localhost:8000",
+    endpoint_url: str | None = None,
     messages: tuple[dict[str, str], ...] | None = None,
     system_prompt: str | None = None,
     tools: tuple[ModelLlmToolDefinition, ...] | None = None,
@@ -78,11 +78,18 @@ def _make_chat_request(
     max_tokens: int | None = None,
     stop: tuple[str, ...] | None = None,
 ) -> ModelLlmInferenceRequest:
-    """Create a valid CHAT_COMPLETION request with sensible defaults."""
+    """Create a valid CHAT_COMPLETION request with sensible defaults.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint posted
+    verbatim; defaults to the full chat-completions URL derived from base_url.
+    """
     if messages is None:
         messages = ({"role": "user", "content": "Hello"},)
+    if endpoint_url is None:
+        endpoint_url = f"{base_url.rstrip('/')}/v1/chat/completions"
     return ModelLlmInferenceRequest(
         base_url=base_url,
+        endpoint_url=endpoint_url,
         model=model,
         operation_type=EnumLlmOperationType.CHAT_COMPLETION,
         messages=messages,
@@ -100,15 +107,23 @@ def _make_completion_request(
     *,
     model: str = "gpt-4",
     base_url: str = "http://localhost:8000",
+    endpoint_url: str | None = None,
     prompt: str = "Once upon a time",
     temperature: float | None = None,
     top_p: float | None = None,
     max_tokens: int | None = None,
     stop: tuple[str, ...] | None = None,
 ) -> ModelLlmInferenceRequest:
-    """Create a valid COMPLETION request with sensible defaults."""
+    """Create a valid COMPLETION request with sensible defaults.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint posted
+    verbatim; defaults to the full completions URL derived from base_url.
+    """
+    if endpoint_url is None:
+        endpoint_url = f"{base_url.rstrip('/')}/v1/completions"
     return ModelLlmInferenceRequest(
         base_url=base_url,
+        endpoint_url=endpoint_url,
         model=model,
         operation_type=EnumLlmOperationType.COMPLETION,
         prompt=prompt,
@@ -196,17 +211,6 @@ class TestClassConstants:
         result = _FINISH_REASON_MAP.get("something_else", EnumLlmFinishReason.UNKNOWN)
         assert result == EnumLlmFinishReason.UNKNOWN
 
-    def test_operation_paths_chat_completion(self) -> None:
-        """CHAT_COMPLETION maps to /v1/chat/completions."""
-        assert (
-            _OPERATION_PATHS[EnumLlmOperationType.CHAT_COMPLETION]
-            == "/v1/chat/completions"
-        )
-
-    def test_operation_paths_completion(self) -> None:
-        """COMPLETION maps to /v1/completions."""
-        assert _OPERATION_PATHS[EnumLlmOperationType.COMPLETION] == "/v1/completions"
-
 
 # ---------------------------------------------------------------------------
 # Tests: _build_url()
@@ -214,41 +218,27 @@ class TestClassConstants:
 
 
 class TestBuildUrl:
-    """Tests for HandlerLlmOpenaiCompatible._build_url()."""
+    """Tests for HandlerLlmOpenaiCompatible._build_url() (OMN-12815).
 
-    def test_chat_completion_url(self) -> None:
-        """CHAT_COMPLETION appends /v1/chat/completions."""
-        request = _make_chat_request(base_url="http://localhost:8000")
-        url = HandlerLlmOpenaiCompatible._build_url(request)
+    The POST URL is the contract ``endpoint_url`` verbatim — no construction,
+    no path append, fail-closed when absent.
+    """
 
-        assert url == "http://localhost:8000/v1/chat/completions"
+    def test_endpoint_url_returned_verbatim(self) -> None:
+        """The complete endpoint_url is returned exactly as supplied."""
+        full_url = "http://localhost:8000/v1/chat/completions"
+        request = _make_chat_request(endpoint_url=full_url)
+        assert HandlerLlmOpenaiCompatible._build_url(request) == full_url
 
-    def test_completion_url(self) -> None:
-        """COMPLETION appends /v1/completions."""
-        request = _make_completion_request(base_url="http://localhost:8000")
-        url = HandlerLlmOpenaiCompatible._build_url(request)
+    def test_no_path_appended(self) -> None:
+        """A bare endpoint_url is returned untouched — no operation path added."""
+        request = _make_chat_request(endpoint_url="http://localhost:8000")
+        assert HandlerLlmOpenaiCompatible._build_url(request) == "http://localhost:8000"
 
-        assert url == "http://localhost:8000/v1/completions"
-
-    def test_trailing_slash_stripped(self) -> None:
-        """Trailing slash on base_url is stripped before appending path."""
-        request = _make_chat_request(base_url="http://localhost:8000/")
-        url = HandlerLlmOpenaiCompatible._build_url(request)
-
-        assert url == "http://localhost:8000/v1/chat/completions"
-
-    def test_unsupported_operation_type_raises(self) -> None:
-        """Unsupported operation type raises ValueError (legacy path, no endpoint_url)."""
-        # Use SimpleNamespace to bypass model validation and provide an
-        # operation_type not in _OPERATION_PATHS (EMBEDDING).
-        # endpoint_url=None forces the legacy base_url + path construction path.
-        fake_request = SimpleNamespace(
-            endpoint_url=None,
-            operation_type=EnumLlmOperationType.EMBEDDING,
-            base_url="http://localhost:8000",
-        )
-
-        with pytest.raises(ValueError, match="Unsupported operation type"):
+    def test_missing_endpoint_url_fails_closed(self) -> None:
+        """endpoint_url missing raises ValueError — no base_url fallback."""
+        fake_request = SimpleNamespace(endpoint_url=None)
+        with pytest.raises(ValueError, match="endpoint_url is required"):
             HandlerLlmOpenaiCompatible._build_url(fake_request)  # type: ignore[arg-type]
 
 

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_metrics.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_metrics.py
@@ -68,9 +68,14 @@ def _make_handler(
 
 
 def _make_chat_request(**overrides: Any) -> ModelLlmInferenceRequest:
-    """Build a valid CHAT_COMPLETION request."""
+    """Build a valid CHAT_COMPLETION request.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint posted
+    verbatim by the OpenAI-compatible effect.
+    """
     defaults: dict[str, Any] = {
         "base_url": _BASE_URL,
+        "endpoint_url": f"{_BASE_URL}/v1/chat/completions",
         "model": _MODEL,
         "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
         "messages": ({"role": "user", "content": "Hello"},),
@@ -80,9 +85,14 @@ def _make_chat_request(**overrides: Any) -> ModelLlmInferenceRequest:
 
 
 def _make_completion_request(**overrides: Any) -> ModelLlmInferenceRequest:
-    """Build a valid COMPLETION request."""
+    """Build a valid COMPLETION request.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint posted
+    verbatim by the OpenAI-compatible effect.
+    """
     defaults: dict[str, Any] = {
         "base_url": _BASE_URL,
+        "endpoint_url": f"{_BASE_URL}/v1/completions",
         "model": _MODEL,
         "operation_type": EnumLlmOperationType.COMPLETION,
         "prompt": "Once upon a time",

--- a/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
+++ b/tests/unit/nodes/node_llm_inference_effect/services/test_service_llm_metrics_publisher.py
@@ -93,9 +93,14 @@ def _make_response_with_usage(
 
 
 def _make_chat_request(**overrides: Any) -> ModelLlmInferenceRequest:
-    """Build a valid CHAT_COMPLETION request."""
+    """Build a valid CHAT_COMPLETION request.
+
+    OMN-12815: ``endpoint_url`` is the COMPLETE contract endpoint posted
+    verbatim by the OpenAI-compatible effect.
+    """
     defaults: dict[str, Any] = {
         "base_url": _BASE_URL,
+        "endpoint_url": f"{_BASE_URL}/v1/chat/completions",
         "model": _MODEL,
         "operation_type": EnumLlmOperationType.CHAT_COMPLETION,
         "messages": ({"role": "user", "content": "Hello"},),


### PR DESCRIPTION
## OMN-12815 — A1: post contract endpoint_url VERBATIM in the OpenAI-compatible effect (omnibase_infra)

Close-the-loop track A1 (AUDIT CORRECTION wwmx7fobe/D1: the *actual* POST-URL builder is the infra effect boundary).

`HandlerLlmOpenaiCompatible._build_url` now returns `request.endpoint_url` VERBATIM and **fails closed** when it is empty/missing. Deleted the legacy `base_url` + operation-path append branch and the `_OPERATION_PATHS` map. The effect performs no URL construction; the contract endpoint URL is the single source of the POST URL.

Pairs with the omnimarket PR that deletes the market-side constructors and supplies COMPLETE endpoint URLs in `bifrost_delegation.yaml`.

### dod_evidence
- `_OPERATION_PATHS` absent from src (grep exit 1); `TestBuildUrl` proves verbatim for local/gemini/openrouter/zai, no append to a bare URL, fail-closed when missing; `tests/unit/nodes/node_llm_inference_effect/` green; `mypy src/omnibase_infra/ --strict` clean; ruff clean; pre-commit pass.
- Evidence contract: `contracts/OMN-12815.yaml`.

Evidence-Source: OCC#2339
Evidence-Ticket: OMN-12815
