### PR TITLE
build(OMN-12928): update structlog dependency range

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "c68f428c0086620d5190d127e6de73a0",
+  "identity_digest": "7f4a28050457a278a6712b05de154cb8",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "882244b1d89b9eba03fa1b95",
+  "shared_env_digest": "83c23e55321a8c8cb95d48c1",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "dependency-injector>=4.48.1,<5.0.0", # Enhanced dependency injection
     # Tracing and observability dependencies
     "sqlparse>=0.4.4,<0.6.0", # For secure SQL query sanitization in tracing
-    "structlog>=23.2.0,<26.0.0", # Structured logging
+    "structlog>=23.2.0,<27.0.0", # Structured logging
     "prometheus-client>=0.19.0,<0.26.0", # Metrics collection
     "opentelemetry-api>=1.27.0,<2.0.0", # OpenTelemetry API
     "opentelemetry-sdk>=1.27.0,<2.0.0", # OpenTelemetry SDK

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -28,5 +28,5 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    assert lock["identity_digest"] == "c68f428c0086620d5190d127e6de73a0"
-    assert lock["shared_env_digest"] == "882244b1d89b9eba03fa1b95"
+    assert lock["identity_digest"] == "7f4a28050457a278a6712b05de154cb8"
+    assert lock["shared_env_digest"] == "83c23e55321a8c8cb95d48c1"

--- a/uv.lock
+++ b/uv.lock
@@ -2212,7 +2212,7 @@ requires-dist = [
     { name = "sigstore", specifier = ">=4.0.0,<5.0.0" },
     { name = "slowapi", specifier = ">=0.1.9,<0.2.0" },
     { name = "sqlparse", specifier = ">=0.4.4,<0.6.0" },
-    { name = "structlog", specifier = ">=23.2.0,<26.0.0" },
+    { name = "structlog", specifier = ">=23.2.0,<27.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
     { name = "textual", specifier = ">=0.89.0,<9.0.0" },
     { name = "uvicorn", specifier = ">=0.32.0,<0.50.0" },


### PR DESCRIPTION
## Summary
- update the structlog dependency range from <26.0.0 to <27.0.0
- carry the matching uv.lock metadata change
- regenerate the runner image identity lock because pyproject.toml and uv.lock are bound into the CI runner identity

## Verification
- uv run python scripts/ci/runner_image_identity.py --mode generate
- uv run python scripts/ci/runner_image_identity.py --mode verify
- uv run pytest tests/ci/test_runner_image_identity.py -q
- uv sync --frozen --all-extras --all-groups --no-install-project

Evidence-Ticket: OMN-12928
Supersedes: https://github.com/OmniNode-ai/omnibase_infra/pull/1920
Evidence-Source: OCC#2440
Evidence-PR: https://github.com/OmniNode-ai/onex_change_control/pull/2440