### PR TITLE
feat(OMN-13094): --output receipt mode on onex node/run — quiet typed receipts with durable capture

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "79b08f44a87a6a380e4ac398dd24c581",
+  "identity_digest": "9bce87358ac31006180ffdc8eaa1d370",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "90c8b3b96fd5085dd8cc4c3e",
+  "shared_env_digest": "0f0276f1dab9c86d39fef288",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,10 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-12957: pin core to the merged runtime-profile registry/validator rules so
-# infra tests and the runtime-profile gate consume the canonical profile set.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "2defabef4d1a7558f59f9d2a3f7f42831b00fb51" }
+# OMN-13094: pin core to the merged ArtifactStore (OMN-13093) +
+# ModelArtifactRef/ModelSkillResult (OMN-13091) so `onex node --output receipt`
+# consumes the canonical content-addressed capture surface.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "ae8793bdad96c12a0b47e2f4d1d0f179618553b8" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/src/omnibase_infra/cli/cli_node.py
+++ b/src/omnibase_infra/cli/cli_node.py
@@ -23,6 +23,10 @@ from pathlib import Path
 import click
 
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_infra.cli.receipt_mode import (
+    default_emit_socket_path,
+    run_receipt_mode,
+)
 from omnibase_infra.runtime.runtime_local import RuntimeLocal, parse_backend_overrides
 from omnibase_infra.utils.util_error_sanitization import sanitize_error_message
 
@@ -126,6 +130,30 @@ def _entry_point_module(value: str) -> str:
     default=False,
     help="Enable DEBUG-level logging (default is INFO).",
 )
+@click.option(
+    "--output",
+    "output_mode",
+    type=click.Choice(["default", "receipt"]),
+    default="default",
+    show_default=True,
+    help=(
+        "Output mode. 'receipt' routes ALL runtime logging to a capture "
+        "file under the state root, content-addresses the capture log and "
+        "handler result in the artifact store, and prints exactly one typed "
+        "ModelSkillResult JSON to stdout (OMN-13094)."
+    ),
+)
+@click.option(
+    "--emit-socket",
+    "emit_socket",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Unix socket of the emit daemon for receipt-mode capture events "
+        "(default: ~/.claude/emit.sock). Unreachable daemon => events spool "
+        "under <state-root>/emit_spool/ for later replay."
+    ),
+)
 def run_node_by_name(
     node_name: str,
     contract_path: Path | None,
@@ -134,6 +162,8 @@ def run_node_by_name(
     backend: tuple[str, ...],
     timeout: int,
     verbose: bool,
+    output_mode: str,
+    emit_socket: Path | None,
 ) -> None:
     """Run a packaged ONEX node on the local runtime, resolved by NAME.
 
@@ -151,13 +181,8 @@ def run_node_by_name(
         onex node merge_sweep
         onex node merge_sweep --input fixtures/real_prs.json
         onex node merge_sweep --contract ./custom_contract.yaml --state-root ./state
+        onex node merge_sweep --output receipt   # one typed result JSON on stdout
     """
-    logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
-        datefmt="%H:%M:%S",
-    )
-
     resolved_contract = contract_path or _resolve_packaged_contract(node_name)
 
     try:
@@ -165,6 +190,28 @@ def run_node_by_name(
     except ModelOnexError as exc:
         click.echo(f"Error: {sanitize_error_message(exc)}", err=True)
         sys.exit(1)
+
+    if output_mode == "receipt":
+        # Receipt mode (OMN-13094): runtime logging goes to a capture file,
+        # never the console; stdout carries exactly one ModelSkillResult JSON.
+        sys.exit(
+            run_receipt_mode(
+                node_name=node_name,
+                contract_path=resolved_contract,
+                input_path=input_path,
+                state_root=state_root,
+                backend_overrides=backend_overrides,
+                timeout=timeout,
+                verbose=verbose,
+                emit_socket=emit_socket or default_emit_socket_path(),
+            )
+        )
+
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+    )
 
     runtime = RuntimeLocal(
         workflow_path=resolved_contract,

--- a/src/omnibase_infra/cli/model_receipt_runtime_summary.py
+++ b/src/omnibase_infra/cli/model_receipt_runtime_summary.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed receipt ``result`` payload for runs without a handler result (OMN-13094).
+
+When ``onex node``/``onex run`` executes in ``--output receipt`` mode, the
+receipt's ``result`` field carries the node's full handler result whenever one
+exists. Runs that produce no handler result (event-only orchestrations) or
+that fail carry this summary model instead, so the receipt's ``result`` is
+always a typed model and errors are never hidden: on failure the FULL capture
+log and error text travel inline in the receipt (parent invariant — see
+``docs/plans/2026-06-12-skill-output-suppression-plan.md``, Phase 2 item 1).
+
+.. versionadded:: OMN-13094
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+__all__ = ["ModelReceiptRuntimeSummary"]
+
+
+class ModelReceiptRuntimeSummary(BaseModel):
+    """Receipt ``result`` payload when no handler result exists or the run failed.
+
+    Carries the full ``workflow_result.json`` content plus — on non-success —
+    the FULL capture log and error text inline. Errors are never hidden
+    behind an artifact ref.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    workflow_result: str = Field(
+        ...,
+        description=(
+            "Terminal workflow result value ('completed', 'partial', "
+            "'failed', 'timeout') or 'error' when the runtime raised before "
+            "producing a result."
+        ),
+    )
+    exit_code: int = Field(
+        ...,
+        description="CLI exit code corresponding to the workflow result.",
+    )
+    workflow: str = Field(
+        ...,
+        description="Path of the contract that was executed.",
+    )
+    terminal_payload: JsonValue = Field(
+        default=None,
+        description="Terminal event payload from workflow_result.json, if any.",
+    )
+    handler_result: JsonValue = Field(
+        default=None,
+        description="Handler result from workflow_result.json, if any.",
+    )
+    error: str = Field(
+        default="",
+        description=(
+            "Full error text (including traceback) when the runtime raised. "
+            "Empty when the run produced a terminal workflow result."
+        ),
+    )
+    capture_log: str = Field(
+        default="",
+        description=(
+            "FULL runtime capture log text, inlined on non-success outcomes "
+            "so errors are never hidden behind an artifact ref. Empty on "
+            "success (the log remains retrievable via the receipt's "
+            "artifact_refs)."
+        ),
+    )

--- a/src/omnibase_infra/cli/receipt_mode.py
+++ b/src/omnibase_infra/cli/receipt_mode.py
@@ -1,0 +1,453 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Receipt-mode execution for ``onex node`` / ``onex run`` (OMN-13094).
+
+Layer A of the skill-output-suppression slice
+(``docs/plans/2026-06-12-skill-output-suppression-plan.md``, Phase 2 item 1):
+
+- ALL runtime logging routes to a run_id-suffixed capture file under the
+  node's state root — console handlers are never installed, which kills the
+  25-50-line RuntimeLocal INFO stream at the source.
+- After the run, the full capture log and the full handler result are written
+  to the content-addressed artifact store (omnibase_core, OMN-13093),
+  ``artifact.captured`` + ``tool.output.captured`` events are emitted via the
+  emit daemon socket, and stdout receives exactly ONE typed
+  :class:`~omnibase_core.models.dispatch.model_skill_result.ModelSkillResult`
+  JSON object carrying the FULL result.
+
+Failure asymmetry (capture vs telemetry):
+
+- Artifact write failure ⇒ the FULL output is printed instead of the receipt
+  (no hidden loss — parent invariant 1; no silent fallback).
+- Artifact write success but event emission failure ⇒ the receipt still
+  prints; the event is spooled to a local outbox under the state root for
+  later replay. A transient emit-daemon outage never re-floods the caller
+  when the artifact exists.
+
+.. versionadded:: OMN-13094
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import time
+import traceback
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import click
+from pydantic import JsonValue, ValidationError
+
+from omnibase_core.artifacts.artifact_store import ArtifactStore
+from omnibase_core.enums.enum_skill_result_status import EnumSkillResultStatus
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
+from omnibase_core.models.dispatch.model_skill_result import ModelSkillResult
+from omnibase_infra.cli.model_receipt_runtime_summary import ModelReceiptRuntimeSummary
+from omnibase_infra.runtime.runtime_local import RuntimeLocal
+
+__all__ = [
+    "CAPTURE_DIR_NAME",
+    "SPOOL_DIR_NAME",
+    "default_emit_socket_path",
+    "run_receipt_mode",
+]
+
+logger = logging.getLogger(__name__)
+
+# Capture logs and the emission spool live under the node's state root
+# (matching the workflow_result.json convention — plan Open Question 4).
+CAPTURE_DIR_NAME = "captures"
+SPOOL_DIR_NAME = "emit_spool"
+
+# Socket timeout for emit-daemon calls. Emission is telemetry, never the
+# critical path — a slow daemon must not stall the dispatch.
+_EMIT_TIMEOUT_SECONDS = 2.0
+
+_MAX_EMIT_RESPONSE_BYTES = 65536
+
+_WORKFLOW_TO_STATUS: dict[EnumWorkflowResult, EnumSkillResultStatus] = {
+    EnumWorkflowResult.COMPLETED: EnumSkillResultStatus.SUCCESS,
+    EnumWorkflowResult.PARTIAL: EnumSkillResultStatus.PARTIAL,
+    EnumWorkflowResult.FAILED: EnumSkillResultStatus.FAILED,
+    EnumWorkflowResult.TIMEOUT: EnumSkillResultStatus.FAILED,
+}
+
+
+def default_emit_socket_path() -> Path:
+    """Deterministic address of the live emit daemon's Unix domain socket.
+
+    ``~/.claude/emit.sock`` — the same default as omniclaude's emit client
+    wrapper. This is the daemon's published address; nothing is ever written
+    there by this module (emission failures spool under the node's state
+    root instead). Override per-invocation via ``onex node --emit-socket``.
+    """
+    return Path.home() / ".claude" / "emit.sock"
+
+
+def _emit_via_socket(
+    socket_path: Path, event_type: str, payload: dict[str, JsonValue]
+) -> None:
+    """Send one event to the emit daemon (newline-delimited JSON protocol).
+
+    Raises on any failure — the caller decides whether to spool.
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(_EMIT_TIMEOUT_SECONDS)
+    try:
+        sock.connect(str(socket_path))
+        request = {"event_type": event_type, "payload": payload}
+        sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > _MAX_EMIT_RESPONSE_BYTES:
+                raise ConnectionError(
+                    f"emit daemon response exceeded {_MAX_EMIT_RESPONSE_BYTES} bytes"
+                )
+            chunks.append(chunk)
+            if b"\n" in chunk:
+                break
+        raw = b"".join(chunks).split(b"\n", 1)[0].decode("utf-8").strip()
+        if not raw:
+            raise ConnectionError("emit daemon closed connection without responding")
+        response: object = json.loads(raw)
+        if not isinstance(response, dict) or response.get("status") != "queued":
+            raise RuntimeError(f"emit daemon rejected {event_type}: {response!r}")
+    finally:
+        sock.close()
+
+
+def _emit_or_spool(
+    event_type: str,
+    payload: dict[str, JsonValue],
+    *,
+    spool_dir: Path,
+    spool_stem: str,
+    socket_path: Path,
+) -> None:
+    """Emit ``event_type`` via the daemon socket; spool locally on failure.
+
+    Telemetry asymmetry (plan Phase 2 item 1): once the artifact exists, an
+    emission failure must never re-flood the caller — the event is recorded
+    to a local outbox file for later replay and the receipt still prints.
+    """
+    try:
+        _emit_via_socket(socket_path, event_type, payload)
+    except (OSError, ValueError, RuntimeError) as exc:
+        # OSError covers socket/connection/timeout failures; ValueError covers
+        # malformed daemon JSON; RuntimeError covers daemon rejections.
+        # Spool-on-failure is the contract here — never raise past this point.
+        spool_dir.mkdir(parents=True, exist_ok=True)
+        spool_path = spool_dir / f"{event_type.replace('.', '-')}-{spool_stem}.json"
+        spool_record = {
+            "event_type": event_type,
+            "payload": payload,
+            "spooled_at_utc": datetime.now(UTC).isoformat(),
+            "spool_reason": f"{type(exc).__name__}: {exc}",
+        }
+        spool_path.write_text(json.dumps(spool_record, indent=2), encoding="utf-8")
+        logger.warning(
+            "receipt_mode: emit of %s failed (%s); spooled to %s",
+            event_type,
+            type(exc).__name__,
+            spool_path,
+        )
+
+
+def _configure_capture_logging(capture_path: Path, *, verbose: bool) -> None:
+    """Route ALL logging to ``capture_path``; install no console handlers.
+
+    ``force=True`` removes any pre-existing root handlers so the runtime
+    INFO stream can never leak to stdout/stderr in receipt mode (F7).
+    """
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[logging.FileHandler(capture_path, encoding="utf-8")],
+        force=True,
+    )
+
+
+def _close_capture_logging() -> None:
+    """Flush and close all root handlers, then install a ``NullHandler``.
+
+    The ``NullHandler`` prevents Python's ``lastResort`` handler from leaking
+    post-capture log records (e.g. spool warnings) to stderr — receipt mode
+    allows nothing but the receipt on stdout/stderr. Spool records carry
+    their own ``spool_reason``, so the dropped log line loses nothing.
+    """
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        handler.flush()
+        handler.close()
+        root.removeHandler(handler)
+    root.addHandler(logging.NullHandler())
+
+
+def _fully_qualified_name(obj: object) -> str:
+    """Return ``module.QualName`` for the concrete type of ``obj``."""
+    cls = type(obj)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _extract_correlation_id(workflow_data: dict[str, JsonValue]) -> uuid.UUID:
+    """Extract the run's correlation_id from workflow state, else mint one."""
+    for key in ("handler_result", "terminal_payload"):
+        candidate = workflow_data.get(key)
+        if isinstance(candidate, dict):
+            raw = candidate.get("correlation_id")
+            if isinstance(raw, str):
+                try:
+                    return uuid.UUID(raw)
+                except ValueError:
+                    continue
+    return uuid.uuid4()
+
+
+def _load_workflow_data(state_root: Path) -> dict[str, JsonValue]:
+    """Read ``workflow_result.json`` if the runtime wrote one."""
+    result_path = state_root / "workflow_result.json"
+    if not result_path.exists():
+        return {}
+    parsed: object = json.loads(result_path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        return {}
+    return cast("dict[str, JsonValue]", parsed)
+
+
+def _print_full_output_on_capture_failure(
+    *,
+    reason: str,
+    capture_text: str,
+    workflow_data: dict[str, JsonValue],
+    runtime_error: str,
+) -> None:
+    """No-hidden-loss path: artifact write failed, so print EVERYTHING.
+
+    Parent invariant 1 / no-silent-fallback: when durable capture is not
+    possible, suppression is not allowed — the full output passes through.
+    """
+    click.echo(
+        f"receipt mode: artifact capture failed ({reason}); "
+        "printing full output instead of a receipt (no hidden loss).",
+        err=True,
+    )
+    if capture_text:
+        click.echo(capture_text, nl=False)
+    if runtime_error:
+        click.echo(runtime_error, nl=False)
+    if workflow_data:
+        click.echo(json.dumps(workflow_data, indent=2))
+
+
+def run_receipt_mode(
+    *,
+    node_name: str,
+    contract_path: Path,
+    input_path: Path | None,
+    state_root: Path,
+    backend_overrides: dict[str, str],
+    timeout: int,
+    verbose: bool,
+    emit_socket: Path,
+) -> int:
+    """Execute the node and print exactly one ``ModelSkillResult`` JSON.
+
+    Returns the process exit code (the runtime's exit code; 1 when the
+    runtime raised before producing a workflow result).
+    """
+    run_id = uuid.uuid4()
+    capture_path = state_root / CAPTURE_DIR_NAME / f"{node_name}-{run_id}.log"
+    spool_dir = state_root / SPOOL_DIR_NAME
+    _configure_capture_logging(capture_path, verbose=verbose)
+
+    started = time.monotonic()
+    runtime_error = ""
+    workflow_result: EnumWorkflowResult | None = None
+    exit_code = 1
+    handler_result_obj: object | None = None
+    try:
+        runtime = RuntimeLocal(
+            workflow_path=contract_path,
+            state_root=state_root,
+            backend_overrides=backend_overrides,
+            input_path=input_path,
+            timeout=timeout,
+        )
+        workflow_result = runtime.run()
+        exit_code = runtime.exit_code
+        handler_result_obj = runtime.handler_result
+    except Exception:
+        # RuntimeLocal.run() records execution failures itself; reaching here
+        # means contract load / bus construction raised. Errors are never
+        # hidden: the traceback goes to the capture AND inline in the result.
+        runtime_error = traceback.format_exc()
+        logger.exception("receipt_mode: runtime raised")
+    duration_ms = int((time.monotonic() - started) * 1000)
+
+    _close_capture_logging()
+    capture_text = (
+        capture_path.read_text(encoding="utf-8") if capture_path.exists() else ""
+    )
+    workflow_data = _load_workflow_data(state_root)
+    correlation_id = _extract_correlation_id(workflow_data)
+
+    if runtime_error:
+        status = EnumSkillResultStatus.ERROR
+    else:
+        # workflow_result is always set when runtime_error is empty.
+        status = _WORKFLOW_TO_STATUS[
+            workflow_result
+            if workflow_result is not None
+            else EnumWorkflowResult.FAILED
+        ]
+
+    # --- Layer B: durable capture (parent invariant 1) -------------------
+    handler_result_json = workflow_data.get("handler_result")
+    artifact_payloads: list[dict[str, JsonValue]] = []
+    artifact_refs: list[ModelArtifactRef] = []
+    try:
+        store = ArtifactStore()
+        captures: list[tuple[bytes, str, str]] = [
+            (capture_text.encode("utf-8"), "text/plain", "runtime_capture_log"),
+        ]
+        if handler_result_json is not None:
+            captures.append(
+                (
+                    json.dumps(handler_result_json).encode("utf-8"),
+                    "application/json",
+                    "handler_result",
+                )
+            )
+        for data, media_type, artifact_kind in captures:
+            ref = store.write_blob(
+                data,
+                media_type=media_type,
+                artifact_kind=artifact_kind,
+                source_system="onex_cli",
+                scope_ref=node_name,
+                correlation_id=str(correlation_id),
+            )
+            artifact_refs.append(ref)
+            artifact_payloads.append(
+                {
+                    "artifact_ref": ref.ref,
+                    "artifact_hash": ref.hex_digest,
+                    "artifact_size_bytes": len(data),
+                    "artifact_media_type": media_type,
+                    "artifact_kind": artifact_kind,
+                    "source_system": "onex_cli",
+                    "scope_ref": node_name,
+                    "correlation_id": str(correlation_id),
+                    "run_id": str(run_id),
+                    "redaction_state": "raw",
+                }
+            )
+    except (KeyError, OSError, ValueError) as exc:
+        # Artifact write failed ⇒ NO receipt, FULL output (invariant 1).
+        reason = f"{type(exc).__name__}: {exc}"
+        _print_full_output_on_capture_failure(
+            reason=reason,
+            capture_text=capture_text,
+            workflow_data=workflow_data,
+            runtime_error=runtime_error,
+        )
+        return exit_code
+
+    # --- Telemetry: emit or spool (never re-floods the caller) -----------
+    socket_path = emit_socket
+    for index, event_payload in enumerate(artifact_payloads):
+        _emit_or_spool(
+            "artifact.captured",
+            event_payload,
+            spool_dir=spool_dir,
+            spool_stem=f"{run_id}-{index}",
+            socket_path=socket_path,
+        )
+    _emit_or_spool(
+        "tool.output.captured",
+        {
+            "tool_name": "onex_node",
+            "node_name": node_name,
+            "suppression_decision": "receipt_mode",
+            "correlation_id": str(correlation_id),
+            "run_id": str(run_id),
+            "exit_code": exit_code,
+            "status": status.value,
+            "artifact_refs": [ref.ref for ref in artifact_refs],
+            "capture_log_bytes": len(capture_text.encode("utf-8")),
+        },
+        spool_dir=spool_dir,
+        spool_stem=str(run_id),
+        socket_path=socket_path,
+    )
+
+    # --- Layer A: exactly one typed receipt on stdout ---------------------
+    metrics: dict[str, float] = {
+        "capture_log_bytes": float(len(capture_text.encode("utf-8"))),
+    }
+    receipt: ModelSkillResult[JsonValue] | ModelSkillResult[ModelReceiptRuntimeSummary]
+    if (
+        status.is_success_like
+        and handler_result_json is not None
+        and handler_result_obj is not None
+    ):
+        receipt = ModelSkillResult[JsonValue](
+            skill_name=node_name,
+            node_name=node_name,
+            status=status,
+            correlation_id=correlation_id,
+            run_id=run_id,
+            exit_code=exit_code,
+            duration_ms=duration_ms,
+            result=handler_result_json,
+            result_model=_fully_qualified_name(handler_result_obj),
+            metrics=metrics,
+            artifact_refs=artifact_refs,
+        )
+    else:
+        summary = ModelReceiptRuntimeSummary(
+            workflow_result=(
+                workflow_result.value if workflow_result is not None else "error"
+            ),
+            exit_code=exit_code,
+            workflow=str(contract_path),
+            terminal_payload=workflow_data.get("terminal_payload"),
+            handler_result=handler_result_json,
+            error=runtime_error,
+            # Errors are never hidden: non-success inlines the FULL capture
+            # log; success keeps it behind the artifact ref.
+            capture_log="" if status.is_success_like else capture_text,
+        )
+        receipt = ModelSkillResult[ModelReceiptRuntimeSummary](
+            skill_name=node_name,
+            node_name=node_name,
+            status=status,
+            correlation_id=correlation_id,
+            run_id=run_id,
+            exit_code=exit_code,
+            duration_ms=duration_ms,
+            result=summary,
+            result_model=_fully_qualified_name(summary),
+            metrics=metrics,
+            artifact_refs=artifact_refs,
+        )
+
+    try:
+        click.echo(receipt.model_dump_json())
+    except ValidationError as exc:  # pragma: no cover - construction validates
+        click.echo(f"receipt mode: receipt serialization failed: {exc}", err=True)
+        return 1
+    return exit_code

--- a/src/omnibase_infra/runtime/runtime_local.py
+++ b/src/omnibase_infra/runtime/runtime_local.py
@@ -1487,5 +1487,15 @@ class RuntimeLocal:
         """CLI exit code corresponding to the current result."""
         return _exit_code_for(self._result)
 
+    @property
+    def handler_result(self) -> object | None:
+        """The terminal handler's result object, if the run produced one.
+
+        Receipt mode (OMN-13094) uses the concrete type of this object as
+        the receipt's ``result_model`` schema identity; the JSON-serialized
+        form lives in ``workflow_result.json`` under ``handler_result``.
+        """
+        return self._handler_result
+
     # Prevent resource leaks — reserved for future bus/container teardown.
     del_alias = None  # placeholder for __del__ if needed

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -15,7 +15,9 @@ def test_release_backmerge_preserves_proven_runtime_core_pin() -> None:
 
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
-    expected_core = "2defabef4d1a7558f59f9d2a3f7f42831b00fb51"
+    # OMN-13094: pin advanced to the merged ArtifactStore slice (OMN-13093) —
+    # receipt mode consumes omnibase_core.artifacts + ModelSkillResult.
+    expected_core = "ae8793bdad96c12a0b47e2f4d1d0f179618553b8"
 
     assert expected_core in pyproject
     assert expected_core in uv_lock
@@ -28,5 +30,7 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    assert lock["identity_digest"] == "79b08f44a87a6a380e4ac398dd24c581"
-    assert lock["shared_env_digest"] == "90c8b3b96fd5085dd8cc4c3e"
+    # OMN-13094: identity regenerated for the advanced core pin (both digests
+    # bind pyproject.toml + uv.lock).
+    assert lock["identity_digest"] == "9bce87358ac31006180ffdc8eaa1d370"
+    assert lock["shared_env_digest"] == "0f0276f1dab9c86d39fef288"

--- a/tests/unit/cli/test_cli_node_receipt.py
+++ b/tests/unit/cli/test_cli_node_receipt.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``onex node --output receipt`` (OMN-13094).
+
+Acceptance is STRUCTURAL, not size-based (plan Open Question 3 resolution):
+
+- stdout parses as exactly ONE JSON object validating against
+  ``ModelSkillResult`` — zero intermediate context leaks;
+- zero RuntimeLocal INFO lines on stdout/stderr;
+- the full capture log and handler result are content-addressed in the
+  artifact store and hash-verified on retrieval;
+- ``artifact.captured`` + ``tool.output.captured`` are emitted via the emit
+  daemon socket, or spooled locally when the daemon is unreachable;
+- artifact-write failure prints the FULL output instead of a receipt
+  (no hidden loss);
+- node failure produces ``status=failed`` with the full error output inline.
+
+These tests run the REAL dispatch path: the actual click command through the
+actual RuntimeLocal with the in-memory bus and the committed proof-noop
+fixture handler (no mocked runtime).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+from omnibase_core.artifacts.artifact_store import ArtifactStore
+from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
+from omnibase_core.models.dispatch.model_skill_result import ModelSkillResult
+from omnibase_infra.cli.cli_node import run_node_by_name
+from omnibase_infra.cli.receipt_mode import CAPTURE_DIR_NAME, SPOOL_DIR_NAME
+
+pytestmark = pytest.mark.unit
+
+_PROOF_NOOP_CONTRACT = (
+    "---\n"
+    "name: proof_noop\n"
+    "node_type: compute\n"
+    "terminal_event: onex.evt.proof.noop-completed.v1\n"
+    "handler:\n"
+    "  module: tests.fixtures.handler_proof_noop\n"
+    "  class: HandlerProofNoop\n"
+    "  input_model: tests.fixtures.handler_proof_noop.ModelProofNoopRequest\n"
+    "handler_routing:\n"
+    "  default_handler: tests.fixtures.handler_proof_noop:HandlerProofNoop\n"
+)
+
+_BROKEN_CONTRACT = (
+    "---\n"
+    "name: broken_node\n"
+    "node_type: compute\n"
+    "terminal_event: onex.evt.proof.broken-completed.v1\n"
+    "handler:\n"
+    "  module: tests.fixtures.does_not_exist_module\n"
+    "  class: HandlerDoesNotExist\n"
+    "handler_routing:\n"
+    "  default_handler: tests.fixtures.does_not_exist_module:HandlerDoesNotExist\n"
+)
+
+
+def _write_fixture_inputs(tmp_path: Path, contract_text: str) -> tuple[Path, Path]:
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(contract_text, encoding="utf-8")
+    input_path = tmp_path / "input.json"
+    input_path.write_text(
+        json.dumps({"name": "receipt-proof", "count": 3}), encoding="utf-8"
+    )
+    return contract_path, input_path
+
+
+def _invoke_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    contract_text: str = _PROOF_NOOP_CONTRACT,
+    store_root: Path | None | str = "default",
+    socket_path: Path | None = None,
+) -> tuple[Result, Path]:
+    """Run the real CLI in receipt mode against the proof-noop fixture."""
+    contract_path, input_path = _write_fixture_inputs(tmp_path, contract_text)
+    state_root = tmp_path / "state"
+
+    if store_root == "default":
+        store_root = tmp_path / "artifacts"
+    if store_root is None:
+        monkeypatch.delenv("ONEX_ARTIFACT_STORE_ROOT", raising=False)
+    else:
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(store_root))
+
+    resolved_socket = socket_path or (tmp_path / "no-daemon.sock")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        run_node_by_name,
+        [
+            "proof_noop",
+            "--contract",
+            str(contract_path),
+            "--input",
+            str(input_path),
+            "--state-root",
+            str(state_root),
+            "--output",
+            "receipt",
+            "--emit-socket",
+            str(resolved_socket),
+        ],
+        catch_exceptions=False,
+    )
+    return result, state_root
+
+
+def _parse_single_receipt(stdout: str) -> dict[str, object]:
+    """stdout must be exactly one JSON object — anything else is a leak."""
+    stripped = stdout.strip()
+    parsed: object = json.loads(stripped)  # raises if anything else leaked
+    assert isinstance(parsed, dict)
+    # Round-trip guard: the single line IS the whole stdout payload.
+    assert stripped.startswith("{") and stripped.endswith("}")
+    assert "\n" not in stripped, "receipt must be a single JSON line"
+    return parsed
+
+
+class TestReceiptModeSuccess:
+    def test_stdout_is_exactly_one_validated_skill_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result, _ = _invoke_receipt(tmp_path, monkeypatch)
+        assert result.exit_code == 0, result.output
+        payload = _parse_single_receipt(result.stdout)
+        receipt = ModelSkillResult.model_validate(payload)
+        assert receipt.node_name == "proof_noop"
+        assert receipt.status.is_success_like
+        assert receipt.exit_code == 0
+        # The FULL handler result travels in the receipt, untruncated.
+        assert payload["result"] == {
+            "status": "success",
+            "echoed_name": "receipt-proof",
+            "echoed_count": 3,
+        }
+        assert str(payload["result_model"]).endswith("ModelProofNoopResult")
+        assert receipt.artifact_refs, "capture log must be artifact-backed"
+
+    def test_zero_runtime_log_lines_on_stdout_or_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result, state_root = _invoke_receipt(tmp_path, monkeypatch)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "RuntimeLocal" not in combined
+        assert "INFO" not in combined
+        # The runtime stream went to the run_id-suffixed capture file instead.
+        captures = list((state_root / CAPTURE_DIR_NAME).glob("proof_noop-*.log"))
+        assert len(captures) == 1
+        capture_text = captures[0].read_text(encoding="utf-8")
+        assert "RuntimeLocal" in capture_text
+
+    def test_artifacts_are_retrievable_and_hash_verified(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result, state_root = _invoke_receipt(tmp_path, monkeypatch)
+        assert result.exit_code == 0
+        payload = _parse_single_receipt(result.stdout)
+        refs = payload["artifact_refs"]
+        assert isinstance(refs, list) and len(refs) == 2  # capture log + result
+
+        store = ArtifactStore()
+        blobs = []
+        for raw_ref in refs:
+            assert isinstance(raw_ref, dict)
+            ref = ModelArtifactRef.model_validate(raw_ref)
+            # read_blob re-hashes and raises on mismatch — retrieval IS the
+            # hash verification.
+            blobs.append(store.read_blob(ref))
+            meta = store.read_meta(ref)
+            assert meta["source_system"] == "onex_cli"
+
+        capture_file = next((state_root / CAPTURE_DIR_NAME).glob("proof_noop-*.log"))
+        assert capture_file.read_bytes() in blobs
+        assert json.dumps(payload["result"]).encode("utf-8") in blobs
+
+    def test_events_spooled_when_daemon_unreachable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result, state_root = _invoke_receipt(tmp_path, monkeypatch)
+        assert result.exit_code == 0
+        # Receipt still printed — telemetry failure never re-floods the caller.
+        _parse_single_receipt(result.stdout)
+
+        spool_dir = state_root / SPOOL_DIR_NAME
+        artifact_events = sorted(spool_dir.glob("artifact-captured-*.json"))
+        tool_events = sorted(spool_dir.glob("tool-output-captured-*.json"))
+        assert len(artifact_events) == 2
+        assert len(tool_events) == 1
+
+        for spool_file in artifact_events:
+            record = json.loads(spool_file.read_text(encoding="utf-8"))
+            assert record["event_type"] == "artifact.captured"
+            for field in (
+                "artifact_ref",
+                "artifact_hash",
+                "artifact_size_bytes",
+                "artifact_kind",
+                "source_system",
+                "correlation_id",
+            ):
+                assert field in record["payload"], field
+
+        tool_record = json.loads(tool_events[0].read_text(encoding="utf-8"))
+        assert tool_record["event_type"] == "tool.output.captured"
+        for field in ("tool_name", "suppression_decision", "correlation_id"):
+            assert field in tool_record["payload"], field
+        assert tool_record["payload"]["suppression_decision"] == "receipt_mode"
+
+    def test_events_emitted_when_daemon_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # UDS paths are capped (~104 chars on macOS); pytest tmp_path under
+        # xdist can exceed that, so the socket gets its own short tempdir.
+        socket_dir = Path(tempfile.mkdtemp(prefix="omn13094-"))
+        socket_path = socket_dir / "emit.sock"
+        if len(str(socket_path)) > 100:
+            pytest.skip("temp dir too long for a Unix domain socket")
+
+        received: list[dict[str, object]] = []
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(socket_path))
+        server.listen(8)
+        server.settimeout(10.0)
+        stop = threading.Event()
+
+        def serve() -> None:
+            while not stop.is_set():
+                try:
+                    conn, _ = server.accept()
+                except (TimeoutError, OSError):
+                    return
+                with conn:
+                    data = b""
+                    while not data.endswith(b"\n"):
+                        chunk = conn.recv(4096)
+                        if not chunk:
+                            break
+                        data += chunk
+                    if data:
+                        received.append(json.loads(data.decode("utf-8")))
+                    conn.sendall(b'{"status": "queued", "event_id": "test"}\n')
+
+        thread = threading.Thread(target=serve, daemon=True)
+        thread.start()
+        try:
+            result, state_root = _invoke_receipt(
+                tmp_path, monkeypatch, socket_path=socket_path
+            )
+        finally:
+            stop.set()
+            server.close()
+            thread.join(timeout=5.0)
+            shutil.rmtree(socket_dir, ignore_errors=True)
+
+        assert result.exit_code == 0
+        _parse_single_receipt(result.stdout)
+        event_types = sorted(str(r["event_type"]) for r in received)
+        assert event_types == [
+            "artifact.captured",
+            "artifact.captured",
+            "tool.output.captured",
+        ]
+        # Daemon accepted everything — nothing may be spooled.
+        spool_dir = state_root / SPOOL_DIR_NAME
+        assert not spool_dir.exists() or not list(spool_dir.iterdir())
+
+
+class TestReceiptModeFailureAsymmetry:
+    def test_artifact_write_failure_prints_full_output_not_receipt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing ONEX_ARTIFACT_STORE_ROOT ⇒ FULL output, no receipt."""
+        result, _ = _invoke_receipt(tmp_path, monkeypatch, store_root=None)
+        # The run itself succeeded; capture failed; nothing may be hidden.
+        assert result.exit_code == 0
+        assert "no hidden loss" in result.stderr
+        # Full capture stream passes through instead of a receipt.
+        assert "RuntimeLocal" in result.stdout
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result.stdout.strip())
+
+    def test_node_failure_reports_failed_with_error_inline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result, _ = _invoke_receipt(
+            tmp_path, monkeypatch, contract_text=_BROKEN_CONTRACT
+        )
+        assert result.exit_code != 0
+        payload = _parse_single_receipt(result.stdout)
+        receipt = ModelSkillResult.model_validate(payload)
+        assert not receipt.status.is_success_like
+        result_body = payload["result"]
+        assert isinstance(result_body, dict)
+        # Errors are never hidden: the full capture log travels inline.
+        assert result_body["capture_log"], "failure must inline the capture log"
+        assert str(payload["result_model"]).endswith("ModelReceiptRuntimeSummary")
+        # The capture log is ADDITIONALLY artifact-backed.
+        assert payload["artifact_refs"]
+
+
+class TestDefaultModeUnchanged:
+    def test_default_mode_does_not_print_receipt_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path, input_path = _write_fixture_inputs(
+            tmp_path, _PROOF_NOOP_CONTRACT
+        )
+        monkeypatch.delenv("ONEX_ARTIFACT_STORE_ROOT", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(
+            run_node_by_name,
+            [
+                "proof_noop",
+                "--contract",
+                str(contract_path),
+                "--input",
+                str(input_path),
+                "--state-root",
+                str(tmp_path / "state"),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # No single-JSON receipt contract in default mode (behavior preserved).
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result.stdout.strip() or "not-json")

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -2076,7 +2076,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.44.2"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51#2defabef4d1a7558f59f9d2a3f7f42831b00fb51" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8#ae8793bdad96c12a0b47e2f4d1d0f179618553b8" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=2defabef4d1a7558f59f9d2a3f7f42831b00fb51" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
Phase 2a of the skill-output-suppression slice (epic **OMN-13089**, plan `docs/plans/2026-06-12-skill-output-suppression-plan.md` Phase 2 item 1).

Depends on OMN-13093 (ArtifactStore) and OMN-13092 (capture topics/event types) — both merged. Blocks Phase 2b and Phase 4a.

Evidence-Source: 8c3541cf45b7c1b7c3fe62c2dde795ff975a6aa2
Evidence-Ticket: OMN-13094

## What was built

`onex node` / `onex run` gain `--output receipt`:

- **Layer A (quiet receipt):** ALL runtime logging routes to a run_id-suffixed capture file under `<state-root>/captures/` — no console handlers are installed (`basicConfig(..., handlers=[FileHandler], force=True)`), killing the 25-50-line RuntimeLocal INFO stream at the source (F7). stdout carries exactly ONE typed `ModelSkillResult` JSON with the FULL handler result; `result_model` is the concrete handler-result type FQN.
- **Layer B (durable capture):** the full capture log and the full handler result are content-addressed via the omnibase_core `ArtifactStore` (OMN-13093). `artifact.captured` (per body) + `tool.output.captured` events are emitted to the emit-daemon Unix socket (`--emit-socket`, default `~/.claude/emit.sock`) using the daemon's newline-JSON protocol — no omniclaude import, no raw topic literals (the daemon maps event types to the OMN-13092 topics).
- **Failure asymmetry (capture vs telemetry):** artifact write failure ⇒ the FULL output is printed, NOT a receipt (no hidden loss — parent invariant 1, no silent fallback). Artifact write success but emission failure ⇒ the receipt still prints and the event is spooled to `<state-root>/emit_spool/` for replay — a transient daemon outage never re-floods the caller when the artifact exists.
- **Node failure** ⇒ `status=failed`/`error` with the full error + capture log INLINE in the receipt (errors are never hidden) and the capture log additionally artifact-backed.
- **Default output mode unchanged** in this phase (enforcement is Phase 4).
- `RuntimeLocal` exposes `handler_result` for receipt schema identity.
- core pin bumped to `ae8793bd` (merged OMN-13091/13093 receipt models + ArtifactStore); runner-image identity lock + OMN-12765 backmerge identity constants updated for the new pin.

New/changed files: `cli/cli_node.py` (`--output`/`--emit-socket` wiring), `cli/receipt_mode.py` (run path), `cli/model_receipt_runtime_summary.py` (typed receipt result for failure/event-only runs), `runtime/runtime_local.py` (`handler_result` property), `tests/unit/cli/test_cli_node_receipt.py`.

## dod_evidence — exact commands run + results

- `uv run ruff format src/ tests/` → clean (no reformatting)
- `uv run ruff check --fix src/ tests/` → **All checks passed!**
- `uv run mypy src/ --strict` → **Success: no issues found in 2435 source files**
- `uv run pytest tests/unit/cli/test_cli_node_receipt.py tests/unit/cli/test_cli_node.py tests/unit/cli/test_onex_run.py -v` → **20 passed**, covering every acceptance probe:
  - stdout parses as exactly one validated `ModelSkillResult`
  - zero runtime INFO lines on stdout/stderr
  - artifacts retrievable and hash-verified
  - events spooled when daemon unreachable / emitted when available
  - failure asymmetry: artifact-write-failure prints full output; node-failure reports failed with error inline
  - default mode prints no receipt JSON
- `uv run pytest tests/ -m "unit and not slow" -n auto` → **20926 passed, 17 skipped, 2 failed**. The 2 failures (`test_node_migration_discovery::test_sync_check_reports_in_sync`, `test_cli::test_registration_only`) reproduce identically on `origin/dev` WITHOUT this change — pre-existing, caused by local omnimarket migration drift + an unrelated verification-CLI expectation; not introduced here.
- `pre-commit run --files <changed files>` → all hooks pass on this PR's files. (Repo-wide `--all-files` surfaces pre-existing red on untouched contracts — runtime_profiles/SPDX/topic-parity — also red on origin/dev.)
