### PR TITLE
fix(OMN-13118): pin terminal-consumer read offset synchronously (close lazy seek_to_end publish race)

### DIFF
--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -260,12 +260,54 @@ async def _assign_direct_terminal_partitions(
         await _refresh_terminal_topic_metadata(consumer)
 
 
+async def _pin_direct_terminal_end_offsets(consumer: AIOKafkaConsumer) -> None:
+    """Resolve the current end offsets SYNCHRONOUSLY and pin them via ``seek``.
+
+    Why not ``seek_to_end`` (OMN-13118 strike-three)
+    ------------------------------------------------
+    ``AIOKafkaConsumer.seek_to_end`` is LAZY: it calls
+    ``Fetcher.request_offset_reset(partitions, LATEST)``, which only marks the
+    partition "awaiting reset" and registers a position future. The actual LATEST
+    offset is resolved by a ``ListOffsets`` round-trip that happens on the FIRST
+    ``getone`` — which is AFTER the caller has published its command. With
+    generation completing in ~1s (dispatch loop freed, OMN-13010), the correlated
+    terminal lands in the gap between this open() and the first poll, so the
+    lazily-resolved LATEST position is the high-water-mark AFTER the record and
+    the poll starts reading PAST it. The terminal is never read, the trial never
+    correlates, and the experiment matrix re-fires the same cell forever — the
+    consume-leg wedge that survived PR #1969 (set_topics no-op) and PR #1970
+    (partition-less assign-cap) because neither addressed the seek timing.
+
+    ``end_offsets`` is a SYNCHRONOUS broker round-trip that returns the HWM
+    observed NOW (without changing the consumer position); ``seek`` then pins each
+    partition's read offset to that value deterministically. The resume position
+    is therefore fixed at open() time, BEFORE the publish, so any terminal emitted
+    at-or-after this offset is delivered to the subsequent poll. This is the real
+    subscribe-before-publish guarantee the two-phase protocol promised.
+
+    An empty assignment (partition-less reply topic, OMN-13118) has no offsets to
+    resolve, so this is a no-op for that leg.
+    """
+    assignment = consumer.assignment()
+    if not assignment:
+        return
+    end_offsets = await consumer.end_offsets(list(assignment))
+    for topic_partition, offset in end_offsets.items():
+        consumer.seek(topic_partition, offset)
+
+
 async def open_direct_terminal_consumer(
     *,
     event_bus: object,
     terminal_topic: str,
 ) -> DirectTerminalConsumer:
-    """Start, assign, and seek an ephemeral terminal consumer to the current end."""
+    """Start, assign, and pin an ephemeral terminal consumer to the current end.
+
+    The read position is captured SYNCHRONOUSLY via ``end_offsets`` + ``seek`` (not
+    the lazy ``seek_to_end``) so it is fixed at open() time, before the caller
+    publishes — the subscribe-before-publish guarantee that closes the
+    seek-past-the-terminal race (OMN-13118).
+    """
     consumer = _build_direct_terminal_consumer(event_bus)
     try:
         await asyncio.wait_for(
@@ -277,7 +319,7 @@ async def open_direct_terminal_consumer(
             terminal_topic,
             _DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS,
         )
-        await consumer.seek_to_end(*consumer.assignment())
+        await _pin_direct_terminal_end_offsets(consumer)
     except BaseException:
         await close_direct_terminal_consumer(
             DirectTerminalConsumer(consumer),
@@ -558,7 +600,11 @@ class RuntimePatternBBroker:
                 terminal_topics,
                 command.timeout_seconds,
             )
-            await consumer.seek_to_end(*consumer.assignment())
+            # Pin the read position SYNCHRONOUSLY at the current end (OMN-13118):
+            # ``seek_to_end`` is a lazy LATEST reset resolved on the first poll —
+            # AFTER this publish — so a terminal landing in the publish→poll gap
+            # is skipped. ``end_offsets`` + ``seek`` fixes the position now.
+            await _pin_direct_terminal_end_offsets(consumer)
             await self._publish_worker_command(command, route)
 
             deadline = asyncio.get_running_loop().time() + command.timeout_seconds

--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -260,7 +260,11 @@ async def _assign_direct_terminal_partitions(
         await _refresh_terminal_topic_metadata(consumer)
 
 
-async def _pin_direct_terminal_end_offsets(consumer: AIOKafkaConsumer) -> None:
+async def _pin_direct_terminal_end_offsets(
+    consumer: AIOKafkaConsumer,
+    *,
+    timeout_seconds: float,
+) -> None:
     """Resolve the current end offsets SYNCHRONOUSLY and pin them via ``seek``.
 
     Why not ``seek_to_end`` (OMN-13118 strike-three)
@@ -287,11 +291,20 @@ async def _pin_direct_terminal_end_offsets(consumer: AIOKafkaConsumer) -> None:
 
     An empty assignment (partition-less reply topic, OMN-13118) has no offsets to
     resolve, so this is a no-op for that leg.
+
+    ``end_offsets`` is a broker ``ListOffsets`` round-trip that aiokafka documents
+    as able to block indefinitely. It is bounded by ``timeout_seconds`` (the same
+    cap as ``start`` and partition assignment) so a stalled broker fails fast here
+    instead of hanging the pre-publish positioning and reintroducing a wait wedge
+    in a new spot.
     """
     assignment = consumer.assignment()
     if not assignment:
         return
-    end_offsets = await consumer.end_offsets(list(assignment))
+    end_offsets = await asyncio.wait_for(
+        consumer.end_offsets(list(assignment)),
+        timeout=timeout_seconds,
+    )
     for topic_partition, offset in end_offsets.items():
         consumer.seek(topic_partition, offset)
 
@@ -319,7 +332,10 @@ async def open_direct_terminal_consumer(
             terminal_topic,
             _DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS,
         )
-        await _pin_direct_terminal_end_offsets(consumer)
+        await _pin_direct_terminal_end_offsets(
+            consumer,
+            timeout_seconds=_DIRECT_TERMINAL_ASSIGN_TIMEOUT_CAP_SECONDS,
+        )
     except BaseException:
         await close_direct_terminal_consumer(
             DirectTerminalConsumer(consumer),
@@ -604,7 +620,10 @@ class RuntimePatternBBroker:
             # ``seek_to_end`` is a lazy LATEST reset resolved on the first poll —
             # AFTER this publish — so a terminal landing in the publish→poll gap
             # is skipped. ``end_offsets`` + ``seek`` fixes the position now.
-            await _pin_direct_terminal_end_offsets(consumer)
+            await _pin_direct_terminal_end_offsets(
+                consumer,
+                timeout_seconds=min(30, command.timeout_seconds),
+            )
             await self._publish_worker_command(command, route)
 
             deadline = asyncio.get_running_loop().time() + command.timeout_seconds

--- a/tests/integration/test_pattern_b_broker_terminal_waiter.py
+++ b/tests/integration/test_pattern_b_broker_terminal_waiter.py
@@ -46,6 +46,9 @@ class _TerminalConsumer:
         self.topics_calls = 0
         self.set_topics_calls: list[tuple[str, ...]] = []
         self.seeked_to_end = False
+        # True once the read position is pinned to the current end (synchronous
+        # end_offsets + seek, OMN-13118).
+        self.positioned = False
         self.started = False
         self.stopped = False
         type(self).created.append(self)
@@ -72,6 +75,16 @@ class _TerminalConsumer:
 
     async def seek_to_end(self, *_assignment: object) -> None:
         self.seeked_to_end = True
+        self.positioned = True
+
+    async def end_offsets(self, partitions: object) -> dict[object, int]:
+        # Synchronous HWM round-trip (OMN-13118). Queue-backed fake delivers
+        # regardless of offset, so 0 is faithful for the next-message offset.
+        return dict.fromkeys(partitions, 0)
+
+    def seek(self, _partition: object, _offset: int) -> None:
+        # Synchronous position pin (OMN-13118).
+        self.positioned = True
 
     async def getone(self) -> SimpleNamespace:
         return await self.messages.get()
@@ -117,7 +130,7 @@ class _KafkaLikeTransport:
         assert consumer.kwargs["group_id"] is None
         assert consumer.topics == ()
         assert consumer.assigned_partitions
-        assert consumer.seeked_to_end is True
+        assert consumer.positioned is True
 
         command_envelope = ModelEventEnvelope[object].model_validate_json(value)
         terminal_envelope = ModelEventEnvelope[object](

--- a/tests/integration/test_terminal_consumer_battery_load_wedge.py
+++ b/tests/integration/test_terminal_consumer_battery_load_wedge.py
@@ -225,6 +225,17 @@ class _FakeConsumer:
         assert self._topic is not None
         self._cursor = self._cluster.logs[self._topic].hwm
 
+    async def end_offsets(self, partitions: Any) -> dict[Any, int]:
+        # Synchronous HWM round-trip (OMN-13118): the offset of the next message,
+        # captured NOW without changing the consumer position.
+        assert self._topic is not None
+        hwm = self._cluster.logs[self._topic].hwm
+        return dict.fromkeys(partitions, hwm)
+
+    def seek(self, _partition: Any, offset: int) -> None:
+        # Synchronous position pin (OMN-13118) replacing the lazy seek_to_end.
+        self._cursor = offset
+
     async def getone(self) -> SimpleNamespace:
         assert self._topic is not None
         log = self._cluster.logs[self._topic]

--- a/tests/integration/test_terminal_consumer_concurrent_assign_race.py
+++ b/tests/integration/test_terminal_consumer_concurrent_assign_race.py
@@ -155,6 +155,15 @@ class _FakeConsumer:
     async def seek_to_end(self, *_assignment: object) -> None:
         return None
 
+    async def end_offsets(self, partitions: Any) -> dict[Any, int]:
+        # Synchronous HWM round-trip (OMN-13118 pinning). This fake delivers by
+        # pending-payload dict rather than offset, so the value is incidental.
+        return dict.fromkeys(partitions, 0)
+
+    def seek(self, _partition: Any, _offset: int) -> None:
+        # Synchronous position pin (OMN-13118): no-op for the payload-dict fake.
+        return None
+
     async def getone(self) -> SimpleNamespace:
         # The COMPLETED-topic consumer delivers each pending correlated terminal
         # exactly once; otherwise (FAILED topic, or no pending payload) block

--- a/tests/integration/test_terminal_consumer_seek_reset_race.py
+++ b/tests/integration/test_terminal_consumer_seek_reset_race.py
@@ -532,7 +532,7 @@ def test_open_pins_end_offset_before_publish(
         assert fake._cursor == pre_publish_hwm, (
             "open() did not pin the pre-publish end offset synchronously — the "
             f"read cursor is {fake._cursor!r}, expected {pre_publish_hwm} "
-            "(an unresolved cursor means a deferred LATEST reset that races the "
+            "(an unresolved cursor means a lazy LATEST reset that races the "
             "publish)"
         )
     finally:

--- a/tests/integration/test_terminal_consumer_seek_reset_race.py
+++ b/tests/integration/test_terminal_consumer_seek_reset_race.py
@@ -1,0 +1,539 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Lazy-``seek_to_end`` reset race regression for the consume-leg wedge (OMN-13118).
+
+Ticket: OMN-13118 (strike-three residual after PR #1969 set_topics no-op fix and
+PR #1970 partition-less assign-cap fix; the wedge PERSISTS on REBUILD-4
+``ab9d606d1``).
+
+Why a NEW test instead of the two existing consume-leg regressions
+------------------------------------------------------------------
+``test_terminal_consumer_concurrent_assign_race.py`` (OMN-13012/#1969) models the
+``set_topics`` metadata no-op. ``test_terminal_consumer_battery_load_wedge.py``
+(OMN-13118/#1970) models the partition-less FAILED-open assign-cap burn. BOTH are
+GREEN on the wedging image — and both miss the live defect, because both fakes
+make ``seek_to_end`` SYNCHRONOUS and EXACT: they snapshot the partition HWM the
+instant ``seek_to_end`` is called and read from that cursor. The real
+``AIOKafkaConsumer.seek_to_end`` does NOT do that.
+
+The live defect (per HALT_K10_WEDGE_PERSISTS.md + runner-logs-tail.txt)
+-----------------------------------------------------------------------
+Per ~30s cycle on the wedged battery:
+  1. the FAILED-topic wait times out (empty message) — EXPECTED, nothing is ever
+     produced to FAILED, so its consumer correctly returns None; and
+  2. the COMPLETED terminal IS published every trial (decisive: the ``cid`` that
+     "wait failed" in cycle N is the ``correlation_id`` published to COMPLETED in
+     cycle N-1), yet
+  3. the matrix re-fires the SAME cell forever — the COMPLETED ``wait`` returns
+     None even though the correlated terminal was published at an offset
+     at-or-after the consumer's open() position.
+
+Root mechanism modeled here (the real aiokafka 0.13.0 semantics)
+----------------------------------------------------------------
+``open_direct_terminal_consumer`` does ``start -> assign -> seek_to_end`` and
+then the caller publishes; ``poll`` then ``getone``s. But
+``AIOKafkaConsumer.seek_to_end`` is LAZY: it calls
+``Fetcher.request_offset_reset(partitions, LATEST)``, which only marks the
+partition "awaiting reset" and registers a ``wait_for_position()`` future. The
+actual LATEST offset is resolved by a ``ListOffsets`` round-trip that happens on
+the FIRST fetch/poll — AFTER the caller has published. With generation completing
+in ~1s (dispatch loop freed, OMN-13010), the correlated COMPLETED terminal lands
+in the gap between ``assign`` and that lazy LATEST resolution, so the resolved
+position is the HWM AFTER the record. ``getone`` then starts reading past the
+already-published terminal and blocks forever — the COMPLETED ``wait`` returns
+None and the trial never correlates. This is the OMN-13012 probe3 "seek past the
+terminal" race resurfacing: ``seek_to_end`` does not actually pin a pre-publish
+offset, it requests a position that resolves LATER, after the publish.
+
+This fake therefore models ``seek_to_end`` FAITHFULLY as a deferred LATEST reset
+(NOT an immediate HWM snapshot): the resolved read offset is whatever the
+partition HWM is at the time of the FIRST ``getone``, which by then includes the
+freshly-published terminal — skipping it.
+
+The defining assertions (RED before the fix, GREEN after)
+---------------------------------------------------------
+Driving the REAL ``TerminalEventConsumer.open()/wait()`` the way
+``HandlerContextRoiRunner._run_trial`` does — open BOTH terminals per trial,
+publish the correlated COMPLETED terminal in the publish->wait gap, race the wait
+— across K>=10 trials over >=2 cells x >=2 arms:
+  - every trial's COMPLETED terminal is published (HWM climbs to total), and
+  - every cell across both arms correlates its COMPLETED terminal (no degenerate
+    rows, matrix advances through both arms), and
+  - HWMs settle (FAILED stays 0).
+
+RED on the lazy-reset consume leg (the resolved position lands past the terminal,
+every cell degenerate); GREEN once the consume leg pins the EXACT pre-publish end
+offset synchronously (``end_offsets`` + ``seek``) instead of a deferred LATEST
+reset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+
+from omnibase_infra.runtime import service_pattern_b_broker
+from omnibase_infra.runtime.service_terminal_event_consumer import (
+    make_terminal_event_consumer,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_COMPLETED_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+_FAILED_TOPIC = "onex.evt.omnimarket.node-generation-failed.v1"
+_HANDLER = "HandlerContextRoiRunner"
+
+# Battery shape: K trials over >=2 cells x >=2 arms (mirrors the STRONG K>=10
+# multi-cell reprobe that wedged on REBUILD-4 without launching the full 160).
+_TRIALS_PER_CELL = 10
+_CELLS = ("bool_flag", "address_norm")
+_ARMS = ("off", "golden_exemplar")
+
+
+class _BrokerLog:
+    """Append-only partition log for one terminal topic with a high-water-mark.
+
+    Models a Redpanda partition. The COMPLETED topic's HWM advances every trial
+    (generation succeeds and publishes its correlated terminal); the FAILED
+    topic's HWM stays 0 (nothing ever lands there).
+    """
+
+    def __init__(self) -> None:
+        self._records: list[tuple[str, bytes]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def hwm(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    def append(self, correlation_id: str, value: bytes) -> None:
+        with self._lock:
+            self._records.append((correlation_id, value))
+
+    def read_from(self, offset: int) -> list[tuple[str, bytes]]:
+        with self._lock:
+            return list(self._records[offset:])
+
+
+class _Cluster:
+    """Cluster-wide shared state across all ephemeral consumers (load model).
+
+    The COMPLETED topic has a partition (produced to every trial). The FAILED
+    topic does NOT (never written in this battery), modeling Redpanda's
+    auto-create-on-produce — a partition-less reply topic.
+    """
+
+    def __init__(self) -> None:
+        self.logs: dict[str, _BrokerLog] = {
+            _COMPLETED_TOPIC: _BrokerLog(),
+            _FAILED_TOPIC: _BrokerLog(),
+        }
+        self.topics_with_partitions: set[str] = {_COMPLETED_TOPIC}
+
+
+class _FakeClient:
+    """``AIOKafkaClient`` topic-tracking stand-in with awaitable metadata ops."""
+
+    def __init__(self, consumer: _FakeConsumer) -> None:
+        self._consumer = consumer
+        self.tracked: set[str] = set()
+
+    async def _refresh(self) -> bool:
+        await asyncio.sleep(0)
+        return True
+
+    def set_topics(self, topics: list[str]) -> Any:
+        self.tracked = set(topics)
+        return self._refresh()
+
+    def force_metadata_update(self) -> Any:
+        return self._refresh()
+
+
+class _FakeConsumer:
+    """Faithful ``AIOKafkaConsumer`` stand-in modeling LAZY ``seek_to_end``.
+
+    Drives ``open_direct_terminal_consumer`` / ``poll_direct_terminal_consumer``
+    UNCHANGED: ``start`` -> ``partitions_for_topic`` -> ``assign`` ->
+    ``seek_to_end`` -> ``getone`` (or ``end_offsets`` + ``seek`` once the consume
+    leg is fixed).
+
+    The critical fidelity — and the difference from the two prior consume-leg
+    fakes — is that ``seek_to_end`` is a DEFERRED LATEST reset, NOT an immediate
+    HWM snapshot. Calling ``seek_to_end`` only marks the partition "awaiting
+    reset". The read offset is resolved on the FIRST ``getone`` to the partition
+    HWM AT THAT MOMENT (a real broker ``ListOffsets`` round-trip that happens
+    after the caller has already published). So a record produced in the
+    open()->getone() gap is SKIPPED — exactly the live wedge.
+
+    A consume leg that instead synchronously captures the end offset via
+    ``end_offsets`` and pins it via ``seek`` resolves the read position at open()
+    time (before the publish), so the gap record is delivered. ``end_offsets``
+    here returns the HWM at the instant it is called (a real synchronous broker
+    round-trip), and ``seek`` pins that offset deterministically.
+    """
+
+    cluster: ClassVar[_Cluster | None] = None
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self._client = _FakeClient(self)
+        self._topic: str | None = None
+        self._assigned_partitions: set[Any] = set()
+        # None => the partition is "awaiting (lazy) reset"; the read offset is
+        # resolved to the live HWM on the first getone. An int => a pinned offset
+        # (set synchronously by seek()).
+        self._cursor: int | None = None
+        self.started = False
+        self.stopped = False
+
+    @property
+    def _cluster(self) -> _Cluster:
+        cluster = type(self).cluster
+        assert cluster is not None, "test must set _FakeConsumer.cluster"
+        return cluster
+
+    async def start(self) -> None:
+        self.started = True
+
+    def partitions_for_topic(self, topic: str) -> set[int]:
+        self._topic = topic
+        if topic not in self._client.tracked:
+            return set()
+        if topic not in self._cluster.topics_with_partitions:
+            return set()
+        return {0}
+
+    def assign(self, partitions: Any) -> None:
+        self._assigned_partitions = set(partitions)
+        # A fresh assignment with auto_offset_reset="latest" leaves the position
+        # UNRESOLVED until seek_to_end / end_offsets+seek positions it.
+        self._cursor = None
+
+    def assignment(self) -> set[Any]:
+        return set(self._assigned_partitions)
+
+    async def seek_to_end(self, *assignment: object) -> None:
+        # LAZY: request a LATEST reset but DO NOT resolve the offset now. The
+        # real Fetcher.request_offset_reset only marks the partition "awaiting
+        # reset"; the LATEST offset is fetched on the first poll. Leaving the
+        # cursor unresolved here models that deferral faithfully.
+        return None
+
+    async def end_offsets(self, partitions: Any) -> dict[Any, int]:
+        # Synchronous broker round-trip: return the CURRENT HWM (the offset of
+        # the next message). Does NOT change the consumer position. This is the
+        # offset the fixed consume leg pins via seek() at open() time.
+        assert self._topic is not None
+        hwm = self._cluster.logs[self._topic].hwm
+        return dict.fromkeys(partitions, hwm)
+
+    def seek(self, partition: Any, offset: int) -> None:
+        # Deterministically pin the read offset NOW (synchronous, no broker
+        # round-trip): the position the fixed consume leg resumes from.
+        self._cursor = offset
+
+    async def getone(self) -> SimpleNamespace:
+        assert self._topic is not None
+        log = self._cluster.logs[self._topic]
+        while True:
+            if self._cursor is None:
+                # Deferred LATEST reset resolves NOW — to the live HWM, which by
+                # this point includes the terminal published in the open->getone
+                # gap. That record is therefore skipped (the live wedge).
+                self._cursor = log.hwm
+            records = log.read_from(self._cursor)
+            if records:
+                _cid, value = records[0]
+                self._cursor += 1
+                return SimpleNamespace(topic=self._topic, value=value)
+            await asyncio.sleep(0.002)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _KafkaLikeBus:
+    config = SimpleNamespace(
+        session_timeout_ms=45000,
+        heartbeat_interval_ms=15000,
+        max_poll_interval_ms=1800000,
+        reconnect_backoff_ms=2000,
+    )
+    _bootstrap_servers = "omn-13118-seek-race-test-broker"
+
+    def _build_auth_kwargs(self) -> dict[str, object]:
+        return {}
+
+
+def _terminal_envelope_json(correlation_id: str) -> bytes:
+    return json.dumps(
+        {
+            "correlation_id": correlation_id,
+            "payload": {
+                "attempt_count": 1,
+                "contract_passed": True,
+                "model_id": "Qwen3.6-35B-A3B",
+                "provider": "local",
+                "prompt_tokens": 128,
+                "completion_tokens": 64,
+            },
+        }
+    ).encode("utf-8")
+
+
+def _open_session_or_none(consumer_factory: Any, topic: str) -> Any:
+    """Open a terminal session, returning None if open raises.
+
+    Mirrors ``HandlerContextRoiRunner._open_terminal_session``: a failed open is
+    caught and the runner falls back to the legacy single-call path for that
+    topic.
+    """
+    try:
+        return consumer_factory.open(topic)
+    except Exception:  # noqa: BLE001 — mirrors handler's catch-all open fallback
+        return None
+
+
+def _run_one_trial(
+    *,
+    consumer_factory: Any,
+    cluster: _Cluster,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Drive ONE trial as ``HandlerContextRoiRunner._run_trial`` does.
+
+    Ordering (subscribe-before-publish, OMN-13012/13038):
+      1. open the COMPLETED terminal session to current end;
+      2. open the FAILED terminal session to current end (partition-less, returns
+         promptly post-#1970);
+      3. "publish" the generation command — FAST generation appends the
+         correlated COMPLETED terminal IMMEDIATELY, in the open->wait gap;
+      4. wait on the COMPLETED session.
+
+    The terminal landing in step 3 is the whole point: a consume leg that only
+    resolves its read offset on the first poll (lazy ``seek_to_end``) lands PAST
+    this record and never reads it.
+    """
+    completed_session = _open_session_or_none(consumer_factory, _COMPLETED_TOPIC)
+    failed_session = _open_session_or_none(consumer_factory, _FAILED_TOPIC)
+
+    # FAST generation publishes the correlated COMPLETED terminal in the gap
+    # between open() and the wait()'s first poll (mirrors ~1s gen vs the per-trial
+    # consumer open). The HWM has now advanced past the consumer's open position.
+    cluster.logs[_COMPLETED_TOPIC].append(
+        correlation_id, _terminal_envelope_json(correlation_id)
+    )
+
+    try:
+        if completed_session is None:
+            return None
+        return completed_session.wait(correlation_id, timeout_seconds)
+    finally:
+        if failed_session is not None:
+            failed_session.close()
+
+
+@pytest.mark.timeout(180)
+def test_full_battery_consume_leg_reads_terminal_published_in_open_wait_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """K>=10 x 2 cells x 2 arms: the correlated COMPLETED terminal published in
+    the open->wait gap must be read by every trial; the matrix must not wedge.
+
+    RED on the lazy-``seek_to_end`` consume leg: the read offset resolves on the
+    first poll to the HWM that ALREADY includes the gap-published terminal, so
+    every cell is degenerate and the matrix never advances. GREEN once the consume
+    leg pins the exact pre-publish end offset synchronously.
+    """
+    cluster = _Cluster()
+    _FakeConsumer.cluster = cluster
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeConsumer,
+    )
+    # Keep the partition-less grace tiny so the FAILED open returns promptly
+    # (post-#1970 behavior) and the test stays fast; the seek-race is independent
+    # of this grace.
+    monkeypatch.setattr(
+        service_pattern_b_broker,
+        "_DIRECT_TERMINAL_PARTITIONLESS_GRACE_SECONDS",
+        0.05,
+        raising=False,
+    )
+
+    bus = _KafkaLikeBus()
+    consumer = make_terminal_event_consumer(event_bus=bus, handler_name=_HANDLER)
+
+    # The runner's per-arm timeout (generation_timeout_seconds in the battery),
+    # scaled down so a wedged battery (every trial burns its full window then
+    # returns None) still completes inside the test timeout while remaining
+    # unambiguously RED. A correctly-positioned consumer correlates in
+    # milliseconds; a wedged one burns this whole window per degenerate trial.
+    timeout_seconds = 1.0
+
+    correlated: list[tuple[str, str, int]] = []
+    degenerate: list[tuple[str, str, int]] = []
+    arms_with_real_rows: set[str] = set()
+    cells_with_real_rows: set[str] = set()
+
+    run_order = 0
+    for cell in _CELLS:
+        for trial in range(1, _TRIALS_PER_CELL + 1):
+            for arm in _ARMS:
+                run_order += 1
+                cid = f"omn-13118-{cell}-{arm}-t{trial}"
+                result = _run_one_trial(
+                    consumer_factory=consumer,
+                    cluster=cluster,
+                    correlation_id=cid,
+                    timeout_seconds=timeout_seconds,
+                )
+                if result is not None and str(result.get("correlation_id")) == cid:
+                    correlated.append((cell, arm, trial))
+                    arms_with_real_rows.add(arm)
+                    cells_with_real_rows.add(cell)
+                else:
+                    degenerate.append((cell, arm, trial))
+
+    total = len(_CELLS) * _TRIALS_PER_CELL * len(_ARMS)
+
+    # The COMPLETED-topic HWM CLIMBED (every trial published its terminal) — the
+    # wedge is NOT a missing-publish problem but a consume-leg positioning failure.
+    assert cluster.logs[_COMPLETED_TOPIC].hwm == total, (
+        "every trial's correlated COMPLETED terminal must have been published "
+        f"(HWM should climb to {total}, got {cluster.logs[_COMPLETED_TOPIC].hwm})"
+    )
+    # HWMs settle: nothing ever lands on FAILED.
+    assert cluster.logs[_FAILED_TOPIC].hwm == 0, (
+        "the FAILED topic must stay at HWM 0 (nothing lands there)"
+    )
+
+    # Every cell across both arms correlates its COMPLETED terminal: no degenerate
+    # rows, matrix advances through both cells AND both arms.
+    assert not degenerate, (
+        f"{len(degenerate)}/{total} trials produced a degenerate row — the "
+        "per-trial consume leg failed to read the COMPLETED terminal published "
+        "in the open->wait gap (lazy seek_to_end resolved the read offset PAST "
+        f"the record). First few degenerate: {degenerate[:5]}"
+    )
+    assert len(correlated) == total, (
+        f"expected all {total} trials correlated, got {len(correlated)}"
+    )
+    assert cells_with_real_rows == set(_CELLS), (
+        f"matrix did not advance through both cells with real rows: "
+        f"{cells_with_real_rows} != {set(_CELLS)}"
+    )
+    assert arms_with_real_rows == set(_ARMS), (
+        f"matrix did not advance through both arms with real rows: "
+        f"{arms_with_real_rows} != {set(_ARMS)}"
+    )
+
+
+@pytest.mark.timeout(60)
+def test_single_trial_reads_terminal_published_immediately_after_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Focused unit-style repro: a terminal published in the open->wait gap is read.
+
+    The minimal shape of the wedge: open COMPLETED to current end, publish the
+    correlated terminal, then wait. The fixed consume leg pins the pre-publish end
+    offset so the wait reads the record; the lazy-reset leg resolves past it.
+    """
+    cluster = _Cluster()
+    _FakeConsumer.cluster = cluster
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeConsumer,
+    )
+
+    bus = _KafkaLikeBus()
+    consumer = make_terminal_event_consumer(event_bus=bus, handler_name=_HANDLER)
+    cid = "omn-13118-single-gap-0001"
+
+    session = consumer.open(_COMPLETED_TOPIC)
+    # Terminal lands in the open->wait gap (HWM advances past the open position).
+    cluster.logs[_COMPLETED_TOPIC].append(cid, _terminal_envelope_json(cid))
+
+    result = session.wait(cid, timeout_seconds=5.0)
+
+    assert result is not None, (
+        "the COMPLETED terminal published in the open->wait gap was not read — "
+        "the consume leg resolved its read offset to the post-publish HWM "
+        "(lazy seek_to_end) instead of pinning the pre-publish end offset"
+    )
+    assert str(result.get("correlation_id")) == cid
+
+
+@pytest.mark.timeout(60)
+def test_open_pins_end_offset_before_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consume leg must resolve its read position at open() time, not on poll.
+
+    Asserts the structural fix: after ``open`` returns, the assigned partition's
+    read offset is already pinned (an int, captured synchronously) rather than
+    left as a deferred LATEST reset that resolves on the first poll. This is the
+    invariant that makes a terminal published in the open->wait gap readable.
+    """
+    cluster = _Cluster()
+    _FakeConsumer.cluster = cluster
+    captured: dict[str, _FakeConsumer] = {}
+
+    real_init = _FakeConsumer.__init__
+
+    def _tracking_init(self: _FakeConsumer, *args: object, **kwargs: object) -> None:
+        real_init(self, *args, **kwargs)
+        # Record the consumer the moment partitions_for_topic binds its topic so
+        # the test can inspect the pinned cursor after open().
+        original = self.partitions_for_topic
+
+        def _track(topic: str) -> set[int]:
+            result = original(topic)
+            if topic == _COMPLETED_TOPIC:
+                captured["completed"] = self
+            return result
+
+        self.partitions_for_topic = _track  # type: ignore[method-assign]
+
+    monkeypatch.setattr(_FakeConsumer, "__init__", _tracking_init)
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeConsumer,
+    )
+
+    bus = _KafkaLikeBus()
+    consumer = make_terminal_event_consumer(event_bus=bus, handler_name=_HANDLER)
+
+    # Seed one pre-existing record so a pinned end offset is a non-zero, exact
+    # value the fix must capture synchronously.
+    cluster.logs[_COMPLETED_TOPIC].append(
+        "preexisting", _terminal_envelope_json("preexisting")
+    )
+    pre_publish_hwm = cluster.logs[_COMPLETED_TOPIC].hwm
+
+    session = consumer.open(_COMPLETED_TOPIC)
+    try:
+        # Give the worker loop a beat to finish open().
+        deadline = time.monotonic() + 5.0
+        while "completed" not in captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert "completed" in captured, "COMPLETED consumer was never constructed"
+        fake = captured["completed"]
+        assert fake._assigned_partitions, "COMPLETED partition was never assigned"
+        assert fake._cursor == pre_publish_hwm, (
+            "open() did not pin the pre-publish end offset synchronously — the "
+            f"read cursor is {fake._cursor!r}, expected {pre_publish_hwm} "
+            "(an unresolved cursor means a deferred LATEST reset that races the "
+            "publish)"
+        )
+    finally:
+        session.close()

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -116,6 +116,10 @@ class _FakeAIOKafkaConsumer:
         self.topics_calls = 0
         self.set_topics_calls: list[tuple[str, ...]] = []
         self.seeked_to_end = False
+        # True once the consume leg has pinned its read position to the current
+        # end — either the legacy lazy ``seek_to_end`` or, post-OMN-13118, the
+        # synchronous ``end_offsets`` + ``seek`` pinning.
+        self.positioned = False
         self.started = False
         self.stopped = False
         type(self).created.append(self)
@@ -155,6 +159,18 @@ class _FakeAIOKafkaConsumer:
     async def seek_to_end(self, *_assignment: object) -> None:
         await asyncio.sleep(0)
         self.seeked_to_end = True
+        self.positioned = True
+
+    async def end_offsets(self, partitions: object) -> dict[object, int]:
+        # Synchronous broker round-trip returning the current HWM per partition
+        # (queue-backed fake delivers regardless of offset, so 0 is faithful for
+        # the "next message" offset here). Does not change position.
+        await asyncio.sleep(0)
+        return dict.fromkeys(partitions, 0)
+
+    def seek(self, _partition: object, _offset: int) -> None:
+        # Synchronous pin (OMN-13118): the position is fixed at open() time.
+        self.positioned = True
 
     async def getone(self) -> SimpleNamespace:
         return await self.messages.get()
@@ -235,7 +251,7 @@ class _FakeKafkaTransport:
         assert self._consumers
         consumer = self._consumers[-1]
         if self._assert_seeked:
-            assert consumer.seeked_to_end is True
+            assert consumer.positioned is True
 
         command_envelope = ModelEventEnvelope[object].model_validate_json(value)
         terminal_topic = self._terminal_topic or self._route.terminal_event or "unknown"
@@ -391,7 +407,7 @@ async def test_service_pattern_b_broker_returns_failed_for_failure_terminal() ->
 
 
 @pytest.mark.asyncio
-async def test_service_pattern_b_broker_kafka_waiter_seeks_before_dispatch(
+async def test_service_pattern_b_broker_kafka_waiter_pins_end_offset_before_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     route = _route()
@@ -820,8 +836,10 @@ async def test_runtime_host_process_starts_pattern_b_broker_when_enabled(
 
     monkeypatch.setattr(
         "omnibase_infra.runtime.runtime_host_process.discover_runtime_local_ingress_routes",
-        lambda packages: captured.setdefault("packages", packages)
-        and {"session_orchestrator": route},
+        lambda packages: (
+            captured.setdefault("packages", packages)
+            and {"session_orchestrator": route}
+        ),
     )
     monkeypatch.setattr(
         "omnibase_infra.runtime.runtime_host_process.RuntimePatternBBroker",
@@ -936,8 +954,10 @@ async def test_runtime_host_process_broker_package_names_ignore_active_runtime_e
     monkeypatch.setenv("ONEX_ACTIVE_RUNTIME_PACKAGES", "omnibase_infra")
     monkeypatch.setattr(
         "omnibase_infra.runtime.runtime_host_process.discover_runtime_local_ingress_routes",
-        lambda packages: captured.setdefault("packages", packages)
-        and {"session_orchestrator": route},
+        lambda packages: (
+            captured.setdefault("packages", packages)
+            and {"session_orchestrator": route}
+        ),
     )
     monkeypatch.setattr(
         "omnibase_infra.runtime.runtime_host_process.RuntimePatternBBroker",


### PR DESCRIPTION
## OMN-13118 — terminal-consumer consume-leg seek race (strike-three follow-up)

Evidence-Source: OCC#2600
Evidence-Ticket: OMN-13118

### Root cause (refined, beyond #1969/#1970)
The consume-leg wedge survived PR #1969 (set_topics no-op) and PR #1970 (partition-less assign-cap) because both addressed the ASSIGN phase, not the SEEK timing. `AIOKafkaConsumer.seek_to_end` is LAZY: it calls `Fetcher.request_offset_reset(partitions, LATEST)`, which only marks the partition "awaiting reset"; the actual LATEST offset is resolved by a `ListOffsets` round-trip on the FIRST `getone()` — AFTER the caller has published. With generation completing in ~1s (dispatch loop freed, OMN-13010), the correlated COMPLETED terminal lands in the `open()`→poll gap, so the lazily-resolved LATEST position is the high-water-mark AFTER the record and the poll reads PAST it. The terminal is never read, the trial never correlates, and the experiment matrix re-fires cell 1 forever.

Decisive live evidence (`HALT_K10_WEDGE_PERSISTS.md`): the COMPLETED terminal IS published every trial — the `cid` that "wait failed" in cycle N is the `correlation_id` published to COMPLETED in cycle N-1.

### Fix
Replace `seek_to_end` with a synchronous `end_offsets()` + `seek()` pin (`_pin_direct_terminal_end_offsets`) in BOTH `open_direct_terminal_consumer` and `RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer`, so the read position is fixed at `open()` time, BEFORE the publish — the real subscribe-before-publish guarantee. An empty assignment (partition-less reply topic, #1970) remains a no-op.

### Repro (RED before fix, GREEN after)
`tests/integration/test_terminal_consumer_seek_reset_race.py` drives the REAL `TerminalEventConsumer.open()/wait()` the way `HandlerContextRoiRunner._run_trial` does — open BOTH terminal topics per trial, publish the correlated COMPLETED terminal in the open→wait gap, race the wait — across K=10 × 2 cells × 2 arms, with a fake that models `seek_to_end` FAITHFULLY as a lazy LATEST reset (resolved to the live HWM on first poll). RED with the lazy reset (every cell degenerate, COMPLETED terminal skipped); GREEN once the read offset is pinned. RED verified by git-stashing ONLY `src/omnibase_infra/runtime/service_pattern_b_broker.py` and re-running.

The two prior consume-leg fakes (`test_terminal_consumer_concurrent_assign_race.py`, `test_terminal_consumer_battery_load_wedge.py`) were updated to model `end_offsets`/`seek` — they previously masked the bug by making `seek_to_end` a synchronous exact snapshot.

### Local verification
- `ruff format` + `ruff check` clean; `mypy src/omnibase_infra/runtime/service_pattern_b_broker.py --strict` Success.
- All 28 consume-leg / pattern-b tests pass; the broad `tests/unit/runtime` + `tests/integration` pass (7224 passed) excluding live-infra-gated tests (Kafka :19092 / container-health / golden-chain-live-runtime require the deployed .201 runtime).
- `pre-commit run` clean on changed files.
