### PR TITLE
fix(OMN-12973): widen migration-gate healthcheck start_period + start-period floor ratchet

### DIFF
--- a/docker/catalog/services/migration-gate.yaml
+++ b/docker/catalog/services/migration-gate.yaml
@@ -14,12 +14,23 @@ hardcoded_env:
 operational_defaults:
   POSTGRES_USER: postgres
 ports: null
+# start_period_s must cover the real forward+intelligence migration window.
+# The sentinel is a long-running keepalive (`while true; sleep 3600`) with a
+# continuous healthcheck against db_metadata.migrations_complete; it is NOT a
+# one-shot. On a cold prod volume, forward-migration + intelligence-migration
+# take ~2 min to apply and stamp the flag (OMN-12973: prod gate started
+# 09:35:22, intelligence-migration finished 09:37:18). With start_period_s=10
+# the gate exited `starting` after 10s and was reported UNHEALTHY for ~2 min
+# until migrations completed. start_period_s=180 keeps the gate in
+# `health: starting` for the full migration window so a still-applying gate is
+# never reported UNHEALTHY. The start_period floor is enforced by
+# validate_migration_gate_start_period (OMN-12973).
 healthcheck:
   test: sh /check_migrations_complete.sh
   interval_s: 10
   timeout_s: 5
   retries: 30
-  start_period_s: 10
+  start_period_s: 180
 volumes:
   - ../scripts/check_migrations_complete.sh:/check_migrations_complete.sh:ro
 depends_on:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -644,11 +644,22 @@ services:
     networks:
       - omnibase-infra-network
     healthcheck:
+      # start_period must cover the real forward+intelligence migration window.
+      # This sentinel is a long-running keepalive (entrypoint above), NOT a
+      # one-shot; the healthcheck runs continuously against
+      # db_metadata.migrations_complete. On a cold prod volume the migrations
+      # take ~2 min to apply and stamp the flag (OMN-12973: prod gate started
+      # 09:35:22, intelligence-migration finished 09:37:18). With start_period
+      # 10s the gate left `starting` after 10s and was reported UNHEALTHY for
+      # ~2 min until migrations completed. start_period 180s keeps the gate in
+      # `health: starting` for the full migration window so a still-applying
+      # gate is never reported UNHEALTHY. Floor enforced by
+      # validate_migration_gate_start_period (OMN-12973).
       test: ["CMD-SHELL", "sh /check_migrations_complete.sh"]
       interval: 10s
       timeout: 5s
       retries: 30
-      start_period: 10s
+      start_period: 180s
     logging: *logging-defaults
     restart: unless-stopped
     deploy:

--- a/src/omnibase_infra/docker/catalog/cli.py
+++ b/src/omnibase_infra/docker/catalog/cli.py
@@ -27,6 +27,9 @@ import yaml
 from omnibase_infra.docker.catalog.generator import generate_compose
 from omnibase_infra.docker.catalog.resolver import CatalogResolver
 from omnibase_infra.docker.catalog.validator import validate_env
+from omnibase_infra.docker.catalog.validator_healthcheck_start_period import (
+    validate_migration_gate_start_period,
+)
 
 _OMNIBASE_ENV = Path.home() / ".omnibase" / ".env"
 
@@ -338,6 +341,12 @@ def cmd_validate_runtime(args: list[str]) -> int:
                 f"{svc_name}: {key!r} appears in both operational_defaults and required_env"
                 " (required_env wins — consider removing from operational_defaults)"
             )
+
+    # Migration-completion gates must keep start_period above the floor so a
+    # still-applying gate is reported `starting`, not UNHEALTHY (OMN-12973).
+    start_period_result = validate_migration_gate_start_period(resolved.manifests)
+    for violation in start_period_result.violations:
+        errors.append(violation.message())
 
     if warnings:
         for w in warnings:

--- a/src/omnibase_infra/docker/catalog/validator_healthcheck_start_period.py
+++ b/src/omnibase_infra/docker/catalog/validator_healthcheck_start_period.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Start-period floor validator for migration-completion gates (OMN-12973).
+
+A *migration-completion gate* is a catalog service that:
+
+1. declares a healthcheck whose pass condition is "migrations are complete", and
+2. waits on one or more sibling services via
+   ``service_completed_successfully`` (the migration runners) before its own
+   health can pass.
+
+The canonical example is ``migration-gate``: a long-running sentinel
+(``while true; sleep 3600``) whose healthcheck polls
+``db_metadata.migrations_complete``. It is *not* a one-shot — it stays alive so
+downstream runtime services can gate on it via ``service_healthy``.
+
+Failure mode this validator prevents (observed in prod 2026-06-11, OMN-12973):
+a too-short ``start_period_s`` lets the container leave Docker's ``starting``
+grace window before the migrations it polls for have actually completed. Past
+the grace window, the still-failing healthcheck is reported ``UNHEALTHY`` until
+migrations finish (~2 min on a cold prod volume), even though nothing is wrong —
+the gate is doing exactly its job. ``start_period_s`` must therefore cover the
+real migration window so a still-applying gate stays in ``health: starting``.
+
+This is a forward-only ratchet: it asserts a floor, never an exact value.
+Raising the floor is a deliberate config decision; lowering a gate's
+``start_period_s`` below the floor is a regression and fails CI + pre-commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from omnibase_infra.docker.catalog.enum_depends_on_condition import (
+    EnumDependsOnCondition,
+)
+from omnibase_infra.docker.catalog.manifest_schema import CatalogManifest, HealthCheck
+
+# Floor (seconds) for a migration-completion gate's healthcheck start_period.
+# Derived from the observed prod migration window (OMN-12973): the gate started
+# at 09:35:22 and intelligence-migration finished at 09:37:18 — ~116s. 120s is
+# the enforced floor; the migration-gate manifest ships 180s for margin.
+MIGRATION_GATE_START_PERIOD_FLOOR_S = 120
+
+# Substring that identifies a healthcheck whose pass-condition is "migrations
+# are complete". The canonical migration sentinel polls
+# ``check_migrations_complete.sh``; its presence in the healthcheck test is the
+# discriminating signal that the service's health *is* migration completion (as
+# opposed to a normal app service that merely depends on a migration runner
+# finishing — e.g. intelligence-api, whose healthcheck is an HTTP liveness probe).
+_MIGRATION_COMPLETION_PROBE_MARKER = "check_migrations_complete"
+
+
+def _healthcheck_polls_migration_completion(healthcheck: HealthCheck) -> bool:
+    """True if the healthcheck command's pass-condition is migration completion.
+
+    ``HealthCheck.test`` is either a shell string (CMD-SHELL form) or an argv
+    list (CMD form); both are joined into one string before scanning for the
+    migration-completion probe marker.
+    """
+    test = healthcheck.test
+    command = test if isinstance(test, str) else " ".join(test)
+    return _MIGRATION_COMPLETION_PROBE_MARKER in command
+
+
+def is_migration_completion_gate(manifest: CatalogManifest) -> bool:
+    """True if ``manifest`` is a sentinel whose own health *is* migration completion.
+
+    The discriminating signature has two parts, both required:
+
+    1. a healthcheck whose pass-condition is "migrations are complete" (its
+       command invokes the migration-completion probe), and
+    2. at least one dependency with
+       ``condition == service_completed_successfully`` (it waits on the
+       migration runner one-shots).
+
+    Part (2) alone is NOT sufficient: ordinary application services (e.g.
+    ``intelligence-api``) also depend on a migration runner completing, but
+    their healthcheck is a liveness probe with a legitimately short
+    ``start_period``. Only the sentinel — whose healthcheck literally polls
+    migration completion — must hold ``starting`` for the full migration window,
+    so only it is subject to the start_period floor.
+    """
+    if manifest.healthcheck is None:
+        return False
+    if not _healthcheck_polls_migration_completion(manifest.healthcheck):
+        return False
+    return any(
+        dep.condition is EnumDependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY
+        for dep in manifest.depends_on
+    )
+
+
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
+class StartPeriodViolation:
+    """A single migration-gate service whose start_period is below the floor."""
+
+    service: str
+    start_period_s: int
+    floor_s: int
+
+    def message(self) -> str:
+        return (
+            f"migration-completion gate '{self.service}' has "
+            f"healthcheck.start_period_s={self.start_period_s}, below the "
+            f"required floor of {self.floor_s}s. A start_period shorter than the "
+            f"real migration window causes the gate to be reported UNHEALTHY "
+            f"while migrations are still applying (OMN-12973). Raise "
+            f"start_period_s to >= {self.floor_s}."
+        )
+
+
+@dataclass(frozen=True)  # internal-dataclass-ok: docker-catalog-internal
+class StartPeriodValidationResult:
+    """Result of validating migration-gate start_period floors."""
+
+    ok: bool
+    violations: list[StartPeriodViolation] = field(default_factory=list)
+
+    def report(self) -> str:
+        if self.ok:
+            return "all migration-completion gates satisfy the start_period floor"
+        return "\n".join(v.message() for v in self.violations)
+
+
+def validate_migration_gate_start_period(
+    manifests: dict[str, CatalogManifest],
+    floor_s: int = MIGRATION_GATE_START_PERIOD_FLOOR_S,
+) -> StartPeriodValidationResult:
+    """Assert every migration-completion gate meets the start_period floor.
+
+    Args:
+        manifests: catalog manifests keyed by service name.
+        floor_s: minimum allowed ``start_period_s`` for a migration gate.
+
+    Returns:
+        A result with ``ok=False`` and one violation per offending gate.
+    """
+    violations: list[StartPeriodViolation] = []
+    for name in sorted(manifests):
+        manifest = manifests[name]
+        if not is_migration_completion_gate(manifest):
+            continue
+        # healthcheck is non-None here (guaranteed by is_migration_completion_gate)
+        assert manifest.healthcheck is not None
+        start_period_s = manifest.healthcheck.start_period_s
+        if start_period_s < floor_s:
+            violations.append(
+                StartPeriodViolation(
+                    service=name,
+                    start_period_s=start_period_s,
+                    floor_s=floor_s,
+                )
+            )
+    return StartPeriodValidationResult(ok=len(violations) == 0, violations=violations)

--- a/tests/unit/infra/test_catalog_healthcheck_start_period.py
+++ b/tests/unit/infra/test_catalog_healthcheck_start_period.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Ratchet tests for migration-gate healthcheck start_period (OMN-12973).
+
+These tests are the enforcement half of the P2.8 fix. They run in the standard
+``uv run pytest tests/`` suite, so they gate every PR (CI) and pre-commit.
+
+The classification (P2.8): the prod migration-gate was reported UNHEALTHY then
+self-resolved to HEALTHY because its healthcheck ``start_period`` (10s) was far
+shorter than the real migration window (~2 min on a cold prod volume). The gate
+is a correctly-modeled long-running sentinel, NOT a mis-modeled one-shot — the
+fix is to widen ``start_period`` so a still-applying gate stays in
+``health: starting`` instead of flipping to UNHEALTHY.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.docker.catalog.enum_depends_on_condition import (
+    EnumDependsOnCondition,
+)
+from omnibase_infra.docker.catalog.manifest_schema import (
+    CatalogManifest,
+    DependsOnEntry,
+    HealthCheck,
+)
+from omnibase_infra.docker.catalog.resolver import CatalogResolver
+from omnibase_infra.docker.catalog.validator_healthcheck_start_period import (
+    MIGRATION_GATE_START_PERIOD_FLOOR_S,
+    is_migration_completion_gate,
+    validate_migration_gate_start_period,
+)
+
+CATALOG_DIR = str(Path(__file__).resolve().parents[3] / "docker" / "catalog")
+
+
+def _gate(start_period_s: int) -> CatalogManifest:
+    """A minimal migration-completion-gate-shaped manifest for unit testing."""
+    return CatalogManifest(
+        name="migration-gate",
+        description="test gate",
+        image="postgres:16-alpine",
+        layer="infrastructure",
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=None,
+        healthcheck=HealthCheck(
+            test="sh /check_migrations_complete.sh",
+            interval_s=10,
+            timeout_s=5,
+            retries=30,
+            start_period_s=start_period_s,
+        ),
+        volumes=[],
+        depends_on=[
+            DependsOnEntry(
+                service="forward-migration",
+                condition=EnumDependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY,
+            ),
+        ],
+    )
+
+
+@pytest.mark.unit
+def test_real_catalog_migration_gate_meets_start_period_floor() -> None:
+    """The shipped migration-gate manifest must satisfy the start_period floor.
+
+    This is the regression lock for the prod fix: if anyone lowers
+    migration-gate.start_period_s below the floor, this fails.
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    result = validate_migration_gate_start_period(resolved.manifests)
+    assert result.ok, result.report()
+
+
+@pytest.mark.unit
+def test_migration_gate_is_classified_as_completion_gate() -> None:
+    """migration-gate must be recognized as a migration-completion gate.
+
+    Guards against the classifier silently no-op'ing (which would let a
+    too-short start_period slip through unvalidated).
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    assert "migration-gate" in resolved.manifests
+    assert is_migration_completion_gate(resolved.manifests["migration-gate"])
+
+
+@pytest.mark.unit
+def test_validator_flags_too_short_start_period() -> None:
+    """A gate below the floor (the pre-fix 10s value) must be flagged."""
+    result = validate_migration_gate_start_period({"migration-gate": _gate(10)})
+    assert not result.ok
+    assert len(result.violations) == 1
+    violation = result.violations[0]
+    assert violation.service == "migration-gate"
+    assert violation.start_period_s == 10
+    assert violation.floor_s == MIGRATION_GATE_START_PERIOD_FLOOR_S
+    assert "UNHEALTHY" in violation.message()
+
+
+@pytest.mark.unit
+def test_validator_passes_at_floor_boundary() -> None:
+    """A gate exactly at the floor passes (>= semantics)."""
+    result = validate_migration_gate_start_period(
+        {"migration-gate": _gate(MIGRATION_GATE_START_PERIOD_FLOOR_S)}
+    )
+    assert result.ok
+
+
+@pytest.mark.unit
+def test_non_migration_gate_is_not_flagged() -> None:
+    """Services without a service_completed_successfully dep are ignored.
+
+    A plain healthcheck service (e.g. postgres) with a short start_period must
+    not be swept into the migration-gate floor.
+    """
+    postgres = CatalogManifest(
+        name="postgres",
+        description="db",
+        image="postgres:16-alpine",
+        layer="infrastructure",
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=None,
+        healthcheck=HealthCheck(
+            test="pg_isready",
+            interval_s=30,
+            timeout_s=10,
+            retries=3,
+            start_period_s=10,
+        ),
+        volumes=[],
+        depends_on=[],
+    )
+    assert not is_migration_completion_gate(postgres)
+    result = validate_migration_gate_start_period({"postgres": postgres})
+    assert result.ok
+
+
+@pytest.mark.unit
+def test_app_service_depending_on_migration_runner_is_not_flagged() -> None:
+    """An app service whose healthcheck is a liveness probe is NOT a gate.
+
+    Regression for the over-broad classifier (OMN-12973): ``intelligence-api``
+    depends on ``intelligence-migration`` via ``service_completed_successfully``
+    but its healthcheck is an HTTP liveness probe, not a migration-completion
+    poll. Its start_period (40s) is legitimately short and must not be swept
+    into the migration-gate floor. Only the sentinel whose healthcheck literally
+    polls migration completion is subject to the floor.
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    assert "intelligence-api" in resolved.manifests
+    intelligence_api = resolved.manifests["intelligence-api"]
+    # It does depend on a migration runner completing...
+    assert any(
+        dep.condition is EnumDependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY
+        for dep in intelligence_api.depends_on
+    )
+    # ...but its healthcheck is a liveness probe, so it is NOT a completion gate.
+    assert not is_migration_completion_gate(intelligence_api)
+    result = validate_migration_gate_start_period(resolved.manifests)
+    assert result.ok, result.report()
+
+
+@pytest.mark.unit
+def test_completion_gate_requires_migration_probe_healthcheck() -> None:
+    """A migration-runner dependant with a non-migration healthcheck is ignored.
+
+    Unit-level guard for the discriminating signal: depending on a
+    ``service_completed_successfully`` sibling is necessary but not sufficient —
+    the healthcheck command must also poll migration completion.
+    """
+    app_service = CatalogManifest(
+        name="some-api",
+        description="app",
+        image="runtime:latest",
+        layer="runtime",
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=None,
+        healthcheck=HealthCheck(
+            test="curl -sf http://localhost:8053/health",
+            interval_s=30,
+            timeout_s=10,
+            retries=3,
+            start_period_s=40,
+        ),
+        volumes=[],
+        depends_on=[
+            DependsOnEntry(
+                service="intelligence-migration",
+                condition=EnumDependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY,
+            ),
+        ],
+    )
+    assert not is_migration_completion_gate(app_service)
+    result = validate_migration_gate_start_period({"some-api": app_service})
+    assert result.ok
+
+
+@pytest.mark.unit
+def test_completion_gate_with_list_form_healthcheck_is_classified() -> None:
+    """The migration probe is detected in CMD (argv-list) healthcheck form too."""
+    gate = CatalogManifest(
+        name="migration-gate",
+        description="gate",
+        image="postgres:16-alpine",
+        layer="infrastructure",
+        required_env=[],
+        hardcoded_env={},
+        operational_defaults={},
+        ports=None,
+        healthcheck=HealthCheck(
+            test=["CMD-SHELL", "sh /check_migrations_complete.sh"],
+            interval_s=10,
+            timeout_s=5,
+            retries=30,
+            start_period_s=180,
+        ),
+        volumes=[],
+        depends_on=[
+            DependsOnEntry(
+                service="forward-migration",
+                condition=EnumDependsOnCondition.SERVICE_COMPLETED_SUCCESSFULLY,
+            ),
+        ],
+    )
+    assert is_migration_completion_gate(gate)


### PR DESCRIPTION
## P2.8 — Prod migration-gate health semantics (OMN-12973)

### Classification (the question P2.8 asks)
**idle-one-shot-mis-modeled = NO.** The prod migration-gate is a *correctly-modeled long-running sentinel*, not a mis-modeled one-shot.

Read-only `.201` prod evidence (`omnibase-infra-prod-migration-gate`):
- **Entrypoint:** `["sh","-c","while true; do sleep 3600; done"]` — a keepalive, not a one-shot.
- **Healthcheck:** `sh /check_migrations_complete.sh` polling `db_metadata.migrations_complete`, continuous.
- **Deployed `StartPeriod` = 10s** (`10000000000` ns) — the bug.
- Container is now `Up 7 hours (healthy)`, `FailingStreak:0` — it self-resolved.

### Root cause
On a cold prod volume, forward + intelligence migrations take ~116s to apply and stamp the flag (gate started 09:35:22, intelligence-migration finished 09:37:18). With `start_period=10s`, the gate left Docker's `starting` grace window after 10s and was reported **UNHEALTHY** for the remaining ~2 min until migrations completed — then flipped HEALTHY. Nothing was actually wrong; the grace window was simply shorter than the work it gates on.

### Fix
Raise migration-gate healthcheck `start_period` **10s → 180s** in:
- `docker/catalog/services/migration-gate.yaml` (authoritative catalog manifest; flows into the generated compose).
- `docker/docker-compose.infra.yml` (the hand-maintained compose that `scripts/deploy-runtime.sh` applies to `.201`).

A still-applying gate now stays in `health: starting` for the full window instead of flipping UNHEALTHY.

### Ratchet (enforcement, not detection — same PR)
New `validator_healthcheck_start_period.py` asserts a **120s floor** for migration-completion gates:
- Wired into `onex validate runtime` (`cmd_validate_runtime`).
- Backed by 8 unit tests in `tests/unit/infra/test_catalog_healthcheck_start_period.py` that gate every PR via pre-commit + CI, including a regression-lock asserting the shipped manifest meets the floor.
- A migration-completion gate is identified by **both** (1) a healthcheck whose command polls migration completion (`check_migrations_complete`) **and** (2) a `service_completed_successfully` dependency. This precision prevents sweeping ordinary app services — e.g. `intelligence-api`, an HTTP liveness probe with a legitimately short 40s `start_period` that depends on `intelligence-migration` — into the floor.

### Verification
- `uv run ruff format/check`: clean.
- `uv run mypy --strict` on changed source: clean.
- `uv run pytest tests/ -m unit`: 20688 passed (the 5 unrelated failures — benchmark-stability, semver-cache stress, union-count guard, receipt-gate PyPI guard — reproduce on clean `dev` HEAD and are outside this change's blast radius).
- `pre-commit run --files <changed>`: all pass.
- Prod probed **read-only**; no prod mutation.

### Deploy
`deploy_pending=true` — the live prod fix lands via the batched stability/prod rebuild from `deploy-runtime.sh`. No live mutation in this PR.

Evidence-Ticket: OMN-12973
Evidence-Source: OCC#2504