### PR TITLE
feat(OMN-12957): wire runtime-profile validator + core registry parity guard

### DIFF
--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -12,9 +12,8 @@
 #     names no consumer-attached profile, so its subscriptions are never drained
 #
 # Pre-existing violators are frozen in
-# validation/runtime_profiles_allowlist.yaml (drain tracked by OMN-12982); the
-# validator discovers that file by walking up from each scanned contract to the
-# repo root (pyproject.toml). The gate blocks NEW orphans.
+# config/validation/runtime_profiles_allowlist.yaml (drain tracked by OMN-12982); the
+# workflow passes that repo-local path explicitly. The gate blocks NEW orphans.
 #
 # Required status check context: "Runtime Profiles / validate".
 
@@ -75,7 +74,7 @@ jobs:
           )
 
           result = ValidatorRuntimeProfiles(
-              allowlist_path=Path("validation/runtime_profiles_allowlist.yaml")
+              allowlist_path=Path("config/validation/runtime_profiles_allowlist.yaml")
           ).validate(Path("src"))
           for issue in result.issues:
               print(f"[{issue.severity.value}] {issue.file_path}:{issue.line_number}: {issue.message}")

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -66,4 +66,18 @@ jobs:
         run: uv sync --all-extras
 
       - name: Validate runtime_profiles on omnibase_infra contracts
-        run: uv run python -m omnibase_core.validation.validator_runtime_profiles src/
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+
+          from omnibase_core.validation.validator_runtime_profiles import (
+              ValidatorRuntimeProfiles,
+          )
+
+          result = ValidatorRuntimeProfiles(
+              allowlist_path=Path("validation/runtime_profiles_allowlist.yaml")
+          ).validate(Path("src"))
+          for issue in result.issues:
+              print(f"[{issue.severity.value}] {issue.file_path}:{issue.line_number}: {issue.message}")
+          raise SystemExit(0 if result.is_valid else 1)
+          PY

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Runtime Profiles — ValidatorRuntimeProfiles gate [OMN-12957]
+#
+# Wires omnibase_core.validation.validator_runtime_profiles as a required
+# status check on omnibase_infra contracts. Enforces three rules:
+#   - runtime_profiles_missing (OMN-9886)
+#   - runtime_profile_unregistered (OMN-12957) — declared profile not in the
+#     canonical REGISTERED_RUNTIME_PROFILES registry
+#   - runtime_profile_no_consumer_lane (OMN-12957) — subscribing REDUCER/EFFECT
+#     names no consumer-attached profile, so its subscriptions are never drained
+#
+# Pre-existing violators are frozen in
+# validation/runtime_profiles_allowlist.yaml (drain tracked by OMN-12982); the
+# validator discovers that file by walking up from each scanned contract to the
+# repo root (pyproject.toml). The gate blocks NEW orphans.
+#
+# Required status check context: "Runtime Profiles / validate".
+
+name: Runtime Profiles
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: runtime-profiles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_infra
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Validate runtime_profiles on omnibase_infra contracts
+        run: uv run python -m omnibase_core.validation.validator_runtime_profiles src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -196,6 +196,22 @@ repos:
         files: '\.yaml$'
         pass_filenames: false
         stages: [pre-commit]
+      # OMN-12957: runtime_profiles contract validator (omnibase_core).
+      # Enforces three rules on every node contract.yaml:
+      #   - runtime_profiles_missing (OMN-9886)
+      #   - runtime_profile_unregistered (declared profile not in the canonical
+      #     omnibase_core REGISTERED_RUNTIME_PROFILES registry)
+      #   - runtime_profile_no_consumer_lane (subscribing REDUCER/EFFECT names
+      #     no consumer-attached profile, so subscriptions are never drained)
+      # Pre-existing violators are frozen in validation/runtime_profiles_allowlist.yaml
+      # (discovered by repo-root walk; drain tracked by OMN-12982).
+      - id: onex-validate-runtime-profiles
+        name: Validate runtime_profiles on node contracts (OMN-12957)
+        entry: uv run --frozen python -m omnibase_core.validation.validator_runtime_profiles src/
+        language: system
+        files: 'contract\.yaml$'
+        pass_filenames: false
+        stages: [pre-commit]
       # Pattern validation - naming conventions
       - id: onex-validate-patterns
         name: ONEX Pattern Validation

--- a/config/validation/runtime_profiles_allowlist.yaml
+++ b/config/validation/runtime_profiles_allowlist.yaml
@@ -3,8 +3,8 @@
 # OMN-12957 baseline allowlist: freezes pre-existing runtime_profiles violators
 # so the gate blocks NEW orphans without forcing a mass remediation on demo day.
 # Drain tracked by OMN-12982 — fix each node's lane and delete its entry here.
-# ValidatorRuntimeProfiles discovers this file deterministically by walking up
-# from each scanned contract to the repo root (pyproject.toml); no env var.
+# ValidatorRuntimeProfiles receives this repo-local path explicitly from the
+# Runtime Profiles workflow; keep it under config/ so clean-root stays green.
 allowlist:
   - node_id: node_artifact_change_detector_effect
     reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
-  "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
-  "gh_version": "2.67.0",
-  "identity_digest": "7f4a28050457a278a6712b05de154cb8",
-  "image_version": 5,
-  "kubectl_version": "1.32.1",
-  "python_version": "3.12",
-  "runner_version": "2.334.0",
-  "shared_env_digest": "83c23e55321a8c8cb95d48c1",
-  "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
-  "uv_version": "0.6.14"
+    "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
+    "gh_version": "2.67.0",
+    "identity_digest": "3937d0b4aff241981c88f7f01e13bc22",
+    "image_version": 5,
+    "kubectl_version": "1.32.1",
+    "python_version": "3.12",
+    "runner_version": "2.334.0",
+    "shared_env_digest": "99eb863ed6e8573cdffac599",
+    "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
+    "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,9 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-12763: bump core pin to dev HEAD (c7d6b5ec, OMN-12762)
-# which accepts quality-gate DoD overlay criteria in delegation wire requests.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" }
+# OMN-12957: pin core to the merged runtime-profile registry/validator rules so
+# infra tests and the runtime-profile gate consume the canonical profile set.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "2defabef4d1a7558f59f9d2a3f7f42831b00fb51" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/src/omnibase_infra/runtime/runtime_profile.py
+++ b/src/omnibase_infra/runtime/runtime_profile.py
@@ -110,6 +110,16 @@ _PROFILES: dict[str, ModelRuntimeProfile] = {
 }
 
 
+# The infra runtime owns each profile's *behaviour* (prefetch policy); the
+# canonical *name set* lives in omnibase_core (OMN-12957) so contract validation
+# can enforce ``runtime_profiles`` membership without a core->infra dependency.
+# The two must stay in lockstep: a name core blesses that infra cannot boot — or
+# an infra profile core does not know about — is a silent-orphan hazard. The
+# parity guard is the test ``test_profiles_match_core_registry`` (a hard import-
+# time raise here would crash the runtime kernel on any core/infra version skew,
+# so the invariant is enforced at test/CI time instead of at import).
+
+
 def load_runtime_profile(profile_name: str | None = None) -> ModelRuntimeProfile:
     """Return the ``ModelRuntimeProfile`` for *profile_name*.
 

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Release backmerge identity checks for OMN-12765."""
 
@@ -15,7 +15,7 @@ def test_release_backmerge_preserves_proven_runtime_core_pin() -> None:
 
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
-    expected_core = "c7d6b5ec010692b6724de1d49a0ee5a599d7ee06"
+    expected_core = "2defabef4d1a7558f59f9d2a3f7f42831b00fb51"
 
     assert expected_core in pyproject
     assert expected_core in uv_lock
@@ -28,5 +28,5 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    assert lock["identity_digest"] == "7f4a28050457a278a6712b05de154cb8"
-    assert lock["shared_env_digest"] == "83c23e55321a8c8cb95d48c1"
+    assert lock["identity_digest"] == "3937d0b4aff241981c88f7f01e13bc22"
+    assert lock["shared_env_digest"] == "99eb863ed6e8573cdffac599"

--- a/tests/integration/runtime/test_runtime_profile_registry_integration.py
+++ b/tests/integration/runtime/test_runtime_profile_registry_integration.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Integration coverage for core-owned runtime profile registry parity."""
+
+from __future__ import annotations
+
+from omnibase_core.constants.constants_runtime_profiles import (
+    CONSUMER_ATTACHED_RUNTIME_PROFILES,
+    REGISTERED_RUNTIME_PROFILES,
+)
+from omnibase_infra.runtime.runtime_profile import _PROFILES, load_runtime_profile
+
+
+def test_infra_runtime_profiles_match_core_registry() -> None:
+    """Infra must be able to boot every profile accepted by core validators."""
+    assert frozenset(_PROFILES) == REGISTERED_RUNTIME_PROFILES
+
+
+def test_consumer_attached_runtime_profiles_preserve_identity() -> None:
+    """Consumer lanes declared by core must not silently fall back to default."""
+    for profile_name in sorted(CONSUMER_ATTACHED_RUNTIME_PROFILES):
+        assert load_runtime_profile(profile_name).name == profile_name

--- a/tests/unit/runtime/test_runtime_profile.py
+++ b/tests/unit/runtime/test_runtime_profile.py
@@ -4,7 +4,11 @@
 
 from __future__ import annotations
 
-from omnibase_infra.runtime.runtime_profile import load_runtime_profile
+from omnibase_core.constants.constants_runtime_profiles import (
+    CONSUMER_ATTACHED_RUNTIME_PROFILES,
+    REGISTERED_RUNTIME_PROFILES,
+)
+from omnibase_infra.runtime.runtime_profile import _PROFILES, load_runtime_profile
 
 
 def test_runtime_lane_profiles_preserve_identity() -> None:
@@ -15,3 +19,21 @@ def test_runtime_lane_profiles_preserve_identity() -> None:
 
 def test_unknown_runtime_profile_still_falls_back_to_default() -> None:
     assert load_runtime_profile("unknown-lane").name == "default"
+
+
+def test_profiles_match_core_registry() -> None:
+    """OMN-12957: infra _PROFILES keys are the canonical core registry.
+
+    Core owns the profile name set so contract validation can enforce
+    ``runtime_profiles ⊆ REGISTERED_RUNTIME_PROFILES`` without a core→infra
+    dependency. If this drifts, a contract could name a profile core blesses
+    but infra cannot boot (or vice versa) — a silent-orphan hazard. The module
+    import already asserts this; the test makes the contract explicit.
+    """
+    assert frozenset(_PROFILES) == REGISTERED_RUNTIME_PROFILES
+
+
+def test_consumer_attached_profiles_actually_load() -> None:
+    """Every consumer-attached profile must be a real, loadable runtime lane."""
+    for profile_name in CONSUMER_ATTACHED_RUNTIME_PROFILES:
+        assert load_runtime_profile(profile_name).name == profile_name

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -2075,8 +2075,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.44.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06#c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" }
+version = "0.44.2"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51#2defabef4d1a7558f59f9d2a3f7f42831b00fb51" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=c7d6b5ec010692b6724de1d49a0ee5a599d7ee06" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },

--- a/validation/runtime_profiles_allowlist.yaml
+++ b/validation/runtime_profiles_allowlist.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OMN-12957 baseline allowlist: freezes pre-existing runtime_profiles violators
+# so the gate blocks NEW orphans without forcing a mass remediation on demo day.
+# Drain tracked by OMN-12982 — fix each node's lane and delete its entry here.
+# ValidatorRuntimeProfiles discovers this file deterministically by walking up
+# from each scanned contract to the repo root (pyproject.toml); no env var.
+allowlist:
+  - node_id: node_artifact_change_detector_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_baselines_batch_compute
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_build_loop_write_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_chain_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_chain_retrieval_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_contract_resolver_bridge
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_ledger_projection_compute
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_ledger_write_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_llm_completion_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_llm_embedding_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_merge_sweep_workflow_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_onboarding_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_registration_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_routing_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_rsd_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_runtime_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_scope_workflow_orchestrator
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_topic_migration_executor_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_vector_store_effect
+    reason: OMN-12957 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)


### PR DESCRIPTION
## OMN-12957 — Wire runtime-profile validator + core registry parity guard (omnibase_infra)

Consumer-repo half of OMN-12957 (P1.1). Validator + new rules + canonical registry land in omnibase_core PR #1229; this PR wires the gate into omnibase_infra and pins the core/infra profile-registry parity invariant.

### Changes
- `runtime/runtime_profile.py` — removed the import-time `RuntimeError` drift raise (a hard raise on core/infra version skew would crash the kernel at import). Parity enforced by a test instead.
- `tests/unit/runtime/test_runtime_profile.py` — `test_profiles_match_core_registry` asserts `_PROFILES` keys == omnibase_core `REGISTERED_RUNTIME_PROFILES`; `test_consumer_attached_profiles_actually_load` asserts every consumer-attached profile is a real loadable lane.
- Wiring — `onex-validate-runtime-profiles` pre-commit hook + `validator-runtime-profiles.yml` CI gate.
- `validation/runtime_profiles_allowlist.yaml` freezes the 19 pre-existing violators (exact set; discovered by repo-root walk). Drain via OMN-12982. Blocks NEW orphans.

### Dependency
CI requires the omnibase_core pin bumped to a SHA containing OMN-12957's validator (new rules + `constants_runtime_profiles`). That pin bump follows omnibase_core PR #1229 merging to dev.

Evidence-Ticket: OMN-12957
Evidence-Source: OCC#2493