### PR TITLE
fix(OMN-12865): validate generated stability compose

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -8,6 +8,7 @@ core:
     - redpanda
     - valkey
     - infisical
+    - keycloak
   includes: []
   inject_env:
     INFISICAL_ADDR: "http://infisical:8080"
@@ -53,6 +54,7 @@ runtime-observability-projections:
     - decision-store-consumer
     - omnimarket-projection-delegation
     - infra-routing-decisions-consumer
+    - projection-api
   includes: []
   inject_env: {}
   inject_required_env:

--- a/docker/catalog/services/keycloak.yaml
+++ b/docker/catalog/services/keycloak.yaml
@@ -4,18 +4,19 @@ image: quay.io/keycloak/keycloak:26.3.3
 layer: infrastructure
 container_name: omnibase-infra-keycloak
 required_env:
-  - KC_DB_PASSWORD
+  - POSTGRES_PASSWORD
 hardcoded_env:
   KC_DB: postgres
   KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
   KC_DB_USERNAME: postgres
+  KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
   KC_HTTP_ENABLED: 'true'
   KC_HTTP_PORT: '8080'
   KC_HOSTNAME_STRICT: 'false'
   KC_LOG_LEVEL: INFO
 operational_defaults:
   KC_BOOTSTRAP_ADMIN_USERNAME: admin
-  KC_BOOTSTRAP_ADMIN_PASSWORD: keycloak-dev-password
+  KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-keycloak-dev-password}
 ports:
   external: 28080
   internal: 8080

--- a/docker/catalog/services/projection-api.yaml
+++ b/docker/catalog/services/projection-api.yaml
@@ -1,6 +1,6 @@
 name: projection-api
 description: OmniMarket projection API server for reducer-owned projection snapshots (OMN-11542)
-image: omnibase-infra-runtime:latest
+image: runtime:latest
 layer: runtime
 container_name: omnimarket-projection-api
 required_env:

--- a/docker/migrations/forward/042_create_keycloak_db.sql
+++ b/docker/migrations/forward/042_create_keycloak_db.sql
@@ -1,8 +1,6 @@
+-- onex-create-database: keycloak
 -- Ensure warm Postgres volumes have the Keycloak database before the
--- keycloak service starts. The forward-migration runner executes SQL files
--- with psql, so \gexec can run CREATE DATABASE outside a transaction while
--- remaining idempotent.
-SELECT 'CREATE DATABASE keycloak'
-WHERE NOT EXISTS (
-    SELECT FROM pg_database WHERE datname = 'keycloak'
-)\gexec
+-- keycloak service starts. The migration runners interpret the directive
+-- above before executing this SQL body so the file stays valid SQL for both
+-- psql and asyncpg-based migration paths.
+SELECT 1;

--- a/docker/migrations/forward/042_create_keycloak_db.sql
+++ b/docker/migrations/forward/042_create_keycloak_db.sql
@@ -1,9 +1,8 @@
--- Placeholder: keycloak database creation is handled by provision-keycloak.py
--- (or by docker-entrypoint-initdb.d on fresh volumes). CREATE DATABASE cannot
--- run inside a transaction block, so it is not executable by the migration
--- runner. This file reserves migration number 041 for documentation purposes.
-DO $$
-BEGIN
-  RAISE NOTICE 'Migration 041: keycloak DB creation handled by provision-keycloak.py (no-op in migration runner)';
-END
-$$;
+-- Ensure warm Postgres volumes have the Keycloak database before the
+-- keycloak service starts. The forward-migration runner executes SQL files
+-- with psql, so \gexec can run CREATE DATABASE outside a transaction while
+-- remaining idempotent.
+SELECT 'CREATE DATABASE keycloak'
+WHERE NOT EXISTS (
+    SELECT FROM pg_database WHERE datname = 'keycloak'
+)\gexec

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:346828d964405807b1a23c27d9f00a7ad15c3cb488c4585549be9f2a36c02669
-generated_at: 2026-06-09T17:32:10Z
+sha256:dc4b265ba91d2d28ca02b75546cf73f4c05be55e8a3ecd27585653959a19c734
+generated_at: 2026-06-09T17:45:31Z
 migration_file_count: 70

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:d887aceeeaca141904e97bb17eb8205df8bf5bca05b7e9da17f8d8ec0c3acaa4
-generated_at: 2026-06-03T20:02:52Z
+sha256:346828d964405807b1a23c27d9f00a7ad15c3cb488c4585549be9f2a36c02669
+generated_at: 2026-06-09T17:32:10Z
 migration_file_count: 70

--- a/scripts/deploy-agent/deploy_agent/agent.py
+++ b/scripts/deploy-agent/deploy_agent/agent.py
@@ -183,6 +183,7 @@ class DeployAgent:
             self.executor.compose_gen(
                 SCOPE_BUNDLES.get(cmd.scope, ["core", "runtime"]),
                 on_phase_update=on_phase_update,
+                lane=cmd.runtime_lane,
             )
 
             # Seed Infisical before containers start (non-fatal)

--- a/scripts/deploy-agent/deploy_agent/executor.py
+++ b/scripts/deploy-agent/deploy_agent/executor.py
@@ -697,7 +697,13 @@ class DeployExecutor:
         on_phase_update(Phase.GIT, PhaseStatus.SUCCESS)
         return sha
 
-    def compose_gen(self, bundles: list[str], on_phase_update: PhaseCallback) -> None:
+    def compose_gen(
+        self,
+        bundles: list[str],
+        on_phase_update: PhaseCallback,
+        *,
+        lane: EnumRuntimeLane = EnumRuntimeLane.DEV,
+    ) -> None:
         """Regenerate docker-compose.infra.yml from the catalog CLI.
 
         Runs ``uv run python -m omnibase_infra.docker.catalog.cli generate
@@ -741,6 +747,31 @@ class DeployExecutor:
             )
         else:
             logger.info("compose_gen complete: %s", result.stdout.strip())
+            profile = "runtime" if "runtime" in selected else "core"
+            config = lane_config_for(lane)
+            validate_cmd = [
+                "docker",
+                "compose",
+                *_compose_file_args(lane),
+                "-p",
+                config.compose_project,
+                "--profile",
+                profile,
+                "config",
+                "--quiet",
+            ]
+            validate_result = _run(
+                validate_cmd,
+                timeout=timeout,
+                cwd=REPO_DIR,
+                env=_compose_env(),
+            )
+            if validate_result.returncode != 0:
+                raise RuntimeError(
+                    "compose_gen produced invalid lane compose for "
+                    f"{lane.value}: "
+                    f"{validate_result.stderr.strip() or validate_result.stdout.strip()}"
+                )
 
         on_phase_update(Phase.COMPOSE_GEN, PhaseStatus.SUCCESS)
 

--- a/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
@@ -52,6 +52,7 @@ def test_compose_env_loads_contract_rendered_runtime_policy(
     assert env["DEV_RUNTIME_MAIN_CAPABILITIES"] == "market.skill-proof,runtime.main"
 
 
+@pytest.mark.unit
 class TestComposeGen:
     """compose_gen must invoke catalog CLI and write to COMPOSE_FILE."""
 

--- a/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
+++ b/scripts/deploy-agent/tests/unit/test_executor_compose_gen.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from deploy_agent.events import Phase, PhaseStatus, Scope
+from deploy_agent.events import EnumRuntimeLane, Phase, PhaseStatus, Scope
 from deploy_agent.executor import SCOPE_BUNDLES, DeployExecutor, _compose_env
 
 
@@ -127,18 +127,19 @@ class TestComposeGen:
         from deploy_agent.executor import REPO_DIR
 
         executor = DeployExecutor()
-        captured_env: dict[str, str] = {}
+        captured_envs: list[dict[str, str]] = []
         monkeypatch.setenv("PYTHONPATH", "/stale/canonical/src")
 
         def fake_run(
             cmd: list[str], timeout: int, **kwargs
         ) -> subprocess.CompletedProcess:
-            captured_env.update(kwargs["env"])
+            captured_envs.append(kwargs["env"])
             return _make_result()
 
         with patch("deploy_agent.executor._run", side_effect=fake_run):
             executor.compose_gen(["core", "runtime"], _noop_phase_update)
 
+        captured_env = captured_envs[0]
         assert captured_env["PYTHONPATH"].split(":")[:2] == [
             f"{REPO_DIR}/src",
             "/stale/canonical/src",
@@ -181,6 +182,62 @@ class TestComposeGen:
             Phase.COMPOSE_GEN,
             PhaseStatus.SUCCESS,
         ) in phase_updates, "Expected SUCCESS update for COMPOSE_GEN"
+
+    def test_compose_gen_validates_generated_lane_compose(self) -> None:
+        """A successful compose_gen must validate the lane compose artifact."""
+        executor = DeployExecutor()
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(cmd)
+            return _make_result()
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            executor.compose_gen(
+                ["core", "runtime"],
+                _noop_phase_update,
+                lane=EnumRuntimeLane.STABILITY_TEST,
+            )
+
+        validate_cmd = captured_cmds[1]
+        assert validate_cmd[:2] == ["docker", "compose"]
+        assert "docker-compose.stability-test.yml" in " ".join(validate_cmd)
+        assert "--profile" in validate_cmd
+        assert validate_cmd[validate_cmd.index("--profile") + 1] == "runtime"
+        assert validate_cmd[-2:] == ["config", "--quiet"]
+
+    def test_compose_gen_rejects_invalid_generated_lane_compose(self) -> None:
+        """compose_gen must fail before deploy effects if validation fails."""
+        executor = DeployExecutor()
+        phase_updates: list[tuple[Phase, PhaseStatus]] = []
+
+        def track_updates(phase: Phase, status: PhaseStatus) -> None:
+            phase_updates.append((phase, status))
+
+        results = [
+            _make_result(stdout="generated"),
+            _make_result(returncode=1, stderr="service x has neither image nor build"),
+        ]
+
+        def fake_run(
+            cmd: list[str], timeout: int, **kwargs
+        ) -> subprocess.CompletedProcess:
+            return results.pop(0)
+
+        with patch("deploy_agent.executor._run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="invalid lane compose"):
+                executor.compose_gen(
+                    ["core", "runtime"],
+                    track_updates,
+                    lane=EnumRuntimeLane.STABILITY_TEST,
+                )
+
+        assert (
+            Phase.COMPOSE_GEN,
+            PhaseStatus.SUCCESS,
+        ) not in phase_updates
 
     def test_scope_bundles_covers_all_scopes(self) -> None:
         """SCOPE_BUNDLES must have an entry for every Scope value."""

--- a/scripts/run-forward-migrations.sh
+++ b/scripts/run-forward-migrations.sh
@@ -63,13 +63,17 @@ validate_database_identifier() {
 
 ensure_directive_database() {
   migration_file="$1"
-  database="$(
-    sed -n -E 's/^--[[:space:]]*onex-create-database:[[:space:]]*([A-Za-z_][A-Za-z0-9_-]*)[[:space:]]*$/\1/p' "$migration_file" \
-      | head -1
+  directive_line="$(
+    grep -i -m 1 -E '^--[[:space:]]*onex-create-database[[:space:]]*:' "$migration_file" || true
   )"
-  if [ -z "$database" ]; then
+  if [ -z "$directive_line" ]; then
     return 0
   fi
+
+  database="$(
+    printf '%s\n' "$directive_line" \
+      | sed -E 's/^--[[:space:]]*onex-create-database[[:space:]]*:[[:space:]]*//; s/[[:space:]]*$//'
+  )"
   validate_database_identifier "$database"
   echo "[forward-migration]   ensure database ${database}..."
   psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -v ON_ERROR_STOP=1 <<-EOSQL

--- a/scripts/run-forward-migrations.sh
+++ b/scripts/run-forward-migrations.sh
@@ -53,6 +53,31 @@ NODE_PGDB="${NODE_POSTGRES_DB:-${PGDB}}"
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
+validate_database_identifier() {
+  database="$1"
+  if ! printf '%s' "$database" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]*$'; then
+    echo "[forward-migration] invalid database identifier in migration directive: ${database}" >&2
+    exit 1
+  fi
+}
+
+ensure_directive_database() {
+  migration_file="$1"
+  database="$(
+    sed -n -E 's/^--[[:space:]]*onex-create-database:[[:space:]]*([A-Za-z_][A-Za-z0-9_-]*)[[:space:]]*$/\1/p' "$migration_file" \
+      | head -1
+  )"
+  if [ -z "$database" ]; then
+    return 0
+  fi
+  validate_database_identifier "$database"
+  echo "[forward-migration]   ensure database ${database}..."
+  psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -v ON_ERROR_STOP=1 <<-EOSQL
+    SELECT 'CREATE DATABASE "$database"'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$database')\gexec
+EOSQL
+}
+
 # ---------------------------------------------------------------------------
 # 1. Ensure schema_migrations tracking table exists (idempotent)
 # ---------------------------------------------------------------------------
@@ -92,6 +117,7 @@ for migration_file in $(ls "${MIGRATIONS_DIR}"/*.sql | sort); do
   echo "[forward-migration]   apply ${filename}..."
 
   # Apply migration then record in tracking table
+  ensure_directive_database "$migration_file"
   psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
     -v ON_ERROR_STOP=1 -f "$migration_file"
 

--- a/scripts/run-migrations.py
+++ b/scripts/run-migrations.py
@@ -37,6 +37,10 @@ CREATE_DATABASE_DIRECTIVE = re.compile(
     r"^--\s*onex-create-database:\s*([A-Za-z_][A-Za-z0-9_-]*)\s*$",
     re.IGNORECASE,
 )
+CREATE_DATABASE_DIRECTIVE_PREFIX = re.compile(
+    r"^--\s*onex-create-database\s*:",
+    re.IGNORECASE,
+)
 
 
 def extract_sequence_number(filename: str) -> int:
@@ -126,7 +130,7 @@ def parse_create_database_directive(sql: str) -> tuple[str | None, str]:
                 database = match.group(1)
                 validate_database_identifier(database)
                 continue
-            if stripped.lower().startswith("-- onex-create-database:"):
+            if CREATE_DATABASE_DIRECTIVE_PREFIX.match(stripped):
                 raise ValueError(f"invalid database name in directive: {stripped!r}")
         remaining.append(line)
 

--- a/scripts/run-migrations.py
+++ b/scripts/run-migrations.py
@@ -33,6 +33,10 @@ MIGRATION_SETS = [
     ("docker", REPO_ROOT / "docker" / "migrations" / "forward"),
     ("src", REPO_ROOT / "src" / "omnibase_infra" / "migrations" / "forward"),
 ]
+CREATE_DATABASE_DIRECTIVE = re.compile(
+    r"^--\s*onex-create-database:\s*([A-Za-z_][A-Za-z0-9_-]*)\s*$",
+    re.IGNORECASE,
+)
 
 
 def extract_sequence_number(filename: str) -> int:
@@ -100,6 +104,33 @@ def parse_connect_directive(sql: str) -> tuple[str | None, str]:
         remaining.append(line)
 
     return target_database, "".join(remaining)
+
+
+def parse_create_database_directive(sql: str) -> tuple[str | None, str]:
+    """Return optional database creation directive and SQL without the directive.
+
+    ``-- onex-create-database: <database>`` is migration metadata consumed by
+    both the Python runner and the shell forward-migration runner. The directive
+    keeps database creation idempotent without embedding psql-only meta commands
+    such as ``\\gexec`` in migrations that CI applies through asyncpg.
+    """
+
+    remaining: list[str] = []
+    database: str | None = None
+
+    for line in sql.splitlines(keepends=True):
+        stripped = line.strip()
+        if database is None:
+            match = CREATE_DATABASE_DIRECTIVE.match(stripped)
+            if match:
+                database = match.group(1)
+                validate_database_identifier(database)
+                continue
+            if stripped.lower().startswith("-- onex-create-database:"):
+                raise ValueError(f"invalid database name in directive: {stripped!r}")
+        remaining.append(line)
+
+    return database, "".join(remaining)
 
 
 def validate_database_identifier(database: str) -> None:
@@ -253,14 +284,20 @@ async def apply_migration(
     source_set: str,
     path: Path,
     dry_run: bool,
+    *,
+    base_conn: asyncpg.Connection | None = None,
 ) -> None:
     mid = migration_id(source_set, path.name)
     _, sql = parse_connect_directive(path.read_text())
+    create_database, sql = parse_create_database_directive(sql)
     checksum = file_checksum(path)
 
     if dry_run:
         print(f"  [dry-run] would apply: {mid}")
         return
+
+    if create_database is not None:
+        await ensure_database_exists(base_conn or conn, create_database)
 
     # Migrations that use CREATE INDEX CONCURRENTLY cannot run inside an implicit
     # transaction block (which Postgres creates when you send multiple statements
@@ -347,7 +384,13 @@ async def run(db_url: str, dry_run: bool, target: int | None) -> int:
         print(f"Applying {len(pending)} pending migration(s)...")
         for _, source_set, path, target_database in pending:
             conn = base_conn if dry_run else await _conn_for_database(target_database)
-            await apply_migration(conn, source_set, path, dry_run)
+            await apply_migration(
+                conn,
+                source_set,
+                path,
+                dry_run,
+                base_conn=base_conn,
+            )
 
         return len(pending)
     finally:

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -178,9 +178,19 @@ def _docker_compose_available() -> bool:
 
 
 def _compose_render_env() -> dict[str, str]:
+    python_path = os.pathsep.join(
+        path
+        for path in (
+            str(REPO_ROOT / "src"),
+            str(REPO_ROOT),
+            os.environ.get("PYTHONPATH", ""),
+        )
+        if path
+    )
     return {
         "HOME": os.environ.get("HOME", ""),
         "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": python_path,
         "USER": os.environ.get("USER", ""),
         **COMPOSE_RENDER_ENV,
     }

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -111,8 +111,11 @@ COMPOSE_RENDER_ENV = {
     "INFISICAL_DB_CONNECTION_URI": "postgresql://postgres:postgres@postgres:5432/infisical",
     "INFISICAL_ENCRYPTION_KEY": "render-only-infisical-encryption-key-32",
     "INFISICAL_REDIS_URL": "redis://:render-only-valkey-password@valkey:6379",
+    "CI_CALLBACK_TOKEN": "deploy-agent-compose-parse-only",
     "GITHUB_TOKEN": "render-only-github-token",
+    "KEYCLOAK_ADMIN_CLIENT_SECRET": "render-only-admin-client-secret",
     "LINEAR_API_KEY": "render-only-linear-api-key",
+    "LINEAR_WEBHOOK_SECRET": "deploy-agent-compose-parse-only",
     "LLM_CODER_FAST_URL": _http_url("llm-coder-fast.invalid"),
     "LLM_CODER_URL": _http_url("llm-coder.invalid"),
     "LLM_DEEPSEEK_R1_URL": _http_url("llm-deepseek.invalid"),
@@ -128,11 +131,20 @@ COMPOSE_RENDER_ENV = {
     "ONEX_INFRA_HOST": "192.168.86.201",
     "ONEX_INFRA_USER": "jonah",
     "ONEX_SERVICE_CLIENT_SECRET": "render-only-client-secret",
+    "OMNIBASE_INFRA_INJECTION_EFFECTIVENESS_POSTGRES_DSN": (
+        "postgresql://postgres:postgres@postgres:5432/omnidash_analytics"
+    ),
+    "OMNIDASH_ANALYTICS_DB_URL": (
+        "postgresql://postgres:postgres@postgres:5432/omnidash_analytics"
+    ),
     "POSTGRES_PASSWORD": "postgres",
     "REDPANDA_ADVERTISE_HOST": "192.168.86.201",
     "STABILITY_TEST_POSTGRES_EXTERNAL_PORT": "15436",
     "STABILITY_TEST_VALKEY_EXTERNAL_PORT": "26379",
     "STABILITY_TEST_KEYCLOAK_EXTERNAL_PORT": "38080",
+    "VALKEY_PASSWORD": "render-only-valkey-password",
+    "WAITLIST_NOTIFIER_SLACK_BOT_TOKEN": "deploy-agent-compose-parse-only",
+    "WAITLIST_NOTIFIER_SLACK_CHANNEL_ID": "deploy-agent-compose-parse-only",
 }
 
 
@@ -224,6 +236,68 @@ def test_stability_lane_runtime_services_render_with_runtime_profile() -> None:
 
     assert rendered_services == EXPECTED_RENDERED_SERVICES
     assert rendered_services.isdisjoint(OUT_OF_LANE_SERVICES)
+
+
+@pytest.mark.integration
+def test_stability_lane_catalog_generated_runtime_compose_is_valid(
+    tmp_path: Path,
+) -> None:
+    """Deploy-agent compose_gen output must validate with the stability overlay."""
+    generated_compose = tmp_path / "docker-compose.generated.yml"
+    generate_result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "omnibase_infra.docker.catalog.cli",
+            "generate",
+            "core",
+            "runtime",
+            "--output",
+            str(generated_compose),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        env=_compose_render_env(),
+        text=True,
+    )
+    assert generate_result.returncode == 0, generate_result.stderr
+
+    compose_prefix = [
+        "docker",
+        "compose",
+        "--env-file",
+        "docker/runtime-policy.env",
+        "-f",
+        str(generated_compose),
+        "-f",
+        COMPOSE_FILES[1],
+        "--profile",
+        "runtime",
+    ]
+    validate_result = subprocess.run(
+        [*compose_prefix, "config", "--quiet"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        env=_compose_render_env(),
+        text=True,
+    )
+    assert validate_result.returncode == 0, validate_result.stderr
+
+    services_result = subprocess.run(
+        [*compose_prefix, "config", "--services"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        env=_compose_render_env(),
+        text=True,
+    )
+    assert services_result.returncode == 0, services_result.stderr
+    rendered_services = set(services_result.stdout.splitlines())
+    assert EXPECTED_RENDERED_SERVICES.issubset(rendered_services)
 
 
 @pytest.mark.integration

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -246,9 +247,7 @@ def test_stability_lane_catalog_generated_runtime_compose_is_valid(
     generated_compose = tmp_path / "docker-compose.generated.yml"
     generate_result = subprocess.run(
         [
-            "uv",
-            "run",
-            "python",
+            sys.executable,
             "-m",
             "omnibase_infra.docker.catalog.cli",
             "generate",

--- a/tests/unit/infra/test_runtime_bundle_decomposition.py
+++ b/tests/unit/infra/test_runtime_bundle_decomposition.py
@@ -151,10 +151,16 @@ def test_union_of_sub_bundles_equals_original_runtime() -> None:
     # set comes from resolving `runtime`.
     resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
     resolved = resolver.resolve(bundles=["runtime"])
-    # Exclude core-bundle services (postgres/redpanda/valkey/infisical) from
-    # the comparison — those come from `includes: [core]`, not from runtime
+    # Exclude services that come from `includes: [core]`, not from runtime
     # decomposition.
-    core_services = {"postgres", "redpanda", "valkey", "infisical", "phoenix"}
+    core_services = {
+        "postgres",
+        "redpanda",
+        "valkey",
+        "infisical",
+        "phoenix",
+        "keycloak",
+    }
     runtime_services_resolved = resolved.service_names - core_services
     assert union == runtime_services_resolved, (
         f"decomposition drift: union={sorted(union)}, "

--- a/tests/unit/migrations/test_keycloak_db_migration.py
+++ b/tests/unit/migrations/test_keycloak_db_migration.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression guard for Keycloak warm-volume database provisioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+KEYCLOAK_MIGRATION = (
+    REPO_ROOT / "docker" / "migrations" / "forward" / "042_create_keycloak_db.sql"
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_keycloak_database_migration_is_executable_not_placeholder() -> None:
+    sql = KEYCLOAK_MIGRATION.read_text(encoding="utf-8")
+
+    assert "CREATE DATABASE keycloak" in sql
+    assert "WHERE NOT EXISTS" in sql
+    assert "\\gexec" in sql
+    assert "no-op" not in sql.lower()

--- a/tests/unit/migrations/test_keycloak_db_migration.py
+++ b/tests/unit/migrations/test_keycloak_db_migration.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.unit
 def test_keycloak_database_migration_is_executable_not_placeholder() -> None:
     sql = KEYCLOAK_MIGRATION.read_text(encoding="utf-8")
 
-    assert "CREATE DATABASE keycloak" in sql
-    assert "WHERE NOT EXISTS" in sql
-    assert "\\gexec" in sql
+    assert "-- onex-create-database: keycloak" in sql
+    assert "SELECT 1;" in sql
     assert "no-op" not in sql.lower()
+    assert "\\gexec" not in sql

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -148,6 +148,40 @@ class TestNamespacedDiscoveryWiring:
         # Node files are tracked as node:<node>:<filename>.
         assert 'migration_id="node:${node_name}:${filename}"' in script
 
+    def test_runner_rejects_malformed_create_database_directive(
+        self, tmp_path: Path
+    ) -> None:
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        (migrations_dir / "001_bad_directive.sql").write_text(
+            "--   onex-create-database: bad/name\nSELECT 1;\n",
+            encoding="utf-8",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        psql = bin_dir / "psql"
+        psql.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        psql.chmod(0o755)
+
+        result = subprocess.run(
+            ["sh", str(RUNNER)],
+            check=False,
+            env={
+                **os.environ,
+                "MIGRATIONS_DIR": str(migrations_dir),
+                "NODE_MIGRATIONS_DIR": str(tmp_path / "no-node-migrations"),
+                "POSTGRES_PASSWORD": "postgres",
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            },
+            text=True,
+            capture_output=True,
+        )
+
+        assert result.returncode == 1
+        assert "invalid database identifier in migration directive: bad/name" in (
+            result.stderr
+        )
+
 
 class TestSyncedNodesAllowlist:
     """The allowlist file scopes which node migrations are vendored."""

--- a/tests/unit/scripts/test_run_migrations.py
+++ b/tests/unit/scripts/test_run_migrations.py
@@ -118,3 +118,11 @@ class TestCreateDatabaseDirective:
             runner.parse_create_database_directive(
                 "-- onex-create-database: bad/name\nSELECT 1;"
             )
+
+    def test_rejects_whitespace_variant_invalid_create_database_directive(self):
+        runner = load_runner()
+
+        with pytest.raises(ValueError, match="invalid database name"):
+            runner.parse_create_database_directive(
+                "--   onex-create-database: bad/name\nSELECT 1;"
+            )

--- a/tests/unit/scripts/test_run_migrations.py
+++ b/tests/unit/scripts/test_run_migrations.py
@@ -97,3 +97,24 @@ class TestConnectDirective:
             runner.database_url_for_database(db_url, "omnidash_analytics")
             == "postgresql://user:pass@example.test:5432/omnidash_analytics?sslmode=prefer"
         )
+
+
+@pytest.mark.unit
+class TestCreateDatabaseDirective:
+    def test_extracts_create_database_directive(self):
+        runner = load_runner()
+        sql = "-- onex-create-database: keycloak\nSELECT 1;"
+
+        database, cleaned = runner.parse_create_database_directive(sql)
+
+        assert database == "keycloak"
+        assert "onex-create-database" not in cleaned
+        assert "SELECT 1;" in cleaned
+
+    def test_rejects_invalid_create_database_directive(self):
+        runner = load_runner()
+
+        with pytest.raises(ValueError, match="invalid database name"):
+            runner.parse_create_database_directive(
+                "-- onex-create-database: bad/name\nSELECT 1;"
+            )


### PR DESCRIPTION
## Summary
- Align catalog runtime/core generation with services the stability-test overlay is allowed to override (`keycloak`, `projection-api`).
- Bring catalog Keycloak/projection-api manifests back in line with runtime compose identity.
- Make deploy-agent validate the generated lane compose artifact with `docker compose config --quiet` before build/up.
- Add regression coverage for catalog-generated stability compose, not only checked-in source compose.
- Make the warm-volume forward migration create the Keycloak database before the Keycloak service starts using runner-native migration directives.

## Verification
- `uv run python scripts/check_schema_fingerprint.py stamp && uv run python scripts/check_schema_fingerprint.py verify`
- `uv run ruff check scripts/run-migrations.py scripts/deploy-agent/deploy_agent/agent.py scripts/deploy-agent/deploy_agent/executor.py scripts/deploy-agent/tests/unit/test_executor_compose_gen.py tests/unit/scripts/test_run_migrations.py tests/unit/migrations/test_keycloak_db_migration.py tests/unit/infra/test_runtime_bundle_decomposition.py tests/integration/infra/test_stability_test_runtime_compose_render.py`
- `uv run pytest tests/unit/scripts/test_run_migrations.py tests/unit/migrations/test_keycloak_db_migration.py tests/unit/infra/test_runtime_bundle_decomposition.py tests/integration/infra/test_stability_test_runtime_compose_render.py -q` (`34 passed`)
- `uv run python -m omnibase_infra.docker.catalog.cli generate core runtime --output /tmp/omn-12865-generated-current.yml && docker compose --env-file docker/runtime-policy.env -f /tmp/omn-12865-generated-current.yml -f docker/docker-compose.stability-test.yml -p omnibase-infra-stability-test --profile runtime config --quiet`

## Lane Order
- No stability mutation from this PR.
- Post-merge runtime order is dev proof first, stability only after dev is clear and working, prod last.

Evidence-Source: OCC#2401
Evidence-Ticket: OMN-12865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak authentication service now included in core infrastructure bundle
  * Projection API service added to runtime observability bundle

* **Chores**
  * Enhanced Keycloak password configuration management with environment variable support
  * Improved deployment validation for lane-specific configurations
  * Added database migration infrastructure for service provisioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->