### PR TITLE
fix(OMN-13070): config_prefetcher overlay wins on controlled lanes

### DIFF
--- a/src/omnibase_infra/runtime/config_discovery/config_prefetcher.py
+++ b/src/omnibase_infra/runtime/config_discovery/config_prefetcher.py
@@ -19,6 +19,21 @@ Design Decisions:
       is unavailable, prefetch fails loudly. When not enforced, missing values
       are logged as warnings and skipped.
 
+Precedence Rules (OMN-13070):
+    On **controlled lanes** (``infisical_required=True``):
+        1. Fetched/overlay config (Infisical) **always wins** over ambient env.
+        2. When Infisical returns ``None`` for a key, ambient env is used as a
+           **declared bootstrap fallback** — but only if the key is present, and
+           a ``INFO``-level provenance log line is emitted identifying that the
+           value came from ambient env rather than the controlled store.
+        3. A key missing from both Infisical and ambient env is reported as an
+           error (not silently dropped).
+
+    On **uncontrolled lanes** (``infisical_required=False``, the default):
+        - Keys already present in the process environment are skipped; the
+          ambient value is used directly (legacy behaviour — local dev
+          without Infisical continues to work).
+
 .. versionadded:: 0.10.0
     Created as part of OMN-2287.
 
@@ -30,6 +45,11 @@ Design Decisions:
     ``BaseModel`` (``ConfigDict(frozen=True, extra="forbid")``).  The
     ``missing`` field type changed from ``list[str]`` to ``tuple[str, ...]``
     to satisfy immutability requirements.
+
+.. versionchanged:: 0.10.3
+    OMN-13070: On controlled lanes (``infisical_required=True``) fetched config
+    wins over ambient env.  Ambient env is now only a declared bootstrap
+    fallback on controlled lanes, with a provenance log line.
 """
 
 from __future__ import annotations
@@ -169,15 +189,95 @@ class ConfigPrefetcher:
             )
             return None
 
+    def _resolve_key(
+        self,
+        key: str,
+        spec: ModelTransportConfigSpec,
+        *,
+        is_env_dep: bool = False,
+    ) -> tuple[str, SecretStr | None, str | None]:
+        """Resolve a single config key and return the outcome to the caller.
+
+        Returns a 3-tuple ``(outcome, value, error)`` where:
+        - ``outcome`` is one of ``"resolved"``, ``"missing"``, or ``"error"``
+        - ``value`` is the ``SecretStr`` when ``outcome == "resolved"``
+        - ``error`` is the error message string when ``outcome == "error"``
+
+        On controlled lanes (``infisical_required=True``), Infisical is
+        always consulted first.  Ambient env is used only as a declared
+        bootstrap fallback when Infisical returns ``None``, and a provenance
+        ``INFO`` log line is emitted in that case.
+
+        On uncontrolled lanes (``infisical_required=False``), a key already
+        present in the process environment is used directly (legacy behaviour
+        — local dev without Infisical continues to work unchanged).
+
+        Args:
+            key: The config key name.
+            spec: The transport config spec (provides the Infisical folder).
+            is_env_dep: ``True`` when the key comes from an explicit
+                ``dependencies[]`` declaration rather than a transport spec.
+
+        Returns:
+            ``(outcome, value, error)`` 3-tuple; callers record into accumulators.
+        """
+        if self._infisical_required:
+            # Controlled lane: Infisical/overlay WINS over ambient env.
+            # Always attempt the fetch; fall back to ambient env only when
+            # Infisical returns None, with an explicit provenance log line.
+            value = self._fetch_key(key, spec)
+            if value is not None:
+                return ("resolved", value, None)
+            if key in os.environ:
+                # Declared bootstrap fallback — log provenance explicitly.
+                logger.info(
+                    "Key %s not found in Infisical; using ambient env as "
+                    "bootstrap fallback (controlled lane) — "
+                    "provenance: process environment",
+                    key,
+                )
+                return ("resolved", SecretStr(os.environ[key]), None)
+            # Missing from both Infisical and ambient env on a controlled
+            # lane: record as error, not silently dropped.
+            if is_env_dep or spec.required:
+                return (
+                    "error",
+                    None,
+                    f"Required key {key} not found at"
+                    f" {spec.infisical_folder} and absent from ambient env",
+                )
+            return ("missing", None, None)
+
+        # Uncontrolled lane: ambient env takes precedence (legacy).
+        if key in os.environ:
+            logger.debug(
+                "Key %s already in environment, skipping prefetch",
+                key,
+            )
+            return ("resolved", SecretStr(os.environ[key]), None)
+
+        value = self._fetch_key(key, spec)
+        if value is not None:
+            return ("resolved", value, None)
+        return ("missing", None, None)
+
     def prefetch(
         self,
         requirements: ModelConfigRequirements,
     ) -> ModelPrefetchResult:
         """Prefetch all configuration values for the given requirements.
 
-        Builds transport specs from the requirements' transport types,
-        then fetches each key via the handler. Keys already present in
-        the process environment are skipped (env always takes precedence).
+        Builds transport specs from the requirements' transport types, then
+        fetches each key via the handler.
+
+        Precedence on controlled lanes (``infisical_required=True``):
+            Infisical/overlay config **wins** over ambient env.  Ambient env is
+            used only as a declared bootstrap fallback when Infisical returns
+            ``None``, and a provenance ``INFO`` log line is emitted.
+
+        Precedence on uncontrolled lanes (``infisical_required=False``):
+            Keys already present in the process environment are skipped; the
+            ambient value is used directly (legacy behaviour for local dev).
 
         Args:
             requirements: Config requirements extracted from contracts.
@@ -216,33 +316,20 @@ class ConfigPrefetcher:
                 env_keys.append(req.key)
 
         logger.info(
-            "Prefetching config: %d transport specs, %d env keys",
+            "Prefetching config: %d transport specs, %d env keys (controlled_lane=%s)",
             len(specs),
             len(env_keys),
+            self._infisical_required,
         )
 
         # Fetch transport-based keys
         for spec in specs:
             for key in spec.keys:
-                # Skip if already in environment (env overrides Infisical).
-                # Use ``key in os.environ`` (not ``os.environ.get(key)``) so
-                # that intentionally empty values are respected and not
-                # overwritten by Infisical.
-                if key in os.environ:
-                    logger.debug(
-                        "Key %s already in environment, skipping prefetch",
-                        key,
-                    )
-                    resolved[key] = SecretStr(os.environ[key])
-                    continue
-
-                value = self._fetch_key(key, spec)
-                if value is not None:
+                outcome, value, error = self._resolve_key(key, spec)
+                if outcome == "resolved" and value is not None:
                     resolved[key] = value
-                elif self._infisical_required and spec.required:
-                    errors[key] = (
-                        f"Required key {key} not found at {spec.infisical_folder}"
-                    )
+                elif outcome == "error" and error is not None:
+                    errors[key] = error
                 else:
                     missing.append(key)
 
@@ -257,18 +344,13 @@ class ConfigPrefetcher:
                 keys=tuple(env_keys),
             )
             for key in env_keys:
-                if key in os.environ:
-                    resolved[key] = SecretStr(os.environ[key])
-                    continue
-
-                value = self._fetch_key(key, env_spec)
-                if value is not None:
+                outcome, value, error = self._resolve_key(
+                    key, env_spec, is_env_dep=True
+                )
+                if outcome == "resolved" and value is not None:
                     resolved[key] = value
-                elif self._infisical_required:
-                    errors[key] = (
-                        f"Required env dependency key {key} not found at"
-                        f" {env_spec.infisical_folder}"
-                    )
+                elif outcome == "error" and error is not None:
+                    errors[key] = error
                 else:
                     missing.append(key)
 
@@ -316,25 +398,45 @@ class ConfigPrefetcher:
     def apply_to_environment(self, result: ModelPrefetchResult) -> int:
         """Apply prefetched values to the process environment.
 
-        Only sets keys that are NOT already in the environment (environment
-        variables always take precedence over Infisical values).
+        On controlled lanes (``infisical_required=True``), fetched config
+        **always wins**: existing ambient env values are overwritten so that
+        stale shell or compose state cannot survive the prefetch boundary.
+
+        On uncontrolled lanes (``infisical_required=False``), only keys that
+        are NOT already present in the environment are set (legacy behaviour
+        — local dev without Infisical continues to work unchanged).
 
         Args:
             result: The prefetch result to apply.
 
         Returns:
-            Number of keys actually set in the environment.
+            Number of keys actually set (or overwritten) in the environment.
         """
         applied = 0
         for key, value in result.resolved.items():
-            if key not in os.environ:
+            if self._infisical_required:
+                # Controlled lane: fetched config wins — overwrite ambient env.
+                existing = os.environ.get(key)
+                os.environ[key] = value.get_secret_value()
+                applied += 1
+                if existing is not None:
+                    logger.info(
+                        "Applied prefetched key %s to environment "
+                        "(controlled lane — overwrote ambient env value)",
+                        key,
+                    )
+                else:
+                    logger.debug("Applied prefetched key %s to environment", key)
+            # Uncontrolled lane: ambient env takes precedence (legacy).
+            elif key not in os.environ:
                 os.environ[key] = value.get_secret_value()
                 applied += 1
                 logger.debug("Applied prefetched key %s to environment", key)
 
         logger.info(
-            "Applied %d/%d prefetched keys to environment",
+            "Applied %d/%d prefetched keys to environment (controlled_lane=%s)",
             applied,
             len(result.resolved),
+            self._infisical_required,
         )
         return applied

--- a/tests/unit/runtime/config_discovery/test_config_prefetcher.py
+++ b/tests/unit/runtime/config_discovery/test_config_prefetcher.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Unit tests for ConfigPrefetcher (OMN-2287)."""
+"""Unit tests for ConfigPrefetcher (OMN-2287, OMN-13070)."""
 
 from __future__ import annotations
 
@@ -140,11 +140,17 @@ class TestConfigPrefetcher:
         assert len(result.missing) > 0
         assert "POSTGRES_HOST" in result.missing
 
-    def test_prefetch_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Keys already in environment should skip Infisical fetch."""
+    def test_prefetch_env_override_uncontrolled_lane(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On uncontrolled lane, keys already in environment skip Infisical fetch.
+
+        Legacy behaviour: local dev without Infisical continues to work.
+        infisical_required=False (default) means ambient env wins.
+        """
         monkeypatch.setenv("POSTGRES_HOST", "from-env")
         handler = self._make_handler(secrets={})
-        prefetcher = ConfigPrefetcher(handler=handler)
+        prefetcher = ConfigPrefetcher(handler=handler)  # infisical_required=False
         reqs = self._make_requirements(
             transport_types=[EnumInfraTransportType.DATABASE]
         )
@@ -153,14 +159,15 @@ class TestConfigPrefetcher:
 
         assert "POSTGRES_HOST" in result.resolved
         assert result.resolved["POSTGRES_HOST"].get_secret_value() == "from-env"
-        # Handler should NOT have been called for POSTGRES_HOST
+        # Handler should NOT have been called for POSTGRES_HOST on uncontrolled lane
         postgres_host_calls = [
             call
             for call in handler.get_secret_sync.call_args_list
             if call.kwargs.get("secret_name") == "POSTGRES_HOST"
         ]
         assert len(postgres_host_calls) == 0, (
-            "POSTGRES_HOST should not be fetched from Infisical when present in env"
+            "POSTGRES_HOST should not be fetched from Infisical on uncontrolled lane "
+            "when present in env"
         )
 
     def test_prefetch_env_dependencies(self) -> None:
@@ -206,8 +213,19 @@ class TestConfigPrefetcher:
         result = prefetcher.prefetch(reqs)
         assert result.failure_count > 0
 
-    def test_prefetch_infisical_required(self) -> None:
-        """Should report errors for required keys when infisical_required=True."""
+    def test_prefetch_infisical_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On controlled lane, missing keys (not in Infisical or env) go to errors."""
+        # Remove all DATABASE transport keys so neither Infisical nor env can
+        # supply them — they must land in result.errors on a controlled lane.
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        for key in TransportConfigMap.keys_for_transport(
+            EnumInfraTransportType.DATABASE
+        ):
+            monkeypatch.delenv(key, raising=False)
+
         handler = self._make_handler(secrets={})
         prefetcher = ConfigPrefetcher(handler=handler, infisical_required=True)
         reqs = self._make_requirements(
@@ -218,9 +236,8 @@ class TestConfigPrefetcher:
 
         # When infisical_required=True, ConfigPrefetcher passes required=True
         # to specs_for_transports(), which sets spec.required=True on all
-        # returned specs. The condition ``self._infisical_required and
-        # spec.required`` therefore fires for every missing transport key,
-        # routing them to result.errors rather than result.missing.
+        # returned specs. Keys missing from both Infisical and ambient env go to
+        # result.errors rather than result.missing.
         assert result.failure_count > 0
         assert len(result.errors) > 0
         assert len(result.missing) == 0
@@ -255,14 +272,17 @@ class TestConfigPrefetcher:
         # Cleanup
         monkeypatch.delenv("TEST_PREFETCH_KEY", raising=False)
 
-    def test_apply_does_not_overwrite_existing(
+    def test_apply_does_not_overwrite_existing_uncontrolled_lane(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Should NOT overwrite keys already in environment."""
+        """On uncontrolled lane, apply_to_environment must NOT overwrite existing env.
+
+        Legacy behaviour: infisical_required=False means ambient env wins.
+        """
         monkeypatch.setenv("EXISTING_KEY", "original")
 
         handler = self._make_handler(secrets={})
-        prefetcher = ConfigPrefetcher(handler=handler)
+        prefetcher = ConfigPrefetcher(handler=handler)  # infisical_required=False
 
         result = ModelPrefetchResult(
             resolved={"EXISTING_KEY": SecretStr("from-infisical")}
@@ -305,3 +325,165 @@ class TestConfigPrefetcher:
         result = prefetcher.prefetch(reqs)
         assert result.success_count == 0
         assert result.failure_count == 0
+
+    # --- OMN-13070 controlled-lane precedence regression tests ---
+
+    def test_controlled_lane_infisical_wins_over_stale_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On controlled lane, Infisical value beats a stale ambient env value.
+
+        Regression for OMN-13070: config_prefetcher previously skipped keys
+        already present in os.environ regardless of lane, allowing stale
+        shell/compose state to override fetched configuration.
+        """
+        # Stale value already in env (e.g. from compose or developer's shell)
+        monkeypatch.setenv("POSTGRES_HOST", "stale-from-compose")
+        # Infisical has the authoritative value
+        handler = self._make_handler(
+            secrets={"POSTGRES_HOST": "authoritative-from-infisical"}
+        )
+        prefetcher = ConfigPrefetcher(handler=handler, infisical_required=True)
+        reqs = self._make_requirements(
+            transport_types=[EnumInfraTransportType.DATABASE]
+        )
+
+        result = prefetcher.prefetch(reqs)
+
+        assert "POSTGRES_HOST" in result.resolved
+        assert (
+            result.resolved["POSTGRES_HOST"].get_secret_value()
+            == "authoritative-from-infisical"
+        ), "Controlled lane: Infisical value must win over stale ambient env"
+        # Handler MUST have been called — we must not short-circuit on env presence
+        postgres_host_calls = [
+            call
+            for call in handler.get_secret_sync.call_args_list
+            if call.kwargs.get("secret_name") == "POSTGRES_HOST"
+        ]
+        assert len(postgres_host_calls) == 1, (
+            "Controlled lane: handler must be called for POSTGRES_HOST even when "
+            "it is present in ambient env"
+        )
+
+    def test_controlled_lane_env_as_bootstrap_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On controlled lane, ambient env is used as bootstrap fallback only when
+        Infisical returns None for a key, and the result is resolved (not missing).
+
+        This covers the bootstrap case where a secret is seeded in env before
+        Infisical is available (e.g. POSTGRES_PASSWORD during first-time startup).
+        """
+        # Infisical has no value for this key (e.g. not seeded yet)
+        handler = self._make_handler(secrets={})
+        # But the key is present in the bootstrap env
+        monkeypatch.setenv("POSTGRES_HOST", "bootstrap-env-value")
+        prefetcher = ConfigPrefetcher(handler=handler, infisical_required=True)
+        reqs = self._make_requirements(
+            transport_types=[EnumInfraTransportType.DATABASE]
+        )
+
+        result = prefetcher.prefetch(reqs)
+
+        # Key must be resolved from env fallback, not reported as error/missing
+        assert "POSTGRES_HOST" in result.resolved, (
+            "Controlled lane: ambient env must be used as bootstrap fallback "
+            "when Infisical returns None"
+        )
+        assert (
+            result.resolved["POSTGRES_HOST"].get_secret_value() == "bootstrap-env-value"
+        )
+        # Handler MUST have been called (we always try Infisical first)
+        postgres_host_calls = [
+            call
+            for call in handler.get_secret_sync.call_args_list
+            if call.kwargs.get("secret_name") == "POSTGRES_HOST"
+        ]
+        assert len(postgres_host_calls) == 1, (
+            "Controlled lane: handler must be called before falling back to env"
+        )
+
+    def test_controlled_lane_apply_overwrites_stale_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On controlled lane, apply_to_environment must overwrite stale ambient env.
+
+        Regression for OMN-13070: apply_to_environment previously skipped keys
+        already present in os.environ on all lanes, allowing stale shell/compose
+        state to survive the prefetch boundary.
+        """
+        monkeypatch.setenv("DB_HOST", "stale-compose-value")
+
+        handler = self._make_handler(secrets={})
+        prefetcher = ConfigPrefetcher(handler=handler, infisical_required=True)
+
+        result = ModelPrefetchResult(
+            resolved={"DB_HOST": SecretStr("authoritative-from-infisical")}
+        )
+
+        applied = prefetcher.apply_to_environment(result)
+
+        assert applied == 1, "Controlled lane: stale env key must be overwritten"
+        assert os.environ.get("DB_HOST") == "authoritative-from-infisical", (
+            "Controlled lane: apply_to_environment must replace stale ambient env "
+            "value with the fetched authoritative value"
+        )
+
+    def test_controlled_lane_missing_from_both_infisical_and_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On controlled lane, a key absent from both Infisical and env is an error."""
+        from omnibase_infra.runtime.config_discovery.transport_config_map import (
+            TransportConfigMap,
+        )
+
+        for key in TransportConfigMap.keys_for_transport(
+            EnumInfraTransportType.DATABASE
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        handler = self._make_handler(secrets={})
+        prefetcher = ConfigPrefetcher(handler=handler, infisical_required=True)
+        reqs = self._make_requirements(
+            transport_types=[EnumInfraTransportType.DATABASE]
+        )
+
+        result = prefetcher.prefetch(reqs)
+
+        # Must appear in errors, not missing — missing is for uncontrolled-lane
+        # soft failures; controlled-lane absence is a hard error.
+        assert len(result.errors) > 0, (
+            "Controlled lane: keys absent from both Infisical and env must be errors"
+        )
+        assert len(result.missing) == 0, (
+            "Controlled lane: result.missing must be empty; use result.errors"
+        )
+
+    def test_precedence_order_uncontrolled_env_wins_infisical_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On uncontrolled lane, Infisical is NOT called when the key is in env.
+
+        Verifies the uncontrolled-lane legacy shortcut is still active and
+        does not regress to always-calling-Infisical after OMN-13070.
+        """
+        monkeypatch.setenv("POSTGRES_HOST", "local-dev-value")
+        handler = self._make_handler(secrets={"POSTGRES_HOST": "infisical-value"})
+        prefetcher = ConfigPrefetcher(handler=handler)  # infisical_required=False
+        reqs = self._make_requirements(
+            transport_types=[EnumInfraTransportType.DATABASE]
+        )
+
+        result = prefetcher.prefetch(reqs)
+
+        assert result.resolved["POSTGRES_HOST"].get_secret_value() == "local-dev-value"
+        # Handler must NOT have been called on uncontrolled lane when env is set
+        postgres_host_calls = [
+            call
+            for call in handler.get_secret_sync.call_args_list
+            if call.kwargs.get("secret_name") == "POSTGRES_HOST"
+        ]
+        assert len(postgres_host_calls) == 0, (
+            "Uncontrolled lane: Infisical must not be called when key is in env"
+        )


### PR DESCRIPTION
Evidence-Source: OCC#2566
Evidence-Ticket: OMN-13070

## Summary

Fixes `config_prefetcher.py` ambient-env precedence defect (OMN-13070).

**Root cause**: `prefetch()` skipped keys already present in `os.environ` regardless of lane, allowing stale shell/compose state to beat fetched configuration. `apply_to_environment()` also skipped existing env keys on all lanes.

**Fix**: On `infisical_required=True` (controlled) lanes:
- `prefetch()` always calls Infisical first; ambient env used only as a declared bootstrap fallback when Infisical returns `None`, with an explicit provenance `INFO` log line.
- `apply_to_environment()` overwrites existing env values so stale state cannot survive the prefetch boundary.

Uncontrolled lane (`infisical_required=False`) behaviour is unchanged — local dev without Infisical continues to work.

**Refactor**: `_resolve_key` now returns a `(outcome, value, error)` tuple instead of mutating accumulator arguments, satisfying the ≤5-param pattern gate.

## Tests

20 unit tests passing, 5 new controlled-lane regression tests:
- `test_controlled_lane_infisical_wins_over_stale_env` — core regression
- `test_controlled_lane_env_as_bootstrap_fallback` — fallback path
- `test_controlled_lane_apply_overwrites_stale_env` — apply regression
- `test_controlled_lane_missing_from_both_infisical_and_env` — error path
- `test_precedence_order_uncontrolled_env_wins_infisical_skipped` — uncontrolled lane unchanged

## Files changed

- `src/omnibase_infra/runtime/config_discovery/config_prefetcher.py`
- `tests/unit/runtime/config_discovery/test_config_prefetcher.py`

Source: `docs/audits/2026-06-10-runtime-env-overlay-authority-audit.md` — Infisical Migration Direction section
