### PR TITLE
chore(OMN-12673): bump omnibase_infra workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   # .evidence/), heavy jobs (test-parallel, migration-integration) skip, while
   # lint, validators, contract gates, and receipt-gate callers still run.
   zone-filter:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/zone-filter.yml@a1e73fff25a05ccb37cbb92d9c91754c59d808c0
+    uses: OmniNode-ai/omnibase_core/.github/workflows/zone-filter.yml@b4a423efb853fdfdfb821ae6af5c7a694a585e36
     with:
       python-version: "3.12"
 

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Clone omnibase_core (provides the receipt-honesty validator)
         run: git clone --depth=1 https://github.com/OmniNode-ai/omnibase_core.git ../omnibase_core
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - name: Set up Python 3.12


### PR DESCRIPTION
Ticket: OMN-12673

## Summary
- bump astral-sh/setup-uv from v4 to v7 in receipt-honesty workflow
- bump the shared omnibase_core zone-filter workflow ref
- replace stock Dependabot PRs #1918 and #1919 with an OMN-bound branch for Receipt Gate

## Verification
- env LC_ALL=C LANG=C uv run pre-commit run --files .github/workflows/ci.yml .github/workflows/receipt-honesty.yml

Note: generic validate-yaml is contract-schema specific and does not apply to GitHub workflow files.

Evidence-Source: OCC#2413
Evidence-Ticket: OMN-12673
