### PR TITLE
fix(OMN-12851): inject event publisher for auto-wired handlers

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1494,8 +1494,64 @@ def _should_skip_sync_container_resolution(handler_cls: type) -> bool:
     """
     required_params = _required_handler_init_params(handler_cls)
     return not required_params or required_params <= frozenset(
-        {"event_bus", "dispatch_port", "provisioner", "drain_proof_gate"}
+        {
+            "event_bus",
+            "event_publisher",
+            "dispatch_port",
+            "provisioner",
+            "drain_proof_gate",
+        }
     )
+
+
+async def _await_event_bus_publish(awaitable: Awaitable[object]) -> None:
+    await awaitable
+
+
+def _make_sync_event_publisher(
+    *,
+    event_bus: object,
+    handler_name: str,
+) -> Callable[[str, bytes], None]:
+    """Adapt async runtime event-bus publish to legacy sync handler publishers."""
+    publish = getattr(event_bus, "publish", None)
+    if not callable(publish):
+        raise ModelOnexError(
+            "handler_wiring: handler "
+            f"{handler_name!r} declares event_publisher, but event_bus "
+            f"{type(event_bus).__name__!r} has no callable publish()."
+        )
+
+    def _publish(topic: str, payload: bytes) -> None:
+        result = publish(topic, None, payload)
+        if not inspect.isawaitable(result):
+            return
+
+        publish_awaitable = cast("Awaitable[object]", result)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(_await_event_bus_publish(publish_awaitable))
+            return
+
+        task = loop.create_task(_await_event_bus_publish(publish_awaitable))
+
+        def _log_publish_failure(done: asyncio.Task[None]) -> None:
+            try:
+                done.result()
+            except Exception as exc:  # noqa: BLE001 — publish boundary logging
+                logger.error(
+                    "Auto-wired event_publisher publish failed: "
+                    "handler=%s topic=%s error_type=%s error=%s",
+                    handler_name,
+                    topic,
+                    type(exc).__name__,
+                    exc,
+                )
+
+        task.add_done_callback(_log_publish_failure)
+
+    return _publish
 
 
 def _contracts_root_for_runtime_dependencies() -> Path:
@@ -1580,7 +1636,12 @@ def _materialize_known_handler_dependencies(
     )
     requires_delegation_port = _handler_requires_delegation_dispatch_port(handler_cls)
     required_params = _required_handler_init_params(handler_cls)
-    if not required_params and not requires_delegation_port:
+    requires_event_publisher = "event_publisher" in constructor_params
+    if (
+        not required_params
+        and not requires_delegation_port
+        and not requires_event_publisher
+    ):
         return materialized_explicit_dependencies
     available = {
         name: value
@@ -1591,10 +1652,18 @@ def _materialize_known_handler_dependencies(
         )
         if value is not None
     }
+    if requires_event_publisher and event_bus is not None:
+        available["event_publisher"] = _make_sync_event_publisher(
+            event_bus=event_bus,
+            handler_name=handler_name,
+        )
     if required_params.issubset(_TOPIC_MIGRATION_EXECUTOR_DEPS):
         available.update(_build_topic_migration_executor_dependencies())
     if not (
-        required_params.intersection({"container", "ownership_query", "dispatch_port"})
+        requires_event_publisher
+        or required_params.intersection(
+            {"container", "ownership_query", "dispatch_port"}
+        )
         or ("dispatch_port" in constructor_params and requires_delegation_port)
         or required_params.issubset(_TOPIC_MIGRATION_EXECUTOR_DEPS)
     ):
@@ -1615,6 +1684,8 @@ def _materialize_known_handler_dependencies(
             )
     if not required_params <= set(available):
         return materialized_explicit_dependencies
+    if requires_event_publisher and "event_publisher" not in available:
+        return materialized_explicit_dependencies
 
     merged = dict(materialized_explicit_dependencies or {})
     handler_dependencies = dict(merged.get(handler_name, {}))
@@ -1622,6 +1693,8 @@ def _materialize_known_handler_dependencies(
         handler_dependencies.setdefault(name, available[name])
     if "dispatch_port" in constructor_params and "dispatch_port" in available:
         handler_dependencies.setdefault("dispatch_port", available["dispatch_port"])
+    if requires_event_publisher and "event_publisher" in available:
+        handler_dependencies.setdefault("event_publisher", available["event_publisher"])
     merged[handler_name] = handler_dependencies
     return merged
 
@@ -2672,6 +2745,19 @@ def _prepare_handler_wiring(
             message_types = (message_types or set()).union(topic_aliases)
 
     handler_cls = _import_handler_class(handler_ref.module, handler_ref.name)
+    handler_constructor_params = inspect.signature(handler_cls).parameters
+    if (
+        "event_publisher" in handler_constructor_params
+        and event_bus is None
+        and contract.event_bus is not None
+        and contract.event_bus.publish_topics
+    ):
+        raise ModelOnexError(
+            "handler_wiring: handler "
+            f"{handler_ref.name!r} declares event_publisher for publishing "
+            f"{tuple(contract.event_bus.publish_topics)!r}, but no runtime "
+            "event_bus was provided."
+        )
 
     # Fast path: if Phase 0 pre-resolved this handler via get_service_async,
     # skip the sync resolver's container Step 3 entirely (OMN-9410).

--- a/tests/unit/runtime/auto_wiring/test_event_publisher_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_event_publisher_injection.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for auto-wired handler event_publisher injection."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.models.errors import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
+from omnibase_core.services.service_local_handler_ownership_query import (
+    ServiceLocalHandlerOwnershipQuery,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _prepare_handler_wiring
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+
+
+class RecordingEventBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes | None, bytes]] = []
+
+    async def publish(self, topic: str, key: bytes | None, value: bytes) -> None:
+        self.published.append((topic, key, value))
+
+
+class HandlerGenerationConsumerShape:
+    """Fake with the constructor shape that regressed in OMN-12851."""
+
+    def __init__(
+        self,
+        event_publisher: Callable[[str, bytes], None] | None = None,
+    ) -> None:
+        self._event_publisher = event_publisher
+
+    async def handle(self, envelope: object) -> None:
+        if self._event_publisher is None:
+            raise AssertionError("event_publisher was not injected")
+        self._event_publisher("onex.cmd.omnimarket.node-deploy.v1", b'{"ok":true}')
+        self._event_publisher("onex.evt.platform.node-registration.v1", b'{"ok":true}')
+
+
+def _make_generation_contract() -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="node_generation_consumer",
+        node_type="EFFECT_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name="node_generation_consumer",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=("onex.cmd.omnimarket.node-generation-requested.v1",),
+            publish_topics=(
+                "onex.evt.omnimarket.node-generation-completed.v1",
+                "onex.cmd.omnimarket.node-deploy.v1",
+                "onex.evt.platform.node-registration.v1",
+            ),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerGenerationConsumer",
+                        module="omnimarket.nodes.node_generation_consumer.handlers.handler_generation_consumer",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auto_wired_optional_event_publisher_emits_side_topics() -> None:
+    contract = _make_generation_contract()
+    event_bus = RecordingEventBus()
+    resolver = ServiceHandlerResolver()
+    ownership_query = ServiceLocalHandlerOwnershipQuery(
+        local_node_names=frozenset({contract.name})
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=HandlerGenerationConsumerShape,
+    ):
+        prepared = _prepare_handler_wiring(
+            contract=contract,
+            entry=contract.handler_routing.handlers[0],  # type: ignore[union-attr]
+            dispatch_engine=None,
+            resolver=resolver,
+            ownership_query=ownership_query,
+            event_bus=event_bus,
+            container=None,
+        )
+
+    assert (
+        prepared.resolution_outcome
+        is EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
+    )
+
+    await prepared.dispatcher(
+        ModelEventEnvelope[dict[str, str]](
+            payload={"prompt": "generate a node"},
+            event_type="omnimarket.node-generation-requested",
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert event_bus.published == [
+        ("onex.cmd.omnimarket.node-deploy.v1", None, b'{"ok":true}'),
+        ("onex.evt.platform.node-registration.v1", None, b'{"ok":true}'),
+    ]
+
+
+@pytest.mark.unit
+def test_event_publisher_handler_fails_fast_without_runtime_event_bus() -> None:
+    contract = _make_generation_contract()
+    resolver = ServiceHandlerResolver()
+    ownership_query = ServiceLocalHandlerOwnershipQuery(
+        local_node_names=frozenset({contract.name})
+    )
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        return_value=HandlerGenerationConsumerShape,
+    ):
+        with pytest.raises(ModelOnexError, match="event_publisher"):
+            _prepare_handler_wiring(
+                contract=contract,
+                entry=contract.handler_routing.handlers[0],  # type: ignore[union-attr]
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership_query,
+                event_bus=None,
+                container=None,
+            )


### PR DESCRIPTION
## Summary
- inject a runtime-backed sync event_publisher for auto-wired handlers that declare event_publisher
- fail fast when an event-publishing handler is wired without a runtime event bus
- add regression coverage for the HandlerGenerationConsumer-shaped optional event_publisher path so side-emits reach the event bus instead of silently using noop defaults

## Verification
- uv run pytest tests/unit/runtime/auto_wiring/test_event_publisher_injection.py -q
- uv run pytest tests/unit/runtime/auto_wiring/test_event_publisher_injection.py tests/unit/runtime/auto_wiring/test_handler_wiring_event_type_alias.py tests/unit/runtime/auto_wiring/test_handler_wiring_payload_type_matcher.py -q
- uv run ruff format src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_event_publisher_injection.py
- uv run ruff check src/omnibase_infra/runtime/auto_wiring/handler_wiring.py tests/unit/runtime/auto_wiring/test_event_publisher_injection.py
- uv run pytest tests/unit/runtime/auto_wiring -q

Evidence-Source: OCC#2366
Evidence-Ticket: OMN-12851
