### PR TITLE
feat(OMN-12827): expose generated COMPUTE nodes as MCP tools (close-loop B2)

### DIFF
--- a/contracts/OMN-12827.yaml
+++ b/contracts/OMN-12827.yaml
@@ -1,0 +1,35 @@
+schema_version: '1.0.0'
+ticket_id: OMN-12827
+title: 'MCP exposure of generated COMPUTE node (close-the-loop B2)'
+summary: >-
+  Relax ServiceMCPToolSync exposure rule so generated COMPUTE nodes (mcp-enabled + node-type:compute + generated) surface as MCP tools alongside orchestrators, without relabeling them as orchestrators. Non-generated compute nodes remain excluded. Implements Plan B2 of docs/plans/2026-06-08-close-the-loop-plan.md.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - public_api
+evidence_requirements:
+  - kind: tests
+    description: MCP exposure rule unit tests pass (orchestrator + generated compute exposed; non-generated compute and non-mcp excluded)
+    command: uv run pytest tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      Exposure predicate exposes mcp-enabled orchestrators and generated compute nodes, and excludes non-generated compute nodes and non-mcp nodes.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py -q'
+  - id: dod-002
+    description: >-
+      Full unit suite remains green after relaxing the exposure rule (no regression in MCP tool sync / registry behavior).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/services/mcp/ -q'

--- a/src/omnibase_infra/services/mcp/service_mcp_tool_sync.py
+++ b/src/omnibase_infra/services/mcp/service_mcp_tool_sync.py
@@ -4,9 +4,16 @@
 
 This service subscribes to node registration events on Kafka and updates
 the MCP tool registry in real-time. It supports:
-- Hot reload: New/updated orchestrators appear as tools without restart
-- Deregistration: Removed orchestrators are removed from tool registry
+- Hot reload: New/updated MCP-exposable nodes appear as tools without restart
+- Deregistration: Removed nodes are removed from tool registry
 - Idempotency: Duplicate/out-of-order events are handled correctly
+
+MCP-exposable nodes (OMN-12827, Plan B2):
+- ORCHESTRATOR nodes tagged ``mcp-enabled`` (original behavior).
+- Generated COMPUTE nodes tagged ``mcp-enabled`` + ``node-type:compute`` +
+  ``generated`` — the SEA self-extension loop output. Generated compute nodes
+  surface as tools without being relabeled as orchestrators; non-generated
+  compute nodes are NOT exposed.
 
 Event Topic: Uses SUFFIX_NODE_REGISTRATION (onex.evt.platform.node-registration.v1)
 Event Types:
@@ -81,6 +88,8 @@ class ServiceMCPToolSync:
     # MCP tag constants
     TAG_MCP_ENABLED = "mcp-enabled"
     TAG_NODE_TYPE_ORCHESTRATOR = "node-type:orchestrator"
+    TAG_NODE_TYPE_COMPUTE = "node-type:compute"
+    TAG_GENERATED = "generated"
     TAG_PREFIX_MCP_TOOL = "mcp-tool:"
 
     # Event types
@@ -271,8 +280,9 @@ class ServiceMCPToolSync:
                     event_id_str.zfill(20) if event_id_str.isdigit() else event_id_str
                 )
 
-            # Check if this is an MCP-enabled orchestrator
-            if not self._is_mcp_orchestrator(tags):
+            # Check if this is an MCP-exposable node (orchestrator or generated
+            # compute node — OMN-12827, Plan B2).
+            if not self._is_mcp_exposable(tags):
                 logger.debug(
                     "Ignoring non-MCP event",
                     extra={
@@ -331,16 +341,31 @@ class ServiceMCPToolSync:
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None
 
-    def _is_mcp_orchestrator(self, tags: Sequence[str]) -> bool:
-        """Check if event is for an MCP-enabled orchestrator.
+    def _is_mcp_exposable(self, tags: Sequence[str]) -> bool:
+        """Check if an event's node should be exposed as an MCP tool.
+
+        A node is MCP-exposable when it carries the ``mcp-enabled`` tag AND is
+        one of:
+
+        - an ORCHESTRATOR node (``node-type:orchestrator``) — original behavior; or
+        - a GENERATED COMPUTE node (``node-type:compute`` + ``generated``) — the
+          SEA self-extension loop output (OMN-12827, Plan B2).
+
+        Non-generated compute nodes are intentionally excluded: only generated
+        compute nodes surface as tools, so hand-authored compute nodes do not
+        leak into the MCP registry.
 
         Args:
             tags: List of tags from the event.
 
         Returns:
-            True if the event is for an MCP-enabled orchestrator.
+            True if the event's node should be exposed as an MCP tool.
         """
-        return self.TAG_MCP_ENABLED in tags and self.TAG_NODE_TYPE_ORCHESTRATOR in tags
+        if self.TAG_MCP_ENABLED not in tags:
+            return False
+        if self.TAG_NODE_TYPE_ORCHESTRATOR in tags:
+            return True
+        return self.TAG_NODE_TYPE_COMPUTE in tags and self.TAG_GENERATED in tags
 
     def _extract_tool_name(self, tags: Sequence[str]) -> str | None:
         """Extract the MCP tool name from tags.
@@ -508,11 +533,18 @@ class ServiceMCPToolSync:
         if not isinstance(timeout_seconds, int) or timeout_seconds < 1:
             timeout_seconds = 30
 
+        tags = self._extract_tags_list(event.get("tags", []))
+        node_kind = (
+            "generated compute node"
+            if self.TAG_NODE_TYPE_COMPUTE in tags
+            else "orchestrator"
+        )
+
         return ModelMCPToolDefinition(
             name=tool_name,
             description=str(description)
             if description
-            else f"ONEX orchestrator: {service_name}",
+            else f"ONEX {node_kind}: {service_name}",
             version="1.0.0",
             parameters=[],
             input_schema={"type": "object", "properties": {}},
@@ -522,7 +554,8 @@ class ServiceMCPToolSync:
             timeout_seconds=timeout_seconds,
             metadata={
                 "service_name": str(service_name),
-                "tags": self._extract_tags_list(event.get("tags", [])),
+                "tags": tags,
+                "node_kind": node_kind,
                 "source": "kafka_event",
             },
         )

--- a/tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py
+++ b/tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ServiceMCPToolSync MCP exposure rule (OMN-12827, Plan B2).
+
+These tests are infrastructure-free: they exercise the pure tag-classification
+predicate that decides whether a node-registration event should surface as an
+MCP tool. Before OMN-12827 only ORCHESTRATOR nodes were exposed; B2 relaxes the
+rule so that generated COMPUTE nodes (the SEA self-extension loop output) are
+also exposed, without falsely re-labeling them as orchestrators.
+
+The exposure contract (the source of truth this test is written from):
+
+- An ``mcp-enabled`` ORCHESTRATOR node is exposed (unchanged behavior).
+- An ``mcp-enabled`` generated COMPUTE node (``node-type:compute`` + ``generated``)
+  is exposed (new B2 behavior).
+- A non-MCP node is never exposed.
+- A NON-generated COMPUTE node is NOT exposed (only generated compute nodes
+  surface as tools; arbitrary compute nodes must not leak into the registry).
+- A node missing the ``mcp-enabled`` tag is never exposed regardless of type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_infra.services.mcp.service_mcp_tool_sync import ServiceMCPToolSync
+
+
+@pytest.fixture
+def sync() -> ServiceMCPToolSync:
+    """Build a ServiceMCPToolSync with direct (mock-free) dependency injection.
+
+    The exposure predicate is pure and does not touch the registry or bus, so a
+    minimal pair of stand-ins is sufficient to construct the service.
+    """
+
+    class _StubRegistry:
+        pass
+
+    class _StubBus:
+        environment = "test"
+
+    return ServiceMCPToolSync(registry=_StubRegistry(), bus=_StubBus())  # type: ignore[arg-type]
+
+
+class TestMcpExposureRule:
+    """Cover the relaxed MCP exposure predicate (B2)."""
+
+    def test_mcp_enabled_orchestrator_is_exposed(
+        self, sync: ServiceMCPToolSync
+    ) -> None:
+        tags = [
+            ServiceMCPToolSync.TAG_MCP_ENABLED,
+            ServiceMCPToolSync.TAG_NODE_TYPE_ORCHESTRATOR,
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}some_orchestrator",
+        ]
+        assert sync._is_mcp_exposable(tags) is True
+
+    def test_mcp_enabled_generated_compute_is_exposed(
+        self, sync: ServiceMCPToolSync
+    ) -> None:
+        tags = [
+            ServiceMCPToolSync.TAG_MCP_ENABLED,
+            ServiceMCPToolSync.TAG_NODE_TYPE_COMPUTE,
+            ServiceMCPToolSync.TAG_GENERATED,
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}generated_compute_node",
+        ]
+        assert sync._is_mcp_exposable(tags) is True
+
+    def test_non_generated_compute_is_not_exposed(
+        self, sync: ServiceMCPToolSync
+    ) -> None:
+        tags = [
+            ServiceMCPToolSync.TAG_MCP_ENABLED,
+            ServiceMCPToolSync.TAG_NODE_TYPE_COMPUTE,
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}hand_authored_compute",
+        ]
+        assert sync._is_mcp_exposable(tags) is False
+
+    def test_non_mcp_node_is_not_exposed(self, sync: ServiceMCPToolSync) -> None:
+        tags = [
+            ServiceMCPToolSync.TAG_NODE_TYPE_ORCHESTRATOR,
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}some_orchestrator",
+        ]
+        assert sync._is_mcp_exposable(tags) is False
+
+    def test_generated_compute_without_mcp_enabled_is_not_exposed(
+        self, sync: ServiceMCPToolSync
+    ) -> None:
+        tags = [
+            ServiceMCPToolSync.TAG_NODE_TYPE_COMPUTE,
+            ServiceMCPToolSync.TAG_GENERATED,
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}generated_compute_node",
+        ]
+        assert sync._is_mcp_exposable(tags) is False
+
+    def test_empty_tags_is_not_exposed(self, sync: ServiceMCPToolSync) -> None:
+        assert sync._is_mcp_exposable([]) is False


### PR DESCRIPTION
## Summary
Implements Plan B2 (`docs/plans/2026-06-08-close-the-loop-plan.md`, §Phase B) — MCP exposure of the generated COMPUTE node from the SEA self-extension loop.

`ServiceMCPToolSync` previously exposed an MCP tool only for events tagged `mcp-enabled` + `node-type:orchestrator` (`_is_mcp_orchestrator`), so generated COMPUTE nodes could never surface as MCP tools. This PR relaxes the rule via a renamed predicate `_is_mcp_exposable(tags)`:

- `mcp-enabled` + `node-type:orchestrator` → exposed (unchanged)
- `mcp-enabled` + `node-type:compute` + `generated` → exposed (**new**)
- `mcp-enabled` + `node-type:compute` WITHOUT `generated` → NOT exposed
- missing `mcp-enabled` → NOT exposed (any type)

Generated compute nodes are NOT relabeled as orchestrators: tool description and `metadata.node_kind` distinguish 'generated compute node' from 'orchestrator', and only `generated` compute nodes surface (hand-authored compute nodes do not leak into the registry).

This is the infra-side classification change only (off the critical path per the plan). The live-runtime 'MCP tool appears' assertion is Phase D (D1/D2), not claimed here.

## Changes
- `src/omnibase_infra/services/mcp/service_mcp_tool_sync.py` — predicate relaxed; `TAG_NODE_TYPE_COMPUTE` + `TAG_GENERATED` constants; type-aware tool description + `node_kind` metadata.
- `tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py` — new TDD unit tests (orchestrator + generated compute exposed; non-generated compute, non-mcp, empty excluded).
- `contracts/OMN-12827.yaml` — evidence contract.

## dod_evidence (OMN-12827)
- TDD red→green observed (red: `AttributeError: ... _is_mcp_exposable`).
- `uv run pytest tests/unit/services/mcp/test_service_mcp_tool_sync_exposure.py -v` → 6 passed.
- `uv run pytest tests/unit/services/mcp/ tests/integration/services/mcp/ -q` → 132 passed, 25 skipped (kafka-gated).
- `uv run mypy src/omnibase_infra/services/mcp/service_mcp_tool_sync.py --strict` → clean.
- `uv run ruff check src/ tests/` → All checks passed; `pre-commit run --files <changed>` → clean.
- Full `tests/unit/` → 20160 passed, 1 pre-existing unrelated failure (migration vendor-sync; reproduces on pristine `main`, caused by uncommitted sibling omnimarket migrations in the shared local clone; not touched by B2).

Paired OCC receipt: OmniNode-ai/onex_change_control#2352

Evidence-Source: 717cc54799bcb16ce469498e73c597415ecca03f
Evidence-Ticket: OMN-12827

<!-- receipt-gate re-trigger: OCC#2352 now carries contracts/OMN-12827.yaml + dod_receipts -->

<!-- receipt-gate re-trigger 2: OCC#2352 receipts repaired + schema-valid -->

