### PR TITLE
fix: probe full chat endpoint siblings [OMN-12819]

### DIFF
--- a/src/omnibase_infra/services/service_llm_endpoint_health.py
+++ b/src/omnibase_infra/services/service_llm_endpoint_health.py
@@ -37,6 +37,7 @@ import logging
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 
 import httpx
@@ -75,6 +76,7 @@ CircuitState = Literal["closed", "open", "half_open"]
 """Valid circuit breaker states for endpoint status."""
 
 _VALID_CIRCUIT_STATES: frozenset[str] = frozenset({"closed", "open", "half_open"})
+_CHAT_COMPLETIONS_PATH_SUFFIX = "/chat/completions"
 
 
 def _parse_circuit_state(
@@ -95,6 +97,30 @@ def _parse_circuit_state(
         # Why: Runtime validation guarantees the returned value matches the contract.
         return raw  # type: ignore[return-value]
     return default
+
+
+def _probe_paths(endpoint_url: str) -> tuple[str, str]:
+    """Return health and model-discovery probe URLs for an endpoint.
+
+    Some contract-owned cloud endpoints are configured as complete chat
+    completion URLs because the inference caller POSTs them verbatim. Health
+    probing still needs to hit sibling discovery paths, not append paths below
+    ``/chat/completions``.
+    """
+    parsed = urlsplit(endpoint_url)
+    path = parsed.path.rstrip("/")
+    if path.endswith(_CHAT_COMPLETIONS_PATH_SUFFIX):
+        path = path[: -len(_CHAT_COMPLETIONS_PATH_SUFFIX)]
+        health_path = f"{path}/health"
+        models_path = f"{path}/models"
+    else:
+        base_path = path.rstrip("/")
+        health_path = f"{base_path}/health"
+        models_path = f"{base_path}/v1/models"
+    return (
+        urlunsplit((parsed.scheme, parsed.netloc, health_path, "", "")),
+        urlunsplit((parsed.scheme, parsed.netloc, models_path, "", "")),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -577,24 +603,28 @@ class ServiceLlmEndpointHealth:
         client = await self._get_http_client()
         primary_error: str = ""
 
+        health_url, models_url = _probe_paths(base_url)
+
         # Primary probe: /health
         try:
-            resp = await client.get(f"{base_url.rstrip('/')}/health")
+            resp = await client.get(health_url)
             if 200 <= resp.status_code < 300:
                 return True, ""
             primary_error = f"Primary /health: HTTP {resp.status_code}"
         except Exception as exc:  # noqa: BLE001 — boundary: returns degraded response
             primary_error = f"Primary /health: {type(exc).__name__}"
 
-        # Fallback probe: /v1/models (vLLM-style)
+        # Fallback probe: model discovery.
         try:
-            resp = await client.get(f"{base_url.rstrip('/')}/v1/models")
+            resp = await client.get(models_url)
             if 200 <= resp.status_code < 300:
                 return True, ""
-            fallback_error = f"Fallback /v1/models: HTTP {resp.status_code}"
+            if resp.status_code in {401, 403}:
+                return True, ""
+            fallback_error = f"Fallback model discovery: HTTP {resp.status_code}"
             return False, f"{primary_error}; {fallback_error}"
         except httpx.HTTPError as exc:
-            fallback_error = f"Fallback /v1/models: {type(exc).__name__}"
+            fallback_error = f"Fallback model discovery: {type(exc).__name__}"
             return False, f"{primary_error}; {fallback_error}"
 
     async def _emit_health_event(

--- a/tests/unit/services/test_service_llm_endpoint_health.py
+++ b/tests/unit/services/test_service_llm_endpoint_health.py
@@ -493,6 +493,65 @@ class TestServiceLlmEndpointHealthProbe:
             assert status.available is True
 
     @pytest.mark.asyncio
+    async def test_probe_full_chat_completion_url_uses_sibling_models_path(
+        self,
+        mock_event_bus: AsyncMock,
+    ) -> None:
+        """Complete chat URLs must not be probed as /chat/completions/v1/models."""
+        cfg = ModelLlmEndpointHealthConfig(
+            endpoints={
+                "cloud-glm": ("https://api.z.ai/api/coding/paas/v4/chat/completions")
+            },
+            probe_interval_seconds=5.0,
+            probe_timeout_seconds=2.0,
+        )
+        service = ServiceLlmEndpointHealth(config=cfg, event_bus=mock_event_bus)
+        seen_urls: list[str] = []
+
+        async def mock_get(url: str, **kwargs: object) -> httpx.Response:
+            seen_urls.append(url)
+            if url.endswith("/health"):
+                return httpx.Response(404, request=httpx.Request("GET", url))
+            return httpx.Response(200, request=httpx.Request("GET", url))
+
+        with patch.object(httpx.AsyncClient, "get", side_effect=mock_get):
+            status_map = await service.probe_all()
+
+        assert status_map["cloud-glm"].available is True
+        assert seen_urls == [
+            "https://api.z.ai/api/coding/paas/v4/health",
+            "https://api.z.ai/api/coding/paas/v4/models",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_probe_auth_gated_models_endpoint_does_not_open_circuit(
+        self,
+        mock_event_bus: AsyncMock,
+    ) -> None:
+        """401/403 model discovery proves cloud reachability without poisoning route health."""
+        cfg = ModelLlmEndpointHealthConfig(
+            endpoints={
+                "cloud-glm": ("https://api.z.ai/api/coding/paas/v4/chat/completions")
+            },
+            probe_interval_seconds=5.0,
+            probe_timeout_seconds=2.0,
+            circuit_breaker_threshold=1,
+        )
+        service = ServiceLlmEndpointHealth(config=cfg, event_bus=mock_event_bus)
+
+        async def mock_get(url: str, **kwargs: object) -> httpx.Response:
+            status_code = 401 if url.endswith("/models") else 404
+            return httpx.Response(status_code, request=httpx.Request("GET", url))
+
+        with patch.object(httpx.AsyncClient, "get", side_effect=mock_get):
+            status_map = await service.probe_all()
+
+        status = status_map["cloud-glm"]
+        assert status.available is True
+        assert status.error == ""
+        assert status.circuit_state == "closed"
+
+    @pytest.mark.asyncio
     async def test_probe_both_fail(
         self,
         service: ServiceLlmEndpointHealth,


### PR DESCRIPTION
## Summary

Follow-up for OMN-12819 source-backed stability replay. The merged GLM contract and renderer fixes produced the correct `cloud-glm` endpoint, but the runtime LLM endpoint health checker appended `/health` and `/v1/models` below the complete `/chat/completions` URL. That opened the `llm-endpoint.glm` circuit before the actual authenticated inference path could run.

This PR makes the health checker derive sibling probe paths for complete chat-completion URLs and treats authenticated model-discovery `401/403` responses as reachable for health-circuit purposes. Inference auth remains enforced by the inference effect.

Evidence-Ticket: OMN-12819
Evidence-Source: OCC#2380

## Verification

- `uv run ruff format src/omnibase_infra/services/service_llm_endpoint_health.py tests/unit/services/test_service_llm_endpoint_health.py`
- `uv run ruff check src/omnibase_infra/services/service_llm_endpoint_health.py tests/unit/services/test_service_llm_endpoint_health.py`
- `uv run pytest tests/unit/services/test_service_llm_endpoint_health.py -q` -> `65 passed`
