### PR TITLE
fix(OMN-12838): allow declared compatibility publish topics

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/discovery.py
+++ b/src/omnibase_infra/runtime/auto_wiring/discovery.py
@@ -57,8 +57,10 @@ def _contract_targets_active_runtime_packages(
     if contract.event_bus is None:
         return True
 
+    compatibility_publish_topics = set(contract.compatibility_publish_topics)
     return all(
         is_runtime_topic_active(topic, active_packages)
+        or topic in compatibility_publish_topics
         for topic in contract.event_bus.publish_topics
     )
 
@@ -395,6 +397,7 @@ def _parse_contract(
         package_name=package_name,
         package_version=package_version,
         runtime_profiles=runtime_profiles,
+        compatibility_publish_topics=raw.get("compatibility_publish_topics"),
         terminal_event=raw.get("terminal_event"),
         event_bus=event_bus,
         handler_routing=handler_routing,

--- a/src/omnibase_infra/runtime/auto_wiring/models/model_discovered_contract.py
+++ b/src/omnibase_infra/runtime/auto_wiring/models/model_discovered_contract.py
@@ -50,6 +50,14 @@ class ModelDiscoveredContract(BaseModel):
             "Empty means backward-compatible ownership by every runtime profile."
         ),
     )
+    compatibility_publish_topics: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Contract-declared cross-package compatibility topics. These are "
+            "allowed to publish into an inactive legacy package domain without "
+            "making that package part of the active runtime surface."
+        ),
+    )
     terminal_event: str | None = Field(
         default=None,
         description="Optional contract-declared terminal event topic.",
@@ -83,3 +91,28 @@ class ModelDiscoveredContract(BaseModel):
                 raise ValueError("runtime_profiles entries cannot be blank")
             profiles.append(profile)
         return tuple(dict.fromkeys(profiles))
+
+    @field_validator("compatibility_publish_topics", mode="before")
+    @classmethod
+    def validate_compatibility_publish_topics(cls, value: object) -> tuple[str, ...]:
+        """Normalize contract-declared compatibility publish topics."""
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            raw_values = (value,)
+        elif isinstance(value, (list, tuple, set)):
+            raw_values = tuple(value)
+        else:
+            raise TypeError(
+                "compatibility_publish_topics must be a string or sequence of strings"
+            )
+
+        topics: list[str] = []
+        for raw in raw_values:
+            if not isinstance(raw, str):
+                raise TypeError("compatibility_publish_topics entries must be strings")
+            topic = raw.strip()
+            if not topic:
+                raise ValueError("compatibility_publish_topics entries cannot be blank")
+            topics.append(topic)
+        return tuple(dict.fromkeys(topics))

--- a/tests/unit/runtime/auto_wiring/test_discovery.py
+++ b/tests/unit/runtime/auto_wiring/test_discovery.py
@@ -501,6 +501,46 @@ class TestDiscoverContractsFromPaths:
         assert manifest.total_errors == 0
 
     @pytest.mark.unit
+    def test_compatibility_publish_topics_do_not_block_contract_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra,omnimarket")
+        node_dir = tmp_path / "delegation_orchestrator"
+        node_dir.mkdir()
+        path = node_dir / "contract.yaml"
+        path.write_text(
+            dedent("""\
+                name: "node_delegation_orchestrator"
+                node_type: "ORCHESTRATOR_GENERIC"
+                contract_version:
+                  major: 1
+                  minor: 0
+                  patch: 0
+                node_version: "1.0.0"
+                description: "Delegation orchestrator with a legacy dashboard event"
+                compatibility_publish_topics:
+                  - "onex.evt.omniclaude.task-delegated.v1"
+                event_bus:
+                  subscribe_topics:
+                    - "onex.cmd.omnibase-infra.delegation-request.v1"
+                  publish_topics:
+                    - "onex.evt.omnibase-infra.delegation-completed.v1"
+                    - "onex.evt.omniclaude.task-delegated.v1"
+                  plugin_managed: true
+            """)
+        )
+
+        manifest = discover_contracts_from_paths([path])
+
+        assert manifest.total_discovered == 1
+        assert manifest.total_errors == 0
+        contract = manifest.contracts[0]
+        assert contract.name == "node_delegation_orchestrator"
+        assert contract.compatibility_publish_topics == (
+            "onex.evt.omniclaude.task-delegated.v1",
+        )
+
+    @pytest.mark.unit
     def test_projection_consumer_subscribing_to_inactive_package_domain_is_included(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Add `compatibility_publish_topics` to discovered auto-wiring contracts.
- Keep active runtime package filtering strict for ordinary publish topics.
- Allow only contract-declared compatibility publish topics to bypass inactive-package domain filtering.

## Root cause
`node_delegation_orchestrator` publishes the legacy compatibility event `onex.evt.omniclaude.task-delegated.v1`. The active stability runtime packages are `omnibase_infra,omnimarket`, so auto-wiring treated the legacy `omniclaude` topic as an inactive runtime package domain and skipped the entire contract. The plugin consumer still subscribed to the delegation command topic, which produced consume-without-route DLQ failures.

## Verification
- `uv run pytest tests/unit/runtime/auto_wiring/test_discovery.py -q` -> 26 passed
- `uv run ruff check src/omnibase_infra/runtime/auto_wiring/discovery.py src/omnibase_infra/runtime/auto_wiring/models/model_discovered_contract.py tests/unit/runtime/auto_wiring/test_discovery.py`
- Cross-worktree parser proof with `ONEX_ACTIVE_RUNTIME_PACKAGES=omnibase_infra,omnimarket` discovered the delegation orchestrator contract and preserved `onex.evt.omniclaude.task-delegated.v1` as a declared compatibility publish topic.

## Deploy / retest
Merge and deploy this before the dependent Omnimarket contract PR. Then rerun L3 delegation from the entry point and require a terminal delegate-skill event plus same-day `delegation_events` projection row.

Evidence-Source: OCC#2354
Evidence-Ticket: OMN-12838

Evidence-Source: b8802f40b50a32d7d804d84f113f8f7c5dc88d11

Paired OCC receipt: OmniNode-ai/onex_change_control#2354

<!-- receipt-gate re-trigger: repinned OMN-12835 evidence to merged OCC#2354 b8802f40b50a32d7d804d84f113f8f7c5dc88d11 -->


---
_Tracking reassigned from OMN-12835 → OMN-12838 (scope split: OMN-12835 is typed-DAG-only; delegation compatibility_publish_topics work lives in OMN-12838). Committed OCC evidence contract retains its historical name contracts/OMN-12835.yaml._