### PR TITLE
fix(OMN-12848): register dispatch route for sole-handler multi-topic contracts + cachetools in workspace image

### DIFF
--- a/contracts/OMN-12848.yaml
+++ b/contracts/OMN-12848.yaml
@@ -1,0 +1,34 @@
+schema_version: '1.0.0'
+ticket_id: OMN-12848
+title: 'stability-test rebuild lost node-generation-requested dispatch route → DLQ + cachetools missing in workspace image'
+summary: >-
+  Fix two defects blocking the close-the-loop demo. (1) Routing regression: a sole handler entry that declares an event_model and subscribes to more than one topic (node_generation_consumer subscribing to node-generation-requested AND node-deploy after OMN-12826) fell through _topics_for_handler_entry to return () and registered ZERO dispatch routes, so generation commands were consumed then DLQ'd ("No dispatcher found for category 'command'"). A sole handler unambiguously owns every subscribe topic; only competing multi-handler entries keep the ambiguity guard. (2) Workspace-mode image missing cachetools (omnimemory transitive dep) → node_semantic_analyzer_compute / node_agent_learning_retrieval_effect failed to load. Added cachetools to the runtime external-deps install + a build-time import smoke check so a missing transitive dep fails the build instead of degrading at runtime.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: _topics_for_handler_entry assigns all topics to a sole handler entry (regression covered); existing multi-handler ambiguity and per-handler event_type behavior preserved
+    command: uv run pytest tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      A single-handler contract with an event_model and multiple subscribe topics gets all topics assigned (dispatch route registered), fixing the node-generation-requested → DLQ regression. Multi-handler ambiguity guard and per-handler event_type selection unchanged.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py -q'
+  - id: dod-002
+    description: >-
+      Full auto_wiring unit suite remains green after the topic-assignment fix (no regression in dispatcher/route registration).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/auto_wiring/ -q'

--- a/contracts/OMN-12848.yaml
+++ b/contracts/OMN-12848.yaml
@@ -1,14 +1,25 @@
+---
 schema_version: '1.0.0'
 ticket_id: OMN-12848
-title: 'stability-test rebuild lost node-generation-requested dispatch route → DLQ + cachetools missing in workspace image'
+title: 'stability-test rebuild lost node-generation-requested dispatch route → DLQ + cachetools missing
+  in workspace image'
 summary: >-
-  Fix two defects blocking the close-the-loop demo. (1) Routing regression: a sole handler entry that declares an event_model and subscribes to more than one topic (node_generation_consumer subscribing to node-generation-requested AND node-deploy after OMN-12826) fell through _topics_for_handler_entry to return () and registered ZERO dispatch routes, so generation commands were consumed then DLQ'd ("No dispatcher found for category 'command'"). A sole handler unambiguously owns every subscribe topic; only competing multi-handler entries keep the ambiguity guard. (2) Workspace-mode image missing cachetools (omnimemory transitive dep) → node_semantic_analyzer_compute / node_agent_learning_retrieval_effect failed to load. Added cachetools to the runtime external-deps install + a build-time import smoke check so a missing transitive dep fails the build instead of degrading at runtime.
+  Fix two defects blocking the close-the-loop demo. (1) Routing regression: a sole handler entry that
+  declares an event_model and subscribes to more than one topic (node_generation_consumer subscribing
+  to node-generation-requested AND node-deploy after OMN-12826) fell through _topics_for_handler_entry
+  to return () and registered ZERO dispatch routes, so generation commands were consumed then DLQ'd ("No
+  dispatcher found for category 'command'"). A sole handler unambiguously owns every subscribe topic;
+  only competing multi-handler entries keep the ambiguity guard. (2) Workspace-mode image missing cachetools
+  (omnimemory transitive dep) → node_semantic_analyzer_compute / node_agent_learning_retrieval_effect
+  failed to load. Added cachetools to the runtime external-deps install + a build-time import smoke check
+  so a missing transitive dep fails the build instead of degrading at runtime.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
-    description: _topics_for_handler_entry assigns all topics to a sole handler entry (regression covered); existing multi-handler ambiguity and per-handler event_type behavior preserved
+    description: _topics_for_handler_entry assigns all topics to a sole handler entry (regression covered);
+      existing multi-handler ambiguity and per-handler event_type behavior preserved
     command: uv run pytest tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py -q
   - kind: ci
     description: CI pipeline green on PR
@@ -20,14 +31,17 @@ emergency_bypass:
 dod_evidence:
   - id: dod-001
     description: >-
-      A single-handler contract with an event_model and multiple subscribe topics gets all topics assigned (dispatch route registered), fixing the node-generation-requested → DLQ regression. Multi-handler ambiguity guard and per-handler event_type selection unchanged.
+      A single-handler contract with an event_model and multiple subscribe topics gets all topics assigned
+      (dispatch route registered), fixing the node-generation-requested → DLQ regression. Multi-handler
+      ambiguity guard and per-handler event_type selection unchanged.
     source: generated
     checks:
       - check_type: command
         check_value: 'uv run pytest tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py -q'
   - id: dod-002
     description: >-
-      Full auto_wiring unit suite remains green after the topic-assignment fix (no regression in dispatcher/route registration).
+      Full auto_wiring unit suite remains green after the topic-assignment fix (no regression in dispatcher/route
+      registration).
     source: generated
     checks:
       - check_type: command

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -359,7 +359,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "pytest>=8.4.0,<10.0.0" \
     "pytest-asyncio>=1.3.0,<2.0.0" \
     "docker>=7.0.0,<8.0.0" \
-    "python-snappy>=0.7.0,<1.0.0"
+    "python-snappy>=0.7.0,<1.0.0" \
+    "cachetools>=6.2.4,<8.0.0"
 
 # Security: upgrade protobuf to clear CVE-2026-0994 (HIGH, DoS, fixed in >=5.29.6).
 # protobuf 4.25.8 (from transitive deps) is flagged by Trivy scan (ignore-unfixed: true).
@@ -380,6 +381,16 @@ assert torch.version.cuda is None, f'Expected CPU torch, got CUDA {torch.version
 nvidia_pkgs = [m.name for m in pkgutil.iter_modules() if 'nvidia' in m.name]; \
 assert not nvidia_pkgs, f'Unexpected NVIDIA packages: {nvidia_pkgs}'; \
 print(f'torch {torch.__version__} (CPU-only) verified, no NVIDIA packages')"
+
+# OMN-12848: fail the build if a generation-path transitive dep is missing.
+# omnimemory declares cachetools; node_semantic_analyzer_compute /
+# node_agent_learning_retrieval_effect import omnimemory. A missing transitive
+# dep previously degraded silently at runtime (entry-point load failure) instead
+# of failing the build. Assert the imports succeed at build time.
+RUN /app/.venv/bin/python -c "\
+import importlib; \
+[importlib.import_module(m) for m in ('cachetools', 'omnimemory')]; \
+print('generation-path transitive deps verified: cachetools, omnimemory')"
 
 # Cleanup: remove __pycache__ and .pyc files from venv
 # Note: does NOT touch /root/.cache/uv (that's a cache mount, not persisted in layer)

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1697,6 +1697,20 @@ def _topics_for_handler_entry(
     if len(topics) == 1:
         return topics
 
+    # OMN-12848: a sole handler entry unambiguously owns every subscribe topic.
+    # The ambiguity guard below (return ()) only applies when MULTIPLE handler
+    # entries compete for the same topics without per-handler event_type
+    # disambiguation. A single-handler contract with an event_model and more
+    # than one subscribe topic (e.g. node_generation_consumer subscribing to
+    # both node-generation-requested and node-deploy) previously fell through to
+    # return () and registered ZERO dispatch routes — the command was consumed
+    # then DLQ'd ("No dispatcher found"). Assign all topics to the sole handler.
+    if (
+        contract.handler_routing is not None
+        and len(contract.handler_routing.handlers) == 1
+    ):
+        return topics
+
     return ()
 
 

--- a/tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py
+++ b/tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for _topics_for_handler_entry topic assignment [OMN-12848].
+
+Regression: a single-handler contract that declares an ``event_model`` and
+subscribes to MORE THAN ONE topic (e.g. ``node_generation_consumer`` subscribing
+to both ``node-generation-requested`` and ``node-deploy``) previously fell
+through to ``return ()`` — registering ZERO dispatch routes. Commands were
+consumed then routed to DLQ with "No dispatcher found for category 'command'".
+
+The fix: a SOLE handler entry unambiguously owns every subscribe topic. The
+ambiguity guard (``return ()``) only applies when MULTIPLE handler entries
+compete for the same topics without per-handler ``event_type``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _topics_for_handler_entry,
+)
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+
+
+def _entry(
+    *,
+    event_model_name: str | None = "ModelFoo",
+    event_type: str | None = None,
+) -> ModelHandlerRoutingEntry:
+    kwargs: dict[str, object] = {
+        "handler": ModelHandlerRef(name="HandlerFoo", module="fake.module"),
+        "operation": None,
+    }
+    if event_model_name is not None:
+        kwargs["event_model"] = ModelHandlerRef(
+            name=event_model_name, module="fake.models"
+        )
+    if event_type is not None:
+        kwargs["event_type"] = event_type
+    return ModelHandlerRoutingEntry(**kwargs)
+
+
+def _contract(
+    *,
+    entries: tuple[ModelHandlerRoutingEntry, ...],
+    subscribe_topics: tuple[str, ...],
+) -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="node_local",
+        node_type="ORCHESTRATOR_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name="node_local",
+        package_name="test-pkg",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=subscribe_topics,
+            publish_topics=(),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="operation_match",
+            handlers=entries,
+        ),
+    )
+
+
+def test_sole_handler_event_model_multi_topic_assigns_all_topics() -> None:
+    """OMN-12848: the regression case — must assign ALL topics, not empty."""
+    topics = (
+        "onex.cmd.omnimarket.node-generation-requested.v1",
+        "onex.cmd.omnimarket.node-deploy.v1",
+    )
+    entry = _entry(event_model_name="ModelNodeGenerationRequest", event_type=None)
+    contract = _contract(entries=(entry,), subscribe_topics=topics)
+
+    assigned = _topics_for_handler_entry(contract, entry)
+
+    assert assigned == topics, (
+        "A sole handler entry must own every subscribe topic so a dispatch route "
+        "is registered; empty assignment causes node-generation-requested to DLQ."
+    )
+
+
+def test_sole_handler_event_model_single_topic_unchanged() -> None:
+    """Single-topic single-handler still resolves to its one topic."""
+    topics = ("onex.cmd.omnimarket.node-generation-requested.v1",)
+    entry = _entry(event_model_name="ModelNodeGenerationRequest")
+    contract = _contract(entries=(entry,), subscribe_topics=topics)
+
+    assert _topics_for_handler_entry(contract, entry) == topics
+
+
+def test_multi_handler_event_model_no_event_type_stays_ambiguous() -> None:
+    """Multiple competing handlers without event_type keep the ambiguity guard."""
+    topics = (
+        "onex.cmd.platform.a.v1",
+        "onex.cmd.platform.b.v1",
+    )
+    e1 = _entry(event_model_name="ModelA", event_type=None)
+    e2 = _entry(event_model_name="ModelB", event_type=None)
+    contract = _contract(entries=(e1, e2), subscribe_topics=topics)
+
+    # Neither competing entry can deterministically claim a topic.
+    assert _topics_for_handler_entry(contract, e1) == ()
+    assert _topics_for_handler_entry(contract, e2) == ()
+
+
+def test_per_handler_event_type_still_matches_specific_topic() -> None:
+    """A per-handler event_type continues to select only its matching topic."""
+    topics = (
+        "onex.cmd.omnimarket.node-generation-requested.v1",
+        "onex.cmd.omnimarket.node-deploy.v1",
+    )
+    e1 = _entry(
+        event_model_name="ModelGen",
+        event_type="omnimarket.node-generation-requested",
+    )
+    e2 = _entry(event_model_name="ModelDeploy", event_type="omnimarket.node-deploy")
+    contract = _contract(entries=(e1, e2), subscribe_topics=topics)
+
+    assert _topics_for_handler_entry(contract, e1) == (
+        "onex.cmd.omnimarket.node-generation-requested.v1",
+    )
+    assert _topics_for_handler_entry(contract, e2) == (
+        "onex.cmd.omnimarket.node-deploy.v1",
+    )
+
+
+def test_no_event_model_returns_all_topics() -> None:
+    """An entry without an event_model keeps the legacy all-topics behavior."""
+    topics = ("onex.cmd.platform.a.v1", "onex.cmd.platform.b.v1")
+    entry = _entry(event_model_name=None)
+    contract = _contract(entries=(entry,), subscribe_topics=topics)
+
+    assert _topics_for_handler_entry(contract, entry) == topics


### PR DESCRIPTION
## OMN-12848 — register dispatch route for sole-handler multi-topic contracts + cachetools

Evidence-Ticket: OMN-12848
Evidence-Source: OCC#2364

### Root cause (diagnosed live on stability-test, systematic-debugging Phase 1–4)

stability-test consumed `node-generation-requested` commands then routed them to DLQ:
`No dispatcher found for category 'command' and message type 'omnimarket.node-generation-requested'`.

The handler loaded and the Kafka subscription was created, but **zero dispatch routes** were
registered. `_topics_for_handler_entry()` returns `()` for a single handler entry that declares
an `event_model` and subscribes to **more than one** topic. The route-build loop iterates that
empty tuple → no `ModelDispatchRoute` → unreachable dispatcher → DLQ.

It worked on omnimarket **v0.4.3** (generation_consumer had ONE subscribe topic) and broke after
**OMN-12826** added a second subscribe topic (`node-deploy.v1`) to the same single-handler
contract. Real source regression, not the OMN-12525 baseline divergence and not a generic
workspace-build defect.

Eliminated (in-container proof): handler import OK, event_model import OK, computed `message_types`
includes the correct alias, OMN-12416 `payload_type_matcher` type-scoping returns True for the real
envelope payload. The only failing surface was topic→route assignment.

### Fix

1. **Routing (primary blocker):** a sole handler entry unambiguously owns every subscribe topic.
   The `return ()` ambiguity guard now only applies when MULTIPLE handler entries compete for the
   same topics without per-handler `event_type`. Fixes every single-handler multi-topic contract.
2. **cachetools:** added `cachetools>=6.2.4,<8.0.0` (omnimemory transitive dep) to the runtime
   external-deps install + build-time `import cachetools, omnimemory` smoke check so a missing
   transitive dep fails the BUILD instead of degrading at runtime.

### Tests (TDD)

`tests/unit/runtime/auto_wiring/test_topics_for_handler_entry.py` — regression proven to FAIL
without the fix and PASS with it; behavior-preservation for single-topic, multi-handler ambiguity,
per-handler `event_type`, and no-event_model.

- `uv run pytest tests/unit/runtime/auto_wiring/ -q` → 257 passed
- ruff format/check clean, `mypy --strict` clean on changed module, pre-commit all-pass

Diagnosis doc: `omni_home/docs/diagnosis/OMN-12848-generation-dispatch-dlq.md`.
