### PR TITLE
fix(OMN-12987): workspace-build sibling lock-pin preflight (vendored stale infra 0.37.0-dev caused the 06-11 stability bootstrap crash)

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -320,7 +320,7 @@ RUN set -eu; \
     if [ "${BUILD_SOURCE}" = "workspace" ]; then \
         /app/.venv/bin/python /workspace/compute_workspace_provenance.py; \
     else \
-        printf '{\n  "build_source": "release",\n  "build_time": "%s",\n  "vcs_ref": "%s",\n  "proofs": []\n}\n' \
+        printf '{\n  "build_source": "release",\n  "build_time": "%s",\n  "vcs_ref": "%s",\n  "proofs": [],\n  "lock_pin_comparison": []\n}\n' \
             "${BUILD_DATE:-unknown}" "${VCS_REF:-unknown}" > /app/build-provenance.json; \
     fi
 

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -564,6 +564,56 @@ stage_workspace_if_needed() {
     log_step "Stage Workspace Sibling Repos"
     log_cmd "OMNI_HOME=${omni_home} bash ${stage_script}"
     (cd "${repo_root}" && OMNI_HOME="${omni_home}" bash "${stage_script}")
+
+    check_sibling_lock_pins "${repo_root}" "${omni_home}"
+}
+
+check_sibling_lock_pins() {
+    # Fail-fast preflight (OMN-12987): every vendored sibling's version/SHA must
+    # match the consuming repo's (omnimarket) uv.lock pin. The 2026-06-11
+    # stability crash shipped a 13-day-stale infra 0.37.0 because the build
+    # ignored the dev lock; this guard refuses to build a stale image.
+    local repo_root="$1"
+    local omni_home="$2"
+    local guard="${repo_root}/scripts/runtime_build/check_sibling_lock_pins.py"
+    if [[ ! -f "${guard}" ]]; then
+        log_error "Sibling lock-pin preflight not found: ${guard}"
+        log_error "Cannot verify vendored siblings match the consuming lock. Aborting."
+        exit 1
+    fi
+
+    log_step "Sibling Lock-Pin Preflight (OMN-12987)"
+    # Write under sibling-repos/ so it rides along with the directory the
+    # Dockerfile already COPYs into the build image (no extra COPY needed).
+    mkdir -p "${repo_root}/workspace/sibling-repos"
+    local provenance_out="${repo_root}/workspace/sibling-repos/.sibling-lock-pins.json"
+    local python_bin
+    if [[ -x "${repo_root}/.venv/bin/python" ]]; then
+        python_bin="${repo_root}/.venv/bin/python"
+    elif command -v uv &>/dev/null; then
+        python_bin="uv-run"
+    elif command -v python3 &>/dev/null; then
+        python_bin="python3"
+    else
+        log_error "No Python interpreter available to run the sibling lock-pin preflight."
+        exit 1
+    fi
+
+    log_cmd "OMNI_HOME=${omni_home} ${guard} --provenance-out ${provenance_out}"
+    if [[ "${python_bin}" == "uv-run" ]]; then
+        if ! OMNI_HOME="${omni_home}" uv run --project "${repo_root}" python "${guard}" \
+            --provenance-out "${provenance_out}"; then
+            log_error "Sibling lock-pin preflight FAILED. Refusing to build a stale image."
+            exit 1
+        fi
+    else
+        if ! OMNI_HOME="${omni_home}" "${python_bin}" "${guard}" \
+            --provenance-out "${provenance_out}"; then
+            log_error "Sibling lock-pin preflight FAILED. Refusing to build a stale image."
+            exit 1
+        fi
+    fi
+    log_info "Sibling lock-pin preflight passed: all vendored siblings match the lock."
 }
 
 check_git_dirty() {
@@ -1115,6 +1165,9 @@ if spec and spec.origin:
     log_cmd "rsync -a --delete workspace/sibling-repos/ -> deployed"
     rsync -a --delete \
         "${repo_root}/workspace/sibling-repos/" "${deploy_target}/workspace/sibling-repos/"
+    # The lock-pin preflight result (OMN-12987) lives under sibling-repos/ as
+    # .sibling-lock-pins.json, so the rsync above already carries it into the
+    # build context for the in-image provenance merge.
 
     # 6. Migration scripts (bind-mounted by docker-compose.infra.yml)
     log_info "Syncing migration scripts..."

--- a/scripts/runtime_build/check_sibling_lock_pins.py
+++ b/scripts/runtime_build/check_sibling_lock_pins.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Fail-fast preflight: vendored sibling versions/SHAs must match the lock pin.
+
+Surfaced by the 2026-06-11 resolver-crash diagnosis (OMN-12987). A workspace-mode
+``--no-cache`` rebuild vendored omnibase_infra ``0.37.0-dev`` (~``2c1d672f``) +
+omnibase_core ``0.42.0`` even though omnimarket dev's ``uv.lock`` pinned infra
+``0.38.1 @ e2dbdc95`` + core ``0.44.0 @ c97c2c9a``. The build silently shipped a
+13-day-stale sibling that predated the OMN-12501 Protocol-quarantine guard,
+turning a latent contract defect into a fatal bootstrap crash.
+
+This preflight resolves the *expected* sibling pins from the consuming repo's lock
+(the authority) and compares them against the *actual* version/SHA of each repo
+the build vendors. Any mismatch aborts the build — there is no silent fallback.
+
+The comparison is also serialised so the deploy verifier (and
+``build-provenance.json``) can record expected-vs-actual per sibling.
+
+Run on the host before staging/building (it needs the canonical clones' git SHAs):
+
+    OMNI_HOME=/data/omninode/omni_home \\
+      uv run python scripts/runtime_build/check_sibling_lock_pins.py \\
+        --consuming-repo omnimarket \\
+        --build-context-repo omnibase_infra
+
+Exit codes:
+  0  all vendored siblings match the consuming repo's lock pin
+  1  one or more siblings mismatch (version and/or SHA)
+  2  malformed inputs (missing lock, missing pyproject, unreadable git SHA)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# Distribution name (as it appears in uv.lock) -> repo directory name under OMNI_HOME.
+# These are the siblings the workspace build either vendors directly
+# (compat/onex_change_control/omnimarket) or builds *from* as the build context
+# (omnibase_infra). omnibase_core is pinned transitively and vendored via the
+# infra wheel, so it is included too: the 06-11 crash shipped a stale core.
+PACKAGE_TO_REPO: dict[str, str] = {
+    "omnibase-compat": "omnibase_compat",
+    "omnibase-core": "omnibase_core",
+    "omnibase-infra": "omnibase_infra",
+    "onex-change-control": "onex_change_control",
+}
+
+
+@dataclass(frozen=True)
+class ExpectedPin:
+    """Expected sibling pin resolved from the consuming repo's lock."""
+
+    package: str
+    version: str
+    git_rev: str  # empty string when the lock pins a non-git (registry) source
+
+
+@dataclass(frozen=True)
+class PinComparison:
+    """Expected-vs-actual comparison for a single vendored sibling."""
+
+    package: str
+    repo: str
+    expected_version: str
+    actual_version: str
+    expected_git_rev: str
+    actual_git_rev: str
+    version_match: bool
+    sha_match: bool
+
+    @property
+    def ok(self) -> bool:
+        # SHA is the authoritative pin; version is a secondary signal. When the
+        # lock pins a git source we require the SHA to match. When the lock has
+        # no git rev (registry source) we fall back to the version match.
+        if self.expected_git_rev:
+            return self.sha_match
+        return self.version_match
+
+
+def parse_lock_pins(lock_path: Path) -> dict[str, ExpectedPin]:
+    """Extract expected sibling pins from a uv.lock TOML file.
+
+    Returns a mapping of distribution name -> ExpectedPin for every sibling in
+    PACKAGE_TO_REPO that the lock declares. Siblings absent from the lock are
+    simply omitted (the caller decides whether that is an error).
+    """
+    if not lock_path.is_file():
+        raise FileNotFoundError(f"consuming-repo lock not found: {lock_path}")
+
+    data = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    pins: dict[str, ExpectedPin] = {}
+    for pkg in data.get("package", []):
+        name = pkg.get("name", "")
+        if name not in PACKAGE_TO_REPO:
+            continue
+        version = str(pkg.get("version", ""))
+        git_rev = _extract_git_rev(pkg.get("source", {}))
+        pins[name] = ExpectedPin(package=name, version=version, git_rev=git_rev)
+    return pins
+
+
+def _extract_git_rev(source: dict[str, object]) -> str:
+    """Return the resolved git commit SHA from a uv.lock source table.
+
+    uv records git sources as ``{"git": "<url>?rev=<sha>#<sha>"}``; the resolved
+    commit is the fragment after ``#``. Registry/path sources yield an empty rev.
+    """
+    git = source.get("git")
+    if not isinstance(git, str):
+        return ""
+    _, _, fragment = git.partition("#")
+    return fragment.strip()
+
+
+def read_actual_version(repo_path: Path) -> str:
+    """Read the installed version from a repo's pyproject.toml ``[project]``."""
+    pyproject = repo_path / "pyproject.toml"
+    if not pyproject.is_file():
+        raise FileNotFoundError(f"pyproject.toml not found for repo: {repo_path}")
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version", "")
+    if not version:
+        raise ValueError(f"no [project].version in {pyproject}")
+    return str(version)
+
+
+def read_actual_git_rev(repo_path: Path) -> str:
+    """Return the full HEAD SHA of a repo.
+
+    Prefers a committed ``.build-sha`` marker (staged trees rsync without
+    ``.git``); falls back to ``git rev-parse HEAD`` for live canonical clones.
+    """
+    marker = repo_path / ".build-sha"
+    if marker.is_file():
+        return marker.read_text(encoding="utf-8").strip()
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"cannot resolve git SHA for {repo_path}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def compare_pin(expected: ExpectedPin, repo_path: Path) -> PinComparison:
+    """Build the expected-vs-actual comparison for one sibling."""
+    actual_version = read_actual_version(repo_path)
+    actual_rev = read_actual_git_rev(repo_path)
+    # SHA equality is prefix-tolerant: lock records full 40-char rev, markers or
+    # short SHAs may be abbreviated. Compare on the shorter length.
+    n = min(len(expected.git_rev), len(actual_rev)) if expected.git_rev else 0
+    sha_match = (
+        bool(expected.git_rev) and n > 0 and (expected.git_rev[:n] == actual_rev[:n])
+    )
+    return PinComparison(
+        package=expected.package,
+        repo=PACKAGE_TO_REPO[expected.package],
+        expected_version=expected.version,
+        actual_version=actual_version,
+        expected_git_rev=expected.git_rev,
+        actual_git_rev=actual_rev,
+        version_match=expected.version == actual_version,
+        sha_match=sha_match,
+    )
+
+
+def evaluate(
+    pins: dict[str, ExpectedPin],
+    repo_root: Path,
+    build_context_repo: str,
+    repo_path_overrides: dict[str, Path] | None = None,
+) -> list[PinComparison]:
+    """Compare every locked sibling pin against the repo the build will vendor.
+
+    ``repo_root`` is OMNI_HOME (canonical clones live directly beneath it).
+    ``repo_path_overrides`` lets callers point a package at a staged tree.
+    """
+    overrides = repo_path_overrides or {}
+    comparisons: list[PinComparison] = []
+    for package, expected in sorted(pins.items()):
+        repo_dir = PACKAGE_TO_REPO[package]
+        repo_path = overrides.get(package, repo_root / repo_dir)
+        if not repo_path.is_dir():
+            raise FileNotFoundError(
+                f"sibling repo for '{package}' not found at {repo_path}"
+            )
+        comparisons.append(compare_pin(expected, repo_path))
+    # build_context_repo is documented for the operator; the comparison itself
+    # already covers it because the infra package is in PACKAGE_TO_REPO.
+    _ = build_context_repo
+    return comparisons
+
+
+def render_report(comparisons: list[PinComparison]) -> str:
+    """Human-readable summary, one line per sibling."""
+    lines: list[str] = []
+    for c in comparisons:
+        flag = "OK " if c.ok else "MISMATCH"
+        lines.append(
+            f"  [{flag}] {c.package}: "
+            f"expected {c.expected_version}@{c.expected_git_rev[:12] or '(no-rev)'} "
+            f"actual {c.actual_version}@{c.actual_git_rev[:12] or '(no-rev)'}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--consuming-repo",
+        default="omnimarket",
+        help="repo whose uv.lock is the pin authority (default: omnimarket)",
+    )
+    parser.add_argument(
+        "--build-context-repo",
+        default="omnibase_infra",
+        help="repo the image is built FROM (default: omnibase_infra)",
+    )
+    parser.add_argument(
+        "--omni-home",
+        default=os.environ.get("OMNI_HOME", ""),
+        help="path to OMNI_HOME (canonical clones root). Defaults to $OMNI_HOME.",
+    )
+    parser.add_argument(
+        "--provenance-out",
+        default="",
+        help="optional path to write the expected-vs-actual JSON report.",
+    )
+    args = parser.parse_args()
+
+    if not args.omni_home:
+        print(
+            "ERROR: OMNI_HOME not set; pass --omni-home or export OMNI_HOME.",
+            file=sys.stderr,
+        )
+        return 2
+    repo_root = Path(args.omni_home)
+    lock_path = repo_root / args.consuming_repo / "uv.lock"
+
+    try:
+        pins = parse_lock_pins(lock_path)
+        comparisons = evaluate(pins, repo_root, args.build_context_repo)
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        print(f"ERROR: sibling lock-pin preflight failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Sibling lock-pin preflight (authority: {args.consuming_repo}/uv.lock):")
+    print(render_report(comparisons))
+
+    if args.provenance_out:
+        Path(args.provenance_out).write_text(
+            json.dumps([asdict(c) for c in comparisons], indent=2),
+            encoding="utf-8",
+        )
+
+    mismatches = [c for c in comparisons if not c.ok]
+    if mismatches:
+        print(
+            f"\nFATAL: {len(mismatches)} vendored sibling(s) do not match the "
+            f"{args.consuming_repo} lock pin. Refusing to build a stale image.",
+            file=sys.stderr,
+        )
+        for c in mismatches:
+            print(
+                f"  - {c.package}: lock pins "
+                f"{c.expected_version}@{c.expected_git_rev[:12] or '(no-rev)'} but "
+                f"vendored tree is "
+                f"{c.actual_version}@{c.actual_git_rev[:12] or '(no-rev)'}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"\nAll {len(comparisons)} vendored siblings match the lock pin.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/runtime_build/compute_workspace_provenance.py
+++ b/scripts/runtime_build/compute_workspace_provenance.py
@@ -28,6 +28,11 @@ from pathlib import Path
 SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")
 VENV_DIR = Path("/app/.venv")
 OUTPUT_MANIFEST = Path("/app/build-provenance.json")
+# Expected-vs-actual sibling pin comparison produced by the host-side lock-pin
+# preflight (check_sibling_lock_pins.py, OMN-12987). Staged under sibling-repos/
+# so it rides along into the build image. Absent on builds that skipped the
+# preflight (e.g. release mode); the manifest then records an empty comparison.
+LOCK_PIN_COMPARISON = SIBLING_REPOS_DIR / ".sibling-lock-pins.json"
 
 # Canonical set of sibling repos that workspace mode must provision.
 # Keys are the directory names under sibling-repos/; values are installed
@@ -67,6 +72,22 @@ def _installed_direct_url(dist_name: str) -> dict | None:
     if direct_url_text is None:
         return None
     return json.loads(direct_url_text)
+
+
+def _load_lock_pin_comparison() -> list[dict]:
+    """Return the host-side expected-vs-actual sibling pin comparison.
+
+    The list is produced by check_sibling_lock_pins.py (OMN-12987) and staged
+    into the build image. Returns an empty list when the file is absent (the
+    preflight was skipped) so the manifest is always well-formed.
+    """
+    if not LOCK_PIN_COMPARISON.is_file():
+        return []
+    try:
+        data = json.loads(LOCK_PIN_COMPARISON.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
 
 
 def main() -> int:
@@ -137,11 +158,15 @@ def main() -> int:
             f"install={install_url}"
         )
 
+    lock_pin_comparison = _load_lock_pin_comparison()
     manifest = {
         "build_source": "workspace",
         "build_time": os.environ.get("BUILD_DATE", "unknown"),
         "vcs_ref": os.environ.get("VCS_REF", "unknown"),
         "proofs": proofs,
+        # OMN-12987: expected-vs-actual sibling lock pins so deploy verifiers can
+        # detect a stale-sibling build without re-running the host preflight.
+        "lock_pin_comparison": lock_pin_comparison,
     }
 
     OUTPUT_MANIFEST.write_text(json.dumps(manifest, indent=2), encoding="utf-8")

--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -59,6 +59,15 @@ for repo in "${SIBLING_REPOS[@]}"; do
         --exclude='.venv' \
         --exclude='*.egg-info' \
         "${src}/" "${dst}/"
+    # Record the source HEAD SHA so the lock-pin preflight and provenance can
+    # identify exactly which commit was vendored. rsync drops .git, so without
+    # this marker the staged tree has no recoverable SHA (OMN-12987).
+    if git -C "${src}" rev-parse HEAD >/dev/null 2>&1; then
+        git -C "${src}" rev-parse HEAD > "${dst}/.build-sha"
+    else
+        echo "ERROR: cannot resolve HEAD SHA for ${src}; refusing to stage an unverifiable tree" >&2
+        exit 3
+    fi
 done
 
 echo "workspace staging complete: ${#SIBLING_REPOS[@]} repos staged to ${STAGING_DIR}"

--- a/tests/scripts/test_check_sibling_lock_pins.py
+++ b/tests/scripts/test_check_sibling_lock_pins.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for scripts/runtime_build/check_sibling_lock_pins.py (OMN-12987).
+
+Recurrence guard for the 2026-06-11 stability bootstrap crash: a workspace-mode
+rebuild vendored omnibase_infra 0.37.0 / core 0.42.0 even though omnimarket dev's
+uv.lock pinned infra 0.38.1 @ e2dbdc95 / core 0.44.0 @ c97c2c9a. The preflight
+must fail-fast when a vendored sibling drifts from the consuming repo's lock.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "runtime_build" / "check_sibling_lock_pins.py"
+
+
+def _load_module() -> Any:
+    mod_name = "check_sibling_lock_pins"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPT)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+_mod = _load_module()
+
+
+# The exact pins from omnimarket dev's uv.lock at the time of the 06-11 crash.
+_LOCK_INFRA_REV = "e2dbdc950540df8bc59ca4370b2d4a0f5b8d6c59"
+_LOCK_CORE_REV = "c97c2c9a45c5fb0def5fb7dacfd5f01278bb9f55"
+# The stale SHA the crashing build actually vendored.
+_STALE_INFRA_REV = "2c1d672f00000000000000000000000000000000"
+
+
+def _write_lock(path: Path) -> None:
+    """Write a minimal uv.lock that pins the four siblings to git revs."""
+    path.write_text(
+        f"""
+version = 1
+
+[[package]]
+name = "omnibase-compat"
+version = "0.5.1"
+source = {{ git = "https://github.com/OmniNode-ai/omnibase_compat.git?rev=4d887307#4d887307aae34d9d40d389ba91070cb411ce3df5" }}
+
+[[package]]
+name = "omnibase-core"
+version = "0.44.0"
+source = {{ git = "https://github.com/OmniNode-ai/omnibase_core.git?rev={_LOCK_CORE_REV}#{_LOCK_CORE_REV}" }}
+
+[[package]]
+name = "omnibase-infra"
+version = "0.38.1"
+source = {{ git = "https://github.com/OmniNode-ai/omnibase_infra.git?rev={_LOCK_INFRA_REV}#{_LOCK_INFRA_REV}" }}
+
+[[package]]
+name = "onex-change-control"
+version = "0.5.0"
+source = {{ git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=4877d3c2#4877d3c223517cb0c7e1eca462ba0f4d38916314" }}
+""",
+        encoding="utf-8",
+    )
+
+
+def _make_repo(root: Path, repo_dir: str, version: str, sha: str) -> Path:
+    repo = root / repo_dir
+    repo.mkdir(parents=True)
+    (repo / "pyproject.toml").write_text(
+        f'[project]\nname = "{repo_dir}"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    (repo / ".build-sha").write_text(sha + "\n", encoding="utf-8")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# parse_lock_pins
+# ---------------------------------------------------------------------------
+
+
+def test_parse_lock_pins_extracts_git_revs(tmp_path: Path) -> None:
+    lock = tmp_path / "uv.lock"
+    _write_lock(lock)
+    pins = _mod.parse_lock_pins(lock)
+    assert pins["omnibase-infra"].version == "0.38.1"
+    assert pins["omnibase-infra"].git_rev == _LOCK_INFRA_REV
+    assert pins["omnibase-core"].git_rev == _LOCK_CORE_REV
+    # Only the four known siblings are extracted.
+    assert set(pins) == {
+        "omnibase-compat",
+        "omnibase-core",
+        "omnibase-infra",
+        "onex-change-control",
+    }
+
+
+def test_parse_lock_pins_missing_lock_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        _mod.parse_lock_pins(tmp_path / "nope.lock")
+
+
+# ---------------------------------------------------------------------------
+# evaluate — matched and mismatched
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_all_pins_match(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.lock"
+    _write_lock(lock)
+    pins = _mod.parse_lock_pins(lock)
+    root = tmp_path / "omni_home"
+    _make_repo(
+        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
+    )
+    _make_repo(root, "omnibase_core", "0.44.0", _LOCK_CORE_REV)
+    _make_repo(root, "omnibase_infra", "0.38.1", _LOCK_INFRA_REV)
+    _make_repo(
+        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
+    )
+
+    comparisons = _mod.evaluate(pins, root, "omnibase_infra")
+    assert all(c.ok for c in comparisons)
+    assert [c.ok for c in comparisons].count(True) == 4
+
+
+def test_evaluate_stale_infra_sha_fails(tmp_path: Path) -> None:
+    """The exact 06-11 failure: infra vendored at a stale SHA must mismatch."""
+    lock = tmp_path / "lock.lock"
+    _write_lock(lock)
+    pins = _mod.parse_lock_pins(lock)
+    root = tmp_path / "omni_home"
+    _make_repo(
+        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
+    )
+    _make_repo(root, "omnibase_core", "0.42.0", _STALE_INFRA_REV)
+    # infra at the stale pre-OMN-12501-guard SHA + downgraded version.
+    _make_repo(root, "omnibase_infra", "0.37.0", _STALE_INFRA_REV)
+    _make_repo(
+        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
+    )
+
+    comparisons = _mod.evaluate(pins, root, "omnibase_infra")
+    by_pkg = {c.package: c for c in comparisons}
+    assert not by_pkg["omnibase-infra"].ok
+    assert not by_pkg["omnibase-core"].ok
+    assert by_pkg["omnibase-compat"].ok
+    assert by_pkg["onex-change-control"].ok
+
+
+def test_evaluate_missing_repo_raises(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.lock"
+    _write_lock(lock)
+    pins = _mod.parse_lock_pins(lock)
+    root = tmp_path / "omni_home"
+    # Only create one repo; the others are absent.
+    _make_repo(
+        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
+    )
+    with pytest.raises(FileNotFoundError):
+        _mod.evaluate(pins, root, "omnibase_infra")
+
+
+# ---------------------------------------------------------------------------
+# read_actual_git_rev — marker vs git fallback
+# ---------------------------------------------------------------------------
+
+
+def test_read_actual_git_rev_prefers_marker(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    (repo / ".build-sha").write_text("deadbeefcafebabe\n", encoding="utf-8")
+    assert _mod.read_actual_git_rev(repo) == "deadbeefcafebabe"
+
+
+# ---------------------------------------------------------------------------
+# main — end-to-end exit codes
+# ---------------------------------------------------------------------------
+
+
+def _run_main(
+    tmp_path: Path, versions: dict[str, tuple[str, str]]
+) -> subprocess.CompletedProcess:
+    root = tmp_path / "omni_home"
+    consuming = root / "omnimarket"
+    consuming.mkdir(parents=True)
+    _write_lock(consuming / "uv.lock")
+    for repo_dir, (ver, sha) in versions.items():
+        _make_repo(root, repo_dir, ver, sha)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--omni-home", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_main_exit_zero_on_match(tmp_path: Path) -> None:
+    res = _run_main(
+        tmp_path,
+        {
+            "omnibase_compat": ("0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"),
+            "omnibase_core": ("0.44.0", _LOCK_CORE_REV),
+            "omnibase_infra": ("0.38.1", _LOCK_INFRA_REV),
+            "onex_change_control": (
+                "0.5.0",
+                "4877d3c223517cb0c7e1eca462ba0f4d38916314",
+            ),
+        },
+    )
+    assert res.returncode == 0, res.stderr
+
+
+def test_main_exit_one_on_stale_infra(tmp_path: Path) -> None:
+    res = _run_main(
+        tmp_path,
+        {
+            "omnibase_compat": ("0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"),
+            "omnibase_core": ("0.42.0", _STALE_INFRA_REV),
+            "omnibase_infra": ("0.37.0", _STALE_INFRA_REV),
+            "onex_change_control": (
+                "0.5.0",
+                "4877d3c223517cb0c7e1eca462ba0f4d38916314",
+            ),
+        },
+    )
+    assert res.returncode == 1, res.stdout
+    assert "do not match" in res.stderr
+    assert "omnibase-infra" in res.stderr
+
+
+def test_provenance_script_folds_lock_pin_comparison(tmp_path: Path) -> None:
+    """compute_workspace_provenance.py must merge the staged lock-pin JSON."""
+    prov_script = (
+        _REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
+    )
+    sibling_dir = tmp_path / "workspace" / "sibling-repos"
+    for repo in ("omnibase_compat", "onex_change_control", "omnimarket"):
+        (sibling_dir / repo).mkdir(parents=True)
+        (sibling_dir / repo / "pyproject.toml").write_text(
+            f'[project]\nname = "{repo}"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+    # Stage a lock-pin comparison file the provenance step should fold in.
+    pin_payload = [
+        {
+            "package": "omnibase-infra",
+            "repo": "omnibase_infra",
+            "expected_version": "0.38.1",
+            "actual_version": "0.38.1",
+            "expected_git_rev": _LOCK_INFRA_REV,
+            "actual_git_rev": _LOCK_INFRA_REV,
+            "version_match": True,
+            "sha_match": True,
+        }
+    ]
+    (sibling_dir / ".sibling-lock-pins.json").write_text(
+        json.dumps(pin_payload), encoding="utf-8"
+    )
+
+    manifest_path = tmp_path / "build-provenance.json"
+    script_src = prov_script.read_text(encoding="utf-8")
+    script_src = script_src.replace(
+        'SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")',
+        f'SIBLING_REPOS_DIR = Path("{sibling_dir}")',
+    ).replace(
+        'OUTPUT_MANIFEST = Path("/app/build-provenance.json")',
+        f'OUTPUT_MANIFEST = Path("{manifest_path}")',
+    )
+    patched = tmp_path / "prov_folded.py"
+    patched.write_text(script_src, encoding="utf-8")
+
+    subprocess.run(
+        [sys.executable, str(patched)], capture_output=True, text=True, check=False
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert "lock_pin_comparison" in manifest
+    assert manifest["lock_pin_comparison"] == pin_payload
+
+
+def test_provenance_script_lock_pin_comparison_empty_when_absent(
+    tmp_path: Path,
+) -> None:
+    """Missing staged lock-pin file yields an empty (well-formed) comparison."""
+    prov_script = (
+        _REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
+    )
+    sibling_dir = tmp_path / "workspace" / "sibling-repos"
+    for repo in ("omnibase_compat", "onex_change_control", "omnimarket"):
+        (sibling_dir / repo).mkdir(parents=True)
+        (sibling_dir / repo / "pyproject.toml").write_text(
+            f'[project]\nname = "{repo}"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+    manifest_path = tmp_path / "build-provenance.json"
+    script_src = prov_script.read_text(encoding="utf-8")
+    script_src = script_src.replace(
+        'SIBLING_REPOS_DIR = Path("/workspace/sibling-repos")',
+        f'SIBLING_REPOS_DIR = Path("{sibling_dir}")',
+    ).replace(
+        'OUTPUT_MANIFEST = Path("/app/build-provenance.json")',
+        f'OUTPUT_MANIFEST = Path("{manifest_path}")',
+    )
+    patched = tmp_path / "prov_empty.py"
+    patched.write_text(script_src, encoding="utf-8")
+    subprocess.run(
+        [sys.executable, str(patched)], capture_output=True, text=True, check=False
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["lock_pin_comparison"] == []
+
+
+def test_main_provenance_out_written(tmp_path: Path) -> None:
+    root = tmp_path / "omni_home"
+    consuming = root / "omnimarket"
+    consuming.mkdir(parents=True)
+    _write_lock(consuming / "uv.lock")
+    _make_repo(
+        root, "omnibase_compat", "0.5.1", "4d887307aae34d9d40d389ba91070cb411ce3df5"
+    )
+    _make_repo(root, "omnibase_core", "0.44.0", _LOCK_CORE_REV)
+    _make_repo(root, "omnibase_infra", "0.38.1", _LOCK_INFRA_REV)
+    _make_repo(
+        root, "onex_change_control", "0.5.0", "4877d3c223517cb0c7e1eca462ba0f4d38916314"
+    )
+    out = tmp_path / "pins.json"
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--omni-home",
+            str(root),
+            "--provenance-out",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, res.stderr
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert len(report) == 4
+    infra = next(r for r in report if r["package"] == "omnibase-infra")
+    assert infra["expected_git_rev"] == _LOCK_INFRA_REV
+    assert infra["actual_git_rev"] == _LOCK_INFRA_REV
+    assert infra["sha_match"] is True

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -142,3 +142,35 @@ def test_deploy_runtime_stages_workspace_and_passes_omni_home_arg() -> None:
         '--build-arg "EXPECTED_BUILD_SOURCE=${expected_build_source}"' in deploy_script
     )
     assert '--build-arg "OMNI_HOME=${omni_home}"' in deploy_script
+
+
+@pytest.mark.unit
+def test_deploy_runtime_runs_sibling_lock_pin_preflight() -> None:
+    """Workspace staging must run the OMN-12987 lock-pin preflight before build.
+
+    Recurrence guard: the 2026-06-11 stability crash shipped a 13-day-stale
+    infra 0.37.0 because the build ignored the omnimarket dev lock. The deploy
+    script must invoke check_sibling_lock_pins after staging and abort on
+    failure.
+    """
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    # The preflight is called from stage_workspace_if_needed after staging.
+    assert 'check_sibling_lock_pins "${repo_root}" "${omni_home}"' in deploy_script
+    # The preflight function references the guard script and aborts on failure.
+    assert "scripts/runtime_build/check_sibling_lock_pins.py" in deploy_script
+    assert "Refusing to build a stale image." in deploy_script
+
+
+@pytest.mark.unit
+def test_stage_workspace_emits_build_sha_marker() -> None:
+    """stage_workspace.sh must record each sibling's HEAD SHA (OMN-12987).
+
+    rsync drops .git, so without a .build-sha marker the staged tree has no
+    recoverable SHA and the lock-pin preflight cannot verify the vendored commit.
+    """
+    stage_script = (
+        DEPLOY_SCRIPT.parent / "runtime_build" / "stage_workspace.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'git -C "${src}" rev-parse HEAD > "${dst}/.build-sha"' in stage_script


### PR DESCRIPTION
## Summary

Recurrence ratchet (build-vendor lock-pin preflight) for the 2026-06-11 stability bootstrap crash diagnosed in `docs/evidence/2026-06-11-full-feature-pass/03-buildout/materialization-gap/RESOLVER-CRASH-DIAGNOSIS.md`.

The 11:20Z `--no-cache` stability-test rebuild vendored **omnibase_infra 0.37.0-dev (~`2c1d672f`, 2026-05-29, pre-OMN-12501-guard) + omnibase_core 0.42.0** even though omnimarket dev's `uv.lock` pins **infra 0.38.1 @ `e2dbdc95`** + **core 0.44.0 @ `c97c2c9a`**. The build ignored the consuming repo's lock and shipped a 13-day-stale sibling lacking the OMN-12501 Protocol-quarantine guard, turning a latent contract defect into a fatal bootstrap crash that crash-looped the main runtime on demo day.

## Change

- **`scripts/runtime_build/check_sibling_lock_pins.py`** (new) — host-side fail-fast preflight. Resolves expected sibling versions/SHAs from the consuming repo's (`omnimarket`) `uv.lock` and compares them against each vendored tree (compat, core, infra, onex_change_control). Any mismatch aborts with a structured report; no silent fallback.
- **`scripts/runtime_build/stage_workspace.sh`** — emits a `.build-sha` marker per staged sibling (rsync drops `.git`) so the preflight and provenance can identify the exact vendored commit.
- **`scripts/deploy-runtime.sh`** — runs the preflight after staging, before build; aborts the build on mismatch. Writes the comparison under `workspace/sibling-repos/.sibling-lock-pins.json`.
- **`scripts/runtime_build/compute_workspace_provenance.py`** + **`docker/Dockerfile.runtime`** — fold the expected-vs-actual `lock_pin_comparison` into `build-provenance.json` so deploy verifiers can detect a stale-sibling build.

## Tests / proof

- `tests/scripts/test_check_sibling_lock_pins.py` (11 tests): recurrence guard proving stale infra `0.37.0`/`2c1d672f` vs lock-pinned `0.38.1`/`e2dbdc95` **fails** the preflight, matched pins **pass**, missing repos raise, and the provenance merge works.
- `tests/scripts/test_deploy_runtime_build_context.py`: static guards asserting the deploy script wires the preflight and the stage script emits `.build-sha`.
- Live proof against the canonical clones: the preflight correctly flags the current drift (infra `0.38.3@b7c93a8e` vs lock `0.38.1@e2dbdc95`) and exits 1 — it would have aborted the crashing build.
- `uv run pytest tests/ -v` full suite: 23776 passed; the 13 failures + 74 errors are pre-existing live-infra/integration/performance tests (Postgres/Kafka/Docker/LLM endpoints, omnimarket migration drift) untouched by this change.

No live rebuild performed (local/throwaway proof only).

Evidence-Ticket: OMN-12987
Evidence-Source: OCC#2488