### PR TITLE
fix(OMN-12987): project-namespace forward-migration container_name to stop cross-lane collision

### DIFF
--- a/docker/catalog/services/forward-migration.yaml
+++ b/docker/catalog/services/forward-migration.yaml
@@ -2,7 +2,7 @@ name: forward-migration
 description: One-shot runner for pending forward SQL migrations
 image: postgres:16-alpine
 layer: infrastructure
-container_name: omnibase-forward-migration
+container_name: omnibase-infra-forward-migration
 required_env:
   - POSTGRES_PASSWORD
 hardcoded_env:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -608,7 +608,14 @@ services:
   # successfully before checking the sentinel flag.
   forward-migration:
     image: postgres:16-alpine
-    container_name: omnibase-forward-migration
+    # Project-namespaced to match the omnibase-infra-* convention used by every
+    # other base service (postgres, redpanda, valkey, ...). The bare
+    # "omnibase-forward-migration" name was the one base container_name NOT
+    # carrying the lane prefix, so it collided across compose projects on the
+    # same host (e.g. a leftover dev-lane container blocked a stability rebuild).
+    # Lane overlays append their lane segment, yielding the derivable form
+    # <compose-project>-forward-migration that deploy-runtime.sh waits on (OMN-12987).
+    container_name: omnibase-infra-forward-migration
     profiles: ["runtime", "full"]
     depends_on:
       postgres:

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1594,7 +1594,14 @@ run_runtime_migration_preflight() {
         log_cmd "${cmd[*]}"
         "${cmd[@]}"
         if [[ "${service}" == "forward-migration" ]]; then
-            local wait_cmd=(docker wait omnibase-forward-migration)
+            # Derive the container name from the compose project so the wait
+            # targets the lane being deployed, not a fixed name. The base
+            # compose names it <compose-project>-forward-migration and each
+            # lane overlay follows the same form (OMN-12987), so this resolves
+            # to omnibase-infra-forward-migration for dev and
+            # omnibase-infra-stability-test-forward-migration for stability.
+            local forward_migration_container="${compose_project}-forward-migration"
+            local wait_cmd=(docker wait "${forward_migration_container}")
             log_cmd "${wait_cmd[*]}"
             if [[ "$("${wait_cmd[@]}")" != "0" ]]; then
                 log_error "forward-migration did not complete successfully."
@@ -1603,9 +1610,15 @@ run_runtime_migration_preflight() {
         fi
     done
 
+    # Postgres follows the same lane-derivable naming as forward-migration:
+    # <compose-project>-postgres (omnibase-infra-postgres for dev,
+    # omnibase-infra-stability-test-postgres for stability). Deriving it keeps
+    # the projection-table probe pointed at the lane being deployed instead of
+    # always hitting the dev-lane postgres (OMN-12987).
+    local postgres_container="${compose_project}-postgres"
     for table_name in "${REQUIRED_PROJECTION_TABLES[@]}"; do
         local check_cmd=(
-            docker exec omnibase-infra-postgres
+            docker exec "${postgres_container}"
             psql
             -U postgres
             -d omnidash_analytics

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -84,7 +84,7 @@ PRODUCTION_CONTAINER_NAMES = {
     "omnibase-infra-postgres",
     "omnibase-infra-redpanda",
     "omnibase-infra-valkey",
-    "omnibase-forward-migration",
+    "omnibase-infra-forward-migration",
     "omnibase-infra-infisical",
     "omninode-agent-actions-consumer",
     "omninode-skill-lifecycle-consumer",

--- a/tests/unit/infra/test_stability_test_runtime_lane.py
+++ b/tests/unit/infra/test_stability_test_runtime_lane.py
@@ -34,7 +34,7 @@ PRODUCTION_CONTAINER_NAMES = {
     "omnibase-infra-postgres",
     "omnibase-infra-redpanda",
     "omnibase-infra-valkey",
-    "omnibase-forward-migration",
+    "omnibase-infra-forward-migration",
     "omnibase-infra-infisical",
     "omninode-agent-actions-consumer",
     "omninode-skill-lifecycle-consumer",


### PR DESCRIPTION
## Summary

Project-namespaces the `forward-migration` container so it stops colliding across compose projects on the same host. The base `docker-compose.infra.yml` named it `omnibase-forward-migration` — the **only** base `container_name` not carrying the `omnibase-infra-*` prefix that every other base service uses (postgres, redpanda, valkey, ...). Since `container_name` is an absolute Docker name that ignores the compose `-p` project prefix, the bare name collided: a leftover dev-lane forward-migration container blocked a stability-lane rebuild, breaking clean `deploy-runtime.sh` end-to-end deploys (FINDING #4).

Renamed to `omnibase-infra-forward-migration`, which both follows the base convention and matches the lane-overlay form (`omnibase-infra-stability-test-forward-migration`, ...). The container name is now the derivable `<compose-project>-forward-migration`.

## Coordinated changes (nothing references the old literal afterward)

- **`docker/catalog/services/forward-migration.yaml`** — `container_name` updated. The catalog is the **source of truth**: `deploy-agent` regenerates `docker-compose.infra.yml` from it (`omnibase_infra.docker.catalog.cli generate`). Verified the generator now emits `omnibase-infra-forward-migration`, matching the committed compose.
- **`docker/docker-compose.infra.yml`** — `container_name` updated (+ rationale comment).
- **`scripts/deploy-runtime.sh`** — the migration preflight no longer hard-codes `docker wait omnibase-forward-migration` (the lane-blind name that false-failed stability deploys). It now derives `${compose_project}-forward-migration` so the wait targets the lane being deployed. The projection-table probe is fixed the same way: it derived `${compose_project}-postgres` instead of the hard-coded `omnibase-infra-postgres`, so a stability deploy probes its own postgres.
- **tests** — `PRODUCTION_CONTAINER_NAMES` sets updated to the new base name in `test_stability_test_runtime_lane.py` and `test_stability_test_runtime_compose_render.py`.

## dod_evidence

- `test_stability_test_runtime_lane.py`: 19 passed
- `test_omn8738_compose_migration_manifests.py`: 36 passed
- deploy-agent `test_executor_compose_gen.py`: 14 passed
- catalog `generate runtime-infrastructure`: `container_name: omnibase-infra-forward-migration` (catalog/compose in sync)
- `bash -n scripts/deploy-runtime.sh`: OK
- grep: no remaining live reference to the bare `omnibase-forward-migration` (only an explanatory comment naming the old form)
- pre-commit ran on commit (no `--no-verify`)

Note: a clean stability-lane `deploy-runtime.sh` re-prove requires Docker on the `.201` server (not available in CI sandbox); see the combined re-prove note in the handoff.

## OCC pairing

Honest OCC pairing: this is the infra half of OMN-12987; the OCC half is #2619 (deploy-context-json), already open on OCC `dev`.

OMN-12987
Evidence-Ticket: OMN-12987
Evidence-Source: OCC#2619