### PR TITLE
fix(OMN-13020): vendor missing node migrations — llm_routing 0000 + context_roi 001 (prod forward-migration exit 3)

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_context_roi/001_create_context_roi_scores.sql
+++ b/docker/migrations/forward/nodes/node_projection_context_roi/001_create_context_roi_scores.sql
@@ -1,0 +1,66 @@
+-- OMN-12955: Context-ROI experiment scores projection table.
+--
+-- Backs the projection topic
+--   onex.snapshot.projection.context.experiment-scores.v1
+-- consumed by the omnidash /experiments ContextExperimentHero and
+-- ContextEffectivenessHeatmap panels.
+--
+-- Source: per-(task x arm x trial) ModelAttemptReductionRow instances carried
+-- on the runner terminal event onex.evt.omnimarket.context-roi-run-completed.v1.
+-- One projection row per (run_id, task_id, context_factor_subset, correlation_id)
+-- cell. Identity is the runner correlation_id which is unique per cell.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS context_roi_scores (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Identity / correlation
+    run_id TEXT NOT NULL,
+    correlation_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    run_order INTEGER NOT NULL DEFAULT 0 CHECK (run_order >= 0),
+    -- Arm / context pack (the heatmap "segment")
+    context_factor_subset TEXT NOT NULL DEFAULT 'off',
+    context_pack_hash TEXT NOT NULL DEFAULT '',
+    -- Generation telemetry
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    first_pass_success BOOLEAN NOT NULL DEFAULT FALSE,
+    final_success BOOLEAN NOT NULL DEFAULT FALSE,
+    failure_stage TEXT NOT NULL DEFAULT 'none',
+    -- Token accounting
+    prompt_tokens INTEGER NOT NULL DEFAULT 0 CHECK (prompt_tokens >= 0),
+    completion_tokens INTEGER NOT NULL DEFAULT 0 CHECK (completion_tokens >= 0),
+    tokens_used INTEGER NOT NULL DEFAULT 0 CHECK (tokens_used >= 0),
+    estimated_cost NUMERIC(18, 6) NOT NULL DEFAULT 0 CHECK (estimated_cost >= 0),
+    -- Model / routing identity
+    model_id TEXT NOT NULL DEFAULT '',
+    provider TEXT NOT NULL DEFAULT '',
+    endpoint_ref TEXT NOT NULL DEFAULT '',
+    -- Evidence classification
+    proof_class TEXT NOT NULL DEFAULT 'runtime-observed-only',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_context_roi_scores_identity
+    ON context_roi_scores (correlation_id);
+
+CREATE INDEX IF NOT EXISTS ix_context_roi_scores_run
+    ON context_roi_scores (run_id);
+
+CREATE INDEX IF NOT EXISTS ix_context_roi_scores_segment_model
+    ON context_roi_scores (context_factor_subset, model_id);
+
+CREATE OR REPLACE FUNCTION refresh_context_roi_scores_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_context_roi_scores_updated_at ON context_roi_scores;
+CREATE TRIGGER trg_context_roi_scores_updated_at
+    BEFORE UPDATE ON context_roi_scores
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_context_roi_scores_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_llm_routing/0000_create_llm_routing_decisions.sql
+++ b/docker/migrations/forward/nodes/node_projection_llm_routing/0000_create_llm_routing_decisions.sql
@@ -1,0 +1,72 @@
+-- OMN-12942: base table for the routing-decision dashboard projection view.
+--
+-- node_projection_llm_routing/0001_create_routing_dashboard_projection_view.sql
+-- composes the `projection_routing_decision` view over `llm_routing_decisions`.
+-- That base table is also created by the flat infra forward set
+-- (omnibase_infra docker/migrations/forward/065_create_llm_routing_decisions.sql),
+-- which the runner applies in its first phase. But this node-owned migration set
+-- must be SELF-CONTAINED: the node forward-migration runner applies node dirs in
+-- their own pass, and a clean apply of the node set alone (the path used by the
+-- node-migration vendoring/sync flow) hard-fails the view migration when the flat
+-- infra table is absent — exactly what happened during the 2026-06-11 04:24Z
+-- stability hot-patch, which forced the view migration to be pruned. Owning the
+-- base table inside the node removes that ordering dependency.
+--
+-- Schema is identical to the flat infra 065 table. All statements are
+-- IF NOT EXISTS, so re-applying after 065 (or vice-versa) is a no-op — the two
+-- migrations converge on the same table and are safe in either order.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS llm_routing_decisions (
+    id                      UUID        NOT NULL DEFAULT gen_random_uuid(),
+    correlation_id          UUID        NOT NULL,
+    session_id              TEXT,
+
+    -- Routing decision
+    llm_agent               TEXT        NOT NULL,
+    fuzzy_agent             TEXT,
+    agreement               BOOLEAN     NOT NULL DEFAULT FALSE,
+
+    -- Confidence scores (0-1, NULL when not provided)
+    llm_confidence          NUMERIC(5, 4) CHECK (llm_confidence IS NULL OR (llm_confidence >= 0 AND llm_confidence <= 1)),
+    fuzzy_confidence        NUMERIC(5, 4) CHECK (fuzzy_confidence IS NULL OR (fuzzy_confidence >= 0 AND fuzzy_confidence <= 1)),
+
+    -- Latency
+    llm_latency_ms          INTEGER     NOT NULL DEFAULT 0,
+    fuzzy_latency_ms        INTEGER     NOT NULL DEFAULT 0,
+
+    -- Routing metadata
+    used_fallback           BOOLEAN     NOT NULL DEFAULT FALSE,
+    routing_prompt_version  TEXT        NOT NULL DEFAULT 'unknown',
+    intent                  TEXT,
+    model                   TEXT,
+    cost_usd                NUMERIC(12, 8) CHECK (cost_usd IS NULL OR cost_usd >= 0),
+
+    -- Audit
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    projected_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT pk_llm_routing_decisions PRIMARY KEY (id),
+    CONSTRAINT uq_llm_routing_decisions_correlation UNIQUE (correlation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lrd_created_at
+    ON llm_routing_decisions (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lrd_agreement
+    ON llm_routing_decisions (agreement, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lrd_used_fallback
+    ON llm_routing_decisions (used_fallback, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lrd_prompt_version
+    ON llm_routing_decisions (routing_prompt_version, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lrd_agent_pair
+    ON llm_routing_decisions (llm_agent, fuzzy_agent, created_at DESC)
+    WHERE agreement = FALSE;
+
+COMMENT ON TABLE llm_routing_decisions IS
+    'LLM routing decision projection from onex.evt.omniclaude.llm-routing-decision.v1. '
+    'UPSERT key: correlation_id (UUID). Base table for projection_routing_decision view (OMN-12942).';


### PR DESCRIPTION
## Summary

Fixes **OMN-13020**. Vendors two omnimarket node-source migrations into `docker/migrations/forward/nodes/` via the canonical mechanism (`scripts/sync-node-migrations.sh`, OMN-12559):

| File | Source of truth (already on omnimarket dev) | sha256 |
|---|---|---|
| `node_projection_llm_routing/0000_create_llm_routing_decisions.sql` | omnimarket #1168 (OMN-12942, merge `ed6734f8`) | `f8a8b339…77db` |
| `node_projection_context_roi/001_create_context_roi_scores.sql` | omnimarket #1178 (OMN-12955, merge `5010b1f4`) | `c4126e65…5f52` |

## Why

Prod forward-migration exited **3** at 2026-06-11T09:35:52Z: `node_projection_llm_routing/0001…sql:135` → `relation "llm_routing_decisions" does not exist`. The 0001 VIEW runs against `NODE_POSTGRES_DB=omnidash_analytics`, where the base table (created by flat infra `065` only in `omnibase_infra` DB) never existed. The fix file existed in omnimarket dev source and as untracked hot-patch residue on the .201 stability clone — but in **no omnibase_infra ref**, so every clean build reproduces the failure. Vendored copies here are byte-identical to the omnimarket dev blobs and the .201 copies (sha256 probes in evidence).

Because the runner walks node dirs in order and aborts on first failure, the committed `node_projection_overnight` + `node_projection_session_outcome` sets also never applied on prod; after this merges (and is promoted to main), the user-gated re-run (`omni_home/docs/runbooks/2026-06-12-prod-migration-rerun.md`) applies all three.

## Safety

- `0000_…` sorts lexically before `0001_…`; node identity space is namespaced (`node:<node>:<file>`) — no flat-sequence renumber.
- Both files are self-contained, all-statements-`IF NOT EXISTS`; converge with flat `065` in either order.
- `scripts/validation/validate_migration_sequence.py` → exit 0; `sync-node-migrations.sh --check` → `in sync` (exit 0).

## Verification (local, worktree @ rebased dev tip 1e4cfa380)

- `uv run ruff format && ruff check --fix` → clean (0 changes); `uv run mypy src/ --strict` → Success (2418 files).
- `uv run pytest tests/ -n 8` (full suite, no filter) → **23846 passed**, 381 skipped; 16F/79E all in live-infra-dependent integration/performance surfaces or xdist logging-capture flakes (`test_util_db_transaction` passes serially) — diff is 2 SQL files, no Python touched; `tests/ci/test_receipt_gate_install_guard.py` failure reproduces on byte-identical dev-tip content (pre-existing).
- `pre-commit run --all-files`: staged-set hooks pass; three all-files failures are pre-existing dev-tip content untouched by this diff — 19 contracts missing `runtime_profiles` (tracked: OMN-12957), SPDX year + yamlfmt drift in freshly-merged `node_bus_forwarder_effect` (files byte-identical to origin/dev).

Evidence ledger: `omni_home/docs/evidence/2026-06-12-dev-integration-pass/P4-prod-migration/01-vendoring-fix.md`.

Related tickets filed this lane: OMN-13062 (migration-gate vacuity, retro A-10), OMN-13063 (prod worker decision).

Evidence-Ticket: OMN-13020
Evidence-Source: OCC#2541
