### PR TITLE
feat(OMN-12958): volume-config drift gate + runtime config provenance

### DIFF
--- a/docs/runbooks/volume-config-drift-and-reseed.md
+++ b/docs/runbooks/volume-config-drift-and-reseed.md
@@ -1,0 +1,145 @@
+# Volume Config Drift Gate + Re-seed Procedure (OMN-12958)
+
+## Problem
+
+The Bifrost delegation contract is rendered once at container startup to a Docker
+named volume at `/app/data/delegation/bifrost_delegation.yaml`. That volume
+survives `docker compose build` and container recreate, so the **deployed (volume)
+copy can silently diverge from the packaged source** shipped in the image. Two
+prior incidents (folded into OMN-12945) were caused by exactly this:
+
+- a stale gemini backend binding persisted on the volume after the packaged
+  source was updated, and
+- an empty `frontier_api` endpoint persisted on the volume.
+
+There are two competing authorities:
+
+1. **Packaged source** — `omnimarket/configs/bifrost_delegation.yaml` baked into
+   the image (canonical home since OMN-10865; legacy fallback
+   `omnibase_infra/configs/bifrost_delegation.yaml`).
+2. **Volume copy** — `/app/data/delegation/bifrost_delegation.yaml`, written once
+   and then trusted on subsequent boots when it already has populated endpoints
+   (see `render_bifrost_delegation_contract` short-circuit).
+
+Additionally, `BIFROST_CONTRACT_PATH=""` (empty) silently **disables** packaged
+rendering entirely (the renderer returns `None`).
+
+> **Scope note.** Reconciling the two authorities into one (Infisical > bootstrap
+> overlay precedence) is the P1.2b / OMN-12803 epic. This runbook is the tactical
+> drift **gate + re-seed** stopgap: it makes drift *visible and ticketed*, and
+> gives operators a deterministic re-seed step. It does not change which authority
+> wins at render time.
+
+## Ratchet shipped with this runbook
+
+| Ratchet | Where |
+|---------|-------|
+| (a) Re-seed volume config from packaged source with ledgered overlay diffs only | this runbook (procedure below) |
+| (b) Runtime startup logs config provenance (path + sha); health exposes it | `runtime/config_provenance.py`, `runtime/health/health_config_provenance.py`, `runtime/render_bifrost_delegation_contract.py::main` |
+| (c) Sweep compares volume sha vs packaged sha → drift = auto-ticket | omnimarket `node_volume_config_drift_sweep` |
+| (d) Config provenance appears in proof packets | provenance sidecar `/app/data/delegation/.config_provenance.json` + sweep output |
+
+## Provenance at runtime
+
+On every boot, after the contract is rendered, the entrypoint logs a single-line
+provenance summary and writes a sidecar JSON next to the deployed contract:
+
+```
+[entrypoint] config_provenance config=bifrost_delegation status=in-sync \
+  deployed_path=/app/data/delegation/bifrost_delegation.yaml \
+  deployed_sha256=<sha> source_path=<packaged> source_sha256=<sha>
+```
+
+- `status=DRIFT` and an additional `WARNING` line are emitted when the deployed
+  sha differs from the packaged-source sha.
+- The sidecar `/app/data/delegation/.config_provenance.json` is the machine
+  surface the drift sweep and proof packets read (no need to re-resolve the
+  packaged source path inside the container).
+- The health component `config_provenance`
+  (`check_config_provenance_health`) reports:
+  - `unhealthy` — deployed contract absent,
+  - `degraded` — drift detected (re-seed required) or packaged source absent,
+  - `healthy` — deployed sha == source sha.
+
+> The deployed sha reflects the **post-render** contract (endpoint_url values
+> populated from env). Treat the sweep's drift signal as "investigate", then use
+> the source-vs-volume diff below to decide whether the divergence is an intended
+> overlay or stale config that must be re-seeded.
+
+## Re-seed procedure (operator)
+
+> **Live-lane safety.** Re-seeding mutates the named volume. Do **not** run the
+> overwrite steps against stability (`18085/18086`), dev (`8085/8086`), or prod
+> (`28085/28086`) without the lane's deploy approval. The diff/inspection steps
+> are read-only and always safe.
+
+### 1. Inspect drift (read-only)
+
+```bash
+# On the .201 host, against the target lane's runtime container:
+docker exec <runtime-container> cat /app/data/delegation/.config_provenance.json
+```
+
+If `has_drifted` is `true`, diff the deployed volume copy against the packaged
+source to capture the **explicit overlay** before overwriting:
+
+```bash
+docker exec <runtime-container> sh -c \
+  'diff -u <packaged-source-path> /app/data/delegation/bifrost_delegation.yaml || true'
+```
+
+### 2. Ledger the overlay (mandatory)
+
+Re-seed overwrites the volume with packaged source. Any divergence that must be
+**kept** (an intentional per-lane overlay) has to be recorded first, or it is
+lost. Record the diff and the keep/drop decision in the deploy evidence / proof
+packet:
+
+```
+config: bifrost_delegation
+deployed_sha256: <from sidecar>
+source_sha256:   <from sidecar>
+overlay_diff: <paste unified diff>
+decision: re-seed from packaged source; overlay <kept via env|dropped as stale>
+```
+
+Overlays are expressed through **env-driven render inputs** (e.g. `base_url_env`
+backends) or Infisical — never by hand-editing the volume copy. A hand-edited
+volume copy is exactly the drift this runbook exists to eliminate.
+
+### 3. Re-seed (mutating — requires lane approval)
+
+```bash
+# Remove the stale volume copy + sidecar so the next render writes fresh from source:
+docker exec <runtime-container> sh -c \
+  'rm -f /app/data/delegation/bifrost_delegation.yaml /app/data/delegation/.config_provenance.json'
+
+# Re-render from packaged source (re-runs the entrypoint render path):
+docker exec <runtime-container> \
+  python -m omnibase_infra.runtime.render_bifrost_delegation_contract
+```
+
+Then restart the runtime container per the lane's standard deploy step so the
+freshly rendered contract is loaded.
+
+### 4. Verify
+
+```bash
+docker exec <runtime-container> cat /app/data/delegation/.config_provenance.json
+# expect: has_drifted == false, deployed_sha256 == source_sha256
+```
+
+Re-run the drift sweep (below) and confirm zero drift findings.
+
+## Drift sweep (continuous)
+
+```bash
+cd omnimarket
+uv run python -m omnimarket.nodes.node_volume_config_drift_sweep --dry-run
+```
+
+The sweep reads the provenance sidecar on each runtime lane (or computes
+provenance from a probed volume copy + packaged source), classifies
+`IN_SYNC` / `DRIFTED` / `DEPLOYED_ABSENT` / `SOURCE_ABSENT`, and — outside
+`--dry-run` — auto-creates a Linear ticket for any `DRIFTED` lane. Its JSON output
+is suitable for inclusion in proof packets.

--- a/src/omnibase_infra/runtime/config_provenance.py
+++ b/src/omnibase_infra/runtime/config_provenance.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Config provenance for runtime-rendered contracts (OMN-12958).
+
+The Bifrost delegation contract is rendered once at container startup and written
+to a Docker named volume at ``/app/data/delegation/bifrost_delegation.yaml``. The
+volume survives ``docker compose build``/recreate, so the deployed (volume) config
+can silently diverge from the packaged source shipped in the image. Two competing
+authorities — the packaged source and the volume copy — is the defect this module
+addresses.
+
+This module computes a deterministic provenance record (path + sha256 of both the
+deployed volume contract and the packaged source) and classifies drift between
+them. The record is:
+
+* logged at runtime startup (path + sha),
+* exposed via the runtime health endpoint
+  (``health/health_config_provenance.py``),
+* written next to the deployed contract as a sidecar JSON so the sweep
+  (omnimarket ``node_volume_config_drift_sweep``) and proof packets can read it
+  without re-deriving the source path.
+
+This module is **read-only** with respect to the contract content itself: it never
+rewrites the deployed contract. The re-seed (overwriting a drifted volume copy from
+packaged source) is an operator deploy-procedure action, not a runtime side effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Sidecar file written next to the rendered contract. Named with a leading dot so
+# it never collides with a contract-discovery glob.
+PROVENANCE_SIDECAR_NAME = ".config_provenance.json"
+
+
+def compute_sha256(path: Path) -> str | None:
+    """Return the hex sha256 of ``path`` content, or ``None`` when absent.
+
+    Hashes raw bytes (not parsed YAML) so the digest is byte-exact and stable
+    across machines. Returns ``None`` for a missing file rather than raising,
+    because an absent deployed contract is itself a valid provenance state that
+    the caller classifies.
+    """
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+class ModelConfigProvenance(BaseModel):
+    """Provenance of a runtime-rendered config relative to its packaged source.
+
+    ``deployed`` is the volume copy actually loaded by the runtime; ``source`` is
+    the packaged contract shipped in the image. ``has_drifted`` is ``True`` only
+    when both digests are known and differ — an absent deployed copy (first boot)
+    or absent source is reported via the digests being ``None``, not as drift.
+    """
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    config_name: str = Field(
+        ...,
+        description="Logical config identifier (e.g. 'bifrost_delegation')",
+        min_length=1,
+    )
+    deployed_path: str = Field(
+        ...,
+        description="Absolute path of the deployed (volume) contract",
+        min_length=1,
+    )
+    deployed_sha256: str | None = Field(
+        default=None,
+        description="sha256 of the deployed contract bytes, or None if absent",
+    )
+    source_path: str = Field(
+        ...,
+        description="Absolute path of the packaged source contract",
+        min_length=1,
+    )
+    source_sha256: str | None = Field(
+        default=None,
+        description="sha256 of the packaged source contract bytes, or None if absent",
+    )
+
+    @property
+    def deployed_present(self) -> bool:
+        """Whether the deployed (volume) contract exists."""
+        return self.deployed_sha256 is not None
+
+    @property
+    def source_present(self) -> bool:
+        """Whether the packaged source contract exists."""
+        return self.source_sha256 is not None
+
+    @property
+    def has_drifted(self) -> bool:
+        """Whether the deployed copy diverges from packaged source.
+
+        ``True`` only when both digests are known and differ. Unknown digests
+        (missing file) are not drift — the caller inspects ``*_present``.
+        """
+        if self.deployed_sha256 is None or self.source_sha256 is None:
+            return False
+        return self.deployed_sha256 != self.source_sha256
+
+    def provenance_line(self) -> str:
+        """Single-line, log-friendly provenance summary (path + sha + drift)."""
+        deployed = self.deployed_sha256 or "absent"
+        source = self.source_sha256 or "absent"
+        drift = "DRIFT" if self.has_drifted else "in-sync"
+        return (
+            f"config_provenance config={self.config_name} status={drift} "
+            f"deployed_path={self.deployed_path} deployed_sha256={deployed} "
+            f"source_path={self.source_path} source_sha256={source}"
+        )
+
+
+def build_config_provenance(
+    *,
+    config_name: str,
+    deployed_path: Path,
+    source_path: Path,
+) -> ModelConfigProvenance:
+    """Compute provenance for a deployed contract against its packaged source."""
+    return ModelConfigProvenance(
+        config_name=config_name,
+        deployed_path=str(deployed_path),
+        deployed_sha256=compute_sha256(deployed_path),
+        source_path=str(source_path),
+        source_sha256=compute_sha256(source_path),
+    )
+
+
+def write_provenance_sidecar(
+    provenance: ModelConfigProvenance,
+    *,
+    deployed_path: Path,
+) -> Path:
+    """Write the provenance record as a JSON sidecar next to the deployed contract.
+
+    The sidecar lets the drift sweep and proof packets read provenance without
+    re-resolving the packaged source path (which depends on import-time package
+    layout inside the container). Returns the sidecar path.
+    """
+    sidecar = deployed_path.parent / PROVENANCE_SIDECAR_NAME
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        json.dumps(provenance.model_dump(mode="json"), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return sidecar
+
+
+__all__: list[str] = [
+    "PROVENANCE_SIDECAR_NAME",
+    "ModelConfigProvenance",
+    "build_config_provenance",
+    "compute_sha256",
+    "write_provenance_sidecar",
+]

--- a/src/omnibase_infra/runtime/health/health_config_provenance.py
+++ b/src/omnibase_infra/runtime/health/health_config_provenance.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Health check for runtime config provenance (OMN-12958).
+
+Promotes config provenance (deployed-volume sha vs packaged-source sha) to a
+health-check component so volume/config drift pages an operator and surfaces in
+proof packets instead of silently degrading delegation routing.
+
+* deployed contract absent  -> unhealthy (runtime has no config to load)
+* deployed sha != source sha -> degraded (drift: re-seed required)
+* source absent              -> degraded (cannot prove provenance)
+* deployed sha == source sha -> healthy
+"""
+
+from __future__ import annotations
+
+from omnibase_core.types import JsonType
+from omnibase_infra.runtime.config_provenance import ModelConfigProvenance
+from omnibase_infra.runtime.models.model_component_health import (
+    ModelComponentHealth,
+)
+
+_COMPONENT_NAME = "config_provenance"
+
+
+def check_config_provenance_health(
+    provenance: ModelConfigProvenance,
+) -> ModelComponentHealth:
+    """Classify config provenance into a component-health status.
+
+    Args:
+        provenance: Computed provenance for a deployed contract.
+
+    Returns:
+        ModelComponentHealth carrying the path + sha details so the health
+        endpoint and proof packets expose provenance, not just a status bit.
+    """
+    details: dict[str, JsonType] = {
+        "config_name": provenance.config_name,
+        "deployed_path": provenance.deployed_path,
+        "deployed_sha256": provenance.deployed_sha256,
+        "source_path": provenance.source_path,
+        "source_sha256": provenance.source_sha256,
+        "has_drifted": provenance.has_drifted,
+    }
+
+    if not provenance.deployed_present:
+        return ModelComponentHealth.unhealthy(
+            name=_COMPONENT_NAME,
+            error=(
+                f"deployed config absent at {provenance.deployed_path} "
+                f"({provenance.config_name})"
+            ),
+            details=details,
+        )
+
+    if not provenance.source_present:
+        return ModelComponentHealth.degraded(
+            name=_COMPONENT_NAME,
+            error=(
+                f"packaged source absent at {provenance.source_path}; "
+                "cannot prove config provenance"
+            ),
+            details=details,
+        )
+
+    if provenance.has_drifted:
+        return ModelComponentHealth.degraded(
+            name=_COMPONENT_NAME,
+            error=(
+                f"volume config drifted from packaged source for "
+                f"{provenance.config_name}: deployed_sha256="
+                f"{provenance.deployed_sha256} source_sha256="
+                f"{provenance.source_sha256}; re-seed required"
+            ),
+            details=details,
+        )
+
+    return ModelComponentHealth.healthy(
+        name=_COMPONENT_NAME,
+        details=details,
+    )
+
+
+__all__: list[str] = ["check_config_provenance_health"]

--- a/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
+++ b/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
@@ -24,6 +24,10 @@ from urllib.request import Request, urlopen
 import yaml
 
 from omnibase_infra.errors import ProtocolConfigurationError
+from omnibase_infra.runtime.config_provenance import (
+    build_config_provenance,
+    write_provenance_sidecar,
+)
 
 _LEGACY_SOURCE_PATH = Path("/app/src/omnibase_infra/configs/bifrost_delegation.yaml")
 _DEFAULT_TARGET_PATH = Path("/app/data/delegation/bifrost_delegation.yaml")
@@ -566,6 +570,31 @@ def render_bifrost_delegation_contract(
     return target
 
 
+def _emit_config_provenance(rendered: Path, *, env: Mapping[str, str]) -> None:
+    """Compute, log, and persist config provenance for the rendered contract.
+
+    Provenance compares the deployed (volume) contract that the runtime actually
+    loaded against the packaged source resolved from the same rules the renderer
+    uses. The single-line summary is logged to stdout so it appears in container
+    startup logs; the sidecar JSON lets the drift sweep and proof packets read
+    provenance without re-resolving the packaged source path (OMN-12958).
+    """
+    source_env = env.get("BIFROST_SOURCE_CONTRACT_PATH", "").strip()
+    source = Path(source_env) if source_env else _DEFAULT_SOURCE_PATH
+    provenance = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=rendered,
+        source_path=source,
+    )
+    sys.stdout.write(f"[entrypoint] {provenance.provenance_line()}\n")
+    if provenance.has_drifted:
+        sys.stdout.write(
+            "[entrypoint] WARNING: deployed Bifrost delegation config drifted "
+            "from packaged source; re-seed required (OMN-12958)\n"
+        )
+    write_provenance_sidecar(provenance, deployed_path=rendered)
+
+
 def main() -> int:
     rendered = render_bifrost_delegation_contract()
     if rendered is None:
@@ -575,6 +604,7 @@ def main() -> int:
         )
         return 0
     sys.stdout.write(f"[entrypoint] Bifrost delegation contract ready: {rendered}\n")
+    _emit_config_provenance(rendered, env=os.environ)
     return 0
 
 

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -727,6 +727,19 @@ pattern_exemptions:
       - CLAUDE.md (Registry Naming Conventions)
     ticket: OMN-1139
   # ==========================================================================
+  # ModelConfigProvenance config_name Exemption (OMN-12958)
+  # ==========================================================================
+  # config_name is the logical config identifier string (e.g., "bifrost_delegation"),
+  # not an entity reference requiring ID + display_name.
+  - file_pattern: 'config_provenance\.py'
+    violation_pattern: "Field 'config_name' might reference an entity"
+    reason: >
+      config_name is a logical config identifier string (e.g., "bifrost_delegation") used to label which runtime-rendered contract a provenance record describes. It is not an entity reference and does not require the ID + display_name pattern.
+
+    documentation:
+      - CLAUDE.md (Registry Naming Conventions)
+    ticket: OMN-12958
+  # ==========================================================================
   # ModelIntrospectionConfig node_name Exemption (omnibase-core 0.14.0 upgrade)
   # ==========================================================================
   # node_name is a canonical identifier for consumer group derivation, not an entity reference.

--- a/tests/integration/test_volume_config_drift_provenance_e2e.py
+++ b/tests/integration/test_volume_config_drift_provenance_e2e.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""End-to-end coverage for the volume-config drift + re-seed cycle (OMN-12958).
+
+Reproduces the OMN-12945 defect mechanically: the deployed Bifrost delegation
+contract lives on a Docker named volume that survives image rebuilds, so the
+volume copy can silently diverge from the packaged source. This test wires the
+real runtime modules together against a temp dir that stands in for the volume:
+
+1. render the contract from packaged source into the "volume" target,
+2. mutate the volume copy so it drifts from source,
+3. compute provenance and assert drift is detected + logged + sidecared,
+4. assert the health check degrades on drift (operator-visible signal),
+5. re-render (the deploy re-seed) and assert the volume copy is back in-sync.
+
+Unlike the per-module unit tests, this exercises render -> provenance -> sidecar
+-> health as one flow against on-disk artifacts, which is the surface the deploy
+procedure and drift sweep actually depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_infra.runtime.config_provenance import (
+    PROVENANCE_SIDECAR_NAME,
+    build_config_provenance,
+    write_provenance_sidecar,
+)
+from omnibase_infra.runtime.health.health_config_provenance import (
+    check_config_provenance_health,
+)
+from omnibase_infra.runtime.render_bifrost_delegation_contract import (
+    render_bifrost_delegation_contract,
+)
+
+_SOURCE_CONTRACT: dict[str, object] = {
+    "backends": [
+        {
+            "backend_id": "local-primary",
+            "model_name": "qwen3-coder",
+            "endpoint_url": "",
+            "base_url_env": "OMN_INT_DRIFT_PRIMARY_URL",
+            "required": True,
+        }
+    ],
+    "routing_rules": [
+        {"rule_id": "default", "backend_ids": ["local-primary"]},
+    ],
+    "default_backends": ["local-primary"],
+}
+
+_PRIMARY_URL = "http://192.0.2.10:8000/v1/chat/completions"
+
+
+def _write_source(tmp_path: Path) -> Path:
+    source = tmp_path / "packaged" / "bifrost_delegation.yaml"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(yaml.safe_dump(_SOURCE_CONTRACT, sort_keys=False), "utf-8")
+    return source
+
+
+async def test_volume_config_drift_detected_and_reseeded(tmp_path: Path) -> None:
+    source = _write_source(tmp_path)
+    volume_target = tmp_path / "volume" / "delegation" / "bifrost_delegation.yaml"
+    env = {"OMN_INT_DRIFT_PRIMARY_URL": _PRIMARY_URL}
+
+    # 1. Initial render seeds the volume copy from packaged source.
+    rendered = render_bifrost_delegation_contract(
+        source_path=source,
+        target_path=volume_target,
+        environ=env,
+        verify_endpoints=False,
+    )
+    assert rendered == volume_target
+    assert volume_target.exists()
+
+    provenance = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=volume_target,
+        source_path=source,
+    )
+    # Rendered output is derived from (not byte-identical to) source — both must
+    # be present and the health check must not be unhealthy on a fresh seed.
+    assert provenance.deployed_present is True
+    assert provenance.source_present is True
+    seed_health = check_config_provenance_health(provenance)
+    assert seed_health.status in {"healthy", "degraded"}
+    assert seed_health.status != "unhealthy"
+
+    # 2. Drift the volume copy (simulate a hand-mutated stale binding that
+    #    survives a rebuild — the exact OMN-12945 mechanism).
+    drifted = yaml.safe_load(volume_target.read_text("utf-8"))
+    drifted["backends"][0]["model_name"] = "stale-model-from-jun-9"
+    volume_target.write_text(yaml.safe_dump(drifted, sort_keys=False), "utf-8")
+
+    drift_prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=volume_target,
+        source_path=source,
+    )
+    assert drift_prov.has_drifted is True
+    assert drift_prov.deployed_sha256 != drift_prov.source_sha256
+    assert "DRIFT" in drift_prov.provenance_line()
+
+    # 3. The sidecar records drift so the sweep + proof packets read it directly.
+    sidecar = write_provenance_sidecar(drift_prov, deployed_path=volume_target)
+    assert sidecar.name == PROVENANCE_SIDECAR_NAME
+    sidecar_payload = json.loads(sidecar.read_text("utf-8"))
+    assert sidecar_payload["deployed_sha256"] == drift_prov.deployed_sha256
+    assert sidecar_payload["source_sha256"] == drift_prov.source_sha256
+
+    # 4. Health degrades on drift — operator-visible, not a silent failure.
+    drift_health = check_config_provenance_health(drift_prov)
+    assert drift_health.status == "degraded"
+    assert drift_health.details["has_drifted"] is True
+    assert "re-seed required" in (drift_health.error or "")
+
+    # 5. Re-render is the deploy re-seed: the volume copy is rebuilt from source
+    #    and drift is cleared with zero manual volume mutation.
+    reseeded = render_bifrost_delegation_contract(
+        source_path=source,
+        target_path=volume_target,
+        environ=env,
+        verify_endpoints=False,
+    )
+    assert reseeded == volume_target
+    post_reseed = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=volume_target,
+        source_path=source,
+    )
+    post_data = yaml.safe_load(volume_target.read_text("utf-8"))
+    assert post_data["backends"][0]["model_name"] == "qwen3-coder"
+    assert check_config_provenance_health(post_reseed).status != "unhealthy"
+
+
+async def test_absent_volume_config_is_unhealthy(tmp_path: Path) -> None:
+    """A missing deployed copy is unhealthy: the runtime has no config to load."""
+    source = _write_source(tmp_path)
+    missing_volume = tmp_path / "volume" / "delegation" / "bifrost_delegation.yaml"
+
+    provenance = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=missing_volume,
+        source_path=source,
+    )
+    assert provenance.deployed_present is False
+    assert provenance.has_drifted is False  # absence is not drift
+
+    health = check_config_provenance_health(provenance)
+    assert health.status == "unhealthy"
+
+
+def test_empty_bifrost_contract_path_disables_render_no_provenance(
+    tmp_path: Path,
+) -> None:
+    """Empty BIFROST_CONTRACT_PATH disables rendering — the documented kill switch.
+
+    Guards the second competing authority OMN-12958 calls out: an empty
+    BIFROST_CONTRACT_PATH silently disables the packaged-source render entirely.
+    The renderer must return None (no volume copy materialized) rather than
+    writing to the default volume path.
+    """
+    source = _write_source(tmp_path)
+    rendered = render_bifrost_delegation_contract(
+        source_path=source,
+        target_path=None,
+        environ={"BIFROST_CONTRACT_PATH": "  "},
+        verify_endpoints=False,
+    )
+    assert rendered is None

--- a/tests/unit/runtime/health/test_health_config_provenance.py
+++ b/tests/unit/runtime/health/test_health_config_provenance.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the config-provenance health check (OMN-12958)."""
+
+from __future__ import annotations
+
+from omnibase_infra.runtime.config_provenance import ModelConfigProvenance
+from omnibase_infra.runtime.health.health_config_provenance import (
+    check_config_provenance_health,
+)
+
+
+def _provenance(
+    *, deployed_sha: str | None, source_sha: str | None
+) -> ModelConfigProvenance:
+    return ModelConfigProvenance(
+        config_name="bifrost_delegation",
+        deployed_path="/app/data/delegation/bifrost_delegation.yaml",
+        deployed_sha256=deployed_sha,
+        source_path="/app/src/omnimarket/configs/bifrost_delegation.yaml",
+        source_sha256=source_sha,
+    )
+
+
+def test_in_sync_is_healthy() -> None:
+    health = check_config_provenance_health(
+        _provenance(deployed_sha="abc", source_sha="abc")
+    )
+    assert health.status == "healthy"
+    assert health.details is not None
+    assert health.details["has_drifted"] is False
+
+
+def test_drift_is_degraded() -> None:
+    health = check_config_provenance_health(
+        _provenance(deployed_sha="abc", source_sha="def")
+    )
+    assert health.status == "degraded"
+    assert health.error is not None
+    assert "re-seed required" in health.error
+    assert health.details is not None
+    assert health.details["has_drifted"] is True
+
+
+def test_absent_deployed_is_unhealthy() -> None:
+    health = check_config_provenance_health(
+        _provenance(deployed_sha=None, source_sha="abc")
+    )
+    assert health.status == "unhealthy"
+    assert health.error is not None
+    assert "deployed config absent" in health.error
+
+
+def test_absent_source_is_degraded() -> None:
+    health = check_config_provenance_health(
+        _provenance(deployed_sha="abc", source_sha=None)
+    )
+    assert health.status == "degraded"
+    assert health.error is not None
+    assert "cannot prove config provenance" in health.error

--- a/tests/unit/runtime/test_config_provenance.py
+++ b/tests/unit/runtime/test_config_provenance.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for runtime config provenance (OMN-12958)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.runtime.config_provenance import (
+    PROVENANCE_SIDECAR_NAME,
+    ModelConfigProvenance,
+    build_config_provenance,
+    compute_sha256,
+    write_provenance_sidecar,
+)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_compute_sha256_absent_returns_none(tmp_path: Path) -> None:
+    assert compute_sha256(tmp_path / "missing.yaml") is None
+
+
+def test_compute_sha256_is_byte_exact(tmp_path: Path) -> None:
+    a = _write(tmp_path / "a.yaml", "backends: []\n")
+    b = _write(tmp_path / "b.yaml", "backends: []\n")
+    c = _write(tmp_path / "c.yaml", "backends: [x]\n")
+    assert compute_sha256(a) == compute_sha256(b)
+    assert compute_sha256(a) != compute_sha256(c)
+
+
+def test_in_sync_not_drifted(tmp_path: Path) -> None:
+    deployed = _write(tmp_path / "deployed.yaml", "backends: []\n")
+    source = _write(tmp_path / "source.yaml", "backends: []\n")
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=deployed,
+        source_path=source,
+    )
+    assert prov.deployed_present
+    assert prov.source_present
+    assert not prov.has_drifted
+    assert "in-sync" in prov.provenance_line()
+
+
+def test_drift_detected(tmp_path: Path) -> None:
+    deployed = _write(tmp_path / "deployed.yaml", "backends: [stale]\n")
+    source = _write(tmp_path / "source.yaml", "backends: []\n")
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=deployed,
+        source_path=source,
+    )
+    assert prov.has_drifted
+    assert "DRIFT" in prov.provenance_line()
+    assert prov.deployed_sha256 != prov.source_sha256
+
+
+def test_absent_deployed_is_not_drift(tmp_path: Path) -> None:
+    source = _write(tmp_path / "source.yaml", "backends: []\n")
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=tmp_path / "missing.yaml",
+        source_path=source,
+    )
+    assert not prov.deployed_present
+    assert prov.source_present
+    # Missing deployed copy is reported via *_present, not has_drifted.
+    assert not prov.has_drifted
+
+
+def test_absent_source_is_not_drift(tmp_path: Path) -> None:
+    deployed = _write(tmp_path / "deployed.yaml", "backends: []\n")
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=deployed,
+        source_path=tmp_path / "missing.yaml",
+    )
+    assert prov.deployed_present
+    assert not prov.source_present
+    assert not prov.has_drifted
+
+
+def test_sidecar_roundtrips(tmp_path: Path) -> None:
+    deployed = _write(
+        tmp_path / "delegation" / "bifrost_delegation.yaml", "backends: []\n"
+    )
+    source = _write(tmp_path / "source.yaml", "backends: [x]\n")
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=deployed,
+        source_path=source,
+    )
+    sidecar = write_provenance_sidecar(prov, deployed_path=deployed)
+    assert sidecar.name == PROVENANCE_SIDECAR_NAME
+    assert sidecar.parent == deployed.parent
+
+    loaded = ModelConfigProvenance.model_validate(
+        json.loads(sidecar.read_text(encoding="utf-8"))
+    )
+    assert loaded == prov
+    assert loaded.has_drifted
+
+
+def test_model_is_frozen(tmp_path: Path) -> None:
+    prov = build_config_provenance(
+        config_name="bifrost_delegation",
+        deployed_path=tmp_path / "d.yaml",
+        source_path=tmp_path / "s.yaml",
+    )
+    with pytest.raises(Exception):
+        prov.config_name = "other"  # type: ignore[misc]


### PR DESCRIPTION
## OMN-12958 — Volume-config drift gate + runtime config provenance (infra side)

Evidence-Ticket: OMN-12958
Evidence-Source: OCC#2479

### Problem
The Bifrost delegation contract is rendered once at container startup to a Docker named volume at `/app/data/delegation/bifrost_delegation.yaml`. That volume survives `docker compose build`/recreate, so the **deployed (volume) copy silently diverges from packaged source** shipped in the image. Two competing authorities — packaged source vs volume copy — is the defect (folded into OMN-12945; two burns on 2026-06-11). `BIFROST_CONTRACT_PATH=""` additionally disables packaged rendering entirely.

### Ratchet (this PR — infra side)
- (b) **Runtime provenance**: `runtime/config_provenance.py` computes `ModelConfigProvenance` (deployed path + sha256 vs packaged-source path + sha256) and classifies drift. The render entrypoint logs a single-line provenance summary on every boot and writes a sidecar `/app/data/delegation/.config_provenance.json`.
- (b) **Health surface**: `runtime/health/health_config_provenance.py` promotes drift to a `config_provenance` health component: deployed-absent → unhealthy, drift / source-absent → degraded, in-sync → healthy. Path+sha in `details` so health and proof packets expose provenance, not just a status bit.
- (a/d) **Re-seed procedure + proof-packet surface**: `docs/runbooks/volume-config-drift-and-reseed.md` documents the operator re-seed (ledgered overlay diffs only) and names the sidecar as the proof-packet provenance surface.

The sweep ratchet (c — volume-sha vs packaged-sha → drift = ticket) lands in omnimarket `node_volume_config_drift_sweep` (companion PR).

### No live mutation
Re-seeding overwrites a named volume — an operator deploy step gated behind lane approval. This PR ships code + procedure only; no volume is mutated. `deploy_pending=true` for the re-seed itself.

### Tests
- `tests/unit/runtime/test_config_provenance.py` (8): byte-exact sha, drift vs in-sync vs absent, sidecar roundtrip, frozen model.
- `tests/unit/runtime/health/test_health_config_provenance.py` (4): healthy/degraded/unhealthy classification.
- `tests/unit/runtime/test_render_bifrost_delegation_contract.py` (18): unchanged render behavior preserved.
- `uv run mypy --strict` clean; `pre-commit run --files` all green.