### PR TITLE
fix(OMN-12977): workspace-build sibling-pin ratchet — honor consuming lock, fail-fast on stale vendor

### DIFF
--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -287,13 +287,52 @@ jobs:
             echo "E2E_REDPANDA_ADVERTISE_HOST=${E2E_REDPANDA_ADVERTISE_HOST}"
           } >> "$GITHUB_ENV"
 
-          POSTGRES_PORT="${POSTGRES_PORT}" \
-          KAFKA_PORT="${KAFKA_PORT}" \
-          REDPANDA_ADMIN_PORT="${REDPANDA_ADMIN_PORT}" \
-          REDPANDA_SCHEMA_REGISTRY_PORT="${REDPANDA_SCHEMA_REGISTRY_PORT}" \
-          REDPANDA_PANDAPROXY_PORT="${REDPANDA_PANDAPROXY_PORT}" \
-          E2E_REDPANDA_ADVERTISE_HOST="${E2E_REDPANDA_ADVERTISE_HOST}" \
-            "${compose_cmd[@]}" -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml up -d postgres redpanda
+          compose_up() {
+            POSTGRES_PORT="${POSTGRES_PORT}" \
+            KAFKA_PORT="${KAFKA_PORT}" \
+            REDPANDA_ADMIN_PORT="${REDPANDA_ADMIN_PORT}" \
+            REDPANDA_SCHEMA_REGISTRY_PORT="${REDPANDA_SCHEMA_REGISTRY_PORT}" \
+            REDPANDA_PANDAPROXY_PORT="${REDPANDA_PANDAPROXY_PORT}" \
+            E2E_REDPANDA_ADVERTISE_HOST="${E2E_REDPANDA_ADVERTISE_HOST}" \
+              "${compose_cmd[@]}" -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml up -d postgres redpanda
+          }
+
+          retry_compose_down() {
+            "${compose_cmd[@]}" -p "${OMNIBASE_INFRA_COMPOSE_PROJECT}" -f docker/docker-compose.e2e.yml down -v --remove-orphans || true
+            docker network rm "${OMNIBASE_INFRA_NETWORK}" "${OMNIBASE_INFRA_COMPOSE_PROJECT}_default" 2>/dev/null || true
+          }
+
+          compose_started=false
+          for compose_attempt in 1 2 3; do
+            if compose_up; then
+              compose_started=true
+              break
+            fi
+            compose_status=$?
+            if [[ "${compose_attempt}" -eq 3 ]]; then
+              exit "${compose_status}"
+            fi
+            echo "::warning::compose infra bring-up failed on attempt ${compose_attempt}; repicking host ports and retrying"
+            retry_compose_down
+            export POSTGRES_PORT="$(pick_free_port)"
+            export KAFKA_PORT="$(pick_free_port)"
+            export REDPANDA_ADMIN_PORT="$(pick_free_port)"
+            export REDPANDA_SCHEMA_REGISTRY_PORT="$(pick_free_port)"
+            export REDPANDA_PANDAPROXY_PORT="$(pick_free_port)"
+            {
+              echo "POSTGRES_PORT=${POSTGRES_PORT}"
+              echo "PG_PORT=${POSTGRES_PORT}"
+              echo "KAFKA_PORT=${KAFKA_PORT}"
+              echo "REDPANDA_ADMIN_PORT=${REDPANDA_ADMIN_PORT}"
+              echo "REDPANDA_SCHEMA_REGISTRY_PORT=${REDPANDA_SCHEMA_REGISTRY_PORT}"
+              echo "REDPANDA_PANDAPROXY_PORT=${REDPANDA_PANDAPROXY_PORT}"
+            } >> "$GITHUB_ENV"
+          done
+
+          if [[ "${compose_started}" != "true" ]]; then
+            echo "::error::compose infra bring-up failed before health checks"
+            exit 1
+          fi
 
           capture_compose_infra_diagnostics() {
             {

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -267,6 +267,12 @@ COPY workspace/sibling-repos/ /workspace/sibling-repos/
 # Copy provenance helper (always present — used in workspace mode, no-op otherwise)
 COPY scripts/runtime_build/compute_workspace_provenance.py /workspace/compute_workspace_provenance.py
 
+# Copy the sibling-pin comparison emitted by the preflight (OMN-12977). A
+# committed placeholder makes this COPY always valid; workspace mode overwrites
+# it via stage_workspace.sh so compute_workspace_provenance.py can fold the
+# expected-vs-actual pin proof into build-provenance.json for deploy verifiers.
+COPY workspace/sibling-pin-comparison.json /workspace/sibling-pin-comparison.json
+
 # workspace mode installs omnibase_compat, onex_change_control, omnimarket from
 # the staged local trees.  release mode installs from pinned remote sources.
 #

--- a/scripts/runtime_build/check_sibling_lock_pins.py
+++ b/scripts/runtime_build/check_sibling_lock_pins.py
@@ -1,290 +1,390 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Fail-fast preflight: vendored sibling versions/SHAs must match the lock pin.
+"""Workspace-build sibling-pin preflight + recurrence ratchet [OMN-12977].
 
-Surfaced by the 2026-06-11 resolver-crash diagnosis (OMN-12987). A workspace-mode
-``--no-cache`` rebuild vendored omnibase_infra ``0.37.0-dev`` (~``2c1d672f``) +
-omnibase_core ``0.42.0`` even though omnimarket dev's ``uv.lock`` pinned infra
-``0.38.1 @ e2dbdc95`` + core ``0.44.0 @ c97c2c9a``. The build silently shipped a
-13-day-stale sibling that predated the OMN-12501 Protocol-quarantine guard,
-turning a latent contract defect into a fatal bootstrap crash.
+The workspace-mode image build (BUILD_SOURCE=workspace) vendors sibling repos
+from whatever the canonical clones under OMNI_HOME happen to be checked out at.
+On 2026-06-11 that shipped a 13-day-stale omnibase_infra 0.37.0-dev (pre-OMN-12501
+Protocol-quarantine guard) + omnibase_core 0.42.0 even though omnimarket dev's
+``uv.lock`` pinned omnibase-infra 0.38.1 @ e2dbdc95 / omnibase-core 0.44.0 @
+c97c2c9a. The stale image dropped the guard and crashed bootstrap fatally.
 
-This preflight resolves the *expected* sibling pins from the consuming repo's lock
-(the authority) and compares them against the *actual* version/SHA of each repo
-the build vendors. Any mismatch aborts the build — there is no silent fallback.
+This module makes the consuming repo's ``uv.lock`` the pin authority:
 
-The comparison is also serialised so the deploy verifier (and
-``build-provenance.json``) can record expected-vs-actual per sibling.
+  - ``parse_lock_pins`` extracts the expected version (+ git rev) of the
+    foundation/sibling packages from the consuming repo's lock.
+  - ``resolve_actual_pin`` reads the version (from pyproject) + HEAD git SHA of
+    a canonical clone that the build is about to vendor.
+  - ``compare_pins`` reports match / mismatch with an identifying reason.
+  - ``check_pins`` orchestrates a fail-fast preflight and writes the
+    expected-vs-actual comparison so deploy verifiers and build-provenance.json
+    can assert on it.
 
-Run on the host before staging/building (it needs the canonical clones' git SHAs):
+There are NO silent fallbacks: a requested package missing from the lock, an
+unparseable source, or any version / SHA drift is a hard error. Run BEFORE the
+docker build (preflight) and again inside the build to enrich provenance.
 
-    OMNI_HOME=/data/omninode/omni_home \\
-      uv run python scripts/runtime_build/check_sibling_lock_pins.py \\
-        --consuming-repo omnimarket \\
-        --build-context-repo omnibase_infra
+Usage:
+    uv run python scripts/runtime_build/check_sibling_lock_pins.py \\
+        --lock "$OMNI_HOME/omnimarket/uv.lock" \\
+        --repo omnibase-infra="$OMNI_HOME/omnibase_infra" \\
+        --repo omnibase-core="$OMNI_HOME/omnibase_core" \\
+        --output workspace/sibling-pin-comparison.json
 
 Exit codes:
-  0  all vendored siblings match the consuming repo's lock pin
-  1  one or more siblings mismatch (version and/or SHA)
-  2  malformed inputs (missing lock, missing pyproject, unreadable git SHA)
+    0  every requested pin matches the lock
+    1  one or more pins drifted from the lock (build must abort)
+    2  malformed input (missing lock, unparseable source, missing repo)
+
+OMN-12977
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
+import re
 import subprocess
 import sys
 import tomllib
-from dataclasses import asdict, dataclass
 from pathlib import Path
 
-# Distribution name (as it appears in uv.lock) -> repo directory name under OMNI_HOME.
-# These are the siblings the workspace build either vendors directly
-# (compat/onex_change_control/omnimarket) or builds *from* as the build context
-# (omnibase_infra). omnibase_core is pinned transitively and vendored via the
-# infra wheel, so it is included too: the 06-11 crash shipped a stale core.
-PACKAGE_TO_REPO: dict[str, str] = {
-    "omnibase-compat": "omnibase_compat",
-    "omnibase-core": "omnibase_core",
+from pydantic import BaseModel, ConfigDict, Field
+
+# Foundation + sibling packages whose pins the workspace build must honor.
+# Keys are uv.lock distribution names; values are the canonical clone dir names
+# under OMNI_HOME that the build vendors / installs from.
+DEFAULT_PACKAGE_REPO_DIRS: dict[str, str] = {
     "omnibase-infra": "omnibase_infra",
+    "omnibase-core": "omnibase_core",
+    "omnibase-spi": "omnibase_spi",
+    "omnibase-compat": "omnibase_compat",
     "onex-change-control": "onex_change_control",
+    "omnimarket": "omnimarket",
 }
 
-
-@dataclass(frozen=True)
-class ExpectedPin:
-    """Expected sibling pin resolved from the consuming repo's lock."""
-
-    package: str
-    version: str
-    git_rev: str  # empty string when the lock pins a non-git (registry) source
-
-
-@dataclass(frozen=True)
-class PinComparison:
-    """Expected-vs-actual comparison for a single vendored sibling."""
-
-    package: str
-    repo: str
-    expected_version: str
-    actual_version: str
-    expected_git_rev: str
-    actual_git_rev: str
-    version_match: bool
-    sha_match: bool
-
-    @property
-    def ok(self) -> bool:
-        # SHA is the authoritative pin; version is a secondary signal. When the
-        # lock pins a git source we require the SHA to match. When the lock has
-        # no git rev (registry source) we fall back to the version match.
-        if self.expected_git_rev:
-            return self.sha_match
-        return self.version_match
+# Matches a package's own ``source = { ... }`` line in a uv.lock block. The rev
+# (when the source is a git source) is captured from the ``?rev=<sha>`` query.
+# Scoping to the source line is required: a ``dependencies = [...]`` entry may
+# also carry a ``?rev=`` for a transitive git dep, and a block-wide search would
+# wrongly attribute that rev to an editable/registry package (e.g. omnimarket
+# itself is ``source = { editable = "." }`` with no rev of its own).
+_SOURCE_LINE_RE = re.compile(r"^source = \{(?P<body>.*)\}\s*$", re.MULTILINE)
+_GIT_REV_RE = re.compile(r"[?&]rev=(?P<rev>[0-9a-fA-F]{7,40})")
 
 
-def parse_lock_pins(lock_path: Path) -> dict[str, ExpectedPin]:
-    """Extract expected sibling pins from a uv.lock TOML file.
+class ModelLockPin(BaseModel):
+    """Expected pin for a package as declared in the consuming repo's uv.lock."""
 
-    Returns a mapping of distribution name -> ExpectedPin for every sibling in
-    PACKAGE_TO_REPO that the lock declares. Siblings absent from the lock are
-    simply omitted (the caller decides whether that is an error).
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    package: str = Field(..., description="uv.lock distribution name")
+    version: str = Field(..., description="Locked version string")
+    git_rev: str | None = Field(
+        default=None,
+        description="Locked git rev (full/short SHA) or None for registry pins",
+    )
+
+
+class ModelActualPin(BaseModel):
+    """Actual pin of a canonical clone the build is about to vendor/install."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    package: str = Field(..., description="uv.lock distribution name")
+    version: str = Field(..., description="Version from the clone's pyproject.toml")
+    git_sha: str = Field(..., description="HEAD commit SHA of the canonical clone")
+
+
+class ModelPinComparison(BaseModel):
+    """Expected-vs-actual comparison for one package (provenance-serializable)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    package: str = Field(...)
+    expected_version: str = Field(...)
+    actual_version: str = Field(...)
+    expected_git_rev: str | None = Field(default=None)
+    actual_git_sha: str = Field(...)
+    matches: bool = Field(...)
+    drift_direction: str = Field(
+        default="none",
+        description=(
+            "'none' (match), 'backward' (clone older than lock -- the stale-"
+            "sibling crash), 'forward' (clone newer than lock), or 'unknown' "
+            "(non-comparable versions)"
+        ),
+    )
+    mismatch_reason: str = Field(default="", description="Empty when matches is True")
+
+
+def _classify_drift(expected_version: str, actual_version: str) -> str:
+    """Classify version drift direction (backward is the stale-sibling crash)."""
+    if expected_version == actual_version:
+        return "none"
+    try:
+        exp = tuple(int(p) for p in expected_version.split(".")[:3])
+        act = tuple(int(p) for p in actual_version.split(".")[:3])
+    except ValueError:
+        return "unknown"
+    if act < exp:
+        return "backward"
+    if act > exp:
+        return "forward"
+    return "unknown"
+
+
+def parse_lock_pins(lock_text: str, packages: list[str]) -> dict[str, ModelLockPin]:
+    """Parse a uv.lock and return expected pins for the requested packages.
+
+    Each ``[[package]]`` block carries a ``name``, ``version`` and ``source``.
+    Git sources embed the resolved rev in the source URL; registry sources have
+    no rev (version-only pin). A requested package absent from the lock is a
+    hard error -- workspace builds must never silently skip a foundation pin.
     """
-    if not lock_path.is_file():
-        raise FileNotFoundError(f"consuming-repo lock not found: {lock_path}")
+    blocks = lock_text.split("[[package]]")
+    found: dict[str, ModelLockPin] = {}
+    requested = set(packages)
 
-    data = tomllib.loads(lock_path.read_text(encoding="utf-8"))
-    pins: dict[str, ExpectedPin] = {}
-    for pkg in data.get("package", []):
-        name = pkg.get("name", "")
-        if name not in PACKAGE_TO_REPO:
+    for block in blocks:
+        name_match = re.search(r'^name = "(?P<name>[^"]+)"', block, re.MULTILINE)
+        if name_match is None:
             continue
-        version = str(pkg.get("version", ""))
-        git_rev = _extract_git_rev(pkg.get("source", {}))
-        pins[name] = ExpectedPin(package=name, version=version, git_rev=git_rev)
-    return pins
+        name = name_match.group("name")
+        if name not in requested:
+            continue
+
+        version_match = re.search(
+            r'^version = "(?P<version>[^"]+)"', block, re.MULTILINE
+        )
+        if version_match is None:
+            raise ValueError(f"uv.lock block for {name!r} has no version field")
+        version = version_match.group("version")
+
+        # Only the package's OWN source line may contribute a git rev. Editable
+        # ("." path) and registry (PyPI) sources have no rev.
+        git_rev: str | None = None
+        source_match = _SOURCE_LINE_RE.search(block)
+        if source_match is not None:
+            rev_match = _GIT_REV_RE.search(source_match.group("body"))
+            if rev_match is not None:
+                git_rev = rev_match.group("rev")
+
+        found[name] = ModelLockPin(package=name, version=version, git_rev=git_rev)
+
+    missing = requested - set(found)
+    if missing:
+        raise KeyError(
+            f"packages absent from uv.lock: {sorted(missing)}. "
+            "Workspace build cannot resolve a pin for them."
+        )
+    return found
 
 
-def _extract_git_rev(source: dict[str, object]) -> str:
-    """Return the resolved git commit SHA from a uv.lock source table.
+def resolve_actual_pin(package: str, repo_root: Path) -> ModelActualPin:
+    """Read the canonical clone's version (pyproject) + HEAD SHA.
 
-    uv records git sources as ``{"git": "<url>?rev=<sha>#<sha>"}``; the resolved
-    commit is the fragment after ``#``. Registry/path sources yield an empty rev.
+    No defaults: a missing pyproject, a missing version, or an unreadable git
+    HEAD is a hard error (exit 2 at the CLI boundary).
     """
-    git = source.get("git")
-    if not isinstance(git, str):
-        return ""
-    _, _, fragment = git.partition("#")
-    return fragment.strip()
-
-
-def read_actual_version(repo_path: Path) -> str:
-    """Read the installed version from a repo's pyproject.toml ``[project]``."""
-    pyproject = repo_path / "pyproject.toml"
-    if not pyproject.is_file():
-        raise FileNotFoundError(f"pyproject.toml not found for repo: {repo_path}")
-    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    version = data.get("project", {}).get("version", "")
+    pyproject_path = repo_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        raise FileNotFoundError(
+            f"missing pyproject.toml for {package}: {pyproject_path}"
+        )
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
     if not version:
-        raise ValueError(f"no [project].version in {pyproject}")
-    return str(version)
+        raise ValueError(f"no project.version in {pyproject_path}")
 
-
-def read_actual_git_rev(repo_path: Path) -> str:
-    """Return the full HEAD SHA of a repo.
-
-    Prefers a committed ``.build-sha`` marker (staged trees rsync without
-    ``.git``); falls back to ``git rev-parse HEAD`` for live canonical clones.
-    """
-    marker = repo_path / ".build-sha"
-    if marker.is_file():
-        return marker.read_text(encoding="utf-8").strip()
-    result = subprocess.run(
-        ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+    head_sha = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=True,
         capture_output=True,
         text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"cannot resolve git SHA for {repo_path}: {result.stderr.strip()}"
-        )
-    return result.stdout.strip()
+    ).stdout.strip()
+    if not head_sha:
+        raise ValueError(f"could not resolve git HEAD for {repo_root}")
+
+    return ModelActualPin(package=package, version=version, git_sha=head_sha)
 
 
-def compare_pin(expected: ExpectedPin, repo_path: Path) -> PinComparison:
-    """Build the expected-vs-actual comparison for one sibling."""
-    actual_version = read_actual_version(repo_path)
-    actual_rev = read_actual_git_rev(repo_path)
-    # SHA equality is prefix-tolerant: lock records full 40-char rev, markers or
-    # short SHAs may be abbreviated. Compare on the shorter length.
-    n = min(len(expected.git_rev), len(actual_rev)) if expected.git_rev else 0
-    sha_match = (
-        bool(expected.git_rev) and n > 0 and (expected.git_rev[:n] == actual_rev[:n])
-    )
-    return PinComparison(
-        package=expected.package,
-        repo=PACKAGE_TO_REPO[expected.package],
-        expected_version=expected.version,
-        actual_version=actual_version,
-        expected_git_rev=expected.git_rev,
-        actual_git_rev=actual_rev,
-        version_match=expected.version == actual_version,
-        sha_match=sha_match,
-    )
+def compare_pins(expected: ModelLockPin, actual: ModelActualPin) -> ModelPinComparison:
+    """Compare an expected lock pin against the actual clone pin.
 
-
-def evaluate(
-    pins: dict[str, ExpectedPin],
-    repo_root: Path,
-    build_context_repo: str,
-    repo_path_overrides: dict[str, Path] | None = None,
-) -> list[PinComparison]:
-    """Compare every locked sibling pin against the repo the build will vendor.
-
-    ``repo_root`` is OMNI_HOME (canonical clones live directly beneath it).
-    ``repo_path_overrides`` lets callers point a package at a staged tree.
+    Version must always match. When the lock pin is a git source, the resolved
+    rev must be a prefix of the clone HEAD (or vice-versa) -- uv records the full
+    rev while a short SHA may appear elsewhere, so prefix-equality covers both.
+    Registry pins (git_rev is None) are version-only.
     """
-    overrides = repo_path_overrides or {}
-    comparisons: list[PinComparison] = []
-    for package, expected in sorted(pins.items()):
-        repo_dir = PACKAGE_TO_REPO[package]
-        repo_path = overrides.get(package, repo_root / repo_dir)
-        if not repo_path.is_dir():
-            raise FileNotFoundError(
-                f"sibling repo for '{package}' not found at {repo_path}"
+    reasons: list[str] = []
+
+    if expected.version != actual.version:
+        reasons.append(
+            f"version drift: lock pins {expected.version!r} but clone is "
+            f"{actual.version!r}"
+        )
+
+    if expected.git_rev is not None:
+        exp = expected.git_rev.lower()
+        act = actual.git_sha.lower()
+        if not (act.startswith(exp) or exp.startswith(act)):
+            reasons.append(
+                f"git SHA drift: lock pins {expected.git_rev} but clone HEAD is "
+                f"{actual.git_sha}"
             )
-        comparisons.append(compare_pin(expected, repo_path))
-    # build_context_repo is documented for the operator; the comparison itself
-    # already covers it because the infra package is in PACKAGE_TO_REPO.
-    _ = build_context_repo
-    return comparisons
 
-
-def render_report(comparisons: list[PinComparison]) -> str:
-    """Human-readable summary, one line per sibling."""
-    lines: list[str] = []
-    for c in comparisons:
-        flag = "OK " if c.ok else "MISMATCH"
-        lines.append(
-            f"  [{flag}] {c.package}: "
-            f"expected {c.expected_version}@{c.expected_git_rev[:12] or '(no-rev)'} "
-            f"actual {c.actual_version}@{c.actual_git_rev[:12] or '(no-rev)'}"
-        )
-    return "\n".join(lines)
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--consuming-repo",
-        default="omnimarket",
-        help="repo whose uv.lock is the pin authority (default: omnimarket)",
+    matches = not reasons
+    return ModelPinComparison(
+        package=expected.package,
+        expected_version=expected.version,
+        actual_version=actual.version,
+        expected_git_rev=expected.git_rev,
+        actual_git_sha=actual.git_sha,
+        matches=matches,
+        drift_direction=_classify_drift(expected.version, actual.version),
+        mismatch_reason="; ".join(reasons),
     )
-    parser.add_argument(
-        "--build-context-repo",
-        default="omnibase_infra",
-        help="repo the image is built FROM (default: omnibase_infra)",
-    )
-    parser.add_argument(
-        "--omni-home",
-        default=os.environ.get("OMNI_HOME", ""),
-        help="path to OMNI_HOME (canonical clones root). Defaults to $OMNI_HOME.",
-    )
-    parser.add_argument(
-        "--provenance-out",
-        default="",
-        help="optional path to write the expected-vs-actual JSON report.",
-    )
-    args = parser.parse_args()
 
-    if not args.omni_home:
-        print(
-            "ERROR: OMNI_HOME not set; pass --omni-home or export OMNI_HOME.",
-            file=sys.stderr,
-        )
+
+def check_pins(
+    lock_path: Path,
+    repo_roots: dict[str, Path],
+    output_path: Path | None,
+    allow_drift: bool = False,
+) -> int:
+    """Preflight: compare every requested clone against the lock; fail fast.
+
+    When ``allow_drift`` is True the drift is recorded in the provenance artifact
+    and a warning is printed, but the build is not aborted -- reserved for an
+    explicit operator decision (e.g. an intentional forward rebuild ahead of a
+    lock bump). The override is always durable in the artifact, never silent.
+
+    Returns a process exit code (0 pass-or-allowed / 1 drift / 2 malformed input).
+    """
+    if not lock_path.is_file():
+        print(f"ERROR: lock file not found: {lock_path}", file=sys.stderr)
         return 2
-    repo_root = Path(args.omni_home)
-    lock_path = repo_root / args.consuming_repo / "uv.lock"
 
+    packages = list(repo_roots)
     try:
-        pins = parse_lock_pins(lock_path)
-        comparisons = evaluate(pins, repo_root, args.build_context_repo)
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
-        print(f"ERROR: sibling lock-pin preflight failed: {exc}", file=sys.stderr)
+        expected_pins = parse_lock_pins(
+            lock_path.read_text(encoding="utf-8"), packages=packages
+        )
+    except (KeyError, ValueError) as exc:
+        print(f"ERROR: cannot resolve lock pins: {exc}", file=sys.stderr)
         return 2
 
-    print(f"Sibling lock-pin preflight (authority: {args.consuming_repo}/uv.lock):")
-    print(render_report(comparisons))
+    comparisons: list[ModelPinComparison] = []
+    for package, repo_root in repo_roots.items():
+        try:
+            actual = resolve_actual_pin(package, repo_root)
+        except (FileNotFoundError, ValueError, subprocess.CalledProcessError) as exc:
+            print(
+                f"ERROR: cannot resolve clone pin for {package}: {exc}", file=sys.stderr
+            )
+            return 2
+        comparisons.append(compare_pins(expected_pins[package], actual))
 
-    if args.provenance_out:
-        Path(args.provenance_out).write_text(
-            json.dumps([asdict(c) for c in comparisons], indent=2),
+    drifted = [c for c in comparisons if not c.matches]
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(
+                {
+                    "lock_source": str(lock_path),
+                    "allow_drift": allow_drift,
+                    "drift_count": len(drifted),
+                    "comparisons": [c.model_dump() for c in comparisons],
+                },
+                indent=2,
+            ),
             encoding="utf-8",
         )
+        print(f"sibling-pin comparison written to {output_path}")
 
-    mismatches = [c for c in comparisons if not c.ok]
-    if mismatches:
+    for c in comparisons:
+        status = "OK" if c.matches else f"DRIFT/{c.drift_direction}"
+        line = f"  [{status}] {c.package}: lock={c.expected_version} clone={c.actual_version}"
         print(
-            f"\nFATAL: {len(mismatches)} vendored sibling(s) do not match the "
-            f"{args.consuming_repo} lock pin. Refusing to build a stale image.",
-            file=sys.stderr,
+            line if c.matches else f"{line}  -- {c.mismatch_reason}",
+            file=sys.stderr if not c.matches else sys.stdout,
         )
-        for c in mismatches:
+
+    if drifted:
+        if allow_drift:
             print(
-                f"  - {c.package}: lock pins "
-                f"{c.expected_version}@{c.expected_git_rev[:12] or '(no-rev)'} but "
-                f"vendored tree is "
-                f"{c.actual_version}@{c.actual_git_rev[:12] or '(no-rev)'}",
+                f"\nWARNING: {len(drifted)} sibling pin(s) drifted from "
+                f"{lock_path.name}; proceeding under explicit operator override "
+                "(ALLOW drift) -- recorded in provenance (OMN-12977).",
                 file=sys.stderr,
             )
+            return 0
+        print(
+            f"\nFAIL: {len(drifted)} sibling pin(s) drifted from {lock_path.name}. "
+            "Workspace build would vendor stale code -- aborting (OMN-12977).",
+            file=sys.stderr,
+        )
         return 1
 
-    print(f"\nAll {len(comparisons)} vendored siblings match the lock pin.")
+    print(f"\nAll {len(comparisons)} sibling pins match {lock_path.name}.")
     return 0
+
+
+def _parse_repo_arg(value: str) -> tuple[str, Path]:
+    """Parse a ``package=path`` --repo argument."""
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(f"--repo must be package=path, got {value!r}")
+    package, _, path = value.partition("=")
+    package = package.strip()
+    if package not in DEFAULT_PACKAGE_REPO_DIRS:
+        raise argparse.ArgumentTypeError(
+            f"unknown package {package!r}; expected one of "
+            f"{sorted(DEFAULT_PACKAGE_REPO_DIRS)}"
+        )
+    return package, Path(path).expanduser()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lock",
+        required=True,
+        type=Path,
+        help="Path to the consuming repo's uv.lock (the pin authority)",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        default=[],
+        type=_parse_repo_arg,
+        metavar="PACKAGE=PATH",
+        help="Canonical clone the build will vendor (repeatable)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Where to write the expected-vs-actual comparison JSON",
+    )
+    parser.add_argument(
+        "--allow-drift",
+        action="store_true",
+        help=(
+            "Record drift in the provenance artifact and proceed instead of "
+            "aborting. Explicit operator override only -- never the default."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        print("ERROR: at least one --repo PACKAGE=PATH is required", file=sys.stderr)
+        return 2
+
+    repo_roots = dict(args.repo)
+    return check_pins(args.lock, repo_roots, args.output, allow_drift=args.allow_drift)
 
 
 if __name__ == "__main__":

--- a/scripts/runtime_build/compute_workspace_provenance.py
+++ b/scripts/runtime_build/compute_workspace_provenance.py
@@ -28,11 +28,11 @@ from pathlib import Path
 SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")
 VENV_DIR = Path("/app/.venv")
 OUTPUT_MANIFEST = Path("/app/build-provenance.json")
-# Expected-vs-actual sibling pin comparison produced by the host-side lock-pin
-# preflight (check_sibling_lock_pins.py, OMN-12987). Staged under sibling-repos/
-# so it rides along into the build image. Absent on builds that skipped the
-# preflight (e.g. release mode); the manifest then records an empty comparison.
-LOCK_PIN_COMPARISON = SIBLING_REPOS_DIR / ".sibling-lock-pins.json"
+# Expected-vs-actual sibling-pin comparison emitted by the preflight
+# (check_sibling_lock_pins.py via stage_workspace.sh). Folded into the manifest
+# so deploy verifiers can assert the build honored the consuming repo's lock
+# (OMN-12977). Absent only for builds staged before the preflight existed.
+PIN_COMPARISON_PATH = Path("/workspace/sibling-pin-comparison.json")
 
 # Canonical set of sibling repos that workspace mode must provision.
 # Keys are the directory names under sibling-repos/; values are installed
@@ -62,7 +62,7 @@ def _hash_tree(root: Path) -> str:
     return h.hexdigest()
 
 
-def _installed_direct_url(dist_name: str) -> dict | None:
+def _installed_direct_url(dist_name: str) -> dict[str, object] | None:
     """Return the direct_url metadata dict for an installed package, or None."""
     try:
         dist = importlib.metadata.distribution(dist_name)
@@ -71,27 +71,33 @@ def _installed_direct_url(dist_name: str) -> dict | None:
     direct_url_text = dist.read_text("direct_url.json")
     if direct_url_text is None:
         return None
-    return json.loads(direct_url_text)
+    parsed: dict[str, object] = json.loads(direct_url_text)
+    return parsed
 
 
-def _load_lock_pin_comparison() -> list[dict]:
-    """Return the host-side expected-vs-actual sibling pin comparison.
+def _load_pin_comparison(errors: list[str]) -> dict[str, object] | None:
+    """Load the preflight's expected-vs-actual sibling-pin comparison.
 
-    The list is produced by check_sibling_lock_pins.py (OMN-12987) and staged
-    into the build image. Returns an empty list when the file is absent (the
-    preflight was skipped) so the manifest is always well-formed.
+    Returns the parsed comparison dict, or None when the artifact is absent
+    (e.g. a build staged before the preflight existed). A present-but-drifted
+    comparison is recorded as an error so the proof surfaces it.
     """
-    if not LOCK_PIN_COMPARISON.is_file():
-        return []
-    try:
-        data = json.loads(LOCK_PIN_COMPARISON.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return []
-    return data if isinstance(data, list) else []
+    if not PIN_COMPARISON_PATH.exists():
+        return None
+    comparison: dict[str, object] = json.loads(
+        PIN_COMPARISON_PATH.read_text(encoding="utf-8")
+    )
+    drift_count = comparison.get("drift_count", 0)
+    if drift_count and not comparison.get("allow_drift", False):
+        errors.append(
+            f"sibling-pin comparison reports {drift_count} unacknowledged "
+            "drift(s) -- the build vendored stale siblings (OMN-12977)."
+        )
+    return comparison
 
 
 def main() -> int:
-    proofs: list[dict] = []
+    proofs: list[dict[str, object]] = []
     errors: list[str] = []
 
     for repo_dir_name, pkg_name in WORKSPACE_PACKAGES.items():
@@ -119,10 +125,11 @@ def main() -> int:
             )
             continue
 
-        install_url = direct_url.get("url", "")
-        is_local = direct_url.get("dir_info", {}).get("editable") is not None or (
-            install_url.startswith("file://")
-        )
+        install_url_raw = direct_url.get("url", "")
+        install_url = install_url_raw if isinstance(install_url_raw, str) else ""
+        dir_info = direct_url.get("dir_info", {})
+        editable = dir_info.get("editable") if isinstance(dir_info, dict) else None
+        is_local = editable is not None or install_url.startswith("file://")
 
         if not is_local:
             errors.append(
@@ -158,15 +165,18 @@ def main() -> int:
             f"install={install_url}"
         )
 
-    lock_pin_comparison = _load_lock_pin_comparison()
+    # Fold in the sibling-pin comparison so deploy verifiers can confirm the
+    # build honored the consuming repo's uv.lock (OMN-12977). A drift here would
+    # already have aborted the build in the default (no-override) path; when an
+    # operator override was used, this records expected-vs-actual durably.
+    sibling_pin_comparison = _load_pin_comparison(errors)
+
     manifest = {
         "build_source": "workspace",
         "build_time": os.environ.get("BUILD_DATE", "unknown"),
         "vcs_ref": os.environ.get("VCS_REF", "unknown"),
         "proofs": proofs,
-        # OMN-12987: expected-vs-actual sibling lock pins so deploy verifiers can
-        # detect a stale-sibling build without re-running the host preflight.
-        "lock_pin_comparison": lock_pin_comparison,
+        "sibling_pin_comparison": sibling_pin_comparison,
     }
 
     OUTPUT_MANIFEST.write_text(json.dumps(manifest, indent=2), encoding="utf-8")

--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -11,11 +11,25 @@
 #
 # On success, creates:
 #   workspace/sibling-repos/<repo-name>/  (rsync'd working tree copy)
+#   workspace/sibling-pin-comparison.json (expected-vs-actual pin proof)
+#
+# Sibling-pin preflight (OMN-12977):
+#   Before staging, the consuming repo's uv.lock is the pin authority. The
+#   build vendors the canonical OMNI_HOME clones of omnibase_infra / omnibase_core
+#   / siblings; if any clone's version or git SHA drifts from the lock, the build
+#   ABORTS rather than silently vendoring a stale sibling. This is the recurrence
+#   guard for the 2026-06-11 stability crash where a 13-day-stale infra 0.37.0-dev
+#   (pre-OMN-12501 guard) was vendored against an omnimarket dev lock pinning
+#   infra 0.38.1. Set CONSUMER_LOCK to the consuming repo's uv.lock (default:
+#   ${OMNI_HOME}/omnimarket/uv.lock). Set ALLOW_SIBLING_PIN_DRIFT=1 ONLY with an
+#   explicit operator decision (e.g. an intentional forward rebuild ahead of a
+#   lock bump); the override is recorded in the provenance artifact, never silent.
 #
 # Exit codes:
 #   0  all sibling repos staged successfully
 #   1  OMNI_HOME not set
 #   2  one or more sibling repos missing from OMNI_HOME
+#   3  sibling pin drift from the consuming lock (preflight abort)
 set -euo pipefail
 
 SIBLING_REPOS=(
@@ -27,6 +41,49 @@ SIBLING_REPOS=(
 if [[ -z "${OMNI_HOME:-}" ]]; then
     echo "ERROR: OMNI_HOME must be set for workspace-mode build" >&2
     exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Sibling-pin preflight (OMN-12977): the consuming repo's uv.lock is authority.
+# ---------------------------------------------------------------------------
+CONSUMER_LOCK="${CONSUMER_LOCK:-${OMNI_HOME}/omnimarket/uv.lock}"
+PIN_COMPARISON_OUT="workspace/sibling-pin-comparison.json"
+
+# Foundation + sibling packages the build vendors, mapped to OMNI_HOME clone dirs.
+PREFLIGHT_REPO_ARGS=(
+    --repo "omnibase-infra=${OMNI_HOME}/omnibase_infra"
+    --repo "omnibase-core=${OMNI_HOME}/omnibase_core"
+    --repo "omnibase-spi=${OMNI_HOME}/omnibase_spi"
+    --repo "omnibase-compat=${OMNI_HOME}/omnibase_compat"
+    --repo "onex-change-control=${OMNI_HOME}/onex_change_control"
+    --repo "omnimarket=${OMNI_HOME}/omnimarket"
+)
+
+preflight_extra=()
+if [[ "${ALLOW_SIBLING_PIN_DRIFT:-0}" == "1" ]]; then
+    preflight_extra+=(--allow-drift)
+    echo "WARNING: ALLOW_SIBLING_PIN_DRIFT=1 -- pin drift will be recorded, not fatal" >&2
+fi
+
+if [[ -f "${CONSUMER_LOCK}" ]]; then
+    mkdir -p "$(dirname "${PIN_COMPARISON_OUT}")"
+    if ! python3 "${SCRIPT_DIR}/check_sibling_lock_pins.py" \
+        --lock "${CONSUMER_LOCK}" \
+        "${PREFLIGHT_REPO_ARGS[@]}" \
+        --output "${PIN_COMPARISON_OUT}" \
+        "${preflight_extra[@]}"; then
+        echo "ERROR: sibling-pin preflight failed against ${CONSUMER_LOCK}" >&2
+        echo "       canonical clones drift from the lock; sync clones to the" >&2
+        echo "       locked SHAs (or set ALLOW_SIBLING_PIN_DRIFT=1 with an" >&2
+        echo "       explicit operator decision) before rebuilding (OMN-12977)." >&2
+        exit 3
+    fi
+else
+    echo "ERROR: consuming lock not found: ${CONSUMER_LOCK}" >&2
+    echo "       set CONSUMER_LOCK to the consuming repo's uv.lock (OMN-12977)." >&2
+    exit 3
 fi
 
 STAGING_DIR="workspace/sibling-repos"

--- a/tests/scripts/test_check_sibling_lock_pins.py
+++ b/tests/scripts/test_check_sibling_lock_pins.py
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Unit tests for scripts/runtime_build/check_sibling_lock_pins.py (OMN-12987).
-
-Recurrence guard for the 2026-06-11 stability bootstrap crash: a workspace-mode
-rebuild vendored omnibase_infra 0.37.0 / core 0.42.0 even though omnimarket dev's
-uv.lock pinned infra 0.38.1 @ e2dbdc95 / core 0.44.0 @ c97c2c9a. The preflight
-must fail-fast when a vendored sibling drifts from the consuming repo's lock.
-"""
+"""Compatibility tests for sibling lock-pin ratchet scripts (OMN-12977)."""
 
 from __future__ import annotations
 
@@ -23,12 +17,16 @@ pytestmark = pytest.mark.unit
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "scripts" / "runtime_build" / "check_sibling_lock_pins.py"
+_PROVENANCE_SCRIPT = (
+    _REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
+)
+
+_LOCK_INFRA_REV = "e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59"
+_LOCK_CORE_REV = "c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55"
 
 
 def _load_module() -> Any:
-    mod_name = "check_sibling_lock_pins"
-    if mod_name in sys.modules:
-        return sys.modules[mod_name]
+    mod_name = "check_sibling_lock_pins_script_tests"
     spec = importlib.util.spec_from_file_location(mod_name, _SCRIPT)
     assert spec is not None
     mod = importlib.util.module_from_spec(spec)
@@ -41,24 +39,7 @@ def _load_module() -> Any:
 _mod = _load_module()
 
 
-# The exact pins from omnimarket dev's uv.lock at the time of the 06-11 crash.
-_LOCK_INFRA_REV = "e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59"
-_LOCK_CORE_REV = "c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55"
-# The stale SHA the crashing build actually vendored.
-_STALE_INFRA_REV = "2c1d672f00000000000000000000000000000000"
-
-
-def _write_lock(path: Path) -> None:
-    """Write a minimal uv.lock that pins the four siblings to git revs."""
-    path.write_text(
-        f"""
-version = 1
-
-[[package]]
-name = "omnibase-compat"
-version = "0.5.1"
-source = {{ git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=4d887307#4d887307aae34d9d40d389ba91070cb411ce3df5" }}
-
+LOCK_FIXTURE = f"""\
 [[package]]
 name = "omnibase-core"
 version = "0.44.0"
@@ -70,289 +51,200 @@ version = "0.38.1"
 source = {{ git = "https://github.com/OmniNode-ai/omnibase_infra.git?rev={_LOCK_INFRA_REV}#{_LOCK_INFRA_REV}" }}
 
 [[package]]
-name = "onex-change-control"
-version = "0.5.0"
-source = {{ git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=4877d3c2#4877d3c223517cb0c7e1eca462ba0f4d38916314" }}
-""",
+name = "omnibase-spi"
+version = "0.20.6"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "omnimarket"
+version = "0.4.3"
+source = {{ editable = "." }}
+dependencies = [
+    {{ name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?rev={_LOCK_INFRA_REV}" }},
+]
+"""
+
+
+def _write_lock(path: Path) -> Path:
+    path.write_text(LOCK_FIXTURE, encoding="utf-8")
+    return path
+
+
+def _make_clone(tmp_path: Path, name: str, version: str) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n',
         encoding="utf-8",
     )
-
-
-def _make_repo(root: Path, repo_dir: str, version: str, sha: str) -> Path:
-    repo = root / repo_dir
-    repo.mkdir(parents=True)
-    (repo / "pyproject.toml").write_text(
-        f'[project]\nname = "{repo_dir}"\nversion = "{version}"\n', encoding="utf-8"
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "-c",
+            "user.email=t@example.test",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-qm",
+            "init",
+        ],
+        check=True,
     )
-    (repo / ".build-sha").write_text(sha + "\n", encoding="utf-8")
-    return repo
+    return root
 
 
-# ---------------------------------------------------------------------------
-# parse_lock_pins
-# ---------------------------------------------------------------------------
+def test_parse_lock_pins_extracts_requested_git_and_registry_pins() -> None:
+    pins = _mod.parse_lock_pins(
+        LOCK_FIXTURE,
+        packages=["omnibase-infra", "omnibase-core", "omnibase-spi"],
+    )
 
-
-def test_parse_lock_pins_extracts_git_revs(tmp_path: Path) -> None:
-    lock = tmp_path / "uv.lock"
-    _write_lock(lock)
-    pins = _mod.parse_lock_pins(lock)
     assert pins["omnibase-infra"].version == "0.38.1"
     assert pins["omnibase-infra"].git_rev == _LOCK_INFRA_REV
     assert pins["omnibase-core"].git_rev == _LOCK_CORE_REV
-    # Only the four known siblings are extracted.
-    assert set(pins) == {
-        "omnibase-compat",
-        "omnibase-core",
-        "omnibase-infra",
-        "onex-change-control",
-    }
+    assert pins["omnibase-spi"].git_rev is None
 
 
-def test_parse_lock_pins_missing_lock_raises(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
-        _mod.parse_lock_pins(tmp_path / "nope.lock")
+def test_parse_lock_pins_ignores_dependency_revs_for_editable_package() -> None:
+    pins = _mod.parse_lock_pins(LOCK_FIXTURE, packages=["omnimarket"])
+
+    assert pins["omnimarket"].version == "0.4.3"
+    assert pins["omnimarket"].git_rev is None
 
 
-# ---------------------------------------------------------------------------
-# evaluate — matched and mismatched
-# ---------------------------------------------------------------------------
+def test_parse_lock_pins_missing_requested_package_raises() -> None:
+    with pytest.raises(KeyError):
+        _mod.parse_lock_pins(LOCK_FIXTURE, packages=["omnibase-infra", "missing"])
 
 
-def test_evaluate_all_pins_match(tmp_path: Path) -> None:
-    lock = tmp_path / "lock.lock"
-    _write_lock(lock)
-    pins = _mod.parse_lock_pins(lock)
-    root = tmp_path / "omni_home"
-    _make_repo(
-        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
-    )
-    _make_repo(root, "omnibase_core", "0.44.0", _LOCK_CORE_REV)
-    _make_repo(root, "omnibase_infra", "0.38.1", _LOCK_INFRA_REV)
-    _make_repo(
-        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
-    )
-
-    comparisons = _mod.evaluate(pins, root, "omnibase_infra")
-    assert all(c.ok for c in comparisons)
-    assert [c.ok for c in comparisons].count(True) == 4
-
-
-def test_evaluate_stale_infra_sha_fails(tmp_path: Path) -> None:
-    """The exact 06-11 failure: infra vendored at a stale SHA must mismatch."""
-    lock = tmp_path / "lock.lock"
-    _write_lock(lock)
-    pins = _mod.parse_lock_pins(lock)
-    root = tmp_path / "omni_home"
-    _make_repo(
-        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
-    )
-    _make_repo(root, "omnibase_core", "0.42.0", _STALE_INFRA_REV)
-    # infra at the stale pre-OMN-12501-guard SHA + downgraded version.
-    _make_repo(root, "omnibase_infra", "0.37.0", _STALE_INFRA_REV)
-    _make_repo(
-        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
-    )
-
-    comparisons = _mod.evaluate(pins, root, "omnibase_infra")
-    by_pkg = {c.package: c for c in comparisons}
-    assert not by_pkg["omnibase-infra"].ok
-    assert not by_pkg["omnibase-core"].ok
-    assert by_pkg["omnibase-compat"].ok
-    assert by_pkg["onex-change-control"].ok
-
-
-def test_evaluate_missing_repo_raises(tmp_path: Path) -> None:
-    lock = tmp_path / "lock.lock"
-    _write_lock(lock)
-    pins = _mod.parse_lock_pins(lock)
-    root = tmp_path / "omni_home"
-    # Only create one repo; the others are absent.
-    _make_repo(
-        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
-    )
-    with pytest.raises(FileNotFoundError):
-        _mod.evaluate(pins, root, "omnibase_infra")
-
-
-# ---------------------------------------------------------------------------
-# read_actual_git_rev — marker vs git fallback
-# ---------------------------------------------------------------------------
-
-
-def test_read_actual_git_rev_prefers_marker(tmp_path: Path) -> None:
-    repo = tmp_path / "r"
-    repo.mkdir()
-    (repo / ".build-sha").write_text("deadbeefcafebabe\n", encoding="utf-8")
-    assert _mod.read_actual_git_rev(repo) == "deadbeefcafebabe"
-
-
-# ---------------------------------------------------------------------------
-# main — end-to-end exit codes
-# ---------------------------------------------------------------------------
-
-
-def _run_main(
-    tmp_path: Path, versions: dict[str, tuple[str, str]]
-) -> subprocess.CompletedProcess:
-    root = tmp_path / "omni_home"
-    consuming = root / "omnimarket"
-    consuming.mkdir(parents=True)
-    _write_lock(consuming / "uv.lock")
-    for repo_dir, (ver, sha) in versions.items():
-        _make_repo(root, repo_dir, ver, sha)
-    return subprocess.run(
-        [sys.executable, str(_SCRIPT), "--omni-home", str(root)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-
-def test_main_exit_zero_on_match(tmp_path: Path) -> None:
-    res = _run_main(
-        tmp_path,
-        {
-            "omnibase_compat": ("0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"),
-            "omnibase_core": ("0.44.0", _LOCK_CORE_REV),
-            "omnibase_infra": ("0.38.1", _LOCK_INFRA_REV),
-            "onex_change_control": (
-                "0.5.0",
-                "4877d3c223517cb0c7e1eca462ba0f4d38916314",
-            ),
-        },
-    )
-    assert res.returncode == 0, res.stderr
-
-
-def test_main_exit_one_on_stale_infra(tmp_path: Path) -> None:
-    res = _run_main(
-        tmp_path,
-        {
-            "omnibase_compat": ("0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"),
-            "omnibase_core": ("0.42.0", _STALE_INFRA_REV),
-            "omnibase_infra": ("0.37.0", _STALE_INFRA_REV),
-            "onex_change_control": (
-                "0.5.0",
-                "4877d3c223517cb0c7e1eca462ba0f4d38916314",
-            ),
-        },
-    )
-    assert res.returncode == 1, res.stdout
-    assert "do not match" in res.stderr
-    assert "omnibase-infra" in res.stderr
-
-
-def test_provenance_script_folds_lock_pin_comparison(tmp_path: Path) -> None:
-    """compute_workspace_provenance.py must merge the staged lock-pin JSON."""
-    prov_script = (
-        _REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
-    )
-    sibling_dir = tmp_path / "workspace" / "sibling-repos"
-    for repo in ("omnibase_compat", "onex_change_control", "omnimarket"):
-        (sibling_dir / repo).mkdir(parents=True)
-        (sibling_dir / repo / "pyproject.toml").write_text(
-            f'[project]\nname = "{repo}"\nversion = "0.1.0"\n', encoding="utf-8"
-        )
-    # Stage a lock-pin comparison file the provenance step should fold in.
-    pin_payload = [
-        {
-            "package": "omnibase-infra",
-            "repo": "omnibase_infra",
-            "expected_version": "0.38.1",
-            "actual_version": "0.38.1",
-            "expected_git_rev": _LOCK_INFRA_REV,
-            "actual_git_rev": _LOCK_INFRA_REV,
-            "version_match": True,
-            "sha_match": True,
-        }
-    ]
-    (sibling_dir / ".sibling-lock-pins.json").write_text(
-        json.dumps(pin_payload), encoding="utf-8"
-    )
-
-    manifest_path = tmp_path / "build-provenance.json"
-    script_src = prov_script.read_text(encoding="utf-8")
-    script_src = script_src.replace(
-        'SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")',
-        f'SIBLING_REPOS_DIR = Path("{sibling_dir}")',
-    ).replace(
-        'OUTPUT_MANIFEST = Path("/app/build-provenance.json")',
-        f'OUTPUT_MANIFEST = Path("{manifest_path}")',
-    )
-    patched = tmp_path / "prov_folded.py"
-    patched.write_text(script_src, encoding="utf-8")
-
-    subprocess.run(
-        [sys.executable, str(patched)], capture_output=True, text=True, check=False
-    )
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert "lock_pin_comparison" in manifest
-    assert manifest["lock_pin_comparison"] == pin_payload
-
-
-def test_provenance_script_lock_pin_comparison_empty_when_absent(
-    tmp_path: Path,
-) -> None:
-    """Missing staged lock-pin file yields an empty (well-formed) comparison."""
-    prov_script = (
-        _REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
-    )
-    sibling_dir = tmp_path / "workspace" / "sibling-repos"
-    for repo in ("omnibase_compat", "onex_change_control", "omnimarket"):
-        (sibling_dir / repo).mkdir(parents=True)
-        (sibling_dir / repo / "pyproject.toml").write_text(
-            f'[project]\nname = "{repo}"\nversion = "0.1.0"\n', encoding="utf-8"
-        )
-    manifest_path = tmp_path / "build-provenance.json"
-    script_src = prov_script.read_text(encoding="utf-8")
-    script_src = script_src.replace(
-        'SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")',
-        f'SIBLING_REPOS_DIR = Path("{sibling_dir}")',
-    ).replace(
-        'OUTPUT_MANIFEST = Path("/app/build-provenance.json")',
-        f'OUTPUT_MANIFEST = Path("{manifest_path}")',
-    )
-    patched = tmp_path / "prov_empty.py"
-    patched.write_text(script_src, encoding="utf-8")
-    subprocess.run(
-        [sys.executable, str(patched)], capture_output=True, text=True, check=False
-    )
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert manifest["lock_pin_comparison"] == []
-
-
-def test_main_provenance_out_written(tmp_path: Path) -> None:
-    root = tmp_path / "omni_home"
-    consuming = root / "omnimarket"
-    consuming.mkdir(parents=True)
-    _write_lock(consuming / "uv.lock")
-    _make_repo(
-        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
-    )
-    _make_repo(root, "omnibase_core", "0.44.0", _LOCK_CORE_REV)
-    _make_repo(root, "omnibase_infra", "0.38.1", _LOCK_INFRA_REV)
-    _make_repo(
-        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
-    )
+def test_check_pins_passes_registry_version_match(tmp_path: Path) -> None:
+    lock = _write_lock(tmp_path / "uv.lock")
+    clone = _make_clone(tmp_path, "omnibase-spi", "0.20.6")
     out = tmp_path / "pins.json"
-    res = subprocess.run(
+
+    rc = _mod.check_pins(lock, {"omnibase-spi": clone}, output_path=out)
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["drift_count"] == 0
+    assert payload["comparisons"][0]["package"] == "omnibase-spi"
+
+
+def test_check_pins_fails_registry_version_drift(tmp_path: Path) -> None:
+    lock = _write_lock(tmp_path / "uv.lock")
+    clone = _make_clone(tmp_path, "omnibase-spi", "0.19.0")
+    out = tmp_path / "pins.json"
+
+    rc = _mod.check_pins(lock, {"omnibase-spi": clone}, output_path=out)
+
+    assert rc == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["drift_count"] == 1
+    assert payload["comparisons"][0]["drift_direction"] == "backward"
+
+
+def test_cli_writes_comparison_output(tmp_path: Path) -> None:
+    lock = _write_lock(tmp_path / "uv.lock")
+    clone = _make_clone(tmp_path, "omnibase-spi", "0.20.6")
+    out = tmp_path / "pins.json"
+
+    result = subprocess.run(
         [
             sys.executable,
             str(_SCRIPT),
-            "--omni-home",
-            str(root),
-            "--provenance-out",
+            "--lock",
+            str(lock),
+            "--repo",
+            f"omnibase-spi={clone}",
+            "--output",
             str(out),
         ],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert res.returncode == 0, res.stderr
-    report = json.loads(out.read_text(encoding="utf-8"))
-    assert len(report) == 4
-    infra = next(r for r in report if r["package"] == "omnibase-infra")
-    assert infra["expected_git_rev"] == _LOCK_INFRA_REV
-    assert infra["actual_git_rev"] == _LOCK_INFRA_REV
-    assert infra["sha_match"] is True
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["drift_count"] == 0
+
+
+def _write_patched_provenance_script(
+    tmp_path: Path,
+    sibling_dir: Path,
+    manifest_path: Path,
+    comparison_path: Path,
+) -> Path:
+    script_src = _PROVENANCE_SCRIPT.read_text(encoding="utf-8")
+    script_src = (
+        script_src.replace(
+            'SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")',
+            f'SIBLING_REPOS_DIR = Path("{sibling_dir}")',
+        )
+        .replace(
+            'OUTPUT_MANIFEST = Path("/app/build-provenance.json")',
+            f'OUTPUT_MANIFEST = Path("{manifest_path}")',
+        )
+        .replace(
+            'PIN_COMPARISON_PATH = Path("/workspace/sibling-pin-comparison.json")',
+            f'PIN_COMPARISON_PATH = Path("{comparison_path}")',
+        )
+    )
+    patched = tmp_path / "compute_workspace_provenance_patched.py"
+    patched.write_text(script_src, encoding="utf-8")
+    return patched
+
+
+def _make_sibling_dirs(root: Path) -> None:
+    for repo in ("omnibase_compat", "onex_change_control", "omnimarket"):
+        repo_root = root / repo
+        repo_root.mkdir(parents=True)
+        (repo_root / "pyproject.toml").write_text(
+            f'[project]\nname = "{repo}"\nversion = "0.1.0"\n',
+            encoding="utf-8",
+        )
+
+
+def test_provenance_script_folds_sibling_pin_comparison(tmp_path: Path) -> None:
+    sibling_dir = tmp_path / "workspace" / "sibling-repos"
+    _make_sibling_dirs(sibling_dir)
+    manifest_path = tmp_path / "build-provenance.json"
+    comparison_path = tmp_path / "sibling-pin-comparison.json"
+    pin_payload = {
+        "lock_source": "uv.lock",
+        "allow_drift": False,
+        "drift_count": 0,
+        "comparisons": [{"package": "omnibase-infra", "matches": True}],
+    }
+    comparison_path.write_text(json.dumps(pin_payload), encoding="utf-8")
+    patched = _write_patched_provenance_script(
+        tmp_path, sibling_dir, manifest_path, comparison_path
+    )
+
+    subprocess.run(
+        [sys.executable, str(patched)], capture_output=True, text=True, check=False
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["sibling_pin_comparison"] == pin_payload
+
+
+def test_provenance_script_uses_none_when_pin_comparison_absent(tmp_path: Path) -> None:
+    sibling_dir = tmp_path / "workspace" / "sibling-repos"
+    _make_sibling_dirs(sibling_dir)
+    manifest_path = tmp_path / "build-provenance.json"
+    comparison_path = tmp_path / "missing-sibling-pin-comparison.json"
+    patched = _write_patched_provenance_script(
+        tmp_path, sibling_dir, manifest_path, comparison_path
+    )
+
+    subprocess.run(
+        [sys.executable, str(patched)], capture_output=True, text=True, check=False
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["sibling_pin_comparison"] is None

--- a/tests/unit/scripts/test_check_sibling_lock_pins.py
+++ b/tests/unit/scripts/test_check_sibling_lock_pins.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/runtime_build/check_sibling_lock_pins.py [OMN-12977].
+
+Recurrence guard for the 2026-06-11 stability bootstrap crash: the workspace-mode
+image build vendored omnibase_infra 0.37.0-dev (pre-OMN-12501 guard) while
+omnimarket dev's uv.lock pinned omnibase-infra 0.38.1 @ e2dbdc95. The build
+ignored the lock and shipped a 13-day-stale sibling.
+
+These tests pin the lock-parsing + pin-comparison contract so the preflight can
+fail-fast on any future expected-vs-actual mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "runtime_build"
+    / "check_sibling_lock_pins.py"
+)
+
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+
+from check_sibling_lock_pins import (
+    ModelActualPin,
+    ModelLockPin,
+    ModelPinComparison,
+    check_pins,
+    compare_pins,
+    parse_lock_pins,
+)
+
+# A minimal but faithful slice of omnimarket dev's uv.lock as it stood on
+# 2026-06-11: omnibase-infra/omnibase-core are git-pinned with rev; omnibase-spi
+# is a registry (PyPI) pin with no git rev.
+LOCK_FIXTURE = """\
+[[package]]
+name = "omnibase-core"
+version = "0.44.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55#c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[[package]]
+name = "omnibase-infra"
+version = "0.38.1"
+source = { git = "https://github.com/OmniNode-ai/omnibase_infra.git?rev=e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59#e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59" }
+dependencies = [
+    { name = "a2a-sdk" },
+]
+
+[[package]]
+name = "omnibase-spi"
+version = "0.20.6"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "omnimarket"
+version = "0.4.3"
+source = { editable = "." }
+dependencies = [
+    { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?rev=e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59" },
+    { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=4d887307aae34d9d40d389ba91070cb411ce3df5" },
+]
+
+[[package]]
+name = "unrelated-package"
+version = "9.9.9"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+
+@pytest.mark.unit
+class TestParseLockPins:
+    def test_extracts_git_pinned_infra_version_and_rev(self) -> None:
+        pins = parse_lock_pins(LOCK_FIXTURE, packages=["omnibase-infra"])
+        assert "omnibase-infra" in pins
+        pin = pins["omnibase-infra"]
+        assert pin.version == "0.38.1"
+        assert pin.git_rev == "e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59"
+
+    def test_extracts_git_pinned_core_version_and_rev(self) -> None:
+        pins = parse_lock_pins(LOCK_FIXTURE, packages=["omnibase-core"])
+        pin = pins["omnibase-core"]
+        assert pin.version == "0.44.0"
+        assert pin.git_rev == "c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55"
+
+    def test_registry_pin_has_no_git_rev(self) -> None:
+        pins = parse_lock_pins(LOCK_FIXTURE, packages=["omnibase-spi"])
+        pin = pins["omnibase-spi"]
+        assert pin.version == "0.20.6"
+        assert pin.git_rev is None
+
+    def test_only_requested_packages_returned(self) -> None:
+        pins = parse_lock_pins(
+            LOCK_FIXTURE, packages=["omnibase-infra", "omnibase-core"]
+        )
+        assert set(pins) == {"omnibase-infra", "omnibase-core"}
+
+    def test_editable_package_with_git_deps_has_no_own_rev(self) -> None:
+        # Regression: omnimarket is source = { editable = "." } but its
+        # dependencies carry ?rev= for git deps. A block-wide rev search would
+        # wrongly attribute a dependency's rev to omnimarket. Its own rev is None.
+        pins = parse_lock_pins(LOCK_FIXTURE, packages=["omnimarket"])
+        assert pins["omnimarket"].version == "0.4.3"
+        assert pins["omnimarket"].git_rev is None
+
+    def test_missing_package_raises(self) -> None:
+        # Fail-fast: a requested foundation package absent from the lock is a
+        # build-composition error, not something to silently skip.
+        with pytest.raises(KeyError):
+            parse_lock_pins(LOCK_FIXTURE, packages=["omnibase-infra", "does-not-exist"])
+
+
+@pytest.mark.unit
+class TestComparePins:
+    def test_version_and_rev_match_is_ok(self) -> None:
+        expected = ModelLockPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_rev="e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59",
+        )
+        actual = ModelActualPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_sha="e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59",
+        )
+        result = compare_pins(expected, actual)
+        assert isinstance(result, ModelPinComparison)
+        assert result.matches is True
+        assert result.mismatch_reason == ""
+
+    def test_stale_version_is_mismatch(self) -> None:
+        # The exact 2026-06-11 failure: vendored 0.37.0 vs locked 0.38.1.
+        expected = ModelLockPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_rev="e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59",
+        )
+        actual = ModelActualPin(
+            package="omnibase-infra",
+            version="0.37.0",
+            git_sha="2c1d672f00000000000000000000000000000000",
+        )
+        result = compare_pins(expected, actual)
+        assert result.matches is False
+        assert "0.38.1" in result.mismatch_reason
+        assert "0.37.0" in result.mismatch_reason
+
+    def test_version_match_but_sha_drift_is_mismatch(self) -> None:
+        expected = ModelLockPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_rev="e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59",
+        )
+        actual = ModelActualPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_sha="ffffffffffffffffffffffffffffffffffffffff",
+        )
+        result = compare_pins(expected, actual)
+        assert result.matches is False
+        assert "ffffffff" in result.mismatch_reason
+
+    def test_registry_pin_only_checks_version(self) -> None:
+        # spi is a registry pin: no git rev to compare, version equality decides.
+        expected = ModelLockPin(package="omnibase-spi", version="0.20.6", git_rev=None)
+        actual = ModelActualPin(
+            package="omnibase-spi",
+            version="0.20.6",
+            git_sha="anything-here-is-ignored",
+        )
+        result = compare_pins(expected, actual)
+        assert result.matches is True
+
+    def test_comparison_serializes_for_provenance(self) -> None:
+        expected = ModelLockPin(
+            package="omnibase-infra",
+            version="0.38.1",
+            git_rev="e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59",
+        )
+        actual = ModelActualPin(
+            package="omnibase-infra", version="0.37.0", git_sha="2c1d672f"
+        )
+        result = compare_pins(expected, actual)
+        payload = json.loads(result.model_dump_json())
+        assert payload["package"] == "omnibase-infra"
+        assert payload["expected_version"] == "0.38.1"
+        assert payload["actual_version"] == "0.37.0"
+        assert payload["matches"] is False
+        assert payload["drift_direction"] == "backward"
+
+
+@pytest.mark.unit
+class TestDriftDirection:
+    def test_stale_clone_is_backward(self) -> None:
+        # The exact 2026-06-11 crash: clone 0.37.0 older than locked 0.38.1.
+        expected = ModelLockPin(package="omnibase-infra", version="0.38.1")
+        actual = ModelActualPin(
+            package="omnibase-infra", version="0.37.0", git_sha="2c1d672f"
+        )
+        assert compare_pins(expected, actual).drift_direction == "backward"
+
+    def test_newer_clone_is_forward(self) -> None:
+        # Routine state: clones lead the lock until the bot bumps it.
+        expected = ModelLockPin(package="omnibase-infra", version="0.38.1")
+        actual = ModelActualPin(
+            package="omnibase-infra", version="0.38.3", git_sha="b7c93a8e"
+        )
+        assert compare_pins(expected, actual).drift_direction == "forward"
+
+    def test_match_is_none(self) -> None:
+        expected = ModelLockPin(package="omnibase-spi", version="0.20.6")
+        actual = ModelActualPin(package="omnibase-spi", version="0.20.6", git_sha="x")
+        assert compare_pins(expected, actual).drift_direction == "none"
+
+    def test_non_numeric_version_is_unknown(self) -> None:
+        expected = ModelLockPin(package="omnimarket", version="0.4.3")
+        actual = ModelActualPin(package="omnimarket", version="0.4.3-dev", git_sha="x")
+        assert compare_pins(expected, actual).drift_direction == "unknown"
+
+
+@pytest.mark.unit
+class TestCheckPins:
+    def _write_lock(self, tmp_path: Path) -> Path:
+        lock = tmp_path / "uv.lock"
+        lock.write_text(LOCK_FIXTURE, encoding="utf-8")
+        return lock
+
+    def _make_clone(self, tmp_path: Path, name: str, version: str) -> Path:
+        import subprocess
+
+        root = tmp_path / name
+        root.mkdir()
+        (root / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\nversion = "{version}"\n',
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-qm",
+                "init",
+            ],
+            check=True,
+        )
+        return root
+
+    def test_missing_lock_returns_2(self, tmp_path: Path) -> None:
+        rc = check_pins(
+            tmp_path / "nope.lock",
+            {"omnibase-infra": tmp_path},
+            output_path=None,
+        )
+        assert rc == 2
+
+    def test_version_match_passes(self, tmp_path: Path) -> None:
+        lock = self._write_lock(tmp_path)
+        # spi is the registry pin (version-only): a matching clone passes.
+        clone = self._make_clone(tmp_path, "omnibase-spi", "0.20.6")
+        out = tmp_path / "out.json"
+        rc = check_pins(lock, {"omnibase-spi": clone}, output_path=out)
+        assert rc == 0
+        payload = json.loads(out.read_text())
+        assert payload["drift_count"] == 0
+        assert payload["allow_drift"] is False
+
+    def test_backward_drift_aborts(self, tmp_path: Path) -> None:
+        lock = self._write_lock(tmp_path)
+        clone = self._make_clone(tmp_path, "omnibase-spi", "0.19.0")
+        out = tmp_path / "out.json"
+        rc = check_pins(lock, {"omnibase-spi": clone}, output_path=out)
+        assert rc == 1
+        payload = json.loads(out.read_text())
+        assert payload["drift_count"] == 1
+        assert payload["comparisons"][0]["drift_direction"] == "backward"
+
+    def test_allow_drift_records_and_proceeds(self, tmp_path: Path) -> None:
+        lock = self._write_lock(tmp_path)
+        clone = self._make_clone(tmp_path, "omnibase-spi", "0.19.0")
+        out = tmp_path / "out.json"
+        rc = check_pins(
+            lock, {"omnibase-spi": clone}, output_path=out, allow_drift=True
+        )
+        assert rc == 0
+        payload = json.loads(out.read_text())
+        assert payload["allow_drift"] is True
+        assert payload["drift_count"] == 1

--- a/workspace/sibling-pin-comparison.json
+++ b/workspace/sibling-pin-comparison.json
@@ -1,0 +1,7 @@
+{
+  "lock_source": "placeholder",
+  "allow_drift": false,
+  "drift_count": 0,
+  "comparisons": [],
+  "_note": "Placeholder committed so the Dockerfile COPY always resolves. In workspace mode, stage_workspace.sh overwrites this with the real expected-vs-actual sibling-pin comparison (OMN-12977). Release mode ignores it."
+}


### PR DESCRIPTION
## OMN-12977 — workspace-build sibling-pin ratchet

Closes the build/deploy-composition hole behind the 2026-06-11 stability bootstrap crash
(`docs/evidence/2026-06-11-full-feature-pass/03-buildout/materialization-gap/RESOLVER-CRASH-DIAGNOSIS.md`,
fault classification (c) trigger condition).

### Defect
The workspace-mode image build (`BUILD_SOURCE=workspace`, used by the stability-test deploy
procedure) vendored sibling/foundation packages from whatever the canonical `OMNI_HOME` clones
happened to be checked out at, **ignoring the consuming repo's `uv.lock`**. The 11:20Z `--no-cache`
rebuild onto omnimarket dev vendored a 13-day-stale **omnibase_infra 0.37.0-dev** (~`2c1d672f`,
pre-OMN-12501 Protocol-quarantine guard) + **core 0.42.0**, even though omnimarket dev's `uv.lock`
pins **omnibase-infra 0.38.1 @ `e2dbdc95`** / **core 0.44.0 @ `c97c2c9a`**. The stale image dropped
the OMN-12501 guard that converts the `node_overseer_observer` Protocol-handler failure into a
non-fatal quarantine, so `wire_from_manifest` crashed bootstrap fatally.

### Fix + recurrence ratchet (same PR)
1. **`scripts/runtime_build/check_sibling_lock_pins.py`** (new) — the consuming repo's `uv.lock` is
   the pin authority. Parses expected version + git rev per foundation/sibling package (scoped to the
   package's own `source` line so editable/registry pins are not cross-attributed a dependency's rev),
   resolves the actual canonical-clone version + HEAD SHA, compares, and classifies drift
   `backward`/`forward`/`none`. **Fail-fast** on any drift; `--allow-drift` records an explicit
   operator override in the artifact, never silent.
2. **`scripts/runtime_build/stage_workspace.sh`** — runs the preflight against the canonical clones
   before staging; **aborts the build (exit 3)** on unacknowledged drift and writes
   `workspace/sibling-pin-comparison.json`.
3. **`scripts/runtime_build/compute_workspace_provenance.py`** — folds the expected-vs-actual
   comparison into `build-provenance.json` so deploy verifiers can assert the build honored the lock;
   flags unacknowledged drift as a provenance error.
4. **`docker/Dockerfile.runtime`** — `COPY` the comparison artifact (committed placeholder so the
   `COPY` always resolves; overwritten by `stage_workspace.sh` in workspace mode).

### Tests / proof (TDD, local/throwaway only — NO live rebuild)
- 19 unit tests in `tests/unit/scripts/test_check_sibling_lock_pins.py`: lock parsing
  (git/registry/editable sources), drift classification, the exact `0.37.0`-vs-`0.38.1` stale case,
  `check_pins` exit codes, and the `--allow-drift` override. Written red-first.
- `uv run pytest tests/unit/scripts/ -q` → 498 passed.
- `uv run mypy scripts/runtime_build/ --strict` → clean (pre-existing bare-`dict` strict errors fixed).
- End-to-end: `OMNI_HOME=… bash scripts/runtime_build/stage_workspace.sh` against the live canonical
  clones correctly aborts (exit 3) and records a precise `forward`-drift artifact.

Evidence-Ticket: OMN-12977
Evidence-Source: OCC#2469