### PR TITLE
fix(OMN-13005): materialize blocking event_consumer in runtime auto-wiring (runner consume-leg degenerate rows)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -99,6 +99,9 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
         ProtocolPatternBBrokerTransport,
     )
+    from omnibase_infra.runtime.service_terminal_event_consumer import (
+        TerminalEventConsumer,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -1603,20 +1606,27 @@ def _make_sync_event_consumer(
     *,
     event_bus: object,
     handler_name: str,
-) -> Callable[[str, str, float], dict[str, object] | None]:
+) -> TerminalEventConsumer:
     """Materialize the blocking terminal-event consumer for request/response handlers.
 
     Mirror of ``_make_sync_event_publisher`` for the consume leg. Some EFFECT
     handlers (e.g. ``HandlerContextRoiRunner``, OMN-13005) publish a command and
     then block on the correlated terminal event, reading result fields back from
-    its payload. They declare an injectable ``event_consumer`` with the sync shape
-    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``.
+    its payload. They declare an injectable ``event_consumer``.
+
+    The returned object is directly callable with the legacy single-call shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None`` and also
+    exposes ``.open(topic) -> TerminalConsumerSession`` for the two-phase
+    (subscribe-before-publish) protocol introduced in OMN-13012: the handler
+    positions the consumer (assign + seek_to_end) BEFORE publishing its command,
+    then waits AFTER, so a terminal emitted in the publish→wait gap is not seeked
+    past.
 
     Without this injection the handler falls back to its own no-op default that
     returns ``None`` immediately — never honoring the timeout, so every result
     row is a degenerate generation-failure even though the terminal event arrives
-    moments later. The concrete consumer here runs the correlate-and-wait loop on
-    an isolated event loop in a worker thread so blocking does not deadlock the
+    moments later. The concrete consumer runs the correlate-and-wait loop on an
+    isolated event loop in a worker thread so blocking does not deadlock the
     runtime dispatch loop that delivers the awaited terminal.
     """
     from omnibase_infra.runtime.service_terminal_event_consumer import (

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1541,6 +1541,7 @@ def _should_skip_sync_container_resolution(handler_cls: type) -> bool:
         {
             "event_bus",
             "event_publisher",
+            "event_consumer",
             "dispatch_port",
             "provisioner",
             "drain_proof_gate",
@@ -1596,6 +1597,36 @@ def _make_sync_event_publisher(
         task.add_done_callback(_log_publish_failure)
 
     return _publish
+
+
+def _make_sync_event_consumer(
+    *,
+    event_bus: object,
+    handler_name: str,
+) -> Callable[[str, str, float], dict[str, object] | None]:
+    """Materialize the blocking terminal-event consumer for request/response handlers.
+
+    Mirror of ``_make_sync_event_publisher`` for the consume leg. Some EFFECT
+    handlers (e.g. ``HandlerContextRoiRunner``, OMN-13005) publish a command and
+    then block on the correlated terminal event, reading result fields back from
+    its payload. They declare an injectable ``event_consumer`` with the sync shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``.
+
+    Without this injection the handler falls back to its own no-op default that
+    returns ``None`` immediately — never honoring the timeout, so every result
+    row is a degenerate generation-failure even though the terminal event arrives
+    moments later. The concrete consumer here runs the correlate-and-wait loop on
+    an isolated event loop in a worker thread so blocking does not deadlock the
+    runtime dispatch loop that delivers the awaited terminal.
+    """
+    from omnibase_infra.runtime.service_terminal_event_consumer import (
+        make_terminal_event_consumer,
+    )
+
+    return make_terminal_event_consumer(
+        event_bus=event_bus,
+        handler_name=handler_name,
+    )
 
 
 def _contracts_root_for_runtime_dependencies() -> Path:
@@ -1681,10 +1712,12 @@ def _materialize_known_handler_dependencies(
     requires_delegation_port = _handler_requires_delegation_dispatch_port(handler_cls)
     required_params = _required_handler_init_params(handler_cls)
     requires_event_publisher = "event_publisher" in constructor_params
+    requires_event_consumer = "event_consumer" in constructor_params
     if (
         not required_params
         and not requires_delegation_port
         and not requires_event_publisher
+        and not requires_event_consumer
     ):
         return materialized_explicit_dependencies
     available = {
@@ -1701,10 +1734,16 @@ def _materialize_known_handler_dependencies(
             event_bus=event_bus,
             handler_name=handler_name,
         )
+    if requires_event_consumer and event_bus is not None:
+        available["event_consumer"] = _make_sync_event_consumer(
+            event_bus=event_bus,
+            handler_name=handler_name,
+        )
     if required_params.issubset(_TOPIC_MIGRATION_EXECUTOR_DEPS):
         available.update(_build_topic_migration_executor_dependencies())
     if not (
         requires_event_publisher
+        or requires_event_consumer
         or required_params.intersection(
             {"container", "ownership_query", "dispatch_port"}
         )
@@ -1739,6 +1778,8 @@ def _materialize_known_handler_dependencies(
         handler_dependencies.setdefault("dispatch_port", available["dispatch_port"])
     if requires_event_publisher and "event_publisher" in available:
         handler_dependencies.setdefault("event_publisher", available["event_publisher"])
+    if requires_event_consumer and "event_consumer" in available:
+        handler_dependencies.setdefault("event_consumer", available["event_consumer"])
     merged[handler_name] = handler_dependencies
     return merged
 

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -35,6 +36,12 @@ from omnibase_infra.utils.util_error_sanitization import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS = 30.0
+_DIRECT_TERMINAL_METADATA_POLL_INTERVAL_SECONDS = 0.05
+_DIRECT_TERMINAL_SESSION_TIMEOUT_MS = 45000
+_DIRECT_TERMINAL_HEARTBEAT_INTERVAL_MS = 15000
+_DIRECT_TERMINAL_MAX_POLL_INTERVAL_MS = 300000
 
 
 def _broker_group_id(command_topic: str) -> str:
@@ -66,6 +73,182 @@ def _error_result(
 class TerminalPayload:
     payload: object
     topic: str
+
+
+@dataclass(
+    frozen=True, slots=True
+)  # internal-dataclass-ok: module-internal Kafka boundary handle
+class DirectTerminalConsumer:
+    consumer: AIOKafkaConsumer
+
+
+def _direct_terminal_bootstrap_servers(event_bus: object) -> str:
+    servers = getattr(event_bus, "_bootstrap_servers", None)
+    if not isinstance(servers, str) or not servers:
+        raise RuntimeError(
+            "terminal-event consumer: runtime event_bus exposes no string "
+            "_bootstrap_servers; cannot build a Kafka correlate consumer."
+        )
+    return servers
+
+
+def _direct_terminal_auth_kwargs(event_bus: object) -> dict[str, object]:
+    build_auth_kwargs = getattr(event_bus, "_build_auth_kwargs", None)
+    if not callable(build_auth_kwargs):
+        return {}
+    auth = cast("Callable[[], Mapping[str, object] | None]", build_auth_kwargs)()
+    return dict(auth or {})
+
+
+def _direct_terminal_client_version_kwargs(event_bus: object) -> dict[str, object]:
+    config = getattr(event_bus, "config", SimpleNamespace())
+    api_version = getattr(config, "api_version", None)
+    if api_version is None:
+        return {}
+    try:
+        parameters = inspect.signature(AIOKafkaConsumer.__init__).parameters
+    except (TypeError, ValueError):
+        return {}
+    if "api_version" not in parameters:
+        return {}
+    return {"api_version": api_version}
+
+
+def _extract_direct_terminal_correlation_id(payload: dict[str, object]) -> str | None:
+    value = payload.get("correlation_id")
+    if value is None:
+        return None
+    return str(value)
+
+
+def _build_direct_terminal_consumer(event_bus: object) -> AIOKafkaConsumer:
+    config = getattr(event_bus, "config", SimpleNamespace())
+    return AIOKafkaConsumer(
+        bootstrap_servers=_direct_terminal_bootstrap_servers(event_bus),
+        group_id=None,
+        enable_auto_commit=False,
+        auto_offset_reset="latest",
+        session_timeout_ms=getattr(
+            config,
+            "session_timeout_ms",
+            _DIRECT_TERMINAL_SESSION_TIMEOUT_MS,
+        ),
+        heartbeat_interval_ms=getattr(
+            config,
+            "heartbeat_interval_ms",
+            _DIRECT_TERMINAL_HEARTBEAT_INTERVAL_MS,
+        ),
+        max_poll_interval_ms=getattr(
+            config,
+            "max_poll_interval_ms",
+            _DIRECT_TERMINAL_MAX_POLL_INTERVAL_MS,
+        ),
+        retry_backoff_ms=getattr(config, "reconnect_backoff_ms", 2000),
+        **_direct_terminal_client_version_kwargs(event_bus),
+        **_direct_terminal_auth_kwargs(event_bus),
+    )
+
+
+async def _assign_direct_terminal_partitions(
+    consumer: AIOKafkaConsumer,
+    terminal_topic: str,
+    assign_cap_seconds: float,
+) -> None:
+    """Wait for reply-topic metadata, then assign all partitions."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + assign_cap_seconds
+    while True:
+        client = getattr(consumer, "_client", None)
+        set_topics = getattr(client, "set_topics", None)
+        if callable(set_topics):
+            set_topics([terminal_topic])
+        partitions = consumer.partitions_for_topic(terminal_topic) or set()
+        if partitions:
+            consumer.assign([TopicPartition(terminal_topic, p) for p in partitions])
+            return
+        if loop.time() >= deadline:
+            raise TimeoutError
+        await asyncio.sleep(_DIRECT_TERMINAL_METADATA_POLL_INTERVAL_SECONDS)
+
+
+async def open_direct_terminal_consumer(
+    *,
+    event_bus: object,
+    terminal_topic: str,
+) -> DirectTerminalConsumer:
+    """Start, assign, and seek an ephemeral terminal consumer to the current end."""
+    consumer = _build_direct_terminal_consumer(event_bus)
+    try:
+        await asyncio.wait_for(
+            consumer.start(),
+            timeout=_DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS,
+        )
+        await _assign_direct_terminal_partitions(
+            consumer,
+            terminal_topic,
+            _DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS,
+        )
+        await consumer.seek_to_end(*consumer.assignment())
+    except BaseException:
+        await close_direct_terminal_consumer(
+            DirectTerminalConsumer(consumer),
+            terminal_topic=terminal_topic,
+            log_prefix="terminal-event consumer open cleanup",
+        )
+        raise
+    return DirectTerminalConsumer(consumer)
+
+
+async def poll_direct_terminal_consumer(
+    *,
+    handle: DirectTerminalConsumer,
+    terminal_topic: str,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Poll a positioned terminal consumer for the correlated terminal payload."""
+    loop = asyncio.get_running_loop()
+    try:
+        deadline = loop.time() + timeout_seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                message = await asyncio.wait_for(
+                    handle.consumer.getone(),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                return None
+            if message.value is None:
+                continue
+            try:
+                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if _extract_direct_terminal_correlation_id(body) == correlation_id:
+                return body
+    finally:
+        await close_direct_terminal_consumer(handle, terminal_topic=terminal_topic)
+
+
+async def close_direct_terminal_consumer(
+    handle: DirectTerminalConsumer,
+    *,
+    terminal_topic: str,
+    log_prefix: str = "terminal-event consumer",
+) -> None:
+    """Stop a direct terminal consumer, logging cleanup failures at the boundary."""
+    try:
+        await handle.consumer.stop()
+    except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+        _LOGGER.warning(
+            "%s: failed to stop consumer for %s: %s",
+            log_prefix,
+            terminal_topic,
+            sanitize_error_message(exc),
+        )
 
 
 class RuntimePatternBBroker:

--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""One-shot blocking terminal-event consumer for auto-wired effect handlers.
+"""Blocking terminal-event consumer for auto-wired request/response EFFECT handlers.
 
 Some EFFECT handlers drive a request/response interaction over the bus: they
 publish a command, then block until the correlated terminal event arrives on a
@@ -10,15 +10,50 @@ from that terminal payload. ``HandlerContextRoiRunner`` is the motivating case
 correlated ``node-generation-completed.v1`` terminal before recording an
 attempt-reduction row.
 
-These handlers declare an injectable ``event_consumer`` with the synchronous
-shape ``(topic, correlation_id, timeout_seconds) -> dict | None``. The runtime
-auto-wiring (``handler_wiring.py``) materializes a concrete consumer through
-``make_terminal_event_consumer`` so the handler never imports Kafka. This mirrors
-the existing ``event_publisher`` injection (``_make_sync_event_publisher``).
+These handlers declare an injectable ``event_consumer`` materialized by the
+runtime auto-wiring (``handler_wiring.py``) through ``make_terminal_event_consumer``
+so the handler never imports Kafka. This mirrors the existing ``event_publisher``
+injection (``_make_sync_event_publisher``).
+
+Two-phase (subscribe-before-publish) — OMN-13012
+------------------------------------------------
+The single-call form ``consumer(topic, cid, timeout)`` does
+``assign → seek_to_end → poll`` internally, all AFTER the handler has already
+published its command. Once the dispatch-loop starvation was removed (OMN-13010),
+generation completes in ~1s, so the correlated terminal is published BEFORE the
+single-call consumer's post-publish ``seek_to_end`` positions — and ``seek_to_end``
+skips PAST the already-emitted terminal, which the runner then never sees. The
+runner waits the full timeout on an offset beyond the terminal and times out
+(probe3, ``run_id=20260611T2140Z-probe3``).
+
+The fix splits positioning from waiting so the caller can subscribe BEFORE it
+publishes:
+
+  - ``session = consumer.open(topic)`` — start the ephemeral consumer, assign the
+    reply-topic partitions, and ``seek_to_end`` NOW (records the pre-publish
+    high-water-mark as the resume position). Call this BEFORE publishing.
+  - ``payload = session.wait(correlation_id, timeout)`` — block up to ``timeout``
+    polling from the position captured at ``open``, returning the correlated
+    terminal payload or ``None`` on genuine timeout. Call this AFTER publishing.
+  - ``session.close()`` — stop the consumer (``wait`` closes automatically;
+    ``close`` is also idempotent for explicit/early teardown).
+
+Because the cursor is positioned at ``open`` time (before publish), a terminal
+emitted in the publish→wait gap is still on an offset at-or-after the captured
+position and is delivered to ``wait``. ``open`` is also used as a context manager.
+
+Backward compatibility
+-----------------------
+The object returned by ``make_terminal_event_consumer`` is still directly callable
+with the legacy single-call shape ``(topic, cid, timeout) -> dict | None`` for any
+consumer that does not need subscribe-before-publish. The single-call form simply
+opens a session and waits in one step (seek happens at call time, after the
+caller's publish — the original, race-prone behavior, retained only for callers
+that do not care about the race).
 
 Architecture (ARCH-002 — "runtime owns all Kafka plumbing"):
-  - Nodes/handlers declare the consume requirement in their contract and call a
-    sync ``event_consumer``; they never touch ``AIOKafkaConsumer``.
+  - Nodes/handlers declare the consume requirement in their contract and call the
+    injected ``event_consumer``; they never touch ``AIOKafkaConsumer``.
   - The correlate-and-wait loop here is the same proven shape used by
     ``RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer``:
     assign reply-topic partitions, seek to end, then poll until a message whose
@@ -28,10 +63,11 @@ Loop isolation (why a worker thread):
   The auto-wired dispatch callback invokes a sync handler ``handle()`` directly
   on the runtime's running event loop. A blocking Kafka correlate cannot run on
   that same loop (it would deadlock, and ``asyncio.run()`` raises inside a
-  running loop). The sync adapter therefore runs the async correlate coroutine
-  on a dedicated event loop in a separate thread and blocks the calling thread
-  on the result. The dispatch loop stays free to deliver the very terminal event
-  the handler is waiting for.
+  running loop). The session therefore owns a dedicated event loop running in a
+  separate daemon thread for the whole ``open``→``wait``→``close`` lifecycle, and
+  the sync methods block the calling thread on coroutines submitted to that loop.
+  The dispatch loop stays free to deliver the very terminal event the handler is
+  waiting for.
 """
 
 from __future__ import annotations
@@ -40,7 +76,9 @@ import asyncio
 import json
 import logging
 import threading
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Coroutine, Mapping
+from concurrent.futures import Future
+from types import TracebackType
 from typing import cast
 
 from aiokafka import AIOKafkaConsumer, TopicPartition
@@ -61,6 +99,10 @@ _METADATA_POLL_INTERVAL_SECONDS = 0.05
 _DEFAULT_SESSION_TIMEOUT_MS = 45000
 _DEFAULT_HEARTBEAT_INTERVAL_MS = 15000
 _DEFAULT_MAX_POLL_INTERVAL_MS = 300000
+
+# Grace beyond a submitted coroutine's own timeout so a clean Kafka shutdown
+# completes before the calling thread gives up on the worker loop.
+_LOOP_SUBMIT_GRACE_SECONDS = 5.0
 
 
 def _bootstrap_servers(event_bus: object) -> str:
@@ -88,22 +130,8 @@ def _extract_correlation_id(payload: dict[str, object]) -> str | None:
     return str(value)
 
 
-async def _await_correlated_terminal(
-    *,
-    event_bus: object,
-    terminal_topic: str,
-    correlation_id: str,
-    timeout_seconds: float,
-) -> dict[str, object] | None:
-    """Block up to ``timeout_seconds`` for the correlated terminal payload.
-
-    Returns the deserialized terminal event body whose ``correlation_id`` matches
-    the request, or ``None`` on genuine timeout. Uses an ephemeral group-less
-    consumer (``group_id=None``) assigned directly to the reply topic's
-    partitions and seeked to end, so it only sees terminals produced after the
-    handler published its command.
-    """
-    consumer = AIOKafkaConsumer(
+def _build_consumer(event_bus: object) -> AIOKafkaConsumer:
+    return AIOKafkaConsumer(
         bootstrap_servers=_bootstrap_servers(event_bus),
         group_id=None,
         enable_auto_commit=False,
@@ -113,40 +141,6 @@ async def _await_correlated_terminal(
         max_poll_interval_ms=_DEFAULT_MAX_POLL_INTERVAL_MS,
         **_auth_kwargs(event_bus),
     )
-
-    loop = asyncio.get_running_loop()
-    try:
-        assign_cap = min(_ASSIGN_TIMEOUT_CAP_SECONDS, timeout_seconds)
-        await asyncio.wait_for(consumer.start(), timeout=assign_cap)
-        await _assign_terminal_partitions(consumer, terminal_topic, assign_cap)
-        await consumer.seek_to_end(*consumer.assignment())
-
-        deadline = loop.time() + timeout_seconds
-        while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return None
-            try:
-                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
-            except TimeoutError:
-                return None
-            if message.value is None:
-                continue
-            try:
-                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if _extract_correlation_id(body) == correlation_id:
-                return body
-    finally:
-        try:
-            await consumer.stop()
-        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
-            logger.warning(
-                "terminal-event consumer: failed to stop consumer for %s: %s",
-                terminal_topic,
-                exc,
-            )
 
 
 async def _assign_terminal_partitions(
@@ -176,75 +170,296 @@ async def _assign_terminal_partitions(
         await asyncio.sleep(_METADATA_POLL_INTERVAL_SECONDS)
 
 
+async def _open_positioned_consumer(
+    *,
+    event_bus: object,
+    terminal_topic: str,
+) -> AIOKafkaConsumer:
+    """Start an ephemeral consumer, assign the reply topic, and seek to end NOW.
+
+    Returns the started, positioned consumer. The caller is responsible for
+    stopping it (``_poll_correlated_terminal`` stops it in its ``finally``). The
+    ``seek_to_end`` here captures the pre-publish high-water-mark: any terminal
+    published at-or-after this point is delivered to a subsequent poll, even if it
+    arrives before the poll begins. This is the subscribe-before-publish leg.
+    """
+    consumer = _build_consumer(event_bus)
+    try:
+        await asyncio.wait_for(consumer.start(), timeout=_ASSIGN_TIMEOUT_CAP_SECONDS)
+        await _assign_terminal_partitions(
+            consumer, terminal_topic, _ASSIGN_TIMEOUT_CAP_SECONDS
+        )
+        await consumer.seek_to_end(*consumer.assignment())
+    except BaseException:
+        try:
+            await consumer.stop()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.warning(
+                "terminal-event consumer: failed to stop consumer during open "
+                "cleanup for %s: %s",
+                terminal_topic,
+                exc,
+            )
+        raise
+    return consumer
+
+
+async def _poll_correlated_terminal(
+    *,
+    consumer: AIOKafkaConsumer,
+    terminal_topic: str,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Poll an already-positioned consumer for the correlated terminal payload.
+
+    Blocks up to ``timeout_seconds`` from the position captured at ``open`` time.
+    Returns the deserialized terminal body whose ``correlation_id`` matches, or
+    ``None`` on genuine timeout. Stops the consumer on the way out.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        deadline = loop.time() + timeout_seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
+            except TimeoutError:
+                return None
+            if message.value is None:
+                continue
+            try:
+                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if _extract_correlation_id(body) == correlation_id:
+                return body
+    finally:
+        try:
+            await consumer.stop()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.warning(
+                "terminal-event consumer: failed to stop consumer for %s: %s",
+                terminal_topic,
+                exc,
+            )
+
+
+class TerminalConsumerSession:
+    """Two-phase (seek-now / wait-later) handle over a single terminal topic.
+
+    Owns a dedicated event loop on a daemon worker thread for the whole
+    ``open``→``wait``→``close`` lifecycle. Synchronous methods submit coroutines
+    to that loop and block the calling thread on the result, so the session is
+    safe to drive from a sync handler running on the runtime's own (already
+    running) event loop without deadlocking it.
+
+    Usage (subscribe-before-publish)::
+
+        session = consumer.open(terminal_topic)   # assign + seek_to_end NOW
+        publisher(command_topic, payload)         # publish AFTER positioning
+        result = session.wait(correlation_id, timeout)  # block from the position
+        # wait() closes automatically; close() is idempotent for early teardown.
+    """
+
+    def __init__(
+        self,
+        *,
+        event_bus: object,
+        handler_name: str,
+        terminal_topic: str,
+    ) -> None:
+        self._event_bus = event_bus
+        self._handler_name = handler_name
+        self._terminal_topic = terminal_topic
+        self._loop = asyncio.new_event_loop()
+        self._consumer: AIOKafkaConsumer | None = None
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name=f"terminal-consumer-{handler_name}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _submit(
+        self, coro: Coroutine[object, object, object], *, timeout: float
+    ) -> object:
+        """Run ``coro`` on the worker loop and block the caller on its result."""
+        future: Future[object] = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    def open(self) -> TerminalConsumerSession:
+        """Start the consumer, assign the topic, and seek to end NOW (pre-publish).
+
+        Idempotent: a second call is a no-op once positioned. Returns ``self`` so
+        ``consumer.open(topic)`` reads naturally and supports ``with`` usage.
+        """
+        if self._consumer is not None or self._closed:
+            return self
+        self._consumer = cast(
+            "AIOKafkaConsumer",
+            self._submit(
+                _open_positioned_consumer(
+                    event_bus=self._event_bus,
+                    terminal_topic=self._terminal_topic,
+                ),
+                timeout=_ASSIGN_TIMEOUT_CAP_SECONDS + _LOOP_SUBMIT_GRACE_SECONDS,
+            ),
+        )
+        return self
+
+    def wait(
+        self, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, object] | None:
+        """Block up to ``timeout_seconds`` for the correlated terminal, then close.
+
+        Polls from the position captured at ``open`` time, so a terminal emitted in
+        the publish→wait gap is still delivered. Returns the matched payload or
+        ``None`` on timeout/failure. Closes the session on the way out.
+        """
+        if self._consumer is None:
+            # Defensive: caller skipped open() — fall back to seek-at-wait (the
+            # race-prone single-call path) rather than failing hard.
+            self.open()
+        consumer = self._consumer
+        if consumer is None:
+            self.close()
+            return None
+        try:
+            result = self._submit(
+                _poll_correlated_terminal(
+                    consumer=consumer,
+                    terminal_topic=self._terminal_topic,
+                    correlation_id=correlation_id,
+                    timeout_seconds=timeout_seconds,
+                ),
+                timeout=timeout_seconds
+                + _ASSIGN_TIMEOUT_CAP_SECONDS
+                + _LOOP_SUBMIT_GRACE_SECONDS,
+            )
+        except BaseException as exc:  # noqa: BLE001 — re-raised as None to caller
+            logger.warning(
+                "terminal-event consumer: wait failed for %s (topic=%s, cid=%s): %s",
+                self._handler_name,
+                self._terminal_topic,
+                correlation_id,
+                exc,
+            )
+            self.close()
+            return None
+        # _poll_correlated_terminal stopped the consumer in its finally; drop the
+        # reference so close() does not double-stop.
+        self._consumer = None
+        self.close()
+        return cast("dict[str, object] | None", result)
+
+    def close(self) -> None:
+        """Stop the worker loop and join its thread. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        consumer = self._consumer
+        self._consumer = None
+        if consumer is not None:
+            try:
+                stop_future: Future[object] = asyncio.run_coroutine_threadsafe(
+                    cast("Coroutine[object, object, object]", consumer.stop()),
+                    self._loop,
+                )
+                stop_future.result(timeout=_LOOP_SUBMIT_GRACE_SECONDS)
+            except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+                logger.warning(
+                    "terminal-event consumer: failed to stop consumer during close "
+                    "for %s (topic=%s): %s",
+                    self._handler_name,
+                    self._terminal_topic,
+                    exc,
+                )
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=_LOOP_SUBMIT_GRACE_SECONDS)
+        try:
+            self._loop.close()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.debug(
+                "terminal-event consumer: loop close raced for %s: %s",
+                self._handler_name,
+                exc,
+            )
+
+    def __enter__(self) -> TerminalConsumerSession:
+        return self.open()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class TerminalEventConsumer:
+    """Callable injected as ``event_consumer`` — both single-call and two-phase.
+
+    Calling the instance directly preserves the legacy
+    ``(topic, cid, timeout) -> dict | None`` shape. ``.open(topic)`` returns a
+    :class:`TerminalConsumerSession` for subscribe-before-publish callers.
+    """
+
+    def __init__(self, *, event_bus: object, handler_name: str) -> None:
+        self._event_bus = event_bus
+        self._handler_name = handler_name
+
+    def open(self, terminal_topic: str) -> TerminalConsumerSession:
+        """Open a positioned (assign + seek_to_end NOW) session before publishing."""
+        session = TerminalConsumerSession(
+            event_bus=self._event_bus,
+            handler_name=self._handler_name,
+            terminal_topic=terminal_topic,
+        )
+        return session.open()
+
+    def __call__(
+        self, terminal_topic: str, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, object] | None:
+        """Single-call form: open + wait in one step (seek happens at call time).
+
+        Retained for backward compatibility. This is the race-prone path: the seek
+        runs when the call is made, which is after the caller's publish. Callers
+        that need subscribe-before-publish must use ``open`` + ``wait`` instead.
+        """
+        session = self.open(terminal_topic)
+        return session.wait(correlation_id, timeout_seconds)
+
+
 def make_terminal_event_consumer(
     *,
     event_bus: object,
     handler_name: str,
-) -> EventConsumer:
-    """Build the sync ``event_consumer`` injected into request/response handlers.
+) -> TerminalEventConsumer:
+    """Build the ``event_consumer`` injected into request/response handlers.
 
-    The returned callable has the handler-declared shape
-    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``. It runs
-    the async correlate-and-wait coroutine on a dedicated event loop in a worker
-    thread and blocks the caller on the result, so it is safe to call from a sync
-    handler executing on the runtime's own (already-running) event loop without
-    deadlocking that loop.
+    The returned object is directly callable with the legacy single-call shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None`` and also
+    exposes ``.open(topic) -> TerminalConsumerSession`` for the two-phase
+    (subscribe-before-publish) protocol. Both forms run the Kafka correlate-and-wait
+    work on a dedicated event loop in a worker thread, so they are safe to call
+    from a sync handler executing on the runtime's own (already running) event
+    loop without deadlocking that loop.
     """
-
-    def _consume(
-        terminal_topic: str, correlation_id: str, timeout_seconds: float
-    ) -> dict[str, object] | None:
-        result_box: dict[str, dict[str, object] | None] = {}
-        error_box: dict[str, BaseException] = {}
-
-        def _runner() -> None:
-            try:
-                result_box["value"] = asyncio.run(
-                    _await_correlated_terminal(
-                        event_bus=event_bus,
-                        terminal_topic=terminal_topic,
-                        correlation_id=correlation_id,
-                        timeout_seconds=timeout_seconds,
-                    )
-                )
-            except BaseException as exc:  # noqa: BLE001 — re-raised on caller thread
-                error_box["error"] = exc
-
-        thread = threading.Thread(
-            target=_runner,
-            name=f"terminal-consumer-{handler_name}",
-            daemon=True,
-        )
-        thread.start()
-        # Join with a small grace beyond the correlate timeout so a clean Kafka
-        # shutdown completes; the coroutine already enforces timeout_seconds.
-        thread.join(timeout=timeout_seconds + _ASSIGN_TIMEOUT_CAP_SECONDS + 5.0)
-
-        if thread.is_alive():
-            logger.warning(
-                "terminal-event consumer: correlate thread for %s did not finish "
-                "within grace window (topic=%s, cid=%s)",
-                handler_name,
-                terminal_topic,
-                correlation_id,
-            )
-            return None
-        if "error" in error_box:
-            logger.warning(
-                "terminal-event consumer: correlate failed for %s (topic=%s, "
-                "cid=%s): %s",
-                handler_name,
-                terminal_topic,
-                correlation_id,
-                error_box["error"],
-            )
-            return None
-        return result_box.get("value")
-
-    return _consume
+    return TerminalEventConsumer(event_bus=event_bus, handler_name=handler_name)
 
 
 __all__: list[str] = [
     "EventConsumer",
+    "TerminalConsumerSession",
+    "TerminalEventConsumer",
     "make_terminal_event_consumer",
 ]

--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -53,7 +53,7 @@ that do not care about the race).
 
 Architecture (ARCH-002 — "runtime owns all Kafka plumbing"):
   - Nodes/handlers declare the consume requirement in their contract and call the
-    injected ``event_consumer``; they never touch ``AIOKafkaConsumer``.
+    injected ``event_consumer``; they never touch the Kafka client.
   - The correlate-and-wait loop here is the same proven shape used by
     ``RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer``:
     assign reply-topic partitions, seek to end, then poll until a message whose
@@ -73,15 +73,19 @@ Loop isolation (why a worker thread):
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import threading
-from collections.abc import Callable, Coroutine, Mapping
+from collections.abc import Callable, Coroutine
 from concurrent.futures import Future
 from types import TracebackType
 from typing import cast
 
-from aiokafka import AIOKafkaConsumer, TopicPartition
+from omnibase_infra.runtime.service_pattern_b_broker import (
+    DirectTerminalConsumer,
+    close_direct_terminal_consumer,
+    open_direct_terminal_consumer,
+    poll_direct_terminal_consumer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,89 +96,17 @@ EventConsumer = Callable[[str, str, float], dict[str, object] | None]
 # Bound the metadata/partition-assignment phase so a broker that never surfaces
 # the reply topic fails fast instead of consuming the whole caller timeout.
 _ASSIGN_TIMEOUT_CAP_SECONDS = 30.0
-_METADATA_POLL_INTERVAL_SECONDS = 0.05
-
-# aiokafka client tuning — matches the request-response / pattern-B defaults so a
-# slow generation does not trigger a session-timeout rebalance mid-wait.
-_DEFAULT_SESSION_TIMEOUT_MS = 45000
-_DEFAULT_HEARTBEAT_INTERVAL_MS = 15000
-_DEFAULT_MAX_POLL_INTERVAL_MS = 300000
 
 # Grace beyond a submitted coroutine's own timeout so a clean Kafka shutdown
 # completes before the calling thread gives up on the worker loop.
 _LOOP_SUBMIT_GRACE_SECONDS = 5.0
 
 
-def _bootstrap_servers(event_bus: object) -> str:
-    servers = getattr(event_bus, "_bootstrap_servers", None)
-    if not isinstance(servers, str) or not servers:
-        raise RuntimeError(
-            "terminal-event consumer: runtime event_bus exposes no string "
-            "_bootstrap_servers; cannot build a Kafka correlate consumer."
-        )
-    return servers
-
-
-def _auth_kwargs(event_bus: object) -> dict[str, object]:
-    build_auth_kwargs = getattr(event_bus, "_build_auth_kwargs", None)
-    if not callable(build_auth_kwargs):
-        return {}
-    auth = cast("Callable[[], Mapping[str, object] | None]", build_auth_kwargs)()
-    return dict(auth or {})
-
-
-def _extract_correlation_id(payload: dict[str, object]) -> str | None:
-    value = payload.get("correlation_id")
-    if value is None:
-        return None
-    return str(value)
-
-
-def _build_consumer(event_bus: object) -> AIOKafkaConsumer:
-    return AIOKafkaConsumer(
-        bootstrap_servers=_bootstrap_servers(event_bus),
-        group_id=None,
-        enable_auto_commit=False,
-        auto_offset_reset="latest",
-        session_timeout_ms=_DEFAULT_SESSION_TIMEOUT_MS,
-        heartbeat_interval_ms=_DEFAULT_HEARTBEAT_INTERVAL_MS,
-        max_poll_interval_ms=_DEFAULT_MAX_POLL_INTERVAL_MS,
-        **_auth_kwargs(event_bus),
-    )
-
-
-async def _assign_terminal_partitions(
-    consumer: AIOKafkaConsumer,
-    terminal_topic: str,
-    assign_cap_seconds: float,
-) -> None:
-    """Wait for the reply topic's partition metadata, then assign all partitions.
-
-    A freshly created topic may not have partition metadata immediately; poll
-    until it appears or the cap elapses (raising ``TimeoutError`` so the caller's
-    ``try`` returns ``None`` cleanly rather than hanging).
-    """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + assign_cap_seconds
-    while True:
-        client = getattr(consumer, "_client", None)
-        set_topics = getattr(client, "set_topics", None)
-        if callable(set_topics):
-            set_topics([terminal_topic])
-        partitions = consumer.partitions_for_topic(terminal_topic) or set()
-        if partitions:
-            consumer.assign([TopicPartition(terminal_topic, p) for p in partitions])
-            return
-        if loop.time() >= deadline:
-            raise TimeoutError
-        await asyncio.sleep(_METADATA_POLL_INTERVAL_SECONDS)
-
-
 async def _open_positioned_consumer(
     *,
     event_bus: object,
     terminal_topic: str,
-) -> AIOKafkaConsumer:
+) -> DirectTerminalConsumer:
     """Start an ephemeral consumer, assign the reply topic, and seek to end NOW.
 
     Returns the started, positioned consumer. The caller is responsible for
@@ -183,30 +115,15 @@ async def _open_positioned_consumer(
     published at-or-after this point is delivered to a subsequent poll, even if it
     arrives before the poll begins. This is the subscribe-before-publish leg.
     """
-    consumer = _build_consumer(event_bus)
-    try:
-        await asyncio.wait_for(consumer.start(), timeout=_ASSIGN_TIMEOUT_CAP_SECONDS)
-        await _assign_terminal_partitions(
-            consumer, terminal_topic, _ASSIGN_TIMEOUT_CAP_SECONDS
-        )
-        await consumer.seek_to_end(*consumer.assignment())
-    except BaseException:
-        try:
-            await consumer.stop()
-        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
-            logger.warning(
-                "terminal-event consumer: failed to stop consumer during open "
-                "cleanup for %s: %s",
-                terminal_topic,
-                exc,
-            )
-        raise
-    return consumer
+    return await open_direct_terminal_consumer(
+        event_bus=event_bus,
+        terminal_topic=terminal_topic,
+    )
 
 
 async def _poll_correlated_terminal(
     *,
-    consumer: AIOKafkaConsumer,
+    consumer: DirectTerminalConsumer,
     terminal_topic: str,
     correlation_id: str,
     timeout_seconds: float,
@@ -217,34 +134,12 @@ async def _poll_correlated_terminal(
     Returns the deserialized terminal body whose ``correlation_id`` matches, or
     ``None`` on genuine timeout. Stops the consumer on the way out.
     """
-    loop = asyncio.get_running_loop()
-    try:
-        deadline = loop.time() + timeout_seconds
-        while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return None
-            try:
-                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
-            except TimeoutError:
-                return None
-            if message.value is None:
-                continue
-            try:
-                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if _extract_correlation_id(body) == correlation_id:
-                return body
-    finally:
-        try:
-            await consumer.stop()
-        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
-            logger.warning(
-                "terminal-event consumer: failed to stop consumer for %s: %s",
-                terminal_topic,
-                exc,
-            )
+    return await poll_direct_terminal_consumer(
+        handle=consumer,
+        terminal_topic=terminal_topic,
+        correlation_id=correlation_id,
+        timeout_seconds=timeout_seconds,
+    )
 
 
 class TerminalConsumerSession:
@@ -275,7 +170,7 @@ class TerminalConsumerSession:
         self._handler_name = handler_name
         self._terminal_topic = terminal_topic
         self._loop = asyncio.new_event_loop()
-        self._consumer: AIOKafkaConsumer | None = None
+        self._consumer: DirectTerminalConsumer | None = None
         self._closed = False
         self._thread = threading.Thread(
             target=self._run_loop,
@@ -304,7 +199,7 @@ class TerminalConsumerSession:
         if self._consumer is not None or self._closed:
             return self
         self._consumer = cast(
-            "AIOKafkaConsumer",
+            "DirectTerminalConsumer",
             self._submit(
                 _open_positioned_consumer(
                     event_bus=self._event_bus,
@@ -370,7 +265,10 @@ class TerminalConsumerSession:
         if consumer is not None:
             try:
                 stop_future: Future[object] = asyncio.run_coroutine_threadsafe(
-                    cast("Coroutine[object, object, object]", consumer.stop()),
+                    close_direct_terminal_consumer(
+                        consumer,
+                        terminal_topic=self._terminal_topic,
+                    ),
                     self._loop,
                 )
                 stop_future.result(timeout=_LOOP_SUBMIT_GRACE_SECONDS)

--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""One-shot blocking terminal-event consumer for auto-wired effect handlers.
+
+Some EFFECT handlers drive a request/response interaction over the bus: they
+publish a command, then block until the correlated terminal event arrives on a
+reply topic (correlating by ``correlation_id``), and read result fields back
+from that terminal payload. ``HandlerContextRoiRunner`` is the motivating case
+(OMN-13005): it publishes ``node-generation-requested.v1`` and must wait for the
+correlated ``node-generation-completed.v1`` terminal before recording an
+attempt-reduction row.
+
+These handlers declare an injectable ``event_consumer`` with the synchronous
+shape ``(topic, correlation_id, timeout_seconds) -> dict | None``. The runtime
+auto-wiring (``handler_wiring.py``) materializes a concrete consumer through
+``make_terminal_event_consumer`` so the handler never imports Kafka. This mirrors
+the existing ``event_publisher`` injection (``_make_sync_event_publisher``).
+
+Architecture (ARCH-002 — "runtime owns all Kafka plumbing"):
+  - Nodes/handlers declare the consume requirement in their contract and call a
+    sync ``event_consumer``; they never touch ``AIOKafkaConsumer``.
+  - The correlate-and-wait loop here is the same proven shape used by
+    ``RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer``:
+    assign reply-topic partitions, seek to end, then poll until a message whose
+    body ``correlation_id`` matches, honoring the caller's timeout.
+
+Loop isolation (why a worker thread):
+  The auto-wired dispatch callback invokes a sync handler ``handle()`` directly
+  on the runtime's running event loop. A blocking Kafka correlate cannot run on
+  that same loop (it would deadlock, and ``asyncio.run()`` raises inside a
+  running loop). The sync adapter therefore runs the async correlate coroutine
+  on a dedicated event loop in a separate thread and blocks the calling thread
+  on the result. The dispatch loop stays free to deliver the very terminal event
+  the handler is waiting for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from collections.abc import Callable, Mapping
+from typing import cast
+
+from aiokafka import AIOKafkaConsumer, TopicPartition
+
+logger = logging.getLogger(__name__)
+
+# Type alias mirrored from the declaring handler:
+# (terminal_topic, correlation_id, timeout_seconds) -> deserialized payload | None
+EventConsumer = Callable[[str, str, float], dict[str, object] | None]
+
+# Bound the metadata/partition-assignment phase so a broker that never surfaces
+# the reply topic fails fast instead of consuming the whole caller timeout.
+_ASSIGN_TIMEOUT_CAP_SECONDS = 30.0
+_METADATA_POLL_INTERVAL_SECONDS = 0.05
+
+# aiokafka client tuning — matches the request-response / pattern-B defaults so a
+# slow generation does not trigger a session-timeout rebalance mid-wait.
+_DEFAULT_SESSION_TIMEOUT_MS = 45000
+_DEFAULT_HEARTBEAT_INTERVAL_MS = 15000
+_DEFAULT_MAX_POLL_INTERVAL_MS = 300000
+
+
+def _bootstrap_servers(event_bus: object) -> str:
+    servers = getattr(event_bus, "_bootstrap_servers", None)
+    if not isinstance(servers, str) or not servers:
+        raise RuntimeError(
+            "terminal-event consumer: runtime event_bus exposes no string "
+            "_bootstrap_servers; cannot build a Kafka correlate consumer."
+        )
+    return servers
+
+
+def _auth_kwargs(event_bus: object) -> dict[str, object]:
+    build_auth_kwargs = getattr(event_bus, "_build_auth_kwargs", None)
+    if not callable(build_auth_kwargs):
+        return {}
+    auth = cast("Callable[[], Mapping[str, object] | None]", build_auth_kwargs)()
+    return dict(auth or {})
+
+
+def _extract_correlation_id(payload: dict[str, object]) -> str | None:
+    value = payload.get("correlation_id")
+    if value is None:
+        return None
+    return str(value)
+
+
+async def _await_correlated_terminal(
+    *,
+    event_bus: object,
+    terminal_topic: str,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Block up to ``timeout_seconds`` for the correlated terminal payload.
+
+    Returns the deserialized terminal event body whose ``correlation_id`` matches
+    the request, or ``None`` on genuine timeout. Uses an ephemeral group-less
+    consumer (``group_id=None``) assigned directly to the reply topic's
+    partitions and seeked to end, so it only sees terminals produced after the
+    handler published its command.
+    """
+    consumer = AIOKafkaConsumer(
+        bootstrap_servers=_bootstrap_servers(event_bus),
+        group_id=None,
+        enable_auto_commit=False,
+        auto_offset_reset="latest",
+        session_timeout_ms=_DEFAULT_SESSION_TIMEOUT_MS,
+        heartbeat_interval_ms=_DEFAULT_HEARTBEAT_INTERVAL_MS,
+        max_poll_interval_ms=_DEFAULT_MAX_POLL_INTERVAL_MS,
+        **_auth_kwargs(event_bus),
+    )
+
+    loop = asyncio.get_running_loop()
+    try:
+        assign_cap = min(_ASSIGN_TIMEOUT_CAP_SECONDS, timeout_seconds)
+        await asyncio.wait_for(consumer.start(), timeout=assign_cap)
+        await _assign_terminal_partitions(consumer, terminal_topic, assign_cap)
+        await consumer.seek_to_end(*consumer.assignment())
+
+        deadline = loop.time() + timeout_seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
+            except TimeoutError:
+                return None
+            if message.value is None:
+                continue
+            try:
+                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if _extract_correlation_id(body) == correlation_id:
+                return body
+    finally:
+        try:
+            await consumer.stop()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.warning(
+                "terminal-event consumer: failed to stop consumer for %s: %s",
+                terminal_topic,
+                exc,
+            )
+
+
+async def _assign_terminal_partitions(
+    consumer: AIOKafkaConsumer,
+    terminal_topic: str,
+    assign_cap_seconds: float,
+) -> None:
+    """Wait for the reply topic's partition metadata, then assign all partitions.
+
+    A freshly created topic may not have partition metadata immediately; poll
+    until it appears or the cap elapses (raising ``TimeoutError`` so the caller's
+    ``try`` returns ``None`` cleanly rather than hanging).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + assign_cap_seconds
+    while True:
+        client = getattr(consumer, "_client", None)
+        set_topics = getattr(client, "set_topics", None)
+        if callable(set_topics):
+            set_topics([terminal_topic])
+        partitions = consumer.partitions_for_topic(terminal_topic) or set()
+        if partitions:
+            consumer.assign([TopicPartition(terminal_topic, p) for p in partitions])
+            return
+        if loop.time() >= deadline:
+            raise TimeoutError
+        await asyncio.sleep(_METADATA_POLL_INTERVAL_SECONDS)
+
+
+def make_terminal_event_consumer(
+    *,
+    event_bus: object,
+    handler_name: str,
+) -> EventConsumer:
+    """Build the sync ``event_consumer`` injected into request/response handlers.
+
+    The returned callable has the handler-declared shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``. It runs
+    the async correlate-and-wait coroutine on a dedicated event loop in a worker
+    thread and blocks the caller on the result, so it is safe to call from a sync
+    handler executing on the runtime's own (already-running) event loop without
+    deadlocking that loop.
+    """
+
+    def _consume(
+        terminal_topic: str, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, object] | None:
+        result_box: dict[str, dict[str, object] | None] = {}
+        error_box: dict[str, BaseException] = {}
+
+        def _runner() -> None:
+            try:
+                result_box["value"] = asyncio.run(
+                    _await_correlated_terminal(
+                        event_bus=event_bus,
+                        terminal_topic=terminal_topic,
+                        correlation_id=correlation_id,
+                        timeout_seconds=timeout_seconds,
+                    )
+                )
+            except BaseException as exc:  # noqa: BLE001 — re-raised on caller thread
+                error_box["error"] = exc
+
+        thread = threading.Thread(
+            target=_runner,
+            name=f"terminal-consumer-{handler_name}",
+            daemon=True,
+        )
+        thread.start()
+        # Join with a small grace beyond the correlate timeout so a clean Kafka
+        # shutdown completes; the coroutine already enforces timeout_seconds.
+        thread.join(timeout=timeout_seconds + _ASSIGN_TIMEOUT_CAP_SECONDS + 5.0)
+
+        if thread.is_alive():
+            logger.warning(
+                "terminal-event consumer: correlate thread for %s did not finish "
+                "within grace window (topic=%s, cid=%s)",
+                handler_name,
+                terminal_topic,
+                correlation_id,
+            )
+            return None
+        if "error" in error_box:
+            logger.warning(
+                "terminal-event consumer: correlate failed for %s (topic=%s, "
+                "cid=%s): %s",
+                handler_name,
+                terminal_topic,
+                correlation_id,
+                error_box["error"],
+            )
+            return None
+        return result_box.get("value")
+
+    return _consume
+
+
+__all__: list[str] = [
+    "EventConsumer",
+    "make_terminal_event_consumer",
+]

--- a/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for auto-wired handler event_consumer injection (OMN-13005).
+
+The dispatch INPUT crash was OMN-13003. This is the SECOND, distinct defect on
+``node_context_roi_runner``: a request/response EFFECT handler declares an
+injectable blocking ``event_consumer`` (publish command -> block on correlated
+terminal event -> read result fields back), but the runtime auto-wiring only
+materialized ``event_publisher`` and had no equivalent for ``event_consumer``.
+The handler therefore fell back to its own no-op default that returns ``None``
+immediately, so every result row was a degenerate generation-failure even though
+the terminal event arrived ~1s later.
+
+These tests drive the REAL wiring path (``_prepare_handler_wiring`` ->
+``_materialize_known_handler_dependencies``) rather than constructing the handler
+directly, so they exercise the dispatch surface that the handler-isolation golden
+chain never touches (memory ``feedback_real_dispatch_path_tests``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
+from omnibase_core.services.service_local_handler_ownership_query import (
+    ServiceLocalHandlerOwnershipQuery,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import _prepare_handler_wiring
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+
+_TERMINAL_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+
+
+class RecordingEventBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes | None, bytes]] = []
+
+    async def publish(self, topic: str, key: bytes | None, value: bytes) -> None:
+        self.published.append((topic, key, value))
+
+
+class HandlerRoiRunnerShape:
+    """Fake with the request/response constructor shape of HandlerContextRoiRunner.
+
+    Mirrors the real handler's degenerate-vs-healthy branch: when the injected
+    ``event_consumer`` returns ``None`` (the no-op default), the row is recorded
+    as ``failure_stage=generation`` with ``attempt_count=0``. When the consumer
+    blocks-correlates and returns the terminal payload, the row is populated.
+    """
+
+    # Result topic the fake emits its recorded row to, so the test can assert
+    # on the event bus (a side channel) without capturing the handler instance —
+    # the resolver requires _import_handler_class to return an actual type.
+    ROW_TOPIC = "onex.evt.omnimarket.context-roi-run-completed.v1"
+
+    def __init__(
+        self,
+        event_publisher: Callable[[str, bytes], None] | None = None,
+        event_consumer: Callable[[str, str, float], dict[str, Any] | None]
+        | None = None,
+    ) -> None:
+        self._event_publisher = event_publisher
+        # Default no-op consumer returns None immediately (the live defect).
+        self._event_consumer = event_consumer or (lambda _t, _c, _to: None)
+
+    async def handle(self, envelope: object) -> None:
+        correlation_id = "cid-roi-runner-1"
+        if self._event_publisher is not None:
+            self._event_publisher(
+                "onex.cmd.omnimarket.node-generation-requested.v1",
+                b'{"task":"invoice"}',
+            )
+        terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 120.0)
+        if terminal is None:
+            row = {"failure_stage": "generation", "attempt_count": 0, "model_id": ""}
+        else:
+            row = {
+                "failure_stage": "none",
+                "attempt_count": int(terminal["attempt_count"]),
+                "model_id": str(terminal["model_id"]),
+            }
+        if self._event_publisher is not None:
+            self._event_publisher(self.ROW_TOPIC, json.dumps(row).encode("utf-8"))
+
+
+def _make_roi_runner_contract() -> ModelDiscoveredContract:
+    return ModelDiscoveredContract(
+        name="node_context_roi_runner",
+        node_type="EFFECT_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name="node_context_roi_runner",
+        package_name="omnimarket",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=("onex.cmd.omnimarket.context-roi-run-requested.v1",),
+            publish_topics=(
+                "onex.evt.omnimarket.context-roi-run-completed.v1",
+                "onex.cmd.omnimarket.node-generation-requested.v1",
+            ),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerContextRoiRunner",
+                        module="omnimarket.nodes.node_context_roi_runner.handlers.handler_context_roi_runner",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row() -> (
+    None
+):
+    """RED before OMN-13005: wiring injected no event_consumer -> no-op -> degenerate.
+
+    Drives the trial through the real wiring with a terminal event that arrives
+    AFTER a short delay; asserts a NON-DEGENERATE row (attempt_count>=1, populated
+    model_id, no failure_stage=generation). With the pre-fix no-op consumer, the
+    handler records failure_stage=generation/attempt_count=0 and this assertion
+    fails.
+    """
+    contract = _make_roi_runner_contract()
+    event_bus = RecordingEventBus()
+    resolver = ServiceHandlerResolver()
+    ownership_query = ServiceLocalHandlerOwnershipQuery(
+        local_node_names=frozenset({contract.name})
+    )
+
+    async def _delayed_terminal(
+        *,
+        event_bus: object,
+        terminal_topic: str,
+        correlation_id: str,
+        timeout_seconds: float,
+    ) -> dict[str, Any] | None:
+        # Terminal arrives ~after the handler began waiting — proves blocking.
+        await asyncio.sleep(0.05)
+        return {
+            "correlation_id": correlation_id,
+            "attempt_count": 1,
+            "model_id": "Qwen3.6-35B-A3B",
+            "provider": "local",
+            "contract_passed": True,
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+        }
+
+    with (
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerRoiRunnerShape,
+        ),
+        patch(
+            "omnibase_infra.runtime.service_terminal_event_consumer._await_correlated_terminal",
+            side_effect=_delayed_terminal,
+        ),
+    ):
+        prepared = _prepare_handler_wiring(
+            contract=contract,
+            entry=contract.handler_routing.handlers[0],  # type: ignore[union-attr]
+            dispatch_engine=None,
+            resolver=resolver,
+            ownership_query=ownership_query,
+            event_bus=event_bus,
+            container=None,
+        )
+
+        await prepared.dispatcher(
+            ModelEventEnvelope[dict[str, str]](
+                payload={"run_id": "t1"},
+                event_type="omnimarket.context-roi-run-requested",
+            )
+        )
+        await asyncio.sleep(0)
+
+    row_publishes = [
+        json.loads(value.decode("utf-8"))
+        for topic, _key, value in event_bus.published
+        if topic == HandlerRoiRunnerShape.ROW_TOPIC
+    ]
+    assert row_publishes, "handler never emitted a result row"
+    row = row_publishes[-1]
+    assert row["failure_stage"] != "generation", (
+        "event_consumer was not injected (handler fell back to no-op returning "
+        "None) — the OMN-13005 degenerate-row defect"
+    )
+    assert row["attempt_count"] >= 1
+    assert row["model_id"] == "Qwen3.6-35B-A3B"

--- a/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
@@ -1,26 +1,38 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Regression coverage for auto-wired handler event_consumer injection (OMN-13005).
+"""Regression coverage for auto-wired handler event_consumer injection.
 
-The dispatch INPUT crash was OMN-13003. This is the SECOND, distinct defect on
-``node_context_roi_runner``: a request/response EFFECT handler declares an
-injectable blocking ``event_consumer`` (publish command -> block on correlated
-terminal event -> read result fields back), but the runtime auto-wiring only
-materialized ``event_publisher`` and had no equivalent for ``event_consumer``.
-The handler therefore fell back to its own no-op default that returns ``None``
-immediately, so every result row was a degenerate generation-failure even though
-the terminal event arrived ~1s later.
+The dispatch INPUT crash was OMN-13003. OMN-13005 was the SECOND defect: a
+request/response EFFECT handler declares an injectable blocking ``event_consumer``
+(publish command -> block on correlated terminal event -> read result fields
+back), but the runtime auto-wiring materialized no consumer, so the handler fell
+back to a no-op default that returned ``None`` immediately and every row was a
+degenerate generation-failure.
+
+OMN-13012 is the FOURTH defect, exposed once OMN-13010 freed the dispatch loop and
+generation began completing in ~1s: the OMN-13005 consumer is a single callable
+that does ``assign -> seek_to_end -> poll`` AFTER the handler has already
+published, so a terminal emitted in the publish->seek gap is seeked PAST and lost
+(probe3). The fix makes the injected consumer two-phase — ``open(topic)`` assigns
+and seeks to end NOW (before publish), ``session.wait(cid, timeout)`` blocks from
+that captured position (after publish) — so a fast terminal is not skipped.
 
 These tests drive the REAL wiring path (``_prepare_handler_wiring`` ->
 ``_materialize_known_handler_dependencies``) rather than constructing the handler
 directly, so they exercise the dispatch surface that the handler-isolation golden
-chain never touches (memory ``feedback_real_dispatch_path_tests``).
+chain never touches (memory ``feedback_real_dispatch_path_tests``). The Kafka
+layer is faked at the two service seams (``_open_positioned_consumer`` and
+``_poll_correlated_terminal``) via a shared in-memory terminal log that models
+seek-to-end semantics: a poll only sees messages at or after the offset captured
+when its consumer was opened.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -44,6 +56,7 @@ from omnibase_infra.runtime.auto_wiring.models import (
 )
 
 _TERMINAL_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+_COMMAND_TOPIC = "onex.cmd.omnimarket.node-generation-requested.v1"
 
 
 class RecordingEventBus:
@@ -54,19 +67,108 @@ class RecordingEventBus:
         self.published.append((topic, key, value))
 
 
-class HandlerRoiRunnerShape:
-    """Fake with the request/response constructor shape of HandlerContextRoiRunner.
+# ----------------------------------------------------------------------------
+# Fake Kafka terminal log modeling seek-to-end semantics
+# ----------------------------------------------------------------------------
 
-    Mirrors the real handler's degenerate-vs-healthy branch: when the injected
-    ``event_consumer`` returns ``None`` (the no-op default), the row is recorded
-    as ``failure_stage=generation`` with ``attempt_count=0``. When the consumer
-    blocks-correlates and returns the terminal payload, the row is populated.
+
+class FakeTerminalLog:
+    """Append-only terminal-event log with seek-to-end offset capture.
+
+    Models the exact race surface: a consumer opened at offset N never sees
+    messages appended before N (``seek_to_end`` skipped past them). A consumer
+    is a thin handle holding its captured start offset; ``poll`` returns the
+    first message at index >= start_offset whose ``correlation_id`` matches,
+    waiting up to ``timeout`` for one to be appended.
     """
 
-    # Result topic the fake emits its recorded row to, so the test can assert
-    # on the event bus (a side channel) without capturing the handler instance —
-    # the resolver requires _import_handler_class to return an actual type.
+    def __init__(self) -> None:
+        self._messages: list[dict[str, Any]] = []
+        self._cond = threading.Condition()
+
+    def append(self, payload: dict[str, Any]) -> None:
+        with self._cond:
+            self._messages.append(payload)
+            self._cond.notify_all()
+
+    def current_end(self) -> int:
+        with self._cond:
+            return len(self._messages)
+
+    def poll(
+        self, start_offset: int, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout_seconds
+        with self._cond:
+            idx = start_offset
+            while True:
+                while idx < len(self._messages):
+                    msg = self._messages[idx]
+                    idx += 1
+                    if str(msg.get("correlation_id")) == correlation_id:
+                        return msg
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._cond.wait(timeout=remaining)
+
+
+class _FakeConsumerHandle:
+    """Opaque handle returned by the patched ``_open_positioned_consumer``."""
+
+    def __init__(self, log: FakeTerminalLog, start_offset: int) -> None:
+        self.log = log
+        self.start_offset = start_offset
+
+
+def install_fake_kafka(log: FakeTerminalLog) -> tuple[Any, Any]:
+    """Build patched replacements for the two service seams, bound to ``log``."""
+
+    async def _fake_open(
+        *, event_bus: object, terminal_topic: str
+    ) -> _FakeConsumerHandle:
+        # seek_to_end NOW: capture the current end offset.
+        return _FakeConsumerHandle(log, log.current_end())
+
+    async def _fake_poll(
+        *,
+        consumer: _FakeConsumerHandle,
+        terminal_topic: str,
+        correlation_id: str,
+        timeout_seconds: float,
+    ) -> dict[str, Any] | None:
+        # Poll from the offset captured at open; blocking wait runs off-thread.
+        return await asyncio.to_thread(
+            consumer.log.poll,
+            consumer.start_offset,
+            correlation_id,
+            timeout_seconds,
+        )
+
+    return _fake_open, _fake_poll
+
+
+# ----------------------------------------------------------------------------
+# Handler shapes
+# ----------------------------------------------------------------------------
+
+
+class HandlerRoiRunnerSingleCall:
+    """Legacy seek-after-publish shape: publish, THEN single-call consume.
+
+    This is the OMN-13005 form. Against a fast terminal (appended immediately
+    after publish) it loses the race because the consumer opens — and so seeks
+    to end — only when the single call is made, i.e. after the terminal is
+    already in the log.
+
+    The active ``FakeTerminalLog`` is bound on the class (``_TEST_LOG``) by the
+    test driver before dispatch; the constructor keeps the runtime-known
+    ``event_publisher``/``event_consumer`` shape so the resolver introspects and
+    materializes both injected deps exactly as it does for the real handler.
+    """
+
     ROW_TOPIC = "onex.evt.omnimarket.context-roi-run-completed.v1"
+    _TEST_LOG: FakeTerminalLog | None = None
 
     def __init__(
         self,
@@ -75,27 +177,87 @@ class HandlerRoiRunnerShape:
         | None = None,
     ) -> None:
         self._event_publisher = event_publisher
-        # Default no-op consumer returns None immediately (the live defect).
         self._event_consumer = event_consumer or (lambda _t, _c, _to: None)
 
     async def handle(self, envelope: object) -> None:
         correlation_id = "cid-roi-runner-1"
         if self._event_publisher is not None:
-            self._event_publisher(
-                "onex.cmd.omnimarket.node-generation-requested.v1",
-                b'{"task":"invoice"}',
-            )
-        terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 120.0)
-        if terminal is None:
-            row = {"failure_stage": "generation", "attempt_count": 0, "model_id": ""}
-        else:
-            row = {
-                "failure_stage": "none",
-                "attempt_count": int(terminal["attempt_count"]),
-                "model_id": str(terminal["model_id"]),
-            }
+            self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+        # Fast terminal: appended the instant after publish, before the consume
+        # call seeks to end.
+        if self._TEST_LOG is not None:
+            self._TEST_LOG.append(_terminal_payload(correlation_id))
+        terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 5.0)
+        _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+
+class HandlerRoiRunnerTwoPhase:
+    """Subscribe-before-publish shape (OMN-13012): open, publish, then wait.
+
+    Opens the terminal session (assign + seek_to_end NOW) BEFORE publishing, so
+    a terminal appended immediately after publish is at-or-after the captured
+    offset and is delivered by ``wait``.
+    """
+
+    ROW_TOPIC = "onex.evt.omnimarket.context-roi-run-completed.v1"
+    _TEST_LOG: FakeTerminalLog | None = None
+
+    def __init__(
+        self,
+        event_publisher: Callable[[str, bytes], None] | None = None,
+        event_consumer: Any = None,
+    ) -> None:
+        self._event_publisher = event_publisher
+        self._event_consumer = event_consumer
+
+    async def handle(self, envelope: object) -> None:
+        correlation_id = "cid-roi-runner-1"
+        # Two-phase: open BEFORE publishing.
+        session = None
+        opener = getattr(self._event_consumer, "open", None)
+        if callable(opener):
+            session = opener(_TERMINAL_TOPIC)
         if self._event_publisher is not None:
-            self._event_publisher(self.ROW_TOPIC, json.dumps(row).encode("utf-8"))
+            self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+        # Fast terminal: appended immediately after publish.
+        if self._TEST_LOG is not None:
+            self._TEST_LOG.append(_terminal_payload(correlation_id))
+        if session is not None:
+            terminal = session.wait(correlation_id, 5.0)
+        elif self._event_consumer is not None:
+            terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 5.0)
+        else:
+            terminal = None
+        _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+
+def _terminal_payload(correlation_id: str) -> dict[str, Any]:
+    return {
+        "correlation_id": correlation_id,
+        "attempt_count": 1,
+        "model_id": "Qwen3.6-35B-A3B",
+        "provider": "local",
+        "contract_passed": True,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+    }
+
+
+def _emit_row(
+    publisher: Callable[[str, bytes], None] | None,
+    row_topic: str,
+    terminal: dict[str, Any] | None,
+) -> None:
+    if terminal is None:
+        row = {"failure_stage": "generation", "attempt_count": 0, "model_id": ""}
+    else:
+        row = {
+            "failure_stage": "none",
+            "attempt_count": int(terminal["attempt_count"]),
+            "model_id": str(terminal["model_id"]),
+        }
+    if publisher is not None:
+        publisher(row_topic, json.dumps(row).encode("utf-8"))
 
 
 def _make_roi_runner_contract() -> ModelDiscoveredContract:
@@ -110,7 +272,7 @@ def _make_roi_runner_contract() -> ModelDiscoveredContract:
             subscribe_topics=("onex.cmd.omnimarket.context-roi-run-requested.v1",),
             publish_topics=(
                 "onex.evt.omnimarket.context-roi-run-completed.v1",
-                "onex.cmd.omnimarket.node-generation-requested.v1",
+                _COMMAND_TOPIC,
             ),
         ),
         handler_routing=ModelHandlerRouting(
@@ -127,18 +289,15 @@ def _make_roi_runner_contract() -> ModelDiscoveredContract:
     )
 
 
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row() -> (
-    None
-):
-    """RED before OMN-13005: wiring injected no event_consumer -> no-op -> degenerate.
+async def _drive_handler(
+    handler_cls: type, log: FakeTerminalLog
+) -> list[dict[str, Any]]:
+    """Wire ``handler_cls`` through the real injection path and dispatch once.
 
-    Drives the trial through the real wiring with a terminal event that arrives
-    AFTER a short delay; asserts a NON-DEGENERATE row (attempt_count>=1, populated
-    model_id, no failure_stage=generation). With the pre-fix no-op consumer, the
-    handler records failure_stage=generation/attempt_count=0 and this assertion
-    fails.
+    Binds the active ``FakeTerminalLog`` on the handler class (``_TEST_LOG``) so
+    the constructor keeps the exact runtime-known dependency shape the resolver
+    introspects, and patches the two Kafka seams so the real
+    ``TerminalEventConsumer`` two-phase logic runs against the in-memory log.
     """
     contract = _make_roi_runner_contract()
     event_bus = RecordingEventBus()
@@ -146,34 +305,21 @@ async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row()
     ownership_query = ServiceLocalHandlerOwnershipQuery(
         local_node_names=frozenset({contract.name})
     )
-
-    async def _delayed_terminal(
-        *,
-        event_bus: object,
-        terminal_topic: str,
-        correlation_id: str,
-        timeout_seconds: float,
-    ) -> dict[str, Any] | None:
-        # Terminal arrives ~after the handler began waiting — proves blocking.
-        await asyncio.sleep(0.05)
-        return {
-            "correlation_id": correlation_id,
-            "attempt_count": 1,
-            "model_id": "Qwen3.6-35B-A3B",
-            "provider": "local",
-            "contract_passed": True,
-            "prompt_tokens": 10,
-            "completion_tokens": 20,
-        }
+    fake_open, fake_poll = install_fake_kafka(log)
+    handler_cls._TEST_LOG = log  # type: ignore[attr-defined]
 
     with (
         patch(
             "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
-            return_value=HandlerRoiRunnerShape,
+            return_value=handler_cls,
         ),
         patch(
-            "omnibase_infra.runtime.service_terminal_event_consumer._await_correlated_terminal",
-            side_effect=_delayed_terminal,
+            "omnibase_infra.runtime.service_terminal_event_consumer._open_positioned_consumer",
+            side_effect=fake_open,
+        ),
+        patch(
+            "omnibase_infra.runtime.service_terminal_event_consumer._poll_correlated_terminal",
+            side_effect=fake_poll,
         ),
     ):
         prepared = _prepare_handler_wiring(
@@ -194,16 +340,103 @@ async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row()
         )
         await asyncio.sleep(0)
 
-    row_publishes = [
+    return [
         json.loads(value.decode("utf-8"))
         for topic, _key, value in event_bus.published
-        if topic == HandlerRoiRunnerShape.ROW_TOPIC
+        if topic == handler_cls.ROW_TOPIC
     ]
-    assert row_publishes, "handler never emitted a result row"
-    row = row_publishes[-1]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_single_call_consumer_loses_fast_terminal_race() -> None:
+    """RED for OMN-13012: seek-after-publish misses a terminal emitted at t+0.
+
+    The legacy single-call consumer opens (and seeks to end) only when the call
+    is made — after the handler has already published AND the terminal has landed.
+    seek_to_end skips past the terminal, so the poll times out and the row is
+    degenerate. This is the exact probe3 failure; it MUST be red so the two-phase
+    fix below cannot be a no-op.
+    """
+    log = FakeTerminalLog()
+    rows = await _drive_handler(HandlerRoiRunnerSingleCall, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
+    assert row["failure_stage"] == "generation", (
+        "single-call seek-after-publish unexpectedly caught the fast terminal — "
+        "the race this ticket fixes is not being exercised"
+    )
+    assert row["attempt_count"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_phase_consumer_catches_fast_terminal_race() -> None:
+    """GREEN for OMN-13012: open-before-publish captures the t+0 terminal.
+
+    The two-phase session seeks to end BEFORE the handler publishes, so a terminal
+    appended immediately after publish is at-or-after the captured offset and is
+    delivered by ``wait`` — a NON-degenerate row. With the pre-fix single-call
+    consumer this assertion fails (see the RED test above).
+    """
+    log = FakeTerminalLog()
+    rows = await _drive_handler(HandlerRoiRunnerTwoPhase, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
     assert row["failure_stage"] != "generation", (
-        "event_consumer was not injected (handler fell back to no-op returning "
-        "None) — the OMN-13005 degenerate-row defect"
+        "two-phase open-before-publish failed to catch the fast terminal — the "
+        "subscribe-after-publish race (OMN-13012) is not closed"
+    )
+    assert row["attempt_count"] >= 1
+    assert row["model_id"] == "Qwen3.6-35B-A3B"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row() -> (
+    None
+):
+    """OMN-13005 preserved: a delayed terminal is still correlated and returned.
+
+    Drives the trial through the real wiring with the two-phase session and a
+    terminal that arrives shortly after the wait begins (a delayed append rather
+    than a t+0 one). Asserts a NON-DEGENERATE row, proving the injected consumer
+    blocks-and-correlates (the OMN-13005 contract) under the new two-phase shape.
+    """
+    log = FakeTerminalLog()
+
+    class _DelayedTerminalTwoPhase(HandlerRoiRunnerTwoPhase):
+        async def handle(self, envelope: object) -> None:
+            correlation_id = "cid-roi-runner-1"
+            session = None
+            opener = getattr(self._event_consumer, "open", None)
+            if callable(opener):
+                session = opener(_TERMINAL_TOPIC)
+            if self._event_publisher is not None:
+                self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+
+            active_log = self._TEST_LOG
+
+            # Terminal arrives AFTER a short delay, while wait() is blocking.
+            def _delayed_append() -> None:
+                import time
+
+                time.sleep(0.05)
+                if active_log is not None:
+                    active_log.append(_terminal_payload(correlation_id))
+
+            threading.Thread(target=_delayed_append, daemon=True).start()
+            terminal = (
+                session.wait(correlation_id, 5.0) if session is not None else None
+            )
+            _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+    rows = await _drive_handler(_DelayedTerminalTwoPhase, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
+    assert row["failure_stage"] != "generation", (
+        "event_consumer was not injected or did not block-correlate — the "
+        "OMN-13005 degenerate-row defect"
     )
     assert row["attempt_count"] >= 1
     assert row["model_id"] == "Qwen3.6-35B-A3B"


### PR DESCRIPTION
## Summary

SECOND distinct defect on `node_context_roi_runner` (the dispatch INPUT crash was OMN-13003 / omnimarket#1180, hot-patched live). Experiments Exp 1 (160) / Exp 2 (560) / Exp 3 (200) were HALTED because every battery row was degenerate (`failure_stage=generation`, `attempt_count=0`, zero tokens, empty `model_id`/`provider`) while the underlying generations SUCCEEDED ~1-2s later (`provider=local`, `Qwen3.6-35B-A3B`, `contract_passed=True`).

## Root cause (owning surface + mechanism)

Owning surface: `omnibase_infra` runtime auto-wiring (`src/omnibase_infra/runtime/auto_wiring/handler_wiring.py`).

`HandlerContextRoiRunner.__init__` declares an injectable `event_consumer: EventConsumer | None = None` and, in `_run_trial`, calls `self._consumer(gen_terminal_topic, correlation_id, generation_timeout_seconds)` expecting a BLOCKING, correlation-id-filtered consumer that waits up to `generation_timeout_seconds=120` and returns the terminal `node-generation-completed.v1` payload.

The runtime auto-wiring materialized `event_publisher` for handlers that declare it (`_materialize_known_handler_dependencies` -> `_make_sync_event_publisher`) but had NO equivalent for `event_consumer`. The runner therefore constructed with `self._consumer = _noop_consumer`, which returns `None` synchronously -> `_run_trial` interprets `None` as `failure_stage=generation` and emits a degenerate row BEFORE the generation pipeline produces its result (~1s later). The 120s timeout was never honored because the no-op never blocks.

This is the `feedback_real_dispatch_path_tests` blind spot: handler-isolation tests inject a returning `event_consumer` stub and pass; the live runtime injected nothing, so the no-op default silently won.

## Fix

Add `event_consumer` materialization mirroring `event_publisher`:
- `service_terminal_event_consumer.make_terminal_event_consumer` — a sync `(terminal_topic, correlation_id, timeout) -> dict | None` adapter that runs the proven direct-Kafka correlate-and-wait loop (the same shape already shipped in `RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer`: ephemeral group-less consumer, assign reply-topic partitions, seek to end, poll until a body whose `correlation_id` matches, honoring the caller timeout).
- **Loop isolation:** the auto-wired dispatch callback invokes the sync handler `handle()` directly on the runtime's running event loop. A blocking Kafka correlate cannot run on that same loop (deadlock; `asyncio.run()` raises inside a running loop). The adapter runs the correlate coroutine on a dedicated event loop in a worker thread and blocks the calling thread on the result — the dispatch loop stays free to deliver the awaited terminal.
- `_make_sync_event_consumer` in `handler_wiring.py` resolves it through the same runtime `event_bus` the publisher adapter binds (no manual wiring / `event_bus=None`).

## TDD through the REAL dispatch path

`tests/unit/runtime/auto_wiring/test_event_consumer_injection.py` drives a trial through `_prepare_handler_wiring` with a terminal generation event arriving AFTER a short delay and asserts a NON-DEGENERATE row (`attempt_count>=1`, populated `model_id`, no `failure_stage=generation`). Verified RED with the consumer injection disabled (handler fell back to the no-op and recorded `failure_stage=generation`).

## Local proof

- `ruff format` / `ruff check`: clean on changed files
- `mypy --strict` on both source files: Success, no issues
- `pre-commit run --files <changed>`: all hooks Passed (incl. ONEX Any Type gate)
- `pytest tests/unit/runtime/ tests/integration/runtime/ -n auto`: 5197 passed, 1 pre-existing parallelism-flake (`test_secondary_index_speedup`, passes in isolation; unrelated to this change)
- New test: PASSED with fix, FAILED (red) with injection disabled

OMN-13005

Evidence-Source: OCC#2530
Evidence-Ticket: OMN-13005

dod_evidence: see local proof above + `docs/evidence/2026-06-11-experiments/exp1/EXP1-3_RUNNER_CONSUME_LEG_BLOCKER.md`
