### PR TITLE
fix(OMN-13118): correlator resolves matched terminal in place for late awaiter

### DIFF
--- a/src/omnibase_infra/runtime/service_terminal_event_consumer.py
+++ b/src/omnibase_infra/runtime/service_terminal_event_consumer.py
@@ -260,7 +260,16 @@ class LongLivedTerminalCorrelator:
         correlation_id = _extract_direct_terminal_correlation_id(body)
         if correlation_id is None:
             return
-        future = self._pending.pop(correlation_id, None)
+        # OMN-13118 (P_RESOLVE_BEFORE_AWAIT fix): resolve the future IN PLACE; do
+        # NOT pop on match. The always-on poll loop typically delivers the
+        # terminal before the runner's wait() attaches (publish -> generation ->
+        # wait latency, ~28s observed live), so popping on match discarded the
+        # resolved result and the late awaiter found nothing -> 120s timeout ->
+        # zero rows. Leaving the resolved future in the registry lets a late
+        # _wait read it; _wait pops on exit. register() (pre-publish) guarantees
+        # the future exists when this matches. Idempotent under a duplicate
+        # delivery via the future.done() guard.
+        future = self._pending.get(correlation_id)
         if future is None:
             # Unmatched terminal (late, or a correlation no live trial awaits).
             # Drop it — the correlator is fire-and-forget for unawaited cids.
@@ -345,8 +354,13 @@ class LongLivedTerminalCorrelator:
                 asyncio.shield(future), timeout=timeout_seconds
             )
         except TimeoutError:
-            self._pending.pop(correlation_id, None)
             return None
+        finally:
+            # OMN-13118 (P_RESOLVE_BEFORE_AWAIT fix): the awaiter owns removal now
+            # that _deliver resolves the future in place (no pop-on-match). Pop on
+            # BOTH success and timeout so a resolved-and-read future does not
+            # linger in the registry. Idempotent if two waiters share the cid.
+            self._pending.pop(correlation_id, None)
 
     def close(self) -> None:
         """Stop the poll loop, the consumer, and the worker loop. Idempotent."""

--- a/tests/unit/runtime/test_terminal_correlator_resolve_before_await.py
+++ b/tests/unit/runtime/test_terminal_correlator_resolve_before_await.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Focused regression for the P_RESOLVE_BEFORE_AWAIT correlator race (OMN-13118).
+
+The live wedge (and the defect this test pins) is a delivery-ordering race in
+``LongLivedTerminalCorrelator``: the always-on poll loop runs continuously, so it
+typically consumes and matches the correlated terminal BEFORE the runner's
+``wait()`` attaches. The publish -> generation -> wait latency is large (~28s
+observed live), so by the time the runner blocks on its future the terminal has
+already been delivered.
+
+Before the fix, ``_deliver`` popped the future on match. When delivery beat the
+awaiter, the resolved future was removed from the registry, so the late ``_wait``
+found nothing, created a fresh (unresolved) future, and timed out at the trial
+cap -> ``None`` -> degenerate generation-failure row -> zero rows.
+
+The fix: ``_deliver`` resolves the future IN PLACE (``get``, not ``pop``); the
+awaiter (``_wait``) owns removal and pops on exit (``finally``). A future resolved
+before the awaiter attaches therefore survives in the registry until ``_wait``
+reads it.
+
+These tests prove the resolve-before-await ordering deterministically: register
+the cid, append the terminal, and wait (in the test) until the registry future is
+``done()`` — i.e. ``_deliver`` has already resolved it IN PLACE — and ONLY THEN
+call ``wait()``. The fix means ``wait()`` returns the body; the pre-fix
+pop-on-match would have returned ``None``/timed out.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+
+from omnibase_infra.runtime.service_terminal_event_consumer import (
+    LongLivedTerminalCorrelator,
+)
+
+pytestmark = [pytest.mark.unit]
+
+_TERMINAL_TOPIC = "onex.evt.omnimarket.node-generation-completed.v1"
+_HANDLER = "HandlerContextRoiRunner"
+
+
+class _PartitionLog:
+    """Append-only partition log for one terminal topic with a high-water-mark."""
+
+    def __init__(self) -> None:
+        self._records: list[tuple[str, bytes]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def hwm(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    def append(self, correlation_id: str, value: bytes) -> None:
+        with self._lock:
+            self._records.append((correlation_id, value))
+
+    def read_at(self, offset: int) -> tuple[str, bytes] | None:
+        with self._lock:
+            if offset < len(self._records):
+                return self._records[offset]
+            return None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.tracked: set[str] = set()
+
+    async def _refresh(self) -> bool:
+        return True
+
+    def set_topics(self, topics: list[str]) -> Any:
+        self.tracked = set(topics)
+        return self._refresh()
+
+    def force_metadata_update(self) -> Any:
+        return self._refresh()
+
+
+class _FakeConsumer:
+    """Single long-lived ``AIOKafkaConsumer`` stand-in over one terminal topic."""
+
+    log: ClassVar[_PartitionLog | None] = None
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._client = _FakeClient()
+        self._assigned: set[Any] = set()
+        self._cursor = 0
+
+    async def start(self) -> None:
+        return None
+
+    def partitions_for_topic(self, topic: str) -> set[int]:
+        self._client.tracked.add(topic)
+        return {0}
+
+    def assign(self, partitions: Any) -> None:
+        self._assigned = set(partitions)
+
+    def assignment(self) -> set[Any]:
+        return set(self._assigned)
+
+    async def seek_to_end(self, *assignment: object) -> None:
+        return None
+
+    async def end_offsets(self, partitions: Any) -> dict[Any, int]:
+        assert type(self).log is not None
+        return dict.fromkeys(partitions, type(self).log.hwm)
+
+    def seek(self, partition: Any, offset: int) -> None:
+        self._cursor = offset
+
+    async def getone(self) -> SimpleNamespace:
+        import asyncio
+
+        assert type(self).log is not None
+        while True:
+            record = type(self).log.read_at(self._cursor)
+            if record is not None:
+                self._cursor += 1
+                _cid, value = record
+                return SimpleNamespace(topic=_TERMINAL_TOPIC, value=value)
+            await asyncio.sleep(0.002)
+
+    async def stop(self) -> None:
+        return None
+
+
+class _KafkaLikeBus:
+    config = SimpleNamespace(
+        session_timeout_ms=45000,
+        heartbeat_interval_ms=15000,
+        max_poll_interval_ms=1800000,
+        reconnect_backoff_ms=2000,
+    )
+    _bootstrap_servers = "omn-13118-resolve-before-await-broker"
+
+    def _build_auth_kwargs(self) -> dict[str, object]:
+        return {}
+
+
+def _terminal_envelope_json(correlation_id: str) -> bytes:
+    return json.dumps(
+        {
+            "correlation_id": correlation_id,
+            "payload": {
+                "attempt_count": 1,
+                "contract_passed": True,
+                "model_id": "Qwen3.6-35B-A3B",
+                "provider": "local",
+                "prompt_tokens": 128,
+                "completion_tokens": 64,
+            },
+        }
+    ).encode("utf-8")
+
+
+def _await_future_resolved(
+    correlator: LongLivedTerminalCorrelator,
+    correlation_id: str,
+    timeout_seconds: float = 5.0,
+) -> bool:
+    """Block until the registry future for ``correlation_id`` is ``done()``.
+
+    Returning True proves ``_deliver`` matched the terminal and resolved the
+    future IN PLACE *before* any ``wait()`` attached — the exact resolve-before-
+    await ordering. The future is read on the worker loop (where it lives) via a
+    thread-safe submit to avoid touching loop state from the test thread.
+    """
+    import asyncio
+
+    deadline = time.monotonic() + timeout_seconds
+
+    async def _is_done() -> bool:
+        future = correlator._pending.get(correlation_id)
+        return future is not None and future.done()
+
+    while time.monotonic() < deadline:
+        resolved = asyncio.run_coroutine_threadsafe(
+            _is_done(), correlator._loop
+        ).result(timeout=1.0)
+        if resolved:
+            return True
+        time.sleep(0.005)
+    return False
+
+
+@pytest.mark.timeout(30)
+def test_wait_returns_body_when_terminal_resolved_before_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """register -> deliver (resolved IN PLACE) -> THEN wait must return the body.
+
+    This is the P_RESOLVE_BEFORE_AWAIT fix: the poll loop delivers and matches the
+    terminal before ``wait()`` attaches. The test makes the ordering deterministic
+    by blocking on the registry future being ``done()`` (proving ``_deliver``
+    resolved it in place) BEFORE calling ``wait()``.
+
+    Pre-fix (``_deliver`` popped on match): the resolved future was removed, the
+    late ``wait()`` created a fresh future and timed out -> ``None``. The
+    resolve-in-place fix keeps the resolved future in the registry until ``wait()``
+    reads it, then ``_wait`` pops it on exit.
+    """
+    log = _PartitionLog()
+    _FakeConsumer.log = log
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeConsumer,
+    )
+
+    correlator = LongLivedTerminalCorrelator(
+        event_bus=_KafkaLikeBus(), handler_name=_HANDLER
+    )
+    cid = "omn-13118-resolve-before-await-0001"
+    try:
+        # 1. Subscribe + register the cid BEFORE the terminal exists (pre-publish).
+        correlator.ensure_topic(_TERMINAL_TOPIC)
+        correlator.register(cid)
+
+        # 2. Deliver the terminal. The always-on poll loop consumes + matches it.
+        log.append(cid, _terminal_envelope_json(cid))
+
+        # 3. Block (in the test) until the registry future is resolved IN PLACE by
+        #    _deliver — i.e. delivery has provably BEATEN the awaiter. This is the
+        #    late-awaiter ordering the fix targets.
+        assert _await_future_resolved(correlator, cid), (
+            "the poll loop never resolved the registry future for the matched "
+            "terminal — _deliver did not match/resolve in place"
+        )
+
+        # 4. ONLY NOW attach the awaiter. With the resolve-in-place fix the body
+        #    is still in the registry; pre-fix pop-on-match would return None.
+        result = correlator.wait(cid, timeout_seconds=2.0)
+        assert result is not None, (
+            "wait() returned None for a terminal that was delivered and resolved "
+            "BEFORE the awaiter attached — the P_RESOLVE_BEFORE_AWAIT race "
+            "(_deliver must resolve in place, not pop on match)"
+        )
+        assert str(result.get("correlation_id")) == cid
+
+        # 5. The awaiter owns removal: the cid is popped from the registry on exit.
+        import asyncio
+
+        still_pending = asyncio.run_coroutine_threadsafe(
+            _pending_contains(correlator, cid), correlator._loop
+        ).result(timeout=1.0)
+        assert not still_pending, (
+            "_wait must pop the cid on exit so a resolved-and-read future does not "
+            "linger in the registry"
+        )
+    finally:
+        correlator.close()
+
+
+@pytest.mark.timeout(30)
+def test_wait_still_returns_body_when_terminal_arrives_during_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sibling ordering: terminal arrives DURING the wait — body still returned.
+
+    Confirms the fix does not regress the in-window delivery path: the awaiter
+    attaches first, then the terminal lands and the poll loop resolves the
+    already-attached future.
+    """
+    log = _PartitionLog()
+    _FakeConsumer.log = log
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.service_pattern_b_broker.AIOKafkaConsumer",
+        _FakeConsumer,
+    )
+
+    correlator = LongLivedTerminalCorrelator(
+        event_bus=_KafkaLikeBus(), handler_name=_HANDLER
+    )
+    cid = "omn-13118-resolve-during-await-0001"
+    try:
+        correlator.ensure_topic(_TERMINAL_TOPIC)
+        correlator.register(cid)
+
+        def _publish_during_wait() -> None:
+            time.sleep(0.2)
+            log.append(cid, _terminal_envelope_json(cid))
+
+        threading.Thread(target=_publish_during_wait, daemon=True).start()
+        result = correlator.wait(cid, timeout_seconds=5.0)
+        assert result is not None, (
+            "wait() returned None for a terminal that arrived during the await"
+        )
+        assert str(result.get("correlation_id")) == cid
+    finally:
+        correlator.close()
+
+
+async def _pending_contains(
+    correlator: LongLivedTerminalCorrelator, correlation_id: str
+) -> bool:
+    return correlation_id in correlator._pending


### PR DESCRIPTION
## OMN-13118 — correlator resolves matched terminal in place for the late awaiter (P_RESOLVE_BEFORE_AWAIT)

Ticket: OMN-13118 (Tier B consume-leg redesign; epic OMN-12525)

### The race (P_RESOLVE_BEFORE_AWAIT)

`LongLivedTerminalCorrelator` runs ONE always-on poll loop over a single
runtime-lifetime consumer. A trial `register(cid)`s its future BEFORE publishing
its command (subscribe-before-publish at the correlation level), publishes, then
blocks on `wait(cid)`.

Because the poll loop runs continuously and the publish -> generation -> wait
latency is large (~28s observed live), the loop **typically consumes and matches
the correlated terminal BEFORE the runner's `wait()` attaches**. With the old
`_deliver` that **popped** the future on match, the resolved future was removed
from the registry the instant it was matched. The late `_wait` then found
nothing in `_pending`, created a fresh (unresolved) future, and timed out at the
120s trial cap -> `None` -> degenerate generation-failure row -> zero rows.

This is the live "strike-seven" wedge: the COMPLETED terminal was published and
its HWM climbed every trial, but the delivered-and-discarded match meant the
runner saw no terminal.

### The fix (this PR — clean, no instrumentation)

- `_deliver` resolves the future **IN PLACE**: `self._pending.get(cid)` +
  `future.set_result(body)` — no pop on match. A future resolved before the
  awaiter attaches now survives in the registry until the awaiter reads it.
- `_wait` **owns removal**: pops the cid in a `finally` on BOTH success and
  timeout, so a resolved-and-read future does not linger.
- Idempotent under duplicate delivery via the existing `future.done()` guard;
  `register()` (pre-publish) guarantees the future exists when `_deliver` matches.

Two-line load-bearing change in `service_terminal_event_consumer.py`:
`pop` -> `get` in `_deliver`, and move the registry removal into `_wait`'s
`finally`. **No DIAG13118 instrumentation** is included in this PR — this is the
clean fix only.

### Regression test

New `tests/unit/runtime/test_terminal_correlator_resolve_before_await.py` drives
the real `LongLivedTerminalCorrelator` and pins the exact ordering: `register(cid)`
-> append terminal -> **block until the registry future is `done()`** (proving
`_deliver` resolved it IN PLACE, i.e. delivery provably beat the awaiter) ->
**THEN** `wait(cid)` and assert it returns the body. Verified RED->GREEN: with
`_deliver` reverted to pop-on-match the test FAILS (the resolved future is gone
before the awaiter attaches); with the resolve-in-place fix it PASSES and the
awaiter also pops the cid on exit. A sibling test asserts the in-window
(arrive-during-await) path is not regressed.

### Acceptance — LIVE K>=10 gate (PASSED on rebuild-10)

The acceptance gate for this defect class is NOT a unit test; it is the **LIVE
K>=10 multi-cell battery** on the stability-test lane. It PASSED on
`reprobe-K10-rebuild10` (2026-06-13T23:39Z, omnibase-infra-stability-test
:18085/:18086, projection-api :13002), VERDICT **PASS**:

- 40/40 trials' primary `wait()` logged **RESOLVED** (rebuild-9 had RESOLVED=0,
  3 `no terminal event received` warnings; rebuild-10 had **0**).
- Terminal `context-roi-run-completed.v1` HWM advanced 22 -> 24.
- Projection `total_rows` 448 -> 488 (**+40**); `rows_for_fresh_run_id = 40` via
  projection API (20 bool_flag + 20 address_norm, 40 distinct cids, sample
  `final_success=True first_pass_success=True attempt_count=1`).
- Aggregate trace: MATCHED=80, UNMATCHED=0, RESOLVED=40, trial-terminal
  TIMEOUT=0. (Residual TIMEOUT=39 / NO_PRE_REGISTER=40 are the benign
  second-redundant-waiter from the runner opening two sessions per trial sharing
  one cid — reported, not suppressed; candidate cleanup is register/await once
  per trial.)

Evidence bundle: `docs/evidence/2026-06-12-weekend-pass/experiments/probe4-stability/reprobe-K10-rebuild10/`
(FINDINGS.md, build-provenance.json, projection-check.txt, watermarks-before/after.txt, diag13118-effects.log).

Honest pairing note: the live-proven deploy commit `0d958ea45` carried the
DIAG13118 instrumentation alongside this same logical fix (get-not-pop in
`_deliver`, `_wait` pops on exit). **This PR ships the identical load-bearing
change WITHOUT the instrumentation.** The runner-side `register(cid)`-before-publish
half of the pairing (omnimarket `cc1f658d`, OMN-13118 runner-register-order) is a
separate PR.

### Local verification

- `uv run ruff format` / `uv run ruff check` — clean on both changed files.
- `uv run mypy src/ --strict` — Success, no issues in 2442 source files.
- `uv run pytest tests/unit/runtime/auto_wiring/test_event_consumer_injection.py tests/integration/test_terminal_consumer_longlived_correlator.py tests/unit/runtime/test_terminal_correlator_resolve_before_await.py -q` — **7 passed**.
- `pre-commit run --files ...` — all hooks pass.

### Evidence-Source (OCC pairing)

The OCC evidence PR for the reprobe-K10-rebuild10 acceptance bundle is OCC#2616
(onex_change_control, base dev). It carries the OMN-13118 contract + the four
receipts (`dod-omnimarket-runner-pr`, `dod-omnibase-infra-correlator-pr`,
`dod-live-gate`, `dod-deploy-assessment`); the decisive evidence is the live
K>=10 reprobe-K10-rebuild10 PASS (`dod-live-gate`). Receipt-Gate + deploy-gate
resolve against OCC#2616.

Evidence-Source: OCC#2616
Evidence-Ticket: OMN-13118