### PR TITLE
feat(OMN-13014): hot-patch ledger rebuild preflight gate (retro B-1)

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -684,6 +684,88 @@ guard_prod_promotion_lineage() {
     log_info "Prod promotion-lineage guard passed: source clean + promoted."
 }
 
+guard_hotpatch_ledger() {
+    # Hot-patch ledger rebuild preflight (OMN-13014, retro B-1).
+    #
+    # In-container hot-patches (.prepatch sibling discipline) silently revert
+    # on any image rebuild / force-recreate. When a hot-patch ledger exists on
+    # this host, refuse to build a lane whose recorded patches have source PRs
+    # not merged into the build ref, or whose containers carry unledgered
+    # .prepatch files. Delegates to scripts/preflight_hotpatch_ledger.py.
+    # Sole bypass: HOTPATCH_PREFLIGHT_BYPASS with a Rule-10 user-approval
+    # receipt ('# skip-token-allowed: <receipt-id>'), validated by the gate.
+    local repo_root="$1"
+    local git_sha="$2"
+    local compose_project="$3"
+
+    log_step "Hot-Patch Ledger Preflight (OMN-13014)"
+
+    local ledger_path="${HOTPATCH_LEDGER_PATH:-/data/omninode/hotpatch-ledger/ledger.yaml}"
+    if [[ ! -f "${ledger_path}" ]]; then
+        log_warn "No hot-patch ledger at ${ledger_path} — nothing recorded on this host; gate skipped."
+        log_warn "If containers here carry live hot-patches, STOP and write the ledger first."
+        return 0
+    fi
+
+    local gate="${repo_root}/scripts/preflight_hotpatch_ledger.py"
+    if [[ ! -f "${gate}" ]]; then
+        log_error "Hot-patch ledger exists at ${ledger_path} but the gate script is missing: ${gate}"
+        log_error "Refusing to rebuild over recorded hot-patches without the preflight."
+        exit 1
+    fi
+
+    # Lane = compose project suffix (omnibase-infra-stability-test -> stability-test);
+    # the bare dev project (omnibase-infra) maps to lane 'dev'.
+    local lane="${compose_project#omnibase-infra}"
+    lane="${lane#-}"
+    if [[ -z "${lane}" ]]; then
+        lane="dev"
+    fi
+
+    # Workspace builds vendor sibling repos from OMNI_HOME clones; the gate
+    # resolves each ledger row's repo build ref (clone HEAD unless overridden
+    # via --build-ref) and runs git merge-base --is-ancestor per merge commit.
+    local clones_root="${OMNI_HOME:-}"
+    if [[ -z "${clones_root}" ]]; then
+        log_error "Hot-patch ledger present but OMNI_HOME is unset."
+        log_error "Cannot resolve build-input clones for the hot-patch preflight."
+        exit 1
+    fi
+
+    local python_bin=""
+    if [[ -x "${repo_root}/.venv/bin/python" ]]; then
+        python_bin="${repo_root}/.venv/bin/python"
+    elif command -v uv &>/dev/null; then
+        python_bin="uv-run"
+    elif command -v python3 &>/dev/null; then
+        python_bin="python3"
+    else
+        log_error "No Python interpreter available to run the hot-patch ledger preflight."
+        exit 1
+    fi
+
+    local gate_args=(
+        --lane "${lane}"
+        --ledger "${ledger_path}"
+        --clones-root "${clones_root}"
+        --build-ref "omnibase_infra=${git_sha}"
+    )
+    log_cmd "${gate} ${gate_args[*]}"
+    if [[ "${python_bin}" == "uv-run" ]]; then
+        if ! uv run --project "${repo_root}" python "${gate}" "${gate_args[@]}"; then
+            log_error "Hot-patch ledger preflight FAILED. Refusing to rebuild over live hot-patches."
+            exit 1
+        fi
+    else
+        if ! "${python_bin}" "${gate}" "${gate_args[@]}"; then
+            log_error "Hot-patch ledger preflight FAILED. Refusing to rebuild over live hot-patches."
+            exit 1
+        fi
+    fi
+
+    log_info "Hot-patch ledger preflight passed: all recorded patches merged into the build ref."
+}
+
 # =============================================================================
 # Concurrency Lock
 # =============================================================================
@@ -1832,6 +1914,11 @@ main() {
     local deploy_target="${DEPLOY_ROOT}/deployed/${version}"
     local compose_project
     compose_project="$(resolve_compose_project)"
+
+    # Hot-patch ledger preflight: refuse to rebuild over live in-container
+    # hot-patches whose source PRs are not merged into the build ref.
+    # Runs in both dry-run and execute modes (OMN-13014, retro B-1).
+    guard_hotpatch_ledger "${repo_root}" "${git_sha}" "${compose_project}"
 
     # --print-compose-cmd: show commands and exit
     if [[ "${PRINT_COMPOSE_CMD}" == true ]]; then

--- a/scripts/preflight_hotpatch_ledger.py
+++ b/scripts/preflight_hotpatch_ledger.py
@@ -268,12 +268,12 @@ def run_preflight(args: argparse.Namespace) -> int:
                 failures.append(str(exc))
                 continue
             unledgered = [path for path in found if path not in ledgered]
-            missing = sorted(
-                path
-                for path in ledgered
-                if path not in found
-                and any(row["container"] == container for row in rows)
-            )
+            container_ledgered = {
+                str(row["prepatch_path"])
+                for row in rows
+                if row["container"] == container
+            }
+            missing = sorted(path for path in container_ledgered if path not in found)
             print(
                 f"HOTPATCH-PREFLIGHT: tripwire {container}: "
                 f"{len(found)} .prepatch file(s) live"

--- a/scripts/preflight_hotpatch_ledger.py
+++ b/scripts/preflight_hotpatch_ledger.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Hot-patch ledger rebuild preflight (OMN-13014, night-plan retro B-1).
+
+Container-layer hot-patches (``.prepatch`` sibling discipline) silently revert
+on any image rebuild or ``compose up --force-recreate``. This gate refuses to
+rebuild a container when:
+
+1. any hot-patch ledger row for the target container/lane has a source PR
+   merge commit that is NOT an ancestor of the build ref for that repo
+   (``git merge-base --is-ancestor``), or
+2. the running container carries ``.prepatch`` files that are NOT recorded in
+   the ledger (unledgered patches would be silently destroyed), or
+3. with ``--post-rebuild``: any ``.prepatch`` file survives the rebuild.
+
+The canonical ledger lives at ``/data/omninode/hotpatch-ledger/ledger.yaml``
+on the runtime host (override with ``--ledger`` or ``HOTPATCH_LEDGER_PATH``).
+
+Sole bypass: export ``HOTPATCH_PREFLIGHT_BYPASS`` containing a line of the
+exact Rule-10 form ``# skip-token-allowed: <user-approval-receipt-id>`` where
+the receipt id is a real user-issued approval handle. Any other value of the
+variable is a hard failure.
+
+Exit codes: 0 = pass (or authorized bypass), 1 = gate failure, 2 = usage or
+configuration error (missing ledger, unknown commit, malformed bypass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_LEDGER_PATH = "/data/omninode/hotpatch-ledger/ledger.yaml"
+BYPASS_PATTERN = re.compile(r"^# skip-token-allowed: (\S+)$")
+TRIPWIRE_SEARCH_PATHS = ("/app", "/usr/local/lib", "/usr/lib/python3", "/opt")
+SUPPORTED_SCHEMA = 1
+
+
+def fail(message: str, *, code: int = 1) -> int:
+    print(f"HOTPATCH-PREFLIGHT FAIL: {message}", file=sys.stderr)
+    return code
+
+
+def load_ledger(ledger_path: Path) -> dict[str, Any]:
+    if not ledger_path.is_file():
+        raise FileNotFoundError(
+            f"hot-patch ledger not found at {ledger_path}; refusing to guess. "
+            "If this host has never recorded a hot-patch, create an empty "
+            "ledger (schema: 1, rows: [])."
+        )
+    raw = yaml.safe_load(ledger_path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"ledger at {ledger_path} is not a mapping")
+    schema = raw.get("schema")
+    if schema != SUPPORTED_SCHEMA:
+        raise ValueError(
+            f"unsupported ledger schema {schema!r} (expected {SUPPORTED_SCHEMA})"
+        )
+    rows = raw.get("rows")
+    if rows is None:
+        raise ValueError("ledger has no 'rows' key")
+    if not isinstance(rows, list):
+        raise ValueError("ledger 'rows' must be a list")
+    return raw
+
+
+def select_rows(
+    rows: list[dict[str, Any]],
+    container: str | None,
+    lane: str | None,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for row in rows:
+        if container is not None and row.get("container") != container:
+            continue
+        if lane is not None and row.get("lane") != lane:
+            continue
+        selected.append(row)
+    return selected
+
+
+def resolve_build_ref(
+    repo: str,
+    explicit_refs: dict[str, str],
+    clones_root: Path,
+) -> str:
+    """Return the build ref for *repo*, defaulting to the clone's HEAD.
+
+    Workspace-mode builds vendor sibling repos from their clone working tree,
+    so the clone HEAD *is* the build ref when not explicitly overridden. The
+    resolved SHA is always printed so the deploy ledger can record it.
+    """
+    if repo in explicit_refs:
+        return explicit_refs[repo]
+    clone = clones_root / repo
+    head = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if head.returncode != 0:
+        raise ValueError(
+            f"no --build-ref given for repo {repo!r} and could not resolve "
+            f"HEAD of clone {clone}: {head.stderr.strip()}"
+        )
+    return head.stdout.strip()
+
+
+def commit_known(clone: Path, commit: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(clone), "cat-file", "-e", f"{commit}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def is_ancestor(clone: Path, commit: str, build_ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(clone), "merge-base", "--is-ancestor", commit, build_ref],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise ValueError(
+        f"git merge-base failed in {clone} for {commit}..{build_ref}: "
+        f"{result.stderr.strip()}"
+    )
+
+
+def tripwire_prepatch_files(container: str, docker_cmd: str) -> list[str]:
+    """Return every ``.prepatch`` path found inside the running container."""
+    find_cmd = " ".join(
+        f'find {path} -name "*.prepatch" 2>/dev/null;' for path in TRIPWIRE_SEARCH_PATHS
+    )
+    result = subprocess.run(
+        [docker_cmd, "exec", container, "sh", "-c", find_cmd],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"tripwire probe could not exec into container {container!r}: "
+            f"{result.stderr.strip()}"
+        )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_bypass() -> str | None:
+    """Return the receipt id when an authorized bypass is present.
+
+    Raises ValueError when the bypass variable is set but malformed — a
+    malformed bypass is a hard failure, never a silent pass-through.
+    """
+    raw = os.environ.get("HOTPATCH_PREFLIGHT_BYPASS")
+    if raw is None:
+        return None
+    match = BYPASS_PATTERN.fullmatch(raw.strip())
+    if match is None:
+        raise ValueError(
+            "HOTPATCH_PREFLIGHT_BYPASS is set but does not match the required "
+            "form '# skip-token-allowed: <user-approval-receipt-id>'"
+        )
+    return match.group(1)
+
+
+def parse_build_refs(pairs: list[str]) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for pair in pairs:
+        repo, sep, ref = pair.partition("=")
+        if not sep or not repo or not ref:
+            raise ValueError(f"--build-ref must be <repo>=<ref>, got {pair!r}")
+        refs[repo] = ref
+    return refs
+
+
+def run_preflight(args: argparse.Namespace) -> int:
+    try:
+        receipt = check_bypass()
+    except ValueError as exc:
+        return fail(str(exc), code=2)
+    if receipt is not None:
+        print(
+            "HOTPATCH-PREFLIGHT BYPASS: authorized by user approval receipt "
+            f"{receipt!r} — gate checks skipped."
+        )
+        return 0
+
+    ledger_path = Path(args.ledger)
+    try:
+        ledger = load_ledger(ledger_path)
+        explicit_refs = parse_build_refs(args.build_ref)
+    except (FileNotFoundError, ValueError) as exc:
+        return fail(str(exc), code=2)
+
+    rows = select_rows(ledger["rows"] or [], args.container, args.lane)
+    scope = args.container or args.lane
+    print(
+        f"HOTPATCH-PREFLIGHT: ledger {ledger_path} — {len(rows)} row(s) "
+        f"in scope {scope!r}"
+    )
+
+    failures: list[str] = []
+    clones_root = Path(args.clones_root)
+    resolved_refs: dict[str, str] = {}
+
+    for row in rows:
+        repo = row["source_repo"]
+        commit = row["merge_commit"]
+        clone = clones_root / repo
+        if repo not in resolved_refs:
+            try:
+                resolved_refs[repo] = resolve_build_ref(
+                    repo, explicit_refs, clones_root
+                )
+            except ValueError as exc:
+                return fail(str(exc), code=2)
+            print(f"HOTPATCH-PREFLIGHT: build ref {repo}={resolved_refs[repo]}")
+        build_ref = resolved_refs[repo]
+        if not commit_known(clone, commit):
+            return fail(
+                f"merge commit {commit} ({row['source_pr']}) is unknown in "
+                f"clone {clone} — the clone is stale or wrong; "
+                "run 'git fetch' on the build host first.",
+                code=2,
+            )
+        try:
+            merged = is_ancestor(clone, commit, build_ref)
+        except ValueError as exc:
+            return fail(str(exc), code=2)
+        marker = "ancestor-of-build-ref" if merged else "NOT in build ref"
+        print(
+            f"HOTPATCH-PREFLIGHT: {row['container']} {row['file']} "
+            f"<- {row['source_pr']} ({commit[:12]}): {marker}"
+        )
+        if not merged:
+            failures.append(
+                f"{row['file']} in {row['container']} is hot-patched from "
+                f"{row['source_pr']} (merge commit {commit}) which is NOT "
+                f"merged into build ref {build_ref} for repo {repo}; "
+                "rebuilding would silently destroy this patch."
+            )
+
+    if not args.skip_tripwire:
+        containers = sorted({str(row["container"]) for row in rows})
+        if args.container is not None:
+            containers = sorted(set(containers) | {args.container})
+        ledgered = {str(row["prepatch_path"]) for row in rows}
+        for container in containers:
+            try:
+                found = tripwire_prepatch_files(container, args.docker_cmd)
+            except ValueError as exc:
+                failures.append(str(exc))
+                continue
+            unledgered = [path for path in found if path not in ledgered]
+            missing = sorted(
+                path
+                for path in ledgered
+                if path not in found
+                and any(row["container"] == container for row in rows)
+            )
+            print(
+                f"HOTPATCH-PREFLIGHT: tripwire {container}: "
+                f"{len(found)} .prepatch file(s) live"
+            )
+            if args.post_rebuild and found:
+                failures.append(
+                    f"post-rebuild tripwire: {container} still carries "
+                    f".prepatch files {found}; the rebuild did not start from "
+                    "a clean image."
+                )
+            if not args.post_rebuild and unledgered:
+                failures.append(
+                    f"tripwire: {container} carries UNLEDGERED .prepatch "
+                    f"files {unledgered}; record them in the ledger before "
+                    "any rebuild."
+                )
+            if not args.post_rebuild and missing:
+                print(
+                    f"HOTPATCH-PREFLIGHT WARN: ledgered .prepatch missing from "
+                    f"{container}: {missing} (patch may already be reverted)"
+                )
+
+    if failures:
+        for failure in failures:
+            fail(failure)
+        return 1
+    print("HOTPATCH-PREFLIGHT PASS: all in-scope hot-patches merged into build ref.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--container", help="exact container name to gate")
+    scope.add_argument("--lane", help="gate every ledger row in this lane")
+    parser.add_argument(
+        "--build-ref",
+        action="append",
+        default=[],
+        metavar="REPO=REF",
+        help="build ref per repo (repeatable); defaults to clone HEAD",
+    )
+    parser.add_argument(
+        "--clones-root",
+        required=True,
+        help="directory containing the build-input git clones, one per repo",
+    )
+    parser.add_argument(
+        "--ledger",
+        default=os.environ.get("HOTPATCH_LEDGER_PATH", DEFAULT_LEDGER_PATH),
+        help="hot-patch ledger path (env HOTPATCH_LEDGER_PATH overrides default)",
+    )
+    parser.add_argument("--docker-cmd", default="docker")
+    parser.add_argument(
+        "--skip-tripwire",
+        action="store_true",
+        help="skip the running-container .prepatch probe (offline analysis)",
+    )
+    parser.add_argument(
+        "--post-rebuild",
+        action="store_true",
+        help="post-rebuild mode: any surviving .prepatch file is a failure",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return run_preflight(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_receipt_gate_install_guard.py
+++ b/tests/ci/test_receipt_gate_install_guard.py
@@ -145,8 +145,15 @@ class TestReceiptGateInstallSafeguards:
             "candidate-selection and force the local wheel (OMN-9283)"
         )
 
-    def test_install_uninstalls_stale_pypi_package_first(self) -> None:
-        """The install step must uninstall omnibase-core/compat before reinstalling from source."""
+    def test_install_uses_clean_workspace_venv(self) -> None:
+        """The install step must start from a freshly cleared workspace venv.
+
+        OMN-12565 (core PR #1189) replaced the 'uninstall stale PyPI package
+        first' step (OMN-9198) with `uv venv --clear` into a workspace-rooted
+        venv: a cleared venv cannot carry a stale PyPI omnibase-core, which is
+        the same contamination guarantee without writing the system
+        interpreter.
+        """
         workflow = self._load_receipt_gate()
         steps = workflow["jobs"]["verify"]["steps"]
         install_step = next(
@@ -155,9 +162,10 @@ class TestReceiptGateInstallSafeguards:
         )
         assert install_step is not None
         run_script: str = install_step.get("run", "")
-        assert "uv pip uninstall" in run_script and "omnibase-core" in run_script, (
-            "Install omnibase_core step must uninstall the stale PyPI omnibase-core "
-            "package before installing from source (OMN-9198)"
+        assert "uv venv" in run_script and "--clear" in run_script, (
+            "Install omnibase_core step must create a cleared workspace venv "
+            "(`uv venv --clear`) so no stale PyPI omnibase-core package can "
+            "leak into the gate environment (OMN-12565, supersedes OMN-9198)"
         )
 
     def test_install_builds_wheel_from_source(self) -> None:

--- a/tests/unit/scripts/test_preflight_hotpatch_ledger.py
+++ b/tests/unit/scripts/test_preflight_hotpatch_ledger.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/preflight_hotpatch_ledger.py (OMN-13014, retro B-1)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "preflight_hotpatch_ledger.py"
+)
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "preflight_hotpatch_ledger", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    return result.stdout.strip()
+
+
+def _make_repo(root: Path, name: str) -> Path:
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "dev")
+    (repo / "f.txt").write_text("one\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "c1")
+    return repo
+
+
+def _commit(repo: Path, content: str) -> str:
+    (repo / "f.txt").write_text(content)
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", content)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _write_ledger(
+    path: Path,
+    rows: list[dict[str, object]],
+    schema: int = 1,
+) -> Path:
+    path.write_text(yaml.safe_dump({"schema": schema, "rows": rows}))
+    return path
+
+
+def _row(
+    container: str,
+    repo: str,
+    commit: str,
+    *,
+    lane: str = "stability-test",
+    file: str = "/app/x.py",
+    prepatch: str = "/app/x.py.prepatch",
+) -> dict[str, object]:
+    return {
+        "container": container,
+        "lane": lane,
+        "file": file,
+        "prepatch_path": prepatch,
+        "source_repo": repo,
+        "source_pr": f"OmniNode-ai/{repo}#1",
+        "merge_commit": commit,
+        "merged": True,
+    }
+
+
+def _fake_docker(bin_dir: Path, prepatch_lines: list[str], rc: int = 0) -> str:
+    """Create a stub docker executable whose `exec` prints the given paths."""
+    script = bin_dir / "docker"
+    body = "\n".join(prepatch_lines)
+    script.write_text(
+        f'#!/bin/sh\nif [ "$1" = "exec" ]; then\n'
+        f'cat <<"EOF"\n{body}\nEOF\nexit {rc}\nfi\nexit 0\n'
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script)
+
+
+@pytest.mark.unit
+class TestAncestorGate:
+    def test_pass_when_merge_commit_in_build_ref(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "omnimarket")
+        sha = _commit(repo, "two")
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml", [_row("c1", "omnimarket", sha)]
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                f"omnimarket={_git(repo, 'rev-parse', 'HEAD')}",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 0
+
+    def test_fail_when_merge_commit_not_in_build_ref(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "omnimarket")
+        base = _git(repo, "rev-parse", "HEAD")
+        unmerged = _commit(repo, "two")  # build ref = base, patch commit after it
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml", [_row("c1", "omnimarket", unmerged)]
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                f"omnimarket={base}",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 1
+
+    def test_unknown_commit_is_config_error(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "omnimarket")
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml",
+            [_row("c1", "omnimarket", "0" * 40)],
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                f"omnimarket={_git(repo, 'rev-parse', 'HEAD')}",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 2
+
+    def test_build_ref_defaults_to_clone_head(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "omnimarket")
+        sha = _commit(repo, "two")
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml", [_row("c1", "omnimarket", sha)]
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 0
+
+    def test_lane_scope_selects_rows(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "omnimarket")
+        base = _git(repo, "rev-parse", "HEAD")
+        unmerged = _commit(repo, "two")
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml",
+            [
+                _row("c1", "omnimarket", unmerged, lane="stability-test"),
+                _row("c2", "omnimarket", base, lane="prod"),
+            ],
+        )
+        # prod lane only sees the merged row -> pass
+        rc = MODULE.main(
+            [
+                "--lane",
+                "prod",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                f"omnimarket={base}",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 0
+        # stability lane sees the unmerged row -> fail
+        rc = MODULE.main(
+            [
+                "--lane",
+                "stability-test",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                f"omnimarket={base}",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 1
+
+
+@pytest.mark.unit
+class TestLedgerLoading:
+    def test_missing_ledger_is_config_error(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, "omnimarket")
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(tmp_path / "nope.yaml"),
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 2
+
+    def test_unsupported_schema_is_config_error(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, "omnimarket")
+        ledger = _write_ledger(tmp_path / "ledger.yaml", [], schema=99)
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 2
+
+    def test_empty_rows_pass(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, "omnimarket")
+        ledger = _write_ledger(tmp_path / "ledger.yaml", [])
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 0
+
+
+@pytest.mark.unit
+class TestTripwire:
+    def _ledger_with_merged_row(
+        self, tmp_path: Path, prepatch: str
+    ) -> tuple[Path, str]:
+        repo = _make_repo(tmp_path, "omnimarket")
+        sha = _commit(repo, "two")
+        ledger = _write_ledger(
+            tmp_path / "ledger.yaml",
+            [_row("c1", "omnimarket", sha, prepatch=prepatch)],
+        )
+        return ledger, sha
+
+    def test_ledgered_prepatch_passes_pre_rebuild(self, tmp_path: Path) -> None:
+        ledger, _ = self._ledger_with_merged_row(tmp_path, "/app/x.py.prepatch")
+        docker = _fake_docker(tmp_path, ["/app/x.py.prepatch"])
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--docker-cmd",
+                docker,
+            ]
+        )
+        assert rc == 0
+
+    def test_unledgered_prepatch_fails(self, tmp_path: Path) -> None:
+        ledger, _ = self._ledger_with_merged_row(tmp_path, "/app/x.py.prepatch")
+        docker = _fake_docker(
+            tmp_path, ["/app/x.py.prepatch", "/app/rogue.py.prepatch"]
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--docker-cmd",
+                docker,
+            ]
+        )
+        assert rc == 1
+
+    def test_post_rebuild_fails_on_any_prepatch(self, tmp_path: Path) -> None:
+        ledger, _ = self._ledger_with_merged_row(tmp_path, "/app/x.py.prepatch")
+        docker = _fake_docker(tmp_path, ["/app/x.py.prepatch"])
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--docker-cmd",
+                docker,
+                "--post-rebuild",
+            ]
+        )
+        assert rc == 1
+
+    def test_post_rebuild_passes_when_clean(self, tmp_path: Path) -> None:
+        ledger, _ = self._ledger_with_merged_row(tmp_path, "/app/x.py.prepatch")
+        docker = _fake_docker(tmp_path, [])
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--docker-cmd",
+                docker,
+                "--post-rebuild",
+            ]
+        )
+        assert rc == 0
+
+    def test_exec_failure_fails_gate(self, tmp_path: Path) -> None:
+        ledger, _ = self._ledger_with_merged_row(tmp_path, "/app/x.py.prepatch")
+        docker = _fake_docker(tmp_path, [], rc=1)
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--docker-cmd",
+                docker,
+            ]
+        )
+        assert rc == 1
+
+
+@pytest.mark.unit
+class TestBypass:
+    def test_valid_receipt_bypasses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "HOTPATCH_PREFLIGHT_BYPASS", "# skip-token-allowed: receipt-abc-123"
+        )
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(tmp_path / "absent.yaml"),
+            ]
+        )
+        assert rc == 0
+
+    def test_malformed_bypass_is_hard_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOTPATCH_PREFLIGHT_BYPASS", "because I said so")
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(tmp_path / "absent.yaml"),
+            ]
+        )
+        assert rc == 2
+
+    def test_no_bypass_var_runs_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without bypass, missing ledger is a config error (proves gate ran).
+        monkeypatch.delenv("HOTPATCH_PREFLIGHT_BYPASS", raising=False)
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(tmp_path / "absent.yaml"),
+            ]
+        )
+        assert rc == 2
+
+
+@pytest.mark.unit
+class TestBuildRefParsing:
+    def test_malformed_build_ref_is_config_error(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, "omnimarket")
+        ledger = _write_ledger(tmp_path / "ledger.yaml", [])
+        rc = MODULE.main(
+            [
+                "--container",
+                "c1",
+                "--clones-root",
+                str(tmp_path),
+                "--ledger",
+                str(ledger),
+                "--build-ref",
+                "missing-equals",
+                "--skip-tripwire",
+            ]
+        )
+        assert rc == 2


### PR DESCRIPTION
## Summary

OMN-13014 (night-plan v3 §P0.3, retro **B-1**, NEVER-CUT). Container-layer hot-patches on .201 (`.prepatch` sibling discipline) silently revert on any image rebuild / `compose up --force-recreate` — the 2026-06-11 20:58Z rebuild already erased a live `/api/generate` patch once. This PR ships the rebuild-path gate.

## Changes

- **`scripts/preflight_hotpatch_ledger.py`** — given `--container <name>` or `--lane <lane>` plus per-repo `--build-ref repo=ref` (default: clone HEAD, printed), hard-fails when any hot-patch ledger row's source-PR merge commit is NOT an ancestor of the build ref (`git merge-base --is-ancestor`). `.prepatch` tripwire of the running container: unledgered `.prepatch` files = hard fail; `--post-rebuild` = any surviving `.prepatch` = hard fail. Missing/malformed ledger, unknown merge commit, malformed bypass = exit 2 (config error), never a silent pass. Sole bypass: `HOTPATCH_PREFLIGHT_BYPASS` carrying the Rule-10 user-approval-receipt form, validated by regex; free text hard-fails.
- **`scripts/deploy-runtime.sh`** — `guard_hotpatch_ledger` wired into `main()` (dry-run + execute, same pattern as the prod promotion-lineage guard). Lane derived from compose project (`omnibase-infra-stability-test` → `stability-test`; bare project → `dev`). Skips loudly only when no ledger file exists on the host; ledger-present-but-gate-missing or OMNI_HOME-unset aborts.
- **`tests/unit/scripts/test_preflight_hotpatch_ledger.py`** — 17 unit tests: ancestor pass/fail, unknown-commit, default build ref, lane scoping, ledger schema/missing/empty, tripwire (ledgered pass, unledgered fail, post-rebuild both ways, exec failure), bypass (valid receipt / malformed / absent), build-ref parsing.
- **`tests/ci/test_receipt_gate_install_guard.py`** — repair stale cross-repo guard: core OMN-12565 (core PR #1189) replaced the OMN-9198 "uv pip uninstall first" install step with a cleared workspace venv; `uv pip uninstall` no longer exists on core main OR dev, so `test_install_uninstalls_stale_pypi_package_first` failed against every current core ref (CI never saw it — the autouse fixture skips when the sibling clone is absent). Replaced with `test_install_uses_clean_workspace_venv` asserting `uv venv --clear`, the superseding contamination guarantee.

## Operational state (done in-session, evidence on the omni_home docs branch)

- Live census 2026-06-12T06:50:56Z across all 10 app containers on stability/prod/judge (no dev lane exists): exactly **5 `.prepatch` files**, all stability, reconciling the findings report (5 patch rows / 4 source PRs).
- Ledger installed at `/data/omninode/hotpatch-ledger/ledger.yaml` on .201 (sha256 `50b28669c6539c242c5bace9fd955d5b88d685787098654f52e485fcf142bec5`), mirrored at `docs/evidence/2026-06-12-dev-integration-pass/hotpatch-ledger.yaml` in omni_home.
- All 4 source PRs MERGED to dev: omnimarket#1180 (`a4e13e9b`), #1181 (`a0ad3c99`), #1184 (`1d5074d9`), omnibase_infra#1951 (`36d98275`) — probed live 2026-06-12T06:52Z.
- Standalone copy installed at `/data/omninode/hotpatch-ledger/preflight.sh` on .201 for tonight's rebuild (pre-merge drop-in per plan P0.3).

## Verification

- `uv run pytest tests/unit/scripts/test_preflight_hotpatch_ledger.py -v` → 17 passed
- `uv run pytest tests/ -n auto` (no `-k`) → 23,876 passed; remaining 11F/79E are live-infra-dependent (Kafka .201:19092 unreachable from this host, local docker runtime health, Postgres handler integration, LLM endpoint SLO, vendored-tree sibling drift) — none touch this diff
- `uv run mypy scripts/preflight_hotpatch_ledger.py --strict` + `uv run mypy src/ --strict` → clean
- `uv run ruff format` + `ruff check` → clean; `bash -n` + shellcheck on deploy-runtime.sh → clean
- pre-commit at commit time → all hooks passed

Ticket: OMN-13014

Evidence-Source: OCC#2548
Evidence-Ticket: OMN-13014

---

Closes OMN-13014.

dod_evidence: contracts/OMN-13014.yaml + drift/dod_receipts/OMN-13014/{dod-infra-pr,dod-deploy-assessment,dod-occ-pr}/command.yaml on OCC#2548; local validator_receipt_gate_cli run: RECEIPT GATE PASSED (3 checks).