### PR TITLE
fix(OMN-12987): stage workspace/sibling-pin-comparison.json into deployed build context

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1273,6 +1273,24 @@ if spec and spec.origin:
     # .sibling-lock-pins.json, so the rsync above already carries it into the
     # build context for the in-image provenance merge.
 
+    # Carry the root-level workspace/ file that Dockerfile.runtime COPYs
+    # (workspace/sibling-pin-comparison.json, line ~278). The sibling-repos/
+    # rsync above only covers the subdirectory; without this the deployed build
+    # context lacks the comparison file and `docker build` fails with
+    # "failed to calculate checksum of ref ...:/workspace/sibling-pin-comparison.json:
+    # not found" -- the bug fixed in OMN-12987 (the dev compose build only worked
+    # because it runs from the repo root where the committed placeholder exists).
+    # Release mode ships the committed placeholder; workspace mode ships the real
+    # expected-vs-actual comparison stage_workspace.sh wrote into the repo root
+    # (OMN-12977). The regression test
+    # tests/scripts/test_deploy_runtime_build_context.py asserts every
+    # COPY-from-workspace path the Dockerfile references is staged here, so a
+    # future Dockerfile COPY without a matching rsync fails CI.
+    log_cmd "rsync -a workspace/sibling-pin-comparison.json -> deployed"
+    rsync -a \
+        "${repo_root}/workspace/sibling-pin-comparison.json" \
+        "${deploy_target}/workspace/sibling-pin-comparison.json"
+
     # 6. Migration scripts (bind-mounted by docker-compose.infra.yml)
     log_info "Syncing migration scripts..."
     mkdir -p "${deploy_target}/scripts"

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -14,6 +15,35 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-runtime.sh"
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.runtime"
+
+# Matches a COPY directive's argument list. We discard `--from=<stage>` lines
+# (those copy from a prior build stage, not the host build context) and any
+# remaining `--flag` tokens (e.g. `--chown=...`), then keep the source operands
+# that pull from the workspace/ tree.
+_COPY_LINE_RE = re.compile(r"^COPY\s+(?P<args>.+)$", re.MULTILINE)
+
+
+def _dockerfile_workspace_copy_sources() -> list[str]:
+    """Every Dockerfile.runtime COPY source that pulls from the workspace/ tree.
+
+    The deployed build context is assembled by deploy-runtime.sh's sync_files;
+    each of these paths must be rsynced (or generated) into that context or the
+    workspace-mode `docker build` fails with "failed to calculate checksum ...:
+    not found" (the OMN-12987 regression). This list is derived from the live
+    Dockerfile so a future COPY workspace/<x> without a matching rsync is caught.
+    """
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    sources: list[str] = []
+    for match in _COPY_LINE_RE.finditer(dockerfile):
+        tokens = match.group("args").split()
+        # `--from=<stage>` copies from a build stage, never the host context.
+        if any(tok.startswith("--from=") for tok in tokens):
+            continue
+        # Drop flag tokens (--chown=, --link, ...); the last operand is the
+        # destination, everything before it is a build-context source.
+        operands = [tok for tok in tokens if not tok.startswith("--")]
+        sources.extend(src for src in operands[:-1] if src.startswith("workspace/"))
+    return sources
 
 
 @pytest.mark.unit
@@ -31,6 +61,47 @@ def test_deploy_runtime_syncs_runtime_dockerfile_copy_sources() -> None:
 
     assert '"${repo_root}/workspace/sibling-repos/"' in deploy_script
     assert '"${repo_root}/scripts/runtime_build/"' in deploy_script
+
+
+@pytest.mark.unit
+def test_deploy_runtime_stages_every_workspace_copy_source() -> None:
+    """Every `COPY workspace/<x>` in Dockerfile.runtime must be staged.
+
+    Regression guard for OMN-12987: Dockerfile.runtime COPYs
+    workspace/sibling-pin-comparison.json (and workspace/sibling-repos/), but an
+    earlier deploy-runtime.sh only rsynced workspace/sibling-repos/ into the
+    deployed build context. The root-level comparison file was never carried
+    over, so every workspace-mode `docker build` failed with "failed to
+    calculate checksum of ref ...:/workspace/sibling-pin-comparison.json: not
+    found". The dev compose build masked this because it runs from the repo root
+    where the committed placeholder exists.
+
+    This test derives the workspace/ COPY sources from the live Dockerfile and
+    asserts deploy-runtime.sh references each as an rsync source for the deployed
+    context, so a future Dockerfile COPY without a matching rsync fails CI.
+    """
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    workspace_sources = _dockerfile_workspace_copy_sources()
+    # The Dockerfile must at minimum COPY the two known workspace/ paths; a regex
+    # that silently matched nothing would make this guard vacuously pass.
+    assert "workspace/sibling-repos/" in workspace_sources
+    assert "workspace/sibling-pin-comparison.json" in workspace_sources
+
+    missing: list[str] = []
+    for source in workspace_sources:
+        # A directory source (trailing slash) and a file source both appear in
+        # deploy-runtime.sh as an rsync argument quoted under ${repo_root}.
+        staged = f'"${{repo_root}}/{source}"' in deploy_script
+        if not staged:
+            missing.append(source)
+
+    assert not missing, (
+        "Dockerfile.runtime COPYs these workspace/ paths but deploy-runtime.sh "
+        f"does not stage them into the deployed build context: {missing}. Add an "
+        "rsync of each into sync_files() or workspace-mode `docker build` will "
+        "fail with 'failed to calculate checksum ...: not found' (OMN-12987)."
+    )
 
 
 def _init_git_repo(path: Path, marker: str) -> str:


### PR DESCRIPTION
## Summary

`Dockerfile.runtime` (~line 278) COPYs `workspace/sibling-pin-comparison.json`, but `deploy-runtime.sh` `sync_files()` only rsynced `workspace/sibling-repos/` into the deployed build context. The root-level comparison file was never carried over, so **EVERY** workspace-mode `docker build` (every `deploy-runtime.sh --execute` workspace deploy) failed with:

```
failed to calculate checksum of ref ...:/workspace/sibling-pin-comparison.json: not found
```

The dev compose build masked this because `docker compose build` runs from the repo root where the committed placeholder exists; `deploy-runtime.sh` builds from the assembled deployed context, which lacked the file. This blocked the stability-lane clean rebuild **after** the OMN-12987 lock-pin preflight + caller-fix correctly passed.

## Root cause

- `docker/Dockerfile.runtime` COPYs two `workspace/` paths: `workspace/sibling-repos/` (line 265) and `workspace/sibling-pin-comparison.json` (line 278).
- `scripts/deploy-runtime.sh` `sync_files()` rsynced only `workspace/sibling-repos/` (lines ~1269) — never the root-level json.
- `workspace/sibling-pin-comparison.json` is a committed placeholder (release mode) that `scripts/runtime_build/stage_workspace.sh` overwrites in workspace mode with the real expected-vs-actual comparison (OMN-12977). Either way the deployed context needs it.

## Fix (minimal + correct)

`sync_files()` now rsyncs `workspace/sibling-pin-comparison.json` into the deployed context alongside `workspace/sibling-repos/`. Release mode ships the placeholder; workspace mode ships the staged comparison.

## Regression test

New permanent test `test_deploy_runtime_stages_every_workspace_copy_source` parses `Dockerfile.runtime`'s `COPY`-from-`workspace/` paths (excluding `--from=` stage copies) and asserts `deploy-runtime.sh` stages each into the deployed context — so a future `Dockerfile` `COPY workspace/<x>` without a matching rsync **fails CI**. Negative control verified: removing the rsync makes the test fail with the exact `['workspace/sibling-pin-comparison.json']` missing-path error.

## Verification

- `bash -n scripts/deploy-runtime.sh` OK; `ruff format/check` clean; full pre-commit on changed files GREEN.
- `uv run pytest tests/scripts/test_deploy_runtime_build_context.py` → 7 passed; `uv run pytest tests/scripts/` → 136 passed.
- **Live RE-PROVE on .201 stability-test lane** with the FIXED script: `rsync -a workspace/sibling-pin-comparison.json -> deployed` runs, the `COPY workspace/sibling-pin-comparison.json` build steps **succeed**, `Image build complete` — the original blocker is gone. The clean end-to-end deploy did NOT finish due to a **separate, pre-existing** defect: `docker-compose.infra.yml` line 611 hard-codes a non-namespaced `container_name: omnibase-forward-migration` colliding with the running dev lane; per "roll back + report; do not force" the dev container was NOT removed and the deploy auto-rolled-back. Stability lane remains healthy at dev tip (0.38.3 / c5130711, DIAG13118=0, :18085+:18086 = 200). Follow-up ticket recommended to namespace the migration container_name per compose project.

Evidence-Ticket: OMN-12987
Evidence-Source: OCC#2619