### PR TITLE
fix(OMN-12940): recursively unwrap double-wrapped transport envelopes in auto-wiring dispatch

### DIFF
--- a/contracts/OMN-12940.yaml
+++ b/contracts/OMN-12940.yaml
@@ -1,0 +1,78 @@
+# OMN-12940 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-12940"
+title: "Recursively unwrap double-wrapped transport envelopes in auto-wiring dispatch"
+summary: >-
+  The runtime auto-wiring dispatch layer constructs the contract input_model
+  itself via model_validate(_extract_dispatch_payload(envelope)) before the
+  handler runs. _extract_dispatch_payload unwrapped exactly one level, so a
+  double-wrapped delivery stayed an envelope and model_validate raised
+  "N validation errors ... Field required" — bypassing the omnimarket
+  handler-side coerce/unwrap fixes (OMN-12935/12936) entirely. A second site,
+  the post-handler correlation read in _normalize_handler_result, called bare
+  UUID() on a non-hex candidate and crashed dispatch. This makes the unwrap
+  recursive/envelope-aware and routes the correlation read through the existing
+  _coerce_uuid_or_none guard, unblocking runtime verification of the evidence
+  pipeline and readiness gate.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Double-wrapped envelope unwrap + UUID-guard unit tests pass"
+    command: >-
+      uv run pytest
+      tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py -q
+  - kind: "tests"
+    description: "Full auto-wiring unit suite passes (no regression in dispatch path)"
+    command: >-
+      uv run pytest tests/unit/runtime/auto_wiring/ -q
+  - kind: "ci"
+    description: "Touched files pass ruff and mypy --strict"
+    command: >-
+      uv run ruff check
+      src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+      tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py
+      && uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict
+  - kind: "manual"
+    description: >-
+      Post-merge stability redeploy re-runs the evidence-pipeline verification
+      leg and captures a fresh projection row / correlation-ID-backed traversal
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-double-wrapped-unit"
+    description: "Failing-first unit tests reproduce the live ValidationError + UUID crash and now pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest
+          tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py -q
+  - id: "dod-auto-wiring-suite"
+    description: "Full auto-wiring unit suite green (no dispatch-path regression)"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest tests/unit/runtime/auto_wiring/ -q
+  - id: "dod-type-and-lint"
+    description: "Changed source passes mypy --strict and ruff"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict
+  - id: "dod-runtime-reverify"
+    description: "Stability redeploy + evidence-pipeline re-verification leg before declaring fixed"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          rebuild stability runtime images from omnibase_infra@dev including this
+          fix; thin-publish to onex.cmd.omnimarket.evidence-pipeline-start.v1;
+          assert no ValidationError on dispatcher.auto.* and a fresh projection
+          row materializes keyed by the correlation id

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -719,10 +719,52 @@ def _materialize_typed_event_envelope(
     )
 
 
+# Transport-envelope keys the runtime adds around the domain payload. When the
+# dispatch engine materializes a ModelEventEnvelope to a dict it nests the domain
+# fields under ``payload`` and carries routing metadata (``partition_key`` etc.)
+# alongside. Domain models never declare these keys, so a mapping that carries a
+# ``payload`` mapping plus any marker is a transport envelope to unwrap. Mirrors
+# omnimarket's ``_ENVELOPE_MARKER_KEYS`` predicate (OMN-12935/12936); the
+# auto-wiring kernel unwraps here because it constructs the typed model itself,
+# upstream of the handler's own coercion (OMN-12940).
+_ENVELOPE_MARKER_KEYS: frozenset[str] = frozenset(
+    {
+        "partition_key",
+        "event_type",
+        "envelope_id",
+        "event_id",
+        "correlation_id",
+        "__debug_trace",
+    }
+)
+
+
+def _is_transport_envelope(value: object) -> bool:
+    """True when ``value`` is a transport envelope wrapping a domain payload.
+
+    A transport envelope is a mapping that carries a ``payload`` mapping plus at
+    least one transport marker key. Requiring a marker avoids over-unwrapping a
+    legitimate domain model that happens to declare its own ``payload`` field.
+    """
+    return (
+        isinstance(value, Mapping)
+        and isinstance(value.get("payload"), Mapping)
+        and bool(_ENVELOPE_MARKER_KEYS & value.keys())
+    )
+
+
 def _extract_dispatch_payload(envelope: object) -> object:
-    if isinstance(envelope, Mapping):
-        return envelope.get("payload", envelope)
-    return getattr(envelope, "payload", envelope)
+    # The runtime may deliver a DOUBLE- (or deeper-) wrapped envelope, e.g.
+    # ``{"payload": {"payload": {domain}, ...markers}, "partition_key": None}``.
+    # Unwrap recursively until the domain payload is reached so the kernel's
+    # ``model_validate`` (and the post-handler correlation read) operate on the
+    # domain, not on an intermediate envelope (OMN-12940).
+    candidate: object = envelope
+    if not isinstance(candidate, Mapping):
+        candidate = getattr(candidate, "payload", candidate)
+    while _is_transport_envelope(candidate):
+        candidate = cast("Mapping[str, object]", candidate)["payload"]
+    return candidate
 
 
 def _extract_dispatch_topic(envelope: object) -> str:
@@ -779,12 +821,14 @@ def _normalize_handler_result(
 
     payload = _extract_dispatch_payload(envelope)
     correlation_candidate = _extract_dispatch_correlation_id(envelope, payload)
-    if isinstance(correlation_candidate, UUID):
-        correlation_id = correlation_candidate
-    elif isinstance(correlation_candidate, str) and correlation_candidate:
-        correlation_id = UUID(correlation_candidate)
-    else:
-        correlation_id = uuid4()
+    # Guard the coercion: a non-hex correlation candidate must fall back to a
+    # fresh uuid4() rather than crash dispatch with ``ValueError: badly formed
+    # hexadecimal UUID string`` (OMN-12940). ``_coerce_uuid_or_none`` already
+    # guards every other correlation read site (555/702/1207/1278).
+    coerced_correlation = _coerce_uuid_or_none(correlation_candidate)
+    correlation_id: UUID = (
+        coerced_correlation if isinstance(coerced_correlation, UUID) else uuid4()
+    )
 
     output_events: list[BaseModel] = []
     output_intents: tuple[object, ...] = ()

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression tests for double-wrapped transport-envelope unwrap (OMN-12940).
+
+The runtime auto-wiring dispatch layer constructs the contract ``input_model``
+itself, BEFORE the handler runs, via
+``model_cls.model_validate(_extract_dispatch_payload(envelope))``. The runtime
+delivers a DOUBLE-wrapped envelope::
+
+    {"payload": {"payload": {domain}, ...markers}, "partition_key": None, ...}
+
+``_extract_dispatch_payload`` previously unwrapped exactly ONE level, leaving an
+inner envelope, so ``model_validate`` raised ``N validation errors ... Field
+required`` before the omnimarket handler's own ``coerce_command``/
+``_unwrap_envelope`` (OMN-12935/12936) could run. A second site,
+``_normalize_handler_result``, re-read ``correlation_id`` off the still-wrapped
+inner envelope and called bare ``UUID(...)`` with no guard, crashing dispatch
+with ``ValueError: badly formed hexadecimal UUID string``.
+
+These tests pin both fixes:
+  - ``_extract_dispatch_payload`` recursively reaches the domain payload through
+    arbitrarily nested transport envelopes, while leaving single-wrapped,
+    domain-only, and legitimate ``payload``-field payloads untouched;
+  - ``_normalize_handler_result`` tolerates a non-hex correlation candidate by
+    falling back to ``uuid4()`` instead of raising.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _extract_dispatch_payload,
+    _make_dispatch_callback,
+    _normalize_handler_result,
+)
+from omnibase_infra.runtime.auto_wiring.models import ModelHandlerRef
+
+
+class RuntimeDomainCommand(BaseModel):
+    """Importable domain model the auto-wiring kernel constructs via model_validate."""
+
+    correlation_id: UUID
+    source_commit_sha: str
+
+
+_THIS_MODULE = (
+    "tests.unit.runtime.auto_wiring.test_handler_wiring_double_wrapped_envelope"
+)
+
+
+def _domain() -> dict[str, object]:
+    return {
+        "correlation_id": str(uuid4()),
+        "source_commit_sha": "abcdef1",
+    }
+
+
+def _envelope(inner: dict[str, object]) -> dict[str, object]:
+    """Wrap ``inner`` in one transport-envelope layer with marker keys."""
+    return {
+        "payload": inner,
+        "partition_key": None,
+        "correlation_id": "not-a-hex-uuid",
+        "event_type": "onex.cmd.test.command.v1",
+        "envelope_id": "not-a-hex-uuid",
+    }
+
+
+@pytest.mark.unit
+class TestExtractDispatchPayloadRecursiveUnwrap:
+    def test_double_wrapped_reaches_domain(self) -> None:
+        domain = _domain()
+        double_wrapped = _envelope(_envelope(domain))
+        # Must reach the domain mapping, not the still-wrapped inner envelope.
+        assert _extract_dispatch_payload(double_wrapped) == domain
+
+    def test_single_wrapped_reaches_domain(self) -> None:
+        domain = _domain()
+        assert _extract_dispatch_payload(_envelope(domain)) == domain
+
+    def test_domain_only_is_unchanged(self) -> None:
+        domain = _domain()
+        # No transport markers + no nested ``payload`` mapping → returned as-is.
+        assert _extract_dispatch_payload(domain) == domain
+
+    def test_legitimate_payload_domain_field_not_over_unwrapped(self) -> None:
+        # A domain payload that legitimately has a ``payload`` mapping field but
+        # NO transport marker keys must not be unwrapped.
+        domain = {"payload": {"nested": "value"}, "name": "real-domain"}
+        assert _extract_dispatch_payload(domain) == domain
+
+    def test_triple_wrapped_reaches_domain(self) -> None:
+        domain = _domain()
+        triple = _envelope(_envelope(_envelope(domain)))
+        assert _extract_dispatch_payload(triple) == domain
+
+
+@pytest.mark.unit
+class TestDoubleWrappedTypedModelConstruction:
+    async def test_double_wrapped_envelope_constructs_typed_model(self) -> None:
+        """The kernel-side model_validate must succeed on a double-wrapped delivery.
+
+        Reproduces the live evidence-pipeline / readiness-gate failure: a
+        contract-typed auto-wired callback fed a double-wrapped envelope must
+        reach the domain payload and construct the typed model without a
+        ValidationError.
+        """
+        captured: dict[str, object] = {}
+
+        class _Handler:
+            async def handle(self, payload: object) -> None:
+                captured["payload"] = payload
+
+        callback = _make_dispatch_callback(
+            _Handler(),
+            event_model=ModelHandlerRef(
+                name="RuntimeDomainCommand", module=_THIS_MODULE
+            ),
+        )
+
+        domain = _domain()
+        double_wrapped = _envelope(_envelope(domain))
+
+        # Before the fix this raised pydantic.ValidationError (N missing fields).
+        await callback(double_wrapped)
+
+        constructed = captured["payload"]
+        assert isinstance(constructed, RuntimeDomainCommand)
+        assert constructed.source_commit_sha == domain["source_commit_sha"]
+
+
+@pytest.mark.unit
+class TestNormalizeHandlerResultUuidGuard:
+    def test_non_hex_correlation_falls_back_to_uuid4(self) -> None:
+        """A non-hex correlation candidate must not crash dispatch (line 785)."""
+
+        class _Event(BaseModel):
+            value: str
+
+        # Envelope carries a non-hex correlation_id; the handler returned a
+        # plain BaseModel so _normalize_handler_result runs the correlation read.
+        envelope = _envelope(_domain())
+        result = _normalize_handler_result(_Event(value="x"), envelope, "test")
+        assert result is not None
+        # No ValueError raised; a valid UUID is synthesized.
+        assert isinstance(result.correlation_id, UUID)


### PR DESCRIPTION
## Summary

Fixes OMN-12940. The runtime auto-wiring dispatch layer fails to deliver **double-wrapped** transport envelopes to contract-typed handlers, breaking the evidence-pipeline and readiness-gate orchestrators on the live stability runtime. This is the TRUE root cause that the merged OMN-12935 (omnimarket#1151) and OMN-12936 (omnimarket#1152) handler-side fixes **cannot reach** — the kernel constructs the typed model itself, upstream of the handler's own coercion.

## Root cause (verified in-container)

`src/omnibase_infra/runtime/auto_wiring/handler_wiring.py`:

1. **Pre-handler model construction** (line 439-445): the kernel runs `model_cls.model_validate(_extract_dispatch_payload(envelope))` BEFORE the handler. `_extract_dispatch_payload` unwrapped exactly ONE level, so a double-wrapped delivery `{'payload': {'payload': {domain}, …markers}, 'partition_key': None}` stayed an envelope -> `ValidationError: N validation errors … Field required`.
2. **Post-handler correlation read** (`_normalize_handler_result`, line ~785): re-read `correlation_id` off the still-wrapped inner envelope and called bare `UUID(...)` -> `ValueError: badly formed hexadecimal UUID string`.

Both reproduced in-container on the 04:24Z stability rebuild (omnimarket dfb65f9, which contains both merged PRs — ancestry confirmed, source staleness ruled out).

## Fix

- `_extract_dispatch_payload` is now envelope-aware/recursive via `_is_transport_envelope` (mapping carrying a `payload` mapping + a transport marker key, mirroring omnimarket's `_ENVELOPE_MARKER_KEYS`; includes `__debug_trace`). Unwraps until the domain payload is reached; single-wrapped, domain-only, and legitimate `payload`-field payloads stay correct.
- The correlation read routes through the existing `_coerce_uuid_or_none` guard -> non-hex correlation falls back to `uuid4()` instead of crashing dispatch.

## Tests

`tests/unit/runtime/auto_wiring/test_handler_wiring_double_wrapped_envelope.py` — failing-first, now green: recursive unwrap (single/double/triple, no over-unwrap of legitimate `payload` field), double-wrapped -> typed-model construction succeeds, and the UUID-guard fallback. Full `tests/unit/runtime/auto_wiring/` (266) green; integration auto-wiring/dispatch (166) green; `mypy --strict` clean; pre-commit all-pass.

## dod_evidence

OCC contract: `contracts/OMN-12940.yaml`; paired OCC receipt PR OmniNode-ai/onex_change_control#2451 (Evidence-Source).

In-container reproduction of both failure sites; ancestry proof; diagnosis in `docs/evidence/2026-06-11-full-feature-pass/03-buildout/ADDENDUM.md` + `DIAGNOSIS_OMN-12935-12936.md`. Discovered during the 2026-06-11 full-feature pass (`CLASSIFICATION_MATRIX.md` BROKEN items 1 & 2). Unblocks runtime verification of OMN-12935 and OMN-12936.

Evidence-Source: OCC#2451
Evidence-Ticket: OMN-12940
