### PR TITLE
fix(OMN-13118): independent per-terminal-topic consumers in Pattern B direct-Kafka wait (strike-5 follow-up)

### DIFF
--- a/src/omnibase_infra/runtime/service_pattern_b_broker.py
+++ b/src/omnibase_infra/runtime/service_pattern_b_broker.py
@@ -394,6 +394,55 @@ async def poll_direct_terminal_consumer(
         await close_direct_terminal_consumer(handle, terminal_topic=terminal_topic)
 
 
+async def _poll_terminal_without_close(
+    *,
+    handle: DirectTerminalConsumer,
+    terminal_topic: str,
+    correlation_id: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    """Poll one positioned consumer for the correlated terminal, WITHOUT closing.
+
+    ``poll_direct_terminal_consumer`` stops its consumer in a ``finally`` because
+    its single-topic callers own one consumer for the whole open→wait→close
+    lifecycle. The Pattern B broker races MULTIPLE independent consumers and tears
+    them ALL down together after the race resolves (so the losing leg is unblocked
+    by ``close`` rather than waiting out its own timeout). This thin wrapper runs
+    the same correlate-and-wait body without the inner close so the broker keeps a
+    single teardown point.
+    """
+    loop = asyncio.get_running_loop()
+    if not handle.consumer.assignment():
+        # Partition-less reply topic (OMN-13118): nothing will arrive here. Sleep
+        # out the caller timeout so the race lets a real-partition topic win; the
+        # broker cancels this task the moment the winner correlates.
+        try:
+            await asyncio.sleep(timeout_seconds)
+        except asyncio.CancelledError:
+            pass
+        return None
+    deadline = loop.time() + timeout_seconds
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return None
+        try:
+            message = await asyncio.wait_for(
+                handle.consumer.getone(),
+                timeout=remaining,
+            )
+        except TimeoutError:
+            return None
+        if message.value is None:
+            continue
+        try:
+            body: dict[str, object] = json.loads(message.value.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if _extract_direct_terminal_correlation_id(body) == correlation_id:
+            return body
+
+
 async def close_direct_terminal_consumer(
     handle: DirectTerminalConsumer,
     *,
@@ -588,118 +637,117 @@ class RuntimePatternBBroker:
         command: ModelDispatchBusCommand,
         route: ModelRuntimeLocalIngressRoute,
     ) -> TerminalPayload:
+        """Wait for the correlated terminal with ONE consumer PER terminal topic.
+
+        Independent consumers, not one shared subscription (OMN-13128/13118 strike-5)
+        ----------------------------------------------------------------------------
+        The generation consumer emits exactly one terminal per command —
+        ``completed`` (``contract_passed=True``) or ``failed``
+        (``contract_passed=False``) — on DIFFERENT topics, so the broker must wait
+        on BOTH within the single per-command timeout. The prior shape assigned
+        BOTH topics' partitions to a SINGLE ephemeral ``group_id=None`` consumer.
+        A single aiokafka consumer holds ONE manual subscription
+        (``ManualSubscription`` over its assigned partitions); the live battery
+        diagnosis (HALT_K10_WEDGE_PERSISTS, strikes 3+4) showed that consumer's
+        COMPLETED-topic delivery window collapsing before it could surface the
+        correlated record, so the trial never correlated and the K>=10 matrix
+        re-fired cell 1 forever.
+
+        The fix gives EACH terminal topic its OWN independent
+        ``open_direct_terminal_consumer`` — each started, assigned, and
+        offset-pinned (``end_offsets()`` + ``seek()``, #1971) at open() BEFORE the
+        worker command is published (subscribe-before-publish). The two waits then
+        run CONCURRENTLY via ``asyncio.wait(..., FIRST_COMPLETED)``; the first
+        correlated terminal wins and the losing wait is cancelled. No consumer ever
+        holds two subscriptions, so there is no subscription to tear down out from
+        under the COMPLETED delivery.
+
+        The #1970 partition-less no-op and the #1971 synchronous offset pin are
+        preserved: they live in ``open_direct_terminal_consumer`` /
+        ``poll_direct_terminal_consumer``, which each consumer goes through. A
+        never-produced FAILED topic assigns the empty set, ``poll`` sleeps out its
+        timeout returning ``None``, and the COMPLETED consumer wins the race fast.
+        """
         terminal_topics = _terminal_topics(route)
         if not terminal_topics:
             raise RuntimeError(f"Route '{command.command_name}' has no terminal event")
 
-        kafka_event_bus = self._kafka_event_bus()
-        config = getattr(kafka_event_bus, "config", SimpleNamespace())
-        consumer = AIOKafkaConsumer(
-            bootstrap_servers=self._kafka_bootstrap_servers(),
-            group_id=None,
-            auto_offset_reset="latest",
-            enable_auto_commit=False,
-            session_timeout_ms=getattr(config, "session_timeout_ms", 45000),
-            heartbeat_interval_ms=getattr(config, "heartbeat_interval_ms", 15000),
-            max_poll_interval_ms=getattr(config, "max_poll_interval_ms", 300000),
-            retry_backoff_ms=getattr(config, "reconnect_backoff_ms", 2000),
-            **self._direct_kafka_client_version_kwargs(AIOKafkaConsumer),
-            **self._direct_kafka_auth_kwargs(),
-        )
-
+        event_bus = self._event_bus
+        handles: dict[str, DirectTerminalConsumer] = {}
         try:
-            await asyncio.wait_for(
-                consumer.start(), timeout=min(30, command.timeout_seconds)
-            )
-            await self._assign_terminal_topic_partitions(
-                consumer,
-                terminal_topics,
-                command.timeout_seconds,
-            )
-            # Pin the read position SYNCHRONOUSLY at the current end (OMN-13118):
-            # ``seek_to_end`` is a lazy LATEST reset resolved on the first poll —
-            # AFTER this publish — so a terminal landing in the publish→poll gap
-            # is skipped. ``end_offsets`` + ``seek`` fixes the position now.
-            await _pin_direct_terminal_end_offsets(
-                consumer,
-                timeout_seconds=min(30, command.timeout_seconds),
-            )
+            # Open one independent consumer per terminal topic, each positioned at
+            # the current end BEFORE we publish. Open serially so a partition-less
+            # FAILED topic's bounded grace does not race the COMPLETED open; both
+            # are positioned before any command is on the wire.
+            for terminal_topic in terminal_topics:
+                handles[terminal_topic] = await open_direct_terminal_consumer(
+                    event_bus=event_bus,
+                    terminal_topic=terminal_topic,
+                )
+
             await self._publish_worker_command(command, route)
 
-            deadline = asyncio.get_running_loop().time() + command.timeout_seconds
-            while True:
-                remaining = deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    raise TimeoutError
-                message = await asyncio.wait_for(consumer.getone(), timeout=remaining)
-                terminal_envelope = ModelEventEnvelope[object].model_validate_json(
-                    message.value
-                )
-                if terminal_envelope.correlation_id == command.correlation_id:
-                    topic = getattr(message, "topic", None)
-                    if not isinstance(topic, str) or not topic:
-                        topic = str(
-                            terminal_envelope.event_type or route.terminal_event
-                        )
-                    return TerminalPayload(
-                        payload=terminal_envelope.payload,
-                        topic=topic,
-                    )
+            return await self._race_correlated_terminals(
+                handles,
+                correlation_id=str(command.correlation_id),
+                timeout_seconds=float(command.timeout_seconds),
+            )
         finally:
-            try:
-                await consumer.stop()
-            except Exception as exc:  # noqa: BLE001
-                _LOGGER.warning(
-                    "Failed to stop Pattern B terminal Kafka consumer: %s",
-                    sanitize_error_message(exc),
+            for terminal_topic, handle in handles.items():
+                await close_direct_terminal_consumer(
+                    handle,
+                    terminal_topic=terminal_topic,
+                    log_prefix="Pattern B terminal Kafka consumer",
                 )
 
-    async def _assign_terminal_topic_partitions(
+    async def _race_correlated_terminals(
         self,
-        consumer: AIOKafkaConsumer,
-        topics: tuple[str, ...],
-        timeout_seconds: int,
-    ) -> None:
-        deadline = asyncio.get_running_loop().time() + min(30, timeout_seconds)
-        expected_topics = set(topics)
-        while True:
-            await self._refresh_terminal_topic_metadata(consumer, topics)
-            partitions: set[TopicPartition] = set()
-            ready_topics: set[str] = set()
-            for topic in topics:
-                topic_partitions = consumer.partitions_for_topic(topic) or set()
-                if topic_partitions:
-                    ready_topics.add(topic)
-                partitions.update(
-                    TopicPartition(topic, partition) for partition in topic_partitions
+        handles: Mapping[str, DirectTerminalConsumer],
+        *,
+        correlation_id: str,
+        timeout_seconds: float,
+    ) -> TerminalPayload:
+        """Poll every terminal consumer concurrently; first correlated wins.
+
+        Each topic's poll runs as its own task. ``asyncio.wait(FIRST_COMPLETED)``
+        returns as soon as one task finishes; a task that found the correlated
+        record yields the payload, a task that timed out yields ``None`` (and we
+        keep waiting on the rest until one correlates or all are exhausted). The
+        losing tasks are cancelled on the way out so the winner returns
+        immediately without joining a full-timeout sleep on the partition-less leg.
+        """
+        tasks: dict[asyncio.Task[dict[str, object] | None], str] = {}
+        for terminal_topic, handle in handles.items():
+            task = asyncio.ensure_future(
+                _poll_terminal_without_close(
+                    handle=handle,
+                    terminal_topic=terminal_topic,
+                    correlation_id=correlation_id,
+                    timeout_seconds=timeout_seconds,
                 )
-            if ready_topics == expected_topics:
-                consumer.assign(partitions)
-                return
-            if asyncio.get_running_loop().time() >= deadline:
-                raise TimeoutError
-            await asyncio.sleep(0.05)
+            )
+            tasks[task] = terminal_topic
 
-    async def _refresh_terminal_topic_metadata(
-        self,
-        consumer: AIOKafkaConsumer,
-        topics: tuple[str, ...],
-    ) -> None:
-        client = getattr(consumer, "_client", None)
-        set_topics = getattr(client, "set_topics", None)
-        if callable(set_topics):
-            set_topics(list(topics))
-            return
-
-        add_topic = getattr(client, "add_topic", None)
-        if callable(add_topic):
-            for topic in topics:
-                add_topic(topic)
-            return
-
-        topics_method = getattr(type(consumer), "topics", None)
-        if callable(topics_method):
-            await topics_method(consumer)
+        pending = set(tasks)
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    body = task.result()
+                    if body is None:
+                        continue
+                    return TerminalPayload(
+                        payload=body.get("payload", body),
+                        topic=tasks[task],
+                    )
+            raise TimeoutError
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def _supports_direct_kafka_terminal_consumer(self) -> bool:
         return (
@@ -707,44 +755,6 @@ class RuntimePatternBBroker:
             and hasattr(self._event_bus, "_build_auth_kwargs")
             and hasattr(self._event_bus, "config")
         )
-
-    def _direct_kafka_auth_kwargs(self) -> dict[str, object]:
-        build_auth_kwargs = getattr(  # noqa: B009
-            self._kafka_event_bus(),
-            "_build_auth_kwargs",
-        )
-        auth_kwargs = cast(
-            "Callable[[], Mapping[str, object] | None]",
-            build_auth_kwargs,
-        )()
-        return dict(auth_kwargs or {})
-
-    def _direct_kafka_client_version_kwargs(
-        self, client_cls: type[object]
-    ) -> dict[str, object]:
-        config = getattr(self._kafka_event_bus(), "config", SimpleNamespace())
-        api_version = getattr(config, "api_version", None)
-        if api_version is None:
-            return {}
-        try:
-            parameters = inspect.signature(client_cls.__init__).parameters
-        except (TypeError, ValueError):
-            return {}
-        if "api_version" not in parameters:
-            return {}
-        return {"api_version": api_version}
-
-    def _kafka_bootstrap_servers(self) -> str:
-        bootstrap_servers = getattr(  # noqa: B009
-            self._kafka_event_bus(),
-            "_bootstrap_servers",
-        )
-        if not isinstance(bootstrap_servers, str):
-            raise RuntimeError("Kafka event bus bootstrap servers are not configured")
-        return bootstrap_servers
-
-    def _kafka_event_bus(self) -> object:
-        return self._event_bus
 
     async def _publish_worker_command(
         self,

--- a/tests/integration/test_terminal_consumer_subscription_flip_wedge.py
+++ b/tests/integration/test_terminal_consumer_subscription_flip_wedge.py
@@ -1,0 +1,420 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""K>=10 multi-cell regression for the terminal-consumer SUBSCRIPTION-flip wedge.
+
+Ticket: OMN-13128 (OMN-13118 strike-5 follow-up).
+
+What this test models that the #1970/#1971 repros did NOT
+--------------------------------------------------------
+``test_terminal_consumer_battery_load_wedge.py`` (OMN-13118 / #1970) models the
+FAILED-topic *assign-cap* stall, and ``test_..._seek_reset_race`` (#1971) models
+the lazy ``seek_to_end`` *offset* race. Both prior fixes went RED->GREEN offline
+yet the LIVE K>=10 multi-cell battery on the stability lane WEDGED every time
+(HALT_K10_WEDGE_PERSISTS, strikes 3 + 4). The reason the offline repros kept
+lying: their fakes collapsed the COMPLETED and FAILED waits onto behaviour that a
+SINGLE consumer could satisfy, so they never exercised the actual live fault —
+the runtime waited for each trial's terminal across BOTH topics
+(``node-generation-completed.v1`` + ``node-generation-failed.v1``) using ONE
+ephemeral ``group_id=None`` consumer assigned the partitions of both topics, and a
+single aiokafka consumer cannot deliver from two topics at once: its delivery
+window flips between them and the COMPLETED record is torn down before it is read
+(the live ``Updating subscribed topics`` flip the HALT log captured).
+
+This test models that fault HONESTLY: the fake consumer's delivery is faithful
+ONLY when its assignment is confined to a SINGLE topic. The moment ONE consumer is
+assigned partitions spanning BOTH terminal topics, the fake flips its readable
+topic every poll and DROPS any record sitting on the non-current topic — exactly
+the live subscription-flip that loses the already-published COMPLETED terminal.
+
+  - RED (single-consumer-both-topics, the pre-OMN-13128 shape): a consumer
+    assigned both topics flips, the COMPLETED terminal is dropped, the trial never
+    correlates, and the K>=10 x 2-cell x 2-arm matrix produces degenerate rows /
+    times out — the live wedge.
+  - GREEN (OMN-13128, one INDEPENDENT consumer per terminal topic): each consumer
+    holds exactly one topic, never flips, and the COMPLETED consumer surfaces the
+    correlated record on its own subscription while the partition-less FAILED
+    consumer sleeps out its timeout — every cell across both arms correlates.
+
+RED genuineness: revert ONLY the source change in
+``RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer`` (back to a
+single consumer assigned both topics) and this test fails — the single consumer's
+flip drops every COMPLETED terminal. The fix is what makes it pass; the assertion
+is the live battery bar (matrix advances through both arms with non-degenerate
+rows), not a unit-isolated probe.
+
+NOT the acceptance gate: per the task standing orders, the consume-leg wedge is
+declared cleared ONLY by the LIVE K>=10 multi-cell reprobe on the stability lane,
+never by this test. A green run here is necessary but not sufficient.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any, ClassVar
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
+from omnibase_infra.runtime.service_pattern_b_broker import RuntimePatternBBroker
+
+pytestmark = [pytest.mark.integration]
+
+_COMPLETED_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+_FAILED_TOPIC = "onex.evt.omnimarket.node-generation-failed.v1"
+_COMMAND_TOPIC = "onex.cmd.omnimarket.node-generation-requested.v1"
+
+# Battery shape: K trials over >=2 cells x >=2 arms.
+_TRIALS_PER_CELL = 10
+_CELLS = ("bool_flag", "address_norm")
+_ARMS = ("off", "golden_exemplar")
+
+
+def _generation_route() -> ModelRuntimeLocalIngressRoute:
+    """Route declaring BOTH terminal topics (completed + failed), like the runner."""
+    return ModelRuntimeLocalIngressRoute(
+        node_name="node_generation_consumer",
+        contract_name="generation_consumer",
+        command_topic=_COMMAND_TOPIC,
+        event_type="omnimarket.node-generation-requested",
+        terminal_event=_COMPLETED_TOPIC,
+        contract_path="/tmp/node_generation_consumer/contract.yaml",  # noqa: S108
+        package_name="omnimarket",
+        terminal_events=(_COMPLETED_TOPIC, _FAILED_TOPIC),
+    )
+
+
+class _PartitionLog:
+    """Append-only partition log with a high-water-mark (Redpanda-like)."""
+
+    def __init__(self) -> None:
+        self._records: list[tuple[str, bytes]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def hwm(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    def append(self, correlation_id: str, value: bytes) -> None:
+        with self._lock:
+            self._records.append((correlation_id, value))
+
+    def at(self, offset: int) -> tuple[str, bytes] | None:
+        with self._lock:
+            if 0 <= offset < len(self._records):
+                return self._records[offset]
+            return None
+
+
+class _Cluster:
+    """Shared broker state across all ephemeral consumers in a battery run.
+
+    COMPLETED is produced to every trial (it advertises a partition); FAILED is
+    never produced to in a pass-only battery (no partition advertised — the
+    Redpanda auto-create-on-produce steady state).
+    """
+
+    def __init__(self) -> None:
+        self.logs: dict[str, _PartitionLog] = {
+            _COMPLETED_TOPIC: _PartitionLog(),
+            _FAILED_TOPIC: _PartitionLog(),
+        }
+        self.topics_with_partitions: set[str] = {_COMPLETED_TOPIC}
+
+
+class _FakeFlipConsumer:
+    """``AIOKafkaConsumer`` stand-in that models the live subscription flip.
+
+    Faithful single-topic delivery, faithless multi-topic delivery
+    --------------------------------------------------------------
+    Delivery is correct ONLY when the consumer's assignment is confined to a
+    SINGLE topic: ``getone`` returns the next record on that topic at/after the
+    pinned offset. When ONE consumer is assigned partitions spanning MULTIPLE
+    topics (the pre-OMN-13128 single-consumer-both-topics shape), the fake models
+    the live aiokafka fault: it can only hold ONE topic's delivery subscription at
+    a time and FLIPS which topic it reads each poll, so a record sitting on the
+    topic that is not currently subscribed is never surfaced — exactly the
+    COMPLETED terminal the live wedge dropped.
+
+    The cluster's COMPLETED log advances every trial; the FAILED topic stays at
+    HWM 0 and advertises no partition (partition-less, #1970).
+    """
+
+    cluster: ClassVar[_Cluster | None] = None
+    refresh_latency_seconds: ClassVar[float] = 0.0
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self._client = _FakeClient(self)
+        self._assigned: list[Any] = []
+        self._cursors: dict[str, int] = {}
+        self._flip_index = 0
+        self.started = False
+        self.stopped = False
+
+    @property
+    def _cluster(self) -> _Cluster:
+        cluster = type(self).cluster
+        assert cluster is not None, "test must set _FakeFlipConsumer.cluster"
+        return cluster
+
+    @property
+    def _assigned_topics(self) -> list[str]:
+        seen: list[str] = []
+        for tp in self._assigned:
+            topic = getattr(tp, "topic", None)
+            if isinstance(topic, str) and topic not in seen:
+                seen.append(topic)
+        return seen
+
+    async def start(self) -> None:
+        self.started = True
+
+    def partitions_for_topic(self, topic: str) -> set[int]:
+        if topic not in self._client.tracked:
+            return set()
+        if topic not in self._cluster.topics_with_partitions:
+            return set()
+        return {0}
+
+    def assign(self, partitions: Any) -> None:
+        self._assigned = list(partitions)
+
+    def assignment(self) -> set[Any]:
+        return set(self._assigned)
+
+    async def end_offsets(self, partitions: Any) -> dict[Any, int]:
+        # Synchronous HWM round-trip (#1971): the next-message offset captured NOW
+        # per assigned partition, without moving the consumer position.
+        offsets: dict[Any, int] = {}
+        for tp in partitions:
+            topic = getattr(tp, "topic", "")
+            offsets[tp] = self._cluster.logs[topic].hwm if topic else 0
+        return offsets
+
+    def seek(self, partition: Any, offset: int) -> None:
+        topic = getattr(partition, "topic", "")
+        if topic:
+            self._cursors[topic] = offset
+
+    async def seek_to_end(self, *partitions: object) -> None:
+        for tp in partitions:
+            topic = getattr(tp, "topic", "")
+            if topic:
+                self._cursors[topic] = self._cluster.logs[topic].hwm
+
+    async def getone(self) -> SimpleNamespace:
+        while True:
+            topics = self._assigned_topics
+            if not topics:
+                await asyncio.sleep(0.005)
+                continue
+            if len(topics) == 1:
+                # FAITHFUL single-topic delivery.
+                record = self._read(topics[0])
+                if record is not None:
+                    return record
+            else:
+                # FAITHLESS multi-topic delivery: the live subscription flip. Only
+                # ONE topic is readable per poll; a record on the other topic is
+                # NOT surfaced (its delivery window was torn down by the flip).
+                topic = topics[self._flip_index % len(topics)]
+                self._flip_index += 1
+                record = self._read(topic)
+                if record is not None:
+                    return record
+            await asyncio.sleep(0.005)
+
+    def _read(self, topic: str) -> SimpleNamespace | None:
+        cursor = self._cursors.get(topic, 0)
+        record = self._cluster.logs[topic].at(cursor)
+        if record is None:
+            return None
+        self._cursors[topic] = cursor + 1
+        _cid, value = record
+        return SimpleNamespace(topic=topic, value=value)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _FakeClient:
+    def __init__(self, consumer: _FakeFlipConsumer) -> None:
+        self._consumer = consumer
+        self.tracked: set[str] = set()
+
+    async def _refresh(self) -> bool:
+        latency = type(self._consumer).refresh_latency_seconds
+        if latency:
+            await asyncio.sleep(latency)
+        return True
+
+    def set_topics(self, topics: list[str]) -> Any:
+        self.tracked = set(topics)
+        return self._refresh()
+
+    def force_metadata_update(self) -> Any:
+        return self._refresh()
+
+
+class _FlipBattyTransport:
+    """Bus that publishes the generation command and appends a COMPLETED terminal.
+
+    Models the live FAST generation (dispatch loop freed, OMN-13010): the moment
+    the broker publishes the worker command, the correlated COMPLETED terminal
+    lands on its partition log (in the open->wait gap). The FAILED topic is never
+    written (every generation passes).
+    """
+
+    config = SimpleNamespace(
+        session_timeout_ms=45000,
+        heartbeat_interval_ms=15000,
+        max_poll_interval_ms=1800000,
+        reconnect_backoff_ms=2000,
+    )
+    _bootstrap_servers = "omn-13128-flip-test-broker"
+
+    def __init__(self, cluster: _Cluster) -> None:
+        self._cluster = cluster
+
+    def _build_auth_kwargs(self) -> dict[str, object]:
+        return {}
+
+    async def publish(
+        self,
+        topic: str,
+        _key: bytes | None,
+        value: bytes,
+        _headers: object | None = None,
+    ) -> None:
+        if topic != _COMMAND_TOPIC:
+            return
+        command_envelope = ModelEventEnvelope[object].model_validate_json(value)
+        correlation_id = str(command_envelope.correlation_id)
+        terminal = ModelEventEnvelope[object](
+            payload={
+                "attempt_count": 1,
+                "contract_passed": True,
+                "model_id": "Qwen3.6-35B-A3B",
+                "provider": "local",
+            },
+            correlation_id=command_envelope.correlation_id,
+            envelope_timestamp=datetime.now(UTC),
+            event_type=_COMPLETED_TOPIC,
+            source_tool="node_generation_consumer",
+        )
+        self._cluster.logs[_COMPLETED_TOPIC].append(
+            correlation_id, terminal.model_dump_json().encode("utf-8")
+        )
+
+    def subscribe(self, *_args: object, **_kwargs: object) -> object:
+        pytest.fail("Kafka-backed terminal waits must use the direct consumer path")
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio
+async def test_battery_correlates_with_independent_terminal_consumers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """K>=10 x 2 cells x 2 arms each correlate; no consumer holds two subscriptions.
+
+    GREEN only when each terminal topic has its OWN consumer (OMN-13128): the
+    COMPLETED consumer surfaces the correlated record on its single, non-flipping
+    subscription while the partition-less FAILED consumer sleeps out its timeout.
+    RED (single consumer assigned both topics): the flip drops every COMPLETED
+    terminal and the matrix produces degenerate rows.
+    """
+    cluster = _Cluster()
+    _FakeFlipConsumer.cluster = cluster
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeFlipConsumer,
+    )
+    # Scale the live 2s partition-less grace down so the FAILED open (serial,
+    # pre-publish, per trial) returns its empty assignment promptly. This is the
+    # #1970 grace window, unchanged in behaviour — only its duration is scaled so
+    # the K>=10 x 2-cell x 2-arm matrix is fast under test. (At the live 2s the
+    # battery still passes; it is just slow.)
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker."
+        "_DIRECT_TERMINAL_PARTITIONLESS_GRACE_SECONDS",
+        0.05,
+    )
+
+    broker = RuntimePatternBBroker(
+        _FlipBattyTransport(cluster),
+        command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
+        routes={"generation": _generation_route()},
+    )
+
+    # The runner's per-arm generation timeout (scaled down from the live 120s). A
+    # correctly-positioned independent consumer correlates in milliseconds; a
+    # flipping single consumer burns this whole window per trial and the matrix
+    # blows past the @timeout, so RED reproduces in bounded time.
+    timeout_seconds = 1
+
+    correlated: list[tuple[str, str, int]] = []
+    degenerate: list[tuple[str, str, int]] = []
+    arms_with_real_rows: set[str] = set()
+    cells_with_real_rows: set[str] = set()
+
+    for cell in _CELLS:
+        for trial in range(1, _TRIALS_PER_CELL + 1):
+            for arm in _ARMS:
+                command = ModelDispatchBusCommand(
+                    command_name="generation",
+                    requester="context-roi-runner",
+                    payload={"cell": cell, "arm": arm, "trial": trial},
+                    response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+                    timeout_seconds=timeout_seconds,
+                    correlation_id=uuid4(),
+                )
+                _route, result = await broker.dispatch_request(command)
+                if (
+                    result.status == "completed"
+                    and result.correlation_id == command.correlation_id
+                ):
+                    correlated.append((cell, arm, trial))
+                    arms_with_real_rows.add(arm)
+                    cells_with_real_rows.add(cell)
+                else:
+                    degenerate.append((cell, arm, trial))
+
+    total = len(_CELLS) * _TRIALS_PER_CELL * len(_ARMS)
+
+    # The COMPLETED terminal IS published every trial (HWM climbs) — confirms this
+    # is a consume-leg correlation failure, not a missing publish (the exact live
+    # signature: COMPLETED HWM climbs, FAILED HWM stays 0).
+    assert cluster.logs[_COMPLETED_TOPIC].hwm == total, (
+        "every trial must have published its correlated COMPLETED terminal "
+        f"(HWM should climb to {total}, got {cluster.logs[_COMPLETED_TOPIC].hwm})"
+    )
+    assert cluster.logs[_FAILED_TOPIC].hwm == 0, (
+        "the FAILED topic must stay at HWM 0 in a pass-only battery"
+    )
+
+    assert not degenerate, (
+        f"{len(degenerate)}/{total} trials produced a degenerate row — a consumer "
+        "that holds both terminal subscriptions flips and drops the already-"
+        f"published COMPLETED terminal. First few: {degenerate[:5]}"
+    )
+    assert len(correlated) == total, (
+        f"expected all {total} trials correlated, got {len(correlated)}"
+    )
+    assert cells_with_real_rows == set(_CELLS), (
+        f"matrix did not advance through both cells with real rows: "
+        f"{cells_with_real_rows} != {set(_CELLS)}"
+    )
+    assert arms_with_real_rows == set(_ARMS), (
+        f"matrix did not advance through both arms with real rows: "
+        f"{arms_with_real_rows} != {set(_ARMS)}"
+    )

--- a/tests/unit/runtime/test_service_pattern_b_broker.py
+++ b/tests/unit/runtime/test_service_pattern_b_broker.py
@@ -249,12 +249,28 @@ class _FakeKafkaTransport:
         _headers: object | None = None,
     ) -> None:
         assert self._consumers
-        consumer = self._consumers[-1]
-        if self._assert_seeked:
-            assert consumer.positioned is True
-
         command_envelope = ModelEventEnvelope[object].model_validate_json(value)
         terminal_topic = self._terminal_topic or self._route.terminal_event or "unknown"
+
+        # OMN-13128: the broker opens one INDEPENDENT consumer per terminal topic.
+        # Deliver the terminal to the consumer that actually holds the terminal
+        # topic's partition (mirrors the real broker producing to a topic and the
+        # subscribed consumer reading it). Fall back to the last-created consumer
+        # for the single-terminal-topic routes where there is exactly one.
+        target = next(
+            (
+                consumer
+                for consumer in self._consumers
+                if any(
+                    getattr(partition, "topic", "") == terminal_topic
+                    for partition in consumer.assigned_partitions
+                )
+            ),
+            self._consumers[-1],
+        )
+        if self._assert_seeked:
+            assert all(consumer.positioned is True for consumer in self._consumers)
+
         terminal_envelope = ModelEventEnvelope[object](
             payload=self._terminal_payload,
             correlation_id=command_envelope.correlation_id,
@@ -262,7 +278,7 @@ class _FakeKafkaTransport:
             event_type=terminal_topic,
             source_tool="session_orchestrator",
         )
-        await consumer.messages.put(
+        await target.messages.put(
             SimpleNamespace(
                 topic=terminal_topic,
                 value=terminal_envelope.model_dump_json().encode(),
@@ -497,43 +513,83 @@ async def test_service_pattern_b_broker_kafka_waiter_consumes_failure_terminal(
     resolved_route, result = await broker.dispatch_request(command)
 
     assert resolved_route == route
-    assert created_consumers[0].topics == ()
-    assert created_consumers[0].kwargs["group_id"] is None
-    assert {
-        getattr(partition, "topic", "")
-        for partition in created_consumers[0].assigned_partitions
-    } == set(route.terminal_events)
+    # OMN-13128: one INDEPENDENT consumer per terminal topic, never one consumer
+    # holding both subscriptions. The broker opens completed then failed, so two
+    # consumers are created, each assigned the partitions of EXACTLY ONE topic.
+    assert len(created_consumers) == len(route.terminal_events)
+    assert all(consumer.topics == () for consumer in created_consumers)
+    assert all(consumer.kwargs["group_id"] is None for consumer in created_consumers)
+    per_consumer_topics = [
+        {getattr(partition, "topic", "") for partition in consumer.assigned_partitions}
+        for consumer in created_consumers
+    ]
+    # Each consumer's assignment is confined to a single terminal topic, and the
+    # union across the independent consumers covers both terminal topics.
+    assert all(len(topics) == 1 for topics in per_consumer_topics)
+    assert set().union(*per_consumer_topics) == set(route.terminal_events)
     assert result.status == "failed"
     assert result.error_message == "routing contract missing"
-    assert created_consumers[0].stopped is True
+    assert all(consumer.stopped is True for consumer in created_consumers)
 
 
 @pytest.mark.asyncio
-async def test_service_pattern_b_broker_kafka_waiter_requires_all_terminal_topics(
+async def test_service_pattern_b_broker_correlates_completed_when_failed_topic_partitionless(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """OMN-13128: a never-produced FAILED topic must not block the COMPLETED win.
+
+    The runtime opens ONE independent consumer per terminal topic. When the FAILED
+    reply topic has never been produced to (zero partitions advertised — the
+    Redpanda auto-create-on-produce steady state, #1970), its consumer assigns the
+    empty set and its poll sleeps out the timeout, while the COMPLETED consumer —
+    its own independent subscription, positioned pre-publish — correlates the
+    terminal and wins the race. The prior single-consumer-both-topics shape could
+    not express this: it assigned both topics to one consumer and required BOTH to
+    surface partitions before it would assign at all.
+    """
     route = _route_with_failure_terminal()
-    _install_fake_aiokafka_consumer(monkeypatch)
+    completed_topic, failed_topic = route.terminal_events
+    created_consumers = _install_fake_aiokafka_consumer(monkeypatch)
+    # COMPLETED has a partition (produced to); FAILED never has (partition-less).
     _FakeAIOKafkaConsumer.topic_partitions_by_topic = {
-        route.terminal_events[0]: {0},
-        route.terminal_events[1]: set(),
+        completed_topic: {0},
+        failed_topic: set(),
     }
-    consumer = _FakeAIOKafkaConsumer()
-    await consumer.start()
+    _FakeAIOKafkaConsumer.require_metadata_refresh = True
+
     broker = RuntimePatternBBroker(
-        _FakeKafkaTransport(route, [consumer]),
+        _FakeKafkaTransport(route, created_consumers, terminal_topic=completed_topic),
         command_topic="onex.cmd.omnibase-infra.pattern-b-dispatch.v1",
         routes={"session_orchestrator": route},
     )
+    command = ModelDispatchBusCommand(
+        command_name="session_orchestrator",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic="onex.evt.pattern-b.dispatch-completed.v1",
+        timeout_seconds=1,
+    )
 
-    with pytest.raises(TimeoutError):
-        await broker._assign_terminal_topic_partitions(
-            consumer,
-            route.terminal_events,
-            timeout_seconds=0,
+    resolved_route, result = await broker.dispatch_request(command)
+
+    assert resolved_route == route
+    # Two independent consumers were opened, one per terminal topic.
+    assert len(created_consumers) == len(route.terminal_events)
+    completed_consumer = next(
+        c
+        for c in created_consumers
+        if any(
+            getattr(p, "topic", "") == completed_topic for p in c.assigned_partitions
         )
-
-    assert consumer.assigned_partitions == set()
+    )
+    failed_consumer = next(c for c in created_consumers if c is not completed_consumer)
+    # The COMPLETED consumer holds its real partition; the partition-less FAILED
+    # consumer assigns the empty set and never blocks the COMPLETED win.
+    assert completed_consumer.assigned_partitions
+    assert not failed_consumer.assigned_partitions
+    assert result.status == "completed"
+    assert result.payload == {"status": "complete", "dispatch_count": 5}
+    assert all(consumer.stopped is True for consumer in created_consumers)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## OMN-13118 — independent per-terminal-topic consumers (strike-5 follow-up)

Evidence-Source: OCC#2608
Evidence-Ticket: OMN-13118

### Root cause (beyond #1969/#1970/#1971)
The consume-leg wedge survived four merged fixes — #1969 (`set_topics` no-op), #1970 (partition-less assign-cap), #1971 (synchronous `end_offsets()`+`seek()` pin). The STRONG K>=10 multi-cell reprobe on the stability lane STILL wedged on REBUILD-5 (`cdf53d963f7b`, the #1971 merge commit), verifier-confirmed: `docs/evidence/2026-06-12-weekend-pass/experiments/probe4-stability/reprobe-K10-rebuild5/HALT_K10_WEDGE_PERSISTS.md`.

Converged diagnosis (strikes 3+4, `docs/evidence/2026-06-12-weekend-pass/experiments/exp1/CONSUME_LEG_DECISION.md`): the runtime waits for each trial's terminal across TWO topics (`node-generation-completed.v1` + `node-generation-failed.v1`). `RuntimePatternBBroker._dispatch_and_wait_with_direct_kafka_consumer` assigned BOTH topics' partitions to a SINGLE ephemeral `group_id=None` consumer. A single aiokafka consumer holds ONE manual subscription; the live runner log captured the alternating `Updating subscribed topics` flip and a clean 1:1 cid pairing — the `correlation_id` published to COMPLETED in cycle N is the `cid` whose FAILED-topic wait fails in cycle N+1. The COMPLETED delivery window collapsed before surfacing the correlated record, so the trial never correlated and the K>=10 matrix re-fired cell 1 forever. None of the four prior fixes touched the single-consumer-both-topics structure — they fixed assign-cap and seek-offset timing only.

### Fix
`_dispatch_and_wait_with_direct_kafka_consumer` now gives EACH terminal topic its OWN independent `AIOKafkaConsumer` via the module-level `open_direct_terminal_consumer` — each started, assigned, and offset-pinned (`end_offsets()`+`seek()`, #1971) at `open()` BEFORE the worker command is published (subscribe-before-publish). The two waits then run CONCURRENTLY via `asyncio.wait(..., FIRST_COMPLETED)` in a new `_race_correlated_terminals` helper; the first correlated terminal wins, the losing wait is cancelled, and both consumers are torn down together. No consumer ever holds two subscriptions, so there is no subscription to tear down out from under the COMPLETED delivery.

KEEP: the #1970 partition-less no-op and the #1971 synchronous offset pin — both live unchanged in `open_direct_terminal_consumer` / `poll_direct_terminal_consumer`, which each independent consumer goes through. A never-produced FAILED topic assigns the empty set, its poll sleeps out the timeout, and the COMPLETED consumer wins the race fast.

Removed the now-dead single-consumer helpers (`_assign_terminal_topic_partitions`, the method-level `_refresh_terminal_topic_metadata`, `_direct_kafka_*` kwargs builders, `_kafka_bootstrap_servers`/`_kafka_event_bus`).

### Repro (RED before fix, GREEN after)
`tests/integration/test_terminal_consumer_subscription_flip_wedge.py` drives the REAL `RuntimePatternBBroker.dispatch_request` over the direct-Kafka terminal-wait path across K=10 x 2 cells x 2 arms, with a fake that models the live fault HONESTLY: delivery is faithful ONLY for a single-topic assignment; the moment one consumer spans BOTH topics it flips its readable topic each poll and DROPS the COMPLETED record. The prior consume-leg fakes masked this by collapsing both waits onto a single fake consumer. **RED genuineness**: reverting ONLY `src/omnibase_infra/runtime/service_pattern_b_broker.py` to the single-consumer-both-topics shape makes the test hang past its `@pytest.mark.timeout` (every trial's COMPLETED terminal dropped). **GREEN** with the fix in ~2.3s.

`tests/unit/runtime/test_service_pattern_b_broker.py` was updated to assert one independent consumer per terminal topic (replacing the single-consumer-both-topics assertions and the removed-method test).

### Acceptance is NOT this PR
Per standing orders, the consume-leg wedge is declared cleared ONLY by the LIVE K>=10 multi-cell reprobe on the stability lane (later rebuild-6 phase), never by this offline repro. A green unit repro is necessary but NOT sufficient — the explicit lesson of four prior RED->GREEN unit fixes that each wedged live.

### Local verification
- `ruff format` + `ruff check` clean; `mypy src/omnibase_infra/runtime/service_pattern_b_broker.py --strict` Success.
- `tests/unit/runtime` + subscription-flip repro + #1970 battery repro: 4882 passed / 5 skipped; no pattern-b / terminal-consumer regression.
- `pre-commit run` clean on changed files.
- The full `tests/` run is green except live-infra-gated tests (Kafka `:19092` `pytest.mark.kafka` requires the deployed broker, unavailable locally — CI provides it).
