### PR TITLE
fix(OMN-12917): discover contract topics from installed marketplace packages

### DIFF
--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -31,24 +31,14 @@ from pydantic import BaseModel
 
 from omnibase_infra.utils.util_runtime_packages import (
     get_active_runtime_packages,
-    is_runtime_package_active,
+    normalize_runtime_package_name,
 )
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants / allowlists
+# Constants
 # ---------------------------------------------------------------------------
-
-_APPROVED_PACKAGES: tuple[str, ...] = (
-    "omnibase_core",
-    "omnibase_infra",
-    "omnibase_spi",
-    "omniintelligence",
-    "omnimemory",
-    "omniclaude",
-    "omnimarket",
-)
 
 _VALID_KINDS: frozenset[str] = frozenset({"evt", "cmd", "intent", "dlq"})
 _VALID_DLQ_CATEGORIES: frozenset[str] = frozenset({"intents", "events", "commands"})
@@ -405,6 +395,35 @@ def _find_package_root(
     return None
 
 
+def _entry_point_package_name(value: str) -> str | None:
+    """Return the top-level package name from an entry-point value."""
+
+    module_path = value.split(":", 1)[0].strip()
+    if not module_path:
+        return None
+    return module_path.split(".", 1)[0]
+
+
+def _discover_installed_topic_packages() -> tuple[str, ...]:
+    """Discover installed packages that can own contract-declared topics."""
+
+    active_packages = get_active_runtime_packages()
+    if active_packages is not None:
+        return tuple(sorted(active_packages))
+
+    candidates: set[str] = set()
+
+    for ep in importlib.metadata.entry_points(group="onex.node_package"):
+        candidates.add(normalize_runtime_package_name(ep.name))
+
+    for ep in importlib.metadata.entry_points(group="onex.nodes"):
+        package_name = _entry_point_package_name(ep.value)
+        if package_name is not None:
+            candidates.add(normalize_runtime_package_name(package_name))
+
+    return tuple(sorted(candidates))
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -419,7 +438,8 @@ class ContractTopicExtractor:
 
     Args:
         include_installed_packages: When True, ``extract_all()`` will also
-            discover contracts from approved installed packages via importlib.
+            discover contracts from installed ONEX runtime packages via
+            importlib metadata.
     """
 
     def __init__(self, *, include_installed_packages: bool = False) -> None:
@@ -655,12 +675,12 @@ class ContractTopicExtractor:
 
     def extract_from_installed_packages(
         self,
-        approved_packages: tuple[str, ...] = _APPROVED_PACKAGES,
+        packages: tuple[str, ...] | None = None,
     ) -> list[ModelContractTopicEntry]:
-        """Extract topics from contract.yaml files in approved installed packages.
+        """Extract topics from contract.yaml files in installed ONEX packages.
 
         Uses ``importlib.metadata`` and ``importlib.resources`` to discover
-        contract YAML files bundled inside approved packages.  Works with both
+        contract YAML files bundled inside runtime packages.  Works with both
         editable installs (``pip install -e .``) and normal installs.
 
         The discovery strategy for each package:
@@ -672,8 +692,9 @@ class ContractTopicExtractor:
            ``<install_root>/nodes/**/contract.yaml`` on the filesystem.
 
         Args:
-            approved_packages: Tuple of package names to scan.  Defaults to
-                the platform-approved set (omnibase_core, omnibase_infra, etc.).
+            packages: Optional tuple of package names to scan. When omitted,
+                package names are discovered from ``ONEX_ACTIVE_RUNTIME_PACKAGES``
+                or installed ``onex.node_package`` / ``onex.nodes`` entry points.
 
         Returns:
             Sorted, deduplicated list of ``ModelContractTopicEntry`` objects.
@@ -682,18 +703,24 @@ class ContractTopicExtractor:
             ValueError: If the same logical package is discovered via multiple
                 install paths (duplicate discovery).
 
-        Ticket: OMN-5132
+        Ticket: OMN-5132, OMN-12917
         """
         accumulated: dict[str, ModelContractTopicEntry] = {}
         seen_package_roots: dict[str, Path] = {}
         active_packages = get_active_runtime_packages()
-        approved_packages = tuple(
-            pkg
-            for pkg in approved_packages
-            if is_runtime_package_active(pkg, active_packages)
+        candidate_packages = (
+            tuple(normalize_runtime_package_name(pkg) for pkg in packages)
+            if packages is not None
+            else _discover_installed_topic_packages()
         )
+        if active_packages is not None:
+            candidate_packages = tuple(
+                pkg
+                for pkg in candidate_packages
+                if normalize_runtime_package_name(pkg) in active_packages
+            )
 
-        for pkg_name in approved_packages:
+        for pkg_name in candidate_packages:
             contract_paths = self._discover_package_contracts(pkg_name)
             if contract_paths is None:
                 # Package not installed or has no contracts — non-fatal

--- a/src/omnibase_infra/topics/contract_topic_extractor.py
+++ b/src/omnibase_infra/topics/contract_topic_extractor.py
@@ -292,37 +292,35 @@ class ContractTopicExtractor:
             OMN-5132
         """
         from omnibase_infra.tools.contract_topic_extractor import (
-            _APPROVED_PACKAGES,
-        )
-        from omnibase_infra.tools.contract_topic_extractor import (
             ContractTopicExtractor as _CanonicalExtractor,
         )
 
         manifest = TopicManifest()
         canonical = _CanonicalExtractor()
+        contract_paths = sorted(
+            {
+                contract_path
+                for entry in canonical.extract_from_installed_packages()
+                for contract_path in entry.source_contracts
+            }
+        )
 
-        for pkg_name in _APPROVED_PACKAGES:
-            contract_paths = canonical._discover_package_contracts(pkg_name)
-            if contract_paths is None:
-                continue
-
-            for contract_path in contract_paths:
-                try:
-                    node_topics = self.extract_from_file(contract_path)
-                    manifest.nodes[node_topics.node_name] = node_topics
-                except (
-                    OSError,
-                    yaml.YAMLError,
-                    KeyError,
-                    TypeError,
-                    ValueError,
-                ):
-                    logger.warning(
-                        "Failed to parse contract from package %s: %s",
-                        pkg_name,
-                        contract_path,
-                        exc_info=True,
-                    )
+        for contract_path in contract_paths:
+            try:
+                node_topics = self.extract_from_file(contract_path)
+                manifest.nodes[node_topics.node_name] = node_topics
+            except (
+                OSError,
+                yaml.YAMLError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ):
+                logger.warning(
+                    "Failed to parse installed package contract: %s",
+                    contract_path,
+                    exc_info=True,
+                )
 
         return manifest
 

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -734,19 +736,47 @@ def test_extract_from_real_nodes_directory() -> None:
 
 
 @pytest.mark.unit
-def test_approved_packages_includes_omnimarket() -> None:
-    """omnimarket must be in _APPROVED_PACKAGES so its topics are provisioned on boot.
-
-    Without omnimarket in the approved list, ContractTopicExtractor skips all
-    omnimarket contracts even when include_installed_packages=True, leaving 41+
-    nodes with unprovisioned topics and InfraTimeoutError on every boot cycle.
-    """
-    from omnibase_infra.tools.contract_topic_extractor import _APPROVED_PACKAGES
-
-    assert "omnimarket" in _APPROVED_PACKAGES, (
-        "omnimarket must be in _APPROVED_PACKAGES — omitting it causes 41+ nodes "
-        "to fail with InfraTimeoutError on every boot cycle"
+def test_installed_package_discovery_has_no_static_marketplace_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any installed ONEX package can contribute contract-declared topics."""
+    contract = write_contract(
+        tmp_path,
+        "node_marketplace",
+        """
+        event_bus:
+          publish_topics:
+            - "onex.evt.marketplace-plugin.ready.v1"
+        """,
     )
+    monkeypatch.delenv("ONEX_ACTIVE_RUNTIME_PACKAGES", raising=False)
+
+    def fake_entry_points(*, group: str):
+        if group == "onex.node_package":
+            return [SimpleNamespace(name="marketplace_plugin")]
+        if group == "onex.nodes":
+            return []
+        return []
+
+    with (
+        patch(
+            "omnibase_infra.tools.contract_topic_extractor.importlib.metadata.entry_points",
+            fake_entry_points,
+        ),
+        patch.object(
+            ContractTopicExtractor,
+            "_discover_package_contracts",
+            return_value=[contract],
+        ),
+    ):
+        entries = ContractTopicExtractor(
+            include_installed_packages=True
+        ).extract_from_installed_packages()
+
+    assert [entry.topic for entry in entries] == [
+        "onex.evt.marketplace-plugin.ready.v1"
+    ]
 
 
 @pytest.mark.unit
@@ -785,7 +815,7 @@ def test_extract_from_installed_packages_respects_active_runtime_packages(
 
     extractor = ContractTopicExtractor(include_installed_packages=True)
     entries = extractor.extract_from_installed_packages(
-        approved_packages=("omniclaude", "omnimarket")
+        packages=("omniclaude", "omnimarket")
     )
 
     assert entries


### PR DESCRIPTION
Evidence-Ticket: OMN-12917
Evidence-Source: OCC#2432
Evidence-PR: https://github.com/OmniNode-ai/onex_change_control/pull/2432



## Summary
- remove the static installed-package topic discovery allowlist
- discover installed topic-owning packages from ONEX entry points or ONEX_ACTIVE_RUNTIME_PACKAGES
- preserve contract topic syntax validation and active-runtime package filtering

## Verification
- env -u PYTHONPATH uv run python scripts/run_codex_runtime_request.py --command-name bus_audit_compute --payload ... --compile-only
- uv run pytest tests/unit/tools/test_contract_topic_extractor.py tests/integration/event_bus/test_topic_provisioner_integration.py tests/unit/event_bus/test_topic_startup_validator.py -q
- uv run ruff check src/omnibase_infra/tools/contract_topic_extractor.py tests/unit/tools/test_contract_topic_extractor.py
- uv run ruff format --check src/omnibase_infra/tools/contract_topic_extractor.py tests/unit/tools/test_contract_topic_extractor.py
- uv run mypy src/omnibase_infra/tools/contract_topic_extractor.py --strict

## Deploy Notes
- No live deploy/restart performed. Topic provisioning change should be validated in runtime by dry-run/extractor output before broker mutation.