### PR TITLE
feat(OMN-13096): onex delegate single-command subcommand (Phase 2b)

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "9bce87358ac31006180ffdc8eaa1d370",
+  "identity_digest": "6f936c328d331c1e8f62594473c2dcc2",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "0f0276f1dab9c86d39fef288",
+  "shared_env_digest": "6b42c54bfa466bd4d93fcc8c",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ onex-status = "omnibase_infra.tui.__main__:run_status_tui"
 verify-container-manifest = "omnibase_infra.scripts.verify_container_manifest:main"
 
 [project.entry-points."onex.cli"]
+delegate = "omnibase_infra.cli.cli_delegate:delegate_command"
 kafka = "omnibase_infra.cli.cli_kafka:kafka"
 node = "omnibase_infra.cli.cli_node:run_node_by_name"
 run = "omnibase_infra.cli.cli_node:run_node_by_name"

--- a/src/omnibase_infra/cli/cli_delegate.py
+++ b/src/omnibase_infra/cli/cli_delegate.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""``onex delegate`` — single-command local-LLM delegation (OMN-13096).
+
+Phase 2b of the skill-output-suppression slice
+(``docs/plans/2026-06-12-skill-output-suppression-plan.md``): the
+governing simplification is that **a dispatch skill IS one CLI call**.
+
+``onex delegate "<prompt>" [--task-type X] [--max-tokens N]`` wraps, inside
+the CLI entrypoint:
+
+1. task-type classification (when ``--task-type`` is omitted),
+2. typed payload construction written to ``<state-root>/tmp/<run_id>.json``
+   (run_id-suffixed scratch — never ``/tmp``; ``feedback_no_tmp_use_workspace``),
+3. resolution of the packaged ``node_delegate_skill_orchestrator`` contract,
+4. dispatch through the OMN-13094 receipt-mode path
+   (:func:`omnibase_infra.cli.receipt_mode.run_receipt_mode`).
+
+stdout receives exactly ONE
+:class:`~omnibase_core.models.dispatch.model_skill_result.ModelSkillResult`
+JSON whose ``result`` is the FULL
+``ModelDelegateSkillResponse`` (status, response, model_name, provider,
+task_type, quality_gate_passed, metrics). RuntimeLocal logs, envelope dumps,
+and progress go to the capture file + artifact store and never reach the
+caller. Non-zero exit on failure.
+
+This replaces the multi-step ``omniclaude`` delegate shim
+(payload temp file + ``cd omnimarket`` + ``onex node`` log flood +
+``cat workflow_result.json``) with one command, one typed result.
+
+.. versionadded:: OMN-13096
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import click
+
+from omnibase_infra.cli.cli_node import _resolve_packaged_contract
+from omnibase_infra.cli.receipt_mode import (
+    default_emit_socket_path,
+    run_receipt_mode,
+)
+
+__all__ = [
+    "DELEGATE_NODE_NAME",
+    "DELEGATE_SOURCE",
+    "DEFAULT_MAX_TOKENS",
+    "DEFAULT_TASK_TYPE",
+    "TASK_TYPE_CHOICES",
+    "classify_task_type",
+    "run_delegate",
+]
+
+# The omnimarket node that owns the consumer-facing delegation contract. It is
+# registered under the ``onex.nodes`` entry-point group and resolvable from
+# this CLI's environment (the delegate node ships its packaged contract.yaml).
+DELEGATE_NODE_NAME = "node_delegate_skill_orchestrator"
+
+# Registered adapter source for ``ModelDelegateSkillRequest`` (Literal field).
+DELEGATE_SOURCE = "claude-code"
+
+# Default response budget when ``--max-tokens`` is omitted. Matches the
+# historical delegate-shim default; the node enforces its own hard ceiling.
+DEFAULT_MAX_TOKENS = 2048
+
+# Fallback classification when no keyword matches (the prompt.md default).
+DEFAULT_TASK_TYPE = "research"
+
+# The MVP task taxonomy the delegate node accepts (a subset of the
+# ``ModelDelegateSkillRequest`` Literal — the surfaces the shim exposed).
+# Source of truth for routing is the node contract's allowed_task_types; this
+# CLI exposes the same classification mapping the legacy skill markdown used.
+TASK_TYPE_CHOICES = (
+    "test",
+    "document",
+    "research",
+    "code_generation",
+    "refactor",
+    "reasoning",
+    "review",
+)
+
+# Ordered keyword → task_type rules (first match wins). Lifted verbatim from
+# the legacy ``delegate/prompt.md`` classification table so behavior is
+# unchanged; the glue now lives in the CLI, not skill markdown.
+_CLASSIFICATION_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("test", "pytest", "unit test", "assert"), "test"),
+    (("document", "docstring", "readme", "explain how"), "document"),
+    (("refactor", "cleanup", "simplify"), "refactor"),
+    (("review", "audit", "check"), "review"),
+    (("reason", "think through", "decide", "compare"), "reasoning"),
+    (("write", "create", "implement", "build", "generate"), "code_generation"),
+)
+
+
+def classify_task_type(prompt: str) -> str:
+    """Classify ``prompt`` into a delegate task type via keyword match.
+
+    First matching rule wins; falls back to :data:`DEFAULT_TASK_TYPE` when no
+    keyword is present. Matching is case-insensitive against the lowercased
+    prompt. This is the same table the legacy skill markdown carried — the
+    glue moved into the CLI per the plan's single-command simplification.
+    """
+    lowered = prompt.lower()
+    for keywords, task_type in _CLASSIFICATION_RULES:
+        if any(keyword in lowered for keyword in keywords):
+            return task_type
+    return DEFAULT_TASK_TYPE
+
+
+def _write_payload(
+    *, prompt: str, task_type: str, max_tokens: int, state_root: Path, run_id: uuid.UUID
+) -> Path:
+    """Write the delegation input payload to run_id-suffixed scratch.
+
+    Scratch lives under ``<state-root>/tmp/`` (never ``/tmp`` —
+    ``feedback_no_tmp_use_workspace``). The payload validates against the
+    delegate node's input model (``ModelDelegateSkillRequest``); only the
+    fields the consumer supplies are set.
+    """
+    tmp_dir = state_root / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    payload_path = tmp_dir / f"delegate-input-{run_id}.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "prompt": prompt,
+                "task_type": task_type,
+                "source": DELEGATE_SOURCE,
+                "max_tokens": max_tokens,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return payload_path
+
+
+@click.command("delegate")
+@click.argument("prompt")
+@click.option(
+    "--task-type",
+    "task_type",
+    type=click.Choice(TASK_TYPE_CHOICES),
+    default=None,
+    help=(
+        "Task classification for routing. Omit to auto-classify from the "
+        "prompt keywords (default fallback: research)."
+    ),
+)
+@click.option(
+    "--max-tokens",
+    "max_tokens",
+    type=click.IntRange(min=1),
+    default=DEFAULT_MAX_TOKENS,
+    show_default=True,
+    help="Maximum tokens for the delegated LLM response.",
+)
+@click.option(
+    "--state-root",
+    type=click.Path(path_type=Path),
+    default=".onex_state",
+    show_default=True,
+    help="Root directory for disk state, scratch payloads, and captures.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=300,
+    show_default=True,
+    help="Max delegation time in seconds.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Capture DEBUG-level logging (still routed to the capture file).",
+)
+@click.option(
+    "--emit-socket",
+    "emit_socket",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Unix socket of the emit daemon for capture events (default: "
+        "~/.claude/emit.sock). Unreachable daemon => events spool under "
+        "<state-root>/emit_spool/ for later replay."
+    ),
+)
+def delegate_command(
+    prompt: str,
+    task_type: str | None,
+    max_tokens: int,
+    state_root: Path,
+    timeout: int,
+    verbose: bool,
+    emit_socket: Path | None,
+) -> None:
+    """Delegate PROMPT to a local LLM and print exactly one typed result.
+
+    stdout carries exactly ONE ``ModelSkillResult[ModelDelegateSkillResponse]``
+    JSON — the full LLM response and metrics, never truncated. RuntimeLocal
+    logs go to a capture file + the content-addressed artifact store, never to
+    stdout. Exits non-zero on failure.
+
+    \b
+    Examples:
+        onex delegate "explain what a calendar app needs"
+        onex delegate "write a Python HTTP server" --task-type code_generation
+        onex delegate "analyze the routing architecture" --max-tokens 4096
+    """
+    sys.exit(
+        run_delegate(
+            prompt=prompt,
+            task_type=task_type,
+            max_tokens=max_tokens,
+            state_root=state_root,
+            timeout=timeout,
+            verbose=verbose,
+            emit_socket=emit_socket,
+        )
+    )
+
+
+def run_delegate(
+    *,
+    prompt: str,
+    task_type: str | None,
+    max_tokens: int,
+    state_root: Path,
+    timeout: int,
+    verbose: bool,
+    emit_socket: Path | None,
+) -> int:
+    """Build the payload, resolve the contract, and dispatch in receipt mode.
+
+    Returns the process exit code. Payload construction, node dispatch, and
+    result extraction are all internal — the caller supplies a prompt and
+    receives one typed receipt on stdout.
+    """
+    resolved_task_type = task_type or classify_task_type(prompt)
+    run_id = uuid.uuid4()
+    payload_path = _write_payload(
+        prompt=prompt,
+        task_type=resolved_task_type,
+        max_tokens=max_tokens,
+        state_root=state_root,
+        run_id=run_id,
+    )
+    contract_path = _resolve_packaged_contract(DELEGATE_NODE_NAME)
+    return run_receipt_mode(
+        node_name=DELEGATE_NODE_NAME,
+        contract_path=contract_path,
+        input_path=payload_path,
+        state_root=state_root,
+        backend_overrides={"event_bus": "inmemory"},
+        timeout=timeout,
+        verbose=verbose,
+        emit_socket=emit_socket or default_emit_socket_path(),
+    )

--- a/src/omnibase_infra/validation/validation_exemptions.yaml
+++ b/src/omnibase_infra/validation/validation_exemptions.yaml
@@ -324,6 +324,15 @@ pattern_exemptions:
     documentation:
       - OMN-11546 concrete-node audit
     ticket: OMN-11570
+  - file_pattern: 'cli_delegate\.py'
+    method_pattern: "Function 'delegate_command'"
+    violation_pattern: 'has \d+ parameters'
+    reason: >
+      Click injects command arguments and options directly into the command callback (same contract as run_node_by_name). The callback immediately forwards those values to run_delegate; replacing the signature with an intermediate model would obscure the Click contract without reducing runtime complexity.
+
+    documentation:
+      - OMN-13096 onex delegate single-command rewrite
+    ticket: OMN-13096
   # ==========================================================================
   # KafkaContractCache Exemptions (OMN-1989)
   # ==========================================================================

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -30,7 +30,7 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    # OMN-13094: identity regenerated for the advanced core pin (both digests
-    # bind pyproject.toml + uv.lock).
-    assert lock["identity_digest"] == "9bce87358ac31006180ffdc8eaa1d370"
-    assert lock["shared_env_digest"] == "0f0276f1dab9c86d39fef288"
+    # OMN-13096: identity regenerated after adding the 'delegate' onex.cli
+    # entry point to pyproject.toml (both digests bind pyproject.toml + uv.lock).
+    assert lock["identity_digest"] == "6f936c328d331c1e8f62594473c2dcc2"
+    assert lock["shared_env_digest"] == "6b42c54bfa466bd4d93fcc8c"

--- a/tests/unit/cli/test_cli_delegate.py
+++ b/tests/unit/cli/test_cli_delegate.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``onex delegate`` single-command delegation (OMN-13096).
+
+The acceptance probe is STRUCTURAL (no size assertions, plan Phase 2 item 1):
+
+- ``classify_task_type`` maps prompt keywords to the delegate task taxonomy
+  (first match wins, research fallback);
+- ``run_delegate`` writes its scratch payload under ``<state-root>/tmp/`` with
+  a run_id-suffixed name — never ``/tmp`` (``feedback_no_tmp_use_workspace``);
+- the payload validates against the delegate node's input model
+  (``ModelDelegateSkillRequest``) — prompt, task_type, source, max_tokens;
+- the command dispatches through receipt mode so stdout is exactly ONE
+  ``ModelSkillResult`` JSON with zero RuntimeLocal log leakage.
+
+The end-to-end probe against the live delegate node (which requires a vLLM
+endpoint) lives in the OCC evidence run, not the unit suite. These unit tests
+exercise the REAL CLI wiring against a committed proof contract by pointing
+``_resolve_packaged_contract`` at it — the dispatch path, payload write, and
+receipt envelope are all real.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_core.models.dispatch.model_skill_result import ModelSkillResult
+from omnibase_infra.cli import cli_delegate
+from omnibase_infra.cli.cli_delegate import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_TASK_TYPE,
+    DELEGATE_SOURCE,
+    classify_task_type,
+    delegate_command,
+    run_delegate,
+)
+
+pytestmark = pytest.mark.unit
+
+# A proof contract that runs a deterministic in-process handler — no vLLM, no
+# network. It stands in for the delegate node so the CLI wiring (payload write,
+# receipt-mode dispatch, single typed result) is exercised end-to-end.
+_PROOF_NOOP_CONTRACT = (
+    "---\n"
+    "name: proof_noop\n"
+    "node_type: compute\n"
+    "terminal_event: onex.evt.proof.noop-completed.v1\n"
+    "handler:\n"
+    "  module: tests.fixtures.handler_proof_noop\n"
+    "  class: HandlerProofNoop\n"
+    "  input_model: tests.fixtures.handler_proof_noop.ModelProofNoopRequest\n"
+    "handler_routing:\n"
+    "  default_handler: tests.fixtures.handler_proof_noop:HandlerProofNoop\n"
+)
+
+
+class TestClassifyTaskType:
+    @pytest.mark.parametrize(
+        ("prompt", "expected"),
+        [
+            ("write unit tests for verify.py", "test"),
+            ("add a pytest for the parser", "test"),
+            ("document the routing module", "document"),
+            ("write a docstring for this fn", "document"),
+            ("refactor the dispatch loop", "refactor"),
+            ("simplify the config parsing", "refactor"),
+            ("review this PR for correctness", "review"),
+            ("audit the auth flow", "review"),
+            ("reason through the tradeoffs", "reasoning"),
+            ("compare two architectures", "reasoning"),
+            ("implement an HTTP server", "code_generation"),
+            ("build a CLI scaffold", "code_generation"),
+            ("what does a calendar app need", DEFAULT_TASK_TYPE),
+        ],
+    )
+    def test_keyword_mapping(self, prompt: str, expected: str) -> None:
+        assert classify_task_type(prompt) == expected
+
+    def test_first_match_wins_test_before_code_generation(self) -> None:
+        # "write" maps to code_generation, "test" maps to test; "test" rule is
+        # ordered first, so a prompt with both classifies as test.
+        assert classify_task_type("write a test for the handler") == "test"
+
+    def test_case_insensitive(self) -> None:
+        assert classify_task_type("REFACTOR the LOOP") == "refactor"
+
+
+class TestPayloadScratch:
+    def test_payload_written_under_state_root_tmp_not_slash_tmp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path = tmp_path / "contract.yaml"
+        contract_path.write_text(_PROOF_NOOP_CONTRACT, encoding="utf-8")
+        monkeypatch.setattr(
+            cli_delegate,
+            "_resolve_packaged_contract",
+            lambda _name: contract_path,
+        )
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(tmp_path / "artifacts"))
+        state_root = tmp_path / "state"
+
+        run_delegate(
+            prompt="implement an HTTP server",
+            task_type=None,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            state_root=state_root,
+            timeout=60,
+            verbose=False,
+            emit_socket=tmp_path / "no-daemon.sock",
+        )
+
+        scratch_dir = state_root / "tmp"
+        assert scratch_dir.is_dir(), "scratch dir must be under <state-root>/tmp/"
+        payloads = list(scratch_dir.glob("delegate-input-*.json"))
+        assert len(payloads) == 1, "exactly one run_id-suffixed scratch payload"
+        # No scratch leaked to the system temp dir.
+        assert not list(Path(tempfile.gettempdir()).glob("delegate-input-*.json"))
+
+    def test_payload_validates_against_delegate_request_model(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path = tmp_path / "contract.yaml"
+        contract_path.write_text(_PROOF_NOOP_CONTRACT, encoding="utf-8")
+        monkeypatch.setattr(
+            cli_delegate,
+            "_resolve_packaged_contract",
+            lambda _name: contract_path,
+        )
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(tmp_path / "artifacts"))
+        state_root = tmp_path / "state"
+
+        run_delegate(
+            prompt="refactor the loop",
+            task_type=None,
+            max_tokens=4096,
+            state_root=state_root,
+            timeout=60,
+            verbose=False,
+            emit_socket=tmp_path / "no-daemon.sock",
+        )
+
+        payload_path = next((state_root / "tmp").glob("delegate-input-*.json"))
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        # The payload carries exactly the fields the delegate node's input
+        # model (ModelDelegateSkillRequest) requires from a consumer: prompt,
+        # task_type, source, max_tokens. omnibase_infra does NOT depend on
+        # omnimarket (layering), so the node owns model validation at dispatch;
+        # the CLI's contract here is the payload shape.
+        assert payload == {
+            "prompt": "refactor the loop",
+            "task_type": "refactor",
+            "source": DELEGATE_SOURCE,
+            "max_tokens": 4096,
+        }
+
+    def test_explicit_task_type_overrides_classification(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path = tmp_path / "contract.yaml"
+        contract_path.write_text(_PROOF_NOOP_CONTRACT, encoding="utf-8")
+        monkeypatch.setattr(
+            cli_delegate,
+            "_resolve_packaged_contract",
+            lambda _name: contract_path,
+        )
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(tmp_path / "artifacts"))
+        state_root = tmp_path / "state"
+
+        # Prompt would classify as code_generation; explicit flag wins.
+        run_delegate(
+            prompt="write an HTTP server",
+            task_type="research",
+            max_tokens=DEFAULT_MAX_TOKENS,
+            state_root=state_root,
+            timeout=60,
+            verbose=False,
+            emit_socket=tmp_path / "no-daemon.sock",
+        )
+        payload_path = next((state_root / "tmp").glob("delegate-input-*.json"))
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        assert payload["task_type"] == "research"
+
+
+class TestSingleReceiptOnStdout:
+    def test_stdout_is_exactly_one_validated_skill_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path = tmp_path / "contract.yaml"
+        contract_path.write_text(_PROOF_NOOP_CONTRACT, encoding="utf-8")
+        monkeypatch.setattr(
+            cli_delegate,
+            "_resolve_packaged_contract",
+            lambda _name: contract_path,
+        )
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(tmp_path / "artifacts"))
+        state_root = tmp_path / "state"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            delegate_command,
+            [
+                "implement an HTTP server",
+                "--state-root",
+                str(state_root),
+                "--emit-socket",
+                str(tmp_path / "no-daemon.sock"),
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        stripped = result.stdout.strip()
+        # Exactly one JSON object — any RuntimeLocal log line would break this.
+        parsed = json.loads(stripped)
+        assert isinstance(parsed, dict)
+        assert "\n" not in stripped, "receipt must be a single JSON line"
+        ModelSkillResult.model_validate(parsed)
+
+    def test_no_runtime_info_logs_on_stdout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        contract_path = tmp_path / "contract.yaml"
+        contract_path.write_text(_PROOF_NOOP_CONTRACT, encoding="utf-8")
+        monkeypatch.setattr(
+            cli_delegate,
+            "_resolve_packaged_contract",
+            lambda _name: contract_path,
+        )
+        monkeypatch.setenv("ONEX_ARTIFACT_STORE_ROOT", str(tmp_path / "artifacts"))
+        state_root = tmp_path / "state"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            delegate_command,
+            [
+                "research the routing architecture",
+                "--state-root",
+                str(state_root),
+                "--emit-socket",
+                str(tmp_path / "no-daemon.sock"),
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "INFO" not in result.stdout
+        assert "RuntimeLocal" not in result.stdout


### PR DESCRIPTION
## OMN-13096 — `onex delegate` single-command subcommand (Phase 2b)

Part of epic OMN-13089 (Skill Output Suppression). Depends on OMN-13094 (receipt mode, merged).

Evidence-Source: OCC#2593
Evidence-Ticket: OMN-13096

### What was built
Adds `onex delegate "<prompt>" [--task-type X] [--max-tokens N]` as a subcommand on the existing `onex` CLI (`src/omnibase_infra/cli/cli_delegate.py`), registered under the `onex.cli` entry-point group. The command wraps, internally:
- task-type classification (keyword table from the legacy skill markdown; first-match-wins, `research` fallback),
- typed payload construction written to `<state-root>/tmp/delegate-input-<run_id>.json` (never `/tmp` — `feedback_no_tmp_use_workspace`),
- resolution of the packaged `node_delegate_skill_orchestrator` contract via the `onex.nodes` entry-point group,
- dispatch through the OMN-13094 receipt-mode path (`run_receipt_mode`).

stdout carries exactly ONE `ModelSkillResult[ModelDelegateSkillResponse]` — the full LLM response + metrics, never truncated. RuntimeLocal logs go to the capture file + content-addressed artifact store, never to stdout. Non-zero exit on failure.

**Architecture:** omnibase_infra does NOT depend on omnimarket — the delegate node is resolved at runtime via the `onex.nodes` entry-point group (registered by omnimarket). `delegate_command` is added to the `>5-param` patterns-gate exemption list (same Click-callback rationale as `run_node_by_name`).

### Tests run
- `uv run pytest tests/unit/cli/test_cli_delegate.py -v` → **20 passed** (classification first-match/fallback/case-insensitive, scratch-under-state-root-not-/tmp, explicit task-type override, exactly one validated `ModelSkillResult` on stdout, zero `INFO`/`RuntimeLocal` log leakage).
- `uv run mypy src/ --strict` → **no issues found in 2436 source files**.
- `pre-commit run --files <changed>` → all hooks pass (patterns gate green via documented exemption).
- Full suite: remaining failures are pre-existing environmental integration/perf tests (Postgres/Kafka/Docker, local omnimarket-clone migration drift, node-registration env) — reproduced identically on the clean canonical dev clone with none of this change present.
