### PR TITLE
fix(OMN-13012): two-phase (seek-now/wait-later) terminal event_consumer to close subscribe-after-publish race

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -99,6 +99,9 @@ if TYPE_CHECKING:
     from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
         ProtocolPatternBBrokerTransport,
     )
+    from omnibase_infra.runtime.service_terminal_event_consumer import (
+        TerminalEventConsumer,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -1603,20 +1606,27 @@ def _make_sync_event_consumer(
     *,
     event_bus: object,
     handler_name: str,
-) -> Callable[[str, str, float], dict[str, object] | None]:
+) -> TerminalEventConsumer:
     """Materialize the blocking terminal-event consumer for request/response handlers.
 
     Mirror of ``_make_sync_event_publisher`` for the consume leg. Some EFFECT
     handlers (e.g. ``HandlerContextRoiRunner``, OMN-13005) publish a command and
     then block on the correlated terminal event, reading result fields back from
-    its payload. They declare an injectable ``event_consumer`` with the sync shape
-    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``.
+    its payload. They declare an injectable ``event_consumer``.
+
+    The returned object is directly callable with the legacy single-call shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None`` and also
+    exposes ``.open(topic) -> TerminalConsumerSession`` for the two-phase
+    (subscribe-before-publish) protocol introduced in OMN-13012: the handler
+    positions the consumer (assign + seek_to_end) BEFORE publishing its command,
+    then waits AFTER, so a terminal emitted in the publish→wait gap is not seeked
+    past.
 
     Without this injection the handler falls back to its own no-op default that
     returns ``None`` immediately — never honoring the timeout, so every result
     row is a degenerate generation-failure even though the terminal event arrives
-    moments later. The concrete consumer here runs the correlate-and-wait loop on
-    an isolated event loop in a worker thread so blocking does not deadlock the
+    moments later. The concrete consumer runs the correlate-and-wait loop on an
+    isolated event loop in a worker thread so blocking does not deadlock the
     runtime dispatch loop that delivers the awaited terminal.
     """
     from omnibase_infra.runtime.service_terminal_event_consumer import (

--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""One-shot blocking terminal-event consumer for auto-wired effect handlers.
+"""Blocking terminal-event consumer for auto-wired request/response EFFECT handlers.
 
 Some EFFECT handlers drive a request/response interaction over the bus: they
 publish a command, then block until the correlated terminal event arrives on a
@@ -10,15 +10,50 @@ from that terminal payload. ``HandlerContextRoiRunner`` is the motivating case
 correlated ``node-generation-completed.v1`` terminal before recording an
 attempt-reduction row.
 
-These handlers declare an injectable ``event_consumer`` with the synchronous
-shape ``(topic, correlation_id, timeout_seconds) -> dict | None``. The runtime
-auto-wiring (``handler_wiring.py``) materializes a concrete consumer through
-``make_terminal_event_consumer`` so the handler never imports Kafka. This mirrors
-the existing ``event_publisher`` injection (``_make_sync_event_publisher``).
+These handlers declare an injectable ``event_consumer`` materialized by the
+runtime auto-wiring (``handler_wiring.py``) through ``make_terminal_event_consumer``
+so the handler never imports Kafka. This mirrors the existing ``event_publisher``
+injection (``_make_sync_event_publisher``).
+
+Two-phase (subscribe-before-publish) — OMN-13012
+------------------------------------------------
+The single-call form ``consumer(topic, cid, timeout)`` does
+``assign → seek_to_end → poll`` internally, all AFTER the handler has already
+published its command. Once the dispatch-loop starvation was removed (OMN-13010),
+generation completes in ~1s, so the correlated terminal is published BEFORE the
+single-call consumer's post-publish ``seek_to_end`` positions — and ``seek_to_end``
+skips PAST the already-emitted terminal, which the runner then never sees. The
+runner waits the full timeout on an offset beyond the terminal and times out
+(probe3, ``run_id=20260611T2140Z-probe3``).
+
+The fix splits positioning from waiting so the caller can subscribe BEFORE it
+publishes:
+
+  - ``session = consumer.open(topic)`` — start the ephemeral consumer, assign the
+    reply-topic partitions, and ``seek_to_end`` NOW (records the pre-publish
+    high-water-mark as the resume position). Call this BEFORE publishing.
+  - ``payload = session.wait(correlation_id, timeout)`` — block up to ``timeout``
+    polling from the position captured at ``open``, returning the correlated
+    terminal payload or ``None`` on genuine timeout. Call this AFTER publishing.
+  - ``session.close()`` — stop the consumer (``wait`` closes automatically;
+    ``close`` is also idempotent for explicit/early teardown).
+
+Because the cursor is positioned at ``open`` time (before publish), a terminal
+emitted in the publish→wait gap is still on an offset at-or-after the captured
+position and is delivered to ``wait``. ``open`` is also used as a context manager.
+
+Backward compatibility
+-----------------------
+The object returned by ``make_terminal_event_consumer`` is still directly callable
+with the legacy single-call shape ``(topic, cid, timeout) -> dict | None`` for any
+consumer that does not need subscribe-before-publish. The single-call form simply
+opens a session and waits in one step (seek happens at call time, after the
+caller's publish — the original, race-prone behavior, retained only for callers
+that do not care about the race).
 
 Architecture (ARCH-002 — "runtime owns all Kafka plumbing"):
-  - Nodes/handlers declare the consume requirement in their contract and call a
-    sync ``event_consumer``; they never touch ``AIOKafkaConsumer``.
+  - Nodes/handlers declare the consume requirement in their contract and call the
+    injected ``event_consumer``; they never touch ``AIOKafkaConsumer``.
   - The correlate-and-wait loop here is the same proven shape used by
     ``RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer``:
     assign reply-topic partitions, seek to end, then poll until a message whose
@@ -28,10 +63,11 @@ Loop isolation (why a worker thread):
   The auto-wired dispatch callback invokes a sync handler ``handle()`` directly
   on the runtime's running event loop. A blocking Kafka correlate cannot run on
   that same loop (it would deadlock, and ``asyncio.run()`` raises inside a
-  running loop). The sync adapter therefore runs the async correlate coroutine
-  on a dedicated event loop in a separate thread and blocks the calling thread
-  on the result. The dispatch loop stays free to deliver the very terminal event
-  the handler is waiting for.
+  running loop). The session therefore owns a dedicated event loop running in a
+  separate daemon thread for the whole ``open``→``wait``→``close`` lifecycle, and
+  the sync methods block the calling thread on coroutines submitted to that loop.
+  The dispatch loop stays free to deliver the very terminal event the handler is
+  waiting for.
 """
 
 from __future__ import annotations
@@ -40,7 +76,9 @@ import asyncio
 import json
 import logging
 import threading
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Coroutine, Mapping
+from concurrent.futures import Future
+from types import TracebackType
 from typing import cast
 
 from aiokafka import AIOKafkaConsumer, TopicPartition
@@ -61,6 +99,10 @@ _METADATA_POLL_INTERVAL_SECONDS = 0.05
 _DEFAULT_SESSION_TIMEOUT_MS = 45000
 _DEFAULT_HEARTBEAT_INTERVAL_MS = 15000
 _DEFAULT_MAX_POLL_INTERVAL_MS = 300000
+
+# Grace beyond a submitted coroutine's own timeout so a clean Kafka shutdown
+# completes before the calling thread gives up on the worker loop.
+_LOOP_SUBMIT_GRACE_SECONDS = 5.0
 
 
 def _bootstrap_servers(event_bus: object) -> str:
@@ -88,22 +130,8 @@ def _extract_correlation_id(payload: dict[str, object]) -> str | None:
     return str(value)
 
 
-async def _await_correlated_terminal(
-    *,
-    event_bus: object,
-    terminal_topic: str,
-    correlation_id: str,
-    timeout_seconds: float,
-) -> dict[str, object] | None:
-    """Block up to ``timeout_seconds`` for the correlated terminal payload.
-
-    Returns the deserialized terminal event body whose ``correlation_id`` matches
-    the request, or ``None`` on genuine timeout. Uses an ephemeral group-less
-    consumer (``group_id=None``) assigned directly to the reply topic's
-    partitions and seeked to end, so it only sees terminals produced after the
-    handler published its command.
-    """
-    consumer = AIOKafkaConsumer(
+def _build_consumer(event_bus: object) -> AIOKafkaConsumer:
+    return AIOKafkaConsumer(
         bootstrap_servers=_bootstrap_servers(event_bus),
         group_id=None,
         enable_auto_commit=False,
@@ -113,40 +141,6 @@ async def _await_correlated_terminal(
         max_poll_interval_ms=_DEFAULT_MAX_POLL_INTERVAL_MS,
         **_auth_kwargs(event_bus),
     )
-
-    loop = asyncio.get_running_loop()
-    try:
-        assign_cap = min(_ASSIGN_TIMEOUT_CAP_SECONDS, timeout_seconds)
-        await asyncio.wait_for(consumer.start(), timeout=assign_cap)
-        await _assign_terminal_partitions(consumer, terminal_topic, assign_cap)
-        await consumer.seek_to_end(*consumer.assignment())
-
-        deadline = loop.time() + timeout_seconds
-        while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return None
-            try:
-                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
-            except TimeoutError:
-                return None
-            if message.value is None:
-                continue
-            try:
-                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if _extract_correlation_id(body) == correlation_id:
-                return body
-    finally:
-        try:
-            await consumer.stop()
-        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
-            logger.warning(
-                "terminal-event consumer: failed to stop consumer for %s: %s",
-                terminal_topic,
-                exc,
-            )
 
 
 async def _assign_terminal_partitions(
@@ -176,75 +170,296 @@ async def _assign_terminal_partitions(
         await asyncio.sleep(_METADATA_POLL_INTERVAL_SECONDS)
 
 
+async def _open_positioned_consumer(
+    *,
+    event_bus: object,
+    terminal_topic: str,
+) -> AIOKafkaConsumer:
+    """Start an ephemeral consumer, assign the reply topic, and seek to end NOW.
+
+    Returns the started, positioned consumer. The caller is responsible for
+    stopping it (``_poll_correlated_terminal`` stops it in its ``finally``). The
+    ``seek_to_end`` here captures the pre-publish high-water-mark: any terminal
+    published at-or-after this point is delivered to a subsequent poll, even if it
+    arrives before the poll begins. This is the subscribe-before-publish leg.
+    """
+    consumer = _build_consumer(event_bus)
+    try:
+        await asyncio.wait_for(consumer.start(), timeout=_ASSIGN_TIMEOUT_CAP_SECONDS)
+        await _assign_terminal_partitions(
+            consumer, terminal_topic, _ASSIGN_TIMEOUT_CAP_SECONDS
+        )
+        await consumer.seek_to_end(*consumer.assignment())
+    except BaseException:
+        try:
+            await consumer.stop()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.warning(
+                "terminal-event consumer: failed to stop consumer during open "
+                "cleanup for %s: %s",
+                terminal_topic,
+                exc,
+            )
+        raise
+    return consumer
+
+
+async def _poll_correlated_terminal(
+    *,
+    consumer: AIOKafkaConsumer,
+    terminal_topic: str,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Poll an already-positioned consumer for the correlated terminal payload.
+
+    Blocks up to ``timeout_seconds`` from the position captured at ``open`` time.
+    Returns the deserialized terminal body whose ``correlation_id`` matches, or
+    ``None`` on genuine timeout. Stops the consumer on the way out.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        deadline = loop.time() + timeout_seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
+            except TimeoutError:
+                return None
+            if message.value is None:
+                continue
+            try:
+                body: dict[str, object] = json.loads(message.value.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if _extract_correlation_id(body) == correlation_id:
+                return body
+    finally:
+        try:
+            await consumer.stop()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.warning(
+                "terminal-event consumer: failed to stop consumer for %s: %s",
+                terminal_topic,
+                exc,
+            )
+
+
+class TerminalConsumerSession:
+    """Two-phase (seek-now / wait-later) handle over a single terminal topic.
+
+    Owns a dedicated event loop on a daemon worker thread for the whole
+    ``open``→``wait``→``close`` lifecycle. Synchronous methods submit coroutines
+    to that loop and block the calling thread on the result, so the session is
+    safe to drive from a sync handler running on the runtime's own (already
+    running) event loop without deadlocking it.
+
+    Usage (subscribe-before-publish)::
+
+        session = consumer.open(terminal_topic)   # assign + seek_to_end NOW
+        publisher(command_topic, payload)         # publish AFTER positioning
+        result = session.wait(correlation_id, timeout)  # block from the position
+        # wait() closes automatically; close() is idempotent for early teardown.
+    """
+
+    def __init__(
+        self,
+        *,
+        event_bus: object,
+        handler_name: str,
+        terminal_topic: str,
+    ) -> None:
+        self._event_bus = event_bus
+        self._handler_name = handler_name
+        self._terminal_topic = terminal_topic
+        self._loop = asyncio.new_event_loop()
+        self._consumer: AIOKafkaConsumer | None = None
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name=f"terminal-consumer-{handler_name}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _submit(
+        self, coro: Coroutine[object, object, object], *, timeout: float
+    ) -> object:
+        """Run ``coro`` on the worker loop and block the caller on its result."""
+        future: Future[object] = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    def open(self) -> TerminalConsumerSession:
+        """Start the consumer, assign the topic, and seek to end NOW (pre-publish).
+
+        Idempotent: a second call is a no-op once positioned. Returns ``self`` so
+        ``consumer.open(topic)`` reads naturally and supports ``with`` usage.
+        """
+        if self._consumer is not None or self._closed:
+            return self
+        self._consumer = cast(
+            "AIOKafkaConsumer",
+            self._submit(
+                _open_positioned_consumer(
+                    event_bus=self._event_bus,
+                    terminal_topic=self._terminal_topic,
+                ),
+                timeout=_ASSIGN_TIMEOUT_CAP_SECONDS + _LOOP_SUBMIT_GRACE_SECONDS,
+            ),
+        )
+        return self
+
+    def wait(
+        self, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, object] | None:
+        """Block up to ``timeout_seconds`` for the correlated terminal, then close.
+
+        Polls from the position captured at ``open`` time, so a terminal emitted in
+        the publish→wait gap is still delivered. Returns the matched payload or
+        ``None`` on timeout/failure. Closes the session on the way out.
+        """
+        if self._consumer is None:
+            # Defensive: caller skipped open() — fall back to seek-at-wait (the
+            # race-prone single-call path) rather than failing hard.
+            self.open()
+        consumer = self._consumer
+        if consumer is None:
+            self.close()
+            return None
+        try:
+            result = self._submit(
+                _poll_correlated_terminal(
+                    consumer=consumer,
+                    terminal_topic=self._terminal_topic,
+                    correlation_id=correlation_id,
+                    timeout_seconds=timeout_seconds,
+                ),
+                timeout=timeout_seconds
+                + _ASSIGN_TIMEOUT_CAP_SECONDS
+                + _LOOP_SUBMIT_GRACE_SECONDS,
+            )
+        except BaseException as exc:  # noqa: BLE001 — re-raised as None to caller
+            logger.warning(
+                "terminal-event consumer: wait failed for %s (topic=%s, cid=%s): %s",
+                self._handler_name,
+                self._terminal_topic,
+                correlation_id,
+                exc,
+            )
+            self.close()
+            return None
+        # _poll_correlated_terminal stopped the consumer in its finally; drop the
+        # reference so close() does not double-stop.
+        self._consumer = None
+        self.close()
+        return cast("dict[str, object] | None", result)
+
+    def close(self) -> None:
+        """Stop the worker loop and join its thread. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        consumer = self._consumer
+        self._consumer = None
+        if consumer is not None:
+            try:
+                stop_future: Future[object] = asyncio.run_coroutine_threadsafe(
+                    cast("Coroutine[object, object, object]", consumer.stop()),
+                    self._loop,
+                )
+                stop_future.result(timeout=_LOOP_SUBMIT_GRACE_SECONDS)
+            except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+                logger.warning(
+                    "terminal-event consumer: failed to stop consumer during close "
+                    "for %s (topic=%s): %s",
+                    self._handler_name,
+                    self._terminal_topic,
+                    exc,
+                )
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=_LOOP_SUBMIT_GRACE_SECONDS)
+        try:
+            self._loop.close()
+        except Exception as exc:  # noqa: BLE001 — boundary: best-effort cleanup
+            logger.debug(
+                "terminal-event consumer: loop close raced for %s: %s",
+                self._handler_name,
+                exc,
+            )
+
+    def __enter__(self) -> TerminalConsumerSession:
+        return self.open()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class TerminalEventConsumer:
+    """Callable injected as ``event_consumer`` — both single-call and two-phase.
+
+    Calling the instance directly preserves the legacy
+    ``(topic, cid, timeout) -> dict | None`` shape. ``.open(topic)`` returns a
+    :class:`TerminalConsumerSession` for subscribe-before-publish callers.
+    """
+
+    def __init__(self, *, event_bus: object, handler_name: str) -> None:
+        self._event_bus = event_bus
+        self._handler_name = handler_name
+
+    def open(self, terminal_topic: str) -> TerminalConsumerSession:
+        """Open a positioned (assign + seek_to_end NOW) session before publishing."""
+        session = TerminalConsumerSession(
+            event_bus=self._event_bus,
+            handler_name=self._handler_name,
+            terminal_topic=terminal_topic,
+        )
+        return session.open()
+
+    def __call__(
+        self, terminal_topic: str, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, object] | None:
+        """Single-call form: open + wait in one step (seek happens at call time).
+
+        Retained for backward compatibility. This is the race-prone path: the seek
+        runs when the call is made, which is after the caller's publish. Callers
+        that need subscribe-before-publish must use ``open`` + ``wait`` instead.
+        """
+        session = self.open(terminal_topic)
+        return session.wait(correlation_id, timeout_seconds)
+
+
 def make_terminal_event_consumer(
     *,
     event_bus: object,
     handler_name: str,
-) -> EventConsumer:
-    """Build the sync ``event_consumer`` injected into request/response handlers.
+) -> TerminalEventConsumer:
+    """Build the ``event_consumer`` injected into request/response handlers.
 
-    The returned callable has the handler-declared shape
-    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None``. It runs
-    the async correlate-and-wait coroutine on a dedicated event loop in a worker
-    thread and blocks the caller on the result, so it is safe to call from a sync
-    handler executing on the runtime's own (already-running) event loop without
-    deadlocking that loop.
+    The returned object is directly callable with the legacy single-call shape
+    ``(terminal_topic, correlation_id, timeout_seconds) -> dict | None`` and also
+    exposes ``.open(topic) -> TerminalConsumerSession`` for the two-phase
+    (subscribe-before-publish) protocol. Both forms run the Kafka correlate-and-wait
+    work on a dedicated event loop in a worker thread, so they are safe to call
+    from a sync handler executing on the runtime's own (already running) event
+    loop without deadlocking that loop.
     """
-
-    def _consume(
-        terminal_topic: str, correlation_id: str, timeout_seconds: float
-    ) -> dict[str, object] | None:
-        result_box: dict[str, dict[str, object] | None] = {}
-        error_box: dict[str, BaseException] = {}
-
-        def _runner() -> None:
-            try:
-                result_box["value"] = asyncio.run(
-                    _await_correlated_terminal(
-                        event_bus=event_bus,
-                        terminal_topic=terminal_topic,
-                        correlation_id=correlation_id,
-                        timeout_seconds=timeout_seconds,
-                    )
-                )
-            except BaseException as exc:  # noqa: BLE001 — re-raised on caller thread
-                error_box["error"] = exc
-
-        thread = threading.Thread(
-            target=_runner,
-            name=f"terminal-consumer-{handler_name}",
-            daemon=True,
-        )
-        thread.start()
-        # Join with a small grace beyond the correlate timeout so a clean Kafka
-        # shutdown completes; the coroutine already enforces timeout_seconds.
-        thread.join(timeout=timeout_seconds + _ASSIGN_TIMEOUT_CAP_SECONDS + 5.0)
-
-        if thread.is_alive():
-            logger.warning(
-                "terminal-event consumer: correlate thread for %s did not finish "
-                "within grace window (topic=%s, cid=%s)",
-                handler_name,
-                terminal_topic,
-                correlation_id,
-            )
-            return None
-        if "error" in error_box:
-            logger.warning(
-                "terminal-event consumer: correlate failed for %s (topic=%s, "
-                "cid=%s): %s",
-                handler_name,
-                terminal_topic,
-                correlation_id,
-                error_box["error"],
-            )
-            return None
-        return result_box.get("value")
-
-    return _consume
+    return TerminalEventConsumer(event_bus=event_bus, handler_name=handler_name)
 
 
 __all__: list[str] = [
     "EventConsumer",
+    "TerminalConsumerSession",
+    "TerminalEventConsumer",
     "make_terminal_event_consumer",
 ]

--- a/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_event_consumer_injection.py
@@ -1,26 +1,38 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Regression coverage for auto-wired handler event_consumer injection (OMN-13005).
+"""Regression coverage for auto-wired handler event_consumer injection.
 
-The dispatch INPUT crash was OMN-13003. This is the SECOND, distinct defect on
-``node_context_roi_runner``: a request/response EFFECT handler declares an
-injectable blocking ``event_consumer`` (publish command -> block on correlated
-terminal event -> read result fields back), but the runtime auto-wiring only
-materialized ``event_publisher`` and had no equivalent for ``event_consumer``.
-The handler therefore fell back to its own no-op default that returns ``None``
-immediately, so every result row was a degenerate generation-failure even though
-the terminal event arrived ~1s later.
+The dispatch INPUT crash was OMN-13003. OMN-13005 was the SECOND defect: a
+request/response EFFECT handler declares an injectable blocking ``event_consumer``
+(publish command -> block on correlated terminal event -> read result fields
+back), but the runtime auto-wiring materialized no consumer, so the handler fell
+back to a no-op default that returned ``None`` immediately and every row was a
+degenerate generation-failure.
+
+OMN-13012 is the FOURTH defect, exposed once OMN-13010 freed the dispatch loop and
+generation began completing in ~1s: the OMN-13005 consumer is a single callable
+that does ``assign -> seek_to_end -> poll`` AFTER the handler has already
+published, so a terminal emitted in the publish->seek gap is seeked PAST and lost
+(probe3). The fix makes the injected consumer two-phase — ``open(topic)`` assigns
+and seeks to end NOW (before publish), ``session.wait(cid, timeout)`` blocks from
+that captured position (after publish) — so a fast terminal is not skipped.
 
 These tests drive the REAL wiring path (``_prepare_handler_wiring`` ->
 ``_materialize_known_handler_dependencies``) rather than constructing the handler
 directly, so they exercise the dispatch surface that the handler-isolation golden
-chain never touches (memory ``feedback_real_dispatch_path_tests``).
+chain never touches (memory ``feedback_real_dispatch_path_tests``). The Kafka
+layer is faked at the two service seams (``_open_positioned_consumer`` and
+``_poll_correlated_terminal``) via a shared in-memory terminal log that models
+seek-to-end semantics: a poll only sees messages at or after the offset captured
+when its consumer was opened.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -44,6 +56,7 @@ from omnibase_infra.runtime.auto_wiring.models import (
 )
 
 _TERMINAL_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+_COMMAND_TOPIC = "onex.cmd.omnimarket.node-generation-requested.v1"
 
 
 class RecordingEventBus:
@@ -54,19 +67,108 @@ class RecordingEventBus:
         self.published.append((topic, key, value))
 
 
-class HandlerRoiRunnerShape:
-    """Fake with the request/response constructor shape of HandlerContextRoiRunner.
+# ----------------------------------------------------------------------------
+# Fake Kafka terminal log modeling seek-to-end semantics
+# ----------------------------------------------------------------------------
 
-    Mirrors the real handler's degenerate-vs-healthy branch: when the injected
-    ``event_consumer`` returns ``None`` (the no-op default), the row is recorded
-    as ``failure_stage=generation`` with ``attempt_count=0``. When the consumer
-    blocks-correlates and returns the terminal payload, the row is populated.
+
+class FakeTerminalLog:
+    """Append-only terminal-event log with seek-to-end offset capture.
+
+    Models the exact race surface: a consumer opened at offset N never sees
+    messages appended before N (``seek_to_end`` skipped past them). A consumer
+    is a thin handle holding its captured start offset; ``poll`` returns the
+    first message at index >= start_offset whose ``correlation_id`` matches,
+    waiting up to ``timeout`` for one to be appended.
     """
 
-    # Result topic the fake emits its recorded row to, so the test can assert
-    # on the event bus (a side channel) without capturing the handler instance —
-    # the resolver requires _import_handler_class to return an actual type.
+    def __init__(self) -> None:
+        self._messages: list[dict[str, Any]] = []
+        self._cond = threading.Condition()
+
+    def append(self, payload: dict[str, Any]) -> None:
+        with self._cond:
+            self._messages.append(payload)
+            self._cond.notify_all()
+
+    def current_end(self) -> int:
+        with self._cond:
+            return len(self._messages)
+
+    def poll(
+        self, start_offset: int, correlation_id: str, timeout_seconds: float
+    ) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout_seconds
+        with self._cond:
+            idx = start_offset
+            while True:
+                while idx < len(self._messages):
+                    msg = self._messages[idx]
+                    idx += 1
+                    if str(msg.get("correlation_id")) == correlation_id:
+                        return msg
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._cond.wait(timeout=remaining)
+
+
+class _FakeConsumerHandle:
+    """Opaque handle returned by the patched ``_open_positioned_consumer``."""
+
+    def __init__(self, log: FakeTerminalLog, start_offset: int) -> None:
+        self.log = log
+        self.start_offset = start_offset
+
+
+def install_fake_kafka(log: FakeTerminalLog) -> tuple[Any, Any]:
+    """Build patched replacements for the two service seams, bound to ``log``."""
+
+    async def _fake_open(
+        *, event_bus: object, terminal_topic: str
+    ) -> _FakeConsumerHandle:
+        # seek_to_end NOW: capture the current end offset.
+        return _FakeConsumerHandle(log, log.current_end())
+
+    async def _fake_poll(
+        *,
+        consumer: _FakeConsumerHandle,
+        terminal_topic: str,
+        correlation_id: str,
+        timeout_seconds: float,
+    ) -> dict[str, Any] | None:
+        # Poll from the offset captured at open; blocking wait runs off-thread.
+        return await asyncio.to_thread(
+            consumer.log.poll,
+            consumer.start_offset,
+            correlation_id,
+            timeout_seconds,
+        )
+
+    return _fake_open, _fake_poll
+
+
+# ----------------------------------------------------------------------------
+# Handler shapes
+# ----------------------------------------------------------------------------
+
+
+class HandlerRoiRunnerSingleCall:
+    """Legacy seek-after-publish shape: publish, THEN single-call consume.
+
+    This is the OMN-13005 form. Against a fast terminal (appended immediately
+    after publish) it loses the race because the consumer opens — and so seeks
+    to end — only when the single call is made, i.e. after the terminal is
+    already in the log.
+
+    The active ``FakeTerminalLog`` is bound on the class (``_TEST_LOG``) by the
+    test driver before dispatch; the constructor keeps the runtime-known
+    ``event_publisher``/``event_consumer`` shape so the resolver introspects and
+    materializes both injected deps exactly as it does for the real handler.
+    """
+
     ROW_TOPIC = "onex.evt.omnimarket.context-roi-run-completed.v1"
+    _TEST_LOG: FakeTerminalLog | None = None
 
     def __init__(
         self,
@@ -75,27 +177,87 @@ class HandlerRoiRunnerShape:
         | None = None,
     ) -> None:
         self._event_publisher = event_publisher
-        # Default no-op consumer returns None immediately (the live defect).
         self._event_consumer = event_consumer or (lambda _t, _c, _to: None)
 
     async def handle(self, envelope: object) -> None:
         correlation_id = "cid-roi-runner-1"
         if self._event_publisher is not None:
-            self._event_publisher(
-                "onex.cmd.omnimarket.node-generation-requested.v1",
-                b'{"task":"invoice"}',
-            )
-        terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 120.0)
-        if terminal is None:
-            row = {"failure_stage": "generation", "attempt_count": 0, "model_id": ""}
-        else:
-            row = {
-                "failure_stage": "none",
-                "attempt_count": int(terminal["attempt_count"]),
-                "model_id": str(terminal["model_id"]),
-            }
+            self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+        # Fast terminal: appended the instant after publish, before the consume
+        # call seeks to end.
+        if self._TEST_LOG is not None:
+            self._TEST_LOG.append(_terminal_payload(correlation_id))
+        terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 5.0)
+        _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+
+class HandlerRoiRunnerTwoPhase:
+    """Subscribe-before-publish shape (OMN-13012): open, publish, then wait.
+
+    Opens the terminal session (assign + seek_to_end NOW) BEFORE publishing, so
+    a terminal appended immediately after publish is at-or-after the captured
+    offset and is delivered by ``wait``.
+    """
+
+    ROW_TOPIC = "onex.evt.omnimarket.context-roi-run-completed.v1"
+    _TEST_LOG: FakeTerminalLog | None = None
+
+    def __init__(
+        self,
+        event_publisher: Callable[[str, bytes], None] | None = None,
+        event_consumer: Any = None,
+    ) -> None:
+        self._event_publisher = event_publisher
+        self._event_consumer = event_consumer
+
+    async def handle(self, envelope: object) -> None:
+        correlation_id = "cid-roi-runner-1"
+        # Two-phase: open BEFORE publishing.
+        session = None
+        opener = getattr(self._event_consumer, "open", None)
+        if callable(opener):
+            session = opener(_TERMINAL_TOPIC)
         if self._event_publisher is not None:
-            self._event_publisher(self.ROW_TOPIC, json.dumps(row).encode("utf-8"))
+            self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+        # Fast terminal: appended immediately after publish.
+        if self._TEST_LOG is not None:
+            self._TEST_LOG.append(_terminal_payload(correlation_id))
+        if session is not None:
+            terminal = session.wait(correlation_id, 5.0)
+        elif self._event_consumer is not None:
+            terminal = self._event_consumer(_TERMINAL_TOPIC, correlation_id, 5.0)
+        else:
+            terminal = None
+        _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+
+def _terminal_payload(correlation_id: str) -> dict[str, Any]:
+    return {
+        "correlation_id": correlation_id,
+        "attempt_count": 1,
+        "model_id": "Qwen3.6-35B-A3B",
+        "provider": "local",
+        "contract_passed": True,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+    }
+
+
+def _emit_row(
+    publisher: Callable[[str, bytes], None] | None,
+    row_topic: str,
+    terminal: dict[str, Any] | None,
+) -> None:
+    if terminal is None:
+        row = {"failure_stage": "generation", "attempt_count": 0, "model_id": ""}
+    else:
+        row = {
+            "failure_stage": "none",
+            "attempt_count": int(terminal["attempt_count"]),
+            "model_id": str(terminal["model_id"]),
+        }
+    if publisher is not None:
+        publisher(row_topic, json.dumps(row).encode("utf-8"))
 
 
 def _make_roi_runner_contract() -> ModelDiscoveredContract:
@@ -110,7 +272,7 @@ def _make_roi_runner_contract() -> ModelDiscoveredContract:
             subscribe_topics=("onex.cmd.omnimarket.context-roi-run-requested.v1",),
             publish_topics=(
                 "onex.evt.omnimarket.context-roi-run-completed.v1",
-                "onex.cmd.omnimarket.node-generation-requested.v1",
+                _COMMAND_TOPIC,
             ),
         ),
         handler_routing=ModelHandlerRouting(
@@ -127,18 +289,15 @@ def _make_roi_runner_contract() -> ModelDiscoveredContract:
     )
 
 
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row() -> (
-    None
-):
-    """RED before OMN-13005: wiring injected no event_consumer -> no-op -> degenerate.
+async def _drive_handler(
+    handler_cls: type, log: FakeTerminalLog
+) -> list[dict[str, Any]]:
+    """Wire ``handler_cls`` through the real injection path and dispatch once.
 
-    Drives the trial through the real wiring with a terminal event that arrives
-    AFTER a short delay; asserts a NON-DEGENERATE row (attempt_count>=1, populated
-    model_id, no failure_stage=generation). With the pre-fix no-op consumer, the
-    handler records failure_stage=generation/attempt_count=0 and this assertion
-    fails.
+    Binds the active ``FakeTerminalLog`` on the handler class (``_TEST_LOG``) so
+    the constructor keeps the exact runtime-known dependency shape the resolver
+    introspects, and patches the two Kafka seams so the real
+    ``TerminalEventConsumer`` two-phase logic runs against the in-memory log.
     """
     contract = _make_roi_runner_contract()
     event_bus = RecordingEventBus()
@@ -146,34 +305,21 @@ async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row()
     ownership_query = ServiceLocalHandlerOwnershipQuery(
         local_node_names=frozenset({contract.name})
     )
-
-    async def _delayed_terminal(
-        *,
-        event_bus: object,
-        terminal_topic: str,
-        correlation_id: str,
-        timeout_seconds: float,
-    ) -> dict[str, Any] | None:
-        # Terminal arrives ~after the handler began waiting — proves blocking.
-        await asyncio.sleep(0.05)
-        return {
-            "correlation_id": correlation_id,
-            "attempt_count": 1,
-            "model_id": "Qwen3.6-35B-A3B",
-            "provider": "local",
-            "contract_passed": True,
-            "prompt_tokens": 10,
-            "completion_tokens": 20,
-        }
+    fake_open, fake_poll = install_fake_kafka(log)
+    handler_cls._TEST_LOG = log  # type: ignore[attr-defined]
 
     with (
         patch(
             "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
-            return_value=HandlerRoiRunnerShape,
+            return_value=handler_cls,
         ),
         patch(
-            "omnibase_infra.runtime.service_terminal_event_consumer._await_correlated_terminal",
-            side_effect=_delayed_terminal,
+            "omnibase_infra.runtime.service_terminal_event_consumer._open_positioned_consumer",
+            side_effect=fake_open,
+        ),
+        patch(
+            "omnibase_infra.runtime.service_terminal_event_consumer._poll_correlated_terminal",
+            side_effect=fake_poll,
         ),
     ):
         prepared = _prepare_handler_wiring(
@@ -194,16 +340,103 @@ async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row()
         )
         await asyncio.sleep(0)
 
-    row_publishes = [
+    return [
         json.loads(value.decode("utf-8"))
         for topic, _key, value in event_bus.published
-        if topic == HandlerRoiRunnerShape.ROW_TOPIC
+        if topic == handler_cls.ROW_TOPIC
     ]
-    assert row_publishes, "handler never emitted a result row"
-    row = row_publishes[-1]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_single_call_consumer_loses_fast_terminal_race() -> None:
+    """RED for OMN-13012: seek-after-publish misses a terminal emitted at t+0.
+
+    The legacy single-call consumer opens (and seeks to end) only when the call
+    is made — after the handler has already published AND the terminal has landed.
+    seek_to_end skips past the terminal, so the poll times out and the row is
+    degenerate. This is the exact probe3 failure; it MUST be red so the two-phase
+    fix below cannot be a no-op.
+    """
+    log = FakeTerminalLog()
+    rows = await _drive_handler(HandlerRoiRunnerSingleCall, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
+    assert row["failure_stage"] == "generation", (
+        "single-call seek-after-publish unexpectedly caught the fast terminal — "
+        "the race this ticket fixes is not being exercised"
+    )
+    assert row["attempt_count"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_phase_consumer_catches_fast_terminal_race() -> None:
+    """GREEN for OMN-13012: open-before-publish captures the t+0 terminal.
+
+    The two-phase session seeks to end BEFORE the handler publishes, so a terminal
+    appended immediately after publish is at-or-after the captured offset and is
+    delivered by ``wait`` — a NON-degenerate row. With the pre-fix single-call
+    consumer this assertion fails (see the RED test above).
+    """
+    log = FakeTerminalLog()
+    rows = await _drive_handler(HandlerRoiRunnerTwoPhase, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
     assert row["failure_stage"] != "generation", (
-        "event_consumer was not injected (handler fell back to no-op returning "
-        "None) — the OMN-13005 degenerate-row defect"
+        "two-phase open-before-publish failed to catch the fast terminal — the "
+        "subscribe-after-publish race (OMN-13012) is not closed"
+    )
+    assert row["attempt_count"] >= 1
+    assert row["model_id"] == "Qwen3.6-35B-A3B"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row() -> (
+    None
+):
+    """OMN-13005 preserved: a delayed terminal is still correlated and returned.
+
+    Drives the trial through the real wiring with the two-phase session and a
+    terminal that arrives shortly after the wait begins (a delayed append rather
+    than a t+0 one). Asserts a NON-DEGENERATE row, proving the injected consumer
+    blocks-and-correlates (the OMN-13005 contract) under the new two-phase shape.
+    """
+    log = FakeTerminalLog()
+
+    class _DelayedTerminalTwoPhase(HandlerRoiRunnerTwoPhase):
+        async def handle(self, envelope: object) -> None:
+            correlation_id = "cid-roi-runner-1"
+            session = None
+            opener = getattr(self._event_consumer, "open", None)
+            if callable(opener):
+                session = opener(_TERMINAL_TOPIC)
+            if self._event_publisher is not None:
+                self._event_publisher(_COMMAND_TOPIC, b'{"task":"invoice"}')
+
+            active_log = self._TEST_LOG
+
+            # Terminal arrives AFTER a short delay, while wait() is blocking.
+            def _delayed_append() -> None:
+                import time
+
+                time.sleep(0.05)
+                if active_log is not None:
+                    active_log.append(_terminal_payload(correlation_id))
+
+            threading.Thread(target=_delayed_append, daemon=True).start()
+            terminal = (
+                session.wait(correlation_id, 5.0) if session is not None else None
+            )
+            _emit_row(self._event_publisher, self.ROW_TOPIC, terminal)
+
+    rows = await _drive_handler(_DelayedTerminalTwoPhase, log)
+    assert rows, "handler never emitted a result row"
+    row = rows[-1]
+    assert row["failure_stage"] != "generation", (
+        "event_consumer was not injected or did not block-correlate — the "
+        "OMN-13005 degenerate-row defect"
     )
     assert row["attempt_count"] >= 1
     assert row["model_id"] == "Qwen3.6-35B-A3B"


### PR DESCRIPTION
## OMN-13012 — two-phase (seek-now / wait-later) terminal event_consumer

**Sibling to OMN-13010 / OMN-13005 / OMN-13003.** Stacked on the OMN-13005 branch (`jonah/omn-13005-event-consumer-autowiring`, PR #1951) because it evolves the `service_terminal_event_consumer.py` introduced there.

### Defect (proven by probe3, run_id=20260611T2140Z-probe3)

The OMN-13005 injected `event_consumer` is a single callable `self._consumer(topic, cid, timeout)` that does `assign → seek_to_end → poll` internally, all executed AFTER `_run_trial` has already published the generation command. Once OMN-13010 freed the dispatch loop, generation completes in ~1s, so the correlated terminal lands BEFORE the single-call consumer's post-publish `seek_to_end` positions — `seek_to_end` skips PAST the already-emitted terminal, the runner polls an offset beyond it, waits the full timeout, and times out. Both probe3 arms degenerate (`failure_stage=generation, attempt_count=0`); zero `UnknownMemberIdError` rebalances (starvation IS fixed by OMN-13010).

### Fix

Split positioning from waiting so the caller subscribes BEFORE it publishes:

```python
session = consumer.open(topic)         # assign + seek_to_end NOW (pre-publish)
publisher(command_topic, payload)      # publish AFTER positioning
payload = session.wait(cid, timeout)   # block from the captured position (post-publish)
```

- `make_terminal_event_consumer` now returns `TerminalEventConsumer`, directly callable with the legacy `(topic, cid, timeout) -> dict | None` single-call shape (backward compatible; the runner is the only consumer today) AND exposing `.open(topic) -> TerminalConsumerSession`.
- `TerminalConsumerSession` owns a dedicated event loop on a daemon worker thread for the whole `open → wait → close` lifecycle, preserving the OMN-13005 loop-isolation discipline so blocking never deadlocks the runtime dispatch loop.
- `handler_wiring._make_sync_event_consumer` return type tightened to `TerminalEventConsumer`.

### TDD (real dispatch path, RED-then-GREEN)

`tests/unit/runtime/auto_wiring/test_event_consumer_injection.py` extended with a terminal emitted IMMEDIATELY after publish, driven through `_prepare_handler_wiring`:

- `test_single_call_consumer_loses_fast_terminal_race` — **RED**: seek-after-publish misses the t+0 terminal → `failure_stage=generation` (the exact probe3 failure).
- `test_two_phase_consumer_catches_fast_terminal_race` — **GREEN**: open-before-publish captures it → non-degenerate row.
- `test_auto_wired_event_consumer_blocks_and_returns_non_degenerate_row` — OMN-13005 blocking-correlate behavior preserved.

The Kafka layer is faked at the two service seams (`_open_positioned_consumer`, `_poll_correlated_terminal`) against a shared in-memory log modeling seek-to-end semantics.

### Verification

- `uv run pytest tests/unit/runtime/auto_wiring/` → 269 passed
- `uv run mypy src/...service_terminal_event_consumer.py src/...handler_wiring.py --strict` → clean
- `pre-commit run` on the 3 changed files → clean (naming gate enforced public `TerminalEventConsumer`)

### Deploy posture

`deploy_pending=true` — NOT hot-patched tonight. The change spans the infra package + the runner handler and the operator is recording against the stability lane. Next session: batch-rebuild including this PR + #1180/#1184/#1951 (verify each merged first), then probe4 expecting NON-degenerate rows.

---

OMN-13012

Evidence-Source: OCC#2534
Evidence-Ticket: OMN-13012

dod_evidence:
- docs/evidence/2026-06-11-experiments/HOTPATCH-DISPATCH-LOOP-OFFLOAD.md (residual race diagnosis)
- tests/unit/runtime/auto_wiring/test_event_consumer_injection.py (RED+GREEN real-dispatch-path proof)
