### PR TITLE
fix(OMN-12966): accept community-edition Infisical status in provision readiness gate + additive stability Infisical

### DIFF
--- a/docker/docker-compose.infisical-stability.yml
+++ b/docker/docker-compose.infisical-stability.yml
@@ -1,0 +1,68 @@
+# Additive Infisical for the stability-test lane (OMN-12966 / P1.2b-A).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The Infisical service declared in docker-compose.infra.yml is disabled in the
+# stability-test and prod lane overlays via `profiles: !override [...-disabled]`,
+# so no Infisical instance is reachable from the runtime/effect containers — the
+# container environment becomes the de-facto secret store. P1.2b ("config
+# authority end-state") requires a real Infisical value store reachable from the
+# runtime boundary. This compose project stands one up ADDITIVELY:
+#
+#   * Own compose project name — does NOT modify or restart any lane container.
+#   * Joins the EXISTING stability-test network as `external`, so runtime/effect
+#     containers reach it in-network at `omnibase-infra-infisical-stability:8080`
+#     and operators reach it at host port 8880.
+#   * Reuses the already-present stability-test postgres (`infisical_db`) and
+#     valkey — no new stateful services.
+#
+# NO SECRETS IN THIS FILE. All credentials are resolved from the operator
+# environment (~/.omnibase/.env), matching the discipline in
+# docker-compose.infra.yml. The required vars are the same ones the canonical
+# infisical service consumes; the only difference is that the connection URIs
+# must point at the stability-test-namespaced service hostnames
+# (omnibase-infra-stability-test-postgres / -valkey), supplied via env.
+#
+# Usage (on .201):
+#   cd <this repo>/docker
+#   INFISICAL_STABILITY_DB_CONNECTION_URI=... \
+#   INFISICAL_STABILITY_REDIS_URL=... \
+#   INFISICAL_ENCRYPTION_KEY=... INFISICAL_AUTH_SECRET=... \
+#   docker compose -f docker-compose.infisical-stability.yml up -d
+#
+# Then provision identity + folders + secrets:
+#   uv run python scripts/provision-infisical.py --addr http://192.168.86.201:8880 \
+#     --org omninode --project onex-platform
+#   uv run python scripts/seed-infisical.py --import-env <env> --set-values \
+#     --create-missing-keys --execute
+name: omnibase-infra-infisical-stability
+services:
+  infisical:
+    image: infisical/infisical:v0.146.0-postgres
+    container_name: omnibase-infra-infisical-stability
+    environment:
+      # Must point at the stability-test-namespaced postgres/valkey hostnames.
+      DB_CONNECTION_URI: ${INFISICAL_STABILITY_DB_CONNECTION_URI:?INFISICAL_STABILITY_DB_CONNECTION_URI must be set (postgresql://...@omnibase-infra-stability-test-postgres:5432/infisical_db)}
+      REDIS_URL: ${INFISICAL_STABILITY_REDIS_URL:?INFISICAL_STABILITY_REDIS_URL must be set (redis://:...@omnibase-infra-stability-test-valkey:6379)}
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY must be set in ~/.omnibase/.env}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET must be set in ~/.omnibase/.env}
+      SITE_URL: ${INFISICAL_SITE_URL:-http://192.168.86.201:8880}
+      TELEMETRY_ENABLED: "false"
+    ports:
+      - "${INFISICAL_EXTERNAL_PORT:-8880}:8080"
+    networks:
+      - stability
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/api/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
+    restart: unless-stopped
+    labels:
+      - "com.omninode.service=infisical"
+      - "com.omninode.lane=stability-test-additive"
+networks:
+  stability:
+    name: omnibase-infra-stability-test-network
+    external: true

--- a/scripts/provision-infisical.py
+++ b/scripts/provision-infisical.py
@@ -629,12 +629,18 @@ def main() -> int:
             resp.raise_for_status()
             try:
                 body = resp.json()
-                if body.get("status") != "ok":
+                # Honor both editions: community returns {"message": "Ok"},
+                # enterprise returns {"status": "ok"}. _is_infisical_ready is the
+                # single source of truth for readiness (the inline status-only
+                # check here was a bug that blocked provisioning against the
+                # community edition deployed on .201 — OMN-12966).
+                if not _is_infisical_ready(body):
                     logger.error(
-                        "Infisical at %s returned HTTP 200 but status field is %r "
-                        "(expected 'ok'). The server may still be initialising.",
+                        "Infisical at %s returned HTTP 200 but body is %r "
+                        "(expected status=ok or message=Ok). "
+                        "The server may still be initialising.",
                         args.addr,
-                        body.get("status"),
+                        body,
                     )
                     return 1
             except (ValueError, KeyError):

--- a/tests/unit/scripts/test_provision_infisical.py
+++ b/tests/unit/scripts/test_provision_infisical.py
@@ -325,7 +325,82 @@ class TestMainAlreadyProvisioned:
         assert len(folder_calls) > 0
 
 
+# ---------------------------------------------------------------------------
+# Tests: main() — fresh-provision readiness gate (OMN-12966)
+# ---------------------------------------------------------------------------
+
+
+class _GatePassedError(Exception):
+    """Raised from the mocked bootstrap call to signal the fresh-provision
+    readiness gate was passed (i.e. did NOT short-circuit with return 1)."""
+
+
+@pytest.mark.unit
+class TestMainFreshProvisionReadinessGate:
+    """The fresh-provision path (no credentials in env) must accept both the
+    enterprise {"status": "ok"} and community {"message": "Ok"} status payloads
+    at its readiness gate before attempting bootstrap.
+
+    Regression for OMN-12966: the fresh-path gate only accepted {"status":
+    "ok"} and rejected the community-edition payload returned by the Infisical
+    instance deployed on .201, returning 1 before bootstrap could run.
+    """
+
+    def _empty_env(self, tmp_path: Path) -> Path:
+        env_file = tmp_path / ".env"
+        _write_env(env_file, "INFRA_HOST=192.168.86.201\n")  # no INFISICAL_* creds
+        return env_file
+
+    def _run_with_status(self, tmp_path: Path, status_body: dict[str, Any]) -> int:
+        env_file = self._empty_env(tmp_path)
+        status_resp = _make_httpx_response(200, status_body)
+
+        # First httpx.Client (readiness probe) returns the status body.
+        # Second httpx.Client (bootstrap flow) raises _GatePassedError so the test
+        # proves the gate was passed without exercising the full bootstrap.
+        probe_client = MagicMock()
+        probe_client.__enter__ = MagicMock(return_value=probe_client)
+        probe_client.__exit__ = MagicMock(return_value=False)
+        probe_client.get.return_value = status_resp
+
+        bootstrap_client = MagicMock()
+        bootstrap_client.__enter__ = MagicMock(side_effect=_GatePassedError())
+
+        with (
+            patch.object(_provision_mod, "_ENV_FILE", env_file),
+            patch.object(
+                _provision_mod, "_ADMIN_TOKEN_FILE", tmp_path / ".infisical-admin-token"
+            ),
+            patch("sys.argv", ["provision-infisical.py", f"--env-file={env_file}"]),
+            patch("httpx.Client", side_effect=[probe_client, bootstrap_client]),
+        ):
+            try:
+                return int(_main())
+            except _GatePassedError:
+                # Reaching the bootstrap client means the readiness gate passed.
+                return 0
+
+    def test_fresh_provision_community_edition_message_ok_passes_gate(
+        self, tmp_path: Path
+    ) -> None:
+        rc = self._run_with_status(tmp_path, {"message": "Ok"})
+        assert rc == 0  # gate passed (bootstrap reached via _GatePassedError)
+
+    def test_fresh_provision_enterprise_status_ok_passes_gate(
+        self, tmp_path: Path
+    ) -> None:
+        rc = self._run_with_status(tmp_path, {"status": "ok"})
+        assert rc == 0
+
+    def test_fresh_provision_not_ready_returns_1(self, tmp_path: Path) -> None:
+        # Neither status=ok nor message=Ok: gate must reject with rc=1, never
+        # reach bootstrap.
+        rc = self._run_with_status(tmp_path, {"message": "initializing"})
+        assert rc == 1
+
+
 __all__: list[str] = [
     "TestCreateInfisicalFoldersIdempotency",
     "TestMainAlreadyProvisioned",
+    "TestMainFreshProvisionReadinessGate",
 ]


### PR DESCRIPTION
## OMN-12966 — P1.2b-A Infisical availability verification (.201)

Fixes the Infisical availability tooling so provisioning works against the
community edition deployed on .201, and adds an ADDITIVE Infisical compose
project for the stability-test lane.

### Problem
- Probe-first confirmed NO Infisical was running/reachable on .201 (de-facto store = container env). Lane overlays disable the in-lane Infisical via `infisical.profiles: !override ["stability-test-disabled"|"prod-disabled"]`.
- `scripts/provision-infisical.py`'s fresh-provision readiness gate accepted ONLY enterprise `{"status": "ok"}` and rejected community `{"message": "Ok"}`, returning 1 before bootstrap could run.

### Fix (+ ratchet)
- `scripts/provision-infisical.py`: fresh-provision readiness gate now routes through the existing `_is_infisical_ready` helper (accepts both editions) — single source of truth.
- `tests/unit/scripts/test_provision_infisical.py`: new `TestMainFreshProvisionReadinessGate` (community `message=Ok`, enterprise `status=ok`, not-ready rc=1). TDD-verified: reverting the source fix fails the community case.
- `docker/docker-compose.infisical-stability.yml`: additive Infisical compose project (own project name, joins existing `omnibase-infra-stability-test-network` as external, reuses stability postgres/valkey, no lane mutation, NO secrets in file).

### Live verification (.201, stability-test lane only, additive — no lane rebuild/restart)
- Container `omnibase-infra-infisical-stability` running/healthy on :8880.
- Reachable FROM effects container: `omninode-stability-test-runtime-effects` → `http://omnibase-infra-infisical-stability:8080/api/status` → 200.
- Known secret end-to-end: provision (with fix) → universal-auth login → seed `OMN_12966_PROBE` → resolve → MATCHES True, including from INSIDE the effects container.
- Evidence: `omni_home/docs/evidence/2026-06-11-OMN-12966-infisical-availability.md`.

### Tests
- `uv run pytest tests/unit/scripts/ -q` → 482 passed.
- `mypy --strict` on changed test → clean. `ruff` clean. `pre-commit` clean (exit 0).

Evidence-Ticket: OMN-12966
Evidence-Source: OCC#2478