### PR TITLE
fix(OMN-12988): pin stability runtime-worker to replicas 1 + silent-drop census ratchet

### DIFF
--- a/docker/docker-compose.stability-test.yml
+++ b/docker/docker-compose.stability-test.yml
@@ -234,7 +234,13 @@ services:
       - "com.omninode.runtime.address=runtime://omninode-pc/stability-test/worker"
       - "com.omninode.runtime.id=stability-test-worker"
     deploy:
-      replicas: ${STABILITY_TEST_WORKER_REPLICAS:-1}
+      # OMN-12988: pin the worker to a literal 1 — the base infra compose
+      # defaults runtime-worker to replicas 0 (${WORKER_REPLICAS:-0}), so a
+      # plain compose up/recreate would silently drop the stability-lane worker
+      # (4-container census: main, effects, worker, projection-api). A literal
+      # (not ${VAR:-1} env indirection) means no stray exported env var can
+      # scale it back to 0 with zero signal.
+      replicas: 1
   agent-actions-consumer:
     profiles: !override ["stability-test-disabled"]
   skill-lifecycle-consumer:

--- a/scripts/deploy-agent/tests/unit/test_runtime_worker_census.py
+++ b/scripts/deploy-agent/tests/unit/test_runtime_worker_census.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Census ratchet for the runtime-worker (OMN-12988, config-drift OMN-12945).
+
+The stability-test lane's required state includes a running ``runtime-worker``
+container (4-container census: main, effects, worker, projection-api). The base
+``docker-compose.infra.yml`` defaults the worker to ``replicas: 0``
+(``${WORKER_REPLICAS:-0}``), so a plain compose ``up``/recreate that does not
+set replicas silently drops the worker — zero errors, zero signal.
+
+Two ratchets guard against that:
+
+1. ``runtime-worker`` MUST remain in the deploy-agent RUNTIME-scope census so
+   ``verify_containers_up`` flags it ``missing`` (deploy failure) rather than
+   silently tolerating its absence. A ``replicas: 0`` worker produces no
+   container, so ``docker compose ps`` omits it and the census check fails —
+   which is the desired loud signal.
+2. The stability-test compose override MUST pin the worker to ``replicas: 1`` as
+   a literal value (no ``${VAR:-default}`` env indirection), so a lane recreate
+   cannot silently scale it to 0 via a stray exported env var.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from deploy_agent.events import SCOPE_SERVICES, Scope, services_for_scope
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+STABILITY_COMPOSE_PATH = REPO_ROOT / "docker" / "docker-compose.stability-test.yml"
+
+
+def test_runtime_worker_in_runtime_scope_census() -> None:
+    """A missing worker must be a deploy failure, not silence.
+
+    ``runtime-worker`` is part of the required runtime census; the deploy-agent
+    verifier polls for every service in this list and raises when any is
+    missing. A ``replicas: 0`` worker is absent from ``docker compose ps`` and
+    is therefore reported missing — the loud signal we want.
+    """
+    assert "runtime-worker" in SCOPE_SERVICES[Scope.RUNTIME]
+    assert "runtime-worker" in services_for_scope(Scope.RUNTIME)
+    assert "runtime-worker" in services_for_scope(Scope.FULL)
+
+
+def test_stability_override_pins_worker_replicas_to_literal_one() -> None:
+    """The stability override pins worker ``replicas: 1`` as a literal.
+
+    Env indirection (``${STABILITY_TEST_WORKER_REPLICAS:-1}``) is a silent-drop
+    surface: an exported ``STABILITY_TEST_WORKER_REPLICAS=0`` or a future edit
+    removing the ``:-1`` fallback would scale the worker to 0 with no signal.
+    The pin must be the literal integer ``1``.
+    """
+    # The stability override uses docker compose custom tags (!override,
+    # !!merge) that yaml.safe_load cannot parse, so assert against the raw text:
+    # locate the runtime-worker service block and its deploy.replicas line.
+    raw = STABILITY_COMPOSE_PATH.read_text(encoding="utf-8")
+
+    worker_block = re.search(
+        r"^  runtime-worker:\n((?:    .*\n|\n)*)",
+        raw,
+        re.MULTILINE,
+    )
+    assert worker_block is not None, (
+        f"could not locate the runtime-worker service block in {STABILITY_COMPOSE_PATH}"
+    )
+
+    replicas_line = re.search(
+        r"^      replicas:\s*(.+?)\s*$",
+        worker_block.group(1),
+        re.MULTILINE,
+    )
+    assert replicas_line is not None, (
+        "stability-test runtime-worker must declare deploy.replicas explicitly; "
+        f"none found in:\n{worker_block.group(1)}"
+    )
+
+    value = replicas_line.group(1)
+    assert value == "1", (
+        "stability-test runtime-worker must pin deploy.replicas to the literal "
+        f"integer 1 (no env-interpolation default that could silently scale to "
+        f"0), got {value!r}"
+    )

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -421,6 +421,27 @@ def test_stability_lane_render_contains_isolated_runtime_identity() -> None:
 
 
 @pytest.mark.integration
+def test_stability_lane_render_pins_worker_replicas_to_one() -> None:
+    """The stability worker must render with deploy.replicas == 1 (OMN-12988).
+
+    The base infra compose defaults runtime-worker to replicas 0
+    (``${WORKER_REPLICAS:-0}``); without a hard pin in the stability override a
+    plain compose recreate silently drops the worker (4-container census). This
+    ratchet fails if the override regresses to 0 or to an env-interpolation
+    default that resolves to anything other than 1.
+    """
+    rendered_config = _compose_config_json()
+    worker = rendered_config["services"]["runtime-worker"]
+
+    deploy = worker.get("deploy")
+    assert deploy is not None, "runtime-worker must declare a deploy block"
+    assert deploy.get("replicas") == 1, (
+        "stability-test runtime-worker must render deploy.replicas == 1; got "
+        f"{deploy.get('replicas')!r}"
+    )
+
+
+@pytest.mark.integration
 def test_stability_lane_render_inherits_release_build_source() -> None:
     rendered_config = _compose_config_json()
     services = rendered_config["services"]

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -145,7 +145,11 @@ def test_stability_lane_runtime_worker_is_not_scaled_to_zero() -> None:
     overlay = _load_overlay()
     worker = overlay["services"]["runtime-worker"]
 
-    assert worker["deploy"]["replicas"] == "${STABILITY_TEST_WORKER_REPLICAS:-1}"
+    # OMN-12988: the worker must be pinned to a literal 1, not an
+    # env-interpolation default. The base infra compose defaults the worker to
+    # replicas 0 (${WORKER_REPLICAS:-0}); an env-indirection pin would let a
+    # stray exported STABILITY_TEST_WORKER_REPLICAS=0 silently drop the worker.
+    assert worker["deploy"]["replicas"] == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The base `docker/docker-compose.infra.yml:862` defaults `runtime-worker` to `replicas: ${WORKER_REPLICAS:-0}`. The stability-test lane's required state includes a running worker (`GATE_ZERO_PROOF.md` 4-container census: main, effects, worker, projection-api), but the override pinned it via an env-interpolation default `${STABILITY_TEST_WORKER_REPLICAS:-1}` — a silent-drop surface. A stray exported `STABILITY_TEST_WORKER_REPLICAS=0`, or a future edit removing the `:-1` fallback, would scale the worker to 0 on a plain compose `up`/recreate with zero errors and zero signal.

## Fix

- `docker/docker-compose.stability-test.yml`: pin `runtime-worker` `deploy.replicas` to the literal `1` (no env indirection).

## Ratchet (recurrence guards, same PR)

- `scripts/deploy-agent/tests/unit/test_runtime_worker_census.py` (new): asserts `runtime-worker` stays in the deploy-agent `SCOPE_SERVICES[RUNTIME]` census so a missing worker (a `replicas: 0` worker is absent from `docker compose ps`) is a deploy failure via `verify_containers_up`, not silence; asserts the stability override pins a literal `1`.
- `tests/integration/infra/test_stability_test_runtime_compose_render.py`: asserts the rendered stability worker resolves `deploy.replicas == 1`.
- `tests/unit/infra/test_stability_test_runtime_lane.py`: existing pin assertion updated to the literal `1`.

## Verification

- `uv run pytest tests/ci/test_runtime_policy_contract.py tests/integration/infra/test_stability_test_runtime_compose_render.py tests/unit/test_verify_container_manifest.py tests/unit/infra/test_stability_test_runtime_lane.py tests/unit/docker/test_docker_performance.py` — all pass (render test confirms `replicas: 1` end-to-end via `docker compose config`).
- New census ratchet: `scripts/deploy-agent` `pytest tests/unit/test_runtime_worker_census.py` — 2 passed.
- ruff format + check clean; pre-commit on changed files passed.

No live lane mutation in this PR; the rebuild agent applies the config to the stability lane.

Evidence-Ticket: OMN-12988
Evidence-Source: OCC#2481

Config-drift family: OMN-12945

