### PR TITLE
fix(OMN-12970): vendor omnimarket projection node migrations into forward/nodes

### DIFF
--- a/docker/migrations/forward/nodes/node_canary_score_reducer/0001_create_capability_scores.sql
+++ b/docker/migrations/forward/nodes/node_canary_score_reducer/0001_create_capability_scores.sql
@@ -1,0 +1,53 @@
+-- OMN-12970: node-owned projection migration for capability_scores.
+--
+-- WHY THIS EXISTS
+--   node_canary_score_reducer declares projection_api over capability_scores
+--   (topic onex.snapshot.projection.capability-scores.v1). The table was
+--   historically created ONLY by omnibase_infra forward migration
+--   060_create_routing_outcomes.sql in the omnibase_infra DB, never in the
+--   dashboard projection DB (omnidash_analytics) the projection API binds to.
+--   Result: the capability-scores topic was DEGRADED at startup
+--   ("table 'public.capability_scores' not found").
+--
+--   Vendored by omnibase_infra/scripts/sync-node-migrations.sh into
+--   docker/migrations/forward/nodes/node_canary_score_reducer/ and applied to
+--   NODE_POSTGRES_DB (omnidash_analytics) by run-forward-migrations.sh under the
+--   namespaced migration id node:node_canary_score_reducer:<file>.
+--
+-- SCHEMA SOURCE OF TRUTH
+--   Mirrors the capability_scores table in omnibase_infra forward migration
+--   060_create_routing_outcomes.sql (table + indexes). routing_outcomes is NOT
+--   created here: no projection contract declares it as a projection-API read
+--   model, so it stays owned by the omnibase_infra DB.
+--
+-- Idempotency: CREATE TABLE / INDEX guarded by IF NOT EXISTS so the migration is
+-- safe on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- CAPABILITY_SCORES TABLE
+-- ============================================================================
+-- Persisted reducer state: rolling capability metrics per (model_key, task_type).
+CREATE TABLE IF NOT EXISTS public.capability_scores (
+    id                      BIGSERIAL        PRIMARY KEY,
+    model_key               TEXT             NOT NULL,
+    task_type               TEXT             NOT NULL,
+    success_count           INT              NOT NULL DEFAULT 0,
+    failure_count           INT              NOT NULL DEFAULT 0,
+    total_count             INT              NOT NULL DEFAULT 0,
+    success_rate            DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    avg_latency_ms          INT              NOT NULL DEFAULT 0,
+    avg_tokens_per_sec      DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    total_cost              DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    graduated               BOOLEAN          NOT NULL DEFAULT FALSE,
+    last_updated            TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    UNIQUE (model_key, task_type)
+);
+
+-- Lookup by model for router input
+CREATE INDEX IF NOT EXISTS idx_capability_scores_model
+    ON capability_scores (model_key);
+
+-- Graduated models for fast filtering
+CREATE INDEX IF NOT EXISTS idx_capability_scores_graduated
+    ON capability_scores (graduated)
+    WHERE graduated = TRUE;

--- a/docker/migrations/forward/nodes/node_projection_cost_summary/0001_create_llm_cost_aggregates.sql
+++ b/docker/migrations/forward/nodes/node_projection_cost_summary/0001_create_llm_cost_aggregates.sql
@@ -1,0 +1,87 @@
+-- OMN-12970: node-owned projection migration for llm_cost_aggregates.
+--
+-- WHY THIS EXISTS
+--   node_projection_cost_summary declares projection_api over llm_cost_aggregates
+--   (topic onex.snapshot.projection.cost.summary.v1). Like llm_call_metrics, this
+--   table was historically created ONLY by omnibase_infra forward migration 031 in
+--   the omnibase_infra DB, never in the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to. Result: the cost-summary
+--   topic was DEGRADED at startup ("table 'public.llm_cost_aggregates' not found").
+--
+--   Vendored by omnibase_infra/scripts/sync-node-migrations.sh into
+--   docker/migrations/forward/nodes/node_projection_cost_summary/ and applied to
+--   NODE_POSTGRES_DB (omnidash_analytics) by run-forward-migrations.sh under the
+--   namespaced migration id node:node_projection_cost_summary:<file>.
+--
+-- SCHEMA SOURCE OF TRUTH
+--   Mirrors omnibase_infra forward migration
+--   031_create_llm_call_metrics_and_cost_aggregates.sql (cost_aggregation_window
+--   enum + llm_cost_aggregates table + indexes + updated_at trigger).
+--
+-- Idempotency: CREATE TYPE / TABLE / INDEX / TRIGGER guarded so the migration is
+-- safe on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- ENUM: cost_aggregation_window
+-- ============================================================================
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cost_aggregation_window') THEN
+        CREATE TYPE cost_aggregation_window AS ENUM ('24h', '7d', '30d');
+    END IF;
+END$$;
+
+-- ============================================================================
+-- LLM_COST_AGGREGATES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS llm_cost_aggregates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    aggregation_key VARCHAR(512) NOT NULL,
+    "window" cost_aggregation_window NOT NULL,
+
+    total_cost_usd NUMERIC(14, 6) NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    call_count INTEGER NOT NULL DEFAULT 0,
+
+    estimated_coverage_pct NUMERIC(5, 2),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT unique_aggregation_key_window UNIQUE (aggregation_key, "window"),
+
+    CONSTRAINT non_negative_total_cost_usd CHECK (total_cost_usd >= 0),
+    CONSTRAINT non_negative_agg_total_tokens CHECK (total_tokens >= 0),
+    CONSTRAINT non_negative_call_count CHECK (call_count >= 0),
+    CONSTRAINT valid_estimated_coverage_pct CHECK (
+        estimated_coverage_pct IS NULL
+        OR (estimated_coverage_pct >= 0.00 AND estimated_coverage_pct <= 100.00)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_aggregates_aggregation_key
+    ON llm_cost_aggregates (aggregation_key);
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_aggregates_window
+    ON llm_cost_aggregates ("window");
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_aggregates_updated_at
+    ON llm_cost_aggregates (updated_at DESC);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_llm_cost_aggregates_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_llm_cost_aggregates_updated_at ON llm_cost_aggregates;
+CREATE TRIGGER trigger_llm_cost_aggregates_updated_at
+    BEFORE UPDATE ON llm_cost_aggregates
+    FOR EACH ROW
+    EXECUTE FUNCTION update_llm_cost_aggregates_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_llm_cost/0001_create_llm_call_metrics.sql
+++ b/docker/migrations/forward/nodes/node_projection_llm_cost/0001_create_llm_call_metrics.sql
@@ -1,0 +1,150 @@
+-- OMN-12970: node-owned projection migration for llm_call_metrics.
+--
+-- WHY THIS EXISTS
+--   The projection API (omnimarket-*-projection-api) binds to the dashboard
+--   projection database (omnidash_analytics), per
+--   ModelProjectionDatabaseBinding precedence in
+--   omnimarket/projection/api_server.py. Three projection contracts declare
+--   llm_call_metrics as their read model:
+--     - node_ab_compare_reducer        -> onex.snapshot.projection.ab-compare.v1
+--     - node_projection_cost_token_usage -> onex.snapshot.projection.cost.token_usage.v1
+--     - node_projection_llm_cost (writer/owner of this table)
+--   The table was historically created ONLY by omnibase_infra forward
+--   migration 031 in the omnibase_infra DB. It was never created in
+--   omnidash_analytics, so the projection API marked the ab-compare topic
+--   DEGRADED ("table 'public.llm_call_metrics' not found at startup") and the
+--   dashboard panel rendered its empty state.
+--
+--   This node-owned migration is vendored by
+--   omnibase_infra/scripts/sync-node-migrations.sh into
+--   docker/migrations/forward/nodes/node_projection_llm_cost/ and applied to
+--   NODE_POSTGRES_DB (omnidash_analytics) by run-forward-migrations.sh — the
+--   same deploy-time materialization path every other marketplace projection
+--   node uses. No renumber against the flat infra sequence is required: node
+--   migrations are tracked under the namespaced id node:<node>:<file>.
+--
+-- SCHEMA SOURCE OF TRUTH
+--   Mirrors omnibase_infra forward migration
+--   031_create_llm_call_metrics_and_cost_aggregates.sql (table + enum + indexes)
+--   so a row written in omnibase_infra is readable verbatim in omnidash_analytics
+--   for the projection API. llm_cost_aggregates is intentionally NOT created
+--   here: no projection contract declares it as a projection-API read model, so
+--   it stays owned by the omnibase_infra DB.
+--
+-- Idempotency: CREATE TYPE / TABLE / INDEX guarded by IF NOT EXISTS so the
+-- migration is safe on a DB where the table already exists (e.g. omnibase_infra)
+-- and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- ENUM: usage_source_type
+-- ============================================================================
+-- Provenance of token usage data. Mirrors omnibase_infra migration 031.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'usage_source_type') THEN
+        CREATE TYPE usage_source_type AS ENUM ('API', 'ESTIMATED', 'MISSING');
+    END IF;
+END$$;
+
+-- ============================================================================
+-- LLM_CALL_METRICS TABLE
+-- ============================================================================
+-- Per-LLM-call token usage and cost data. Append-only. Column set matches the
+-- projection_api columns declared by node_ab_compare_reducer and
+-- node_projection_cost_token_usage contracts, plus the provenance/idempotency
+-- columns the node_projection_llm_cost consumer writes.
+CREATE TABLE IF NOT EXISTS llm_call_metrics (
+    -- Identity
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id UUID,
+
+    -- Session/run context (logical references, no FK — async event arrival)
+    session_id VARCHAR(255),
+    run_id VARCHAR(255),
+
+    -- Model identification
+    model_id VARCHAR(255) NOT NULL,
+
+    -- Token usage (nullable: not all providers report all fields)
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    total_tokens INTEGER,
+
+    -- Cost (NULL for unknown models, NOT 0)
+    estimated_cost_usd NUMERIC(12, 6),
+
+    -- Performance (nullable: failed LLM calls may not have latency data)
+    latency_ms NUMERIC(10, 2),
+
+    -- Usage provenance
+    usage_source usage_source_type NOT NULL DEFAULT 'MISSING',
+    usage_is_estimated BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Raw provider response (redacted, capped at 64KB)
+    usage_raw JSONB,
+
+    -- Provenance / idempotency columns
+    input_hash VARCHAR(71),
+    code_version VARCHAR(64),
+    contract_version VARCHAR(64),
+    source VARCHAR(255),
+
+    -- Audit
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT non_negative_prompt_tokens CHECK (
+        prompt_tokens IS NULL OR prompt_tokens >= 0
+    ),
+    CONSTRAINT non_negative_completion_tokens CHECK (
+        completion_tokens IS NULL OR completion_tokens >= 0
+    ),
+    CONSTRAINT non_negative_total_tokens CHECK (
+        total_tokens IS NULL OR total_tokens >= 0
+    ),
+    CONSTRAINT non_negative_estimated_cost_usd CHECK (
+        estimated_cost_usd IS NULL OR estimated_cost_usd >= 0
+    ),
+    CONSTRAINT non_negative_latency_ms CHECK (latency_ms IS NULL OR latency_ms >= 0),
+    CONSTRAINT usage_raw_size_limit CHECK (
+        usage_raw IS NULL OR octet_length(usage_raw::text) <= 65536
+    )
+);
+
+-- ============================================================================
+-- IDEMPOTENCY: input_hash unique (mirrors omnibase_infra migration 071)
+-- ============================================================================
+-- The node_projection_llm_cost consumer inserts with
+-- ON CONFLICT (input_hash) DO NOTHING, which requires a unique constraint on
+-- the (non-NULL) input_hash. A partial unique index keeps NULL input_hash rows
+-- (legacy/unattributed writes) unconstrained.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_llm_call_metrics_input_hash
+    ON llm_call_metrics (input_hash)
+    WHERE input_hash IS NOT NULL;
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_session_id
+    ON llm_call_metrics (session_id)
+    WHERE session_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_run_id
+    ON llm_call_metrics (run_id)
+    WHERE run_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_model_id
+    ON llm_call_metrics (model_id);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_correlation_id
+    ON llm_call_metrics (correlation_id)
+    WHERE correlation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_created_at
+    ON llm_call_metrics (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_model_created
+    ON llm_call_metrics (model_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_metrics_usage_source
+    ON llm_call_metrics (usage_source);

--- a/docker/migrations/forward/nodes/node_projection_llm_routing/0001_create_routing_dashboard_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_llm_routing/0001_create_routing_dashboard_projection_view.sql
@@ -1,0 +1,135 @@
+-- OMN-12839: dashboard-ready routing snapshot over llm_routing_decisions.
+--
+-- The raw projection table stores one row per routing decision. The dashboard
+-- routing-decision widget consumes a single composed snapshot row with model,
+-- intent, task preset, and rule arrays. Keep that composition in Postgres so
+-- the projection API remains a typed read surface instead of a client-side
+-- state owner.
+
+CREATE OR REPLACE VIEW projection_routing_decision AS
+WITH totals AS (
+    SELECT
+        COUNT(*)::int AS total_count,
+        MAX(projected_at) AS latest_projection_updated_at
+    FROM llm_routing_decisions
+),
+model_candidates AS (
+    SELECT
+        llm_agent AS model_id,
+        llm_agent AS model_name,
+        COALESCE(cost_usd, 0)::float AS cost_usd,
+        1 AS sort_order
+    FROM llm_routing_decisions
+    WHERE llm_agent IS NOT NULL AND llm_agent <> ''
+    UNION ALL
+    SELECT
+        fuzzy_agent AS model_id,
+        fuzzy_agent AS model_name,
+        0::float AS cost_usd,
+        2 AS sort_order
+    FROM llm_routing_decisions
+    WHERE fuzzy_agent IS NOT NULL AND fuzzy_agent <> ''
+),
+model_summaries AS (
+    SELECT
+        model_id,
+        model_name,
+        MAX(cost_usd)::float AS cost_usd,
+        MIN(sort_order) AS sort_order
+    FROM model_candidates
+    GROUP BY model_id, model_name
+),
+models AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', model_id,
+                'name', model_name,
+                'tier', CASE WHEN cost_usd = 0 THEN 'local' ELSE 'cloud' END,
+                'cost', cost_usd,
+                'host', 'unknown'
+            )
+            ORDER BY sort_order, model_name
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM model_summaries
+),
+intent_rows AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', intent_id,
+                'label', intent_label,
+                'color', 'var(--accent)'
+            )
+            ORDER BY intent_label
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT DISTINCT
+            COALESCE(NULLIF(intent, ''), 'unknown') AS intent_id,
+            COALESCE(NULLIF(intent, ''), 'Unknown') AS intent_label
+        FROM llm_routing_decisions
+    ) intents
+),
+task_presets AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', correlation_id::text,
+                'label', COALESCE(NULLIF(intent, ''), correlation_id::text),
+                'intent', COALESCE(NULLIF(intent, ''), 'unknown'),
+                'chosen', llm_agent
+            )
+            ORDER BY created_at DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT correlation_id, intent, llm_agent, created_at
+        FROM llm_routing_decisions
+        ORDER BY created_at DESC
+        LIMIT 20
+    ) recent
+),
+routing_rules AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'type', intent_label,
+                'model', llm_agent,
+                'cost', cost_usd,
+                'intentId', intent_id
+            )
+            ORDER BY intent_label, llm_agent
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            COALESCE(NULLIF(intent, ''), 'Unknown') AS intent_label,
+            COALESCE(NULLIF(intent, ''), 'unknown') AS intent_id,
+            llm_agent,
+            MIN(COALESCE(cost_usd, 0))::float AS cost_usd
+        FROM llm_routing_decisions
+        WHERE llm_agent IS NOT NULL AND llm_agent <> ''
+        GROUP BY COALESCE(NULLIF(intent, ''), 'Unknown'),
+                 COALESCE(NULLIF(intent, ''), 'unknown'),
+                 llm_agent
+    ) rules
+)
+SELECT
+    COALESCE(models.rows, '[]'::jsonb) AS models,
+    COALESCE(intent_rows.rows, '[]'::jsonb) AS intents,
+    COALESCE(task_presets.rows, '[]'::jsonb) AS task_presets,
+    COALESCE(routing_rules.rows, '[]'::jsonb) AS routing_rules,
+    NOW() AS captured_at,
+    (totals.total_count > 0) AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN models
+CROSS JOIN intent_rows
+CROSS JOIN task_presets
+CROSS JOIN routing_rules;

--- a/docker/migrations/forward/nodes/node_projection_overnight/0000_create_overnight_sessions_tables.sql
+++ b/docker/migrations/forward/nodes/node_projection_overnight/0000_create_overnight_sessions_tables.sql
@@ -1,0 +1,76 @@
+-- OMN-12936: base tables for the overnight readiness projection.
+--
+-- The 0001 view (projection_overnight_readiness) reads from overnight_sessions.
+-- Those base tables were previously created only through the omnibase_infra
+-- schema path (schema_overnight_sessions.sql), which the omnimarket projection
+-- migration runner does not apply. As a result the projection-api startup found
+-- no projection_overnight_readiness relation and served HTTP 503
+-- "table 'public.projection_overnight_readiness' not found at startup".
+--
+-- Shipping the base-table DDL as a node-owned migration ordered before the view
+-- makes the omnimarket migration runner self-sufficient: it creates the base
+-- tables, then the 0001 view materializes against them. The DDL is identical to
+-- omnibase_infra schema_overnight_sessions.sql and fully idempotent
+-- (IF NOT EXISTS throughout), so re-applying over an infra-seeded database is a
+-- no-op.
+--
+-- Related:
+--   - OMN-8455: W2.8 overnight_sessions migration + node_projection_overnight
+--   - node_projection_overnight/migrations/0001_create_overnight_readiness_projection_view.sql
+
+CREATE TABLE IF NOT EXISTS overnight_sessions (
+    session_id           TEXT PRIMARY KEY,             -- correlation_id from executor
+    session_start_ts     TIMESTAMPTZ NOT NULL,
+    contract_path        TEXT,
+    dry_run              BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Aggregate metrics (updated on session-completed)
+    phases_run           TEXT[] NOT NULL DEFAULT '{}',
+    phases_failed        TEXT[] NOT NULL DEFAULT '{}',
+    phases_skipped       TEXT[] NOT NULL DEFAULT '{}',
+    dispatch_count       INT NOT NULL DEFAULT 0,
+
+    -- Halt tracking
+    halt_reason          TEXT,
+
+    -- Terminal state
+    session_status       TEXT NOT NULL DEFAULT 'in_progress',
+    session_end_ts       TIMESTAMPTZ,
+
+    -- Lifecycle
+    accumulated_cost_usd NUMERIC(10,4) NOT NULL DEFAULT 0,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT valid_session_status CHECK (
+        session_status IN ('in_progress', 'completed', 'partial', 'failed')
+    )
+);
+
+-- Normalized phase results table — avoids JSONB overhead, enables per-phase indexing
+CREATE TABLE IF NOT EXISTS overnight_session_phases (
+    id                   BIGSERIAL PRIMARY KEY,
+    session_id           TEXT NOT NULL REFERENCES overnight_sessions(session_id) ON DELETE CASCADE,
+    phase_name           TEXT NOT NULL,
+    phase_status         TEXT NOT NULL,               -- success | failed | skipped
+    duration_ms          INT NOT NULL DEFAULT 0,
+    side_effect_summary  TEXT NOT NULL DEFAULT '',
+    error_message        TEXT,
+    sequence_number      INT NOT NULL DEFAULT 0,
+    recorded_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT valid_phase_status CHECK (
+        phase_status IN ('success', 'failed', 'skipped')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_session_phases_unique
+    ON overnight_session_phases(session_id, phase_name, sequence_number);
+
+CREATE INDEX IF NOT EXISTS ix_overnight_sessions_status
+    ON overnight_sessions(session_status);
+
+CREATE INDEX IF NOT EXISTS ix_overnight_sessions_start
+    ON overnight_sessions(session_start_ts DESC);
+
+CREATE INDEX IF NOT EXISTS ix_overnight_session_phases_session
+    ON overnight_session_phases(session_id);

--- a/docker/migrations/forward/nodes/node_projection_overnight/0001_create_overnight_readiness_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_overnight/0001_create_overnight_readiness_projection_view.sql
@@ -1,0 +1,74 @@
+-- OMN-12839: dashboard readiness snapshot over overnight_sessions.
+--
+-- The readiness gate widget consumes a compact status summary rather than raw
+-- overnight session rows. This view keeps the rollup server-side and exposes a
+-- contract-owned projection topic through projection-api.
+
+CREATE OR REPLACE VIEW projection_overnight_readiness AS
+WITH totals AS (
+    SELECT
+        COUNT(*)::int AS session_count,
+        COALESCE(SUM(CASE WHEN session_status = 'completed' THEN 1 ELSE 0 END), 0)::int
+            AS completed_count,
+        COALESCE(SUM(CASE WHEN session_status = 'partial' THEN 1 ELSE 0 END), 0)::int
+            AS partial_count,
+        COALESCE(SUM(CASE WHEN session_status = 'failed' THEN 1 ELSE 0 END), 0)::int
+            AS failed_count,
+        COALESCE(SUM(CASE WHEN session_status = 'in_progress' THEN 1 ELSE 0 END), 0)::int
+            AS in_progress_count,
+        COALESCE(SUM(dispatch_count), 0)::int AS dispatch_count,
+        COALESCE(SUM(cardinality(phases_failed)), 0)::int AS failed_phase_count,
+        MAX(updated_at) AS latest_projection_updated_at
+    FROM overnight_sessions
+),
+status AS (
+    SELECT
+        CASE
+            WHEN totals.session_count = 0 THEN 'WARN'
+            WHEN totals.failed_count > 0 OR totals.failed_phase_count > 0 THEN 'FAIL'
+            WHEN totals.partial_count > 0 OR totals.in_progress_count > 0 THEN 'WARN'
+            ELSE 'PASS'
+        END AS overall_status
+    FROM totals
+),
+dimensions AS (
+    SELECT jsonb_build_array(
+        jsonb_build_object(
+            'name', 'Sessions completed',
+            'status', CASE
+                WHEN totals.session_count = 0 THEN 'WARN'
+                WHEN totals.completed_count > 0 THEN 'PASS'
+                ELSE 'WARN'
+            END,
+            'detail', totals.completed_count::text || ' completed of '
+                || totals.session_count::text || ' tracked sessions'
+        ),
+        jsonb_build_object(
+            'name', 'Failed phases',
+            'status', CASE
+                WHEN totals.failed_count > 0 OR totals.failed_phase_count > 0 THEN 'FAIL'
+                ELSE 'PASS'
+            END,
+            'detail', totals.failed_phase_count::text || ' failed phases across '
+                || totals.failed_count::text || ' failed sessions'
+        ),
+        jsonb_build_object(
+            'name', 'Dispatch activity',
+            'status', CASE
+                WHEN totals.session_count = 0 THEN 'WARN'
+                WHEN totals.dispatch_count > 0 THEN 'PASS'
+                ELSE 'WARN'
+            END,
+            'detail', totals.dispatch_count::text || ' dispatches recorded'
+        )
+    ) AS rows
+    FROM totals
+)
+SELECT
+    dimensions.rows AS dimensions,
+    status.overall_status AS "overallStatus",
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS "lastCheckedAt",
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN status
+CROSS JOIN dimensions;

--- a/docker/migrations/forward/nodes/node_projection_savings/077_create_cost_savings_overview_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/077_create_cost_savings_overview_projection_view.sql
@@ -1,0 +1,121 @@
+-- OMN-12839: dashboard cost-savings overview snapshot over savings_estimates.
+--
+-- The dashboard overview widget consumes one composed row with KPI totals,
+-- per-model savings rows, recent runs, and warning metadata. Compose that view
+-- next to the savings reducer so the projection API can serve the widget from a
+-- contract-declared read model instead of fixture-only data.
+
+CREATE OR REPLACE VIEW projection_cost_savings_overview AS
+WITH source_rows AS (
+    SELECT
+        session_id,
+        COALESCE(NULLIF(model_local, ''), 'local') AS model_id,
+        COALESCE(NULLIF(model_local, ''), 'Local model') AS display_name,
+        COALESCE(NULLIF(model_cloud_baseline, ''), 'cloud-baseline')
+            AS baseline_model,
+        local_cost_usd::float AS local_cost_usd,
+        cloud_cost_usd::float AS cloud_cost_usd,
+        savings_usd::float AS savings_usd,
+        COALESCE(updated_at, created_at, event_timestamp) AS projected_at
+    FROM savings_estimates
+),
+totals AS (
+    SELECT
+        COALESCE(SUM(local_cost_usd), 0)::float AS total_cost_usd,
+        COALESCE(SUM(cloud_cost_usd), 0)::float AS total_baseline_cost_usd,
+        COALESCE(SUM(savings_usd), 0)::float AS total_savings_usd,
+        COUNT(*)::int AS run_count,
+        MAX(projected_at) AS latest_projection_updated_at
+    FROM source_rows
+),
+model_rows AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_id', model_id,
+                'display_name', display_name,
+                'execution_mode', 'delegated',
+                'task_count', task_count,
+                'tokens_total', 0,
+                'cost_usd', cost_usd,
+                'baseline_cost_usd', baseline_cost_usd,
+                'savings_usd', savings_usd,
+                'savings_pct', CASE WHEN baseline_cost_usd > 0
+                    THEN savings_usd / baseline_cost_usd ELSE 0 END,
+                'runtime_address', NULL,
+                'evidence_ref', NULL
+            )
+            ORDER BY savings_usd DESC, display_name
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            model_id,
+            display_name,
+            COUNT(*)::int AS task_count,
+            COALESCE(SUM(local_cost_usd), 0)::float AS cost_usd,
+            COALESCE(SUM(cloud_cost_usd), 0)::float AS baseline_cost_usd,
+            COALESCE(SUM(savings_usd), 0)::float AS savings_usd
+        FROM source_rows
+        GROUP BY model_id, display_name
+    ) grouped_models
+),
+recent_runs AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'session_id', session_id,
+                'task_type', 'savings-estimated',
+                'model_name', display_name,
+                'prompt_tokens', 0,
+                'completion_tokens', 0,
+                'total_tokens', 0,
+                'savings_usd', savings_usd,
+                'latency_ms', NULL,
+                'created_at', projected_at,
+                'token_provenance', 'unknown'
+            )
+            ORDER BY projected_at DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT *
+        FROM source_rows
+        ORDER BY projected_at DESC
+        LIMIT 20
+    ) limited_runs
+),
+warnings AS (
+    SELECT CASE WHEN totals.run_count > 0 THEN
+        jsonb_build_array(
+            'Token counts unavailable in savings_estimates; token KPIs remain zero until measured token provenance is projected.'
+        )
+    ELSE '[]'::jsonb END AS rows
+    FROM totals
+)
+SELECT
+    'all'::text AS "window",
+    totals.total_cost_usd,
+    totals.total_baseline_cost_usd,
+    totals.total_savings_usd,
+    CASE WHEN totals.total_baseline_cost_usd > 0
+        THEN totals.total_savings_usd / totals.total_baseline_cost_usd
+        ELSE 0
+    END AS savings_rate,
+    0::int AS tokens_total,
+    0::int AS tokens_to_compliance,
+    0::float AS local_token_pct,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    model_rows.rows,
+    recent_runs.rows AS recent_runs,
+    0::int AS measured_run_count,
+    totals.run_count AS zero_token_run_count,
+    warnings.rows AS warnings,
+    (totals.run_count > 0) AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN model_rows
+CROSS JOIN recent_runs
+CROSS JOIN warnings;


### PR DESCRIPTION
## OMN-12970 — vendor omnimarket projection node migrations into `forward/nodes`

Companion to omnimarket PR #1169.

Vendors omnimarket node-owned projection migrations into the namespaced forward-migration tree (`docker/migrations/forward/nodes/`) so `run-forward-migrations.sh` materializes them in the dashboard projection DB (`omnidash_analytics`, = `NODE_POSTGRES_DB`) at deploy, under namespaced migration id `node:<node>:<file>`.

### Primary (OMN-12970)
Creates `llm_call_metrics`, `llm_cost_aggregates`, and `capability_scores` in the projection DB. These were only ever created in the `omnibase_infra` DB by infra migrations `031`/`060`, so the `ab-compare`, `cost.token_usage`, `cost.summary`, and `capability-scores` projection topics were DEGRADED at startup (`table not found`) and their dashboard panels rendered empty.

- `nodes/node_projection_llm_cost/0001_create_llm_call_metrics.sql`
- `nodes/node_projection_cost_summary/0001_create_llm_cost_aggregates.sql`
- `nodes/node_canary_score_reducer/0001_create_capability_scores.sql`

### Drift re-sync (required by the vendor gate)
`sync-node-migrations.sh --check` (pre-commit) compares the **full** vendored tree against omnimarket source. Three omnimarket node migrations had drifted out of the vendored tree and are re-synced here so the gate passes:
- `nodes/node_projection_llm_routing/0001_create_routing_dashboard_projection_view.sql`
- `nodes/node_projection_overnight/0000_create_overnight_sessions_tables.sql`
- `nodes/node_projection_overnight/0001_create_overnight_readiness_projection_view.sql`
- `nodes/node_projection_savings/077_create_cost_savings_overview_projection_view.sql`

### Verification
`OMNIMARKET_SRC=<omn-12970 omnimarket worktree> bash scripts/sync-node-migrations.sh --check` → `check: in sync.` All vendored files are byte-identical mirrors of the omnimarket source migrations (`cmp -s`).

### Deploy
`deploy_pending=true` — applied by the batched stability rebuild (`run-forward-migrations.sh` on warm volumes). No live lane mutation in this PR.

Evidence-Ticket: OMN-12970
Evidence-Source: 6657c3c9a94076953ec68518d072df890d106460


