### PR TITLE
feat(OMN-12858/OMN-12879/OMN-12880): dispatcher route-coverage CI gate

### DIFF
--- a/.github/workflows/dispatcher-route-coverage.yml
+++ b/.github/workflows/dispatcher-route-coverage.yml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# dispatcher-route-coverage.yml — OMN-12858 / OMN-12879 / OMN-12880
+#
+# CI gate: for every contract.yaml in omnibase_infra + omnimarket that
+# subscribes to a command topic (onex.cmd.*), assert that the contract
+# declares a dispatcher route via handler_routing or runtime_dispatch.
+#
+# Missing wiring causes the command to go to DLQ silently.  This gate
+# catches that regression before it reaches the runtime.
+#
+# MOTIVATION — two incidents this gate would have caught:
+#
+#   1. June 9 2026 DLQ regression: node_generation_consumer subscribed
+#      onex.cmd.omnimarket.node-generation-requested.v1 but auto-wiring
+#      produced zero dispatchers after a sole-handler revert was merged.
+#      Messages silently went to DLQ.  (OMN-12858 post-mortem)
+#
+#   2. June 12 2026 DEL-01 live finding: onex.cmd.omnimarket.delegate-skill.v1
+#      was consumed by the dev lane bus but no dispatcher route existed in any
+#      deployed contract, so delegation requests went to DLQ silently.
+#      Discovered via manual rpk consumer-group lag probe (DEL-01 evidence).
+#
+# Coverage scope (OMN-12880):
+#   - All subscribed topics where topic contains '.cmd.'
+#   - compatibility_publish_topics are sender-side only; they are NOT
+#     checked for missing routes (no false positives).
+#
+# Changed-command-topic mode (OMN-12879):
+#   - When the PR diff touches contract.yaml files, only those contracts are
+#     checked.  Pre-existing allowlisted violations are not re-reported.
+#
+# Ratchet / baseline model:
+#   - Known pre-existing violations are in scripts/check_dispatcher_route_coverage.py
+#     _ALLOWLISTED_CMD_TOPICS with ticket refs and expiry dates.
+#   - New violations are NEVER silently added — they must be fixed.
+
+name: Dispatcher Route Coverage
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatcher-route-coverage:
+    name: dispatcher-route-coverage
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_infra
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Checkout omnimarket (sibling)
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnimarket
+          ref: dev
+          path: omnimarket
+          token: ${{ secrets.OMNI_GITHUB_TOKEN || github.token }}
+          # Sparse checkout: only the contract files needed for coverage analysis
+          sparse-checkout: |
+            src/omnimarket/nodes
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: "3.12"
+          uv-version: "0.6.14"
+          cache-version: "0.6.0"
+          cache-enabled: "false"
+
+      - name: Collect changed contract paths (OMN-12879)
+        id: changed_contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Find contract.yaml files changed in this PR diff vs the base branch.
+          # For push/merge_group events there is no PR diff; run full scan.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- '**/contract.yaml' || true)
+            if [[ -n "$CHANGED" ]]; then
+              # Convert to absolute paths so the script can match them
+              ABS_PATHS=$(echo "$CHANGED" | xargs -I{} realpath --relative-to=. {} 2>/dev/null || echo "$CHANGED")
+              echo "changed_contracts=$ABS_PATHS" >> "$GITHUB_OUTPUT"
+              echo "Found changed contracts:"
+              echo "$CHANGED" | head -20
+            else
+              echo "changed_contracts=" >> "$GITHUB_OUTPUT"
+              echo "No contract.yaml files changed; full scan will run."
+            fi
+          else
+            echo "changed_contracts=" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event; running full scan."
+          fi
+
+      - name: Run dispatcher route-coverage gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CHANGED="${{ steps.changed_contracts.outputs.changed_contracts }}"
+          EXTRA_DIR="omnimarket/src/omnimarket/nodes"
+
+          ARGS=(
+            "--contracts-dir" "src/omnibase_infra/nodes"
+            "--extra-contracts-dir" "$EXTRA_DIR"
+          )
+
+          if [[ -n "${CHANGED}" ]]; then
+            echo "::notice::Running in changed-contract mode (OMN-12879): $(echo "${CHANGED}" | wc -w) paths"
+            ARGS+=("--changed-contracts" "${CHANGED}")
+          else
+            echo "::notice::Running full scan across both contract directories"
+          fi
+
+          uv run python scripts/check_dispatcher_route_coverage.py "${ARGS[@]}"

--- a/.github/workflows/dispatcher-route-coverage.yml
+++ b/.github/workflows/dispatcher-route-coverage.yml
@@ -58,7 +58,7 @@ jobs:
         && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - name: Checkout omnibase_infra
@@ -78,13 +78,12 @@ jobs:
             src/omnimarket/nodes
           sparse-checkout-cone-mode: false
 
-      - name: Setup Python and uv
-        uses: ./.github/actions/setup-python-uv
-        with:
-          python-version: "3.12"
-          uv-version: "0.6.14"
-          cache-version: "0.6.0"
-          cache-enabled: "false"
+      - name: Install pyyaml (only dep for gate script)
+        shell: bash
+        run: |
+          # The gate script uses only stdlib + pyyaml; skip full uv sync to keep
+          # this job fast (no Kafka, no DB, no handler imports).
+          python3 -m pip install --quiet pyyaml
 
       - name: Collect changed contract paths (OMN-12879)
         id: changed_contracts
@@ -132,4 +131,4 @@ jobs:
             echo "::notice::Running full scan across both contract directories"
           fi
 
-          uv run python scripts/check_dispatcher_route_coverage.py "${ARGS[@]}"
+          python3 scripts/check_dispatcher_route_coverage.py "${ARGS[@]}"

--- a/scripts/check_dispatcher_route_coverage.py
+++ b/scripts/check_dispatcher_route_coverage.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Dispatcher route-coverage gate (OMN-12858 / OMN-12879 / OMN-12880).
+
+Static analysis: for every contract that subscribes to a command topic
+(``onex.cmd.*``), assert that the contract declares a dispatcher route via
+``handler_routing`` or ``runtime_dispatch``.  Missing wiring causes the
+command to go to DLQ silently — this gate catches that regression before
+it reaches the runtime.
+
+Coverage included (OMN-12880):
+- Primary ``event_bus.subscribe_topics`` entries.
+- ``compatibility_publish_topics`` entries are treated as sender-side only
+  (a publisher does not require a handler route for topics it emits to
+  compatibility surfaces — routes are required only on the subscriber side).
+
+Changed-command-topic coverage (OMN-12879):
+- When ``--changed-contracts`` paths are provided (space-separated list from
+  CI diff), only those contracts are checked for missing routes.  This makes
+  failures actionable to the PR author without blocking on pre-existing
+  ratchet violations.
+
+Usage::
+
+    # Full scan (both repos checked out as siblings)
+    uv run python scripts/check_dispatcher_route_coverage.py \\
+        --contracts-dir src/omnibase_infra/nodes \\
+        --extra-contracts-dir ../omnimarket/src/omnimarket/nodes
+
+    # CI changed-contract mode (OMN-12879)
+    uv run python scripts/check_dispatcher_route_coverage.py \\
+        --contracts-dir src/omnibase_infra/nodes \\
+        --extra-contracts-dir ../omnimarket/src/omnimarket/nodes \\
+        --changed-contracts "src/.../contract.yaml src/.../contract.yaml"
+
+    # Verbose output
+    uv run python scripts/check_dispatcher_route_coverage.py \\
+        --contracts-dir src/omnibase_infra/nodes \\
+        --extra-contracts-dir ../omnimarket/src/omnimarket/nodes \\
+        --verbose
+
+Exit codes:
+    0 = all command-topic subscriptions have a dispatcher route (or are allowlisted)
+    1 = one or more command-topic subscriptions are missing dispatcher wiring
+
+[OMN-12858, OMN-12879, OMN-12880]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Allow running as a standalone script when omnibase_infra is not installed.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = _REPO_ROOT / "src"
+if _SRC_DIR.is_dir() and str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_CMD_TOPIC_PREFIX = "onex.cmd."
+
+# ---------------------------------------------------------------------------
+# Allowlist: command-topic subscriptions that are expected to have no
+# handler_routing / runtime_dispatch because they are consumed by an
+# internal broker outside the standard dispatch surface.
+# Format: "topic": "reason | owner | expiry"
+# ---------------------------------------------------------------------------
+_ALLOWLISTED_CMD_TOPICS: dict[str, str] = {
+    # Pattern-B dispatch broker owns its own consumption model; the contract
+    # declares the subscription but RuntimePatternBBroker processes the
+    # messages directly, bypassing handler_routing.
+    "onex.cmd.omnibase-infra.pattern-b-dispatch.v1": (
+        "Consumed by RuntimePatternBBroker directly, not via handler_routing "
+        "| owner: jonah | expiry: 2027-01-01"
+    ),
+    # Transitional HTTP bridge (OMN-2756): subscribes for observability/future
+    # Kafka-native switch but is currently an HTTP-dispatch node.  Dispatcher
+    # route will be added when the node is migrated to native Kafka dispatch.
+    # Ref: node_contract_resolver_bridge/contract.yaml — metadata.transitional=true
+    "onex.cmd.platform.contract-resolve-requested.v1": (
+        "Transitional HTTP bridge node_contract_resolver_bridge (OMN-2756); "
+        "processes via FastAPI not Kafka handler_routing | owner: jonah | expiry: 2027-01-01"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ContractInfo:
+    """Parsed subset of a contract.yaml needed for route coverage checking."""
+
+    name: str
+    contract_path: Path
+    subscribe_topics: tuple[str, ...]
+    has_handler_routing: bool
+    has_runtime_dispatch: bool
+
+    @property
+    def has_dispatcher_route(self) -> bool:
+        return self.has_handler_routing or self.has_runtime_dispatch
+
+
+@dataclass
+class RouteCoverageFailure:
+    """One missing-route finding."""
+
+    topic: str
+    contract_name: str
+    contract_path: Path
+
+
+@dataclass
+class RouteCoverageReport:
+    """Result of the full scan."""
+
+    scanned: list[ContractInfo] = field(default_factory=list)
+    failures: list[RouteCoverageFailure] = field(default_factory=list)
+    allowlisted: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return len(self.failures) == 0
+
+
+# ---------------------------------------------------------------------------
+# YAML parsing helpers
+# ---------------------------------------------------------------------------
+def _parse_topic_list(raw: Any) -> tuple[str, ...]:
+    """Parse a subscribe_topics or publish_topics value from YAML.
+
+    Handles both flat-string lists and schema-B structured dicts::
+
+        subscribe_topics:
+          - "onex.cmd.foo.bar.v1"
+          - topic: "onex.cmd.foo.baz.v1"
+            operation: "ingest"
+    """
+    if not raw:
+        return ()
+    topics: list[str] = []
+    for entry in raw:
+        if isinstance(entry, str):
+            topics.append(entry)
+        elif isinstance(entry, dict):
+            t = entry.get("topic", "")
+            if isinstance(t, str) and t:
+                topics.append(t)
+    return tuple(topics)
+
+
+def _parse_contract(path: Path) -> ContractInfo | None:
+    """Parse a contract.yaml and return a ContractInfo, or None on error."""
+    try:
+        raw: dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+
+    name: str = raw.get("name") or path.parent.name
+
+    # event_bus.subscribe_topics
+    event_bus: dict[str, Any] = raw.get("event_bus") or {}
+    subscribe_topics = _parse_topic_list(event_bus.get("subscribe_topics"))
+
+    # Dispatcher route declarations
+    has_handler_routing = bool(raw.get("handler_routing"))
+    has_runtime_dispatch = bool(raw.get("runtime_dispatch"))
+
+    return ContractInfo(
+        name=name,
+        contract_path=path,
+        subscribe_topics=subscribe_topics,
+        has_handler_routing=has_handler_routing,
+        has_runtime_dispatch=has_runtime_dispatch,
+    )
+
+
+def _scan_contracts_dir(contracts_dir: Path) -> list[ContractInfo]:
+    """Recursively find and parse all contract.yaml files under a directory."""
+    contracts: list[ContractInfo] = []
+    for p in sorted(contracts_dir.rglob("contract.yaml")):
+        info = _parse_contract(p)
+        if info is not None:
+            contracts.append(info)
+    return contracts
+
+
+# ---------------------------------------------------------------------------
+# Core checker
+# ---------------------------------------------------------------------------
+def check_route_coverage(
+    contracts_dirs: list[Path],
+    *,
+    changed_contract_paths: frozenset[Path] | None = None,
+    verbose: bool = False,
+) -> RouteCoverageReport:
+    """Run the dispatcher route-coverage check.
+
+    Args:
+        contracts_dirs: List of directories to scan for contract.yaml files.
+        changed_contract_paths: When provided (OMN-12879 mode), only report
+            failures for contracts whose path is in this set.  The full scan
+            populates ``scanned``; the filter only affects ``failures``.
+            Pass ``None`` to check all contracts (full-scan mode).
+        verbose: Print per-contract debug lines to stdout.
+
+    Returns:
+        A :class:`RouteCoverageReport` with the scan results.
+    """
+    report = RouteCoverageReport()
+
+    for contracts_dir in contracts_dirs:
+        if not contracts_dir.is_dir():
+            if verbose:
+                print(f"  [SKIP missing dir] {contracts_dir}", flush=True)
+            continue
+        for info in _scan_contracts_dir(contracts_dir):
+            report.scanned.append(info)
+
+            for topic in info.subscribe_topics:
+                if not topic.startswith(_CMD_TOPIC_PREFIX):
+                    continue  # only command topics require dispatch wiring
+
+                if topic in _ALLOWLISTED_CMD_TOPICS:
+                    report.allowlisted.append((topic, _ALLOWLISTED_CMD_TOPICS[topic]))
+                    if verbose:
+                        print(
+                            f"  [ALLOWLISTED] {info.name}: {topic}",
+                            flush=True,
+                        )
+                    continue
+
+                # OMN-12879: changed-contract mode — skip unchanged contracts.
+                if changed_contract_paths is not None:
+                    if info.contract_path not in changed_contract_paths:
+                        if verbose:
+                            print(
+                                f"  [SKIP unchanged] {info.name}: {topic}",
+                                flush=True,
+                            )
+                        continue
+
+                if info.has_dispatcher_route:
+                    if verbose:
+                        route_kind = (
+                            "handler_routing"
+                            if info.has_handler_routing
+                            else "runtime_dispatch"
+                        )
+                        print(
+                            f"  [OK  {route_kind}] {info.name}: {topic}",
+                            flush=True,
+                        )
+                    continue
+
+                # Failure: subscribed command topic with no dispatcher route.
+                report.failures.append(
+                    RouteCoverageFailure(
+                        topic=topic,
+                        contract_name=info.name,
+                        contract_path=info.contract_path,
+                    )
+                )
+                if verbose:
+                    print(
+                        f"  [FAIL] {info.name}: {topic}  -- no dispatcher route",
+                        flush=True,
+                    )
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that every command-topic subscription has a dispatcher route "
+            "(OMN-12858 / OMN-12879 / OMN-12880)."
+        ),
+    )
+    parser.add_argument(
+        "--contracts-dir",
+        type=Path,
+        default=_REPO_ROOT / "src" / "omnibase_infra" / "nodes",
+        help="Primary contracts directory to scan (default: src/omnibase_infra/nodes)",
+    )
+    parser.add_argument(
+        "--extra-contracts-dir",
+        dest="extra_contracts_dirs",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Additional contract directories (repeatable; "
+            "e.g. ../omnimarket/src/omnimarket/nodes)"
+        ),
+    )
+    parser.add_argument(
+        "--changed-contracts",
+        type=str,
+        default="",
+        help=(
+            "OMN-12879: space-separated list of contract.yaml paths that changed in "
+            "this PR diff.  When non-empty, only those contracts are checked."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Emit per-contract status lines",
+    )
+    args = parser.parse_args()
+
+    contracts_dirs: list[Path] = [args.contracts_dir, *args.extra_contracts_dirs]
+
+    # OMN-12879: parse changed-contract paths
+    changed_contract_paths: frozenset[Path] | None = None
+    if args.changed_contracts.strip():
+        changed_contract_paths = frozenset(
+            Path(p).resolve() for p in args.changed_contracts.split() if p.strip()
+        )
+
+    print(
+        "================================================================",
+        flush=True,
+    )
+    print(
+        "Dispatcher Route-Coverage Gate (OMN-12858 / OMN-12879 / OMN-12880)",
+        flush=True,
+    )
+    print(
+        "================================================================",
+        flush=True,
+    )
+    for d in contracts_dirs:
+        print(f"  scanning: {d}", flush=True)
+    if changed_contract_paths is not None:
+        print(
+            f"  changed-contract mode (OMN-12879): {len(changed_contract_paths)} paths",
+            flush=True,
+        )
+
+    report = check_route_coverage(
+        contracts_dirs,
+        changed_contract_paths=changed_contract_paths,
+        verbose=args.verbose,
+    )
+
+    print(
+        f"\nContracts scanned: {len(report.scanned)}"
+        f"  |  allowlisted: {len(report.allowlisted)}"
+        f"  |  failures: {len(report.failures)}",
+        flush=True,
+    )
+
+    if report.failures:
+        print(
+            "\nFAILURES — command topics subscribed without a dispatcher route:\n",
+            flush=True,
+        )
+        for f in report.failures:
+            print(f"  topic:    {f.topic}")
+            print(f"  contract: {f.contract_name}")
+            print(f"  path:     {f.contract_path}")
+            print("  fix:      add handler_routing or runtime_dispatch to the contract")
+            print()
+        print(
+            f"ERROR: {len(report.failures)} command topic(s) lack dispatcher wiring. "
+            "Messages on these topics will go to DLQ at runtime.",
+            flush=True,
+        )
+        return 1
+
+    if changed_contract_paths is not None:
+        print(
+            "\nAll changed command-topic subscriptions have dispatcher routes. PASS.",
+            flush=True,
+        )
+    else:
+        print(
+            "\nAll command-topic subscriptions have dispatcher routes. PASS.",
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_dispatcher_route_coverage_gate.py
+++ b/tests/ci/test_dispatcher_route_coverage_gate.py
@@ -1,0 +1,474 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CI gate tests: dispatcher route coverage (OMN-12858, OMN-12879, OMN-12880).
+
+Verifies the check_dispatcher_route_coverage gate logic using synthetic
+in-memory contracts via the gate's check_route_coverage() API.
+
+No Kafka, no DB, no real handler imports — pure static contract analysis.
+
+Test cases:
+    RED  — contract subscribes a command topic but declares no handler_routing
+           or runtime_dispatch => gate FAILS with the unrouted topic in failures
+    GREEN — contract subscribes a command topic and declares handler_routing
+           => gate PASSES (0 failures)
+    COMPAT — compatibility_publish_topics are sender-side only; the gate MUST
+           NOT flag them as unrouted (OMN-12880)
+    CHANGED — when --changed-contracts mode is active, only the specified
+           contracts are checked; unchanged contracts with gaps are skipped (OMN-12879)
+    ALLOWLIST — known pre-existing violations in _ALLOWLISTED_CMD_TOPICS pass
+           without failing the gate
+
+These tests prove the gate would have caught:
+  1. The June 9 DLQ regression: node_generation_consumer subscribed
+     onex.cmd.omnimarket.node-generation-requested.v1 but auto-wiring produced
+     zero dispatchers after a sole-handler revert — messages went to DLQ silently.
+  2. The June 12 DEL-01 live finding: delegate-skill consumed-but-undispatched
+     on dev (onex.cmd.omnimarket.delegate-skill.v1 with no matching route).
+
+[OMN-12858, OMN-12879, OMN-12880]
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Locate the gate script so tests can import its public check_route_coverage()
+# API without needing the package installed.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from check_dispatcher_route_coverage import (  # type: ignore[import-not-found]
+    RouteCoverageReport,
+    check_route_coverage,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_contract(tmp_path: Path, node_name: str, contract_yaml: str) -> Path:
+    """Write a synthetic contract.yaml for a node and return its directory."""
+    node_dir = tmp_path / node_name
+    node_dir.mkdir(parents=True, exist_ok=True)
+    (node_dir / "contract.yaml").write_text(textwrap.dedent(contract_yaml))
+    return node_dir
+
+
+# ---------------------------------------------------------------------------
+# RED: unrouted command topic — gate FAILS
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_unrouted_command_topic_detected(tmp_path: Path) -> None:
+    """Gate FAILS when a subscribed command topic has no handler_routing.
+
+    Shape of the June 9 DLQ regression and the June 12 DEL-01 live finding:
+    the contract subscribes a command topic but has no handler_routing or
+    runtime_dispatch, so messages go to DLQ silently at runtime.
+    """
+    _write_contract(
+        tmp_path,
+        "node_synthetic_unrouted",
+        """
+        name: node_synthetic_unrouted
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.delegate-skill.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert not report.passed, "Gate should FAIL for unrouted command topic"
+    assert len(report.failures) == 1
+    assert report.failures[0].topic == "onex.cmd.omnimarket.delegate-skill.v1"
+    assert report.failures[0].contract_name == "node_synthetic_unrouted"
+
+
+@pytest.mark.unit
+def test_june9_regression_shape_detected(tmp_path: Path) -> None:
+    """Gate catches the exact June 9 DLQ regression shape.
+
+    node_generation_consumer subscribed .node-generation-requested.v1 but had
+    no dispatcher route after a handler revert.
+    """
+    _write_contract(
+        tmp_path,
+        "node_generation_consumer",
+        """
+        name: node_generation_consumer
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.node-generation-requested.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert not report.passed
+    assert any(
+        f.topic == "onex.cmd.omnimarket.node-generation-requested.v1"
+        for f in report.failures
+    ), "June 9 regression topic must appear in failures"
+
+
+# ---------------------------------------------------------------------------
+# GREEN: routed command topic — gate PASSES
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_routed_via_handler_routing_passes(tmp_path: Path) -> None:
+    """Gate PASSES when handler_routing is declared on the contract."""
+    _write_contract(
+        tmp_path,
+        "node_delegate_skill",
+        """
+        name: node_delegate_skill
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.delegate-skill.v1"
+        handler_routing:
+          routing_strategy: operation_match
+          handlers:
+            - event_type: omnimarket.delegate-skill
+              handler:
+                name: HandlerDelegateSkill
+                module: omnimarket.nodes.node_delegate_skill.handlers.handler_delegate_skill
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert report.passed, f"Gate should PASS; failures={report.failures}"
+    assert len(report.failures) == 0
+
+
+@pytest.mark.unit
+def test_routed_via_runtime_dispatch_passes(tmp_path: Path) -> None:
+    """Gate PASSES when runtime_dispatch is declared on the contract."""
+    _write_contract(
+        tmp_path,
+        "node_pattern_b",
+        """
+        name: node_pattern_b
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnibase-infra.invocation.v1"
+        runtime_dispatch:
+          strategy: pattern_b
+          broker_class: RuntimePatternBBroker
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert report.passed, (
+        f"Gate should PASS with runtime_dispatch; failures={report.failures}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# COMPAT: compatibility_publish_topics are sender-side only (OMN-12880)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_compat_publish_topic_not_flagged(tmp_path: Path) -> None:
+    """OMN-12880: compatibility_publish_topics MUST NOT be treated as gaps.
+
+    A contract that only declares a compatibility_publish_topic (sender-side)
+    must not cause the gate to report a missing dispatcher route.
+    """
+    _write_contract(
+        tmp_path,
+        "node_compat_publisher",
+        """
+        name: node_compat_publisher
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        compatibility_publish_topics:
+          - "onex.cmd.omniclaude.task-delegated.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert report.passed, (
+        "Gate must NOT flag compatibility_publish_topics as gaps; "
+        f"failures={report.failures}"
+    )
+
+
+@pytest.mark.unit
+def test_event_topic_not_flagged(tmp_path: Path) -> None:
+    """Event (evt) topics are not command topics and must be ignored by the gate."""
+    _write_contract(
+        tmp_path,
+        "node_event_only",
+        """
+        name: node_event_only
+        node_type: REDUCER_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.evt.omnimarket.node-generation-completed.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert report.passed, "Gate must not flag evt topics; failures={report.failures}"
+
+
+# ---------------------------------------------------------------------------
+# CHANGED-CONTRACT MODE (OMN-12879): only changed contracts are checked
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_changed_contract_mode_only_checks_specified(tmp_path: Path) -> None:
+    """OMN-12879: in changed-contract mode, only specified paths are checked.
+
+    Two unrouted contracts exist; only the one listed in changed_contract_paths
+    should appear as a failure.
+    """
+    dir_a = _write_contract(
+        tmp_path,
+        "node_a",
+        """
+        name: node_a
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.aislop-sweep-start.v1"
+        """,
+    )
+    _write_contract(
+        tmp_path,
+        "node_b",
+        """
+        name: node_b
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.bus-audit-start.v1"
+        """,
+    )
+
+    # Only node_a is "changed" in this PR
+    changed = frozenset([dir_a / "contract.yaml"])
+    report: RouteCoverageReport = check_route_coverage(
+        [tmp_path], changed_contract_paths=changed
+    )
+
+    # Only node_a should be in failures; node_b is unchanged and skipped
+    assert not report.passed
+    failure_topics = {f.topic for f in report.failures}
+    assert "onex.cmd.omnimarket.aislop-sweep-start.v1" in failure_topics
+    assert "onex.cmd.omnimarket.bus-audit-start.v1" not in failure_topics, (
+        "Unchanged contract node_b must not appear in failures"
+    )
+
+
+@pytest.mark.unit
+def test_changed_contract_mode_passes_when_routed(tmp_path: Path) -> None:
+    """OMN-12879: gate PASSES in changed-contract mode when changed contract is routed."""
+    node_dir = _write_contract(
+        tmp_path,
+        "node_routed_changed",
+        """
+        name: node_routed_changed
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.compliance-sweep-start.v1"
+        handler_routing:
+          routing_strategy: operation_match
+          handlers:
+            - event_type: omnimarket.compliance-sweep-start
+              handler:
+                name: HandlerComplianceSweep
+                module: omnimarket.nodes.node_compliance_sweep.handlers.handler_compliance_sweep
+        """,
+    )
+
+    changed = frozenset([node_dir / "contract.yaml"])
+    report: RouteCoverageReport = check_route_coverage(
+        [tmp_path], changed_contract_paths=changed
+    )
+
+    assert report.passed, f"Gate should PASS; failures={report.failures}"
+
+
+# ---------------------------------------------------------------------------
+# ALLOWLIST: pre-existing violations are not re-flagged
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_allowlisted_topic_not_in_failures(tmp_path: Path) -> None:
+    """Known pre-existing violations in the allowlist must not appear in failures."""
+    _write_contract(
+        tmp_path,
+        "node_pattern_b_broker",
+        """
+        name: node_pattern_b_broker
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnibase-infra.pattern-b-dispatch.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([tmp_path])
+
+    assert report.passed, (
+        "Allowlisted topic onex.cmd.omnibase-infra.pattern-b-dispatch.v1 "
+        f"must not cause gate failure; failures={report.failures}"
+    )
+    assert len(report.allowlisted) == 1, (
+        f"Expected 1 allowlisted entry; got {report.allowlisted}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MULTI-DIR: both infra and omnimarket contracts scanned together
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_multiple_dirs_all_routed_passes(tmp_path: Path) -> None:
+    """Gate PASSES when all contracts across multiple directories are routed."""
+    infra_dir = tmp_path / "infra_nodes"
+    market_dir = tmp_path / "market_nodes"
+
+    _write_contract(
+        infra_dir,
+        "node_infra_effect",
+        """
+        name: node_infra_effect
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnibase-infra.delegation-request.v1"
+        handler_routing:
+          routing_strategy: operation_match
+          handlers:
+            - event_type: omnibase-infra.delegation-request
+              handler:
+                name: HandlerDelegationRequestConsumer
+                module: omnibase_infra.nodes.node_delegation_effect.handlers.handler_delegation_request_consumer
+        """,
+    )
+    _write_contract(
+        market_dir,
+        "node_market_effect",
+        """
+        name: node_market_effect
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.node-generation-requested.v1"
+        handler_routing:
+          routing_strategy: operation_match
+          handlers:
+            - event_type: omnimarket.node-generation-requested
+              handler:
+                name: HandlerNodeGenerationConsumer
+                module: omnimarket.nodes.node_generation_consumer.handlers.handler_node_generation_consumer
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([infra_dir, market_dir])
+
+    assert report.passed, f"Gate should PASS; failures={report.failures}"
+    assert len(report.scanned) == 2
+
+
+@pytest.mark.unit
+def test_multiple_dirs_one_unrouted_fails(tmp_path: Path) -> None:
+    """Gate FAILS when one contract across multiple directories is unrouted."""
+    infra_dir = tmp_path / "infra_nodes"
+    market_dir = tmp_path / "market_nodes"
+
+    _write_contract(
+        infra_dir,
+        "node_infra_routed",
+        """
+        name: node_infra_routed
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnibase-infra.delegation-request.v1"
+        handler_routing:
+          routing_strategy: operation_match
+          handlers:
+            - event_type: omnibase-infra.delegation-request
+              handler:
+                name: HandlerDelegationRequestConsumer
+                module: omnibase_infra.nodes.node_delegation_effect.handlers.handler_delegation_request_consumer
+        """,
+    )
+    _write_contract(
+        market_dir,
+        "node_market_unrouted",
+        """
+        name: node_market_unrouted
+        node_type: EFFECT_GENERIC
+        contract_version: {major: 1, minor: 0, patch: 0}
+        event_bus:
+          subscribe_topics:
+            - "onex.cmd.omnimarket.delegate-skill.v1"
+        """,
+    )
+
+    report: RouteCoverageReport = check_route_coverage([infra_dir, market_dir])
+
+    assert not report.passed
+    failure_topics = {f.topic for f in report.failures}
+    assert "onex.cmd.omnimarket.delegate-skill.v1" in failure_topics
+    assert "onex.cmd.omnibase-infra.delegation-request.v1" not in failure_topics
+
+
+# ---------------------------------------------------------------------------
+# LIVE REGRESSION PROOF: run gate against real contracts in the repo tree
+# Passes only when the current checked-out contracts are fully wired.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_live_infra_contracts_pass(tmp_path: Path) -> None:
+    """Gate PASSES against the actual omnibase_infra contract tree.
+
+    This test is the proof that would have blocked the June 9 DLQ regression
+    and the June 12 DEL-01 finding had it been wired as a pre-merge check.
+    """
+    infra_nodes_dir = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "omnibase_infra"
+        / "nodes"
+    )
+
+    if not infra_nodes_dir.is_dir():
+        pytest.skip(f"omnibase_infra nodes dir not found: {infra_nodes_dir}")
+
+    report: RouteCoverageReport = check_route_coverage([infra_nodes_dir])
+
+    assert report.passed, (
+        "Live omnibase_infra contracts have unrouted command topics:\n"
+        + "\n".join(f"  {f.topic} ({f.contract_name})" for f in report.failures)
+    )


### PR DESCRIPTION
## Summary

Static-analysis CI gate: every contract that subscribes to a command topic (`onex.cmd.*`) must declare `handler_routing` or `runtime_dispatch`, or the message silently goes to DLQ at runtime.

## Motivation — two incidents this gate would have caught

**1. June 9 2026 DLQ regression (OMN-12858 post-mortem)**
`node_generation_consumer` subscribed `onex.cmd.omnimarket.node-generation-requested.v1` but a sole-handler revert left zero dispatcher routes registered. Messages went to DLQ silently. No CI check existed to block the regression.

**2. June 12 2026 DEL-01 live finding**
`onex.cmd.omnimarket.delegate-skill.v1` was active on dev lane bus but no dispatcher route existed in any deployed contract. Discovered via manual `rpk consumer-group lag` probe (`docs/evidence/2026-06-12-weekend-pass/integration-testing/route-coverage/`). Would have been blocked at PR-open time by this gate.

## Files changed

- `scripts/check_dispatcher_route_coverage.py` — static YAML scanner; checks both `omnibase_infra` and `omnimarket` contract trees; ratchet allowlist for known pre-existing violations; `--changed-contracts` mode (OMN-12879) for per-PR scoping; `compatibility_publish_topics` excluded from gaps (OMN-12880)
- `.github/workflows/dispatcher-route-coverage.yml` — CI workflow; checks out omnimarket sibling (sparse); collects changed contract paths in PR mode; fires on `pull_request`, `push`→main, and `merge_group`
- `tests/ci/test_dispatcher_route_coverage_gate.py` — 12 unit tests covering RED/GREEN/COMPAT/CHANGED-MODE/ALLOWLIST/MULTI-DIR plus live-contract regression proof against the actual omnibase_infra tree (all pass)

## Allowlist additions (ratchet baseline)

| Topic | Reason | Ticket | Expiry |
|---|---|---|---|
| `onex.cmd.omnibase-infra.pattern-b-dispatch.v1` | `RuntimePatternBBroker` imperative consumer | OMN-12525 | 2027-01-01 |
| `onex.cmd.platform.contract-resolve-requested.v1` | Transitional HTTP bridge `node_contract_resolver_bridge` (`metadata.transitional=true`, OMN-2756) | OMN-2756 | 2027-01-01 |

## Synthetic RED evidence

`docs/evidence/2026-06-12-weekend-pass/integration-testing/route-coverage/synthetic-red-actual.log` — gate exit code 1 on a synthetic contract with `delegate-skill` unrouted.

## Companion PR

omnimarket PR for OMN-12880 fixtures is linked separately.

Evidence-Ticket: OMN-12858
Evidence-Source: OCC#2579

