### PR TITLE
ci(OMN-12934): port promotion/* branch allowance to main-target-guard on dev

### DIFF
--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 #
 # OMN-12243: Block PRs targeting main unless they are promotion PRs
-# from dev with a promotion receipt, or hotfix PRs with evidence and
-# a backmerge link.
+# from dev/promotion branches with a promotion receipt, or hotfix PRs
+# with evidence and a backmerge link.
 
 name: Main target guard
 
@@ -41,13 +41,13 @@ jobs:
 
           echo "PR targets main. Checking head ref: '${HEAD_REF}'"
 
-          if [[ "${HEAD_REF}" == "dev" ]]; then
+          if [[ "${HEAD_REF}" == "dev" || "${HEAD_REF}" == promotion/* ]]; then
             if echo "${PR_BODY}" | grep -qE 'promotion-receipt:[[:space:]]*OCC-[0-9]+'; then
-              echo "::notice::Promotion PR from dev with valid promotion-receipt. Allowed."
+              echo "::notice::Promotion PR from '${HEAD_REF}' with valid promotion-receipt. Allowed."
               exit 0
             fi
 
-            echo "::error::PR is from dev but is missing a promotion receipt."
+            echo "::error::Promotion PR from '${HEAD_REF}' is missing a promotion receipt."
             echo "::error::Add a line matching: promotion-receipt: OCC-<number>"
             echo "::error::Retarget this PR to dev; main accepts only promotion or hotfix PRs."
             exit 1

--- a/tests/ci/test_main_target_guard_workflow.py
+++ b/tests/ci/test_main_target_guard_workflow.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression tests for the main-target guard workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAIN_TARGET_GUARD = REPO_ROOT / ".github" / "workflows" / "main-target-guard.yml"
+
+
+def test_main_target_guard_allows_promotion_branches_with_receipts() -> None:
+    workflow = MAIN_TARGET_GUARD.read_text(encoding="utf-8")
+
+    assert '"${HEAD_REF}" == "dev" || "${HEAD_REF}" == promotion/*' in workflow
+    assert "promotion-receipt:[[:space:]]*OCC-[0-9]+" in workflow
+    assert "Promotion PR from '${HEAD_REF}' with valid promotion-receipt" in workflow
+
+
+def test_main_target_guard_keeps_hotfix_evidence_requirements() -> None:
+    workflow = MAIN_TARGET_GUARD.read_text(encoding="utf-8")
+
+    assert '"${HEAD_REF}" == hotfix/*' in workflow
+    assert "hotfix-evidence:[[:space:]]*OCC-[0-9]+" in workflow
+    assert "backmerge:[[:space:]]*#[0-9]+" in workflow


### PR DESCRIPTION
## Summary

Ports the main-only `main-target-guard.yml` `promotion/*` head-ref clause (originally OMN-12816) and its companion test `tests/ci/test_main_target_guard_workflow.py` onto `dev`.

This is the audited preservation step for the OMN-12934 prod-promotion main-alignment. After main is force-aligned to dev's tree, dev's guard must continue to accept `promotion/*` PRs (not only `dev`), so this clause is brought onto dev FIRST.

Evidence-Ticket: OMN-12934
Evidence-Source: 7a27312ef37d29724f38bafe6a0e471f9f142f32

## Change
- `main-target-guard.yml`: `if [[ "${HEAD_REF}" == "dev" || "${HEAD_REF}" == promotion/* ]]` (was `== "dev"` only) + reworded notices.
- Added `tests/ci/test_main_target_guard_workflow.py` (2 unit tests, both passing).

## Evidence
- OCC contract `contracts/OMN-12934.yaml` (OCC dev @ 7a27312) with `dod-infra-dev-promotable-to-main` PASS.
- Audit verdict: `docs/evidence/2026-06-11-prod-promotion/main-unique-audit/omnibase_infra.md` (safe-to-overwrite; this is the optional CI-policy preservation).
- Local: `uv run pytest tests/ci/test_main_target_guard_workflow.py -v` -> 2 passed.
