### PR TITLE
fix(OMN-13058): close TerminalConsumerSession on open() failure (worker thread + event loop leak)

### DIFF
--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -316,13 +316,24 @@ class TerminalEventConsumer:
         self._handler_name = handler_name
 
     def open(self, terminal_topic: str) -> TerminalConsumerSession:
-        """Open a positioned (assign + seek_to_end NOW) session before publishing."""
+        """Open a positioned (assign + seek_to_end NOW) session before publishing.
+
+        The session constructor starts its worker loop thread immediately, so a
+        failure inside ``session.open()`` (consumer start timeout, partition-assign
+        timeout, broker auth error) must close the session before re-raising —
+        otherwise the thread and its event loop leak with no reachable handle
+        (OMN-13058).
+        """
         session = TerminalConsumerSession(
             event_bus=self._event_bus,
             handler_name=self._handler_name,
             terminal_topic=terminal_topic,
         )
-        return session.open()
+        try:
+            return session.open()
+        except BaseException:
+            session.close()
+            raise
 
     def __call__(
         self, terminal_topic: str, correlation_id: str, timeout_seconds: float

--- a/tests/unit/runtime/test_service_terminal_event_consumer_open_failure.py
+++ b/tests/unit/runtime/test_service_terminal_event_consumer_open_failure.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for OMN-13058: no thread/loop leak when ``open()`` fails.
+
+``TerminalConsumerSession.__init__`` starts its dedicated worker loop thread
+immediately. Before the fix, ``TerminalEventConsumer.open`` did
+``session = TerminalConsumerSession(...); return session.open()`` with no
+cleanup: any failure inside ``session.open()`` (consumer start timeout,
+partition-assign timeout, broker auth error, missing event-bus attributes)
+propagated out of the raising expression, the session reference was lost, and
+the daemon worker thread plus its never-closed asyncio event loop leaked — one
+pair per failed open. In the long-lived effects container the motivating caller
+(``HandlerContextRoiRunner``) opens a session per trial, so a 160-560-trial
+battery against a degraded broker accumulated hundreds of leaked threads.
+
+The fix wraps ``session.open()`` in ``TerminalEventConsumer.open`` so the
+session is closed (loop stopped, thread joined) before the failure re-raises.
+This covers both the two-phase ``.open(topic)`` path and the legacy single-call
+``__call__`` path, which opens through the same method.
+
+Failure injection: an event bus exposing no ``_bootstrap_servers`` makes
+``service_pattern_b_broker._direct_terminal_bootstrap_servers`` raise
+``RuntimeError`` inside the submitted ``_open_positioned_consumer`` coroutine —
+a real open-failure through the production code path, no Kafka required.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from omnibase_infra.runtime.service_terminal_event_consumer import (
+    make_terminal_event_consumer,
+)
+
+pytestmark = pytest.mark.unit
+
+_HANDLER_NAME = "Omn13058LeakProbe"
+_THREAD_NAME = f"terminal-consumer-{_HANDLER_NAME}"
+_TOPIC = "onex.evt.omninode.node-generation-completed.v1"
+
+
+def _leaked_threads() -> list[threading.Thread]:
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread.name == _THREAD_NAME and thread.is_alive()
+    ]
+
+
+def test_open_failure_does_not_leak_worker_thread() -> None:
+    """A failing two-phase open must close the session (thread joined)."""
+    consumer = make_terminal_event_consumer(
+        event_bus=object(),  # no _bootstrap_servers -> open fails fast
+        handler_name=_HANDLER_NAME,
+    )
+
+    assert _leaked_threads() == []
+
+    with pytest.raises(RuntimeError, match="_bootstrap_servers"):
+        consumer.open(_TOPIC)
+
+    assert _leaked_threads() == [], (
+        "TerminalEventConsumer.open leaked its session worker thread after a "
+        "failed open; the session must be closed before the failure re-raises "
+        "(OMN-13058)."
+    )
+
+
+def test_single_call_open_failure_does_not_leak_worker_thread() -> None:
+    """The legacy single-call form opens through the same guarded path."""
+    consumer = make_terminal_event_consumer(
+        event_bus=object(),
+        handler_name=_HANDLER_NAME,
+    )
+
+    with pytest.raises(RuntimeError, match="_bootstrap_servers"):
+        consumer(_TOPIC, "cid-omn-13058", 0.1)
+
+    assert _leaked_threads() == []


### PR DESCRIPTION
## Summary

Found by the P3.3 doctrinal review of merged #1951 (`b9712af9` / dev `36d98275`): the CodeRabbit Major on the omnimarket #1184 fold ("session.close possibly never called") is fixed in the merged runner code, but a sibling leak exists one layer down in omnibase_infra.

`TerminalConsumerSession.__init__` starts its dedicated worker loop thread immediately (`service_terminal_event_consumer.py`, the thread runs `loop.run_forever()`). `TerminalEventConsumer.open` did `session = TerminalConsumerSession(...); return session.open()` with no cleanup: any failure inside `session.open()` (consumer start timeout, partition-assign `TimeoutError` at the 30s cap, broker auth error, missing event-bus attributes) propagated out of the raising expression, the session reference was lost, `_closed` stayed `False`, and the daemon worker thread plus its never-closed asyncio event loop leaked — one pair per failed open. The Kafka client itself is NOT leaked (the `BaseException` handler in `service_pattern_b_broker.open_direct_terminal_consumer` stops it); the leak is thread+loop+session.

## Failure mode

The motivating caller (`HandlerContextRoiRunner`, OMN-13005/OMN-13012) opens a session per trial. A 160-560-trial experiment battery against a degraded broker/missing topic accumulates hundreds of leaked threads/loops in the long-lived effects container.

## Fix

Wrap `session.open()` in `TerminalEventConsumer.open` with try/except `BaseException` -> `session.close()` (idempotent: stops the loop, joins the thread) -> re-raise. Covers both the two-phase `.open(topic)` path and the legacy single-call `__call__` path, which opens through the same method.

## TDD (RED-then-GREEN)

`tests/unit/runtime/test_service_terminal_event_consumer_open_failure.py` injects a real open failure through the production code path (event bus exposing no `_bootstrap_servers` -> `_direct_terminal_bootstrap_servers` raises inside the submitted coroutine; no Kafka needed) and asserts no alive `terminal-consumer-*` thread after the raise, for both the two-phase and single-call forms. Verified RED with the fix stashed (2 failed), GREEN with it (2 passed).

## Local proof

- `ruff format` / `ruff check --fix src/ tests/`: clean (4064 files unchanged / all checks passed)
- `mypy src/ --strict`: Success, no issues in 2418 source files
- `pre-commit run --files <changed>`: 40 hooks Passed, 0 failed
- `uv run pytest tests/unit -n auto`: 20277 passed, 2 failed — both failures reproduce with this change fully stashed on clean dev tip and are machine-local artifacts, not regressions: `test_missing_kafka_bootstrap_servers_disables_emitter` fails because the local shell exports `KAFKA_BOOTSTRAP_SERVERS` (test does not isolate ambient env); `test_sync_check_reports_in_sync` compares the worktree's vendored migrations against the sibling canonical omnimarket clone's current state. CI runs both in a clean environment.
- New regression test: PASSED with fix, FAILED (red) with fix stashed.

## Deploy assessment

Additive error-path fix in one runtime module + one new test. No live deploy, restart, topic mutation, or .201 mutation performed. Runtime-loaded file: `src/omnibase_infra/runtime/service_terminal_event_consumer.py`; reaches lanes via the normal post-merge rebuild. deploy_pending = true.

OMN-13058

Evidence-Source: OCC#2542
Evidence-Ticket: OMN-13058

dod_evidence: see local proof above + review doc `omni_home/docs/evidence/2026-06-12-dev-integration-pass/P3.3-review/REVIEW.md`

Sibling review ticket (doctrinal seam formalization, approval-gated): OMN-13059.


