### PR TITLE
feat(OMN-13021): non-dev-base guard — fail feature-base PRs absent Stacked-Parent declaration (retro A-6)

### DIFF
--- a/.github/workflows/non-dev-base-guard.yml
+++ b/.github/workflows/non-dev-base-guard.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-13021 (retro A-6): Fail PRs whose base is neither dev nor main unless
+# the body declares an intentional stack via `Stacked-Parent: #<pr-number>`.
+#
+# Failure class: feedback_stacked_prs_orphan_from_dev — PRs #1185/#1954 were
+# auto-merged INTO parent feature branches, producing misleading MERGED states
+# and stranding the work off dev (recurrence of the June 5 incident, 3 tickets
+# stranded). Base=main is governed by main-target-guard (OMN-12243/OMN-12477).
+
+name: Non-dev base guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  non-dev-base-guard:
+    name: non-dev-base-guard
+    runs-on: >-
+      ${{
+        (github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Check PR base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${BASE_REF}" == "dev" ]]; then
+            echo "::notice::PR targets dev; guard does not apply."
+            exit 0
+          fi
+
+          if [[ "${BASE_REF}" == "main" ]]; then
+            echo "::notice::PR targets main; main-target-guard governs that path."
+            exit 0
+          fi
+
+          echo "PR targets feature base '${BASE_REF}' from head '${HEAD_REF}'."
+
+          if echo "${PR_BODY}" | grep -qE 'Stacked-Parent:[[:space:]]*#[0-9]+'; then
+            echo "::notice::Declared stacked PR (Stacked-Parent found). Allowed."
+            echo "::warning::Stacked PRs merge INTO their parent branch, not dev."
+            echo "::warning::Do NOT arm auto-merge on this PR; land the parent into dev first."
+            exit 0
+          fi
+
+          echo "::error::PR base '${BASE_REF}' is not the integration branch (dev)."
+          echo "::error::Auto-merge on this PR would fold it INTO '${BASE_REF}' and strand it off dev"
+          echo "::error::(feedback_stacked_prs_orphan_from_dev — the #1185/#1954 incident class)."
+          echo "::error::Either retarget to dev, or declare an intentional stack by adding a body line:"
+          echo "::error::  Stacked-Parent: #<parent-pr-number>"
+          exit 1


### PR DESCRIPTION
## Summary

Retro **A-6** (PROCESS_FAILURE_RETRO.md §3.A; Wall of Shame row 4 — feedback_stacked_prs_orphan_from_dev recurred: #1185/#1954 auto-merged INTO parent feature branches, misleading MERGED states, work stranded off dev).

Ticket: OMN-13021 (epic OMN-13013 — process enforcement ratchets, June 12 retro).

## Changes

New workflow `.github/workflows/non-dev-base-guard.yml`: any PR whose base is neither `dev` nor `main` fails unless the body declares `Stacked-Parent: #<pr-number>` (base=main stays governed by main-target-guard). Declared stacks pass with a warning that auto-merge folds into the parent, not dev. Same runs-on selection expression as main-target-guard; identical file landing on all five queue repos (omnibase_infra, omnimarket, onex_change_control, omniclaude, omnibase_compat).

## Enforcement note (operator)

The check runs on every PR immediately. Making it a REQUIRED check needs an all-branches ruleset per repo (dev branch protection cannot see feature-base PRs — the retro's point). Ruleset creation is a branch-protection mutation staged for the operator per the serial/additive live-mutation policy; follow-ups on OMN-13021 (Enable-Auto-Merge refusing non-dev base; done-detection classifying MERGED-into-feature-branch as folded-not-landed) are ticketed there too.

## Verification

Workflow-only change; YAML validated by GitHub at PR time. DoD path: re-running the #1185/#1954 scenario produces a red non-dev-base-guard check absent a Stacked-Parent declaration.


Evidence-Source: OCC#2549
Evidence-Ticket: OMN-13021