### PR TITLE
fix(OMN-12987): deploy-runtime.sh sibling lock-pin preflight uses current --lock/--repo/--output interface

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -599,16 +599,38 @@ check_sibling_lock_pins() {
         exit 1
     fi
 
-    log_cmd "OMNI_HOME=${omni_home} ${guard} --provenance-out ${provenance_out}"
+    # The check_sibling_lock_pins.py interface changed under OMN-12977/12987:
+    # the original single-output flag was removed in favor of --lock (required,
+    # the pin authority), repeatable --repo PACKAGE=PATH (the canonical clones
+    # the build vendors), and --output (where to write the comparison JSON).
+    # The consuming repo's uv.lock (omnimarket) is the pin authority.
+    local lock_path="${omni_home}/omnimarket/uv.lock"
+    local guard_args=(
+        --lock "${lock_path}"
+        --repo "omnibase-infra=${omni_home}/omnibase_infra"
+        --repo "omnibase-core=${omni_home}/omnibase_core"
+        --repo "omnibase-spi=${omni_home}/omnibase_spi"
+        --repo "omnibase-compat=${omni_home}/omnibase_compat"
+        --repo "onex-change-control=${omni_home}/onex_change_control"
+        --output "${provenance_out}"
+    )
+    # Operator override (OMN-12977): ALLOW_SIBLING_PIN_DRIFT=1 records drift in
+    # the provenance artifact and proceeds instead of aborting. Never the default.
+    if [[ "${ALLOW_SIBLING_PIN_DRIFT:-0}" == "1" ]]; then
+        guard_args+=(--allow-drift)
+        log_warn "ALLOW_SIBLING_PIN_DRIFT=1 -- passing --allow-drift to sibling lock-pin preflight (OMN-12977)"
+    fi
+
+    log_cmd "OMNI_HOME=${omni_home} ${guard} ${guard_args[*]}"
     if [[ "${python_bin}" == "uv-run" ]]; then
         if ! OMNI_HOME="${omni_home}" uv run --project "${repo_root}" python "${guard}" \
-            --provenance-out "${provenance_out}"; then
+            "${guard_args[@]}"; then
             log_error "Sibling lock-pin preflight FAILED. Refusing to build a stale image."
             exit 1
         fi
     else
         if ! OMNI_HOME="${omni_home}" "${python_bin}" "${guard}" \
-            --provenance-out "${provenance_out}"; then
+            "${guard_args[@]}"; then
             log_error "Sibling lock-pin preflight FAILED. Refusing to build a stale image."
             exit 1
         fi

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -163,6 +163,46 @@ def test_deploy_runtime_runs_sibling_lock_pin_preflight() -> None:
 
 
 @pytest.mark.unit
+def test_deploy_runtime_uses_current_lock_pin_preflight_interface() -> None:
+    """The preflight caller must match check_sibling_lock_pins.py's current CLI.
+
+    Regression guard: OMN-12977/12987 replaced the original ``--provenance-out``
+    flag with ``--lock`` (required pin authority), repeatable ``--repo
+    PACKAGE=PATH`` (the canonical clones the build vendors), and ``--output``
+    (where to write the comparison JSON). The deploy-runtime.sh caller was left
+    pinned to the removed ``--provenance-out`` flag, so EVERY workspace
+    ``--execute`` deploy failed at argparse (``the following arguments are
+    required: --lock``) before any build started. This test pins the corrected
+    interface so the stale-flag invocation can never come back.
+    """
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    # Removed flag must be gone — its presence is the exact regression we hit.
+    assert "--provenance-out" not in deploy_script
+
+    # Current required + supported flags must be wired into the guard_args.
+    assert '--lock "${lock_path}"' in deploy_script
+    assert "--repo " in deploy_script
+    assert '--output "${provenance_out}"' in deploy_script
+
+    # The consuming repo's omnimarket uv.lock is the pin authority, and every
+    # vendored sibling must be passed as a --repo PACKAGE=PATH entry.
+    assert 'lock_path="${omni_home}/omnimarket/uv.lock"' in deploy_script
+    for package in (
+        "omnibase-infra",
+        "omnibase-core",
+        "omnibase-spi",
+        "omnibase-compat",
+        "onex-change-control",
+    ):
+        assert f'--repo "{package}=' in deploy_script
+
+    # The OMN-12977 operator override must be honored via --allow-drift.
+    assert "ALLOW_SIBLING_PIN_DRIFT" in deploy_script
+    assert "--allow-drift" in deploy_script
+
+
+@pytest.mark.unit
 def test_stage_workspace_emits_build_sha_marker() -> None:
     """stage_workspace.sh must record each sibling's HEAD SHA (OMN-12987).
 


### PR DESCRIPTION
## Summary

The OMN-12987 sibling lock-pin preflight in `scripts/deploy-runtime.sh` called `check_sibling_lock_pins.py` with the **removed `--provenance-out` flag**. The script's interface changed under OMN-12977/12987 (the workspace-build sibling-pin recurrence ratchet) to require:
- `--lock` (the omnimarket `uv.lock` pin authority, required)
- repeatable `--repo PACKAGE=PATH` (the canonical clones the build vendors; at least one required)
- `--output` (where to write the expected-vs-actual comparison JSON)

The stale caller meant **EVERY** workspace `--execute` deploy failed at argparse (`the following arguments are required: --lock`) **before any build started**. It blocked the clean stability-test rebuild; the dev redeploy only worked because it used a different build script.

## Change

`check_sibling_lock_pins()` now builds `guard_args` with the current interface — **behavior is identical**:
- `--lock "${omni_home}/omnimarket/uv.lock"` (same pin authority)
- one `--repo PACKAGE=PATH` per vendored sibling: `omnibase-infra`, `omnibase-core`, `omnibase-spi`, `omnibase-compat`, `onex-change-control` (the valid set per `DEFAULT_PACKAGE_REPO_DIRS`)
- `--output "${provenance_out}"` → the unchanged `workspace/sibling-repos/.sibling-lock-pins.json` destination (still rides into the build image the same way)
- same fail-fast abort (`Refusing to build a stale image`)
- honors `ALLOW_SIBLING_PIN_DRIFT=1` → `--allow-drift` (the OMN-12977 explicit operator override)

Adds `test_deploy_runtime_uses_current_lock_pin_preflight_interface`: a permanent regression guard asserting the removed flag is gone and the current flags are wired, so the stale-flag invocation cannot return.

## Tests / proof

`uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_check_sibling_lock_pins.py -v` → **14 passed**.

RE-PROVE (non-mutating, against canonical clones):
- old `--provenance-out` invocation → `error: the following arguments are required: --lock` (exit 2) — the bug.
- corrected `--lock/--repo/--output` invocation → guard runs and aborts on real clone drift (exit 1, its job); **no `--provenance-out unrecognized`, no stale-flag failure**.
- corrected + `ALLOW_SIBLING_PIN_DRIFT=1` → `--allow-drift` → exit 0, comparison artifact written.

`bash -n` clean; ruff + pre-commit (`--files`) clean. No bypass / skip token. No live deploy/restart/topic/.201 mutation performed.

Evidence-Ticket: OMN-12987
Evidence-Source: OCC#2617