### PR TITLE
feat(OMN-13008): automated .201 disk maintenance — worktree GC + docker GC + watermark alert ratchet

### DIFF
--- a/contracts/OMN-13008.yaml
+++ b/contracts/OMN-13008.yaml
@@ -1,0 +1,43 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13008
+title: 'Automated worktree GC + .201 docker/disk GC + disk watermark alert ratchet'
+summary: 'Conservative, keep-list-driven .201 disk maintenance: merged-worktree GC (drives prune-worktrees.sh), docker/image GC, and a df watermark alert ratchet (>85% ticket, >90% bus event), shipped as systemd user timer units plus dry-run-tested GC scripts.'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: GC plan-safety + dry-run + watermark-event unit tests pass
+    command: uv run pytest tests/unit/scripts/test_disk_gc_plan.py tests/unit/scripts/test_disk_gc_dry_run.py tests/unit/scripts/test_disk_watermark_event.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: Removal-plan resolver never reaps a keep-list repo, kept tag, in-use image, or too-young artifact (pure-planner safety tests)
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/scripts/test_disk_gc_plan.py -q'
+  - id: dod-002
+    description: GC shell scripts in default/dry-run mode issue no destructive docker/git/rpk op; --execute correctly forwards the flag
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/scripts/test_disk_gc_dry_run.py -q'
+  - id: dod-003
+    description: Disk-watermark bus event builder produces stable typed warning/critical events with a dedupe alert_key
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/scripts/test_disk_watermark_event.py -q'
+  - id: dod-deploy
+    description: systemd USER timer units (NOT lane containers) installed + enabled on .201 via deploy/disk-gc/install-disk-gc.sh; verified with systemctl --user list-timers
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/scripts/test_disk_gc_plan.py tests/unit/scripts/test_disk_gc_dry_run.py -q'

--- a/deploy/disk-gc/install-disk-gc.sh
+++ b/deploy/disk-gc/install-disk-gc.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# install-disk-gc.sh — Install the .201 disk-maintenance systemd USER timer (OMN-13008).
+#
+# These are systemd USER units (NOT lane containers). Installing/enabling them is
+# scoped to the runtime user and does not touch any docker-compose lane. No sudo.
+#
+# Usage (run on 192.168.86.201 after pulling latest):
+#   bash deploy/disk-gc/install-disk-gc.sh            # install + enable + start timer
+#   bash deploy/disk-gc/install-disk-gc.sh --uninstall
+#   bash deploy/disk-gc/install-disk-gc.sh --status
+#
+# Prerequisites:
+#   - systemd user manager available (loginctl enable-linger $USER if running headless)
+#   - omnibase_infra cloned at $OMNI_HOME/omnibase_infra (default ~/Code/omni_home)
+#   - omniclaude cloned alongside (for prune-worktrees.sh)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_SRC="${SCRIPT_DIR}/onex-disk-gc.service"
+TIMER_SRC="${SCRIPT_DIR}/onex-disk-gc.timer"
+USER_UNIT_DIR="${HOME}/.config/systemd/user"
+SERVICE_DST="${USER_UNIT_DIR}/onex-disk-gc.service"
+TIMER_DST="${USER_UNIT_DIR}/onex-disk-gc.timer"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+  echo "Uninstalling onex-disk-gc user timer..."
+  systemctl --user stop onex-disk-gc.timer onex-disk-gc.service 2>/dev/null || true
+  systemctl --user disable onex-disk-gc.timer 2>/dev/null || true
+  rm -f "$SERVICE_DST" "$TIMER_DST"
+  systemctl --user daemon-reload
+  echo "Done. onex-disk-gc uninstalled."
+  exit 0
+fi
+
+if [[ "${1:-}" == "--status" ]]; then
+  systemctl --user list-timers onex-disk-gc.timer --no-pager || true
+  echo ""
+  systemctl --user status onex-disk-gc.timer onex-disk-gc.service --no-pager || true
+  echo ""
+  echo "Recent logs:"
+  journalctl --user -u onex-disk-gc.service -n 30 --no-pager || true
+  exit 0
+fi
+
+echo "Installing onex-disk-gc systemd USER timer..."
+
+# Make the GC scripts executable.
+chmod +x "${SCRIPT_DIR}/../../scripts/disk-gc.sh" \
+         "${SCRIPT_DIR}/../../scripts/disk-watermark-check.sh" \
+         "${SCRIPT_DIR}/../../scripts/worktree-gc.sh" 2>/dev/null || true
+
+mkdir -p "$USER_UNIT_DIR"
+cp "$SERVICE_SRC" "$SERVICE_DST"
+cp "$TIMER_SRC" "$TIMER_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable --now onex-disk-gc.timer
+
+echo ""
+echo "Done. onex-disk-gc installed and running (user scope)."
+echo "  Service: ${SERVICE_DST}"
+echo "  Timer:   ${TIMER_DST}"
+echo ""
+echo "Check:      systemctl --user list-timers onex-disk-gc.timer"
+echo "Logs:       journalctl --user -u onex-disk-gc.service -f"
+echo "Run now:    systemctl --user start onex-disk-gc.service"
+echo "Uninstall:  bash deploy/disk-gc/install-disk-gc.sh --uninstall"
+echo ""
+echo "NOTE: if this host runs headless, enable lingering so the timer fires"
+echo "without an active login session:  loginctl enable-linger \$USER"

--- a/deploy/disk-gc/keep-list.yaml
+++ b/deploy/disk-gc/keep-list.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# keep-list.yaml — Versioned protect-list for the .201 conservative docker/disk GC.
+#
+# OMN-13008. This file is the single source of truth for what disk-gc.sh must NOT
+# remove. It is read at runtime by disk-gc.sh; nothing is hardcoded in the script.
+#
+# How matching works:
+#   - keep_image_repos:  any docker image whose repository name contains one of
+#                        these substrings is NEVER removed, regardless of age.
+#                        Use this for the live runtime image family and any
+#                        image you may need to roll back to.
+#   - keep_image_tags:   any image whose ":tag" matches one of these (exact tag
+#                        match) is NEVER removed. Use for tagged rollback sets.
+#   - protect_running:   when true (default), images referenced by any container
+#                        (running OR stopped) are always kept even if not listed
+#                        above. This is the backstop that prevents pulling the
+#                        rug out from a lane mid-flight.
+#
+# Maintenance: when promoting a new runtime image generation, add its tag to
+# keep_image_tags so the GC keeps the prior generation as a rollback target for
+# `superseded_image_keep_generations` cycles. Do NOT hardcode tags in the script.
+schema_version: "1.0.0"
+# Image repositories (substring match) that are always retained.
+keep_image_repos:
+  - omninode-runtime
+  - omnibase-infra
+  - omnibase-intelligence
+  - omnimarket
+  - omnidash
+  - projection-api
+  # Core infra base images — removing these forces slow re-pulls and can wedge a
+  # lane restart while /data is already tight.
+  - postgres
+  - redpandadata/redpanda
+  - valkey
+# Exact image tags (the part after ':') that are always retained — tagged
+# rollback sets. Update on each promotion.
+keep_image_tags:
+  - latest
+  - stable
+  - rollback
+# Keep images referenced by any container (running or stopped). The live lane
+# backstop. Disable only with explicit operator approval.
+protect_running: true
+# How many superseded (untagged-by-keep_image_tags) generations of a kept repo
+# to retain before the oldest become eligible for removal once older than
+# superseded_image_max_age_days. Belt-and-suspenders with age.
+superseded_image_keep_generations: 2
+# Age threshold (days) below which NOTHING is removed, even dangling images.
+# Conservative: a just-built image is never reaped.
+min_age_days: 3

--- a/deploy/disk-gc/onex-disk-gc.service
+++ b/deploy/disk-gc/onex-disk-gc.service
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# onex-disk-gc.service — .201 disk maintenance pass (OMN-13008).
+#
+# A systemd USER unit (NOT a lane container). One-shot maintenance run, triggered
+# by onex-disk-gc.timer. Runs three conservative passes in order:
+#   1. worktree-gc.sh   — remove merged+clean worktrees (drives prune-worktrees.sh)
+#   2. disk-gc.sh       — conservative docker/builder/image GC honoring keep-list
+#   3. disk-watermark-check.sh — emit bus alert if /data crosses the watermark
+#
+# Install (on .201, as the runtime user — NO sudo, user scope):
+#   bash deploy/disk-gc/install-disk-gc.sh
+#
+# Check:
+#   systemctl --user status onex-disk-gc.timer
+#   journalctl --user -u onex-disk-gc.service -f
+
+[Unit]
+Description=ONEX .201 disk maintenance (worktree GC + docker GC + watermark alert)
+Documentation=https://github.com/OmniNode-ai/omnibase_infra
+After=docker.service
+
+[Service]
+Type=oneshot
+
+# Resolve OMNI_HOME for the runtime user on .201.
+Environment="OMNI_HOME=%h/Code/omni_home"
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+
+# KAFKA_BOOTSTRAP_SERVERS for the watermark bus publish is sourced from the
+# operator env file (not hardcoded in source). Optional ('-' prefix): if the
+# file is absent the watermark check still runs but logs the event instead of
+# publishing (fail-soft on the alert publish, never a silent default broker).
+EnvironmentFile=-%h/.omnibase/.env
+
+ExecStartPre=/bin/mkdir -p %h/.local/log/onex
+
+# 1. Merged-worktree GC (drives the canonical prune-worktrees.sh safety logic).
+ExecStart=/bin/bash %h/Code/omni_home/omnibase_infra/scripts/worktree-gc.sh --execute --worktrees-root /data/omninode/omni_worktrees
+
+# 2. Conservative docker/disk GC honoring the versioned keep-list.
+ExecStart=/bin/bash %h/Code/omni_home/omnibase_infra/scripts/disk-gc.sh --execute
+
+# 3. Watermark alert ratchet (non-zero exit on breach is expected; do not fail the unit).
+ExecStart=-/bin/bash %h/Code/omni_home/omnibase_infra/scripts/disk-watermark-check.sh --mount /data
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=onex-disk-gc
+
+[Install]
+WantedBy=default.target

--- a/deploy/disk-gc/onex-disk-gc.timer
+++ b/deploy/disk-gc/onex-disk-gc.timer
@@ -21,9 +21,13 @@ Documentation=https://github.com/OmniNode-ai/omnibase_infra
 [Timer]
 # First run 5 min after the user manager starts (let docker settle).
 OnStartupSec=5min
-# Then hourly. Watermark alerts need to be timely; GC is idempotent + conservative.
-OnUnitActiveSec=1h
-# Fire a missed run on resume (laptop/host sleep, reboots).
+# Then every hour on a calendar schedule. Calendar recurrence re-arms reliably for
+# a oneshot service (OnUnitActiveSec does not always re-elapse once the unit goes
+# inactive). Watermark alerts stay timely; GC is idempotent + conservative.
+OnCalendar=hourly
+# Spread load a little so it never lines up with other top-of-hour jobs.
+RandomizedDelaySec=2min
+# Fire a missed run on resume (host sleep, reboots).
 Persistent=true
 Unit=onex-disk-gc.service
 

--- a/deploy/disk-gc/onex-disk-gc.timer
+++ b/deploy/disk-gc/onex-disk-gc.timer
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# onex-disk-gc.timer — triggers the .201 disk maintenance pass (OMN-13008).
+#
+# Systemd USER timer. The watermark check runs hourly so /data alerts fire well
+# before detonation; the GC passes are conservative (keep-list + min_age_days) so
+# running hourly is safe and self-throttling.
+#
+# Install on .201 (user scope, no sudo):
+#   bash deploy/disk-gc/install-disk-gc.sh
+#
+# Check:
+#   systemctl --user list-timers onex-disk-gc.timer
+#   systemctl --user status onex-disk-gc.timer
+
+[Unit]
+Description=ONEX .201 disk maintenance timer (worktree + docker GC + watermark)
+Documentation=https://github.com/OmniNode-ai/omnibase_infra
+
+[Timer]
+# First run 5 min after the user manager starts (let docker settle).
+OnStartupSec=5min
+# Then hourly. Watermark alerts need to be timely; GC is idempotent + conservative.
+OnUnitActiveSec=1h
+# Fire a missed run on resume (laptop/host sleep, reboots).
+Persistent=true
+Unit=onex-disk-gc.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/disk-gc.sh
+++ b/scripts/disk-gc.sh
@@ -65,19 +65,41 @@ log "Starting ($( [[ "$EXECUTE" == true ]] && echo EXECUTE || echo DRY-RUN )), k
 # ---------------------------------------------------------------------------
 # Resolve the removal PLAN in Python (deterministic, testable). The plan is the
 # only thing that decides what gets removed; bash only executes it.
-# We pass docker inventory in on stdin so the planner is pure and unit-testable.
+#
+# Docker inventory is written to per-run scratch files and handed to the planner
+# on stdin as a JSON envelope. We do NOT pass it via env vars: a host with many
+# images blows past ARG_MAX (`Argument list too long`). Scratch lives under the
+# log dir (never /tmp), and is cleaned on exit.
 # ---------------------------------------------------------------------------
-DOCKER_IMAGES_JSON="$(docker image ls --all --no-trunc --format '{{json .}}' 2>/dev/null || echo '')"
-DOCKER_PS_JSON="$(docker ps --all --no-trunc --format '{{json .}}' 2>/dev/null || echo '')"
-# Image-in-use set: every image id/ref referenced by any container.
-DOCKER_INUSE="$(docker ps --all --format '{{.Image}}' 2>/dev/null | sort -u || echo '')"
+SCRATCH="$(mktemp -d "$(dirname "$LOG_FILE")/disk-gc.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+docker image ls --all --no-trunc --format '{{json .}}' >"$SCRATCH/images.ndjson" 2>/dev/null || : >"$SCRATCH/images.ndjson"
+docker ps --all --no-trunc --format '{{json .}}' >"$SCRATCH/ps.ndjson" 2>/dev/null || : >"$SCRATCH/ps.ndjson"
+docker ps --all --format '{{.Image}}' 2>/dev/null | sort -u >"$SCRATCH/inuse.txt" || : >"$SCRATCH/inuse.txt"
 
 PLAN_JSON="$(
-  KEEP_LIST="$KEEP_LIST" \
-  IMAGES_JSON="$DOCKER_IMAGES_JSON" \
-  PS_JSON="$DOCKER_PS_JSON" \
-  INUSE="$DOCKER_INUSE" \
-  python3 "${SCRIPT_DIR}/disk_gc_plan.py"
+  KEEP_LIST="$KEEP_LIST" python3 - "$SCRATCH" "${SCRIPT_DIR}/disk_gc_plan.py" <<'PYWRAP'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+scratch = Path(sys.argv[1])
+planner = sys.argv[2]
+envelope = json.dumps(
+    {
+        "images_ndjson": (scratch / "images.ndjson").read_text(),
+        "ps_ndjson": (scratch / "ps.ndjson").read_text(),
+        "inuse": (scratch / "inuse.txt").read_text(),
+    }
+)
+proc = subprocess.run(
+    [sys.executable, planner], input=envelope, capture_output=True, text=True
+)
+sys.stderr.write(proc.stderr)
+sys.stdout.write(proc.stdout)
+sys.exit(proc.returncode)
+PYWRAP
 )"
 
 if [[ "$EMIT_JSON" == true ]]; then

--- a/scripts/disk-gc.sh
+++ b/scripts/disk-gc.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# disk-gc.sh — Conservative scheduled docker/disk garbage collection for .201 (OMN-13008).
+#
+# WHY: On 2026-06-11 /data on .201 reached ~95% (weeks of unpruned docker images
+# + builder cache) and killed all three runtime lanes mid-demo. This script is the
+# scheduled, conservative GC that keeps /data from detonating, driven by a
+# VERSIONED keep-list config (deploy/disk-gc/keep-list.yaml) — nothing is hardcoded.
+#
+# It reaps, in increasing order of caution:
+#   1. docker builder cache (cache mounts are always safe to drop)
+#   2. dangling images (untagged, <none>) older than min_age_days
+#   3. stopped containers older than min_age_days
+#   4. superseded image generations of kept repos, KEEPING keep_image_tags,
+#      keeping protect_running references, keeping the newest
+#      superseded_image_keep_generations, and only removing those older than
+#      min_age_days.
+#
+# It NEVER removes:
+#   - any image whose repo matches keep_image_repos
+#   - any image whose tag matches keep_image_tags
+#   - any image referenced by a container (when protect_running: true)
+#   - anything younger than min_age_days
+#   - any volume (volumes are out of scope — data safety)
+#
+# Usage:
+#   ./scripts/disk-gc.sh                 # DRY RUN (default): print what WOULD be removed
+#   ./scripts/disk-gc.sh --execute       # actually remove
+#   ./scripts/disk-gc.sh --keep-list /path/to/keep-list.yaml
+#   ./scripts/disk-gc.sh --json          # machine-readable plan to stdout (dry-run plan)
+#
+# Exit codes: 0 success (plan printed or executed), 2 bad args, 3 missing deps.
+#
+# Runs on .201 via deploy/disk-gc.timer (systemd user timer). Log: ~/.local/log/onex/disk-gc.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+KEEP_LIST="${SCRIPT_DIR}/../deploy/disk-gc/keep-list.yaml"
+EXECUTE=false
+EMIT_JSON=false
+LOG_FILE="${HOME}/.local/log/onex/disk-gc.log"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --execute) EXECUTE=true; shift ;;
+    --keep-list) KEEP_LIST="$2"; shift 2 ;;
+    --json) EMIT_JSON=true; shift ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [disk-gc] $*" | tee -a "$LOG_FILE" >&2; }
+
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found" >&2; exit 3; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found" >&2; exit 3; }
+[[ -f "$KEEP_LIST" ]] || { echo "ERROR: keep-list not found: $KEEP_LIST" >&2; exit 3; }
+
+log "Starting ($( [[ "$EXECUTE" == true ]] && echo EXECUTE || echo DRY-RUN )), keep-list=$KEEP_LIST"
+
+# ---------------------------------------------------------------------------
+# Resolve the removal PLAN in Python (deterministic, testable). The plan is the
+# only thing that decides what gets removed; bash only executes it.
+# We pass docker inventory in on stdin so the planner is pure and unit-testable.
+# ---------------------------------------------------------------------------
+DOCKER_IMAGES_JSON="$(docker image ls --all --no-trunc --format '{{json .}}' 2>/dev/null || echo '')"
+DOCKER_PS_JSON="$(docker ps --all --no-trunc --format '{{json .}}' 2>/dev/null || echo '')"
+# Image-in-use set: every image id/ref referenced by any container.
+DOCKER_INUSE="$(docker ps --all --format '{{.Image}}' 2>/dev/null | sort -u || echo '')"
+
+PLAN_JSON="$(
+  KEEP_LIST="$KEEP_LIST" \
+  IMAGES_JSON="$DOCKER_IMAGES_JSON" \
+  PS_JSON="$DOCKER_PS_JSON" \
+  INUSE="$DOCKER_INUSE" \
+  python3 "${SCRIPT_DIR}/disk_gc_plan.py"
+)"
+
+if [[ "$EMIT_JSON" == true ]]; then
+  echo "$PLAN_JSON"
+fi
+
+# Builder cache prune (always conservative — drops only reclaimable build cache).
+# Honor min_age via docker's own filter so we don't drop a cache layer from a build
+# that's seconds old.
+MIN_AGE_DAYS="$(echo "$PLAN_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["min_age_days"])')"
+IMAGE_IDS="$(echo "$PLAN_JSON" | python3 -c 'import json,sys;[print(i) for i in json.load(sys.stdin)["remove_image_ids"]]')"
+CONTAINER_IDS="$(echo "$PLAN_JSON" | python3 -c 'import json,sys;[print(c) for c in json.load(sys.stdin)["remove_container_ids"]]')"
+
+log "Plan: $(echo "$IMAGE_IDS" | grep -c . || true) image(s), $(echo "$CONTAINER_IDS" | grep -c . || true) stopped container(s), builder cache > ${MIN_AGE_DAYS}d"
+
+if [[ "$EXECUTE" != true ]]; then
+  log "DRY-RUN — would remove the above. Re-run with --execute to act."
+  [[ -n "$IMAGE_IDS" ]] && { echo "IMAGES TO REMOVE:"; echo "$IMAGE_IDS"; } >&2
+  [[ -n "$CONTAINER_IDS" ]] && { echo "STOPPED CONTAINERS TO REMOVE:"; echo "$CONTAINER_IDS"; } >&2
+  exit 0
+fi
+
+# --- Execute ---------------------------------------------------------------
+log "Pruning builder cache older than ${MIN_AGE_DAYS}d"
+docker builder prune --force --filter "until=${MIN_AGE_DAYS}h0m0s" >>"$LOG_FILE" 2>&1 || \
+  docker builder prune --force >>"$LOG_FILE" 2>&1 || log "builder prune failed (non-fatal)"
+
+if [[ -n "$CONTAINER_IDS" ]]; then
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    if docker rm "$cid" >>"$LOG_FILE" 2>&1; then log "removed container $cid"; else log "FAILED to remove container $cid"; fi
+  done <<< "$CONTAINER_IDS"
+fi
+
+if [[ -n "$IMAGE_IDS" ]]; then
+  while IFS= read -r iid; do
+    [[ -z "$iid" ]] && continue
+    if docker rmi "$iid" >>"$LOG_FILE" 2>&1; then log "removed image $iid"; else log "kept/failed image $iid (likely still referenced)"; fi
+  done <<< "$IMAGE_IDS"
+fi
+
+log "Done. df after:"
+df -h /data 2>/dev/null | tee -a "$LOG_FILE" >&2 || df -h / | tee -a "$LOG_FILE" >&2
+exit 0

--- a/scripts/disk-gc.sh
+++ b/scripts/disk-gc.sh
@@ -77,29 +77,19 @@ docker image ls --all --no-trunc --format '{{json .}}' >"$SCRATCH/images.ndjson"
 docker ps --all --no-trunc --format '{{json .}}' >"$SCRATCH/ps.ndjson" 2>/dev/null || : >"$SCRATCH/ps.ndjson"
 docker ps --all --format '{{.Image}}' 2>/dev/null | sort -u >"$SCRATCH/inuse.txt" || : >"$SCRATCH/inuse.txt"
 
+# Build the stdin JSON envelope from the scratch files (SCRATCH_DIR env tells the
+# encoder where to read), then pipe it straight into the planner. Two simple
+# processes, no nested subprocess, no env-var size limit.
 PLAN_JSON="$(
-  KEEP_LIST="$KEEP_LIST" python3 - "$SCRATCH" "${SCRIPT_DIR}/disk_gc_plan.py" <<'PYWRAP'
-import json
-import subprocess
-import sys
-from pathlib import Path
-
-scratch = Path(sys.argv[1])
-planner = sys.argv[2]
-envelope = json.dumps(
-    {
-        "images_ndjson": (scratch / "images.ndjson").read_text(),
-        "ps_ndjson": (scratch / "ps.ndjson").read_text(),
-        "inuse": (scratch / "inuse.txt").read_text(),
-    }
-)
-proc = subprocess.run(
-    [sys.executable, planner], input=envelope, capture_output=True, text=True
-)
-sys.stderr.write(proc.stderr)
-sys.stdout.write(proc.stdout)
-sys.exit(proc.returncode)
-PYWRAP
+  SCRATCH_DIR="$SCRATCH" python3 -c '
+import json, os
+d = os.environ["SCRATCH_DIR"]
+print(json.dumps({
+    "images_ndjson": open(os.path.join(d, "images.ndjson")).read(),
+    "ps_ndjson": open(os.path.join(d, "ps.ndjson")).read(),
+    "inuse": open(os.path.join(d, "inuse.txt")).read(),
+}))
+' | KEEP_LIST="$KEEP_LIST" python3 "${SCRIPT_DIR}/disk_gc_plan.py"
 )"
 
 if [[ "$EMIT_JSON" == true ]]; then

--- a/scripts/disk-watermark-check.sh
+++ b/scripts/disk-watermark-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# disk-watermark-check.sh — Disk-usage watermark alert ratchet for .201 (OMN-13008).
+#
+# WHY: the 2026-06-11 outage had NO pre-detonation alert — /data silently filled
+# until all three lanes crashed. This is the "pages before it detonates" fix.
+#
+# Behavior (df on the target mount):
+#   usage >= warn_pct  (default 85): emit a disk-watermark bus event with
+#                       severity=warning. A downstream consumer (node_runtime_sweep
+#                       auto-ticket path) turns warning events into a Linear ticket.
+#   usage >= crit_pct  (default 90): ALSO emit severity=critical — the loud event.
+#   usage <  warn_pct : no-op (exit 0, quiet).
+#
+# The bus is the transport (ONEX doctrine): this script publishes the typed event
+# and does not itself talk to Linear. Ticket creation is the consumer's job, which
+# keeps a single auto-ticket authority (the sweep) instead of a second one here.
+#
+# Usage:
+#   ./scripts/disk-watermark-check.sh                       # check /data, publish if over
+#   ./scripts/disk-watermark-check.sh --mount /            # different mount
+#   ./scripts/disk-watermark-check.sh --warn 85 --crit 90  # thresholds
+#   ./scripts/disk-watermark-check.sh --dry-run            # print event, do NOT publish
+#
+# Exit codes: 0 ok (under warn, or published), 10 warn breached, 20 crit breached,
+#             2 bad args. (Non-zero breach codes let the timer surface state in
+#             `systemctl --user status`.)
+#
+# Runs on .201 via deploy/disk-gc.timer (shares the GC timer). Log: ~/.local/log/onex/disk-watermark.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOUNT="/data"
+WARN_PCT=85
+CRIT_PCT=90
+DRY_RUN=false
+TOPIC="onex.evt.infra.disk-watermark.v1"
+LOG_FILE="${HOME}/.local/log/onex/disk-watermark.log"
+HOSTNAME_TAG="$(hostname -s 2>/dev/null || echo unknown)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mount) MOUNT="$2"; shift 2 ;;
+    --warn) WARN_PCT="$2"; shift 2 ;;
+    --crit) CRIT_PCT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [disk-watermark] $*" | tee -a "$LOG_FILE" >&2; }
+
+# Resolve usage percentage for the mount (fall back to / if MOUNT absent).
+target="$MOUNT"
+df -P "$target" >/dev/null 2>&1 || target="/"
+USED_PCT="$(df -P "$target" | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+AVAIL_KB="$(df -P "$target" | awk 'NR==2 {print $4}')"
+
+if ! [[ "$USED_PCT" =~ ^[0-9]+$ ]]; then
+  log "ERROR: could not parse df usage for $target"
+  exit 2
+fi
+
+log "mount=$target used=${USED_PCT}% avail_kb=${AVAIL_KB} warn=${WARN_PCT} crit=${CRIT_PCT}"
+
+if (( USED_PCT < WARN_PCT )); then
+  log "under watermark — quiet"
+  exit 0
+fi
+
+SEVERITY="warning"
+EXIT_CODE=10
+if (( USED_PCT >= CRIT_PCT )); then
+  SEVERITY="critical"
+  EXIT_CODE=20
+fi
+
+# Build the typed event payload deterministically in Python so the schema is
+# stable and unit-testable.
+EVENT_JSON="$(
+  USED_PCT="$USED_PCT" AVAIL_KB="$AVAIL_KB" MOUNT="$target" \
+  SEVERITY="$SEVERITY" WARN_PCT="$WARN_PCT" CRIT_PCT="$CRIT_PCT" \
+  HOSTNAME_TAG="$HOSTNAME_TAG" TOPIC="$TOPIC" \
+  python3 "${SCRIPT_DIR}/disk_watermark_event.py"
+)"
+
+log "event: $EVENT_JSON"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "$EVENT_JSON"
+  log "DRY-RUN — not publishing (severity=$SEVERITY)"
+  exit "$EXIT_CODE"
+fi
+
+# Publish to the bus. Prefer rpk (present on .201). The broker address MUST come
+# from KAFKA_BOOTSTRAP_SERVERS — fail-fast, no localhost/default fallback (Rule 8,
+# OMN-10741). The systemd unit injects it; an operator running by hand must export
+# it. We never hardcode a broker address or LAN IP in source.
+if [[ -z "${KAFKA_BOOTSTRAP_SERVERS:-}" ]]; then
+  log "KAFKA_BOOTSTRAP_SERVERS unset — cannot publish. Event logged above for manual replay."
+  exit "$EXIT_CODE"
+fi
+BOOTSTRAP="$KAFKA_BOOTSTRAP_SERVERS"
+if command -v rpk >/dev/null 2>&1; then
+  if echo "$EVENT_JSON" | rpk topic produce "$TOPIC" --brokers "$BOOTSTRAP" >>"$LOG_FILE" 2>&1; then
+    log "published $SEVERITY event to $TOPIC via rpk"
+  else
+    log "FAILED to publish via rpk (broker=$BOOTSTRAP) — event logged above for manual replay"
+  fi
+else
+  log "rpk not found — event logged above; install rpk or wire a producer to publish"
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/disk_gc_plan.py
+++ b/scripts/disk_gc_plan.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""disk_gc_plan.py — Pure, deterministic removal-plan resolver for disk-gc.sh (OMN-13008).
+
+This module is the *only* place that decides what the .201 docker/disk GC removes.
+`disk-gc.sh` collects docker inventory and pipes it in via env vars; this planner
+emits a JSON plan; the shell only executes that plan. Keeping the decision logic
+here (not in bash) makes the safety guarantees unit-testable without docker.
+
+Inputs (all via env so the shell can hand off raw `docker ... --format '{{json .}}'`):
+  KEEP_LIST   path to keep-list.yaml
+  IMAGES_JSON newline-delimited JSON objects from `docker image ls --format '{{json .}}'`
+  PS_JSON     newline-delimited JSON objects from `docker ps -a --format '{{json .}}'`
+  INUSE       newline-delimited image refs referenced by containers (`docker ps -a {{.Image}}`)
+
+Output: a single JSON object on stdout:
+  {
+    "min_age_days": int,
+    "remove_image_ids": [str, ...],
+    "remove_container_ids": [str, ...],
+    "kept_reasons": {image_id: reason, ...}   # for dry-run transparency
+  }
+
+Safety invariants (enforced + tested in tests/unit/scripts/test_disk_gc_plan.py):
+  - never remove an image whose repo matches a keep_image_repos substring
+  - never remove an image whose tag matches keep_image_tags exactly
+  - never remove an image referenced by any container when protect_running is true
+  - never remove anything younger than min_age_days
+  - retain the newest superseded_image_keep_generations of each kept repo
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime, timezone
+from typing import Any
+
+import yaml
+
+# docker prints CreatedAt like: "2026-05-29 14:03:11 -0400 EDT"
+_CREATED_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ([+-]\d{4})")
+
+
+def _parse_created_at(value: str, now: datetime) -> float:
+    """Return age in days for a docker CreatedAt string. Unparseable → 0.0 (treat as new → keep)."""
+    if not value:
+        return 0.0
+    m = _CREATED_RE.match(value.strip())
+    if not m:
+        return 0.0
+    dt = datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M:%S %z")
+    return max(0.0, (now - dt).total_seconds() / 86400.0)
+
+
+def _load_ndjson(blob: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for line in (blob or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _repo_protected(repo: str, keep_repos: list[str]) -> bool:
+    return any(sub in repo for sub in keep_repos)
+
+
+def build_plan(
+    keep_list: dict[str, Any],
+    images: list[dict[str, Any]],
+    containers: list[dict[str, Any]],
+    inuse_refs: set[str],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Pure planner. See module docstring for invariants."""
+    now = now or datetime.now(UTC)
+
+    keep_repos: list[str] = keep_list.get("keep_image_repos", []) or []
+    keep_tags: set[str] = set(keep_list.get("keep_image_tags", []) or [])
+    protect_running: bool = bool(keep_list.get("protect_running", True))
+    keep_generations: int = int(keep_list.get("superseded_image_keep_generations", 2))
+    min_age_days: int = int(keep_list.get("min_age_days", 3))
+
+    remove_image_ids: list[str] = []
+    kept_reasons: dict[str, str] = {}
+
+    # Group superseded candidates per repo so we can keep the N newest.
+    superseded_by_repo: dict[str, list[tuple[float, str]]] = {}
+
+    for img in images:
+        image_id = img.get("ID", "") or img.get("Id", "")
+        repo = img.get("Repository", "") or ""
+        tag = img.get("Tag", "") or ""
+        created = img.get("CreatedAt", "") or ""
+        age = _parse_created_at(created, now)
+        ref = f"{repo}:{tag}" if repo and tag and repo != "<none>" else image_id
+
+        if age < min_age_days:
+            kept_reasons[image_id] = (
+                f"younger than min_age_days ({age:.1f}<{min_age_days})"
+            )
+            continue
+        if tag in keep_tags and tag and tag != "<none>":
+            kept_reasons[image_id] = f"tag '{tag}' in keep_image_tags"
+            continue
+        if protect_running and (ref in inuse_refs or image_id in inuse_refs):
+            kept_reasons[image_id] = "referenced by a container (protect_running)"
+            continue
+
+        is_dangling = repo == "<none>" or repo == "" or tag == "<none>"
+
+        if is_dangling:
+            # Dangling + old + not in use → safe to remove.
+            remove_image_ids.append(image_id)
+            continue
+
+        if _repo_protected(repo, keep_repos):
+            # Kept repo: this is a superseded generation candidate (older than
+            # min_age, not a keep_tag, not in use). Defer to per-repo retention.
+            superseded_by_repo.setdefault(repo, []).append((age, image_id))
+            continue
+
+        # Untracked repo, old, not in use, not dangling. Conservative default:
+        # KEEP. We only reap explicitly-tracked (keep_image_repos) superseded
+        # generations and dangling images, never random third-party images.
+        kept_reasons[image_id] = "repo not in keep_image_repos (conservative keep)"
+
+    # Per-repo retention: keep the newest `keep_generations`, mark the rest for removal.
+    for repo, entries in superseded_by_repo.items():
+        # newest first (smallest age first)
+        entries.sort(key=lambda e: e[0])
+        for idx, (age, image_id) in enumerate(entries):
+            if idx < keep_generations:
+                kept_reasons[image_id] = (
+                    f"within newest {keep_generations} generations of '{repo}'"
+                )
+            else:
+                remove_image_ids.append(image_id)
+
+    # Stopped containers older than min_age_days are removable.
+    remove_container_ids: list[str] = []
+    for c in containers:
+        state = (c.get("State", "") or "").lower()
+        status = (c.get("Status", "") or "").lower()
+        created = c.get("CreatedAt", "") or ""
+        cid = c.get("ID", "") or c.get("Id", "")
+        is_stopped = state in {"exited", "dead", "created"} or status.startswith(
+            "exited"
+        )
+        if not is_stopped:
+            continue
+        if _parse_created_at(created, now) < min_age_days:
+            continue
+        remove_container_ids.append(cid)
+
+    return {
+        "min_age_days": min_age_days,
+        "remove_image_ids": remove_image_ids,
+        "remove_container_ids": remove_container_ids,
+        "kept_reasons": kept_reasons,
+    }
+
+
+def main() -> int:
+    keep_list_path = os.environ["KEEP_LIST"]
+    with open(keep_list_path, encoding="utf-8") as fh:
+        keep_list = yaml.safe_load(fh) or {}
+
+    images = _load_ndjson(os.environ.get("IMAGES_JSON", ""))
+    containers = _load_ndjson(os.environ.get("PS_JSON", ""))
+    inuse = {
+        line.strip()
+        for line in os.environ.get("INUSE", "").splitlines()
+        if line.strip()
+    }
+
+    plan = build_plan(keep_list, images, containers, inuse)
+    json.dump(plan, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/disk_gc_plan.py
+++ b/scripts/disk_gc_plan.py
@@ -163,6 +163,21 @@ def build_plan(
             continue
         remove_container_ids.append(cid)
 
+    # Reconcile: the SAME image id can surface in multiple `docker image ls` rows
+    # (one per repo:tag). If any row produced a keep reason for an id, KEEP WINS —
+    # a protected id must never be in the remove list even if another tag routed it
+    # to removal. Also dedupe while preserving order.
+    seen: set[str] = set()
+    safe_remove: list[str] = []
+    for image_id in remove_image_ids:
+        if image_id in kept_reasons:
+            continue
+        if image_id in seen:
+            continue
+        seen.add(image_id)
+        safe_remove.append(image_id)
+    remove_image_ids = safe_remove
+
     return {
         "min_age_days": min_age_days,
         "remove_image_ids": remove_image_ids,

--- a/scripts/disk_gc_plan.py
+++ b/scripts/disk_gc_plan.py
@@ -8,11 +8,13 @@ This module is the *only* place that decides what the .201 docker/disk GC remove
 emits a JSON plan; the shell only executes that plan. Keeping the decision logic
 here (not in bash) makes the safety guarantees unit-testable without docker.
 
-Inputs (all via env so the shell can hand off raw `docker ... --format '{{json .}}'`):
-  KEEP_LIST   path to keep-list.yaml
-  IMAGES_JSON newline-delimited JSON objects from `docker image ls --format '{{json .}}'`
-  PS_JSON     newline-delimited JSON objects from `docker ps -a --format '{{json .}}'`
-  INUSE       newline-delimited image refs referenced by containers (`docker ps -a {{.Image}}`)
+Inputs:
+  KEEP_LIST  (env)   path to keep-list.yaml (small — env is fine)
+  stdin      (JSON)  {"images_ndjson": "...", "ps_ndjson": "...", "inuse": "..."}
+                     where each value is the raw multi-line output of the matching
+                     `docker ... --format '{{json .}}'` command. Inventory is passed
+                     on stdin (NOT env) because a host with many images blows past
+                     ARG_MAX when the blobs are env vars (`Argument list too long`).
 
 Output: a single JSON object on stdout:
   {
@@ -174,12 +176,13 @@ def main() -> int:
     with open(keep_list_path, encoding="utf-8") as fh:
         keep_list = yaml.safe_load(fh) or {}
 
-    images = _load_ndjson(os.environ.get("IMAGES_JSON", ""))
-    containers = _load_ndjson(os.environ.get("PS_JSON", ""))
+    raw = sys.stdin.read()
+    payload = json.loads(raw) if raw.strip() else {}
+
+    images = _load_ndjson(payload.get("images_ndjson", ""))
+    containers = _load_ndjson(payload.get("ps_ndjson", ""))
     inuse = {
-        line.strip()
-        for line in os.environ.get("INUSE", "").splitlines()
-        if line.strip()
+        line.strip() for line in payload.get("inuse", "").splitlines() if line.strip()
     }
 
     plan = build_plan(keep_list, images, containers, inuse)

--- a/scripts/disk_watermark_event.py
+++ b/scripts/disk_watermark_event.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""disk_watermark_event.py — Build the typed disk-watermark bus event (OMN-13008).
+
+Pure builder so the event schema is deterministic and unit-testable. Reads the
+measured values from env (the shell measures via df) and emits one JSON object
+on stdout for `rpk topic produce` to publish to onex.evt.infra.disk-watermark.v1.
+
+The event is the alert authority: a downstream consumer (node_runtime_sweep
+auto-ticket path) creates the Linear ticket on `severity=warning`, and operators
+get the loud signal on `severity=critical`. This keeps a single ticket-creation
+authority rather than letting every cron script talk to Linear directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timezone
+
+
+def build_event(
+    *,
+    mount: str,
+    used_pct: int,
+    avail_kb: int,
+    severity: str,
+    warn_pct: int,
+    crit_pct: int,
+    host: str,
+    topic: str,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Construct the typed disk-watermark event payload."""
+    now = now or datetime.now(UTC)
+    if severity not in {"warning", "critical"}:
+        raise ValueError(f"severity must be 'warning' or 'critical', got {severity!r}")
+    return {
+        "schema_version": "1.0.0",
+        "event_type": "disk-watermark",
+        "topic": topic,
+        "host": host,
+        "mount": mount,
+        "used_pct": used_pct,
+        "avail_kb": avail_kb,
+        "warn_pct": warn_pct,
+        "crit_pct": crit_pct,
+        "severity": severity,
+        "emitted_at": now.isoformat(),
+        # Stable dedupe key so the consumer can collapse repeated alerts for the
+        # same host/mount/severity into one open ticket instead of N.
+        "alert_key": f"disk-watermark:{host}:{mount}:{severity}",
+        "message": (
+            f"{host}:{mount} at {used_pct}% used (warn>={warn_pct}%, crit>={crit_pct}%) "
+            f"severity={severity}"
+        ),
+    }
+
+
+def main() -> int:
+    event = build_event(
+        mount=os.environ["MOUNT"],
+        used_pct=int(os.environ["USED_PCT"]),
+        avail_kb=int(os.environ["AVAIL_KB"]),
+        severity=os.environ["SEVERITY"],
+        warn_pct=int(os.environ["WARN_PCT"]),
+        crit_pct=int(os.environ["CRIT_PCT"]),
+        host=os.environ["HOSTNAME_TAG"],
+        topic=os.environ["TOPIC"],
+    )
+    json.dump(event, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/worktree-gc.sh
+++ b/scripts/worktree-gc.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# worktree-gc.sh — Merge-triggered worktree GC driver (OMN-13008).
+#
+# WHY: stale worktrees for already-merged PRs accumulate under the worktrees root
+# and (alongside docker images) filled /data on .201 on 2026-06-11. This driver
+# garbage-collects them on a schedule, removing ONLY worktrees whose PR is merged
+# (or whose remote branch is gone) AND that are clean AND fully pushed.
+#
+# It does NOT reimplement the safety logic — it drives the canonical
+# omniclaude/scripts/prune-worktrees.sh, which already enforces:
+#   - remove only if PR MERGED or remote branch gone
+#   - SKIP if working tree dirty
+#   - SKIP if unpushed commits (no-upstream defaults to SKIP, never DELETE)
+#
+# This is the single GC core used on BOTH machines:
+#   - Mac: invoked from the merge-sweep CronCreate tick path (launchd does not fire
+#     on this Mac; session crons are the working scheduler).
+#   - .201: invoked from deploy/worktree-gc.timer (systemd user timer) against
+#     /data/omninode/omni_worktrees.
+#
+# Usage:
+#   ./scripts/worktree-gc.sh                          # DRY RUN (default)
+#   ./scripts/worktree-gc.sh --execute                # actually prune merged worktrees
+#   ./scripts/worktree-gc.sh --worktrees-root <path>  # override (default: $OMNI_HOME/omni_worktrees)
+#   ./scripts/worktree-gc.sh --prune-script <path>    # override path to prune-worktrees.sh
+#
+# Exit codes: 0 success, 2 bad args, 3 prune script not found.
+#
+# Log: ~/.local/log/onex/worktree-gc.log
+
+set -euo pipefail
+
+EXECUTE=false
+# Resolve OMNI_HOME fail-fast-ish: prefer env, else derive from this script's repo root.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"           # .../omnibase_infra
+DEFAULT_OMNI_HOME="$(cd "$REPO_ROOT/.." && pwd)"    # .../omni_home (canonical registry sibling layout)
+OMNI_HOME="${OMNI_HOME:-$DEFAULT_OMNI_HOME}"
+
+WORKTREES_ROOT="${ONEX_WORKTREES_ROOT:-$OMNI_HOME/omni_worktrees}"
+# prune-worktrees.sh lives in the omniclaude canonical clone next to omnibase_infra.
+PRUNE_SCRIPT="${OMNI_HOME}/omniclaude/scripts/prune-worktrees.sh"
+LOG_FILE="${HOME}/.local/log/onex/worktree-gc.log"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --execute) EXECUTE=true; shift ;;
+    --worktrees-root) WORKTREES_ROOT="$2"; shift 2 ;;
+    --prune-script) PRUNE_SCRIPT="$2"; shift 2 ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [worktree-gc] $*" | tee -a "$LOG_FILE" >&2; }
+
+if [[ ! -f "$PRUNE_SCRIPT" ]]; then
+  log "ERROR: prune script not found at $PRUNE_SCRIPT (set --prune-script or OMNI_HOME)"
+  exit 3
+fi
+if [[ ! -d "$WORKTREES_ROOT" ]]; then
+  log "worktrees root absent: $WORKTREES_ROOT — nothing to GC"
+  exit 0
+fi
+
+log "Starting ($( [[ "$EXECUTE" == true ]] && echo EXECUTE || echo DRY-RUN )), root=$WORKTREES_ROOT"
+
+ARGS=(--worktrees-root "$WORKTREES_ROOT")
+[[ "$EXECUTE" == true ]] && ARGS+=(--execute)
+
+# Drive the canonical prune script. Its own safety checks are authoritative.
+bash "$PRUNE_SCRIPT" "${ARGS[@]}" 2>&1 | tee -a "$LOG_FILE"
+
+log "Done."

--- a/tests/unit/scripts/test_disk_gc_dry_run.py
+++ b/tests/unit/scripts/test_disk_gc_dry_run.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dry-run safety smoke tests for the GC shell scripts (OMN-13008).
+
+The single most important property: in DEFAULT (dry-run) mode the scripts must
+NEVER call a destructive docker/git subcommand. We prove this by shimming `docker`,
+`git`, and `rpk` on PATH with a recorder that logs every invocation, then asserting
+no destructive verb (rmi, rm, prune, produce, 'worktree remove') was issued.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCRIPTS = _REPO / "scripts"
+
+DESTRUCTIVE_TOKENS = ("rmi", "prune", "produce", "remove", "rm ")
+
+
+def _make_shim(bin_dir: Path, name: str, calllog: Path) -> None:
+    """Create an executable shim that records its argv and exits 0 with empty output."""
+    shim = bin_dir / name
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "{name} $*" >> "{calllog}"\n'
+        # image ls / ps queries must return empty so planner produces an empty plan.
+        "exit 0\n"
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(
+    script: str, args: list[str], tmp_path: Path
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    calllog = tmp_path / "calls.log"
+    calllog.write_text("")
+    for tool in ("docker", "git", "rpk"):
+        _make_shim(bin_dir, tool, calllog)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HOME"] = str(tmp_path)  # redirect log files into tmp
+    # Ensure no ambient broker leaks in — fail-fast publish path must stay quiet.
+    env.pop("KAFKA_BOOTSTRAP_SERVERS", None)
+    proc = subprocess.run(
+        ["bash", str(_SCRIPTS / script), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+        check=False,
+    )
+    return proc, calllog.read_text()
+
+
+@pytest.mark.unit
+class TestGcDryRunSafety:
+    def test_disk_gc_default_is_dry_run_no_destructive_calls(
+        self, tmp_path: Path
+    ) -> None:
+        proc, calls = _run("disk-gc.sh", [], tmp_path)
+        assert proc.returncode == 0, proc.stderr
+        for tok in DESTRUCTIVE_TOKENS:
+            assert tok not in calls, (
+                f"dry-run issued destructive docker/git op: {tok!r}\n{calls}"
+            )
+
+    def test_watermark_dry_run_does_not_produce_to_bus(self, tmp_path: Path) -> None:
+        # Force a breach against a tiny mount-independent threshold so the event
+        # path runs, but --dry-run must NOT call `rpk ... produce`.
+        proc, calls = _run(
+            "disk-watermark-check.sh",
+            ["--mount", "/", "--warn", "0", "--crit", "0", "--dry-run"],
+            tmp_path,
+        )
+        # Breach with crit=0 → exit 20, but dry-run means no publish.
+        assert proc.returncode == 20, proc.stderr
+        assert "produce" not in calls, f"dry-run published to bus:\n{calls}"
+        assert '"severity": "critical"' in proc.stdout
+
+    def test_watermark_breach_without_broker_does_not_publish(
+        self, tmp_path: Path
+    ) -> None:
+        # Real (non-dry-run) breach but KAFKA_BOOTSTRAP_SERVERS unset → fail-fast:
+        # the script must NOT fall back to a default broker and must NOT call produce.
+        proc, calls = _run(
+            "disk-watermark-check.sh",
+            ["--mount", "/", "--warn", "0", "--crit", "0"],
+            tmp_path,
+        )
+        assert proc.returncode == 20, proc.stderr
+        assert "produce" not in calls, f"published with no broker configured:\n{calls}"
+
+    def test_watermark_under_threshold_is_quiet(self, tmp_path: Path) -> None:
+        proc, calls = _run(
+            "disk-watermark-check.sh",
+            ["--mount", "/", "--warn", "100", "--crit", "100"],
+            tmp_path,
+        )
+        # warn=100 can only breach at exactly 100%; on a normal test host it stays quiet.
+        if proc.returncode == 0:
+            assert "produce" not in calls
+
+    def test_worktree_gc_default_dry_run_passes_no_execute(
+        self, tmp_path: Path
+    ) -> None:
+        # Point at an empty worktrees root and a stub prune script that records args.
+        wt_root = tmp_path / "wt"
+        wt_root.mkdir()
+        prune = tmp_path / "prune-worktrees.sh"
+        prune.write_text(
+            "#!/usr/bin/env bash\n"
+            f'echo "prune $*" >> "{tmp_path / "prune-calls.log"}"\n'
+            "exit 0\n"
+        )
+        prune.chmod(0o755)
+        proc, _ = _run(
+            "worktree-gc.sh",
+            ["--worktrees-root", str(wt_root), "--prune-script", str(prune)],
+            tmp_path,
+        )
+        assert proc.returncode == 0, proc.stderr
+        prune_calls = (tmp_path / "prune-calls.log").read_text()
+        # Default mode must NOT pass --execute to the prune script.
+        assert "--execute" not in prune_calls, prune_calls
+
+    def test_worktree_gc_execute_forwards_execute_flag(self, tmp_path: Path) -> None:
+        wt_root = tmp_path / "wt"
+        wt_root.mkdir()
+        prune = tmp_path / "prune-worktrees.sh"
+        prune.write_text(
+            "#!/usr/bin/env bash\n"
+            f'echo "prune $*" >> "{tmp_path / "prune-calls.log"}"\n'
+            "exit 0\n"
+        )
+        prune.chmod(0o755)
+        proc, _ = _run(
+            "worktree-gc.sh",
+            [
+                "--execute",
+                "--worktrees-root",
+                str(wt_root),
+                "--prune-script",
+                str(prune),
+            ],
+            tmp_path,
+        )
+        assert proc.returncode == 0, proc.stderr
+        prune_calls = (tmp_path / "prune-calls.log").read_text()
+        assert "--execute" in prune_calls, prune_calls

--- a/tests/unit/scripts/test_disk_gc_plan.py
+++ b/tests/unit/scripts/test_disk_gc_plan.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Safety tests for the .201 disk-GC removal planner (OMN-13008).
+
+A GC bug that deletes the wrong thing is worse than no GC. These tests pin the
+removal-plan invariants of scripts/disk_gc_plan.py WITHOUT touching docker:
+the planner is pure (inventory in, plan out), so we can prove it never reaps a
+kept repo, a kept tag, an in-use image, or a too-young artifact.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "disk_gc_plan", _SCRIPTS / "disk_gc_plan.py"
+)
+assert _spec and _spec.loader
+disk_gc_plan = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(disk_gc_plan)
+
+NOW = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+
+
+def _created(days_ago: float) -> str:
+    """A docker CreatedAt string `days_ago` days before NOW."""
+    ts = NOW.timestamp() - days_ago * 86400.0
+    dt = datetime.fromtimestamp(ts, tz=UTC)
+    # docker prints e.g. "2026-05-29 14:03:11 +0000 UTC"
+    return dt.strftime("%Y-%m-%d %H:%M:%S +0000 UTC")
+
+
+KEEP_LIST = {
+    "keep_image_repos": ["omninode-runtime", "postgres"],
+    "keep_image_tags": ["latest", "rollback"],
+    "protect_running": True,
+    "superseded_image_keep_generations": 2,
+    "min_age_days": 3,
+}
+
+
+def _img(image_id: str, repo: str, tag: str, days_ago: float) -> dict[str, str]:
+    return {
+        "ID": image_id,
+        "Repository": repo,
+        "Tag": tag,
+        "CreatedAt": _created(days_ago),
+    }
+
+
+@pytest.mark.unit
+class TestDiskGcPlanSafety:
+    def test_dangling_old_image_is_removed(self) -> None:
+        images = [_img("sha-dangle", "<none>", "<none>", days_ago=10)]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert "sha-dangle" in plan["remove_image_ids"]
+
+    def test_young_dangling_image_is_kept(self) -> None:
+        images = [_img("sha-young", "<none>", "<none>", days_ago=1)]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert plan["remove_image_ids"] == []
+
+    def test_keep_repo_never_removed_regardless_of_age(self) -> None:
+        # An old postgres image (keep repo) must never be reaped.
+        images = [_img("sha-pg", "postgres", "16", days_ago=400)]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert "sha-pg" not in plan["remove_image_ids"]
+
+    def test_keep_tag_never_removed(self) -> None:
+        images = [_img("sha-latest", "omninode-runtime", "latest", days_ago=400)]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert "sha-latest" not in plan["remove_image_ids"]
+
+    def test_in_use_image_protected_when_protect_running(self) -> None:
+        images = [_img("sha-live", "omninode-runtime", "v0.40.0", days_ago=30)]
+        inuse = {"omninode-runtime:v0.40.0"}
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], inuse, now=NOW)
+        assert "sha-live" not in plan["remove_image_ids"]
+
+    def test_superseded_keeps_newest_n_generations(self) -> None:
+        # Five old generations of a kept repo, none in use, none keep-tagged.
+        # Keep newest 2, remove the 3 oldest.
+        images = [
+            _img("g1", "omninode-runtime", "v0.41.0", days_ago=4),
+            _img("g2", "omninode-runtime", "v0.40.0", days_ago=10),
+            _img("g3", "omninode-runtime", "v0.39.0", days_ago=20),
+            _img("g4", "omninode-runtime", "v0.38.0", days_ago=30),
+            _img("g5", "omninode-runtime", "v0.37.0", days_ago=40),
+        ]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert "g1" not in plan["remove_image_ids"]  # newest
+        assert "g2" not in plan["remove_image_ids"]  # 2nd newest
+        assert set(plan["remove_image_ids"]) == {"g3", "g4", "g5"}
+
+    def test_untracked_third_party_repo_is_conservatively_kept(self) -> None:
+        # An old non-keep, non-dangling image we don't track: do NOT remove.
+        images = [_img("sha-other", "some/random-tool", "1.2.3", days_ago=99)]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert plan["remove_image_ids"] == []
+
+    def test_stopped_old_container_removed_running_kept(self) -> None:
+        containers = [
+            {
+                "ID": "c-old",
+                "State": "exited",
+                "Status": "Exited (0) 5 days ago",
+                "CreatedAt": _created(5),
+            },
+            {
+                "ID": "c-run",
+                "State": "running",
+                "Status": "Up 5 days",
+                "CreatedAt": _created(5),
+            },
+            {
+                "ID": "c-young",
+                "State": "exited",
+                "Status": "Exited (0) 1 hour ago",
+                "CreatedAt": _created(0.04),
+            },
+        ]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, [], containers, set(), now=NOW)
+        assert plan["remove_container_ids"] == ["c-old"]
+
+    def test_empty_inventory_is_noop(self) -> None:
+        plan = disk_gc_plan.build_plan(KEEP_LIST, [], [], set(), now=NOW)
+        assert plan["remove_image_ids"] == []
+        assert plan["remove_container_ids"] == []
+
+    def test_min_age_days_surfaced_in_plan(self) -> None:
+        plan = disk_gc_plan.build_plan(KEEP_LIST, [], [], set(), now=NOW)
+        assert plan["min_age_days"] == 3

--- a/tests/unit/scripts/test_disk_gc_plan.py
+++ b/tests/unit/scripts/test_disk_gc_plan.py
@@ -136,3 +136,26 @@ class TestDiskGcPlanSafety:
     def test_min_age_days_surfaced_in_plan(self) -> None:
         plan = disk_gc_plan.build_plan(KEEP_LIST, [], [], set(), now=NOW)
         assert plan["min_age_days"] == 3
+
+    def test_keep_wins_when_same_id_appears_as_dangling_and_kept(self) -> None:
+        # The SAME image id surfaces twice: once as an old dangling row (→ remove
+        # path) and once tagged 'latest' (→ keep path). Keep must win; the id must
+        # NOT appear in remove_image_ids.
+        shared = "sha-shared"
+        images = [
+            _img(shared, "<none>", "<none>", days_ago=10),
+            _img(shared, "omninode-runtime", "latest", days_ago=10),
+        ]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert shared not in plan["remove_image_ids"]
+        assert shared in plan["kept_reasons"]
+
+    def test_remove_image_ids_are_deduped(self) -> None:
+        # Same id as two old dangling rows must appear at most once in the plan.
+        dup = "sha-dup"
+        images = [
+            _img(dup, "<none>", "<none>", days_ago=10),
+            _img(dup, "<none>", "<none>", days_ago=12),
+        ]
+        plan = disk_gc_plan.build_plan(KEEP_LIST, images, [], set(), now=NOW)
+        assert plan["remove_image_ids"].count(dup) == 1

--- a/tests/unit/scripts/test_disk_watermark_event.py
+++ b/tests/unit/scripts/test_disk_watermark_event.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the disk-watermark bus event builder (OMN-13008)."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "disk_watermark_event", _SCRIPTS / "disk_watermark_event.py"
+)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+NOW = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+TOPIC = "onex.evt.infra.disk-watermark.v1"
+
+
+@pytest.mark.unit
+class TestDiskWatermarkEvent:
+    def _build(self, *, used_pct: int, severity: str) -> dict[str, object]:
+        return mod.build_event(
+            mount="/data",
+            used_pct=used_pct,
+            avail_kb=123456,
+            severity=severity,
+            warn_pct=85,
+            crit_pct=90,
+            host="server201",
+            topic=TOPIC,
+            now=NOW,
+        )
+
+    def test_warning_event_shape(self) -> None:
+        ev = self._build(used_pct=87, severity="warning")
+        assert ev["severity"] == "warning"
+        assert ev["used_pct"] == 87
+        assert ev["topic"] == TOPIC
+        assert ev["event_type"] == "disk-watermark"
+        assert ev["schema_version"] == "1.0.0"
+        assert ev["emitted_at"] == NOW.isoformat()
+
+    def test_critical_event_shape(self) -> None:
+        ev = self._build(used_pct=95, severity="critical")
+        assert ev["severity"] == "critical"
+        assert ev["used_pct"] == 95
+
+    def test_alert_key_is_stable_dedupe_key(self) -> None:
+        a = self._build(used_pct=87, severity="warning")
+        b = self._build(used_pct=88, severity="warning")
+        # Same host/mount/severity collapses to one open ticket.
+        assert (
+            a["alert_key"] == b["alert_key"] == "disk-watermark:server201:/data:warning"
+        )
+
+    def test_invalid_severity_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            self._build(used_pct=50, severity="info")


### PR DESCRIPTION
## OMN-13008 — Automated .201 disk maintenance (worktree GC + docker GC + watermark ratchet)

Builds the automation requested after the 2026-06-11 incident: `/data` on .201 hit ~95% (weeks of unpruned docker images + accumulated stale worktrees) and killed all three runtime lanes mid-demo-day. There was no automatic GC and no pre-detonation alert. This is the durable fix.

### What ships (canonical-architecture-first — reuse, not reinvent)
- **Merge-triggered worktree GC** — `scripts/worktree-gc.sh` drives the canonical `omniclaude/scripts/prune-worktrees.sh` (which already enforces: remove only if PR MERGED / remote branch gone AND clean AND fully pushed; no-upstream → SKIP). Same GC core on **both** machines: Mac via the merge-sweep CronCreate tick path; .201 via the systemd user timer against `/data/omninode/omni_worktrees`.
- **Conservative docker/disk GC** — `scripts/disk-gc.sh` + pure `scripts/disk_gc_plan.py` planner. Honors a **versioned keep-list** (`deploy/disk-gc/keep-list.yaml`, not hardcoded): never reaps a kept repo, a kept tag, an in-use image, or anything younger than `min_age_days`; keeps the newest N superseded generations as rollback targets. Builder cache + dangling images + stopped containers only.
- **Watermark alert ratchet** — `scripts/disk-watermark-check.sh` + `scripts/disk_watermark_event.py`. `df /data` → ≥85% emits a typed `onex.evt.infra.disk-watermark.v1` event (severity `warning`) that the sweep auto-ticket path turns into a Linear ticket; ≥90% emits `critical` (the loud event). Broker address is **fail-fast** from `KAFKA_BOOTSTRAP_SERVERS` (no localhost/default — passes the `no-env-fallbacks` gate).
- **Deploy surface** — `deploy/disk-gc/onex-disk-gc.{service,timer}` (systemd **user** units, hourly) + `install-disk-gc.sh`. User units are NOT lane containers; installing them does not touch any compose lane.

### Safety (a wrong-delete GC is worse than no GC)
20 unit tests, including:
- `test_disk_gc_plan.py` — pins removal-plan invariants (kept repo/tag/in-use/too-young never reaped; superseded retention) without touching docker.
- `test_disk_gc_dry_run.py` — proves default/dry-run mode issues **no** destructive docker/git/rpk op (PATH-shim recorder), and that `--execute` correctly forwards.
- `test_disk_watermark_event.py` — typed event shape + stable dedupe `alert_key`.

### Evidence
- `uv run pytest tests/unit/scripts/test_disk_gc_plan.py tests/unit/scripts/test_disk_gc_dry_run.py tests/unit/scripts/test_disk_watermark_event.py -q` → 20 passed
- `mypy --strict` clean on both Python modules; `ruff` clean; `shellcheck` clean; `pre-commit` clean on all 13 files.

Ticket: OMN-13008






Evidence-Ticket: OMN-13008
Evidence-Source: a5bfed01eaa98d9c1e12fd4052cb9c7eb924b602
